### PR TITLE
feat(studio): observer self-health — alarm on the github poller's own blindness

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -837,6 +837,8 @@ class StateDB:
                           project             TEXT,
                           threshold_config    JSON,
                           last_alert_at       REAL,
+                          last_healthy_poll_at    REAL,
+                          poller_consecutive_401  INTEGER NOT NULL DEFAULT 0,
                           created_at          REAL    NOT NULL,
                           updated_at          REAL    NOT NULL
                         )
@@ -2129,6 +2131,8 @@ class StateDB:
             "project",
             "threshold_config",
             "last_alert_at",
+            "last_healthy_poll_at",
+            "poller_consecutive_401",
         }
         bad = set(fields) - allowed
         if bad:
@@ -2321,16 +2325,58 @@ class StateDB:
             "SELECT COALESCE(SUM(total_cost_usd), 0) AS n FROM sessions "
             "WHERE COALESCE(ended_at, started_at, created_at) >= :window_start"
         ),
+        # Attribution metric, not an alarm on its own (github_poll_healthy_age_minutes
+        # is) -- counts consecutive 401s across enabled github_poll schedules so an
+        # alert payload can tell "token problem" apart from "network blip". Point-in-
+        # time like the age gauge below; :window_start is unused (query doesn't
+        # reference it) but the dict lookup + single-aggregate shape are still the
+        # cleanest fit here.
+        "github_poll_consecutive_401": (
+            "SELECT COALESCE(MAX(poller_consecutive_401), 0) AS n FROM schedules "
+            "WHERE trigger_type = 'github_poll' AND enabled = 1"
+        ),
     }
 
     async def metric_value(self, metric: str, window_start: float) -> float:
         """Aggregate a threshold-alert metric over [window_start, now).
 
-        ``failed_sessions`` and ``total_cost_usd`` are single-aggregate SQL
-        queries; ``p95_latency_ms`` needs a sorted sample (SQLite has no
-        built-in percentile function), so it fetches raw invocation
+        ``failed_sessions``, ``total_cost_usd``, and ``github_poll_consecutive_401``
+        are single-aggregate SQL queries; ``p95_latency_ms`` needs a sorted sample
+        (SQLite has no built-in percentile function), so it fetches raw invocation
         durations and computes the 95th percentile in Python.
+        ``github_poll_healthy_age_minutes`` is also handled specially: unlike every
+        other metric here, it is a point-in-time gauge (minutes since the last
+        healthy github_poll() read) rather than a [window_start, now) aggregate, so
+        ``window_start`` is accepted for signature parity but ignored -- "now" is
+        read fresh via ``time.time()`` inside this method instead of being threaded
+        through from the caller, since recovering it from ``window_start`` would
+        also require ``window_minutes`` (not available here).
         """
