### PR TITLE
fix(studio): scheduler GitHub-trigger hardening — fire per event, merged-PR mode, safe bounded pagination

### DIFF
--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -64,6 +64,10 @@ class RunReasons:
     FAILED_EXIT_NONZERO = "run.failed.exit_nonzero"
     FAILED_EXCEPTION = "run.failed.exception"
     FAILED_MISSING_ARTIFACT = "run.failed.missing_artifact"  # ADR-0029
+    # The action_project's registered path no longer existed at fire time
+    # (e.g. a pruned worktree), the run fell back to inheriting the daemon's
+    # own cwd, and the spawned process then exited non-zero.
+    FAILED_MISSING_CWD = "run.failed.missing_cwd"
     FAILED_ESCALATED = "run.failed.escalated"  # undeclared-artifact backstop
     # Loop exited clean but no commits/artifacts were produced (completion-trust gate).
     COMPLETED_EMPTY_NO_EVIDENCE = "run.completed_empty.no_evidence"

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -542,7 +542,17 @@ class SchedulerEngine:
         # released inline (e.g. a max_runs refusal on the first event), so
         # this finally only ever fires for the untouched case.
         try:
-            polled = await github_poll(schedule)
+            poll_result = await github_poll(schedule)
+            polled = poll_result.items
+            if not poll_result.scan_complete:
+                _log.info(
+                    "Schedule %s (%s): merged-PR scan truncated this poll "
+                    "(page cap reached or a pagination fetch error) -- "
+                    "event(s) too close to the unproven boundary are held "
+                    "back for a later poll",
+                    schedule.get("name"),
+                    sid,
+                )
             if not polled:
                 return
 

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -500,57 +500,109 @@ class SchedulerEngine:
             await self._disable_for_budget_exhausted(schedule, now)
             return
 
-        # Reserve the global slot before polling: a filtered/no-slot poll
-        # must not fetch-and-advance-cursor-then-discard.
-        slot_allowed, slot_claim = await self._reserve_global_slot()
+        # Reserve one global slot before polling: a filtered/no-slot poll
+        # must not fetch-and-advance-cursor-then-discard. This first slot is
+        # handed to whichever event ends up firing first below; any further
+        # dispatched events in the same poll reserve their own slot.
+        slot_allowed, pre_slot_claim = await self._reserve_global_slot()
         if not slot_allowed:
             await self._maybe_record_deferred(schedule, now)
             return
 
         from .github import github_poll
 
-        # Every await between reserving the slot and handing it to _fire()
-        # (github_poll, the max_runs reservation, or a cancellation at either)
-        # must release the slot on failure — otherwise a transient DB/count
-        # error mid-poll leaks the slot permanently and eventually saturates
-        # the cap until restart. A single finally covers all of them; once the
-        # claims are passed to _fire() (which owns their release from then on)
-        # handed_off is set so this finally leaves them alone.
-        max_runs_claim: _MaxRunsClaim | None = None
-        handed_off = False
+        sid = schedule["id"]
+        # Every await between reserving pre_slot_claim and handing it off to
+        # the first dispatched _fire() (github_poll, that event's max_runs
+        # reservation, or a cancellation at either) must release it on
+        # failure — otherwise a transient DB/count error mid-poll leaks the
+        # slot permanently. pre_slot_claim is nulled out the moment it is
+        # either handed to _fire() (which owns its release from then on) or
+        # released inline (e.g. a max_runs refusal on the first event), so
+        # this finally only ever fires for the untouched case.
         try:
-            new_events = await github_poll(schedule)
-            if not new_events:
+            polled = await github_poll(schedule)
+            if not polled:
                 return
 
-            allowed, max_runs_claim = await self._reserve_max_runs_budget(schedule)
-            if not allowed:
+            cursor = schedule.get("github_cursor")
+            drop_reason: str | None = None
+            dropped_prs: list[Any] = []
+
+            for idx, item in enumerate(polled):
+                if not item.dispatchable:
+                    # Filtered-out PRs (e.g. drafts under a non-draft filter)
+                    # consume no budget; the cursor can always advance past
+                    # them so they aren't re-listed forever.
+                    cursor = item.updated_at
+                    continue
+
+                if pre_slot_claim is not None:
+                    slot_claim, pre_slot_claim = pre_slot_claim, None
+                else:
+                    slot_allowed, slot_claim = await self._reserve_global_slot()
+                    if not slot_allowed:
+                        drop_reason = "global concurrent-fire cap reached"
+                        dropped_prs = [
+                            e.event.get("pr_number") for e in polled[idx:] if e.dispatchable
+                        ]
+                        break
+
+                # slot_claim is now reserved for this event specifically. A
+                # failure (refusal *or* a raised exception) anywhere before
+                # it is handed off to _fire() must still release it, or a
+                # transient error here leaks the slot permanently.
+                slot_handed_off = False
+                try:
+                    allowed, max_runs_claim = await self._reserve_max_runs_budget(schedule)
+                    if not allowed:
+                        drop_reason = f"max_runs={schedule.get('max_runs')} exhausted"
+                        dropped_prs = [
+                            e.event.get("pr_number") for e in polled[idx:] if e.dispatchable
+                        ]
+                        break
+
+                    ctx = {
+                        "github_events": [item.event],
+                        "repo": schedule.get("github_repo"),
+                        "fired_at": now,
+                    }
+                    run_id = uuid.uuid4().hex[:12]
+                    slot_handed_off = True
+                    await self._fire(
+                        schedule,
+                        run_id,
+                        trigger_context=ctx,
+                        max_runs_claim=max_runs_claim,
+                        global_slot_claim=slot_claim,
+                    )
+                    # Only advance the cursor past a dispatchable event once
+                    # it has actually been fired — the invariant this
+                    # rewrite exists to hold. Any event left undispatched by
+                    # a break above (and everything after it, since PRs are
+                    # processed oldest-first) must be re-listed on the next
+                    # poll.
+                    cursor = item.updated_at
+                finally:
+                    if not slot_handed_off:
+                        slot_claim.release()
+
+            if drop_reason and dropped_prs:
                 _log.info(
-                    "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
+                    "Schedule %s (%s): %d github event(s) not dispatched this "
+                    "poll (%s); PR(s) %s deferred to the next poll",
                     schedule.get("name"),
-                    schedule["id"],
+                    sid,
+                    len(dropped_prs),
+                    drop_reason,
+                    dropped_prs,
                 )
-                return
-            ctx = {
-                "github_events": new_events,
-                "repo": schedule.get("github_repo"),
-                "fired_at": now,
-            }
-            run_id = uuid.uuid4().hex[:12]
-            handed_off = True
-            await self._fire(
-                schedule,
-                run_id,
-                trigger_context=ctx,
-                max_runs_claim=max_runs_claim,
-                global_slot_claim=slot_claim,
-            )
+
+            if cursor != schedule.get("github_cursor"):
+                await self._svc.update_schedule(sid, github_cursor=cursor)
         finally:
-            if not handed_off:
-                if slot_claim is not None:
-                    slot_claim.release()
-                if max_runs_claim is not None:
-                    max_runs_claim.release()
+            if pre_slot_claim is not None:
+                pre_slot_claim.release()
 
     async def _reserve_max_runs_budget(self, schedule: dict) -> tuple[bool, _MaxRunsClaim | None]:
         """Atomically claim one top-level fire against schedule['max_runs'].

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -605,7 +605,11 @@ class SchedulerEngine:
                     # poll.
                     cursor = item.updated_at
                 finally:
-                    if not slot_handed_off:
+                    # slot_claim is None when MAX_SCHEDULED_CONCURRENT is
+                    # unlimited (0) -- _reserve_global_slot() returns an
+                    # allowed no-op claim in that case, same as every other
+                    # call site in this module.
+                    if not slot_handed_off and slot_claim is not None:
                         slot_claim.release()
 
             if drop_reason and dropped_prs:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -101,7 +101,7 @@ def _resolve_scheduler_tzinfo(tz_name: str) -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
-async def _resolve_action_cwd(schedule: dict) -> str | None:
+async def _resolve_action_cwd(schedule: dict) -> tuple[str | None, str | None]:
     """Resolve the working directory for a scheduled subprocess spawn.
 
     Layered resolution (first hit wins):
@@ -113,12 +113,22 @@ async def _resolve_action_cwd(schedule: dict) -> str | None:
          if that directory has no project (e.g. the daemon was started at
          ``/``).
 
+    Returns ``(cwd, missing_project_path)``. ``missing_project_path`` is set
+    only when ``action_project`` was registered with a specific path, that
+    path no longer exists on disk (e.g. a pruned worktree), and nothing else
+    resolved either -- i.e. exactly the case where the eventual
+    inherit-daemon-cwd fallback risks a deep, opaque ``FileNotFoundError``
+    from the spawned process. The caller uses it to attribute a subsequent
+    non-zero exit to a stale cwd via a specific status_reason instead of the
+    generic "process exited non-zero".
+
     Imports ``lionagi.studio.services.projects`` lazily so this module (and
     ``lionagi.studio.scheduler.subprocess``) stay importable without the
     ``studio`` extra (fastapi) — the scheduler engine only actually reaches
     this branch when ``action_project`` is set, i.e. inside a running studio
     daemon where fastapi is already a hard dependency.
     """
+    stale_project_path: str | None = None
     action_project = schedule.get("action_project")
     if action_project:
         from lionagi.studio.services.projects import get_project
@@ -126,12 +136,23 @@ async def _resolve_action_cwd(schedule: dict) -> str | None:
         project = await get_project(action_project)
         if project:
             path = project.get("path")
-            if path and Path(path).is_dir():
-                return path
+            if path:
+                if Path(path).is_dir():
+                    return path, None
+                stale_project_path = path
+                _log.warning(
+                    "Schedule %s: action_project %r is registered at %r, but "
+                    "that path no longer exists on disk (e.g. a pruned "
+                    "worktree); falling back instead of spawning into a "
+                    "missing directory.",
+                    schedule.get("id"),
+                    action_project,
+                    path,
+                )
 
     env_cwd = os.environ.get("LIONAGI_SCHEDULER_CWD")
     if env_cwd and Path(env_cwd).is_dir():
-        return env_cwd
+        return env_cwd, None
 
     _log.warning(
         "No resolvable cwd for schedule %s (action_project=%r); the scheduled "
@@ -140,7 +161,7 @@ async def _resolve_action_cwd(schedule: dict) -> str | None:
         schedule.get("id"),
         action_project,
     )
-    return None
+    return None, stale_project_path
 
 
 class SchedulerEngine:
@@ -1086,20 +1107,30 @@ class SchedulerEngine:
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
             )
 
-            action_cwd = await _resolve_action_cwd(schedule)
+            action_cwd, missing_cwd_path = await _resolve_action_cwd(schedule)
             exit_code, stderr_tail = await _subprocess.spawn_and_wait(
                 argv, inv_id, tmp_path=_tmp_path, cwd=action_cwd
             )
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"
-            reason_code = (
-                RunReasons.COMPLETED_OK if exit_code == 0 else RunReasons.FAILED_EXIT_NONZERO
-            )
-            reason_summary = (
-                "Scheduled process completed successfully."
-                if exit_code == 0
-                else f"Scheduled process exited non-zero: {exit_code}."
-            )
+            if exit_code == 0:
+                reason_code = RunReasons.COMPLETED_OK
+                reason_summary = "Scheduled process completed successfully."
+            elif missing_cwd_path:
+                # The configured project directory was gone at fire time (e.g.
+                # a pruned worktree); the process fell back to the daemon's
+                # own cwd instead and then failed -- attribute that plainly
+                # rather than leaving only a generic non-zero exit code.
+                reason_code = RunReasons.FAILED_MISSING_CWD
+                reason_summary = (
+                    f"Scheduled process exited non-zero ({exit_code}) after its "
+                    f"configured working directory {missing_cwd_path!r} no "
+                    "longer existed on disk; it ran with the daemon's own "
+                    "working directory instead."
+                )
+            else:
+                reason_code = RunReasons.FAILED_EXIT_NONZERO
+                reason_summary = f"Scheduled process exited non-zero: {exit_code}."
 
             await self._svc.update_schedule_run(
                 run_id,

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -320,14 +320,29 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         # further back is too (the API is sorted by updated_at desc), and
         # merged_at <= updated_at always holds for a merged PR, so nothing
         # beyond that point could be an undispatched merge either.
-        for _ in range(_MERGED_MODE_MAX_PAGES - 1):
-            if len(page) < per_page:
-                break
+        #
+        # The safe-boundary check runs at the TOP of every pass, including
+        # the pass evaluating the last page the cap allows fetching -- the
+        # cap alone never marks the scan unsafe; a page is only unsafe when
+        # it is full, has a next link, AND the cursor hasn't been reached,
+        # i.e. there is real, unproven data beyond it.
+        pages_fetched = 1
+        while True:
+            is_short_page = len(page) < per_page
             oldest_updated = page[-1].get("updated_at", "") if page else ""
-            if cursor and oldest_updated <= cursor:
-                break
+            cursor_reached = bool(cursor) and oldest_updated <= cursor
             next_url = _next_page_url(resp)
-            if not next_url:
+            if is_short_page or cursor_reached or not next_url:
+                # This page itself proves the boundary: nothing beyond it
+                # matters (short/no-next), or everything beyond it is
+                # already-seen ground (cursor reached). Safe regardless of
+                # how many pages the cap allowed fetching.
+                break
+            if pages_fetched >= _MERGED_MODE_MAX_PAGES:
+                # This page is full, links to a next page, and the cursor
+                # hasn't been reached -- real, unproven data likely exists
+                # beyond it, but the cap forbids fetching further.
+                scan_complete = False
                 break
             try:
                 resp = await client.get(next_url, headers=headers)
@@ -354,11 +369,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
                 break
             page = resp.json()
             prs.extend(page)
-        else:
-            # The for-loop ran out of pages to fetch (_MERGED_MODE_MAX_PAGES
-            # reached) without ever hitting one of the safe breaks above --
-            # there may still be more pages beyond this one.
-            scan_complete = False
+            pages_fetched += 1
 
     # In merged mode, once the scan is truncated (unsafe boundary), any
     # fetched PR whose cursor field (merged_at) sits at or past the oldest

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -21,11 +21,15 @@ class GithubPollItem:
 
     ``event`` is always populated (even when ``dispatchable`` is False) so a
     caller can log which PR was seen without firing it. ``updated_at`` is the
-    PR's raw GitHub timestamp string, used as the cursor high-water mark.
-    ``dispatchable`` is False when ``github_filter`` (e.g. a draft filter)
-    excludes the PR from firing -- it is still returned, not silently
-    dropped, so the caller can advance the cursor past it without the PR
-    being re-listed on every subsequent poll.
+    cursor high-water-mark field for this item -- normally the PR's raw
+    GitHub ``updated_at``, but under ``github_filter={"event": "pr_merged"}``
+    it holds ``merged_at`` instead, since that's what the merged-PR mode
+    compares against the persisted cursor (the event dict's own
+    ``updated_at`` key still carries the PR's real ``updated_at`` either way,
+    for template rendering). ``dispatchable`` is False when ``github_filter``
+    (e.g. a draft filter) excludes the PR from firing -- it is still
+    returned, not silently dropped, so the caller can advance the cursor
+    past it without the PR being re-listed on every subsequent poll.
     """
 
     event: dict[str, Any]
