### PR TITLE
feat(studio): metric threshold alerts for schedules

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -835,6 +835,8 @@ class StateDB:
                           budget_usd          REAL,
                           budget_tokens       INTEGER,
                           project             TEXT,
+                          threshold_config    JSON,
+                          last_alert_at       REAL,
                           created_at          REAL    NOT NULL,
                           updated_at          REAL    NOT NULL
                         )
@@ -1984,7 +1986,7 @@ class StateDB:
                         action_playbook, action_flow_yaml, action_project, action_extra_args,
                         on_success, on_fail, last_fired_at, next_fire_at,
                         missed_fire_policy, overlap_policy, max_runs, budget_usd, budget_tokens,
-                        project, created_at, updated_at)
+                        project, threshold_config, last_alert_at, created_at, updated_at)
                        VALUES (:id, :name, :description, :enabled, :trigger_type,
                                :cron_expr, :interval_sec, :github_repo, :github_filter,
                                :github_cursor, :poll_interval_sec,
@@ -1992,12 +1994,13 @@ class StateDB:
                                :action_playbook, :action_flow_yaml, :action_project, :action_extra_args,
                                :on_success, :on_fail, :last_fired_at, :next_fire_at,
                                :missed_fire_policy, :overlap_policy, :max_runs, :budget_usd, :budget_tokens,
-                               :project, :created_at, :updated_at)"""
+                               :project, :threshold_config, :last_alert_at, :created_at, :updated_at)"""
                 ).bindparams(
                     bindparam("github_filter", type_=JSON),
                     bindparam("action_extra_args", type_=JSON),
                     bindparam("on_success", type_=JSON),
                     bindparam("on_fail", type_=JSON),
+                    bindparam("threshold_config", type_=JSON),
                 ),
                 {
                     "id": schedule["id"],
@@ -2029,6 +2032,8 @@ class StateDB:
                     "budget_usd": schedule.get("budget_usd"),
                     "budget_tokens": schedule.get("budget_tokens"),
                     "project": schedule.get("project"),
+                    "threshold_config": schedule.get("threshold_config"),
+                    "last_alert_at": schedule.get("last_alert_at"),
                     "created_at": schedule.get("created_at", now),
                     "updated_at": schedule.get("updated_at", now),
                 },
@@ -2122,11 +2127,19 @@ class StateDB:
             "budget_usd",
             "budget_tokens",
             "project",
+            "threshold_config",
+            "last_alert_at",
         }
         bad = set(fields) - allowed
         if bad:
             raise ValueError(f"Invalid schedule field(s): {bad}")
-        json_fields = {"github_filter", "action_extra_args", "on_success", "on_fail"}
+        json_fields = {
+            "github_filter",
+            "action_extra_args",
+            "on_success",
+            "on_fail",
+            "threshold_config",
+        }
         fields["updated_at"] = time.time()
         sets_parts = []
         bind_params = []
@@ -2293,6 +2306,61 @@ class StateDB:
             "cost_usd": float(row["cost_usd"] or 0),
             "tokens": int(row["input_tokens"] or 0) + int(row["output_tokens"] or 0),
         }