+        if metric == "github_poll_healthy_age_minutes":
+            async with self._read() as conn:
+                row = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT MAX(last_healthy_poll_at) AS n FROM schedules "
+                                "WHERE trigger_type = 'github_poll' AND enabled = 1"
+                            )
+                        )
+                    )
+                    .mappings()
+                    .first()
+                )
+            last_healthy = row["n"] if row else None
+            if last_healthy is None:
+                # No enabled github_poll schedule has ever recorded a healthy
+                # poll -- including the case where no github_poll schedule
+                # exists at all. There is nothing to be blind about, so
+                # report a fresh (zero) age rather than a stale one that
+                # would falsely alarm a threshold-alert schedule watching
+                # this metric on a DB with no observed repo yet.
+                return 0.0
+            return (time.time() - float(last_healthy)) / 60.0
+
         if metric == "p95_latency_ms":
             async with self._read() as conn:
                 rows = (

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -451,6 +451,14 @@ CREATE TABLE IF NOT EXISTS schedules (
   -- (no refire until window_minutes has elapsed since the last alert).
   threshold_config    JSON,
   last_alert_at       REAL,
+  -- Observer self-health (github_poll poller): last_healthy_poll_at is
+  -- stamped on any 2xx/304 github_poll() read (including a healthy-empty
+  -- one); poller_consecutive_401 counts consecutive 401s and resets only
+  -- on a healthy read (a transient error/non-200 between 401s does not
+  -- reset the run). Read by the github_poll_healthy_age_minutes /
+  -- github_poll_consecutive_401 threshold metrics.
+  last_healthy_poll_at    REAL,
+  poller_consecutive_401  INTEGER NOT NULL DEFAULT 0,
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL
 );

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -518,6 +518,15 @@ schedules = Table(
     # anchor -- see schema.sql for the fuller comment).
     Column("threshold_config", JSON),
     Column("last_alert_at", Float),
+    # Observer self-health (github_poll poller): last_healthy_poll_at is
+    # stamped on any 2xx/304 github_poll() read (including a healthy-empty
+    # one); poller_consecutive_401 counts consecutive 401s and resets only
+    # on a healthy read (a transient error/non-200 between 401s does not
+    # reset the run). Read by StateDB.metric_value's
+    # github_poll_healthy_age_minutes / github_poll_consecutive_401
+    # threshold metrics -- see SchedulerEngine._tick_github for the stamp.
+    Column("last_healthy_poll_at", Float),
+    Column("poller_consecutive_401", Integer, nullable=False, server_default="0"),
     Column("created_at", Float, nullable=False),
     Column("updated_at", Float, nullable=False),
 )

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -98,6 +98,10 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         # config blob + the cooldown timestamp of the last breach fire.
         ("threshold_config", "JSON"),
         ("last_alert_at", "REAL"),
+        # Observer self-health: last healthy (2xx/304) github_poll() read,
+        # and the consecutive-401 counter (resets only on a healthy read).
+        ("last_healthy_poll_at", "REAL"),
+        ("poller_consecutive_401", "INTEGER NOT NULL DEFAULT 0"),
     ],
     "schedule_runs": [
         # ADR-0028: schedule_runs originally had no updated_at.

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1039,7 +1039,8 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         metavar="JSON",
         help=(
             "Metric threshold alert config as a JSON object: "
-            '{"metric": "failed_sessions|total_cost_usd|p95_latency_ms", '
+            '{"metric": "failed_sessions|total_cost_usd|p95_latency_ms|'
+            'github_poll_healthy_age_minutes|github_poll_consecutive_401", '
             '"op": "gt|gte", "value": N, "window_minutes": N}. When set, '
             "this schedule's own cron/interval cadence only evaluates the "
             "metric on each tick and fires the action only when the "

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -595,6 +595,25 @@ class SchedulerEngine:
                     schedule.get("name"),
                     sid,
                 )
+
+            # Observer self-health: stamp the schedule's health columns from
+            # this poll's outcome regardless of whether it returned items --
+            # a healthy-empty poll ("ok") must reset the blind clock exactly
+            # like a poll that found PRs, so a quiet repo never false-alarms
+            # on github_poll_healthy_age_minutes. "error" (network failure,
+            # missing/invalid repo, no token available) leaves both columns
+            # untouched -- the age metric climbs on its own since
+            # last_healthy_poll_at doesn't move.
+            if poll_result.poll_status == "ok":
+                await self._svc.update_schedule(
+                    sid, last_healthy_poll_at=now, poller_consecutive_401=0
+                )
+            elif poll_result.poll_status == "auth_error":
+                await self._svc.update_schedule(
+                    sid,
+                    poller_consecutive_401=(schedule.get("poller_consecutive_401") or 0) + 1,
+                )
+
             if not polled:
                 return
 

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import httpx
 
@@ -50,10 +50,24 @@ class GithubPollResult(NamedTuple):
     counts; ``scan_complete`` exists for observability -- e.g. logging that
     some events near the cursor boundary are being held for a later poll,
     when a deeper or safely-bounded scan may resolve them.
+
+    ``poll_status`` distinguishes a healthy-but-empty poll from a poll that
+    couldn't actually see GitHub -- ``items == []`` alone is ambiguous
+    between "nothing new" and "blind" (a 401 or a network failure also
+    returns no items). ``"ok"`` is any 2xx or 304 (not-modified, itself a
+    successful authenticated read); ``"auth_error"`` is a 401 that survived
+    the gh-CLI-token fallback retry; ``"error"`` covers everything else that
+    prevented a real poll (network exception, missing/invalid github_repo,
+    no token available, or a non-200/304/401 status). The caller
+    (``SchedulerEngine._tick_github``) uses this to stamp the schedule's
+    observer-self-health columns. Defaults to ``"ok"`` so existing call
+    sites that construct a ``GithubPollResult`` directly (tests, mocks)
+    don't need updating.
     """
 
     items: list[GithubPollItem]
     scan_complete: bool
+    poll_status: Literal["ok", "auth_error", "error"] = "ok"
 
 
 _client: httpx.AsyncClient | None = None
@@ -244,7 +258,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     """
     repo = schedule.get("github_repo")
     if not repo:
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     # Defense-in-depth: validate format before interpolating into the API URL.
     # The service write boundary applies the same check via _svc_validate_github_repo
@@ -260,12 +274,12 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             schedule.get("name"),
             repo,
         )
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     token = await _get_gh_token()
     if not token:
         _log.warning("No GitHub token available for polling %s", repo)
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {token}",
@@ -301,7 +315,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         )
     except httpx.HTTPError:
         _log.exception("GitHub API request failed for %s", repo)
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     # A 401 means the token we used is bad — most often a GITHUB_TOKEN that was
     # valid when the daemon launched but has since expired. Fall through to a