@@ -199,8 +203,11 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
         headers["If-None-Match"] = etag
 
     github_filter = schedule.get("github_filter") or {}
+    merged_mode = github_filter.get("event") == "pr_merged"
     params: dict[str, str] = {
-        "state": github_filter.get("state", "open"),
+        # pr_merged is only ever true on a closed PR, so merged mode always
+        # polls closed PRs regardless of any (nonsensical) explicit state.
+        "state": "closed" if merged_mode else github_filter.get("state", "open"),
         "sort": "updated",
         "direction": "desc",
         "per_page": "20",
@@ -237,8 +244,22 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
     items: list[GithubPollItem] = []
     for pr in prs:
         updated = pr.get("updated_at", "")
-        if cursor and updated <= cursor:
+        if merged_mode:
+            merged_at = pr.get("merged_at")
+            if not merged_at:
+                # Closed but never merged -- not a "PR merged" event under
+                # this filter. It never fires and has no merge time to
+                # compare against the cursor, so it's simply not an item;
+                # it naturally drops off the API's top-N-by-updated window
+                # once nothing about it changes further.
+                continue
+            cursor_at = merged_at
+        else:
+            cursor_at = updated
+
+        if cursor and cursor_at <= cursor:
             continue
+
         is_draft = bool(pr.get("draft", False))
         # Only a real JSON boolean narrows the fire set. A malformed non-bool
         # draft filter is ignored (fail open to no filtering) rather than
@@ -253,10 +274,15 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
             "head_sha": (pr.get("head") or {}).get("sha"),
             "draft": is_draft,
         }
-        items.append(GithubPollItem(event=event, updated_at=updated, dispatchable=dispatchable))
+        if merged_mode:
+            event["pr_merged_at"] = merged_at
+        items.append(GithubPollItem(event=event, updated_at=cursor_at, dispatchable=dispatchable))
 
-    # The API returns PRs sorted by updated_at desc; the caller advances the
-    # persisted cursor incrementally as it processes items in order, so they
-    # must come back oldest-first.
-    items.reverse()
+    # The API returns PRs sorted by updated_at desc, which is the cursor
+    # field itself in the default mode but only a close correlate of it in
+    # merged mode (merging a PR bumps updated_at, but the two aren't
+    # contractually identical) -- sort explicitly by the cursor field so the
+    # caller's incremental cursor advance stays monotone in both modes,
+    # rather than relying on a bare reversal of API order.
+    items.sort(key=lambda it: it.updated_at)
     return items

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 import httpx
 
@@ -37,6 +37,25 @@ class GithubPollItem:
     dispatchable: bool
 
 
+class GithubPollResult(NamedTuple):
+    """Return shape of ``github_poll()``.
+
+    ``scan_complete`` is False only when merged-mode pagination stopped for
+    an UNSAFE reason -- the ``_MERGED_MODE_MAX_PAGES`` cap was hit, or a
+    pagination fetch/status error truncated the scan -- rather than a safe
+    boundary (a short page, no ``rel="next"`` link, or the stored cursor was
+    reached). ``items`` has already had any event that could not be proven
+    complete filtered out in that case (see the truncation-safety filter in
+    ``github_poll``), so a caller does not need to re-derive that from item
+    counts; ``scan_complete`` exists for observability -- e.g. logging that
+    some events near the cursor boundary are being held for a later poll,
+    when a deeper or safely-bounded scan may resolve them.
+    """
+
+    items: list[GithubPollItem]
+    scan_complete: bool
+
+
 _client: httpx.AsyncClient | None = None
 
 # Merged-PR mode's dispatch key (merged_at) differs from the API's sort key
@@ -52,6 +71,18 @@ _client: httpx.AsyncClient | None = None
 # it is found on a later poll once the shallower unmerged noise ages out of
 # GitHub's "recently updated" ordering. Bounded latency, not bounded
 # correctness.
+#
+# That "cursor never advances past anything unseen" guarantee only holds
+# when the scan reaches a SAFE boundary (a short page, no next link, or the
+# stored cursor was reached): pages are sorted by updated_at desc, so
+# stopping there proves every unfetched PR has an older updated_at, and
+# merged_at <= updated_at, than everything already scanned. Stopping for an
+# UNSAFE reason instead -- the page cap above, or a pagination fetch/status
+# error -- proves nothing about what lies beyond the last fetched page.
+# github_poll() tracks this as GithubPollResult.scan_complete and drops any
+# item too close to that unproven boundary (see the truncation-safety
+# filter below) rather than risk advancing the cursor past an event an
+# unfetched page might still hold.
 _MERGED_MODE_MAX_PAGES = 5
 
 _LINK_NEXT_RE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
@@ -182,7 +213,7 @@ async def _get_gh_token() -> str | None:
     return None
 
 
-async def github_poll(schedule: dict) -> list[GithubPollItem]:
+async def github_poll(schedule: dict) -> GithubPollResult:
     """Poll GitHub for PRs newer than the stored cursor.
 
     Returns items ordered oldest-``updated_at``-first (the GitHub API itself
@@ -195,11 +226,12 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
     this poll (max_runs/global-slot exhaustion), and those must be re-listed
     on the next poll rather than silently skipped, so only the caller -- who
     knows what it actually dispatched -- can decide how far the cursor is
-    safe to advance.
+    safe to advance. See ``GithubPollResult.scan_complete`` for the
+    equivalent truncation-safety concern in merged mode.
     """
     repo = schedule.get("github_repo")
     if not repo:
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     # Defense-in-depth: validate format before interpolating into the API URL.
     # The service write boundary applies the same check via _svc_validate_github_repo
@@ -215,12 +247,12 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
             schedule.get("name"),
             repo,
         )
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     token = await _get_gh_token()
     if not token:
         _log.warning("No GitHub token available for polling %s", repo)
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {token}",
@@ -256,14 +288,14 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
         )
     except httpx.HTTPError:
         _log.exception("GitHub API request failed for %s", repo)
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     if resp.status_code == 304:
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     if resp.status_code != 200:
         _log.warning("GitHub API returned %d for %s", resp.status_code, repo)
-        return []
+        return GithubPollResult(items=[], scan_complete=True)
 
     remaining = int(resp.headers.get("x-ratelimit-remaining", "60"))
     if remaining < 10:
@@ -273,6 +305,12 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
     per_page = int(params["per_page"])
     page = resp.json()
     prs = list(page)
+
+    # True once the scan has reached a boundary that PROVES no unfetched
+    # page could hold an event this poll needs to worry about (see the
+    # scan_complete docstring on GithubPollResult). Flipped to False below
+    # only when the loop stops for a reason that does NOT prove that.
+    scan_complete = True
 
     if merged_mode:
         # Page forward while the most recently fetched page was full (a
@@ -296,22 +334,44 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
             except httpx.HTTPError:
                 _log.warning(
                     "GitHub API pagination request failed for %s while paging "
-                    "for merged PRs; using %d PR(s) fetched so far",
+                    "for merged PRs; using %d PR(s) fetched so far -- events "
+                    "too close to the unproven boundary are held for a later poll",
                     repo,
                     len(prs),
                 )
+                scan_complete = False
                 break
             if resp.status_code != 200:
                 _log.warning(
                     "GitHub API returned %d for %s during merged-PR pagination; "
-                    "using %d PR(s) fetched so far",
+                    "using %d PR(s) fetched so far -- events too close to the "
+                    "unproven boundary are held for a later poll",
                     resp.status_code,
                     repo,
                     len(prs),
                 )
+                scan_complete = False
                 break
             page = resp.json()
             prs.extend(page)
+        else:
+            # The for-loop ran out of pages to fetch (_MERGED_MODE_MAX_PAGES
+            # reached) without ever hitting one of the safe breaks above --
+            # there may still be more pages beyond this one.
+            scan_complete = False
+
+    # In merged mode, once the scan is truncated (unsafe boundary), any
+    # fetched PR whose cursor field (merged_at) sits at or past the oldest
+    # updated_at we actually fetched cannot be safely dispatched: we can't
+    # prove an unfetched page doesn't hold an older, still-undispatched
+    # merge, and the cursor can't advance past this PR without risking that
+    # merge being skipped forever. Deferring it (dropping it from this
+    # poll's items entirely, not just marking it non-dispatchable) also
+    # avoids a duplicate fire -- since the cursor stays behind it, it is
+    # re-fetched and reconsidered on a later poll instead.
+    unsafe_floor: str | None = None
+    if merged_mode and not scan_complete and prs:
+        unsafe_floor = min(pr.get("updated_at", "") for pr in prs)
 
     draft_filter = github_filter.get("draft")
     items: list[GithubPollItem] = []
@@ -331,6 +391,9 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
             cursor_at = updated
 
         if cursor and cursor_at <= cursor:
+            continue
+
+        if unsafe_floor is not None and cursor_at >= unsafe_floor:
             continue
 
         is_draft = bool(pr.get("draft", False))
@@ -358,4 +421,4 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
     # caller's incremental cursor advance stays monotone in both modes,
     # rather than relying on a bare reversal of API order.
     items.sort(key=lambda it: it.updated_at)
-    return items
+    return GithubPollResult(items=items, scan_complete=scan_complete)

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -39,6 +39,23 @@ class GithubPollItem:
 
 _client: httpx.AsyncClient | None = None
 
