### PR TITLE
feat(tools): KhiveInjectionProvider + rule-based writeback after-hook

### DIFF
--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -292,6 +292,9 @@ async def operate(
     if not action_response_models:
         return result
 
+    if branch._context_providers:
+        await branch._context_providers.gather_writeback(branch, action_response_models)
+
     if operative is not None and isinstance(result, BaseModel):
         operative.response_model = result
         operative.update_response_model(data={"action_responses": action_response_models})

--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -130,3 +130,21 @@ class ContextProviderRegistry:
                 report.fired.append({"provider_name": entry.name, "tokens": tokens})
 
         return report
+
+    async def gather_writeback(self, branch: Branch, action_responses: list) -> None:
+        """POST-turn after-hook: providers that declare an optional
+        `writeback(branch, action_responses)` method get a chance to persist a
+        rule-based extraction from the turn's action responses. Same containment
+        discipline as `gather`: a raising provider is warned + skipped, never
+        blocks the turn. Off by default — a provider only does this when its own
+        policy opts in."""
+        for entry in self._entries:
+            hook = getattr(entry.provider, "writeback", None)
+            if hook is None:
+                continue
+            try:
+                await hook(branch, action_responses)
+            except Exception:
+                logger.warning(
+                    "context provider %r writeback raised; skipping", entry.name, exc_info=True
+                )

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""KhiveInjectionProvider: the reference ContextProvider (ADR-0100) that recalls
+(and optionally composes) from a khive daemon and renders the result into the
+pre-turn guidance fold. Talks to khive over the same MCP transport lionagi
+already uses for tool servers (`service.connections.mcp_wrapper`) — no new
+transport, and no khive/MCP import at module load, so the core import path
+stays clean without the `mcp` extra installed."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.instruction import Instruction
+    from lionagi.session.branch import Branch
+
+__all__ = (
+    "RecallPolicy",
+    "ComposePolicy",
+    "WritebackPolicy",
+    "KhiveInjectionPolicy",
+    "KhiveInjectionProvider",
+)
+
+logger = logging.getLogger(__name__)
+
+# Same stdio MCP server shape the khive CLI itself exposes; callers with a
+# non-default install pass their own mcp_config.
+_DEFAULT_MCP_CONFIG = {"command": "kkernel", "args": ["mcp"]}
+_VALID_CADENCE = ("first_turn", "every_turn")
+
+
+@dataclass(frozen=True)
+class RecallPolicy:
+    limit: int = 5
+    min_score: float = 0.4
+    max_tokens: int = 800
+
+
+@dataclass(frozen=True)
+class ComposePolicy:
+    enabled: bool = False
+    max_tokens: int = 2000
+
+
+@dataclass(frozen=True)
+class WritebackPolicy:
+    enabled: bool = False
+    salience_cap: float = 0.4
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class KhiveInjectionPolicy:
+    """Policy block controlling pre-turn khive injection (ADR-0100)."""
+
+    profile_id: str
+    enabled: bool = True
+    snapshot_id: str | None = None
+    recall: RecallPolicy = field(default_factory=RecallPolicy)
+    compose: ComposePolicy = field(default_factory=ComposePolicy)
+    cadence: str = "first_turn"
+    writeback: WritebackPolicy = field(default_factory=WritebackPolicy)
+
+    def __post_init__(self):
+        if not self.profile_id:
+            raise ValueError(
+                "KhiveInjectionPolicy.profile_id is required — a catch-all default "
+                "profile mis-attributes feedback events."
+            )
+        if self.cadence not in _VALID_CADENCE:
+            raise ValueError(f"cadence must be one of {_VALID_CADENCE}, got {self.cadence!r}")
+
+
+async def _call_khive(ops: str, mcp_config: dict) -> Any:
+    """One MCP round-trip to khive's `request` tool. Lazy import: the mcp/fastmcp
+    transport is only touched here, never at module load."""
+    from lionagi.service.connections.mcp_wrapper import MCPConnectionPool, MCPSecurityConfig
+
+    security = MCPSecurityConfig(allow_commands=True, allow_urls=True)
+    client = await MCPConnectionPool.get_client(mcp_config, security=security)
+    result = await client.call_tool("request", {"ops": ops})
+    return _unwrap(result)
+
+
+def _unwrap(result: Any) -> Any:
+    """MCP tool results carry a `.content` list of text blocks; khive's own
+    payload is JSON-encoded text, so decode it back into data."""
+    content = getattr(result, "content", None)
+    if isinstance(content, list) and len(content) == 1:
+        item = content[0]
+        text = getattr(item, "text", None)
+        if text is not None:
+            return _maybe_json(text)
+    if isinstance(result, str):
+        return _maybe_json(result)
+    return result
+
+
+def _maybe_json(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError):
+        return text
+
+
+def _first_op_result(khive_response: Any) -> Any:
+    if not isinstance(khive_response, dict):
+        return None
+    results = khive_response.get("results") or []
+    if not results or not isinstance(results[0], dict):
+        return None
+    return results[0].get("result")
+
+
+def _first_result_id(khive_response: Any) -> str | None:
+    op_result = _first_op_result(khive_response)
+    if isinstance(op_result, list) and op_result and isinstance(op_result[0], dict):
+        rid = op_result[0].get("id")
+        return str(rid) if rid else None
+    return None
+
+
+def _render_recall(khive_response: Any) -> str | None:
+    op_result = _first_op_result(khive_response)
+    if not op_result:
+        return None
+    lines = ["# khive recall"]
+    for item in op_result:
+        if isinstance(item, dict):
+            lines.append(f"- {item.get('content', item)}")
+        else:
+            lines.append(f"- {item}")
+    return "\n".join(lines)
+
+
+def _render_compose(khive_response: Any) -> str | None:
+    op_result = _first_op_result(khive_response)
+    if not op_result:
+        return None
+    if isinstance(op_result, str):
+        return f"# khive compose\n{op_result}"
+    return f"# khive compose\n{op_result}"
+
+
+def _truncate(text: str, max_tokens: int | None) -> str:
+    if not text or not max_tokens or max_tokens <= 0:
+        return text
+
+    from lionagi.service.token_calculator import TokenCalculator
+
+    if TokenCalculator.tokenize(text) <= max_tokens:
+        return text
+
+    lo, hi, best = 0, len(text), ""
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        candidate = text[:mid]
+        if TokenCalculator.tokenize(candidate) <= max_tokens:
+            best = candidate
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return best
+
+
+def _extract_writeback_pairs(action_responses: list) -> list[dict]:
+    """FIFO-pair each tool error with the next response that resolves it.
+    Deliberately rule-based: no LLM summarization on the writeback path."""
+    pairs: list[dict] = []
+    pending: list[dict] = []
+    for resp in action_responses:
+        function = getattr(resp, "function", None)
+        output = getattr(resp, "output", None)
+        is_error = isinstance(output, dict) and "error" in output
+        if is_error:
+            pending.append({"function": function, "error": output.get("error")})
+            continue
+        if pending:
+            err = pending.pop(0)
+            pairs.append(
+                {
+                    "function": err["function"],
+                    "error": err["error"],
+                    "resolved_by": function,
+                    "resolution_output": output,
+                }
+            )
+    return pairs
+
+
+class KhiveInjectionProvider:
+    """Pre-turn ContextProvider (ADR-0100): recall + optional compose against khive,
+    rendered into the guidance fold. Every recall emits `brain.auto_feedback` in the
+    same round-trip with the policy's explicit `profile_id` — khive's auto_feedback
+    does no binding resolution, so an implicit/default profile mis-attributes the event.
+
+    `writeback()` is a separate, opt-in POST-turn hook: rule-based tool
+    error/resolution pairs written to `memory.remember` at capped, low-provenance
+    salience. It is invoked by the operate() Middle, not by `provide()`, and it is not
+    the nudge plane — it writes durable memory, never a tool-result suffix.
+
+    Both `provide()` and `writeback()` are fully contained: any transport failure is
+    logged and swallowed so the turn always proceeds.
+    """
+
+    def __init__(self, policy: KhiveInjectionPolicy, mcp_config: dict | None = None):
+        self.policy = policy
+        self.name = f"khive_injection:{policy.profile_id}"
+        self._mcp_config = dict(mcp_config or _DEFAULT_MCP_CONFIG)
+
+    async def provide(self, branch: Branch, instruction: Instruction) -> str | None:
+        if not self.policy.enabled:
+            return None
+        if not self._should_fire(branch):
+            return None
+
+        query = self._build_query(branch, instruction)
+
+        try:
+            blocks = [b for b in (await self._recall(query), await self._maybe_compose(query)) if b]
+        except Exception:
+            logger.warning(
+                "KhiveInjectionProvider transport failure; degrading to no injection this turn",
+                exc_info=True,
+            )
+            return None
+
+        if not blocks:
+            return None
+
+        text = "\n".join(blocks)
+        cap = self.policy.recall.max_tokens + (
+            self.policy.compose.max_tokens if self.policy.compose.enabled else 0
+        )
+        return _truncate(text, cap)
+
+    async def writeback(self, branch: Branch, action_responses: list) -> None:
+        wb = self.policy.writeback
+        if not wb.enabled:
+            return
+
+        pairs = _extract_writeback_pairs(action_responses)
+        if not pairs:
+            return
+
+        role = getattr(branch, "name", None) or "agent"
+        tags = list(wb.tags) or [f"agent:{role}"]
+        for pair in pairs:
+            content = (
+                f"tool '{pair['function']}' failed ({pair['error']!r}); resolved by "
+                f"'{pair['resolved_by']}', output={pair['resolution_output']!r}"
+            )
+            ops = (
+                f"memory.remember(content={json.dumps(content)}, "
+                f"salience={wb.salience_cap}, tags={json.dumps(tags)})"
+            )
+            try:
+                await _call_khive(ops, self._mcp_config)
+            except Exception:
+                logger.warning("KhiveInjectionProvider writeback failed; skipping", exc_info=True)
+                return
+
+    def _should_fire(self, branch: Branch) -> bool:
+        if self.policy.cadence == "every_turn":
+            return True
+        return branch.msgs.last_response is None
+
+    def _build_query(self, branch: Branch, instruction: Instruction) -> str:
+        task_text = ""
+        if instruction is not None:
+            try:
+                rendered = instruction.rendered
+                task_text = rendered if isinstance(rendered, str) else str(rendered)
+            except Exception:
+                task_text = ""
+        task_text = task_text[:400]
+        role = getattr(branch, "name", None) or "agent"
+        return f"role={role} task={task_text}"
+
+    async def _recall(self, query: str) -> str | None:
+        rp = self.policy.recall
+        ops = (
+            f"memory.recall(query={json.dumps(query)}, limit={rp.limit}, min_score={rp.min_score})"
+        )
+        result = await _call_khive(ops, self._mcp_config)
+
+        first_id = _first_result_id(result)
+        if first_id:
+            fb_ops = (
+                f"brain.auto_feedback(query={json.dumps(query)}, "
+                f"results={json.dumps([{'id': first_id}])}, "
+                f"served_by_profile_id={json.dumps(self.policy.profile_id)})"
+            )
+            try:
+                await _call_khive(fb_ops, self._mcp_config)
+            except Exception:
+                logger.warning("KhiveInjectionProvider auto_feedback failed", exc_info=True)
+
+        return _render_recall(result)
+
+    async def _maybe_compose(self, query: str) -> str | None:
+        if not self.policy.compose.enabled:
+            return None
+        cp = self.policy.compose
+        ops = f"knowledge.compose(query={json.dumps(query)}, max_tokens={cp.max_tokens})"
+        result = await _call_khive(ops, self._mcp_config)
+        return _render_compose(result)

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -149,8 +149,12 @@ def _render_compose(khive_response: Any) -> str | None:
 
 
 def _truncate(text: str, max_tokens: int | None) -> str:
-    if not text or not max_tokens or max_tokens <= 0:
+    """None = uncapped; a non-positive cap is a hard zero budget and suppresses
+    the text entirely."""
+    if not text or max_tokens is None:
         return text
+    if max_tokens <= 0:
+        return ""
 
     from lionagi.service.token_calculator import TokenCalculator
 

--- a/tests/tools/test_khive_injection.py
+++ b/tests/tools/test_khive_injection.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for KhiveInjectionProvider (ADR-0100 PR2): query construction, cadence
+"""Tests for KhiveInjectionProvider (ADR-0100): query construction, cadence
 gating, the recall+auto_feedback round-trip, failure containment, writeback
 extraction, and module-load purity. The khive MCP transport is fully mocked —
 no live daemon required."""
 
+import contextlib
 import json
 import sys
 from unittest.mock import AsyncMock, patch
@@ -435,30 +436,65 @@ async def test_writeback_transport_failure_contained(patched_transport):
 # ---------------------------------------------------------------------------
 
 
-def test_module_import_does_not_pull_in_mcp_transport():
-    for mod in ("fastmcp", "mcp"):
-        sys.modules.pop(mod, None)
+class _TransportImportBlocker:
+    """Meta-path finder that raises on any attempt to import the mcp transport,
+    proving the import never happens rather than merely not being cached."""
 
+    BLOCKED = ("fastmcp", "mcp")
+
+    def find_spec(self, fullname, path=None, target=None):
+        root = fullname.split(".")[0]
+        if root in self.BLOCKED:
+            raise ImportError(f"import of {fullname!r} blocked by purity test")
+        return None
+
+
+@contextlib.contextmanager
+def _blocked_transport():
+    saved = {
+        m: sys.modules.pop(m) for m in list(sys.modules) if m.split(".")[0] in ("fastmcp", "mcp")
+    }
+    blocker = _TransportImportBlocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(blocker)
+        sys.modules.update(saved)
+
+
+def test_module_import_does_not_pull_in_mcp_transport():
     import importlib
 
-    import lionagi.tools.khive_injection as mod_
+    with _blocked_transport():
+        with pytest.raises(ImportError):
+            importlib.import_module("fastmcp")  # the blocker actually blocks
 
-    importlib.reload(mod_)
+        import lionagi.tools.khive_injection as mod_
+
+        importlib.reload(mod_)
 
     assert "fastmcp" not in sys.modules
     assert "mcp" not in sys.modules
 
 
 def test_core_lionagi_import_is_clean():
-    """Mirrors the reference core-only-importability pattern: importing lionagi
-    itself must never require fastmcp/mcp to be installed."""
-    for mod in ("fastmcp", "mcp"):
-        sys.modules.pop(mod, None)
-
+    """Importing lionagi itself must never require fastmcp/mcp to be installed."""
     import importlib
 
-    import lionagi
+    with _blocked_transport():
+        import lionagi
 
-    importlib.reload(lionagi)
+        importlib.reload(lionagi)
 
     assert "fastmcp" not in sys.modules
+
+
+def test_truncate_cap_semantics():
+    from lionagi.tools.khive_injection import _truncate
+
+    assert _truncate("hello world", None) == "hello world"
+    assert _truncate("hello world", 0) == ""
+    assert _truncate("hello world", -1) == ""
+    assert _truncate("", 5) == ""
+    assert _truncate("hi", 10_000) == "hi"

--- a/tests/tools/test_khive_injection.py
+++ b/tests/tools/test_khive_injection.py
@@ -472,10 +472,10 @@ def test_module_import_does_not_pull_in_mcp_transport():
 
         import lionagi.tools.khive_injection as mod_
 
+        # reload under the active blocker: any transport import would raise
         importlib.reload(mod_)
-
-    assert "fastmcp" not in sys.modules
-    assert "mcp" not in sys.modules
+        assert "fastmcp" not in sys.modules
+        assert "mcp" not in sys.modules
 
 
 def test_core_lionagi_import_is_clean():
@@ -485,9 +485,9 @@ def test_core_lionagi_import_is_clean():
     with _blocked_transport():
         import lionagi
 
+        # reload under the active blocker: any transport import would raise
         importlib.reload(lionagi)
-
-    assert "fastmcp" not in sys.modules
+        assert "fastmcp" not in sys.modules
 
 
 def test_truncate_cap_semantics():

--- a/tests/tools/test_khive_injection.py
+++ b/tests/tools/test_khive_injection.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for KhiveInjectionProvider (ADR-0100 PR2): query construction, cadence
+gating, the recall+auto_feedback round-trip, failure containment, writeback
+extraction, and module-load purity. The khive MCP transport is fully mocked —
+no live daemon required."""
+
+import json
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.operations.fields import ActionResponseModel
+from lionagi.tools.khive_injection import (
+    ComposePolicy,
+    KhiveInjectionPolicy,
+    KhiveInjectionProvider,
+    RecallPolicy,
+    WritebackPolicy,
+    _extract_writeback_pairs,
+)
+
+# ---------------------------------------------------------------------------
+# Policy validation
+# ---------------------------------------------------------------------------
+
+
+def test_profile_id_required():
+    with pytest.raises(ValueError, match="profile_id is required"):
+        KhiveInjectionPolicy(profile_id="")
+
+
+def test_invalid_cadence_rejected():
+    with pytest.raises(ValueError, match="cadence must be one of"):
+        KhiveInjectionPolicy(profile_id="implementer-recall-v1", cadence="on_task_shift")
+
+
+def test_defaults_mirror_design_yaml():
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    assert policy.enabled is True
+    assert policy.snapshot_id is None
+    assert policy.recall == RecallPolicy(limit=5, min_score=0.4, max_tokens=800)
+    assert policy.compose == ComposePolicy(enabled=False, max_tokens=2000)
+    assert policy.cadence == "first_turn"
+    assert policy.writeback == WritebackPolicy(enabled=False, salience_cap=0.4, tags=())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _khive_recall_response(result_id="abc123", content="a prior lesson"):
+    return json.dumps(
+        {
+            "results": [
+                {
+                    "ok": True,
+                    "tool": "memory.recall",
+                    "result": [{"id": result_id, "content": content, "score": 0.7}],
+                }
+            ],
+            "summary": {"total": 1, "succeeded": 1, "failed": 0},
+        }
+    )
+
+
+def _mcp_result(text):
+    class _Item:
+        def __init__(self, text):
+            self.text = text
+
+    class _Result:
+        def __init__(self, text):
+            self.content = [_Item(text)]
+
+    return _Result(text)
+
+
+class _FakeInstruction:
+    def __init__(self, rendered):
+        self.rendered = rendered
+
+
+class _FakeBranch:
+    def __init__(self, name="tester", last_response=None):
+        self.name = name
+        self.msgs = _FakeMsgs(last_response)
+
+
+class _FakeMsgs:
+    def __init__(self, last_response):
+        self.last_response = last_response
+
+
+@pytest.fixture
+def patched_transport():
+    """Patch the MCP client at the module boundary; returns the mocked call_tool."""
+    call_tool = AsyncMock()
+    fake_client = AsyncMock()
+    fake_client.call_tool = call_tool
+
+    with patch(
+        "lionagi.service.connections.mcp_wrapper.MCPConnectionPool.get_client",
+        AsyncMock(return_value=fake_client),
+    ):
+        yield call_tool
+
+
+# ---------------------------------------------------------------------------
+# Query construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_construction_uses_role_and_truncated_task_text(patched_transport):
+    patched_transport.return_value = _mcp_result(_khive_recall_response())
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(name="implementer")
+    long_task = "x" * 1000
+    instruction = _FakeInstruction(rendered=long_task)
+
+    await provider.provide(branch, instruction)
+
+    recall_call_ops = patched_transport.call_args_list[0].args[1]["ops"]
+    assert "role=implementer" in recall_call_ops
+    assert "x" * 400 in recall_call_ops
+    assert "x" * 401 not in recall_call_ops
+
+
+# ---------------------------------------------------------------------------
+# Cadence gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_turn_cadence_fires_when_no_prior_response(patched_transport):
+    patched_transport.return_value = _mcp_result(_khive_recall_response())
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1", cadence="first_turn")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is not None
+    assert patched_transport.called
+
+
+@pytest.mark.asyncio
+async def test_first_turn_cadence_skips_when_prior_response_exists(patched_transport):
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1", cadence="first_turn")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=object())
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is None
+    assert not patched_transport.called
+
+
+@pytest.mark.asyncio
+async def test_every_turn_cadence_always_fires(patched_transport):
+    patched_transport.return_value = _mcp_result(_khive_recall_response())
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1", cadence="every_turn")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=object())
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is not None
+    assert patched_transport.called
+
+
+@pytest.mark.asyncio
+async def test_disabled_policy_never_calls_transport(patched_transport):
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1", enabled=False)
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is None
+    assert not patched_transport.called
+
+
+# ---------------------------------------------------------------------------
+# auto_feedback emitted in the same round-trip, explicit profile_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_feedback_emitted_with_explicit_profile_id(patched_transport):
+    patched_transport.return_value = _mcp_result(_khive_recall_response(result_id="the-first-id"))
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    await provider.provide(branch, _FakeInstruction("hello"))
+
+    ops_calls = [c.args[1]["ops"] for c in patched_transport.call_args_list]
+    assert any(op.startswith("memory.recall(") for op in ops_calls)
+    feedback_calls = [op for op in ops_calls if op.startswith("brain.auto_feedback(")]
+    assert len(feedback_calls) == 1
+    assert '"the-first-id"' in feedback_calls[0]
+    assert 'served_by_profile_id="implementer-recall-v1"' in feedback_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_no_auto_feedback_when_recall_empty(patched_transport):
+    empty_response = json.dumps(
+        {"results": [{"ok": True, "tool": "memory.recall", "result": []}], "summary": {}}
+    )
+    patched_transport.return_value = _mcp_result(empty_response)
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is None
+    ops_calls = [c.args[1]["ops"] for c in patched_transport.call_args_list]
+    assert not any(op.startswith("brain.auto_feedback(") for op in ops_calls)
+
+
+# ---------------------------------------------------------------------------
+# Transport failure containment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_returns_none_turn_proceeds():
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    with patch(
+        "lionagi.service.connections.mcp_wrapper.MCPConnectionPool.get_client",
+        AsyncMock(side_effect=RuntimeError("khive daemon unreachable")),
+    ):
+        text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is None
+
+
+@pytest.mark.asyncio
+async def test_auto_feedback_failure_does_not_fail_the_turn(patched_transport):
+    async def _side_effect(tool_name, kwargs):
+        if kwargs["ops"].startswith("brain.auto_feedback("):
+            raise RuntimeError("feedback endpoint down")
+        return _mcp_result(_khive_recall_response())
+
+    patched_transport.side_effect = _side_effect
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert text is not None
+    assert "a prior lesson" in text
+
+
+# ---------------------------------------------------------------------------
+# Compose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compose_included_when_enabled(patched_transport):
+    async def _side_effect(tool_name, kwargs):
+        if kwargs["ops"].startswith("knowledge.compose("):
+            return _mcp_result(
+                json.dumps(
+                    {
+                        "results": [
+                            {"ok": True, "tool": "knowledge.compose", "result": "corpus frame"}
+                        ]
+                    }
+                )
+            )
+        return _mcp_result(_khive_recall_response())
+
+    patched_transport.side_effect = _side_effect
+    policy = KhiveInjectionPolicy(
+        profile_id="implementer-recall-v1", compose=ComposePolicy(enabled=True, max_tokens=2000)
+    )
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    assert "corpus frame" in text
+    ops_calls = [c.args[1]["ops"] for c in patched_transport.call_args_list]
+    assert any(op.startswith("knowledge.compose(") for op in ops_calls)
+
+
+@pytest.mark.asyncio
+async def test_compose_not_called_when_disabled(patched_transport):
+    patched_transport.return_value = _mcp_result(_khive_recall_response())
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    await provider.provide(branch, _FakeInstruction("hello"))
+
+    ops_calls = [c.args[1]["ops"] for c in patched_transport.call_args_list]
+    assert not any(op.startswith("knowledge.compose(") for op in ops_calls)
+
+
+# ---------------------------------------------------------------------------
+# Token cap truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_truncated_to_recall_max_tokens(patched_transport):
+    huge_content = "lesson " * 5000
+    patched_transport.return_value = _mcp_result(_khive_recall_response(content=huge_content))
+    policy = KhiveInjectionPolicy(
+        profile_id="implementer-recall-v1",
+        recall=RecallPolicy(limit=5, min_score=0.4, max_tokens=50),
+    )
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(last_response=None)
+
+    text = await provider.provide(branch, _FakeInstruction("hello"))
+
+    from lionagi.service.token_calculator import TokenCalculator
+
+    assert text is not None
+    assert TokenCalculator.tokenize(text) <= 50
+    assert len(text) < len(huge_content)
+
+
+# ---------------------------------------------------------------------------
+# Writeback pair extraction + salience cap
+# ---------------------------------------------------------------------------
+
+
+def _resp(function, output):
+    return ActionResponseModel(function=function, arguments={}, output=output)
+
+
+def test_extract_writeback_pairs_matches_error_then_resolution():
+    responses = [
+        _resp("bash", {"error": "permission denied"}),
+        _resp("bash", {"stdout": "ok now"}),
+    ]
+
+    pairs = _extract_writeback_pairs(responses)
+
+    assert len(pairs) == 1
+    assert pairs[0]["function"] == "bash"
+    assert pairs[0]["error"] == "permission denied"
+    assert pairs[0]["resolved_by"] == "bash"
+    assert pairs[0]["resolution_output"] == {"stdout": "ok now"}
+
+
+def test_extract_writeback_pairs_ignores_unresolved_error():
+    responses = [_resp("bash", {"error": "permission denied"})]
+
+    assert _extract_writeback_pairs(responses) == []
+
+
+def test_extract_writeback_pairs_no_errors_no_pairs():
+    responses = [_resp("bash", {"stdout": "fine"}), _resp("read", {"content": "x"})]
+
+    assert _extract_writeback_pairs(responses) == []
+
+
+@pytest.mark.asyncio
+async def test_writeback_off_by_default_never_calls_transport(patched_transport):
+    policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch()
+    responses = [_resp("bash", {"error": "boom"}), _resp("bash", {"stdout": "fixed"})]
+
+    await provider.writeback(branch, responses)
+
+    assert not patched_transport.called
+
+
+@pytest.mark.asyncio
+async def test_writeback_writes_capped_salience_and_tags(patched_transport):
+    patched_transport.return_value = _mcp_result(json.dumps({"results": [], "summary": {}}))
+    policy = KhiveInjectionPolicy(
+        profile_id="implementer-recall-v1",
+        writeback=WritebackPolicy(enabled=True, salience_cap=0.3, tags=("agent:implementer",)),
+    )
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch(name="implementer")
+    responses = [_resp("bash", {"error": "boom"}), _resp("bash", {"stdout": "fixed"})]
+
+    await provider.writeback(branch, responses)
+
+    assert patched_transport.called
+    ops = patched_transport.call_args_list[0].args[1]["ops"]
+    assert ops.startswith("memory.remember(")
+    assert "salience=0.3" in ops
+    assert '"agent:implementer"' in ops
+
+
+@pytest.mark.asyncio
+async def test_writeback_no_pairs_skips_transport(patched_transport):
+    policy = KhiveInjectionPolicy(
+        profile_id="implementer-recall-v1", writeback=WritebackPolicy(enabled=True)
+    )
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch()
+    responses = [_resp("bash", {"stdout": "fine"})]
+
+    await provider.writeback(branch, responses)
+
+    assert not patched_transport.called
+
+
+@pytest.mark.asyncio
+async def test_writeback_transport_failure_contained(patched_transport):
+    patched_transport.side_effect = RuntimeError("khive down")
+    policy = KhiveInjectionPolicy(
+        profile_id="implementer-recall-v1", writeback=WritebackPolicy(enabled=True)
+    )
+    provider = KhiveInjectionProvider(policy)
+    branch = _FakeBranch()
+    responses = [_resp("bash", {"error": "boom"}), _resp("bash", {"stdout": "fixed"})]
+
+    await provider.writeback(branch, responses)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Module-load purity: core lionagi import path stays clean without the mcp extra
+# ---------------------------------------------------------------------------
+
+
+def test_module_import_does_not_pull_in_mcp_transport():
+    for mod in ("fastmcp", "mcp"):
+        sys.modules.pop(mod, None)
+
+    import importlib
+
+    import lionagi.tools.khive_injection as mod_
+
+    importlib.reload(mod_)
+
+    assert "fastmcp" not in sys.modules
+    assert "mcp" not in sys.modules
+
+
+def test_core_lionagi_import_is_clean():
+    """Mirrors the reference core-only-importability pattern: importing lionagi
+    itself must never require fastmcp/mcp to be installed."""
+    for mod in ("fastmcp", "mcp"):
+        sys.modules.pop(mod, None)
+
+    import importlib
+
+    import lionagi
+
+    importlib.reload(lionagi)
+
+    assert "fastmcp" not in sys.modules


### PR DESCRIPTION
# feat(tools): KhiveInjectionProvider + rule-based writeback after-hook

PR 2 of the ADR-0100 injection design (seam landed in #1886): the reference `ContextProvider` that recalls (and optionally composes) from a khive daemon pre-turn, plus the opt-in post-turn writeback hook.

## What's in here

- `lionagi/tools/khive_injection.py` — `KhiveInjectionPolicy` (profile_id required, snapshot_id accepted, recall/compose/writeback sub-policies, cadence first_turn|every_turn) + `KhiveInjectionProvider`.
  - Query construction in code: first ~400 chars of the instruction's rendered task text + branch role — never a vague query.
  - Every recall emits `brain.auto_feedback` with the explicit `profile_id` in the same round-trip.
  - Transport = the existing `MCPConnectionPool` (`service/connections/mcp_wrapper.py`), lazily imported inside the call — `import lionagi` stays clean without the `mcp` extra (verified with a meta-path import blocker in tests).
  - Full containment: any transport failure logs + degrades to no injection; the turn always proceeds.
- `ContextProviderRegistry.gather_writeback()` — symmetric post-turn pass with the same per-provider containment, wired from `operate()` where the turn's `ActionResponse` outputs exist.
- Writeback v1 is deliberately rule-based: FIFO error→resolution pairs from action responses, written via `memory.remember` at capped salience with role tags. Off by default.
- 24 new tests, transport fully mocked (no live daemon in CI).

## Notes for review

- `snapshot_id` is stored but not yet passed to khive verbs — the recall/compose surface doesn't accept a snapshot parameter yet; the policy field is forward wiring.
- Writeback hooks only `operate()` — the other Middles don't invoke tools directly, so there is nothing to pair there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
