### PR TITLE
fix(studio): stale-chunk resilience — assets excluded from SPA rewrite + one-shot reload on chunk load failure

### DIFF
--- a/apps/studio/frontend/src/main.tsx
+++ b/apps/studio/frontend/src/main.tsx
@@ -8,6 +8,18 @@ import { applyDocumentLocale, getLocaleFromCookie } from "@/i18n/locales";
 // returning ar/ur user never sees an LTR flash while React mounts.
 applyDocumentLocale(getLocaleFromCookie());
 
+// A deploy rotates hashed chunk filenames, so a page loaded before the
+// deploy can fail to lazy-load a route chunk it still references. Reload
+// once to pick up the new index; the flag prevents a reload loop if the
+// failure persists for another reason.
+window.addEventListener("vite:preloadError", (event) => {
+  const key = "studio-chunk-reload";
+  if (sessionStorage.getItem(key)) return;
+  sessionStorage.setItem(key, "1");
+  event.preventDefault();
+  window.location.reload();
+});
+
 const router = createRouter({ routeTree });
 
 declare module "@tanstack/react-router" {

--- a/apps/studio/frontend/vercel.json
+++ b/apps/studio/frontend/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "rewrites": [{ "source": "/((?!assets/).*)", "destination": "/index.html" }],
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
Live incident on lion-studio.khive.ai tonight: after a deploy rotated hashed chunk filenames, an already-open page failed to lazy-load `FleetView-*.js` — and the failing URL returned **200 with `text/html`**, because the catch-all SPA rewrite served `index.html` for the missing asset and the `/assets/*` header rule stamped that response `immutable, max-age=31536000`.

Two fixes:
1. **vercel.json**: the rewrite now excludes `/assets/` (negative lookahead), so missing chunks 404 instead of being served-and-poisoned as year-cached HTML. Vercel purges its edge cache per deploy, so the currently poisoned URL clears on the next deployment.
2. **main.tsx**: `vite:preloadError` handler reloads the page once to pick up the new index after a deploy, with a sessionStorage flag preventing a reload loop on persistent failures.

Verified: `npm run build` green, full frontend suite 750/750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)