+# Merged-PR mode's dispatch key (merged_at) differs from the API's sort key
+# (updated_at): a page full of closed-but-never-merged PRs produces no item
+# at all (see the pr_merged branch in github_poll), so it can push an older,
+# still-undispatched merged PR out of the first page and, without
+# pagination, past the poller's reach permanently -- the cursor would never
+# learn the merge happened. _MERGED_MODE_MAX_PAGES bounds how far
+# github_poll() will page forward hunting for it: worst case
+# _MERGED_MODE_MAX_PAGES * per_page (100) closed PRs inspected in one poll.
+# A merge event buried deeper than that in a single burst is simply not
+# found *this* poll -- the cursor never advances past anything unseen, so
+# it is found on a later poll once the shallower unmerged noise ages out of
+# GitHub's "recently updated" ordering. Bounded latency, not bounded
+# correctness.
+_MERGED_MODE_MAX_PAGES = 5
+
+_LINK_NEXT_RE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
+
 # CWE-918 defense-in-depth: github_repo must be exactly "owner/name" -- one
 # slash, no path traversal sequences, no URL-special chars.
 #
@@ -118,6 +135,21 @@ def _validate_github_repo(repo: str) -> None:
             f"github_repo {repo!r}: repo name {name!r} is a path-traversal "
             "singleton and is not a valid repository name."
         )
+
+
+def _next_page_url(resp: httpx.Response) -> str | None:
+    """Extract the RFC 5988 ``rel="next"`` URL from a GitHub API response's
+    ``Link`` header, or ``None`` on the last page.
+
+    Parsed with a plain regex rather than ``httpx.Response.links`` so a
+    lightweight test double (a bare ``headers`` dict) works the same as a
+    real ``httpx.Response``.
+    """
+    link_header = resp.headers.get("link")
+    if not link_header:
+        return None
+    m = _LINK_NEXT_RE.search(link_header)
+    return m.group(1) if m else None
 
 
 def _get_client() -> httpx.AsyncClient:
@@ -238,7 +270,48 @@ async def github_poll(schedule: dict) -> list[GithubPollItem]:
         _log.warning("GitHub rate limit low: %d remaining for %s", remaining, repo)
 
     cursor = schedule.get("github_cursor")
-    prs = resp.json()
+    per_page = int(params["per_page"])
+    page = resp.json()
+    prs = list(page)
+
+    if merged_mode:
+        # Page forward while the most recently fetched page was full (a
+        # short page means there's nothing more) AND its oldest PR (last in
+        # updated_at-desc order) is still newer than the cursor -- once an
+        # item's updated_at has fallen to or below the cursor, every PR
+        # further back is too (the API is sorted by updated_at desc), and
+        # merged_at <= updated_at always holds for a merged PR, so nothing
+        # beyond that point could be an undispatched merge either.
+        for _ in range(_MERGED_MODE_MAX_PAGES - 1):
+            if len(page) < per_page:
+                break
+            oldest_updated = page[-1].get("updated_at", "") if page else ""
+            if cursor and oldest_updated <= cursor:
+                break
+            next_url = _next_page_url(resp)
+            if not next_url:
+                break
+            try:
+                resp = await client.get(next_url, headers=headers)
+            except httpx.HTTPError:
+                _log.warning(
+                    "GitHub API pagination request failed for %s while paging "
+                    "for merged PRs; using %d PR(s) fetched so far",
+                    repo,
+                    len(prs),
+                )
+                break
+            if resp.status_code != 200:
+                _log.warning(
+                    "GitHub API returned %d for %s during merged-PR pagination; "
+                    "using %d PR(s) fetched so far",
+                    resp.status_code,
+                    repo,
+                    len(prs),
+                )
+                break
+            page = resp.json()
+            prs.extend(page)
 
     draft_filter = github_filter.get("draft")
     items: list[GithubPollItem] = []

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -7,13 +7,31 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
-from lionagi.state.db import StateDB
-
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GithubPollItem:
+    """One PR observed by a poll, past the previously stored cursor.
+
+    ``event`` is always populated (even when ``dispatchable`` is False) so a
+    caller can log which PR was seen without firing it. ``updated_at`` is the
+    PR's raw GitHub timestamp string, used as the cursor high-water mark.
+    ``dispatchable`` is False when ``github_filter`` (e.g. a draft filter)
+    excludes the PR from firing -- it is still returned, not silently
+    dropped, so the caller can advance the cursor past it without the PR
+    being re-listed on every subsequent poll.
+    """
+
+    event: dict[str, Any]
+    updated_at: str
+    dispatchable: bool
+
 
 _client: httpx.AsyncClient | None = None
 
@@ -128,8 +146,21 @@ async def _get_gh_token() -> str | None:
     return None
 
 
-async def github_poll(schedule: dict) -> list[dict[str, Any]]:
-    """Poll GitHub for new/updated PRs. Returns list of new PR dicts."""
+async def github_poll(schedule: dict) -> list[GithubPollItem]:
+    """Poll GitHub for PRs newer than the stored cursor.
+
+    Returns items ordered oldest-``updated_at``-first (the GitHub API itself
+    returns them newest-first) so a caller advancing the persisted cursor
+    incrementally, one dispatched item at a time, stays monotone.
+
+    Does NOT persist ``github_cursor`` -- that is the caller's job now
+    (``SchedulerEngine._tick_github``). Fire-per-event budget gating means
+    some of the dispatchable items returned here may not actually get fired
+    this poll (max_runs/global-slot exhaustion), and those must be re-listed
+    on the next poll rather than silently skipped, so only the caller -- who
+    knows what it actually dispatched -- can decide how far the cursor is
+    safe to advance.
+    """
     repo = schedule.get("github_repo")
     if not repo:
         return []
@@ -199,51 +230,33 @@ async def github_poll(schedule: dict) -> list[dict[str, Any]]:
     if remaining < 10:
         _log.warning("GitHub rate limit low: %d remaining for %s", remaining, repo)
 
-    new_etag = resp.headers.get("etag")
     cursor = schedule.get("github_cursor")
     prs = resp.json()
 
     draft_filter = github_filter.get("draft")
-    new_prs = []
-    max_updated = cursor
+    items: list[GithubPollItem] = []
     for pr in prs:
         updated = pr.get("updated_at", "")
         if cursor and updated <= cursor:
             continue
-        # New PR past the cursor high-water mark. Advance the cursor for it
-        # even if the draft filter drops it below, so a filtered PR is not
-        # re-listed on every poll — a draft toggle bumps updated_at and
-        # naturally re-qualifies the PR when its draft state changes.
-        if not max_updated or updated > max_updated:
-            max_updated = updated
         is_draft = bool(pr.get("draft", False))
         # Only a real JSON boolean narrows the fire set. A malformed non-bool
         # draft filter is ignored (fail open to no filtering) rather than
         # silently matching the wrong side — the string "false" is truthy.
-        if isinstance(draft_filter, bool) and is_draft != draft_filter:
-            continue
-        new_prs.append(
-            {
-                "pr_number": pr.get("number"),
-                "pr_title": pr.get("title"),
-                "pr_url": pr.get("html_url"),
-                "pr_author": (pr.get("user") or {}).get("login"),
-                "updated_at": updated,
-                "head_sha": (pr.get("head") or {}).get("sha"),
-                "draft": is_draft,
-            }
-        )
+        dispatchable = not (isinstance(draft_filter, bool) and is_draft != draft_filter)
+        event = {
+            "pr_number": pr.get("number"),
+            "pr_title": pr.get("title"),
+            "pr_url": pr.get("html_url"),
+            "pr_author": (pr.get("user") or {}).get("login"),
+            "updated_at": updated,
+            "head_sha": (pr.get("head") or {}).get("sha"),
+            "draft": is_draft,
+        }
+        items.append(GithubPollItem(event=event, updated_at=updated, dispatchable=dispatchable))
 
-    # Update cursor on the schedule when new PRs found or etag refreshed
-    update_fields: dict[str, Any] = {}
-    if max_updated and max_updated != cursor:
-        update_fields["github_cursor"] = max_updated
-    if new_etag and not update_fields:
-        # No new PRs but etag changed -- update cursor to avoid redundant refetches
-        # We don't have a dedicated etag column; skip persisting etag alone
-        pass
-    if update_fields:
-        async with StateDB() as db:
-            await db.update_schedule(schedule["id"], **update_fields)
-
-    return new_prs
+    # The API returns PRs sorted by updated_at desc; the caller advances the
+    # persisted cursor incrementally as it processes items in order, so they
+    # must come back oldest-first.
+    items.reverse()
+    return items

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -188,6 +188,49 @@ def _svc_validate_github_repo(repo: str | None) -> None:
     _validate_github_repo(repo)
 
 
