### PR TITLE
fix(studio): inject hosted API base on Vercel builds so the local-first SPA works

### DIFF
--- a/apps/studio/frontend/HOSTING.md
+++ b/apps/studio/frontend/HOSTING.md
@@ -8,18 +8,27 @@ declared in `vercel.json` alongside a catch-all rewrite to `index.html` (client-
 routing) and long-lived immutable caching for the hashed `/assets/*` bundle files.
 
 At runtime the app resolves its API base URL in this order: an injected
-`window.__STUDIO_API_BASE__` (desktop shell), a build-time `VITE_STUDIO_API_BASE` env
-var, a same-hostname `:8765` guess when served from a Vite dev port, and otherwise the
-same origin the page was loaded from — except when the page itself is served over
-https from a non-localhost hostname (as a hosted static deploy is), in which case it
-defaults to `http://127.0.0.1:8765`, since a real daemon never serves https itself.
+`window.__STUDIO_API_BASE__` (highest priority), a build-time `VITE_STUDIO_API_BASE`
+env var, a same-hostname `:8765` guess when served from a Vite dev port, and otherwise
+the same origin the page was loaded from. Same-origin is the right default for a
+single-origin deploy where one server (a Docker image or reverse proxy) serves both the
+SPA and the API. It is the wrong default for a hosted _static_ deploy, whose origin
+has no API at all — so those deploys must set the base explicitly, via either of the
+first two overrides.
 
-This reflects the app's local-first architecture: the hosted page has no backend of
-its own. It is a static client that talks directly to the operator's own `li studio`
-daemon running on their machine, the same way it would if opened from `localhost`.
-There is no login and no server-side state for the hosted deploy to manage — if the
-daemon isn't running, the app shows a state explaining how to start it and keeps
-retrying rather than rendering broken panels.
+The lion-studio hosted deploy is one of those static deploys, and it is local-first:
+the hosted page has no backend of its own. It is a static client that talks directly to
+the operator's own `li studio` daemon running on their machine, the same way it would if
+opened from `localhost`. So the Vite build injects
+`window.__STUDIO_API_BASE__ = "http://127.0.0.1:8765"` into `index.html` on Vercel builds
+only — gated on the `VERCEL` env var every Vercel build sets, so source and Docker
+single-origin builds (which run the same `vite build`) keep their same-origin default. It
+points every visitor's page at their own loopback daemon. (Loopback `http` from an `https`
+page is exempt from mixed-content blocking, so this works from a hosted TLS origin. Set
+`STUDIO_HOSTED_API_BASE` in the Vercel project env to point at a different base.) There is
+no login and no server-side state for the hosted deploy to manage — if the daemon isn't
+running, the app shows a state explaining how to start it and keeps retrying rather than
+rendering broken panels.
 
 On the CLI side, bare `li studio` (equivalently `li studio --web`) is the mode built
 for this deploy: it starts only the local daemon and prints/opens this hosted URL,

--- a/apps/studio/frontend/vite.config.mts
+++ b/apps/studio/frontend/vite.config.mts
@@ -1,7 +1,37 @@
 import { defineConfig } from 'vitest/config'
+import type { Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import path from 'path'
+
+// The hosted Studio (lion-studio.khive.ai and any Vercel preview) is a static,
+// local-first deploy: its origin has no API of its own, the page talks to the
+// operator's own `li studio` daemon on loopback. resolveApiBase() otherwise
+// falls through to same-origin — correct for a single-origin Docker/reverse-proxy
+// build, wrong here, where same-origin /api/* hits the SPA rewrite and returns
+// index.html. So on Vercel builds ONLY (VERCEL=1 is set by every Vercel build,
+// Git-integration or CLI), inject the loopback base as the highest-priority
+// runtime override. Gating on VERCEL keeps source/Docker single-origin builds
+// (which run the same `vite build`) on their correct same-origin default.
+// Loopback http from an https page is exempt from mixed-content blocking.
+function hostedApiBaseInjector(): Plugin {
+  const onVercel = !!process.env.VERCEL
+  const base = process.env.STUDIO_HOSTED_API_BASE ?? 'http://127.0.0.1:8765'
+  return {
+    name: 'studio-hosted-api-base',
+    apply: 'build',
+    transformIndexHtml() {
+      if (!onVercel) return
+      return [
+        {
+          tag: 'script',
+          children: `window.__STUDIO_API_BASE__=${JSON.stringify(base)};`,
+          injectTo: 'head-prepend',
+        },
+      ]
+    },
+  }
+}
 
 // The e2e harness points this at a seeded daemon on a dynamically-allocated
 // free port (see e2e/global-setup.ts); everyone else keeps the default 8765.
@@ -19,6 +49,7 @@ export default defineConfig({
       generatedRouteTree: './src/routeTree.gen.ts',
     }),
     react(),
+    hostedApiBaseInjector(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## The bug (P0)

The hosted Lion Studio (`lion-studio.khive.ai`) served broken panels — every `/api/*` request returned `index.html` instead of JSON (`Studio API returned HTML instead of JSON for /api/runs/…`).

## Root cause

`resolveApiBase()` falls an https non-localhost origin through to **same-origin** — deliberate, so a single-origin Docker/reverse-proxy deploy resolves `/api/*` to its co-located backend. But the hosted deploy is a **static, local-first** deploy: its origin has no API of its own; the page talks to the operator's own `li studio` daemon on loopback. With no base configured, same-origin `/api/*` hits Vercel's SPA rewrite and returns `index.html`.

## Fix

A Vite plugin (`apps/studio/frontend/vite.config.mts`) injects `window.__STUDIO_API_BASE__ = "http://127.0.0.1:8765"` (the highest-priority override in `resolveApiBase`) into `index.html` — **gated on the `VERCEL` env var** every Vercel build sets. Source and Docker single-origin builds run the same `vite build` and are **untouched** (they keep the same-origin default). Overridable via `STUDIO_HOSTED_API_BASE` in the Vercel project env. Loopback `http` from an `https` page is exempt from mixed-content blocking.

## Verification

- `VERCEL=1 vite build` → global injected as the first `<head>` child (before the app module). Plain build → **nothing** injected (Docker/source safe).
- `tsc --noEmit` clean; `src/lib/api.test.ts` 32/32 pass.
- Daemon CORS allowlist already includes `https://lion-studio.khive.ai` (verified live: GET + preflight both return the allow-origin header) — so pointing the SPA at the loopback daemon is sufficient.
- Post-merge: Vercel Git integration rebuilds and I confirm `lion-studio.khive.ai` loads runs.

## Related finding (separate)

`.github/workflows/studio-vercel-deploy.yml` is a **no-op today** — `VERCEL_TOKEN` is not provisioned, so its deploy step skips while the job still reports success. The live deploy is driven by Vercel's own Git integration, which runs this same `vite build`. That's why this fix lives in the build, not the workflow. Whether to wire the workflow (real deploy + smoke-gate) or retire it is a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)