### PR TITLE
refactor(state): derive schedules rebuild DDL from schema_meta; drop dead monitor helper

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -270,35 +270,6 @@ async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | 
     return None
 
 
-# ── Run manifest helpers ──────────────────────────────────────────────────────
-
-
-def _load_run_manifests(*, since: float | None = None) -> list[dict[str, Any]]:
-    """Read run.json files from RUNS_ROOT, newest first."""
-    if not RUNS_ROOT.exists():
-        return []
-    results: list[dict[str, Any]] = []
-    for run_dir in sorted(RUNS_ROOT.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
-        if not run_dir.is_dir():
-            continue
-        manifest_path = run_dir / "run.json"
-        if not manifest_path.exists():
-            continue
-        try:
-            import json as _json
-
-            manifest = _json.loads(manifest_path.read_text())
-        except (OSError, ValueError):
-            continue
-        mtime = run_dir.stat().st_mtime
-        if since is not None and mtime < since:
-            continue
-        manifest["_mtime"] = mtime
-        manifest["_run_dir"] = str(run_dir)
-        results.append(manifest)
-    return results
-
-
 def _stream_tail(run_dir: Path, branch_id: str, n_lines: int = 5) -> list[str]:
     """Return the last N lines from a stream buffer file."""
     buf_path = run_dir / "stream" / f"{branch_id}.buffer.jsonl"

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -10,8 +10,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import JSON, bindparam, event, inspect, text
+from sqlalchemy import JSON, MetaData, bindparam, event, inspect, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.schema import CreateTable
 
 from lionagi._paths import LIONAGI_HOME
 from lionagi.config import settings
@@ -37,6 +38,7 @@ from lionagi.state.reasons import (
     validate_reason_code as _validate_reason_code,
 )
 from lionagi.state.schema_meta import metadata
+from lionagi.state.schema_meta import schedules as _schedules_table
 from lionagi.state.schema_migrations import MIGRATION_COLUMNS as _MIGRATION_COLUMNS
 
 _RUN_DEFAULTS: dict[str, str] = {
@@ -794,57 +796,16 @@ class StateDB:
             cols = [r["name"] for r in cols_rows]
         col_list = ", ".join(cols)
 
+        # Derive the rebuild DDL from the canonical schema_meta Table rather than
+        # a hand-kept literal, so this migration path can never drift from the
+        # live schema (schema.sql / schema_meta.py parity is test-enforced).
+        rebuild_table = _schedules_table.to_metadata(MetaData(), name="schedules_new")
+        create_stmt = str(CreateTable(rebuild_table).compile(dialect=self._engine.dialect))
+
         async with self._engine.begin() as conn:
             await conn.execute(text("PRAGMA foreign_keys = OFF"))
             try:
-                await conn.execute(
-                    text(
-                        """
-                        CREATE TABLE schedules_new (
-                          id                  TEXT    PRIMARY KEY,
-                          name                TEXT    NOT NULL UNIQUE,
-                          description         TEXT,
-                          enabled             INTEGER NOT NULL DEFAULT 1
-                                              CHECK(enabled IN (0, 1)),
-                          trigger_type        TEXT    NOT NULL
-                                              CHECK(trigger_type IN ('cron', 'interval', 'github_poll')),
-                          cron_expr           TEXT,
-                          interval_sec        INTEGER,
-                          github_repo         TEXT,
-                          github_filter       JSON,
-                          github_cursor       TEXT,
-                          poll_interval_sec   INTEGER,
-                          action_kind         TEXT    NOT NULL
-                                              CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml')),
-                          action_model        TEXT,
-                          action_prompt       TEXT,
-                          action_agent        TEXT,
-                          action_playbook     TEXT,
-                          action_flow_yaml    TEXT,
-                          action_project      TEXT,
-                          action_extra_args   JSON    DEFAULT '[]',
-                          on_success          JSON,
-                          on_fail             JSON,
-                          last_fired_at       REAL,
-                          next_fire_at        REAL,
-                          missed_fire_policy  TEXT    NOT NULL DEFAULT 'skip'
-                                              CHECK(missed_fire_policy IN ('skip', 'run_once')),
-                          overlap_policy      TEXT    NOT NULL DEFAULT 'skip'
-                                              CHECK(overlap_policy IN ('skip', 'allow')),
-                          max_runs            INTEGER,
-                          budget_usd          REAL,
-                          budget_tokens       INTEGER,
-                          project             TEXT,
-                          threshold_config    JSON,
-                          last_alert_at       REAL,
-                          last_healthy_poll_at    REAL,
-                          poller_consecutive_401  INTEGER NOT NULL DEFAULT 0,
-                          created_at          REAL    NOT NULL,
-                          updated_at          REAL    NOT NULL
-                        )
-                        """
-                    )
-                )
+                await conn.execute(text(create_stmt))
                 insert_sql = (
                     f"INSERT INTO schedules_new ({col_list}) SELECT {col_list} FROM schedules"  # noqa: S608
                 )

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -452,6 +452,82 @@ def test_legacy_schedules_table_upgraded_and_flow_yaml_insert_succeeds():
     asyncio.run(_run())
 
 
+def test_legacy_rebuild_yields_full_canonical_columns():
+    """Legacy-table rebuild must reproduce the FULL schema_meta column set.
+
+    Guards the drift risk the old hand-written ``schedules_new`` literal carried:
+    the rebuild DDL is now derived from ``schema_meta.schedules``, so a legacy
+    table (missing later-added columns) must come out of ``StateDB`` open with
+    every canonical column — including the self-health poller columns — and a
+    ``github_poll`` schedule carrying those columns must roundtrip.
+    """
+    import asyncio
+    import os
+    import tempfile
+    import uuid
+
+    import aiosqlite
+
+    from lionagi.state.db import StateDB
+    from lionagi.state.schema_meta import schedules as schedules_table
+
+    async def _run():
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            # Pre-PR minimal schedules table: old CHECK, none of the columns
+            # added after the original schema (no self-health columns).
+            async with aiosqlite.connect(db_path) as raw:
+                await raw.execute("""
+                    CREATE TABLE schedules (
+                        id           TEXT PRIMARY KEY,
+                        name         TEXT NOT NULL UNIQUE,
+                        trigger_type TEXT NOT NULL,
+                        action_kind  TEXT NOT NULL
+                            CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play')),
+                        github_repo  TEXT,
+                        created_at   REAL NOT NULL,
+                        updated_at   REAL NOT NULL
+                    )
+                """)
+                await raw.commit()
+
+            async with StateDB(db_path) as db:
+                async with db._engine.connect() as conn:
+                    from sqlalchemy import text as _text
+
+                    rows = (
+                        (await conn.execute(_text("PRAGMA table_info(schedules)"))).mappings().all()
+                    )
+                got = {r["name"] for r in rows}
+                expected = {c.name for c in schedules_table.columns}
+                assert got == expected, (
+                    f"rebuilt table drifted from schema_meta; "
+                    f"missing={expected - got} extra={got - expected}"
+                )
+
+                # A github_poll schedule using the self-health columns roundtrips.
+                sid = uuid.uuid4().hex[:12]
+                await db.create_schedule(
+                    {
+                        "id": sid,
+                        "name": "poller-health-roundtrip",
+                        "trigger_type": "github_poll",
+                        "action_kind": "agent",
+                        "github_repo": "owner/repo",
+                    }
+                )
+                await db.update_schedule(sid, last_healthy_poll_at=123.0, poller_consecutive_401=2)
+                row = await db.get_schedule(sid)
+            assert row is not None
+            assert row["last_healthy_poll_at"] == 123.0
+            assert row["poller_consecutive_401"] == 2
+        finally:
+            os.unlink(db_path)
+
+    asyncio.run(_run())
+
+
 # ---------------------------------------------------------------------------
 # Regression tests: PATCH validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two tech-debt items from the deletion/drift-risk inventory.

**1. Kill the 4th copy of the schedules schema.** `StateDB._drop_legacy_action_kind_check` (the legacy-table rebuild path) carried a hand-maintained `CREATE TABLE schedules_new (...)` literal — a fourth copy of the schedules schema alongside `schema.sql`, `schema_meta.py`, and `schema_migrations.py`. Any column added to the live schema had to be mirrored here by hand or the migration path would silently reconstruct an out-of-date table on legacy DBs.

Now the rebuild DDL is **derived from the canonical `schema_meta.schedules` Table** via `to_metadata(MetaData(), name="schedules_new")` + `CreateTable().compile(dialect=...)`, so it can never drift. The `schema.sql` parity test is left untouched (still the enforced anchor for `schema_meta`).

**2. Delete dead `_load_run_manifests`** in `cli/monitor.py` (zero callers, confirmed).

## Conditions honored

- `schema.sql` parity test untouched.
- **Added** a drift-guard regression test: a legacy schedules table (old 4-value CHECK, missing later columns) opened through `StateDB` must come out with the **full** `schema_meta` column set — including the self-health poller columns — and a `github_poll` schedule using those columns roundtrips.

## Verification

- Local: `tests/state/`, `tests/studio/`, `tests/cli/` (scheduler/monitor) all green; ruff clean.
- Derived DDL confirmed semantically equivalent to the old literal for SQLite (column set + order relative to INSERT SELECT, CHECK constraints incl. `flow_yaml`, PK, UNIQUE(name), NULLability, defaults).
- `to_metadata` targets a throwaway `MetaData()` — does not mutate the global table.
- High-effort codex review: **APPROVE, 0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)