+# github_filter's known keys. "event" narrows *which* PR lifecycle moment
+# fires the trigger; the other three narrow *which PRs* are considered at
+# all. Only "pr_merged" has real dispatch semantics in github_poll() today
+# (state=closed poll, fires on newly-merged PRs only) -- "pr_opened",
+# "pr_updated", and "pr_closed" are accepted because the Studio frontend's
+# create-schedule form already ships all four as event choices (and defaults
+# new schedules to "pr_updated"; see apps/studio/frontend/src/components/
+# schedules/CreateScheduleModal.tsx), but are currently inert server-side:
+# github_poll() only branches on "pr_merged" and otherwise polls open PRs
+# unfiltered by event, the same as omitting the key entirely.
+_GITHUB_FILTER_ALLOWED_KEYS: frozenset[str] = frozenset({"state", "base", "draft", "event"})
+_GITHUB_FILTER_ALLOWED_EVENTS: frozenset[str] = frozenset(
+    {"pr_merged", "pr_opened", "pr_updated", "pr_closed"}
+)
+
+
+def _svc_validate_github_filter(github_filter: Any) -> None:
+    """Service-boundary check: reject unknown github_filter keys/values.
+
+    None means the field was not supplied (no-op). An empty dict matches
+    every PR, same as omitting the field, and is accepted. Unknown keys are
+    rejected outright rather than silently ignored -- a typo'd or
+    speculative filter key would otherwise match everything and fire on
+    every poll instead of failing loudly at create/update time.
+    """
+    if github_filter is None:
+        return
+    if not isinstance(github_filter, dict):
+        raise ValueError(f"github_filter must be an object, got {type(github_filter).__name__!r}")
+    unknown = set(github_filter) - _GITHUB_FILTER_ALLOWED_KEYS
+    if unknown:
+        raise ValueError(
+            f"github_filter has unknown key(s) {sorted(unknown)}; allowed keys are "
+            f"{sorted(_GITHUB_FILTER_ALLOWED_KEYS)}"
+        )
+    event = github_filter.get("event")
+    if event is not None and event not in _GITHUB_FILTER_ALLOWED_EVENTS:
+        raise ValueError(
+            f"github_filter.event {event!r} is not a supported value; allowed values "
+            f"are {sorted(_GITHUB_FILTER_ALLOWED_EVENTS)} (or omit the key)"
+        )
+
+
 def _svc_validate_prompt(prompt: str | None) -> None:
     """Service-boundary check: reject action_prompt == '--'.
 
@@ -392,6 +435,7 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_identifier(data.get("action_playbook"), "action_playbook")
     _svc_validate_extra_args(data.get("action_extra_args"))
     _svc_validate_github_repo(data.get("github_repo"))
+    _svc_validate_github_filter(data.get("github_filter"))
     _svc_validate_max_runs(data.get("max_runs"))
     _svc_validate_budget_usd(data.get("budget_usd"))
     _svc_validate_budget_tokens(data.get("budget_tokens"))
@@ -458,6 +502,8 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
             _svc_validate_extra_args(fields["action_extra_args"])
         if "github_repo" in fields:
             _svc_validate_github_repo(fields["github_repo"])
+        if "github_filter" in fields:
+            _svc_validate_github_filter(fields["github_filter"])
         if "max_runs" in fields:
             _svc_validate_max_runs(fields["max_runs"])
         if "budget_usd" in fields:

--- a/tests/studio/test_github_filter_validation.py
+++ b/tests/studio/test_github_filter_validation.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the github_filter service-boundary allowlist
+(services/schedules._svc_validate_github_filter) on create_schedule and
+update_schedule."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from unittest.mock import AsyncMock, patch
+
+from lionagi.studio.services.schedules import (
+    _svc_validate_github_filter,
+    create_schedule,
+    update_schedule,
+)
+
+
+def _create_data(**overrides) -> dict:
+    base = {
+        "name": "gh-filter-test",
+        "trigger_type": "github_poll",
+        "github_repo": "owner/name",
+        "action_kind": "agent",
+        "action_prompt": "review",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _svc_validate_github_filter — pure logic
+# ---------------------------------------------------------------------------
+
+
+def test_validate_github_filter_none_is_noop():
+    _svc_validate_github_filter(None)
+
+
+def test_validate_github_filter_empty_dict_ok():
+    _svc_validate_github_filter({})
+
+
+def test_validate_github_filter_known_keys_ok():
+    _svc_validate_github_filter({"state": "open", "base": "main", "draft": False})
+    _svc_validate_github_filter({"event": "pr_merged"})
+
+
+def test_validate_github_filter_all_frontend_event_values_ok():
+    """The Studio create-schedule form ships four event choices (pr_merged,
+    pr_opened, pr_updated, pr_closed) and defaults new schedules to
+    pr_updated -- all four must be accepted at the write boundary even
+    though only pr_merged has real dispatch semantics in github_poll()
+    today, or the shipped default create flow would 400 on every save."""
+    for event in ("pr_merged", "pr_opened", "pr_updated", "pr_closed"):
+        _svc_validate_github_filter({"event": event})
+
+
+def test_validate_github_filter_rejects_unknown_key():
+    with pytest.raises(ValueError, match="unknown key"):
+        _svc_validate_github_filter({"labels": ["bug"]})
+
+
+def test_validate_github_filter_rejects_unknown_key_alongside_known_ones():
+    with pytest.raises(ValueError, match="unknown key"):
+        _svc_validate_github_filter({"state": "open", "assignee": "octocat"})
+
+
+def test_validate_github_filter_rejects_unknown_event_value():
+    with pytest.raises(ValueError, match="event"):
+        _svc_validate_github_filter({"event": "pr_reopened"})
+
+
+def test_validate_github_filter_rejects_non_dict():
+    with pytest.raises(ValueError, match="object"):
+        _svc_validate_github_filter("pr_merged")
+
+
+# ---------------------------------------------------------------------------
+# create_schedule / update_schedule — validation fires before any DB write
+# ---------------------------------------------------------------------------
+
+
+def test_create_schedule_rejects_unknown_github_filter_key():
+    data = _create_data(github_filter={"labels": ["bug"]})
+
+    async def _run():
+        await create_schedule(data)
+
+    with pytest.raises(ValueError, match="unknown key"):
+        asyncio.run(_run())
+
+
+def test_create_schedule_rejects_unsupported_event_value():
+    data = _create_data(github_filter={"event": "pr_reopened"})
+
+    async def _run():
+        await create_schedule(data)
+
+    with pytest.raises(ValueError, match="event"):
+        asyncio.run(_run())
+
+
+def test_create_schedule_accepts_pr_merged_filter():
+    """A valid pr_merged filter reaches the DB write (validation passes)."""
+    data = _create_data(github_filter={"event": "pr_merged"})
+
+    async def _run():
+        with patch("lionagi.studio.services.schedules.StateDB") as MockDB:
+            mock_db = AsyncMock()
+            mock_db.create_schedule = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            await create_schedule(data)
+            mock_db.create_schedule.assert_awaited_once()
+
+    asyncio.run(_run())
+
+
+def test_update_schedule_rejects_unknown_github_filter_key():
+    existing = {
+        "id": "sid-gh-1",
+        "name": "gh-filter-patch-test",
+        "trigger_type": "github_poll",
+        "github_repo": "owner/name",
+        "action_kind": "agent",
+    }
+
+    async def _run():
+        with patch("lionagi.studio.services.schedules.StateDB") as MockDB:
+            mock_db = AsyncMock()
+            mock_db.get_schedule = AsyncMock(return_value=existing)
+            mock_db.update_schedule = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ValueError, match="unknown key"):
+                await update_schedule("sid-gh-1", {"github_filter": {"milestone": "v1"}})
+            mock_db.update_schedule.assert_not_called()
+
+    asyncio.run(_run())
+
+
+def test_update_schedule_accepts_pr_merged_filter():
+    existing = {
+        "id": "sid-gh-2",
+        "name": "gh-filter-patch-ok",
+        "trigger_type": "github_poll",
+        "github_repo": "owner/name",
+        "action_kind": "agent",
+    }
+
+    async def _run():
+        with patch("lionagi.studio.services.schedules.StateDB") as MockDB:
+            mock_db = AsyncMock()
+            mock_db.get_schedule = AsyncMock(return_value=existing)
+            mock_db.update_schedule = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await update_schedule("sid-gh-2", {"github_filter": {"event": "pr_merged"}})
+            assert result is True
+            mock_db.update_schedule.assert_awaited_once()
+
+    asyncio.run(_run())

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import asyncio
 
+import httpx
+
 from lionagi.studio.scheduler import github as gh_mod
 
 
@@ -87,6 +89,33 @@ def _install(monkeypatch, prs):
     return client
 
 
+class _FakeErrorClient:
+    """Serves *page0* with a next link, then raises httpx.HTTPError on any
+    subsequent pagination fetch -- for exercising github_poll's truncation
+    handling when a pagination request itself fails mid-scan."""
+
+    def __init__(self, page0):
+        self._page0 = page0
+        self.requests: list[dict] = []
+
+    async def get(self, url, headers=None, params=None):
+        self.requests.append({"url": url, "params": params})
+        if len(self.requests) == 1:
+            next_url = "https://api.github.com/repos/owner/name/pulls?page=2"
+            return _FakeResp(self._page0, link=f'<{next_url}>; rel="next"')
+        raise httpx.HTTPError("boom")
+
+
+def _install_error(monkeypatch, page0):
+    async def _fake_token():
+        return "faketoken"
+
+    client = _FakeErrorClient(page0)
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: client)
+    return client
+
+
 def _install_paginated(monkeypatch, pages):
     """Wire the poller's token and HTTP client to a multi-page fake."""
 
@@ -100,6 +129,10 @@ def _install_paginated(monkeypatch, pages):
 
 
 def _poll(schedule):
+    return asyncio.run(gh_mod.github_poll(schedule)).items
+
+
+def _poll_result(schedule):
     return asyncio.run(gh_mod.github_poll(schedule))
 
 
@@ -455,3 +488,69 @@ def test_github_poll_merged_mode_stops_paging_once_cursor_reached(monkeypatch):
     # Only the initial fetch -- page1's oldest item already reached the
     # cursor, so the pagination loop never follows Link: rel="next".
     assert len(client.requests) == 1
+
+
+def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None = None):
+    """20 closed PRs at a fixed hour, minutes descending. ``merges`` maps a
+    within-page index to a merged_at value for that PR (unmerged otherwise)."""
+    merges = merges or {}
+    items = []
+    for i in range(20):
+        minute = 59 - i * 3
+        updated_at = f"2026-07-06T{hour:02d}:{minute:02d}:00Z"
+        items.append(_pr(base_number + i, updated_at, state="closed", merged_at=merges.get(i)))
+    return items
+
+
+def test_github_poll_merged_mode_cap_truncation_defers_unsafe_boundary_items(monkeypatch):
+    """Hitting _MERGED_MODE_MAX_PAGES (rather than a safe short-page/cursor
+    boundary) makes the scan incomplete: github_poll must not return, as
+    dispatchable, any item whose cursor field (merged_at) sits at or after
+    the oldest updated_at actually fetched -- advancing the cursor to that
+    item risks permanently skipping an unfetched, older, still-undispatched
+    merge. An item merged long before the fetched window entirely (safely
+    below that boundary) is unaffected and still returned.
+    """
+    pages = [
+        _closed_page(15, 1000),
+        _closed_page(14, 1100),
+        _closed_page(13, 1200),
+        _closed_page(12, 1300),
+        _closed_page(
+            11,
+            1400,
+            merges={5: "2026-07-06T11:44:00Z", 10: "2020-01-01T00:00:00Z"},
+        ),
+    ]
+    client = _install_paginated(monkeypatch, pages)
+    result = _poll_result(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+
+    assert result.scan_complete is False
+    # 5 requests: the cap (_MERGED_MODE_MAX_PAGES) was reached exactly.
+    assert len(client.requests) == 5
+    assert [i.event["pr_number"] for i in result.items] == [1410]
+    assert result.items[0].dispatchable is True
+
+
+def test_github_poll_merged_mode_pagination_error_defers_unsafe_boundary_items(monkeypatch):
+    """A pagination fetch/status error mid-scan is exactly as unsafe as
+    hitting the page cap -- the scan stopped without proving there's no
+    unfetched page beyond it, so the same truncation-safety filter applies
+    to whatever was fetched before the failure."""
+    page0 = _closed_page(
+        11,
+        1400,
+        merges={5: "2026-07-06T11:44:00Z", 10: "2020-01-01T00:00:00Z"},
+    )
+    client = _install_error(monkeypatch, page0)
+    result = _poll_result(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+
+    assert result.scan_complete is False
+    # 2 requests: the initial fetch, plus the pagination fetch that raised.
+    assert len(client.requests) == 2
+    assert [i.event["pr_number"] for i in result.items] == [1410]
+    assert result.items[0].dispatchable is True

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -32,10 +32,12 @@ def _pr(number, updated, *, draft=False, sha=None, state="open", merged_at=None)
 
 
 class _FakeResp:
-    def __init__(self, prs):
+    def __init__(self, prs, link=None):
         self._prs = prs
         self.status_code = 200
         self.headers = {"x-ratelimit-remaining": "100", "etag": '"abc"'}
+        if link:
+            self.headers["link"] = link
 
     def json(self):
         return self._prs
@@ -51,6 +53,28 @@ class _FakeClient:
         return _FakeResp(self._prs)
 
 
+class _FakePaginatedClient:
+    """Fake client serving a fixed sequence of pages. Every response but the
+    last carries a ``Link: rel="next"`` header (the real GitHub API shape),
+    so github_poll's merged-mode pagination loop follows it exactly the way
+    it would follow a real Link header."""
+
+    def __init__(self, pages: list[list[dict]]):
+        self._pages = pages
+        self.requests: list[dict] = []
+
+    async def get(self, url, headers=None, params=None):
+        page_index = len(self.requests)
+        self.requests.append({"url": url, "params": params})
+        prs = self._pages[page_index] if page_index < len(self._pages) else []
+        has_next = page_index + 1 < len(self._pages)
+        link = None
+        if has_next:
+            next_url = f"https://api.github.com/repos/owner/name/pulls?page={page_index + 2}"
+            link = f'<{next_url}>; rel="next"'
+        return _FakeResp(prs, link=link)
+
+
 def _install(monkeypatch, prs):
     """Wire the poller's token and HTTP client to fakes."""
 
@@ -58,6 +82,18 @@ def _install(monkeypatch, prs):
         return "faketoken"
 
     client = _FakeClient(prs)
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: client)
+    return client
+
+
+def _install_paginated(monkeypatch, pages):
+    """Wire the poller's token and HTTP client to a multi-page fake."""
+
+    async def _fake_token():
+        return "faketoken"
+
+    client = _FakePaginatedClient(pages)
     monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
     monkeypatch.setattr(gh_mod, "_get_client", lambda: client)
     return client
@@ -333,3 +369,89 @@ def test_github_poll_open_pr_mode_untouched_by_merged_mode_changes(monkeypatch):
     assert [i.event["pr_number"] for i in items] == [1, 2]
     assert [i.updated_at for i in items] == ["2026-07-07T10:00:00Z", "2026-07-07T11:00:00Z"]
     assert "pr_merged_at" not in items[0].event
+
+
+def test_github_poll_merged_mode_pages_past_closed_unmerged_noise(monkeypatch):
+    """Starvation shape: a full first page of closed-but-never-merged PRs (all
+    newer than the cursor) would, without pagination, push an older but still
+    undispatched merged PR on page 2 out of reach forever -- the merged PR's
+    updated_at is older than every unmerged PR on page 1, but its merged_at is
+    still after the cursor, so it must be found and dispatched.
+
+    Page 1 is exactly per_page (20) items long -- the poller's own signal
+    that there may be more -- and its oldest item's updated_at is still newer
+    than the cursor, so github_poll must follow the Link: rel="next" header
+    onto page 2 rather than stopping at page 1.
+    """
+    cursor = "2026-06-01T00:00:00Z"
+    page1 = [
+        _pr(
+            100 + n,
+            f"2026-07-06T{10 - n // 10:02d}:{59 - (n % 10) * 5:02d}:00Z",
+            state="closed",
+            merged_at=None,
+        )
+        for n in range(20)
+    ]
+    # Sanity: page1 is a full page, strictly newer than the cursor throughout.
+    assert len(page1) == 20
+    assert all(pr["updated_at"] > cursor for pr in page1)
+
+    merged_pr = _pr(
+        50,
+        "2026-07-06T09:00:00Z",  # older than every page-1 item's updated_at...
+        state="closed",
+        merged_at="2026-06-15T00:00:00Z",  # ...but merged after the cursor.
+    )
+    page2 = [merged_pr]
+
+    client = _install_paginated(monkeypatch, [page1, page2])
+    items = _poll(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": cursor,
+        }
+    )
+
+    assert [i.event["pr_number"] for i in items] == [50]
+    assert items[0].dispatchable is True
+    # One initial fetch plus exactly one pagination fetch -- page 2 was short
+    # (1 < per_page), so the loop stops there rather than paging further.
+    assert len(client.requests) == 2
+
+
+def test_github_poll_merged_mode_stops_paging_once_cursor_reached(monkeypatch):
+    """Once a fetched page's oldest item has fallen to/below the cursor,
+    github_poll stops paging even if that page is full -- everything past
+    that point is already-seen ground, merged or not."""
+    cursor = "2026-07-06T09:30:00Z"
+    page1 = [
+        _pr(
+            100 + n,
+            f"2026-07-06T{10 - n // 10:02d}:{59 - (n % 10) * 5:02d}:00Z",
+            state="closed",
+            merged_at=None,
+        )
+        for n in range(20)
+    ]
+    # Oldest item on page1 must already be at/under the cursor.
+    assert page1[-1]["updated_at"] <= cursor
+
+    page2 = [_pr(50, "2026-07-06T08:00:00Z", state="closed", merged_at="2026-06-15T00:00:00Z")]
+
+    client = _install_paginated(monkeypatch, [page1, page2])
+    items = _poll(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": cursor,
+        }
+    )
+
+    assert items == []
+    # Only the initial fetch -- page1's oldest item already reached the
+    # cursor, so the pagination loop never follows Link: rel="next".
+    assert len(client.requests) == 1

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -503,13 +503,15 @@ def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None =
 
 
 def test_github_poll_merged_mode_cap_truncation_defers_unsafe_boundary_items(monkeypatch):