@@ -320,10 +334,10 @@ async def github_poll(schedule: dict) -> GithubPollResult:
                 )
             except httpx.HTTPError:
                 _log.exception("GitHub API request failed for %s", repo)
-                return GithubPollResult(items=[], scan_complete=True)
+                return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     if resp.status_code == 304:
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="ok")
 
     if resp.status_code == 401:
         _log.error(
@@ -334,11 +348,11 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             schedule.get("id"),
             schedule.get("name"),
         )
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="auth_error")
 
     if resp.status_code != 200:
         _log.warning("GitHub API returned %d for %s", resp.status_code, repo)
-        return GithubPollResult(items=[], scan_complete=True)
+        return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
     remaining = int(resp.headers.get("x-ratelimit-remaining", "60"))
     if remaining < 10:
@@ -475,4 +489,4 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     # caller's incremental cursor advance stays monotone in both modes,
     # rather than relying on a bare reversal of API order.
     items.sort(key=lambda it: it.updated_at)
-    return GithubPollResult(items=items, scan_complete=scan_complete)
+    return GithubPollResult(items=items, scan_complete=scan_complete, poll_status="ok")

--- a/lionagi/studio/scheduler/threshold.py
+++ b/lionagi/studio/scheduler/threshold.py
@@ -14,7 +14,17 @@ from __future__ import annotations
 
 from typing import Any
 
