### PR TITLE
ci(studio): post-deploy smoke so a broken hosted deploy can't report green

### DIFF
--- a/.github/workflows/studio-post-deploy-smoke.yml
+++ b/.github/workflows/studio-post-deploy-smoke.yml
@@ -1,0 +1,85 @@
+name: Studio post-deploy smoke
+
+# A broken Lion Studio deploy must never look green. The hosted SPA is
+# local-first: its own origin serves no API, so resolveApiBase() has to be
+# steered to the operator's loopback daemon by an injected
+# window.__STUDIO_API_BASE__. If that injection regresses (the Vite plugin is
+# removed, or Vercel stops exposing the VERCEL system env var the plugin gates
+# on) the SPA silently falls back to same-origin and every /api/* request
+# returns index.html -- the "Studio API returned HTML instead of JSON" break.
+# There is no CI-reachable JSON endpoint to hit (the hosted origin has no API
+# of its own -- that is the whole point of local-first), so the meaningful
+# post-deploy signal is the served HTML: assert the SPA shell plus the loopback
+# API-base injection are present. When they are not, this turns red instead of
+# shipping a green deploy that does not work.
+
+on:
+  deployment_status:
+  schedule:
+    - cron: "17 13 * * *" # daily drift catch: a Vercel setting flip won't wait for a push
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Studio URL to smoke"
+        required: false
+        default: "https://lion-studio.khive.ai"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: studio-post-deploy-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    # deployment_status fires for every environment and every state; gate on a
+    # successful Production deploy only. schedule/workflow_dispatch always run.
+    if: >-
+      github.event_name != 'deployment_status' ||
+      (github.event.deployment_status.state == 'success' &&
+       github.event.deployment_status.environment == 'Production')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Smoke the hosted Studio
+        env:
+          STUDIO_URL: ${{ github.event.inputs.url || 'https://lion-studio.khive.ai' }}
+        run: |
+          set -euo pipefail
+          url="${STUDIO_URL%/}/"
+          echo "Smoking $url"
+          # The production alias can lag a few seconds behind the
+          # deployment_status event, so retry before failing.
+          attempt=0
+          max=10
+          injection_re='window\.__STUDIO_API_BASE__="http://127\.0\.0\.1:[0-9]+"'
+          while :; do
+            attempt=$((attempt + 1))
+            code=$(curl -sS -o /tmp/index.html -w '%{http_code}' "$url" || echo "000")
+            if [ "$code" = "200" ] \
+               && grep -q 'id="root"' /tmp/index.html \
+               && grep -Eq "$injection_re" /tmp/index.html; then
+              echo "OK: HTTP 200, SPA shell present, loopback API base injected."
+              grep -o 'window\.__STUDIO_API_BASE__="[^"]*"' /tmp/index.html | head -1
+              exit 0
+            fi
+            echo "attempt $attempt/$max not ready (http=$code)"
+            if [ "$attempt" -ge "$max" ]; then
+              echo "::error::Studio smoke FAILED for $url after $max attempts."
+              echo "  HTTP status: $code (want 200)"
+              if grep -q 'id="root"' /tmp/index.html; then
+                echo "  SPA shell (id=\"root\"): present"
+              else
+                echo "  SPA shell (id=\"root\"): MISSING"
+              fi
+              if grep -Eq "$injection_re" /tmp/index.html; then
+                echo "  loopback API base injection: present"
+              else
+                echo "  loopback API base injection: MISSING -- SPA falls back to same-origin and /api/* returns HTML."
+              fi
+              echo "  --- first 40 lines of served HTML ---"
+              head -40 /tmp/index.html || true
+              exit 1
+            fi
+            sleep 15
+          done

--- a/.github/workflows/studio-post-deploy-smoke.yml
+++ b/.github/workflows/studio-post-deploy-smoke.yml
@@ -44,22 +44,35 @@ jobs:
       - name: Smoke the hosted Studio
         env:
           STUDIO_URL: ${{ github.event.inputs.url || 'https://lion-studio.khive.ai' }}