-    """Hitting _MERGED_MODE_MAX_PAGES (rather than a safe short-page/cursor
-    boundary) makes the scan incomplete: github_poll must not return, as
-    dispatchable, any item whose cursor field (merged_at) sits at or after
-    the oldest updated_at actually fetched -- advancing the cursor to that
-    item risks permanently skipping an unfetched, older, still-undispatched
-    merge. An item merged long before the fetched window entirely (safely
-    below that boundary) is unaffected and still returned.
+    """The 5th (cap) page is itself full, links to a 6th page, and hasn't
+    reached the cursor -- genuinely more data likely exists beyond it, but
+    the cap forbids fetching further. That makes the scan incomplete:
+    github_poll must not return, as dispatchable, any item whose cursor
+    field (merged_at) sits at or after the oldest updated_at actually
+    fetched -- advancing the cursor to that item risks permanently skipping
+    an unfetched, older, still-undispatched merge. An item merged long
+    before the fetched window entirely (safely below that boundary) is
+    unaffected and still returned.
     """
     pages = [
         _closed_page(15, 1000),
@@ -521,6 +523,7 @@ def test_github_poll_merged_mode_cap_truncation_defers_unsafe_boundary_items(mon
             1400,
             merges={5: "2026-07-06T11:44:00Z", 10: "2020-01-01T00:00:00Z"},
         ),
+        _closed_page(10, 1500),  # 6th page: proves page 5 had a real next link.
     ]
     client = _install_paginated(monkeypatch, pages)
     result = _poll_result(
@@ -528,9 +531,36 @@ def test_github_poll_merged_mode_cap_truncation_defers_unsafe_boundary_items(mon
     )
 
     assert result.scan_complete is False
-    # 5 requests: the cap (_MERGED_MODE_MAX_PAGES) was reached exactly.
+    # 5 requests: the cap (_MERGED_MODE_MAX_PAGES) was reached exactly --
+    # the 6th page is never fetched.
     assert len(client.requests) == 5
     assert [i.event["pr_number"] for i in result.items] == [1410]
+    assert result.items[0].dispatchable is True
+
+
+def test_github_poll_merged_mode_cap_reached_but_final_page_is_safe_terminal(monkeypatch):
+    """Four full pages followed by a short (terminal) fifth page containing
+    a merged PR at merged_at == updated_at == the floor. Hitting
+    _MERGED_MODE_MAX_PAGES here is incidental -- the 5th page itself is
+    short, which proves there is nothing beyond it, exactly like reaching a
+    short page on any earlier pass. The scan is COMPLETE and the boundary
+    PR must be returned and dispatchable, not deferred."""
+    pages = [
+        _closed_page(15, 1000),
+        _closed_page(14, 1100),
+        _closed_page(13, 1200),
+        _closed_page(12, 1300),
+        # Short (terminal) 5th page: one PR, merged at its own updated_at.
+        [_pr(1400, "2026-07-06T11:00:00Z", state="closed", merged_at="2026-07-06T11:00:00Z")],
+    ]
+    client = _install_paginated(monkeypatch, pages)
+    result = _poll_result(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+
+    assert result.scan_complete is True
+    assert len(client.requests) == 5
+    assert [i.event["pr_number"] for i in result.items] == [1400]
     assert result.items[0].dispatchable is True
 
 

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -17,7 +17,7 @@ import asyncio
 from lionagi.studio.scheduler import github as gh_mod
 
 
-def _pr(number, updated, *, draft=False, sha=None):
+def _pr(number, updated, *, draft=False, sha=None, state="open", merged_at=None):
     return {
         "number": number,
         "title": f"PR {number}",
@@ -26,6 +26,8 @@ def _pr(number, updated, *, draft=False, sha=None):
         "updated_at": updated,
         "draft": draft,
         "head": {"sha": sha or f"sha{number}"},
+        "state": state,
+        "merged_at": merged_at,
     }
 
 
@@ -42,8 +44,10 @@ class _FakeResp:
 class _FakeClient:
     def __init__(self, prs):
         self._prs = prs
+        self.requests: list[dict] = []
 
     async def get(self, url, headers=None, params=None):
+        self.requests.append({"url": url, "params": params})
         return _FakeResp(self._prs)
 
 
@@ -53,8 +57,10 @@ def _install(monkeypatch, prs):
     async def _fake_token():
         return "faketoken"
 
+    client = _FakeClient(prs)
     monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
-    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakeClient(prs))
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: client)
+    return client
 
 
 def _poll(schedule):
@@ -194,3 +200,136 @@ def test_github_poll_respects_cursor_high_water_mark(monkeypatch):
         {"id": "s1", "github_repo": "owner/name", "github_cursor": "2026-07-07T09:00:00Z"}
     )
     assert [i.event["pr_number"] for i in items] == [2]
+
+
+# ---------------------------------------------------------------------------
+# github_filter={"event": "pr_merged"} -- merged-PR mode
+# ---------------------------------------------------------------------------
+
+
+def test_github_poll_merged_mode_polls_closed_state(monkeypatch):
+    """github_filter={'event': 'pr_merged'} polls state=closed, overriding
+    any explicit (nonsensical) open/other state in the filter."""
+    client = _install(monkeypatch, [])
+    _poll(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged", "state": "open"},
+        }
+    )
+    assert client.requests[-1]["params"]["state"] == "closed"
+
+
+def test_github_poll_merged_mode_fires_only_on_merged_prs(monkeypatch):
+    """A merged PR is dispatchable; a closed-but-unmerged PR in the same
+    response never fires."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T10:00:00Z", state="closed", merged_at="2026-07-07T10:00:00Z"),
+            _pr(2, "2026-07-07T11:00:00Z", state="closed", merged_at=None),
+        ],
+    )
+    items = _poll(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+    assert [i.event["pr_number"] for i in items] == [1]
+    assert items[0].dispatchable is True
+
+
+def test_github_poll_merged_mode_threads_pr_merged_at_into_event(monkeypatch):
+    """The merged event dict carries pr_merged_at for {{pr_merged_at}}
+    template rendering, alongside the PR's own updated_at."""
+    _install(
+        monkeypatch,
+        [
+            _pr(
+                9,
+                "2026-07-07T10:05:00Z",
+                state="closed",
+                merged_at="2026-07-07T10:00:00Z",
+            )
+        ],
+    )
+    items = _poll(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+    assert len(items) == 1
+    ev = items[0].event
+    assert ev["pr_merged_at"] == "2026-07-07T10:00:00Z"
+    assert ev["updated_at"] == "2026-07-07T10:05:00Z"
+
+
+def test_github_poll_merged_mode_cursor_uses_merged_at(monkeypatch):
+    """The cursor high-water-mark field (GithubPollItem.updated_at) holds
+    merged_at, not the PR's raw updated_at, in merged mode -- a PR merged
+    before the stored cursor is excluded even if its updated_at is newer."""
+    _install(
+        monkeypatch,
+        [
+            _pr(
+                1,
+                "2026-07-07T12:00:00Z",  # updated_at is AFTER the cursor...
+                state="closed",
+                merged_at="2026-07-07T09:00:00Z",  # ...but merged_at is BEFORE it.
+            ),
+            _pr(
+                2,
+                "2026-07-07T11:00:00Z",
+                state="closed",
+                merged_at="2026-07-07T10:30:00Z",  # merged_at is AFTER the cursor.
+            ),
+        ],
+    )
+    items = _poll(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": "2026-07-07T10:00:00Z",
+        }
+    )
+    assert [i.event["pr_number"] for i in items] == [2]
+    assert items[0].updated_at == "2026-07-07T10:30:00Z"
+
+
+def test_github_poll_merged_mode_cursor_stays_monotone_when_api_order_diverges(monkeypatch):
+    """Items come back sorted by the cursor field (merged_at in this mode),
+    not by raw API order, even when the two orderings diverge."""
+    _install(
+        monkeypatch,
+        [
+            # API order (updated_at desc): PR 3 first, then PR 1, then PR 2 --
+            # but merged_at order is 1, 2, 3, a different sequence entirely.
+            _pr(3, "2026-07-07T13:00:00Z", state="closed", merged_at="2026-07-07T13:00:00Z"),
+            _pr(1, "2026-07-07T12:00:00Z", state="closed", merged_at="2026-07-07T09:00:00Z"),
+            _pr(2, "2026-07-07T11:00:00Z", state="closed", merged_at="2026-07-07T10:00:00Z"),
+        ],
+    )
+    items = _poll(
+        {"id": "s1", "github_repo": "owner/name", "github_filter": {"event": "pr_merged"}}
+    )
+    assert [i.event["pr_number"] for i in items] == [1, 2, 3]
+    assert [i.updated_at for i in items] == [
+        "2026-07-07T09:00:00Z",
+        "2026-07-07T10:00:00Z",
+        "2026-07-07T13:00:00Z",
+    ]
+
+
+def test_github_poll_open_pr_mode_untouched_by_merged_mode_changes(monkeypatch):
+    """The default (no event filter) open-PR mode is unaffected: it still
+    polls state=open and uses updated_at as the cursor field."""
+    client = _install(
+        monkeypatch,
+        [
+            _pr(2, "2026-07-07T11:00:00Z"),
+            _pr(1, "2026-07-07T10:00:00Z"),
+        ],
+    )
+    items = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert client.requests[-1]["params"]["state"] == "open"
+    assert [i.event["pr_number"] for i in items] == [1, 2]
+    assert [i.updated_at for i in items] == ["2026-07-07T10:00:00Z", "2026-07-07T11:00:00Z"]
+    assert "pr_merged_at" not in items[0].event

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -1,8 +1,14 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the github_poll poller: emitted fields (head_sha, draft) and
-the draft github_filter, with the cursor high-water-mark behavior."""
+"""Unit tests for the github_poll poller: emitted fields (head_sha, draft), the
+draft github_filter, ordering, and the cursor high-water-mark behavior.
+
+github_poll() no longer persists github_cursor itself (that moved to the
+caller, SchedulerEngine._tick_github, so per-event dispatch can gate how far
+the cursor actually advances) -- these tests assert on the returned
+GithubPollItem list instead of a StateDB write.
+"""
 
 from __future__ import annotations
 
@@ -42,29 +48,13 @@ class _FakeClient:
 
 
 def _install(monkeypatch, prs):
-    """Wire the poller's token, HTTP client, and StateDB write to fakes.
-
-    Returns a list that captures (schedule_id, update_fields) for each cursor
-    write so a test can assert the high-water mark that was persisted."""
-    cursor_writes: list = []
+    """Wire the poller's token and HTTP client to fakes."""
 
     async def _fake_token():
         return "faketoken"
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-        async def update_schedule(self, schedule_id, **fields):
-            cursor_writes.append((schedule_id, fields))
-
     monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
     monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakeClient(prs))
-    monkeypatch.setattr(gh_mod, "StateDB", _FakeDB)
-    return cursor_writes
 
 
 def _poll(schedule):
