### PR TITLE
feat(studio): umami page-view tracking snippet

### DIFF
--- a/apps/studio/frontend/index.html
+++ b/apps/studio/frontend/index.html
@@ -12,6 +12,11 @@
         else document.documentElement.classList.remove('dark');
       })();
     </script>
+    <script
+      defer
+      src="https://analytics.khive.ai/script.js"
+      data-website-id="2899c39b-7da3-40b5-bce5-83961982ecc6"
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
One-line `<script defer>` in `apps/studio/frontend/index.html` loading https://analytics.khive.ai/script.js with the lion-studio website id. Page-views only — no data-* event options. noindex posture unaffected.

Opened per lambda:lionagi's handoff of the tracking-snippet PRs to lambda:khive; lionagi owns review/merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)