+
+    # Threshold-alert metrics (studio-wide, not scoped to a single schedule's
+    # own runs -- unlike sum_schedule_spend above, which sums a single
+    # schedule's spawned sessions). Keys must match
+    # lionagi.studio.scheduler.threshold.VALID_METRICS.
+    _THRESHOLD_METRIC_QUERIES: dict[str, str] = {
+        "failed_sessions": (
+            "SELECT COUNT(*) AS n FROM sessions "
+            "WHERE status IN ('failed', 'timed_out') "
+            "AND COALESCE(ended_at, started_at, created_at) >= :window_start"
+        ),
+        "total_cost_usd": (
+            "SELECT COALESCE(SUM(total_cost_usd), 0) AS n FROM sessions "
+            "WHERE COALESCE(ended_at, started_at, created_at) >= :window_start"
+        ),
+    }
+
+    async def metric_value(self, metric: str, window_start: float) -> float:
+        """Aggregate a threshold-alert metric over [window_start, now).
+
+        ``failed_sessions`` and ``total_cost_usd`` are single-aggregate SQL
+        queries; ``p95_latency_ms`` needs a sorted sample (SQLite has no
+        built-in percentile function), so it fetches raw invocation
+        durations and computes the 95th percentile in Python.
+        """
+        if metric == "p95_latency_ms":
+            async with self._read() as conn:
+                rows = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT (ended_at - started_at) AS latency_sec FROM invocations "
+                                "WHERE started_at >= :window_start AND ended_at IS NOT NULL "
+                                "AND ended_at >= started_at"
+                            ),
+                            {"window_start": window_start},
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+            if not rows:
+                return 0.0
+            latencies = sorted(float(r["latency_sec"]) * 1000.0 for r in rows)
+            idx = min(len(latencies) - 1, max(0, -(-95 * len(latencies) // 100) - 1))
+            return latencies[idx]
+
+        query = self._THRESHOLD_METRIC_QUERIES.get(metric)
+        if query is None:
+            raise ValueError(f"Unknown threshold metric: {metric!r}")
+        async with self._read() as conn:
+            row = (
+                (await conn.execute(text(query), {"window_start": window_start})).mappings().first()
+            )
+        return float(row["n"]) if row and row["n"] is not None else 0.0
 
     async def schedule_run_streak(self, schedule_id: str) -> tuple[int, str | None]:
         """Consecutive terminal 'failed' streak and most recent status, newest-first, capped at 50 rows."""
@@ -3872,6 +3940,7 @@ class StateDB:
             "action_extra_args",
             "trigger_context",
             "action_args",
+            "threshold_config",
             "artifact_contract_json",
             "artifact_verification_json",
             "status_evidence_refs",

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -443,6 +443,14 @@ CREATE TABLE IF NOT EXISTS schedules (
   budget_usd          REAL,
   budget_tokens       INTEGER,
   project             TEXT,
+  -- Metric threshold alerts: when set, this schedule's own cron/interval
+  -- cadence only evaluates a metric (does not unconditionally fire); the
+  -- schedule's action fires only when the metric breaches the configured
+  -- threshold. Shape: {metric, op, value, window_minutes}. last_alert_at
+  -- tracks the most recent breach fire so the window doubles as a cooldown
+  -- (no refire until window_minutes has elapsed since the last alert).
+  threshold_config    JSON,
+  last_alert_at       REAL,
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL
 );

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -513,6 +513,11 @@ schedules = Table(
     Column("budget_usd", Float),
     Column("budget_tokens", Integer),
     Column("project", Text),
+    # Metric threshold alerts: {metric, op, value, window_minutes} config
+    # blob + the timestamp of the last breach fire (doubles as the cooldown
+    # anchor -- see schema.sql for the fuller comment).
+    Column("threshold_config", JSON),
+    Column("last_alert_at", Float),
     Column("created_at", Float, nullable=False),
     Column("updated_at", Float, nullable=False),
 )

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -94,6 +94,10 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         # Cumulative spend budget: NULL means unlimited.
         ("budget_usd", "REAL"),
         ("budget_tokens", "INTEGER"),
+        # Metric threshold alerts: {metric, op, value, window_minutes}
+        # config blob + the cooldown timestamp of the last breach fire.
+        ("threshold_config", "JSON"),
+        ("last_alert_at", "REAL"),
     ],
     "schedule_runs": [
         # ADR-0028: schedule_runs originally had no updated_at.

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -784,6 +784,19 @@ def _cmd_create(args: argparse.Namespace) -> int:
             print("Error: --github-filter must be a JSON object.", file=sys.stderr)
             return 1
         body["github_filter"] = parsed_filter
+    if getattr(args, "threshold_config", None):
+        try:
+            parsed_threshold = json.loads(args.threshold_config)
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --threshold-config must be valid JSON: {exc}", file=sys.stderr)
+            return 1
+        if not isinstance(parsed_threshold, dict):
+            print("Error: --threshold-config must be a JSON object.", file=sys.stderr)
+            return 1
+        # Shape/value validation (metric/op vocab, positive window_minutes,
+        # etc.) happens server-side in _svc_validate_threshold_config --
+        # this is just the same JSON-object shape check --github-filter does.
+        body["threshold_config"] = parsed_threshold
     if getattr(args, "poll_interval", None) is not None:
         if args.poll_interval < 1:
             print("Error: --poll-interval must be a positive integer.", file=sys.stderr)
@@ -1018,6 +1031,21 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         help=(
             "JSON object filtering which PRs fire the trigger, e.g. "
             '\'{"state": "open", "base": "main"}\'.'
+        ),
+    )
+    create_p.add_argument(
+        "--threshold-config",
+        dest="threshold_config",
+        metavar="JSON",
+        help=(
+            "Metric threshold alert config as a JSON object: "
+            '{"metric": "failed_sessions|total_cost_usd|p95_latency_ms", '
+            '"op": "gt|gte", "value": N, "window_minutes": N}. When set, '
+            "this schedule's own cron/interval cadence only evaluates the "
+            "metric on each tick and fires the action only when the "
+            "threshold is breached (cooldown = window_minutes). Full "
+            'validation happens server-side, e.g. \'{"metric": '
+            '"failed_sessions", "op": "gt", "value": 5, "window_minutes": 60}\'.'
         ),
     )
     create_p.add_argument(

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -86,6 +86,41 @@ class _GlobalSlotClaim:
         self._engine._release_global_slot()
 
 
+class _ThresholdCooldownClaim:
+    """One-shot handle for an in-process threshold-alert cooldown reservation.
+
+    ``_maybe_fire()`` reserves a schedule's cooldown SYNCHRONOUSLY -- adding
+    its id to ``_threshold_pending`` with no ``await`` between the
+    ``last_alert_at`` gate check and the add -- before ``_tracked_fire()``
+    launches. Without this in-process gate, two ticks separated by
+    ``_TICK_INTERVAL`` could both read the same stale (not-yet-durably-
+    stamped) ``last_alert_at``, both pass the cooldown check, and both fire
+    before either fire's background task reaches the durable stamp --
+    duplicate alerts inside the cooldown window, the exact dedup this
+    feature promises to prevent.
+
+    Held for the full ``_fire_inner()`` duration and released in ``_fire()``
+    's wrapping ``try/finally`` -- same lifecycle as ``_MaxRunsClaim``/
+    ``_GlobalSlotClaim`` -- so it is guaranteed to be released on every exit
+    path, including a failure before the durable stamp is ever written. A
+    leaked reservation would permanently mute the alert, which is worse
+    than the duplicate it exists to prevent.
+    """
+
+    __slots__ = ("_engine", "_schedule_id", "_released")
+
+    def __init__(self, engine: SchedulerEngine, schedule_id: str) -> None:
+        self._engine = engine
+        self._schedule_id = schedule_id
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._engine._threshold_pending.discard(self._schedule_id)
+
+
 def _resolve_scheduler_tzinfo(tz_name: str) -> ZoneInfo:
     """Resolve the configured scheduler timezone name to a ZoneInfo.
 
@@ -162,6 +197,12 @@ class SchedulerEngine:
         self._global_slot_lock = asyncio.Lock()
         self._global_inflight = 0
         self._deferred_log_counts: dict[str, int] = {}  # schedule_id -> deferrals since last record
+        # threshold-alert cooldown reservations (single-process; see
+        # _ThresholdCooldownClaim). Membership means "a fire for this
+        # schedule's current breach is in flight or was just reserved" --
+        # closes the race a DB-only last_alert_at check can't (see
+        # _maybe_fire).
+        self._threshold_pending: set[str] = set()
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -773,6 +814,7 @@ class SchedulerEngine:
 
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
         threshold_extra: dict[str, Any] | None = None
+        threshold_claim: _ThresholdCooldownClaim | None = None
         if schedule.get("threshold_config"):
             breach = await self._evaluate_threshold_breach(schedule, now)
             if breach is None:
@@ -783,14 +825,26 @@ class SchedulerEngine:
             # fire on every tick. The cadence still advances underneath —
             # the next tick re-checks the metric once the cooldown lapses.
             cooldown_sec = breach["window_minutes"] * 60
+            sid = schedule["id"]
             last_alert_at = schedule.get("last_alert_at")
-            if last_alert_at is not None and now - last_alert_at < cooldown_sec:
+            in_cooldown = last_alert_at is not None and now - last_alert_at < cooldown_sec
+            # in_pending closes the race last_alert_at alone can't: a fire
+            # reserved by an earlier tick whose durable stamp hasn't landed
+            # yet still reads as "not in cooldown" from the DB alone. This
+            # check and the reservation immediately below it are both
+            # synchronous -- no await in between -- so a second tick can't
+            # slip in between the gate and the reservation becoming visible.
+            if in_cooldown or sid in self._threshold_pending:
                 await self._advance_next_fire_only(schedule, now)
                 return
+            self._threshold_pending.add(sid)
+            threshold_claim = _ThresholdCooldownClaim(self, sid)
             threshold_extra = breach
 
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
+            if threshold_claim is not None:
+                threshold_claim.release()
             skipped_run_id = uuid.uuid4().hex[:12]
             await create_skipped_run(
                 self._svc,
@@ -808,11 +862,15 @@ class SchedulerEngine:
             return
 
         if await self._check_budget(schedule):
+            if threshold_claim is not None:
+                threshold_claim.release()
             await self._disable_for_budget_exhausted(schedule, now)
             return
 
         allowed, claim = await self._reserve_max_runs_budget(schedule)
         if not allowed:
+            if threshold_claim is not None:
+                threshold_claim.release()
             _log.info(
                 "Schedule %s (%s) has exhausted max_runs=%s; disabling instead of firing",
                 schedule.get("name"),
@@ -828,6 +886,11 @@ class SchedulerEngine:
                 # Give the max_runs reservation back -- we're deferring this
                 # fire, not consuming a run against its budget.
                 claim.release()
+            if threshold_claim is not None:
+                # Give the cooldown reservation back too -- we're deferring
+                # this fire, not abandoning or completing it, so the next
+                # tick must be free to try again.
+                threshold_claim.release()
             await self._maybe_record_deferred(schedule, now)
             # Leave next_fire_at untouched (still due) so the next tick
             # retries this schedule instead of skipping it.
@@ -844,13 +907,16 @@ class SchedulerEngine:
             # consume the cooldown with zero durable record an alert was
             # ever attempted, the exact silent-loss shape this feature
             # exists to prevent. See _fire_inner's own stamp, which only
-            # fires once a schedule_run row actually exists.
+            # fires once a schedule_run row actually exists. The in-process
+            # threshold_claim (released in _fire()'s finally) is what
+            # actually closes the duplicate-fire race in the meantime.
         self._tracked_fire(
             schedule,
             run_id,
             trigger_context=ctx,
             max_runs_claim=claim,
             global_slot_claim=slot_claim,
+            threshold_cooldown_claim=threshold_claim,
         )
 
     async def _guarded_terminal_status(
@@ -933,18 +999,20 @@ class SchedulerEngine:
         chain_depth: int = 0,
         max_runs_claim: _MaxRunsClaim | None = None,
         global_slot_claim: _GlobalSlotClaim | None = None,
+        threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
     ) -> None:
-        """Thin wrapper around _fire_inner() that guarantees max_runs_claim
-        and global_slot_claim are each released exactly once on every exit
-        path.
+        """Thin wrapper around _fire_inner() that guarantees max_runs_claim,
+        global_slot_claim, and threshold_cooldown_claim are each released
+        exactly once on every exit path.
 
         Only top-level callers (_maybe_fire, fire_now, _tick_github) that
         got an allowed reservation from _reserve_max_runs_budget() /
-        _reserve_global_slot() pass a non-None claim; chain children never
-        do. The release lives here — not inside _check_max_runs() — precisely
-        so it still fires even when _fire_inner() blows up before ever
-        reaching _check_max_runs() (e.g. create_invocation() raising), which
-        is the leak this wrapper exists to close.
+        _reserve_global_slot() / the synchronous threshold-cooldown gate
+        pass a non-None claim; chain children never do. The release lives
+        here — not inside _check_max_runs() — precisely so it still fires
+        even when _fire_inner() blows up before ever reaching
+        _check_max_runs() (e.g. create_invocation() raising), which is the
+        leak this wrapper exists to close.
         """
         try:
             await self._fire_inner(
@@ -959,6 +1027,8 @@ class SchedulerEngine:
                 max_runs_claim.release()
             if global_slot_claim is not None:
                 global_slot_claim.release()
+            if threshold_cooldown_claim is not None:
+                threshold_cooldown_claim.release()
 
     def _threshold_alert_update_fields(
         self, schedule: dict, chain_depth: int, now: float

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -841,83 +841,100 @@ class SchedulerEngine:
             threshold_claim = _ThresholdCooldownClaim(self, sid)
             threshold_extra = breach
 
-        if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
-            _log.debug("Skipping overlapping fire for %s", schedule["name"])
-            if threshold_claim is not None:
-                threshold_claim.release()
-            skipped_run_id = uuid.uuid4().hex[:12]
-            await create_skipped_run(
-                self._svc,
-                run_id=skipped_run_id,
-                schedule=schedule,
-                trigger_context={"skipped_overlap": True, "fired_at": now},
-                now=now,
-                reason_code=ScheduleReasons.SKIPPED_OVERLAP,
-                reason_summary="Schedule fire skipped because overlap_policy=skip and a prior run is still active.",
-                metadata={"overlap_policy": schedule.get("overlap_policy")},
+        # Every await from here through _tracked_fire() (create_skipped_run,
+        # _check_budget, _reserve_max_runs_budget, _reserve_global_slot, or
+        # a cancellation at any of them) must release threshold_claim (and,
+        # once reserved, claim/slot_claim) on failure -- a raise mid-gate
+        # would otherwise leak the reservation permanently, muting the
+        # alert until an engine restart. handed_off flips True only once
+        # _tracked_fire() has actually launched and taken ownership of the
+        # claims, mirroring _tick_github's use of the same pattern for its
+        # own claims below.
+        claim: _MaxRunsClaim | None = None
+        slot_claim: _GlobalSlotClaim | None = None
+        handed_off = False
+        try:
+            if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
+                _log.debug("Skipping overlapping fire for %s", schedule["name"])
+                skipped_run_id = uuid.uuid4().hex[:12]
+                await create_skipped_run(
+                    self._svc,
+                    run_id=skipped_run_id,
+                    schedule=schedule,
+                    trigger_context={"skipped_overlap": True, "fired_at": now},
+                    now=now,
+                    reason_code=ScheduleReasons.SKIPPED_OVERLAP,
+                    reason_summary="Schedule fire skipped because overlap_policy=skip and a prior run is still active.",
+                    metadata={"overlap_policy": schedule.get("overlap_policy")},
+                )
+                next_at = self._compute_next_fire(schedule, now)
+                if next_at:
+                    await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
+                return
+
+            if await self._check_budget(schedule):
+                await self._disable_for_budget_exhausted(schedule, now)
+                return
+
+            allowed, claim = await self._reserve_max_runs_budget(schedule)
+            if not allowed:
+                _log.info(
+                    "Schedule %s (%s) has exhausted max_runs=%s; disabling instead of firing",
+                    schedule.get("name"),
+                    schedule["id"],
+                    schedule.get("max_runs"),
+                )
+                await self._svc.update_schedule(schedule["id"], enabled=0)
+                return
+
+            slot_allowed, slot_claim = await self._reserve_global_slot()
+            if not slot_allowed:
+                await self._maybe_record_deferred(schedule, now)
+                # Leave next_fire_at untouched (still due) so the next tick
+                # retries this schedule instead of skipping it. claim (and
+                # threshold_claim, if reserved) are given back by the
+                # finally below -- we're deferring this fire, not
+                # consuming a run against its budget or abandoning the
+                # cooldown.
+                return
+
+            run_id = uuid.uuid4().hex[:12]
+            ctx = {
+                "scheduled": True,
+                "fired_at": now,
+                "next_fire_at": schedule.get("next_fire_at"),
+            }
+            if threshold_extra:
+                ctx.update(threshold_extra)
+                # last_alert_at is NOT stamped here. Every gate above
+                # (overlap, budget, max_runs, global slot) has passed, but
+                # _fire_inner() can still fail before persisting any
+                # schedule_run row (e.g. create_invocation() raising) --
+                # stamping this early would consume the cooldown with zero
+                # durable record an alert was ever attempted, the exact
+                # silent-loss shape this feature exists to prevent. See
+                # _fire_inner's own stamp, which only fires once a
+                # schedule_run row actually exists. The in-process
+                # threshold_claim (released in _fire()'s finally once
+                # handed off) is what actually closes the duplicate-fire
+                # race in the meantime.
+            handed_off = True
+            self._tracked_fire(
+                schedule,
+                run_id,
+                trigger_context=ctx,
+                max_runs_claim=claim,
+                global_slot_claim=slot_claim,
+                threshold_cooldown_claim=threshold_claim,
             )
-            next_at = self._compute_next_fire(schedule, now)
-            if next_at:
-                await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
-            return
-
-        if await self._check_budget(schedule):
-            if threshold_claim is not None:
-                threshold_claim.release()
-            await self._disable_for_budget_exhausted(schedule, now)
-            return
-
-        allowed, claim = await self._reserve_max_runs_budget(schedule)
-        if not allowed:
-            if threshold_claim is not None:
-                threshold_claim.release()
-            _log.info(
-                "Schedule %s (%s) has exhausted max_runs=%s; disabling instead of firing",
-                schedule.get("name"),
-                schedule["id"],
-                schedule.get("max_runs"),
-            )
-            await self._svc.update_schedule(schedule["id"], enabled=0)
-            return
-
-        slot_allowed, slot_claim = await self._reserve_global_slot()
-        if not slot_allowed:
-            if claim is not None:
-                # Give the max_runs reservation back -- we're deferring this
-                # fire, not consuming a run against its budget.
-                claim.release()
-            if threshold_claim is not None:
-                # Give the cooldown reservation back too -- we're deferring
-                # this fire, not abandoning or completing it, so the next
-                # tick must be free to try again.
-                threshold_claim.release()
-            await self._maybe_record_deferred(schedule, now)
-            # Leave next_fire_at untouched (still due) so the next tick
-            # retries this schedule instead of skipping it.
-            return
-
-        run_id = uuid.uuid4().hex[:12]
-        ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
-        if threshold_extra:
-            ctx.update(threshold_extra)
-            # last_alert_at is NOT stamped here. Every gate above (overlap,
-            # budget, max_runs, global slot) has passed, but _fire_inner()
-            # can still fail before persisting any schedule_run row (e.g.
-            # create_invocation() raising) -- stamping this early would
-            # consume the cooldown with zero durable record an alert was
-            # ever attempted, the exact silent-loss shape this feature
-            # exists to prevent. See _fire_inner's own stamp, which only
-            # fires once a schedule_run row actually exists. The in-process
-            # threshold_claim (released in _fire()'s finally) is what
-            # actually closes the duplicate-fire race in the meantime.
-        self._tracked_fire(
-            schedule,
-            run_id,
-            trigger_context=ctx,
-            max_runs_claim=claim,
-            global_slot_claim=slot_claim,
-            threshold_cooldown_claim=threshold_claim,
-        )
+        finally:
+            if not handed_off:
+                if claim is not None:
+                    claim.release()
+                if slot_claim is not None:
+                    slot_claim.release()
+                if threshold_claim is not None:
+                    threshold_claim.release()
 
     async def _guarded_terminal_status(
         self,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -837,12 +837,14 @@ class SchedulerEngine:
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
         if threshold_extra:
             ctx.update(threshold_extra)
-            # Stamp last_alert_at only now that every gate (overlap, budget,
-            # max_runs, global slot) has actually passed and the fire is
-            # really about to happen -- stamping it earlier (before those
-            # checks) would consume the cooldown on a deferred/skipped tick
-            # that never spawned an action, silently swallowing the alert.
-            await self._svc.update_schedule(schedule["id"], last_alert_at=now)
+            # last_alert_at is NOT stamped here. Every gate above (overlap,
+            # budget, max_runs, global slot) has passed, but _fire_inner()
+            # can still fail before persisting any schedule_run row (e.g.
+            # create_invocation() raising) -- stamping this early would
+            # consume the cooldown with zero durable record an alert was
+            # ever attempted, the exact silent-loss shape this feature
+            # exists to prevent. See _fire_inner's own stamp, which only
+            # fires once a schedule_run row actually exists.
         self._tracked_fire(
             schedule,
             run_id,
@@ -958,6 +960,32 @@ class SchedulerEngine:
             if global_slot_claim is not None:
                 global_slot_claim.release()
 
+    def _threshold_alert_update_fields(
+        self, schedule: dict, chain_depth: int, now: float
+    ) -> dict[str, Any]:
+        """Extra ``update_schedule()`` fields for a threshold-alert fire.
+
+        Folded into the SAME schedule update call that already writes
+        ``last_fired_at``/``next_fire_at`` inside ``_fire_inner()`` --
+        deliberately placed AFTER ``create_schedule_run()`` has durably
+        persisted the run row (both the invalid-action-failure branch and
+        the normal running branch call this only once their own
+        ``create_schedule_run()`` has already succeeded). Stamping the
+        cooldown any earlier (e.g. in ``_maybe_fire()`` before ``_fire()``
+        even starts) risks consuming it on a ``create_invocation()`` (or
+        other pre-persistence) failure that leaves zero durable record an
+        alert was ever attempted -- the exact silent-loss shape this
+        feature exists to prevent.
+
+        Only top-level fires (``chain_depth == 0``) of a
+        threshold-configured schedule stamp the cooldown; on_success/
+        on_fail chain children are follow-on actions of the same alert
+        cycle, not a new one, and must not restamp it.
+        """
+        if chain_depth != 0 or not schedule.get("threshold_config"):
+            return {}
+        return {"last_alert_at": now}
+
     async def _fire_inner(
         self,
         schedule: dict,
@@ -1053,6 +1081,7 @@ class SchedulerEngine:
             update_fields: dict[str, Any] = {"last_fired_at": now}
             if next_at:
                 update_fields["next_fire_at"] = next_at
+            update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
             await self._svc.update_schedule(sid, **update_fields)
             await self._check_max_runs(schedule, chain_depth)
             return
@@ -1094,6 +1123,7 @@ class SchedulerEngine:
             update_fields = {"last_fired_at": now}
             if next_at:
                 update_fields["next_fire_at"] = next_at
+            update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
             await self._svc.update_schedule(sid, **update_fields)
 
             _log.info(

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from lionagi.state.reasons import RunReasons, ScheduleReasons
 from lionagi.studio.scheduler import subprocess as _subprocess
+from lionagi.studio.scheduler import threshold as _threshold
 from lionagi.studio.services.scheduler_state import (
     SchedulerStateService,
     create_skipped_run,
@@ -730,7 +731,64 @@ class SchedulerEngine:
         )
         await self._svc.update_schedule(schedule["id"], enabled=0)
 
+    async def _evaluate_threshold_breach(self, schedule: dict, now: float) -> dict[str, Any] | None:
+        """Evaluate ``schedule["threshold_config"]`` against live metrics.
+
+        Returns a breach dict (``metric``, ``op``, ``value`` = observed,
+        ``threshold`` = configured, ``window_minutes``) that renders into
+        ``{{metric}}``/``{{value}}``/``{{threshold}}`` action-prompt
+        templates (see ``_subprocess.render_action_prompt`` and the
+        github_poll precedent it already handles), or ``None`` when the
+        metric is within bounds.
+        """
+        config = schedule.get("threshold_config")
+        if not config:
+            return None
+        metric = config["metric"]
+        op = config["op"]
+        threshold_value = float(config["value"])
+        window_minutes = int(config["window_minutes"])
+        window_start = now - window_minutes * 60
+        observed = await self._svc.metric_value(metric, window_start)
+        if not _threshold.compare(op, observed, threshold_value):
+            return None
+        return {
+            "metric": metric,
+            "op": op,
+            "value": observed,
+            "threshold": threshold_value,
+            "window_minutes": window_minutes,
+        }
+
+    async def _advance_next_fire_only(self, schedule: dict, now: float) -> None:
+        """Advance next_fire_at without firing the schedule's action.
+
+        Used by the threshold-alert paths in ``_maybe_fire`` where the
+        cadence tick fires (so the metric is re-checked next time) but no
+        breach (or an in-cooldown breach) means no action should spawn.
+        """
+        next_at = self._compute_next_fire(schedule, now)
+        if next_at:
+            await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
+
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
+        threshold_extra: dict[str, Any] | None = None
+        if schedule.get("threshold_config"):
+            breach = await self._evaluate_threshold_breach(schedule, now)
+            if breach is None:
+                await self._advance_next_fire_only(schedule, now)
+                return
+            # Cooldown: suppress refiring while still within the metric's
+            # own window of the last alert, so a sustained breach doesn't
+            # fire on every tick. The cadence still advances underneath —
+            # the next tick re-checks the metric once the cooldown lapses.
+            cooldown_sec = breach["window_minutes"] * 60
+            last_alert_at = schedule.get("last_alert_at")
+            if last_alert_at is not None and now - last_alert_at < cooldown_sec:
+                await self._advance_next_fire_only(schedule, now)
+                return
+            threshold_extra = breach
+
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
             skipped_run_id = uuid.uuid4().hex[:12]
@@ -777,6 +835,14 @@ class SchedulerEngine:
 
         run_id = uuid.uuid4().hex[:12]
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
+        if threshold_extra:
+            ctx.update(threshold_extra)
+            # Stamp last_alert_at only now that every gate (overlap, budget,
+            # max_runs, global slot) has actually passed and the fire is
+            # really about to happen -- stamping it earlier (before those
+            # checks) would consume the cooldown on a deferred/skipped tick
+            # that never spawned an action, silently swallowing the alert.
+            await self._svc.update_schedule(schedule["id"], last_alert_at=now)
         self._tracked_fire(
             schedule,
             run_id,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -918,7 +918,6 @@ class SchedulerEngine:
                 # threshold_claim (released in _fire()'s finally once
                 # handed off) is what actually closes the duplicate-fire
                 # race in the meantime.
-            handed_off = True
             self._tracked_fire(
                 schedule,
                 run_id,
@@ -927,6 +926,11 @@ class SchedulerEngine:
                 global_slot_claim=slot_claim,
                 threshold_cooldown_claim=threshold_claim,
             )
+            # Flipped only after _tracked_fire() returns, so even a
+            # synchronous task-launch failure releases the claims below.
+            # Release is idempotent, so no double-free against _fire()'s
+            # own finally once the task is running.
+            handed_off = True
         finally:
             if not handed_off:
                 if claim is not None:

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -166,7 +166,14 @@ def _render_template(template: str, context: dict) -> str:
             val = events[0].get(key)
             if val is not None:
                 return str(val)
-        return context.get(key, m.group(0))
+        # A present-but-non-string value (e.g. the numeric metric/value/
+        # threshold fields threshold-alert fires put directly on
+        # trigger_context) must be stringified same as the github_events
+        # branch above -- re.sub's replacement callback requires a str
+        # return, and returning the raw value crashes on anything but str.
+        if key in context:
+            return str(context[key])
+        return m.group(0)
 
     return _TEMPLATE_RE.sub(_replace, template)
 

--- a/lionagi/studio/scheduler/threshold.py
+++ b/lionagi/studio/scheduler/threshold.py
@@ -16,15 +16,28 @@ from typing import Any
 
 VALID_METRICS: frozenset[str] = frozenset({"failed_sessions", "total_cost_usd", "p95_latency_ms"})
 VALID_OPS: frozenset[str] = frozenset({"gt", "gte"})
+ALLOWED_KEYS: frozenset[str] = frozenset({"metric", "op", "value", "window_minutes"})
 
 
 def validate_threshold_config(config: Any) -> None:
     """Raise ValueError if *config* is not a well-formed threshold spec.
 
-    Shape: ``{"metric": ..., "op": ..., "value": ..., "window_minutes": ...}``.
+    Shape: ``{"metric": ..., "op": ..., "value": ..., "window_minutes": ...}``
+    -- exactly those four keys, nothing else. Rejecting unknown keys (rather
+    than silently ignoring them) catches typos like ``cooldown_minutes``
+    that would otherwise persist and mislead an operator about what the
+    schedule is actually configured to do -- there is no cooldown field;
+    the cooldown reuses ``window_minutes`` (see engine.py's stamp logic).
     """
     if not isinstance(config, dict):
         raise ValueError("threshold_config must be an object")
+
+    unknown = set(config) - ALLOWED_KEYS
+    if unknown:
+        raise ValueError(
+            f"threshold_config has unknown key(s) {sorted(unknown)}. "
+            f"Allowed keys: {sorted(ALLOWED_KEYS)}"
+        )
 
     metric = config.get("metric")
     if metric not in VALID_METRICS:

--- a/lionagi/studio/scheduler/threshold.py
+++ b/lionagi/studio/scheduler/threshold.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Metric threshold alerts: pure schema + comparison helpers for schedule.threshold_config.
+
+Deliberately free of any DB/FastAPI import so the service write-boundary
+validation (services/schedules.py) can call ``validate_threshold_config``
+without pulling in StateDB or the scheduler engine -- same pattern as
+subprocess.py's ``_validate_*`` helpers. Metric aggregation itself lives in
+``StateDB.metric_value()``; the engine composes the two (see
+``SchedulerEngine._evaluate_threshold_breach``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+VALID_METRICS: frozenset[str] = frozenset({"failed_sessions", "total_cost_usd", "p95_latency_ms"})
+VALID_OPS: frozenset[str] = frozenset({"gt", "gte"})
+
+
+def validate_threshold_config(config: Any) -> None:
+    """Raise ValueError if *config* is not a well-formed threshold spec.
+
+    Shape: ``{"metric": ..., "op": ..., "value": ..., "window_minutes": ...}``.
+    """
+    if not isinstance(config, dict):
+        raise ValueError("threshold_config must be an object")
+
+    metric = config.get("metric")
+    if metric not in VALID_METRICS:
+        raise ValueError(
+            f"threshold_config.metric must be one of {sorted(VALID_METRICS)}, got {metric!r}"
+        )
+
+    op = config.get("op")
+    if op not in VALID_OPS:
+        raise ValueError(f"threshold_config.op must be one of {sorted(VALID_OPS)}, got {op!r}")
+
+    value = config.get("value")
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"threshold_config.value must be a number, got {value!r}")
+
+    window_minutes = config.get("window_minutes")
+    if (
+        isinstance(window_minutes, bool)
+        or not isinstance(window_minutes, int)
+        or window_minutes < 1
+    ):
+        raise ValueError(
+            f"threshold_config.window_minutes must be a positive integer, got {window_minutes!r}"
+        )
+
+
+def compare(op: str, observed: float, threshold: float) -> bool:
+    """Evaluate ``observed <op> threshold``; op is pre-validated to gt/gte."""
+    if op == "gt":
+        return observed > threshold
+    if op == "gte":
+        return observed >= threshold
+    raise ValueError(f"Unsupported threshold op: {op!r}")

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -31,6 +31,8 @@ class SchedulerStateService(Protocol):
 
     async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]: ...
 
+    async def metric_value(self, metric: str, window_start: float) -> float: ...
+
     async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
@@ -79,6 +81,10 @@ class _DBSchedulerStateService:
     async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]:
         async with StateDB() as db:
             return await db.sum_schedule_spend(schedule_id)
+
+    async def metric_value(self, metric: str, window_start: float) -> float:
+        async with StateDB() as db:
+            return await db.metric_value(metric, window_start)
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -172,6 +172,20 @@ async def _svc_recompute_next_fire_guarded(effective: dict[str, Any], context: s
             )
 
 
+def _svc_validate_threshold_config(config: dict | None) -> None:
+    """Service-boundary check: validate a metric-threshold alert config.
+
+    Delegates to threshold.validate_threshold_config so the metric/op/shape
+    rules are defined in exactly one place. None (no threshold configured on
+    this schedule) is always accepted.
+    """
+    if config is None:
+        return
+    from lionagi.studio.scheduler.threshold import validate_threshold_config
+
+    validate_threshold_config(config)
+
+
 def _svc_validate_github_repo(repo: str | None) -> None:
     """Service-boundary check: reject github_repo values that would manipulate the API path.
 
@@ -395,6 +409,7 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_max_runs(data.get("max_runs"))
     _svc_validate_budget_usd(data.get("budget_usd"))
     _svc_validate_budget_tokens(data.get("budget_tokens"))
+    _svc_validate_threshold_config(data.get("threshold_config"))
     if data.get("trigger_type") == "cron":
         _svc_validate_cron_expr(data.get("cron_expr"), required=True)
     if data.get("trigger_type") == "interval":
@@ -464,6 +479,8 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
             _svc_validate_budget_usd(fields["budget_usd"])
         if "budget_tokens" in fields:
             _svc_validate_budget_tokens(fields["budget_tokens"])
+        if "threshold_config" in fields:
+            _svc_validate_threshold_config(fields["threshold_config"])
 
         effective = {**schedule, **fields}
         effective_repo = effective.get("github_repo")
@@ -614,6 +631,7 @@ class CreateScheduleRequest(BaseModel):
     budget_usd: float | None = None
     budget_tokens: int | None = None
     project: str | None = None
+    threshold_config: dict | None = None
 
 
 class UpdateScheduleRequest(BaseModel):
@@ -641,6 +659,7 @@ class UpdateScheduleRequest(BaseModel):
     budget_usd: float | None = None
     budget_tokens: int | None = None
     project: str | None = None
+    threshold_config: dict | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1213,6 +1213,82 @@ def test_schedule_create_zero_max_cost_usd_errors(monkeypatch, capsys):
     assert "finite positive number" in capsys.readouterr().err
 
 
+# ---------------------------------------------------------------------------
+# _cmd_create: --threshold-config metric threshold alert flag
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_create_threshold_config_flag_parses():
+    """create accepts --threshold-config as a raw string (JSON parsing happens in _cmd_create)."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "create",
+            "watch-failures",
+            "--interval",
+            "300",
+            "--prompt",
+            "alert on-call",
+            "--threshold-config",
+            '{"metric": "failed_sessions", "op": "gt", "value": 5, "window_minutes": 60}',
+        ]
+    )
+    assert (
+        args.threshold_config
+        == '{"metric": "failed_sessions", "op": "gt", "value": 5, "window_minutes": 60}'
+    )
+
+
+def test_schedule_create_threshold_config_wired_to_body(monkeypatch):
+    """--threshold-config parses to a dict and wires body['threshold_config']."""
+    outcome = _run_create_argv(
+        monkeypatch,
+        [
+            "--interval",
+            "300",
+            "--prompt",
+            "alert on-call",
+            "--threshold-config",
+            '{"metric": "total_cost_usd", "op": "gte", "value": 10.5, "window_minutes": 15}',
+        ],
+    )
+    assert outcome["result"] == 0
+    assert outcome["body"]["threshold_config"] == {
+        "metric": "total_cost_usd",
+        "op": "gte",
+        "value": 10.5,
+        "window_minutes": 15,
+    }
+
+
+def test_schedule_create_threshold_config_invalid_json_errors(monkeypatch, capsys):
+    """A non-JSON --threshold-config returns 1 and never posts to the API."""
+    outcome = _run_create_argv(monkeypatch, ["--threshold-config", "{not json"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be valid JSON" in capsys.readouterr().err
+
+
+def test_schedule_create_threshold_config_non_object_errors(monkeypatch, capsys):
+    """A JSON --threshold-config that isn't an object returns 1 and never posts."""
+    outcome = _run_create_argv(monkeypatch, ["--threshold-config", "[1, 2]"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be a JSON object" in capsys.readouterr().err
+
+
+def test_schedule_create_threshold_config_omitted_by_default(monkeypatch):
+    """No --threshold-config means the body never carries the key at all."""
+    outcome = _run_create_argv(monkeypatch, ["--interval", "300", "--prompt", "ping"])
+    assert outcome["result"] == 0
+    assert "threshold_config" not in outcome["body"]
+
+
 @pytest.mark.parametrize("bad_value", ["nan", "inf", "-inf"])
 def test_schedule_create_non_finite_max_cost_usd_errors(monkeypatch, capsys, bad_value):
     """A non-finite --max-cost-usd (nan/inf/-inf) is rejected before hitting the API.

--- a/tests/studio/test_scheduler_spawn_resolve.py
+++ b/tests/studio/test_scheduler_spawn_resolve.py
@@ -239,3 +239,15 @@ def test_render_action_prompt_substitutes_trigger_context_vars():
 def test_render_action_prompt_returns_none_when_no_prompt_template():
     assert sched_subprocess.render_action_prompt({"action_prompt": None}, {}) is None
     assert sched_subprocess.render_action_prompt({}, {}) is None
+
+
+def test_render_action_prompt_stringifies_non_string_context_values():
+    """A present-but-non-string trigger_context value (e.g. the numeric
+    metric/value/threshold fields a threshold-alert fire puts directly on
+    trigger_context) must be stringified, not passed through raw -- re.sub's
+    replacement callback requires a str return."""
+    schedule = {"action_prompt": "{{metric}} breached {{threshold}} (observed {{value}})"}
+    result = sched_subprocess.render_action_prompt(
+        schedule, {"metric": "failed_sessions", "threshold": 5, "value": 9.0}
+    )
+    assert result == "failed_sessions breached 5 (observed 9.0)"

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -463,6 +463,48 @@ async def test_maybe_fire_reservation_released_after_pre_persistence_failure_all
     mock_tracked.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_maybe_fire_exception_between_reserve_and_fire_releases_threshold_claim():
+    """The reservation happens synchronously before the overlap/budget/
+    max_runs/global-slot gates run -- a raise from ANY of those gates (not
+    just a normal early-return) must still release threshold_claim via
+    _maybe_fire's own try/finally, not just _fire()'s. Otherwise a
+    transient error mid-gate (e.g. a DB blip in _reserve_max_runs_budget)
+    leaks the reservation permanently, muting the alert until an engine
+    restart -- worse than the duplicate it exists to prevent."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with (
+        patch.object(
+            engine,
+            "_reserve_max_runs_budget",
+            AsyncMock(side_effect=RuntimeError("db blip")),
+        ),
+        pytest.raises(RuntimeError, match="db blip"),
+    ):
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    assert schedule["id"] not in engine._threshold_pending
+    assert not engine._fire_tasks
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+    mock_tracked.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # _fire() / _fire_inner() — threshold cooldown stamp lands AFTER the
 # schedule_run row is durably persisted, not before the fire starts.

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -88,6 +88,27 @@ def test_validate_threshold_config_rejects_malformed(bad_config):
         validate_threshold_config(bad_config)
 
 
+def test_validate_threshold_config_rejects_unknown_key():
+    """A typo'd/extra key (e.g. a made-up 'cooldown_minutes') must be
+    rejected rather than silently ignored -- there is no such field; the
+    cooldown reuses window_minutes."""
+    from lionagi.studio.scheduler.threshold import validate_threshold_config
+
+    with pytest.raises(ValueError, match="unknown key") as exc_info:
+        validate_threshold_config(
+            {
+                "metric": "failed_sessions",
+                "op": "gt",
+                "value": 5,
+                "window_minutes": 60,
+                "cooldown_minutes": 120,
+            }
+        )
+    assert "cooldown_minutes" in str(exc_info.value)
+    assert "metric" in str(exc_info.value)  # names the allowed keys too
+    assert "window_minutes" in str(exc_info.value)
+
+
 def test_compare_gt_and_gte():
     from lionagi.studio.scheduler.threshold import compare
 
@@ -121,6 +142,21 @@ def test_svc_validate_threshold_config_rejects_bad_metric():
     with pytest.raises(ValueError, match="metric"):
         _svc_validate_threshold_config(
             {"metric": "nope", "op": "gt", "value": 1, "window_minutes": 5}
+        )
+
+
+def test_svc_validate_threshold_config_rejects_unknown_key():
+    from lionagi.studio.services.schedules import _svc_validate_threshold_config
+
+    with pytest.raises(ValueError, match="unknown key"):
+        _svc_validate_threshold_config(
+            {
+                "metric": "failed_sessions",
+                "op": "gt",
+                "value": 1,
+                "window_minutes": 5,
+                "cooldown_minutes": 10,
+            }
         )
 
 
@@ -250,13 +286,17 @@ async def test_maybe_fire_breach_fires_with_trigger_context():
     assert ctx["threshold"] == 5
     assert ctx["window_minutes"] == 30
 
-    # last_alert_at was stamped as part of the fire (cooldown start).
+    # last_alert_at is NOT stamped by _maybe_fire itself -- _tracked_fire is
+    # mocked here (the actual _fire_inner never runs), and the real stamp
+    # only lands once a schedule_run row is durably persisted inside
+    # _fire_inner (see the "_fire()/_fire_inner() threshold cooldown stamp"
+    # tests further below, which exercise the real fire path). Stamping
+    # this early would consume the cooldown even if the mocked-out fire
+    # never actually happened.
     last_alert_calls = [
         c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs
     ]
-    assert len(last_alert_calls) == 1
-    assert last_alert_calls[0].args[0] == "sched-001"
-    assert last_alert_calls[0].kwargs["last_alert_at"] == 1000.0
+    assert not last_alert_calls
 
 
 @pytest.mark.asyncio
@@ -341,6 +381,179 @@ async def test_maybe_fire_threshold_still_honors_overlap_policy():
         c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs
     ]
     assert not last_alert_calls
+
+
+# ---------------------------------------------------------------------------
+# _fire() / _fire_inner() — threshold cooldown stamp lands AFTER the
+# schedule_run row is durably persisted, not before the fire starts.
+# ---------------------------------------------------------------------------
+
+
+def _threshold_ctx(**overrides) -> dict:
+    ctx = {
+        "scheduled": True,
+        "metric": "failed_sessions",
+        "op": "gt",
+        "value": 9.0,
+        "threshold": 5,
+        "window_minutes": 30,
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+def _last_alert_calls(svc: AsyncMock) -> list:
+    return [c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs]
+
+
+@pytest.mark.asyncio
+async def test_fire_threshold_schedule_stamps_last_alert_at_after_run_persisted():
+    """Happy path: create_schedule_run succeeds, so the cooldown stamp lands
+    in the same update_schedule() call that writes last_fired_at."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-alert-1", trigger_context=_threshold_ctx())
+
+    svc.create_schedule_run.assert_awaited_once()
+    calls = _last_alert_calls(svc)
+    assert len(calls) == 1
+    assert calls[0].args[0] == "sched-001"
+
+
+@pytest.mark.asyncio
+async def test_fire_create_invocation_failure_does_not_stamp_last_alert_at():
+    """The blocking gap this regression pins: create_invocation() raises
+    BEFORE any schedule_run row exists, so the cooldown must NOT be
+    consumed -- the next tick re-evaluates and re-alerts instead of
+    silently losing the alert."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.create_invocation = AsyncMock(side_effect=RuntimeError("db unavailable"))
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="db unavailable"):
+        await engine._fire(schedule, "run-fail-inv", trigger_context=_threshold_ctx())
+
+    svc.create_schedule_run.assert_not_awaited()
+    assert not _last_alert_calls(svc)
+
+
+@pytest.mark.asyncio
+async def test_fire_invalid_action_still_stamps_last_alert_at_after_failed_run_persisted():
+    """build_argv() raising (bad action config) still durably persists a
+    'failed' schedule_run row before the schedule update -- that IS a
+    recorded (if broken) alert attempt, so the cooldown correctly stamps
+    to avoid hammering a schedule with a persistently-broken action."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(schedule, "run-alert-2", trigger_context=_threshold_ctx())
+
+    svc.create_schedule_run.assert_awaited_once()
+    calls = _last_alert_calls(svc)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_fire_chain_child_does_not_restamp_last_alert_at():
+    """on_success/on_fail chain children (chain_depth > 0) inherit
+    threshold_config via the shallow schedule merge but must not restamp
+    the cooldown -- they're a follow-on of the same alert cycle."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-chain-1", trigger_context=_threshold_ctx(), chain_depth=1)
+
+    assert not _last_alert_calls(svc)
+
+
+@pytest.mark.asyncio
+async def test_fire_non_threshold_schedule_never_stamps_last_alert_at():
+    """A schedule with no threshold_config never writes last_alert_at,
+    even on a normal successful fire."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()  # no threshold_config
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-no-threshold", trigger_context={"scheduled": True})
+
+    assert not _last_alert_calls(svc)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -1,0 +1,500 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for metric threshold alerts.
+
+Covers: threshold.validate_threshold_config/compare (pure), SchedulerEngine's
+_evaluate_threshold_breach + _maybe_fire integration (mocked service, mirrors
+test_scheduler_budget.py's pattern), StateDB.metric_value window math (real
+in-memory DB, mirrors test_scheduler_budget.py's sum_schedule_spend tests).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "interval",
+        "interval_sec": 300,
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "{{metric}} breached {{threshold}} (observed {{value}})",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
+    svc.metric_value = AsyncMock(return_value=0.0)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# threshold.py — pure validation + comparison
+# ---------------------------------------------------------------------------
+
+
+def test_validate_threshold_config_accepts_well_formed():
+    from lionagi.studio.scheduler.threshold import validate_threshold_config
+
+    validate_threshold_config(
+        {"metric": "failed_sessions", "op": "gt", "value": 5, "window_minutes": 60}
+    )  # does not raise
+
+
+@pytest.mark.parametrize(
+    "bad_config",
+    [
+        "not-a-dict",
+        {"metric": "bogus_metric", "op": "gt", "value": 5, "window_minutes": 60},
+        {"metric": "failed_sessions", "op": "lt", "value": 5, "window_minutes": 60},
+        {"metric": "failed_sessions", "op": "gt", "value": "five", "window_minutes": 60},
+        {"metric": "failed_sessions", "op": "gt", "value": True, "window_minutes": 60},
+        {"metric": "failed_sessions", "op": "gt", "value": 5, "window_minutes": 0},
+        {"metric": "failed_sessions", "op": "gt", "value": 5, "window_minutes": "60"},
+        {"metric": "failed_sessions", "op": "gt", "value": 5},
+    ],
+)
+def test_validate_threshold_config_rejects_malformed(bad_config):
+    from lionagi.studio.scheduler.threshold import validate_threshold_config
+
+    with pytest.raises(ValueError):
+        validate_threshold_config(bad_config)
+
+
+def test_compare_gt_and_gte():
+    from lionagi.studio.scheduler.threshold import compare
+
+    assert compare("gt", 6, 5) is True
+    assert compare("gt", 5, 5) is False
+    assert compare("gte", 5, 5) is True
+    assert compare("gte", 4, 5) is False
+
+
+def test_compare_rejects_unknown_op():
+    from lionagi.studio.scheduler.threshold import compare
+
+    with pytest.raises(ValueError, match="Unsupported threshold op"):
+        compare("lt", 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# services/schedules.py — service-boundary validation
+# ---------------------------------------------------------------------------
+
+
+def test_svc_validate_threshold_config_accepts_none():
+    from lionagi.studio.services.schedules import _svc_validate_threshold_config
+
+    _svc_validate_threshold_config(None)  # does not raise
+
+
+def test_svc_validate_threshold_config_rejects_bad_metric():
+    from lionagi.studio.services.schedules import _svc_validate_threshold_config
+
+    with pytest.raises(ValueError, match="metric"):
+        _svc_validate_threshold_config(
+            {"metric": "nope", "op": "gt", "value": 1, "window_minutes": 5}
+        )
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine._evaluate_threshold_breach
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_threshold_breach_returns_none_when_no_config():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(threshold_config=None)
+
+    assert await engine._evaluate_threshold_breach(schedule, now=1000.0) is None
+    svc.metric_value.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_threshold_breach_none_when_under_threshold():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=3.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 60,
+        }
+    )
+
+    assert await engine._evaluate_threshold_breach(schedule, now=1000.0) is None
+    svc.metric_value.assert_awaited_once_with("failed_sessions", 1000.0 - 60 * 60)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_threshold_breach_returns_breach_dict_when_over():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=42.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "total_cost_usd",
+            "op": "gte",
+            "value": 10.0,
+            "window_minutes": 15,
+        }
+    )
+
+    breach = await engine._evaluate_threshold_breach(schedule, now=5000.0)
+
+    assert breach == {
+        "metric": "total_cost_usd",
+        "op": "gte",
+        "value": 42.0,
+        "threshold": 10.0,
+        "window_minutes": 15,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine._maybe_fire — full threshold-alert integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_no_breach_advances_next_fire_without_firing():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=1.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    svc.update_schedule.assert_awaited_once()
+    args, kwargs = svc.update_schedule.await_args
+    assert args[0] == "sched-001"
+    assert "next_fire_at" in kwargs
+    assert "last_alert_at" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_breach_fires_with_trigger_context():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_called_once()
+    _, kwargs = mock_tracked.call_args
+    ctx = kwargs["trigger_context"]
+    assert ctx["metric"] == "failed_sessions"
+    assert ctx["op"] == "gt"
+    assert ctx["value"] == 9.0
+    assert ctx["threshold"] == 5
+    assert ctx["window_minutes"] == 30
+
+    # last_alert_at was stamped as part of the fire (cooldown start).
+    last_alert_calls = [
+        c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs
+    ]
+    assert len(last_alert_calls) == 1
+    assert last_alert_calls[0].args[0] == "sched-001"
+    assert last_alert_calls[0].kwargs["last_alert_at"] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_breach_within_cooldown_suppresses_refire():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        last_alert_at=990.0,  # 10s ago, well within the 30-minute cooldown window
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    # Only the next_fire_at advance -- no second last_alert_at stamp.
+    last_alert_calls = [
+        c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs
+    ]
+    assert not last_alert_calls
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_breach_after_cooldown_elapsed_refires():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    window_minutes = 30
+    schedule = _minimal_schedule(
+        next_fire_at=10_000.0,
+        last_alert_at=10_000.0 - (window_minutes * 60) - 1,  # just past cooldown
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": window_minutes,
+        },
+    )
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=10_000.0)
+
+    mock_tracked.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_threshold_still_honors_overlap_policy():
+    """A breach that would fire is still gated by the pre-existing overlap check."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+    engine._running[schedule["id"]] = "some-other-run"
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    # last_alert_at must NOT be consumed by a fire that never actually spawned.
+    last_alert_calls = [
+        c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs
+    ]
+    assert not last_alert_calls
+
+
+# ---------------------------------------------------------------------------
+# StateDB.metric_value — real in-memory DB, window math
+# ---------------------------------------------------------------------------
+
+
+async def _make_session(
+    state, sess_id: str, *, status: str, ended_at: float, total_cost_usd: float = 0.0
+):
+    prog_id = f"prog-{sess_id}"
+    await state.create_progression(prog_id)
+    await state.create_session(
+        {
+            "id": sess_id,
+            "progression_id": prog_id,
+            "status": status,
+            "started_at": ended_at - 1,
+            "ended_at": ended_at,
+        }
+    )
+    await state.update_session(sess_id, total_cost_usd=total_cost_usd)
+
+
+@pytest.mark.asyncio
+async def test_metric_value_failed_sessions_counts_only_in_window():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_session(state, "in-window-failed", status="failed", ended_at=100.0)
+    await _make_session(state, "in-window-timed-out", status="timed_out", ended_at=110.0)
+    await _make_session(state, "in-window-completed", status="completed", ended_at=120.0)
+    await _make_session(state, "before-window-failed", status="failed", ended_at=10.0)
+
+    count = await state.metric_value("failed_sessions", window_start=50.0)
+    assert count == 2.0
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_total_cost_usd_sums_only_in_window():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_session(state, "s1", status="completed", ended_at=100.0, total_cost_usd=1.5)
+    await _make_session(state, "s2", status="completed", ended_at=110.0, total_cost_usd=2.5)
+    await _make_session(state, "s3-before", status="completed", ended_at=10.0, total_cost_usd=100.0)
+
+    total = await state.metric_value("total_cost_usd", window_start=50.0)
+    assert total == pytest.approx(4.0)
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_p95_latency_ms_window_and_percentile():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    # 20 invocations inside the window with latencies 1..20 seconds;
+    # nearest-rank p95 of 20 samples is the 19th smallest (index 18) = 19s.
+    for i in range(1, 21):
+        await state.create_invocation(
+            {
+                "id": f"inv-{i}",
+                "skill": "agent",
+                "started_at": 100.0,
+                "ended_at": 100.0 + i,
+            }
+        )
+    # One invocation before the window with an extreme latency that must not
+    # skew the percentile.
+    await state.create_invocation(
+        {"id": "inv-before", "skill": "agent", "started_at": 10.0, "ended_at": 10.0 + 999}
+    )
+
+    p95 = await state.metric_value("p95_latency_ms", window_start=50.0)
+    assert p95 == pytest.approx(19_000.0)
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_p95_latency_ms_empty_window_returns_zero():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    p95 = await state.metric_value("p95_latency_ms", window_start=50.0)
+    assert p95 == 0.0
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_unknown_metric_raises():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    with pytest.raises(ValueError, match="Unknown threshold metric"):
+        await state.metric_value("bogus", window_start=0.0)
+
+    await state.close()
+
+
+# ---------------------------------------------------------------------------
+# create_schedule / update_schedule round-trip threshold_config + last_alert_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_round_trips_threshold_config_and_last_alert_at():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-threshold-1",
+            "name": "threshold-test",
+            "trigger_type": "interval",
+            "interval_sec": 300,
+            "action_kind": "agent",
+            "threshold_config": {
+                "metric": "failed_sessions",
+                "op": "gt",
+                "value": 5,
+                "window_minutes": 60,
+            },
+        }
+    )
+
+    row = await state.get_schedule("sched-threshold-1")
+    assert row["threshold_config"] == {
+        "metric": "failed_sessions",
+        "op": "gt",
+        "value": 5,
+        "window_minutes": 60,
+    }
+    assert row["last_alert_at"] is None
+
+    await state.update_schedule("sched-threshold-1", last_alert_at=123.0)
+    row = await state.get_schedule("sched-threshold-1")
+    assert row["last_alert_at"] == 123.0
+
+    await state.close()

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -384,6 +384,86 @@ async def test_maybe_fire_threshold_still_honors_overlap_policy():
 
 
 # ---------------------------------------------------------------------------
+# _maybe_fire() — synchronous in-process cooldown reservation. last_alert_at
+# alone (a DB read) can go stale between ticks; these tests pin the
+# in-memory _threshold_pending gate that closes the resulting duplicate-fire
+# race, independent of when (or whether) the durable stamp lands.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_two_ticks_before_first_stamp_fires_only_once():
+    """Regression pin for the duplicate-alert race: without a synchronous
+    in-process reservation, two ticks separated by _TICK_INTERVAL could both
+    read the same stale (not-yet-durably-stamped) last_alert_at and both
+    pass the cooldown gate before either fire's background task reaches its
+    own stamp. _tracked_fire is mocked here, so the first fire never
+    reaches its own release point -- mirroring "tick 2 arrives before tick
+    1's fire has done anything durable yet" -- and the second _maybe_fire
+    call for the same schedule must still be suppressed by the in-process
+    reservation alone."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_called_once()
+    assert schedule["id"] in engine._threshold_pending
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_reservation_released_after_pre_persistence_failure_allows_refire():
+    """create_invocation() raising is a pre-persistence failure -- no
+    schedule_run row is ever written. _fire()'s finally must still release
+    the in-process threshold reservation (mirroring how it already releases
+    max_runs_claim/global_slot_claim on the same exit path), so the next
+    tick is free to try again instead of being permanently muted."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=9.0)
+    svc.create_invocation = AsyncMock(side_effect=RuntimeError("db unavailable"))
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        next_fire_at=1000.0,
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+
+    await engine._maybe_fire(schedule, now=1000.0)
+    assert schedule["id"] in engine._threshold_pending
+    fire_tasks = list(engine._fire_tasks)
+    assert len(fire_tasks) == 1
+    with pytest.raises(RuntimeError, match="db unavailable"):
+        await fire_tasks[0]
+
+    assert schedule["id"] not in engine._threshold_pending
+    svc.create_schedule_run.assert_not_awaited()
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+    mock_tracked.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # _fire() / _fire_inner() — threshold cooldown stamp lands AFTER the
 # schedule_run row is durably persisted, not before the fire starts.
 # ---------------------------------------------------------------------------
@@ -496,6 +576,83 @@ async def test_fire_invalid_action_still_stamps_last_alert_at_after_failed_run_p
     svc.create_schedule_run.assert_awaited_once()
     calls = _last_alert_calls(svc)
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_fire_invalid_action_releases_threshold_cooldown_claim():
+    """The invalid-action branch (build_argv raising) persists a 'failed'
+    schedule_run row and returns normally rather than raising, so _fire()'s
+    finally releases the threshold_cooldown_claim the same way the happy
+    path does -- the claim must not survive past this branch either."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine, _ThresholdCooldownClaim
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+    sid = schedule["id"]
+    engine._threshold_pending.add(sid)
+    claim = _ThresholdCooldownClaim(engine, sid)
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(
+            schedule,
+            "run-alert-invalid",
+            trigger_context=_threshold_ctx(),
+            threshold_cooldown_claim=claim,
+        )
+
+    svc.create_schedule_run.assert_awaited_once()
+    assert sid not in engine._threshold_pending
+
+
+@pytest.mark.asyncio
+async def test_fire_success_releases_threshold_cooldown_claim():
+    """Happy path: the threshold_cooldown_claim is released once _fire()
+    completes, same as max_runs_claim/global_slot_claim."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine, _ThresholdCooldownClaim
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "failed_sessions",
+            "op": "gt",
+            "value": 5,
+            "window_minutes": 30,
+        },
+    )
+    sid = schedule["id"]
+    engine._threshold_pending.add(sid)
+    claim = _ThresholdCooldownClaim(engine, sid)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(
+            schedule,
+            "run-alert-success",
+            trigger_context=_threshold_ctx(),
+            threshold_cooldown_claim=claim,
+        )
+
+    assert sid not in engine._threshold_pending
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Metric threshold alerts for studio schedules — the P1 item from the LangSmith gap map. A schedule with a `threshold_config` fires only when its metric breaches, with a durable cooldown so a sustained breach alerts once per window instead of every tick.

- **Config**: `{"metric", "op", "value", "window_minutes"}` — exactly those keys (unknown keys rejected with the allowed set named). Metrics: `failed_sessions`, `total_cost_usd`, `p95_latency_ms` (nearest-rank). Ops: `gt`, `gte`.
- **Storage**: `threshold_config` (JSON) + `last_alert_at` (REAL) on `schedules`, covered in schema_meta, schema_migrations, schema.sql, and the legacy `schedules_new` rebuild.
- **Engine**: `_maybe_fire` evaluates the breach, then a two-layer cooldown gate:
  - *In-process reservation* (`_threshold_pending` + `_ThresholdCooldownClaim`, mirroring the existing max-runs/global-slot claims): taken synchronously at admission — no await between gate check and reservation — so two ticks can never both pass on stale state. Released via a single `handed_off` try/finally covering every early return AND every raise between reserve and fire; a leaked reservation would mute the alert, so the release invariant is exact (flag flips only after the fire task launches; releases are idempotent).
  - *Durable stamp*: `last_alert_at` is written inside `_fire_inner`, folded into the same `update_schedule` call as `last_fired_at`, only after `create_schedule_run` has persisted a row — a pre-persistence failure (e.g. `create_invocation` raising) never consumes the cooldown. Chain children never restamp.
- **No-breach ticks** advance `next_fire_at` only, so the cadence keeps evaluating.
- **CLI**: `li schedule create --threshold-config '<json>'`.
- Also fixes a latent template bug: `_render_template`'s non-github fallback returned raw non-string context values to `re.sub`'s replacement callback, which crashes on the numeric `{{value}}`/`{{threshold}}` fields threshold fires put on `trigger_context`.

## Review

Iterated through three high-effort reviewer rounds to APPROVE: round 1 (cooldown stamped before any durable record), round 2 (admission race — two ticks both passing before the first stamp), round 3 clean with one nit (handed_off placement), applied in the final commit.

## Tests

39 threshold tests covering the full stamp-timing/reservation matrix: two-ticks-before-first-stamp → one fire; pre-persistence failure → no stamp, refire allowed; exception between reserve and fire → propagates + reservation cleared + next tick fires; invalid-action and happy-path release symmetry; unknown-key rejection; metric SQL + p95 rank math; CLI round-trip. Full `tests/studio tests/cli tests/state`: 2076 passed, 4 environmental skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