@@ -74,17 +64,21 @@ def _poll(schedule):
 def test_github_poll_emits_head_sha_and_draft(monkeypatch):
     """A polled PR surfaces head_sha and draft alongside the existing fields."""
     _install(monkeypatch, [_pr(7, "2026-07-07T10:00:00Z", draft=False, sha="deadbeef")])
-    events = _poll({"id": "s1", "github_repo": "owner/name"})
-    assert len(events) == 1
-    ev = events[0]
+    items = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert len(items) == 1
+    item = items[0]
+    assert item.dispatchable is True
+    assert item.updated_at == "2026-07-07T10:00:00Z"
+    ev = item.event
     assert ev["pr_number"] == 7
     assert ev["head_sha"] == "deadbeef"
     assert ev["draft"] is False
     assert ev["pr_author"] == "octocat"
 
 
-def test_github_poll_draft_filter_true_keeps_only_drafts(monkeypatch):
-    """github_filter={'draft': true} emits only draft PRs."""
+def test_github_poll_draft_filter_true_keeps_only_drafts_dispatchable(monkeypatch):
+    """github_filter={'draft': true} marks only draft PRs dispatchable; the
+    non-draft PR is still returned (for cursor bookkeeping) but flagged off."""
     _install(
         monkeypatch,
         [
@@ -92,13 +86,14 @@ def test_github_poll_draft_filter_true_keeps_only_drafts(monkeypatch):
             _pr(2, "2026-07-07T09:00:00Z", draft=True),
         ],
     )
-    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": True}})
-    assert [e["pr_number"] for e in events] == [2]
-    assert events[0]["draft"] is True
+    items = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": True}})
+    by_number = {i.event["pr_number"]: i for i in items}
+    assert by_number[1].dispatchable is False
+    assert by_number[2].dispatchable is True
 
 
 def test_github_poll_draft_filter_false_excludes_drafts(monkeypatch):
-    """github_filter={'draft': false} emits only non-draft PRs."""
+    """github_filter={'draft': false} marks only non-draft PRs dispatchable."""
     _install(
         monkeypatch,
         [
@@ -106,13 +101,14 @@ def test_github_poll_draft_filter_false_excludes_drafts(monkeypatch):
             _pr(2, "2026-07-07T09:00:00Z", draft=True),
         ],
     )
-    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": False}})
-    assert [e["pr_number"] for e in events] == [1]
-    assert events[0]["draft"] is False
+    items = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": False}})
+    by_number = {i.event["pr_number"]: i for i in items}
+    assert by_number[1].dispatchable is True
+    assert by_number[2].dispatchable is False
 
 
-def test_github_poll_no_draft_filter_emits_all(monkeypatch):
-    """Without a draft key, both draft and ready PRs are emitted."""
+def test_github_poll_no_draft_filter_emits_all_dispatchable(monkeypatch):
+    """Without a draft key, both draft and ready PRs are dispatchable."""
     _install(
         monkeypatch,
         [
@@ -120,14 +116,36 @@ def test_github_poll_no_draft_filter_emits_all(monkeypatch):
             _pr(2, "2026-07-07T09:00:00Z", draft=True),
         ],
     )
-    events = _poll({"id": "s1", "github_repo": "owner/name"})
-    assert sorted(e["pr_number"] for e in events) == [1, 2]
+    items = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert all(i.dispatchable for i in items)
+    assert sorted(i.event["pr_number"] for i in items) == [1, 2]
 
 
-def test_github_poll_cursor_advances_past_filtered_pr(monkeypatch):
-    """A draft-filtered PR that is the newest still advances the persisted cursor,
-    so it is not re-listed on every poll."""
-    writes = _install(
+def test_github_poll_orders_oldest_first(monkeypatch):
+    """The API returns PRs newest-first; github_poll reverses them so a caller
+    advancing the cursor incrementally, oldest event first, stays monotone."""
+    _install(
+        monkeypatch,
+        [
+            _pr(3, "2026-07-07T12:00:00Z"),
+            _pr(2, "2026-07-07T11:00:00Z"),
+            _pr(1, "2026-07-07T10:00:00Z"),
+        ],
+    )
+    items = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert [i.event["pr_number"] for i in items] == [1, 2, 3]
+    assert [i.updated_at for i in items] == [
+        "2026-07-07T10:00:00Z",
+        "2026-07-07T11:00:00Z",
+        "2026-07-07T12:00:00Z",
+    ]
+
+
+def test_github_poll_filtered_pr_still_returned_for_cursor_advance(monkeypatch):
+    """A draft-filtered PR that is the newest is still returned (dispatchable
+    False) rather than dropped, so the caller can advance its cursor past it
+    and avoid re-listing it forever."""
+    _install(
         monkeypatch,
         [
             # Newest is a draft; the filter wants non-drafts only.
@@ -135,7 +153,7 @@ def test_github_poll_cursor_advances_past_filtered_pr(monkeypatch):
             _pr(1, "2026-07-07T10:00:00Z", draft=False),
         ],
     )
-    events = _poll(
+    items = _poll(
         {
             "id": "s1",
             "github_repo": "owner/name",
@@ -143,12 +161,9 @@ def test_github_poll_cursor_advances_past_filtered_pr(monkeypatch):
             "github_cursor": "2026-07-07T09:00:00Z",
         }
     )
-    # Only the non-draft PR is emitted...
-    assert [e["pr_number"] for e in events] == [1]
-    # ...but the cursor advanced to the newest updated_at seen (the filtered draft).
-    assert writes, "expected a cursor write"
-    _sid, fields = writes[-1]
-    assert fields.get("github_cursor") == "2026-07-07T12:00:00Z"
+    assert [i.event["pr_number"] for i in items] == [1, 2]
+    assert [i.dispatchable for i in items] == [True, False]
+    assert items[-1].updated_at == "2026-07-07T12:00:00Z"
 
 
 def test_github_poll_non_bool_draft_filter_ignored(monkeypatch):
@@ -161,5 +176,21 @@ def test_github_poll_non_bool_draft_filter_ignored(monkeypatch):
             _pr(2, "2026-07-07T09:00:00Z", draft=True),
         ],
     )
-    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": "false"}})
-    assert sorted(e["pr_number"] for e in events) == [1, 2]
+    items = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": "false"}})
+    assert all(i.dispatchable for i in items)
+    assert sorted(i.event["pr_number"] for i in items) == [1, 2]
+
+
+def test_github_poll_respects_cursor_high_water_mark(monkeypatch):
+    """PRs at or below the stored cursor are not returned at all."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T09:00:00Z"),
+            _pr(2, "2026-07-07T10:00:00Z"),
+        ],
+    )
+    items = _poll(
+        {"id": "s1", "github_repo": "owner/name", "github_cursor": "2026-07-07T09:00:00Z"}
+    )
+    assert [i.event["pr_number"] for i in items] == [2]

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -262,9 +262,11 @@ async def test_tick_github_polls_normally_when_under_budget():
         budget_tokens=5000,
     )
 
+    from lionagi.studio.scheduler.github import GithubPollResult
+
     with patch(
         "lionagi.studio.scheduler.github.github_poll",
-        new=AsyncMock(return_value=[]),
+        new=AsyncMock(return_value=GithubPollResult(items=[], scan_complete=True)),
     ) as mock_poll:
         await engine._tick_github(schedule, now=10_000.0)
 

--- a/tests/studio/test_scheduler_cwd.py
+++ b/tests/studio/test_scheduler_cwd.py
@@ -100,7 +100,7 @@ async def test_resolve_action_cwd_uses_registered_project_path(tmp_path, monkeyp
     schedule = {"id": "sched-1", "action_project": "myproj"}
     result = await _resolve_action_cwd(schedule)
 
-    assert result == str(project_dir)
+    assert result == (str(project_dir), None)
     fake_get_project.assert_awaited_once_with("myproj")
 
 
@@ -122,7 +122,7 @@ async def test_resolve_action_cwd_falls_back_to_env_when_project_unresolved(tmp_
     schedule = {"id": "sched-2", "action_project": "unknown-project"}
     result = await _resolve_action_cwd(schedule)
 
-    assert result == str(env_dir)
+    assert result == (str(env_dir), None)
 
 
 @pytest.mark.asyncio
@@ -143,7 +143,7 @@ async def test_resolve_action_cwd_env_fallback_when_no_project_set(monkeypatch, 
     schedule = {"id": "sched-3", "action_project": None}
     result = await _resolve_action_cwd(schedule)
 
-    assert result == str(env_dir)
+    assert result == (str(env_dir), None)
     fake_get_project.assert_not_called()
 
 
@@ -159,14 +159,15 @@ async def test_resolve_action_cwd_returns_none_and_warns_when_unresolved(monkeyp
     with caplog.at_level(logging.WARNING, logger="lionagi.studio.scheduler.engine"):
         result = await _resolve_action_cwd(schedule)
 
-    assert result is None
+    assert result == (None, None)
     assert any("sched-4" in rec.getMessage() for rec in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_resolve_action_cwd_ignores_project_with_nonexistent_path(monkeypatch, tmp_path):
     """A registered project whose stored path no longer exists on disk must
-    not be trusted; falls through to env/None."""
+    not be trusted; falls through to env/None, and the caller learns which
+    path was stale so it can attribute a later spawn failure to it."""
     from lionagi.studio.scheduler.engine import _resolve_action_cwd
 
     fake_get_project = AsyncMock(
@@ -180,7 +181,56 @@ async def test_resolve_action_cwd_ignores_project_with_nonexistent_path(monkeypa
     schedule = {"id": "sched-5", "action_project": "stale"}
     result = await _resolve_action_cwd(schedule)
 
-    assert result is None
+    assert result == (None, "/no/such/directory/at/all")
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_stale_project_path_logs_specific_warning(monkeypatch, caplog):
+    """The stale-project-path warning names the schedule, the project, and
+    the exact missing path -- not just the generic 'no resolvable cwd'."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    fake_get_project = AsyncMock(
+        return_value={"name": "stale", "path": "/pruned/worktree/xyz", "source": "studio"}
+    )
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+    monkeypatch.delenv("LIONAGI_SCHEDULER_CWD", raising=False)
+
+    schedule = {"id": "sched-6", "action_project": "stale"}
+    with caplog.at_level(logging.WARNING, logger="lionagi.studio.scheduler.engine"):
+        await _resolve_action_cwd(schedule)
+
+    assert any(
+        "sched-6" in rec.getMessage() and "/pruned/worktree/xyz" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_stale_project_path_overridden_by_env_fallback(
+    monkeypatch, tmp_path
+):
+    """A stale project path is not reported as the failure attribution when
+    LIONAGI_SCHEDULER_CWD resolves a usable directory anyway -- the run isn't
+    actually at risk of the missing-cwd failure mode in that case."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    fake_get_project = AsyncMock(
+        return_value={"name": "stale", "path": "/no/such/directory/at/all", "source": "studio"}
+    )
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+    env_dir = tmp_path / "env-saves-the-day"
+    env_dir.mkdir()
+    monkeypatch.setenv("LIONAGI_SCHEDULER_CWD", str(env_dir))
+
+    schedule = {"id": "sched-7", "action_project": "stale"}
+    result = await _resolve_action_cwd(schedule)
+
+    assert result == (str(env_dir), None)
 
 
 # ---------------------------------------------------------------------------
@@ -255,3 +305,88 @@ async def test_fire_threads_resolved_cwd_into_spawn_and_wait(tmp_path, monkeypat
     spawn_mock.assert_awaited_once()
     _args, kwargs = spawn_mock.await_args
     assert kwargs.get("cwd") == str(project_dir)
+
+
+# ---------------------------------------------------------------------------
+# Status-reason attribution: a stale action_project path that later fails to
+# spawn is recorded with a specific reason_code, not a generic non-zero exit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_attributes_failure_to_missing_cwd(monkeypatch):
+    """A schedule whose registered project path no longer exists, and whose
+    process then exits non-zero (the daemon-inherited cwd wasn't a fit),
+    writes RunReasons.FAILED_MISSING_CWD instead of the generic
+    FAILED_EXIT_NONZERO -- so the failure is attributable without reading a
+    stack trace."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_get_project = AsyncMock(return_value={"name": "gone", "path": "/no/such/directory/at/all"})
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+    monkeypatch.delenv("LIONAGI_SCHEDULER_CWD", raising=False)
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(action_project="gone")
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(1, "boom")),
+        ),
+    ):
+        await engine._fire(schedule, "run-cwd-002", trigger_context={"scheduled": True})
+
+    terminal_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[:2] == ("schedule_run", "run-cwd-002")
+        and c.kwargs.get("new_status") in ("completed", "failed")
+    ]
+    assert terminal_calls
+    (call,) = terminal_calls
+    assert call.kwargs["reason_code"] == RunReasons.FAILED_MISSING_CWD
+    assert "/no/such/directory/at/all" in call.kwargs["reason_summary"]
+
+
+@pytest.mark.asyncio
+async def test_fire_plain_nonzero_exit_keeps_generic_reason(monkeypatch):
+    """A schedule with no action_project (or a healthy one) that exits
+    non-zero keeps the pre-existing generic FAILED_EXIT_NONZERO reason --
+    this rewrite must not misattribute ordinary failures to a missing cwd."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()  # action_project=None
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(1, "boom")),
+        ),
+    ):
+        await engine._fire(schedule, "run-cwd-003", trigger_context={"scheduled": True})
+
+    terminal_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[:2] == ("schedule_run", "run-cwd-003")
+        and c.kwargs.get("new_status") in ("completed", "failed")
+    ]
+    assert terminal_calls
+    (call,) = terminal_calls
+    assert call.kwargs["reason_code"] == RunReasons.FAILED_EXIT_NONZERO

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -19,7 +19,7 @@ import pytest
 
 from lionagi.studio.scheduler import github as gh_mod
 from lionagi.studio.scheduler.engine import SchedulerEngine