+          # On a Production deployment_status the stable alias can briefly still
+          # serve the PREVIOUS deployment before Vercel promotes it to the new
+          # one -- asserting during that window could pass a broken new deploy
+          # against the old healthy alias (false green). The deployment-specific
+          # *.vercel.app URL would test the exact new build, but it sits behind
+          # Vercel Authentication (302 -> SSO) so CI can't fetch it. So on a
+          # deployment_status event, wait out the promotion window before
+          # asserting; schedule/workflow_dispatch test current state with no wait.
+          GRACE: ${{ github.event_name == 'deployment_status' && '60' || '0' }}
         run: |
           set -euo pipefail
           url="${STUDIO_URL%/}/"
+          # Production contract: the hosted build injects the operator's default
+          # local daemon base. Exact match -- a wrong/missing port is a failure.
+          expected='window.__STUDIO_API_BASE__="http://127.0.0.1:8765"'
           echo "Smoking $url"
-          # The production alias can lag a few seconds behind the
-          # deployment_status event, so retry before failing.
+          if [ "${GRACE:-0}" -gt 0 ]; then
+            echo "deployment_status: waiting ${GRACE}s for production alias promotion before asserting"
+            sleep "$GRACE"
+          fi
           attempt=0
           max=10
-          injection_re='window\.__STUDIO_API_BASE__="http://127\.0\.0\.1:[0-9]+"'
           while :; do
             attempt=$((attempt + 1))
             code=$(curl -sS -o /tmp/index.html -w '%{http_code}' "$url" || echo "000")
             if [ "$code" = "200" ] \
                && grep -q 'id="root"' /tmp/index.html \
-               && grep -Eq "$injection_re" /tmp/index.html; then
-              echo "OK: HTTP 200, SPA shell present, loopback API base injected."
+               && grep -Fq "$expected" /tmp/index.html; then
+              echo "OK: HTTP 200, SPA shell present, production API base injected."
               grep -o 'window\.__STUDIO_API_BASE__="[^"]*"' /tmp/index.html | head -1
               exit 0
             fi
@@ -72,10 +85,12 @@ jobs:
               else
                 echo "  SPA shell (id=\"root\"): MISSING"
               fi
-              if grep -Eq "$injection_re" /tmp/index.html; then
-                echo "  loopback API base injection: present"
+              if grep -Fq "$expected" /tmp/index.html; then
+                echo "  API base injection: present"
               else
-                echo "  loopback API base injection: MISSING -- SPA falls back to same-origin and /api/* returns HTML."
+                echo "  expected injection MISSING -- SPA falls back to same-origin and /api/* returns HTML."
+                echo "  expected: $expected"
+                echo -n "  actual:   "; grep -o 'window\.__STUDIO_API_BASE__="[^"]*"' /tmp/index.html | head -1 || echo "<none>"
               fi
               echo "  --- first 40 lines of served HTML ---"
               head -40 /tmp/index.html || true


### PR DESCRIPTION
## Why

Ocean hit `Studio API returned HTML instead of JSON` on the fresh lion-studio.khive.ai deploy, **and the deploy pipeline reported success**. Root cause (fixed in #1877): the hosted SPA is local-first — its origin serves no API, so `resolveApiBase()` must be steered to the operator's loopback daemon by an injected `window.__STUDIO_API_BASE__`. When that injection is absent the SPA falls back to same-origin and every `/api/*` returns `index.html`.

Vercel's Git-integration deploy can ship that broken state and still report green. This closes the "green deploy that doesn't work" gap.

## What

A smoke workflow that fetches the **live production HTML** and asserts:
1. HTTP 200
2. SPA shell present (`id="root"`)
3. Loopback API-base injection present (`window.__STUDIO_API_BASE__="http://127.0.0.1:<port>"`)

Missing shell or injection → the check goes **red**.

**Triggers:**
- `deployment_status` — gated to Production + success, so it runs right after Vercel reports the deploy ready (the post-deploy gate).
- `schedule` (daily) — catches a Vercel setting flip that wouldn't wait for a push.
- `workflow_dispatch` — manual, with an optional `url` input.

## Design note

There is no CI-reachable JSON endpoint to hit — the hosted origin has no API of its own, by design (local-first). So the served HTML is the meaningful signal; asserting the injection is exactly what catches the failure mode Ocean saw. A JSON-endpoint smoke only applies to a single-origin Docker/reverse-proxy deploy.

## Verification

- YAML parses.
- Smoke logic **passes** against live prod (`200 + shell + window.__STUDIO_API_BASE__="http://127.0.0.1:8765"`).
- Smoke logic **fails** against a page without the injection (negative control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)