-VALID_METRICS: frozenset[str] = frozenset({"failed_sessions", "total_cost_usd", "p95_latency_ms"})
+VALID_METRICS: frozenset[str] = frozenset(
+    {
+        "failed_sessions",
+        "total_cost_usd",
+        "p95_latency_ms",
+        # Observer self-health (ADR-0027 poller): point-in-time gauges, not
+        # windowed aggregates -- see StateDB.metric_value.
+        "github_poll_healthy_age_minutes",
+        "github_poll_consecutive_401",
+    }
+)
 VALID_OPS: frozenset[str] = frozenset({"gt", "gte"})
 ALLOWED_KEYS: frozenset[str] = frozenset({"metric", "op", "value", "window_minutes"})
 

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -648,3 +648,98 @@ def test_github_poll_401_no_retry_when_cli_token_matches_env(monkeypatch):
     result = _poll_result({"id": "s1", "github_repo": "owner/name"})
     assert result.items == []
     assert len(client.requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# GithubPollResult.poll_status — observer self-health signal
+# ---------------------------------------------------------------------------
+
+
+def test_github_poll_result_with_items_has_ok_status(monkeypatch):
+    """A normal successful poll that finds PRs is 'ok' -- the poller saw GitHub."""
+    _install(monkeypatch, [_pr(7, "2026-07-07T10:00:00Z")])
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.poll_status == "ok"
+
+
+def test_github_poll_healthy_empty_response_has_ok_status(monkeypatch):
+    """A healthy poll that finds nothing new is still 'ok' -- items == [] alone
+    is ambiguous between 'quiet repo' and 'blind poller'; poll_status
+    disambiguates it. This is what lets github_poll_healthy_age_minutes reset
+    to 0 on a quiet repo instead of climbing forever."""
+    _install(monkeypatch, [])
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.items == []
+    assert result.poll_status == "ok"
+
+
+def test_github_poll_401_persisting_after_cli_fallback_has_auth_error_status(monkeypatch):
+    """A 401 that survives the gh-CLI-token retry is 'auth_error', distinct
+    from a plain network/config failure -- this is the tonight's-incident
+    case (expired GITHUB_TOKEN, no durable gh CLI token to fall back to)."""
+    _install_status(monkeypatch, [(401, []), (401, [])])
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.poll_status == "auth_error"
+
+
+def test_github_poll_401_recovered_by_cli_fallback_has_ok_status(monkeypatch):
+    """A 401 that IS recovered by the gh-CLI-token retry is 'ok', not
+    'auth_error' -- the poller actually saw GitHub on the retry."""
+    pr = _pr(42, "2026-07-07T10:00:00Z")
+    _install_status(monkeypatch, [(401, []), (200, [pr])])
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.poll_status == "ok"
+
+
+class _FakeExceptionClient:
+    """Raises httpx.HTTPError on the very first request -- for exercising
+    github_poll's top-level network-failure path (not the pagination one
+    _FakeErrorClient covers)."""
+
+    async def get(self, url, headers=None, params=None):
+        raise httpx.HTTPError("boom")
+
+
+def test_github_poll_network_exception_has_error_status(monkeypatch):
+    """A network failure on the initial request is 'error' -- distinct from
+    'auth_error' so the alert payload doesn't misattribute a network outage
+    to a token problem."""
+
+    async def _fake_token(prefer_cli: bool = False):
+        return "faketoken"
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakeExceptionClient())
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.items == []
+    assert result.poll_status == "error"
+
+
+def test_github_poll_no_token_available_has_error_status(monkeypatch):
+    """No token available at all (env unset, gh CLI unavailable) is 'error',
+    not 'auth_error' -- there was never a credential for GitHub to reject."""
+
+    async def _fake_no_token(prefer_cli: bool = False):
+        return None
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_no_token)
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.items == []
+    assert result.poll_status == "error"
+
+
+def test_github_poll_missing_repo_has_error_status():
+    """A schedule with no github_repo configured never reaches the network --
+    still 'error', not the 'ok' default, so a misconfigured schedule doesn't
+    silently look healthy."""
+    result = asyncio.run(gh_mod.github_poll({"id": "s1"}))
+    assert result.items == []
+    assert result.poll_status == "error"
+
+
+def test_github_poll_result_default_poll_status_is_ok():
+    """GithubPollResult constructed without poll_status (as older call sites
+    and test fixtures do) defaults to 'ok' -- back-compat for direct
+    construction that predates the observer-self-health signal."""
+    result = gh_mod.GithubPollResult(items=[], scan_complete=True)
+    assert result.poll_status == "ok"

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -271,7 +271,11 @@ async def test_tick_github_polls_normally_when_under_budget():
         await engine._tick_github(schedule, now=10_000.0)
 
     mock_poll.assert_awaited_once()