-from lionagi.studio.scheduler.github import GithubPollItem
+from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
 
 
 def _minimal_schedule(**overrides) -> dict:
@@ -109,7 +109,10 @@ async def test_multi_event_poll_fires_once_per_dispatchable_event():
 
     p_build, p_spawn = _spawn_patches()
     with (
-        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=polled, scan_complete=True)),
+        ),
         p_build,
         p_spawn,
     ):
@@ -143,7 +146,10 @@ async def test_single_event_poll_behavior_unchanged():
 
     p_build, p_spawn = _spawn_patches()
     with (
-        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=polled, scan_complete=True)),
+        ),
         p_build,
         p_spawn,
     ):
@@ -185,7 +191,10 @@ async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(ca
 
     p_build, p_spawn = _spawn_patches()
     with (
-        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=polled, scan_complete=True)),
+        ),
         p_build,
         p_spawn,
         caplog.at_level("INFO"),
@@ -233,7 +242,10 @@ async def test_global_slot_exhaustion_mid_batch_stops_cursor_before_undispatched
 
     p_build, p_spawn = _spawn_patches()
     with (
-        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=polled, scan_complete=True)),
+        ),
         patch.object(engine, "_reserve_global_slot", side_effect=_reserve_limited),
         p_build,
         p_spawn,
@@ -269,7 +281,10 @@ async def test_filtered_event_between_dispatched_events_still_advances_cursor():
 
     p_build, p_spawn = _spawn_patches()
     with (
-        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=polled, scan_complete=True)),
+        ),
         p_build,
         p_spawn,
     ):
@@ -286,7 +301,7 @@ async def test_filtered_event_between_dispatched_events_still_advances_cursor():
 # ---------------------------------------------------------------------------
 
 
-def _pr(number, updated):
+def _pr(number, updated, *, state="open", merged_at=None):
     return {
         "number": number,
         "title": f"PR {number}",
@@ -295,14 +310,18 @@ def _pr(number, updated):
         "updated_at": updated,
         "draft": False,
         "head": {"sha": f"sha{number}"},
+        "state": state,
+        "merged_at": merged_at,
     }
 
 
 class _FakeResp:
-    def __init__(self, prs):
+    def __init__(self, prs, link=None):
         self._prs = prs
         self.status_code = 200
         self.headers = {"x-ratelimit-remaining": "100", "etag": '"abc"'}
+        if link:
+            self.headers["link"] = link
 
     def json(self):
         return self._prs
@@ -314,6 +333,27 @@ class _FakeClient:
 
     async def get(self, url, headers=None, params=None):
         return _FakeResp(self._prs)
+
+
+class _FakePaginatedClient:
+    """Serves a fixed page sequence, each carrying a Link: rel="next" header
+    except the last -- mirrors the fake used in test_github_poller.py for
+    exercising github_poll()'s merged-mode pagination loop end to end."""
+
+    def __init__(self, pages: list[list[dict]]):
+        self._pages = pages
+        self.requests: list[dict] = []
+
+    async def get(self, url, headers=None, params=None):
+        page_index = len(self.requests)
+        self.requests.append({"url": url, "params": params})
+        prs = self._pages[page_index] if page_index < len(self._pages) else []
+        has_next = page_index + 1 < len(self._pages)
+        link = None
+        if has_next:
+            next_url = f"https://api.github.com/repos/acme/widgets/pulls?page={page_index + 2}"
+            link = f'<{next_url}>; rel="next"'
+        return _FakeResp(prs, link=link)
 
 
 @pytest.mark.asyncio
@@ -360,5 +400,98 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
 
     # Simulate the next tick's poll with the persisted cursor.
     schedule_next = {**schedule, "github_cursor": persisted_cursor}
-    items = await gh_mod.github_poll(schedule_next)
+    items = (await gh_mod.github_poll(schedule_next)).items
     assert [i.event["pr_number"] for i in items] == [2]
+
+
+# ---------------------------------------------------------------------------
+# Truncated merged-mode scan: no permanent skip, no duplicate dispatch
+# across two consecutive ticks.
+# ---------------------------------------------------------------------------
+
+
+def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None = None):
+    """20 closed PRs at a fixed hour, minutes descending -- one fake
+    "page" of a merged-mode poll response. ``merges`` maps a within-page
+    index to a merged_at value for that PR (closed-but-unmerged otherwise)."""
+    merges = merges or {}
+    items = []
+    for i in range(20):
+        minute = 59 - i * 3
+        updated_at = f"2026-07-06T{hour:02d}:{minute:02d}:00Z"
+        items.append(_pr(base_number + i, updated_at, state="closed", merged_at=merges.get(i)))
+    return items
+
+
+@pytest.mark.asyncio
+async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(monkeypatch):
+    """A merged-mode poll that hits the page cap must not permanently skip an
+    event too close to the unproven boundary, nor re-fire an event it already
+    dispatched, once that event becomes safely reachable on a later poll."""
+    schedule = _minimal_schedule(github_filter={"event": "pr_merged"})
+
+    # Tick 1: 5 full pages of closed PRs (hits _MERGED_MODE_MAX_PAGES).
+    # PR 1405 sits mid-page-5, merged_at close to the truncation boundary --
+    # unsafe to dispatch this poll. PR 1410 merged long before the fetched
+    # window -- safely below the boundary, dispatchable this poll.
+    pages_tick1 = [
+        _closed_page(15, 1000),
+        _closed_page(14, 1100),
+        _closed_page(13, 1200),
+        _closed_page(12, 1300),
+        _closed_page(
+            11,
+            1400,
+            merges={5: "2026-07-06T11:44:00Z", 10: "2020-01-01T00:00:00Z"},
+        ),
+    ]
+
+    async def _fake_token():
+        return "faketoken"
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakePaginatedClient(pages_tick1))
+
+    svc = _make_svc()
+    fired_prs: list[int] = []
+
+    async def _create_schedule_run(payload):
+        fired_prs.append(payload["trigger_context"]["github_events"][0]["pr_number"])
+
+    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: len(fired_prs))
+
+    engine = SchedulerEngine(svc=svc)
+
+    p_build, p_spawn = _spawn_patches()
+    with p_build, p_spawn:
+        await engine._tick_github(schedule, now=10_000.0)
+
+    # Only the safely-below-the-boundary PR fired. PR 1405 (unsafe) did not.
+    assert fired_prs == [1410]
+
+    persisted_cursor = None
+    for call in svc.update_schedule.await_args_list:
+        if "github_cursor" in call.kwargs:
+            persisted_cursor = call.kwargs["github_cursor"]
+    assert persisted_cursor == "2020-01-01T00:00:00Z"
+
+    # Tick 2: the underlying data has moved on (real GitHub would no longer
+    # surface the now-stale closed-unmerged noise ahead of PR 1405) -- a
+    # single short page is enough this time, so the scan completes safely.
+    pages_tick2 = [
+        [
+            _pr(2000, "2026-07-06T12:00:00Z", state="closed", merged_at=None),
+            _pr(1405, "2026-07-06T11:44:00Z", state="closed", merged_at="2026-07-06T11:44:00Z"),
+        ]
+    ]
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakePaginatedClient(pages_tick2))
+
+    schedule_next = {**schedule, "github_cursor": persisted_cursor, "last_fired_at": 10_000.0}
+    p_build2, p_spawn2 = _spawn_patches()
+    with p_build2, p_spawn2:
+        await engine._tick_github(schedule_next, now=20_000.0)
+
+    # PR 1405 is now dispatched exactly once; PR 1410 (already dispatched in
+    # tick 1) is not re-fired.
+    assert fired_prs == [1410, 1405]

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -430,10 +430,12 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     dispatched, once that event becomes safely reachable on a later poll."""
     schedule = _minimal_schedule(github_filter={"event": "pr_merged"})
 
-    # Tick 1: 5 full pages of closed PRs (hits _MERGED_MODE_MAX_PAGES).
-    # PR 1405 sits mid-page-5, merged_at close to the truncation boundary --
-    # unsafe to dispatch this poll. PR 1410 merged long before the fetched
-    # window -- safely below the boundary, dispatchable this poll.
+    # Tick 1: 5 full pages of closed PRs (hits _MERGED_MODE_MAX_PAGES). The
+    # 5th page itself is full and links to a 6th (never fetched) page, so it
+    # is genuinely unsafe -- not a short/terminal page. PR 1405 sits mid
+    # page 5, merged_at close to the truncation boundary -- unsafe to
+    # dispatch this poll. PR 1410 merged long before the fetched window --
+    # safely below the boundary, dispatchable this poll.
     pages_tick1 = [
         _closed_page(15, 1000),
         _closed_page(14, 1100),
@@ -444,6 +446,7 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
             1400,
             merges={5: "2026-07-06T11:44:00Z", 10: "2020-01-01T00:00:00Z"},
         ),
+        _closed_page(10, 1500),  # 6th page: proves page 5 had a real next link.
     ]
 
     async def _fake_token():

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -1,0 +1,364 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SchedulerEngine._tick_github()'s fire-per-event dispatch.
+
+A poll window can turn up more than one new/updated PR. Each dispatchable PR
+must get its own top-level fire (its own trigger_context, its own max_runs +
+global-slot reservation) rather than a single fire seeing only the first
+event. The persisted github_cursor must advance only past PRs that were
+actually dispatched (or intentionally filtered out) -- never past a PR that
+was skipped for lack of budget/slot, or it would never be re-listed again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.studio.scheduler import github as gh_mod
+from lionagi.studio.scheduler.engine import SchedulerEngine
+from lionagi.studio.scheduler.github import GithubPollItem
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "github_poll",
+        "github_repo": "acme/widgets",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "handle {{pr_number}}",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+        "last_fired_at": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    return svc
+
+
+def _item(pr_number, updated_at, *, dispatchable=True):
+    return GithubPollItem(
+        event={
+            "pr_number": pr_number,
+            "pr_title": f"PR {pr_number}",
+            "pr_url": f"https://github.com/acme/widgets/pull/{pr_number}",
+            "pr_author": "octocat",
+            "updated_at": updated_at,
+            "head_sha": f"sha{pr_number}",
+            "draft": False,
+        },
+        updated_at=updated_at,
+        dispatchable=dispatchable,
+    )
+
+
+def _spawn_patches():
+    return (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-event poll -> N fires, each single-event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_event_poll_fires_once_per_dispatchable_event():
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    polled = [
+        _item(1, "2026-07-07T10:00:00Z"),
+        _item(2, "2026-07-07T11:00:00Z"),
+        _item(3, "2026-07-07T12:00:00Z"),
+    ]
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        p_build,
+        p_spawn,
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    # One create_invocation per dispatched event -- not one for the whole batch.
+    assert svc.create_invocation.await_count == 3
+    contexts = [
+        call.args[0]["trigger_context"]["github_events"]
+        for call in svc.create_schedule_run.await_args_list
+    ]
+    assert [ctx[0]["pr_number"] for ctx in contexts] == [1, 2, 3]
+    for ctx in contexts:
+        assert len(ctx) == 1  # each fire's trigger_context carries exactly its own event
+
+    # Cursor advances to the newest dispatched event.
+    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T12:00:00Z")
+    assert engine._global_inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_single_event_poll_behavior_unchanged():
+    """A single-event poll fires exactly once, with the same single-event
+    trigger_context shape as the multi-event case (regression guard for the
+    common case)."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    polled = [_item(7, "2026-07-07T10:00:00Z")]
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        p_build,
+        p_spawn,
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert svc.create_invocation.await_count == 1
+    (run_payload,), _ = svc.create_schedule_run.await_args
+    assert [e["pr_number"] for e in run_payload["trigger_context"]["github_events"]] == [7]
+    assert run_payload["trigger_context"]["repo"] == "acme/widgets"
+    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T10:00:00Z")
+    assert engine._global_inflight == 0
+
+
+# ---------------------------------------------------------------------------
+# Budget exhaustion mid-batch -> cursor stops before first undispatched event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(caplog):
+    svc = _make_svc()
+    fired = 0
+
+    async def _create_schedule_run(_payload):
+        nonlocal fired
+        fired += 1
+
+    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
+
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=2)
+
+    polled = [
+        _item(1, "2026-07-07T10:00:00Z"),
+        _item(2, "2026-07-07T11:00:00Z"),
+        _item(3, "2026-07-07T12:00:00Z"),
+    ]
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        p_build,
+        p_spawn,
+        caplog.at_level("INFO"),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    # Only the first two (max_runs=2) fired.
+    assert fired == 2
+    assert svc.create_invocation.await_count == 2
+
+    # Cursor stops at PR 2's updated_at, not PR 3's -- PR 3 was never dispatched.
+    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T11:00:00Z")
+    cursor_calls = [c for c in svc.update_schedule.await_args_list if "github_cursor" in c.kwargs]
+    assert all(c.kwargs["github_cursor"] != "2026-07-07T12:00:00Z" for c in cursor_calls)
+
+    # The drop is logged with schedule id and the deferred PR number.
+    assert any(
+        "sched-001" in r.message and "3" in r.message and "max_runs" in r.message
+        for r in caplog.records
+    )
+    assert engine._global_inflight == 0
+    assert engine._max_runs_inflight.get("sched-001", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_global_slot_exhaustion_mid_batch_stops_cursor_before_undispatched(caplog):
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    polled = [
+        _item(1, "2026-07-07T10:00:00Z"),
+        _item(2, "2026-07-07T11:00:00Z"),
+    ]
+
+    real_reserve = engine._reserve_global_slot
+    call_count = 0
+
+    async def _reserve_limited():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return await real_reserve()
+        return False, None
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        patch.object(engine, "_reserve_global_slot", side_effect=_reserve_limited),
+        p_build,
+        p_spawn,
+        caplog.at_level("INFO"),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert svc.create_invocation.await_count == 1
+    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T10:00:00Z")
+    assert any(
+        "sched-001" in r.message and "2" in r.message and "concurrent-fire" in r.message
+        for r in caplog.records
+    )
+    assert engine._global_inflight == 0
+
+
+# ---------------------------------------------------------------------------
+# Draft-filtered events interleaved with dispatchable ones
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filtered_event_between_dispatched_events_still_advances_cursor():
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    polled = [
+        _item(1, "2026-07-07T10:00:00Z", dispatchable=True),
+        _item(2, "2026-07-07T11:00:00Z", dispatchable=False),
+        _item(3, "2026-07-07T12:00:00Z", dispatchable=True),
+    ]
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock(return_value=polled)),
+        p_build,
+        p_spawn,
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert svc.create_invocation.await_count == 2
+    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T12:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# Cursor/re-listing regression: an event dropped for budget must reappear on
+# the next real github_poll() call once the persisted cursor reflects only
+# what was actually dispatched.
+# ---------------------------------------------------------------------------
+
+
+def _pr(number, updated):
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "html_url": f"https://github.com/acme/widgets/pull/{number}",
+        "user": {"login": "octocat"},
+        "updated_at": updated,
+        "draft": False,
+        "head": {"sha": f"sha{number}"},
+    }
+
+
+class _FakeResp:
+    def __init__(self, prs):
+        self._prs = prs
+        self.status_code = 200
+        self.headers = {"x-ratelimit-remaining": "100", "etag": '"abc"'}
+
+    def json(self):
+        return self._prs
+
+
+class _FakeClient:
+    def __init__(self, prs):
+        self._prs = prs
+
+    async def get(self, url, headers=None, params=None):
+        return _FakeResp(self._prs)
+
+
+@pytest.mark.asyncio
+async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
+    """End-to-end across the github_poll/_tick_github boundary: a poll that
+    finds two new PRs but can only afford to dispatch one persists a cursor
+    that still sits before the undispatched PR, so a subsequent github_poll()
+    call (as the next tick would issue) returns it again instead of silently
+    dropping it forever."""
+    # The real GitHub API returns PRs sorted by updated_at desc (newest
+    # first) -- github_poll() reverses this to oldest-first before handing
+    # items to the engine, so the fake response here must match that order.
+    prs = [_pr(2, "2026-07-07T11:00:00Z"), _pr(1, "2026-07-07T10:00:00Z")]
+
+    async def _fake_token():
+        return "faketoken"
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakeClient(prs))
+
+    svc = _make_svc()
+    fired = 0
+
+    async def _create_schedule_run(_payload):
+        nonlocal fired
+        fired += 1
+
+    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
+
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=1)
+
+    p_build, p_spawn = _spawn_patches()
+    with p_build, p_spawn, caplog.at_level("INFO"):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert fired == 1
+    persisted_cursor = None
+    for call in svc.update_schedule.await_args_list:
+        if "github_cursor" in call.kwargs:
+            persisted_cursor = call.kwargs["github_cursor"]
+    assert persisted_cursor == "2026-07-07T10:00:00Z"
+
+    # Simulate the next tick's poll with the persisted cursor.
+    schedule_next = {**schedule, "github_cursor": persisted_cursor}
+    items = await gh_mod.github_poll(schedule_next)
+    assert [i.event["pr_number"] for i in items] == [2]

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -277,9 +277,14 @@ async def test_tick_github_releases_slot_when_max_runs_reservation_raises(monkey
 
     monkeypatch.setattr(engine, "_reserve_max_runs_budget", _boom)
 
+    from lionagi.studio.scheduler.github import GithubPollItem
+
+    poll_result = [
+        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
+    ]
     with patch(
         "lionagi.studio.scheduler.github.github_poll",
-        new=AsyncMock(return_value=[{"number": 1}]),
+        new=AsyncMock(return_value=poll_result),
     ):
         with pytest.raises(RuntimeError, match="count query failed"):
             await engine._tick_github(schedule, now=10_000.0)
@@ -299,10 +304,15 @@ async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
         trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
     )
 
