### PR TITLE
fix(studio): stub external analytics script in e2e smoke suite

### DIFF
--- a/apps/studio/frontend/e2e/smoke.spec.ts
+++ b/apps/studio/frontend/e2e/smoke.spec.ts
@@ -4,6 +4,18 @@ import { test, expect } from "@playwright/test";
 // on below is only ever produced by the seeded daemon's fixtures.
 const SMOKE_SCHEDULE_NAME = "e2e-smoke-nightly-report";
 
+// index.html loads the analytics script from an external host. A deferred
+// script participates in the window load event, so a slow or unreachable
+// external fetch stalls page.goto past the test timeout on CI runners.
+// Fulfill (not abort: a failed resource load is itself a console error,
+// which the boot test asserts against) so the suite never touches the
+// network beyond the app under test.
+test.beforeEach(async ({ page }) => {
+  await page.route("https://analytics.khive.ai/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript", body: "" }),
+  );
+});
+
 test("app boots, root renders, and the page logs no console errors", async ({ page }) => {
   const errors: string[] = [];
   page.on("console", (msg) => {


### PR DESCRIPTION
studio-e2e went red on every PR branch carrying the analytics snippet (#1898): all three smoke tests fail at `page.goto` timeout because the deferred external script participates in the window `load` event, and the CI runner's fetch of it can stall past the 15s test timeout.

Fix: `test.beforeEach` routes `https://analytics.khive.ai/**` to a fulfilled empty-JS response. Fulfill rather than abort, because an aborted resource load logs a console error and the boot test asserts the console is clean. e2e is now network-independent beyond the app under test.

This unblocks #1894 and #1896 (both red on exactly this job after their branch updates pulled in the snippet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)