-    svc.update_schedule.assert_not_awaited()
+    # No items to dispatch -> no cursor advance, but the poll was healthy
+    # (poll_status="ok" by default) so it still stamps observer-self-health.
+    svc.update_schedule.assert_awaited_once_with(
+        "sched-001", last_healthy_poll_at=10_000.0, poller_consecutive_401=0
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -498,3 +498,120 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     # PR 1405 is now dispatched exactly once; PR 1410 (already dispatched in
     # tick 1) is not re-fired.
     assert fired_prs == [1410, 1405]
+
+
+# ---------------------------------------------------------------------------
+# Observer self-health: _tick_github stamps last_healthy_poll_at /
+# poller_consecutive_401 from GithubPollResult.poll_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_github_ok_poll_stamps_healthy_and_resets_401_counter():
+    """A healthy poll (even an empty one) sets last_healthy_poll_at = now and
+    zeroes the 401 counter -- this is the reset half of the self-health
+    signal, so a token fix (or a quiet repo) clears a prior alarm."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(poller_consecutive_401=3)
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(
+            return_value=GithubPollResult(items=[], scan_complete=True, poll_status="ok")
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    svc.update_schedule.assert_any_call(
+        "sched-001", last_healthy_poll_at=10_000.0, poller_consecutive_401=0
+    )
+
+
+@pytest.mark.asyncio
+async def test_tick_github_ok_poll_with_items_also_stamps_healthy():
+    """A healthy poll that finds items still stamps the health columns --
+    dispatching PRs doesn't skip the self-health write."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    polled = [_item(1, "2026-07-07T10:00:00Z")]
+
+    p_build, p_spawn = _spawn_patches()
+    with (
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(
+                return_value=GithubPollResult(items=polled, scan_complete=True, poll_status="ok")
+            ),
+        ),
+        p_build,
+        p_spawn,
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    svc.update_schedule.assert_any_call(
+        "sched-001", last_healthy_poll_at=10_000.0, poller_consecutive_401=0
+    )
+
+
+@pytest.mark.asyncio
+async def test_tick_github_auth_error_increments_401_counter_leaves_healthy_at_untouched():
+    """A 401 (surviving the gh-CLI-token fallback) increments the
+    consecutive-401 counter from the schedule's prior value, and does NOT
+    touch last_healthy_poll_at -- the blind clock keeps climbing."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(poller_consecutive_401=2)
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(
+            return_value=GithubPollResult(items=[], scan_complete=True, poll_status="auth_error")
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    svc.update_schedule.assert_any_call("sched-001", poller_consecutive_401=3)
+    for call in svc.update_schedule.await_args_list:
+        assert "last_healthy_poll_at" not in call.kwargs
+
+
+@pytest.mark.asyncio
+async def test_tick_github_auth_error_first_401_counts_from_zero():
+    """A schedule with no prior poller_consecutive_401 (fresh schedule, key
+    absent from the dict) starts the counter at 1 on its first 401, not a
+    crash on a missing key."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()  # no poller_consecutive_401 key at all
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(
+            return_value=GithubPollResult(items=[], scan_complete=True, poll_status="auth_error")
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    svc.update_schedule.assert_any_call("sched-001", poller_consecutive_401=1)
+
+
+@pytest.mark.asyncio
+async def test_tick_github_network_error_leaves_health_columns_untouched():
+    """A network/config failure ('error') writes nothing -- neither counter
+    nor healthy timestamp move, so the age metric climbs purely from the
+    passage of time since the last real healthy poll."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(
+            return_value=GithubPollResult(items=[], scan_complete=True, poll_status="error")
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    svc.update_schedule.assert_not_awaited()

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -339,9 +339,15 @@ async def test_tick_github_max_runs_refusal_does_not_crash_when_cap_unlimited(mo
         await engine._tick_github(schedule, now=10_000.0)
 
     # Refused for lack of max_runs budget -- the cursor must not advance
-    # past the undispatched event, so it is re-listed on the next poll.
+    # past the undispatched event, so it is re-listed on the next poll. The
+    # poll itself was healthy (poll_status="ok" by default), so it still
+    # stamps the observer-self-health columns -- just never github_cursor.
     assert engine._global_inflight == 0
-    svc.update_schedule.assert_not_called()
+    svc.update_schedule.assert_called_once_with(
+        "sched-001", last_healthy_poll_at=10_000.0, poller_consecutive_401=0
+    )
+    for call in svc.update_schedule.call_args_list:
+        assert "github_cursor" not in call.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -869,6 +869,142 @@ async def test_metric_value_unknown_metric_raises():
 
 
 # ---------------------------------------------------------------------------
+# StateDB.metric_value — github_poll_healthy_age_minutes / _consecutive_401
+# (observer self-health)
+# ---------------------------------------------------------------------------
+
+
+async def _make_github_schedule(state, sched_id: str, **overrides):
+    schedule = {
+        "id": sched_id,
+        "name": sched_id,
+        "trigger_type": "github_poll",
+        "github_repo": "acme/widgets",
+        "action_kind": "agent",
+    }
+    schedule.update(overrides)
+    await state.create_schedule(schedule)
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_healthy_age_minutes_small_age_after_recent_stamp():
+    import time
+
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    now = time.time()
+    await _make_github_schedule(state, "sched-gh-1")
+    await state.update_schedule("sched-gh-1", last_healthy_poll_at=now - 60)  # 1 minute ago
+
+    age = await state.metric_value("github_poll_healthy_age_minutes", window_start=0.0)
+    assert 0.5 <= age <= 2.0  # ~1 minute, generous bound for test wall-clock slop
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_healthy_age_minutes_large_after_stale_stamp():
+    import time
+
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    now = time.time()
+    await _make_github_schedule(state, "sched-gh-1")
+    # Stamped healthy 2 hours ago -- e.g. an auth_error poll never moved it since.
+    await state.update_schedule("sched-gh-1", last_healthy_poll_at=now - 7200)
+
+    age = await state.metric_value("github_poll_healthy_age_minutes", window_start=0.0)
+    assert age >= 100.0  # ~120 minutes
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_healthy_age_minutes_sentinel_when_no_github_schedule():
+    """No github_poll schedule exists at all -- must not report a large,
+    alarm-triggering age; there is nothing to be blind about."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    age = await state.metric_value("github_poll_healthy_age_minutes", window_start=0.0)
+    assert age == 0.0
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_healthy_age_minutes_sentinel_when_never_polled():
+    """A github_poll schedule exists but has never recorded a healthy poll
+    (last_healthy_poll_at still NULL) -- same no-alarm sentinel as no
+    schedule at all, not a crash on the NULL."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_github_schedule(state, "sched-gh-1")
+
+    age = await state.metric_value("github_poll_healthy_age_minutes", window_start=0.0)
+    assert age == 0.0
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_healthy_age_minutes_ignores_disabled_schedules():
+    """A disabled github_poll schedule's stamp doesn't count -- only enabled
+    schedules are actually being observed."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    import time
+
+    now = time.time()
+    await _make_github_schedule(state, "sched-gh-1", enabled=0)
+    await state.update_schedule("sched-gh-1", last_healthy_poll_at=now - 60)
+
+    age = await state.metric_value("github_poll_healthy_age_minutes", window_start=0.0)
+    assert age == 0.0  # disabled schedule's healthy stamp is invisible to the metric
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_value_github_poll_consecutive_401_counts_and_resets():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_github_schedule(state, "sched-gh-1")
+
+    # No 401s yet -- defaults to 0.
+    count = await state.metric_value("github_poll_consecutive_401", window_start=0.0)
+    assert count == 0.0
+
+    await state.update_schedule("sched-gh-1", poller_consecutive_401=3)
+    count = await state.metric_value("github_poll_consecutive_401", window_start=0.0)
+    assert count == 3.0
+
+    # A subsequent healthy poll resets it (mirrors the engine's stamp logic).
+    await state.update_schedule("sched-gh-1", poller_consecutive_401=0)
+    count = await state.metric_value("github_poll_consecutive_401", window_start=0.0)
+    assert count == 0.0
+
+    await state.close()
+
+
+# ---------------------------------------------------------------------------
 # create_schedule / update_schedule round-trip threshold_config + last_alert_at
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Observer self-health: alarm on the poller's own blindness

Closes the gap that tonight's dogfooding surfaced: the Studio scheduler's GitHub poller went **silently blind for ~3h** after an expired `GITHUB_TOKEN` made it return empty on 401 with no alarm. The observer that caught 26 merged PRs had no way to catch its own blindness. This adds that.

### The signal

Two new threshold-alert metrics, plugged into the existing `threshold_config → _evaluate_threshold_breach → metric_value → alert action` path (no new alarm machinery):

- **`github_poll_healthy_age_minutes`** (primary alarm) — minutes since the poller last got a healthy authenticated read (any 2xx or 304, **including a healthy-but-empty poll**). One clock, stopped by all three blindness modes — 401/token-expiry, network failure, and a wedged tick loop — and reset to 0 by any healthy read. Because a quiet repo still returns `2xx`-empty, "nothing merged" and "poller is blind" are cleanly distinguished: only the latter lets the clock climb. Intended threshold `> 30` alarms a 3h blindness at 30 min — a 6× tighter blind window.
- **`github_poll_consecutive_401`** (attribution, not an alarm) — consecutive-401 count that rides in the alert payload so the reader sees "token problem, not network blip" and the fix (refresh the token) is obvious from the alert.

### Mechanism

- `GithubPollResult` gains `poll_status: Literal["ok","auth_error","error"]` (default `"ok"`, so existing direct constructions are untouched), set at every `github_poll()` return site — `ok` on 2xx/304, `auth_error` on a 401 that survives the gh-CLI-token fallback, `error` otherwise.
- `SchedulerEngine._tick_github` stamps `last_healthy_poll_at` / `poller_consecutive_401` on the schedule row from that status each tick, **before** the empty-result early-return so a healthy-empty poll still resets the clock.
- `StateDB.metric_value` computes both metrics globally over `WHERE trigger_type = 'github_poll' AND enabled = 1`. Returns `0.0` when no enabled github_poll schedule has ever recorded a healthy poll (incl. none existing) — no false alarm on a fresh DB.
- Two `schedules` columns added via the schema + the reconcile ADD-COLUMN path + the CHECK-rebuild literal, so both fresh and upgraded DBs get them.

### Scope

Global metric (`MAX` across github_poll schedules = "is any poller healthy") — correct for the single-observer setup today. Per-schedule granularity (threading `schedule_id` through `metric_value`) is a named follow-on, not this PR.

### Verification

- Full repo suite green (11270 passed, 0 failed); full `tests/studio/` green (346 passed).
- New tests: `poll_status` coverage on every `github_poll()` path, engine stamp logic (ok resets / auth_error increments / error untouched), and `metric_value` for both metrics incl. the zero-rows sentinel and 401 accumulation.
- High-effort codex review: **APPROVE, 0 findings** — independently confirmed the poll-status flow, quiet-repo reset, zero-row sentinel, 401 accumulation, migration/rebuild safety, and the `github_poll` trigger value. Its one non-blocking wording note (consecutive-401 reset semantics) is folded in.
- `trigger_type = 'github_poll'` verified against the live daemon db (the filter matches the real W1 schedule — no silent zero-rows).

### Not in this PR

The alert schedule itself (`github_poll_healthy_age_minutes > 30`) is authored against the running daemon after merge; its schedule id + first evaluation tick are the deliverable evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