+    from lionagi.studio.scheduler.github import GithubPollItem
+
+    poll_result = [
+        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
+    ]
     with (
         patch(
             "lionagi.studio.scheduler.github.github_poll",
-            new=AsyncMock(return_value=[{"number": 1}]),
+            new=AsyncMock(return_value=poll_result),
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.build_argv",

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -247,9 +247,11 @@ async def test_tick_github_releases_slot_on_no_events(monkeypatch):
         trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
     )
 
+    from lionagi.studio.scheduler.github import GithubPollResult
+
     with patch(
         "lionagi.studio.scheduler.github.github_poll",
-        new=AsyncMock(return_value=[]),
+        new=AsyncMock(return_value=GithubPollResult(items=[], scan_complete=True)),
     ):
         await engine._tick_github(schedule, now=10_000.0)
 
@@ -277,11 +279,16 @@ async def test_tick_github_releases_slot_when_max_runs_reservation_raises(monkey
 
     monkeypatch.setattr(engine, "_reserve_max_runs_budget", _boom)
 
-    from lionagi.studio.scheduler.github import GithubPollItem
+    from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
 
-    poll_result = [
-        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
-    ]
+    poll_result = GithubPollResult(
+        items=[
+            GithubPollItem(
+                event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True
+            )
+        ],
+        scan_complete=True,
+    )
     with patch(
         "lionagi.studio.scheduler.github.github_poll",
         new=AsyncMock(return_value=poll_result),
@@ -314,11 +321,16 @@ async def test_tick_github_max_runs_refusal_does_not_crash_when_cap_unlimited(mo
 
     monkeypatch.setattr(engine, "_reserve_max_runs_budget", _refuse)
 
-    from lionagi.studio.scheduler.github import GithubPollItem
+    from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
 
-    poll_result = [
-        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
-    ]
+    poll_result = GithubPollResult(
+        items=[
+            GithubPollItem(
+                event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True
+            )
+        ],
+        scan_complete=True,
+    )
     with patch(
         "lionagi.studio.scheduler.github.github_poll",
         new=AsyncMock(return_value=poll_result),
@@ -344,11 +356,16 @@ async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
         trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
     )
 
-    from lionagi.studio.scheduler.github import GithubPollItem
+    from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
 
-    poll_result = [
-        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
-    ]
+    poll_result = GithubPollResult(
+        items=[
+            GithubPollItem(
+                event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True
+            )
+        ],
+        scan_complete=True,
+    )
     with (
         patch(
             "lionagi.studio.scheduler.github.github_poll",

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -293,6 +293,46 @@ async def test_tick_github_releases_slot_when_max_runs_reservation_raises(monkey
 
 
 @pytest.mark.asyncio
+async def test_tick_github_max_runs_refusal_does_not_crash_when_cap_unlimited(monkeypatch):
+    # With MAX_SCHEDULED_CONCURRENT=0 (unlimited), _reserve_global_slot()
+    # returns (True, None) -- an allowed no-op claim, same shape as every
+    # other call site. The per-event finally block that releases the slot
+    # on a dropped/refused event must guard for that None claim rather than
+    # unconditionally calling .release() on it.
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 0)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
+    )
+
+    async def _refuse(_schedule):
+        return False, None
+
+    monkeypatch.setattr(engine, "_reserve_max_runs_budget", _refuse)
+
+    from lionagi.studio.scheduler.github import GithubPollItem
+
+    poll_result = [
+        GithubPollItem(event={"pr_number": 1}, updated_at="2026-07-07T10:00:00Z", dispatchable=True)
+    ]
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(return_value=poll_result),
+    ):
+        # Must complete without raising AttributeError on slot_claim.release().
+        await engine._tick_github(schedule, now=10_000.0)
+
+    # Refused for lack of max_runs budget -- the cursor must not advance
+    # past the undispatched event, so it is re-listed on the next poll.
+    assert engine._global_inflight == 0
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
     import lionagi.studio.config as studio_config
     from lionagi.studio.scheduler.engine import SchedulerEngine


### PR DESCRIPTION
## Summary

Scheduler GitHub-trigger hardening — the fix set behind the pr-merge-review schedule's ~50% failure rate, and the foundation for reviving event-driven PR review (OBSERVER W1).

**Fire per event, not per poll** (`36159e1b0`): `github_poll()` returns structured per-event items (oldest-first) instead of a single "something changed" signal; the engine loops per event with per-event max_runs/global-slot claims, and the cursor advances only past events actually dispatched (or explicitly dropped) — a burst of PRs no longer collapses into one fire that loses the rest.

**Stale cwd attribution + merged-PR mode + filter validation** (`ff15f75f8`): a deleted `action_project` cwd now fails the run with its own reason code instead of a generic spawn error; `github_filter.event=pr_merged` polls closed PRs and dispatches on `merged_at`; the service write boundary validates `github_filter` keys/events against an allowlist matching what the frontend ships.

**Bounded merged-mode pagination** (`95766dcc4` + `9499fcd3b` + `151db3838`): merged events sort by `updated_at` but dispatch on `merged_at`, so first-page noise could starve older merges. The poller now follows `Link: rel="next"` up to 5 pages, stopping at any page that proves the boundary (short page, no next link, or cursor reached). The scan's completeness is an explicit part of the poll result: a truncated scan (cap with a genuine next page beyond, or a mid-scan fetch error) defers boundary events entirely rather than dispatching them, so the cursor provably never advances past an unseen merge — no permanent skips, no duplicate fires (pinned by two-tick tests). A final page that is itself terminal counts as complete even when it lands exactly on the cap.

Plus a cap-zero guard: `MAX_SCHEDULED_CONCURRENT=0` (unlimited) no longer crashes the per-event max-runs refusal path on a `None` slot claim.

## Review

Iterated through four high-effort reviewer rounds to a clean APPROVE: round 1 (merged-mode starvation, cap-zero crash), round 2 (truncated-scan cursor advance skipping unseen merges), round 3 (safe terminal page misclassified as truncated — proven with a live reproducer), round 4 clean, no nits.

## Tests

`tests/studio/`: 284 passed. New coverage: per-event dispatch/claims, cwd attribution, filter validation, merged-mode pagination starvation, cap/error truncation deferral, terminal-page-at-cap classification, two-tick no-skip/no-duplicate, cap-zero refusal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
