### PR TITLE
feat(state): generalize schedule runs into a durable task entity

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -602,6 +603,10 @@ class StateDB:
             # existing DBs created before the completion-trust gate carry a
             # 6-value CHECK on invocations.status that omits 'completed_empty'.
             await self._drop_legacy_invocations_status_check()
+            # ADR-0101 D2: existing DBs carry a 5-value CHECK on
+            # schedule_runs.status and a NOT NULL schedule_id, from before
+            # schedule_runs was generalized into the task-application entity.
+            await self._drop_legacy_schedule_runs_check()
         async with self._engine.begin() as conn:
             await conn.run_sync(metadata.create_all)
             # Seed immutable reference rows; ON CONFLICT DO NOTHING is safe to
@@ -945,6 +950,160 @@ class StateDB:
                 await driver.execute("ALTER TABLE invocations_new RENAME TO invocations")
                 for idx_sql in index_sqls:
                     await driver.execute(idx_sql)
+                await driver.commit()
+            finally:
+                await driver.execute("PRAGMA foreign_keys = ON")
+                await driver.commit()
+
+    async def _backup_before_rebuild(self, label: str) -> None:
+        """Copy the on-disk state.db aside before an in-place table rebuild (ADR-0101 D2).
+
+        No-op for in-memory databases and non-sqlite dialects, where there is no
+        single database file to copy. Rollback path: stop the daemon, restore
+        the backup file over the live state.db, and reinstall the schema
+        version that shipped before this migration by checking out the prior
+        lionagi release before reopening.
+        """
+        if self.dialect != "sqlite":
+            return
+        p = self.path
+        if p is None or str(p) == ":memory:" or not p.exists():
+            return
+        backup_path = p.with_name(f"{p.name}.pre-{label}.{int(time.time())}.bak")
+        shutil.copy2(p, backup_path)
+
+    # Substring present only in the post-ADR-0101 schedule_runs CREATE SQL
+    # (the widened status CHECK); its absence indicates a legacy DB whose
+    # schedule_runs still carries the 5-value CHECK and a NOT NULL schedule_id.
+    _LEGACY_SCHEDULE_RUNS_QUEUE_MARKER = "'waiting_dependency'"
+
+    async def _drop_legacy_schedule_runs_check(self) -> None:
+        """Rebuild ``schedule_runs`` if it still carries the pre-ADR-0101 status CHECK.
+
+        SQLite cannot widen a CHECK constraint nor drop a NOT NULL via ALTER
+        TABLE, so this uses the same rename → CREATE new → INSERT SELECT →
+        DROP old pattern as ``_drop_legacy_action_kind_check`` /
+        ``_drop_legacy_invocations_status_check``. Takes a pre-rebuild backup
+        of the database file first (``_backup_before_rebuild``); see its
+        docstring for the rollback path.
+        """
+        if self.dialect != "sqlite":
+            return
+        async with self._engine.connect() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master "
+                            "WHERE type='table' AND name='schedule_runs'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        if row is None or row["sql"] is None:
+            return
+        create_sql: str = row["sql"]
+        if self._LEGACY_SCHEDULE_RUNS_QUEUE_MARKER in create_sql:
+            # Table was already created / rebuilt with the widened CHECK.
+            return
+
+        await self._backup_before_rebuild("schedule_runs")
+
+        async with self._engine.connect() as conn:
+            index_rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master "
+                            "WHERE type='index' AND tbl_name='schedule_runs' AND sql IS NOT NULL"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            index_sqls = [r["sql"] for r in index_rows]
+
+            cols_rows = (
+                (await conn.execute(text("PRAGMA table_info(schedule_runs)"))).mappings().all()
+            )
+            cols = [r["name"] for r in cols_rows]
+        col_list = ", ".join(cols)
+
+        # ``schedule_runs`` is both an FK source (schedules, invocations) and
+        # an FK target (its own chain_parent_id, and dispatch_outbox's
+        # schedule_run_id) — the same complication documented at
+        # ``_drop_legacy_invocations_status_check``, so this rebuild uses the
+        # same hand-kept-literal + raw-driver-autocommit-pragma technique
+        # rather than ``to_metadata()`` (which cannot resolve those
+        # cross-table foreign keys from an isolated, single-table MetaData).
+        # The literal mirrors the CREATE TABLE in schema.sql; parity between
+        # the two is test-enforced.
+        async with self._engine.connect() as conn:
+            driver = (await conn.get_raw_connection()).driver_connection
+            await driver.execute("PRAGMA foreign_keys = OFF")
+            try:
+                await driver.execute(
+                    """
+                    CREATE TABLE schedule_runs_new (
+                      id                  TEXT    PRIMARY KEY,
+                      schedule_id         TEXT    REFERENCES schedules(id) ON DELETE CASCADE,
+                      invocation_id       TEXT    REFERENCES invocations(id),
+                      trigger_context     JSON    NOT NULL,
+                      action_kind         TEXT    NOT NULL,
+                      action_args         JSON    NOT NULL,
+                      status              TEXT    NOT NULL DEFAULT 'running'
+                                          CHECK(status IN ('queued', 'waiting_dependency',
+                                                'running', 'retry_wait', 'completed',
+                                                'failed', 'timed_out', 'skipped',
+                                                'cancelled')),
+                      exit_code           INTEGER,
+                      chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+                      chain_depth         INTEGER NOT NULL DEFAULT 0,
+                      fired_at            REAL    NOT NULL,
+                      ended_at            REAL,
+                      error_detail        TEXT,
+                      created_at          REAL    NOT NULL,
+                      updated_at          REAL,
+                      status_reason_code     TEXT,
+                      status_reason_summary  TEXT,
+                      status_evidence_refs   JSON,
+                      queued_at           REAL,
+                      leased_by           TEXT,
+                      lease_expires_at    REAL,
+                      concurrency_key     TEXT,
+                      required_capabilities  JSON,
+                      execution_target       TEXT,
+                      library_ref             TEXT,
+                      library_content_hash    TEXT
+                    )
+                    """
+                )
+                insert_sql = (
+                    f"INSERT INTO schedule_runs_new ({col_list}) "  # noqa: S608
+                    f"SELECT {col_list} FROM schedule_runs"
+                )
+                await driver.execute(insert_sql)
+                await driver.execute("DROP TABLE schedule_runs")
+                await driver.execute("ALTER TABLE schedule_runs_new RENAME TO schedule_runs")
+                for idx_sql in index_sqls:
+                    await driver.execute(idx_sql)
+                # New ADR-0061 queue indexes: not part of the pre-rebuild
+                # index set, so replaying index_sqls above never creates
+                # them. Create explicitly (idempotent) so a migrated DB ends
+                # up with the same indexes as a freshly-created one.
+                await driver.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_schedule_runs_queue "
+                    "ON schedule_runs(status, queued_at) "
+                    "WHERE status IN ('queued', 'retry_wait')"
+                )
+                await driver.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_schedule_runs_concurrency "
+                    "ON schedule_runs(concurrency_key, status) "
+                    "WHERE status IN ('queued', 'running', 'retry_wait')"
+                )
                 await driver.commit()
             finally:
                 await driver.execute("PRAGMA foreign_keys = ON")

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1026,6 +1026,22 @@ class StateDB:
             )
             index_sqls = [r["sql"] for r in index_rows]
 
+            # DROP TABLE also drops the table's triggers; capture them for
+            # replay alongside the indexes.
+            trigger_rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master "
+                            "WHERE type='trigger' AND tbl_name='schedule_runs' AND sql IS NOT NULL"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            trigger_sqls = [r["sql"] for r in trigger_rows]
+
             cols_rows = (
                 (await conn.execute(text("PRAGMA table_info(schedule_runs)"))).mappings().all()
             )
@@ -1090,6 +1106,8 @@ class StateDB:
                 await driver.execute("ALTER TABLE schedule_runs_new RENAME TO schedule_runs")
                 for idx_sql in index_sqls:
                     await driver.execute(idx_sql)
+                for trig_sql in trigger_sqls:
+                    await driver.execute(trig_sql)
                 # New ADR-0061 queue indexes: not part of the pre-rebuild
                 # index set, so replaying index_sqls above never creates
                 # them. Create explicitly (idempotent) so a migrated DB ends

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -471,16 +471,22 @@ CREATE INDEX IF NOT EXISTS idx_schedules_project
   ON schedules(project) WHERE project IS NOT NULL;
 
 -- ── Schedule Runs (ADR-0027) ─────────────────────────────────────────────────
+-- ADR-0101 D2: generalized into the durable task-application entity. schedule_id
+-- is nullable so an ad-hoc task application (schedule_id IS NULL) can share this
+-- table with schedule-fired runs; the status CHECK is widened to the ADR-0062
+-- lifecycle; queued_at/leased_by/lease_expires_at/concurrency_key are ADR-0061's
+-- queue columns.
 CREATE TABLE IF NOT EXISTS schedule_runs (
   id                  TEXT    PRIMARY KEY,
-  schedule_id         TEXT    NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+  schedule_id         TEXT    REFERENCES schedules(id) ON DELETE CASCADE,
   invocation_id       TEXT    REFERENCES invocations(id),
   trigger_context     JSON    NOT NULL,
   action_kind         TEXT    NOT NULL,
   action_args         JSON    NOT NULL,
   status              TEXT    NOT NULL DEFAULT 'running'
-                      CHECK(status IN ('running', 'completed', 'failed',
-                                       'skipped', 'cancelled')),
+                      CHECK(status IN ('queued', 'waiting_dependency', 'running',
+                                       'retry_wait', 'completed', 'failed',
+                                       'timed_out', 'skipped', 'cancelled')),
   exit_code           INTEGER,
   chain_parent_id     TEXT    REFERENCES schedule_runs(id),
   chain_depth         INTEGER NOT NULL DEFAULT 0,
@@ -495,7 +501,17 @@ CREATE TABLE IF NOT EXISTS schedule_runs (
   -- ADR-0028: see sessions table for the denormalization rationale.
   status_reason_code     TEXT,
   status_reason_summary  TEXT,
-  status_evidence_refs   JSON
+  status_evidence_refs   JSON,
+  -- ADR-0101 D2 / ADR-0061: durable queue columns.
+  queued_at           REAL,
+  leased_by           TEXT,
+  lease_expires_at    REAL,
+  concurrency_key     TEXT,
+  -- ADR-0101 D2: task-application provenance (seam into ADR-0102).
+  required_capabilities  JSON,
+  execution_target       TEXT,
+  library_ref             TEXT,
+  library_content_hash    TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sched_runs_schedule
@@ -504,6 +520,12 @@ CREATE INDEX IF NOT EXISTS idx_sched_runs_status
   ON schedule_runs(status) WHERE status = 'running';
 CREATE INDEX IF NOT EXISTS idx_sched_runs_invocation
   ON schedule_runs(invocation_id) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_schedule_runs_queue
+  ON schedule_runs(status, queued_at)
+  WHERE status IN ('queued', 'retry_wait');
+CREATE INDEX IF NOT EXISTS idx_schedule_runs_concurrency
+  ON schedule_runs(concurrency_key, status)
+  WHERE status IN ('queued', 'running', 'retry_wait');
 
 -- ── Admin event log (ADR-0024) ───────────────────────────────────────────
 -- Append-only audit log following NIST SP 800-92 pattern. Every admin

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -547,6 +547,10 @@ Index(
 )
 
 # ── schedule_runs ─────────────────────────────────────────────────────────────
+# ADR-0101 D2: generalized into the durable task-application entity. schedule_id
+# is nullable (an ad-hoc task application has schedule_id IS NULL); the status
+# CHECK carries the full ADR-0062 lifecycle; queued_at/leased_by/
+# lease_expires_at/concurrency_key are ADR-0061's queue columns.
 
 schedule_runs = Table(
     "schedule_runs",
@@ -556,7 +560,6 @@ schedule_runs = Table(
         "schedule_id",
         Text,
         ForeignKey("schedules.id", ondelete="CASCADE"),
-        nullable=False,
     ),
     Column("invocation_id", Text, ForeignKey("invocations.id")),
     Column("trigger_context", JSON, nullable=False),
@@ -566,7 +569,8 @@ schedule_runs = Table(
         "status",
         Text,
         CheckConstraint(
-            "status IN ('running','completed','failed','skipped','cancelled')",
+            "status IN ('queued','waiting_dependency','running','retry_wait',"
+            "'completed','failed','timed_out','skipped','cancelled')",
             name="ck_schedule_runs_status",
         ),
         nullable=False,
@@ -584,6 +588,16 @@ schedule_runs = Table(
     Column("status_reason_code", Text),
     Column("status_reason_summary", Text),
     Column("status_evidence_refs", JSON),
+    # ADR-0101 D2 / ADR-0061: durable queue columns.
+    Column("queued_at", Float),
+    Column("leased_by", Text),
+    Column("lease_expires_at", Float),
+    Column("concurrency_key", Text),
+    # ADR-0101 D2: task-application provenance (seam into ADR-0102).
+    Column("required_capabilities", JSON),
+    Column("execution_target", Text),
+    Column("library_ref", Text),
+    Column("library_content_hash", Text),
 )
 
 Index("idx_sched_runs_schedule", schedule_runs.c.schedule_id, schedule_runs.c.fired_at)
@@ -598,6 +612,20 @@ Index(
     schedule_runs.c.invocation_id,
     sqlite_where=text("invocation_id IS NOT NULL"),
     postgresql_where=text("invocation_id IS NOT NULL"),
+)
+Index(
+    "idx_schedule_runs_queue",
+    schedule_runs.c.status,
+    schedule_runs.c.queued_at,
+    sqlite_where=text("status IN ('queued', 'retry_wait')"),
+    postgresql_where=text("status IN ('queued', 'retry_wait')"),
+)
+Index(
+    "idx_schedule_runs_concurrency",
+    schedule_runs.c.concurrency_key,
+    schedule_runs.c.status,
+    sqlite_where=text("status IN ('queued', 'running', 'retry_wait')"),
+    postgresql_where=text("status IN ('queued', 'running', 'retry_wait')"),
 )
 
 # ── admin_events ──────────────────────────────────────────────────────────────

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -110,6 +110,16 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("status_reason_code", "TEXT"),
         ("status_reason_summary", "TEXT"),
         ("status_evidence_refs", "JSON"),
+        # ADR-0101 D2 / ADR-0061: durable queue columns.
+        ("queued_at", "REAL"),
+        ("leased_by", "TEXT"),
+        ("lease_expires_at", "REAL"),
+        ("concurrency_key", "TEXT"),
+        # ADR-0101 D2: task-application provenance columns.
+        ("required_capabilities", "JSON"),
+        ("execution_target", "TEXT"),
+        ("library_ref", "TEXT"),
+        ("library_content_hash", "TEXT"),
     ],
     # Phase C Move 2: engine run persistence.
     # New table created via schema.sql; these columns allow ALTER TABLE on

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -63,8 +63,13 @@ class TransitionResult(BaseModel):
 
 # Entities the minimal fallback knows how to CAS-transition. ADR-0062's full
 # backend generalizes this; slice 1 needs only dispatch_outbox.
+# "schedule_run" is ADR-0101 D2's generalized task-application entity
+# (schedule_runs table, schedule_id now nullable) — registered here so ALL
+# status movement on it can route through this guarded CAS store rather than
+# a second, parallel implementation.
 _ENTITY_TABLES: dict[str, str] = {
     "dispatch": "dispatch_outbox",
+    "schedule_run": "schedule_runs",
 }
 
 

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -1,0 +1,529 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0101 D2 schema-layer tests: schedule_runs generalized into the durable
+task-application entity (nullable schedule_id, widened status CHECK, ADR-0061
+queue columns, CAS registration in transitions._ENTITY_TABLES).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import aiosqlite
+import pytest
+from sqlalchemy import text
+
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+from lionagi.state.transitions import (
+    Actor,
+    StateReason,
+    TransitionRequest,
+    transition,
+)
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+# A `schedules` table already at current shape (the 'flow_yaml' marker in its
+# action_kind CHECK) so opening a legacy schedule_runs fixture through
+# StateDB.open() doesn't also trip the pre-existing, unrelated
+# _drop_legacy_action_kind_check rebuild — these tests are scoped to
+# schedule_runs only.
+_CURRENT_SCHEDULES_DDL = """
+CREATE TABLE schedules (
+  id           TEXT    PRIMARY KEY,
+  name         TEXT    NOT NULL UNIQUE,
+  enabled      INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+  trigger_type TEXT    NOT NULL CHECK(trigger_type IN ('cron', 'interval', 'github_poll')),
+  action_kind  TEXT    NOT NULL CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml')),
+  created_at   REAL    NOT NULL,
+  updated_at   REAL    NOT NULL
+)
+"""
+
+
+async def _make_schedule_run(db: StateDB, *, status: str = "running") -> tuple[str, str]:
+    sched_id = _uid()
+    await db.create_schedule(
+        {
+            "id": sched_id,
+            "name": f"sched-{sched_id}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    run_id = _uid()
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sched_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": {},
+            "status": status,
+            "fired_at": time.time(),
+        }
+    )
+    return sched_id, run_id
+
+
+# ── 1. Migration idempotence ─────────────────────────────────────────────────
+
+
+async def test_migration_idempotent_on_already_migrated_db(tmp_path):
+    """Opening an already-migrated db a second time is a no-op: same schema,
+    same rows, no error."""
+    db_path = tmp_path / "already_migrated.db"
+
+    state = StateDB(db_path)
+    await state.open()
+    sched_id, run_id = await _make_schedule_run(state)
+    await state.close()
+
+    # Re-open the same file — _apply_schema runs again on an already-current schema.
+    state2 = StateDB(db_path)
+    await state2.open()
+    try:
+        async with state2._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master WHERE type='table' AND name='schedule_runs'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )
+            assert "'waiting_dependency'" in row["sql"]
+
+            run_row = (
+                (
+                    await conn.execute(
+                        text("SELECT * FROM schedule_runs WHERE id = :id"), {"id": run_id}
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        assert run_row is not None
+        assert run_row["schedule_id"] == sched_id
+        assert run_row["status"] == "running"
+    finally:
+        await state2.close()
+
+
+async def test_migration_preserves_populated_pre_migration_rows(tmp_path):
+    """Applying the migration to a populated pre-ADR-0101 db preserves every
+    existing row's values (the rebuild copies data, not just structure)."""
+    db_path = tmp_path / "legacy_populated.db"
+
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute("PRAGMA foreign_keys = ON")
+        await raw.execute(_CURRENT_SCHEDULES_DDL)
+        await raw.execute(
+            """
+            CREATE TABLE schedule_runs (
+              id                  TEXT    PRIMARY KEY,
+              schedule_id         TEXT    NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+              invocation_id       TEXT,
+              trigger_context     JSON    NOT NULL,
+              action_kind         TEXT    NOT NULL,
+              action_args         JSON    NOT NULL,
+              status              TEXT    NOT NULL DEFAULT 'running'
+                                  CHECK(status IN ('running', 'completed', 'failed',
+                                                   'skipped', 'cancelled')),
+              exit_code           INTEGER,
+              chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+              chain_depth         INTEGER NOT NULL DEFAULT 0,
+              fired_at            REAL    NOT NULL,
+              ended_at            REAL,
+              error_detail        TEXT,
+              created_at          REAL    NOT NULL,
+              updated_at          REAL,
+              status_reason_code     TEXT,
+              status_reason_summary  TEXT,
+              status_evidence_refs   JSON
+            )
+            """
+        )
+        await raw.execute(
+            "INSERT INTO schedules (id, name, trigger_type, action_kind, created_at, updated_at) "
+            "VALUES ('sched-1', 'sched-1', 'interval', 'agent', 1.0, 1.0)"
+        )
+        await raw.execute(
+            "INSERT INTO schedule_runs "
+            "(id, schedule_id, trigger_context, action_kind, action_args, status, "
+            " exit_code, chain_depth, fired_at, ended_at, error_detail, created_at, "
+            " updated_at, status_reason_code, status_reason_summary, status_evidence_refs) "
+            "VALUES ('run-1', 'sched-1', '{}', 'agent', '{}', 'completed', "
+            " 0, 0, 10.0, 15.0, NULL, 10.0, 15.0, 'run.completed.ok', 'ok', '[]')"
+        )
+        await raw.commit()
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        async with state._read() as conn:
+            table_sql = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master WHERE type='table' AND name='schedule_runs'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )
+            assert "'waiting_dependency'" in table_sql["sql"]
+
+            row = (
+                (await conn.execute(text("SELECT * FROM schedule_runs WHERE id = 'run-1'")))
+                .mappings()
+                .first()
+            )
+        assert row is not None
+        assert row["schedule_id"] == "sched-1"
+        assert row["trigger_context"] == "{}"
+        assert row["action_kind"] == "agent"
+        assert row["action_args"] == "{}"
+        assert row["status"] == "completed"
+        assert row["exit_code"] == 0
+        assert row["chain_depth"] == 0
+        assert row["fired_at"] == 10.0
+        assert row["ended_at"] == 15.0
+        assert row["error_detail"] is None
+        assert row["created_at"] == 10.0
+        assert row["updated_at"] == 15.0
+        assert row["status_reason_code"] == "run.completed.ok"
+        assert row["status_reason_summary"] == "ok"
+        assert row["status_evidence_refs"] == "[]"
+        # New columns exist and default to NULL for pre-existing rows.
+        for col in (
+            "queued_at",
+            "leased_by",
+            "lease_expires_at",
+            "concurrency_key",
+            "required_capabilities",
+            "execution_target",
+            "library_ref",
+            "library_content_hash",
+        ):
+            assert row[col] is None
+    finally:
+        await state.close()
+
+
+# ── 2. Backup before rebuild ─────────────────────────────────────────────────
+
+
+async def test_backup_created_before_rebuild(tmp_path):
+    """A pre-rebuild backup file of state.db is created when the legacy
+    schedule_runs CHECK is detected and the table is rebuilt."""
+    db_path = tmp_path / "legacy_for_backup.db"
+
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute(_CURRENT_SCHEDULES_DDL)
+        await raw.execute(
+            """
+            CREATE TABLE schedule_runs (
+              id                  TEXT    PRIMARY KEY,
+              schedule_id         TEXT    NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+              invocation_id       TEXT,
+              trigger_context     JSON    NOT NULL,
+              action_kind         TEXT    NOT NULL,
+              action_args         JSON    NOT NULL,
+              status              TEXT    NOT NULL DEFAULT 'running'
+                                  CHECK(status IN ('running', 'completed', 'failed',
+                                                   'skipped', 'cancelled')),
+              exit_code           INTEGER,
+              chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+              chain_depth         INTEGER NOT NULL DEFAULT 0,
+              fired_at            REAL    NOT NULL,
+              ended_at            REAL,
+              error_detail        TEXT,
+              created_at          REAL    NOT NULL
+            )
+            """
+        )
+        await raw.commit()
+
+    pre_open_files = set(tmp_path.iterdir())
+
+    state = StateDB(db_path)
+    await state.open()
+    await state.close()
+
+    post_open_files = set(tmp_path.iterdir())
+    new_files = post_open_files - pre_open_files
+    backups = [p for p in new_files if "schedule_runs" in p.name and p.name.endswith(".bak")]
+    assert len(backups) == 1, f"expected exactly one backup file, got {backups}"
+
+
+async def test_backup_not_created_when_no_rebuild_needed(tmp_path):
+    """No backup file is left behind opening a db that already carries the
+    current schema — the backup only fires on an actual rebuild."""
+    db_path = tmp_path / "fresh.db"
+
+    state = StateDB(db_path)
+    await state.open()
+    await state.close()
+
+    pre_reopen_files = set(tmp_path.iterdir())
+
+    state2 = StateDB(db_path)
+    await state2.open()
+    await state2.close()
+
+    post_reopen_files = set(tmp_path.iterdir())
+    new_files = post_reopen_files - pre_reopen_files
+    backups = [p for p in new_files if p.name.endswith(".bak")]
+    assert backups == []
+
+
+# ── 3. Transition-vocab enforcement via the CAS transition store ────────────
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def test_schedule_run_registered_in_cas_entity_tables():
+    from lionagi.state.transitions import _ENTITY_TABLES
+
+    assert _ENTITY_TABLES["schedule_run"] == "schedule_runs"
+
+
+async def test_transition_store_governs_schedule_run_status(db: StateDB) -> None:
+    _sched_id, run_id = await _make_schedule_run(db, status="running")
+
+    result = await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=run_id,
+            from_state="running",
+            to_state="completed",
+            reason=StateReason(code="run.completed.ok", summary="via CAS store"),
+            actor=Actor(type="system", id="test"),
+            idempotency_key=_uid(),
+        ),
+    )
+    assert result.applied is True
+    assert result.previous_state == "running"
+    assert result.current_state == "completed"
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed"
+
+    audit_rows = await db.fetch_all(
+        "SELECT previous_status, status, entity_type FROM status_transitions WHERE entity_id = ?",
+        (run_id,),
+    )
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["previous_status"] == "running"
+    assert audit_rows[0]["status"] == "completed"
+    assert audit_rows[0]["entity_type"] == "schedule_run"
+
+
+async def test_transition_store_rejects_mismatched_from_state(db: StateDB) -> None:
+    _sched_id, run_id = await _make_schedule_run(db, status="running")
+
+    result = await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=run_id,
+            from_state="completed",  # wrong — row is still "running"
+            to_state="failed",
+            reason=StateReason(code="run.failed.exit_nonzero"),
+            actor=Actor(type="system", id="test"),
+            idempotency_key=_uid(),
+        ),
+    )
+    assert result.applied is False
+    assert result.conflict is True
+    assert result.previous_state == "running"
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "running"  # untouched
+
+
+async def test_transition_store_rejects_unknown_reason_code(db: StateDB) -> None:
+    _sched_id, run_id = await _make_schedule_run(db, status="running")
+
+    with pytest.raises(ValueError, match="invalid reason_code"):
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="running",
+                to_state="completed",
+                reason=StateReason(code="not.a.real_code"),
+                actor=Actor(type="system", id="test"),
+                idempotency_key=_uid(),
+            ),
+        )
+
+
+# ── 4. Load-bearing: schedule-spawned runs stay byte-identical ──────────────
+#
+# Golden values captured by running the ORIGINAL (pre-ADR-0101) codebase
+# through the exact same operations below (create_schedule_run then
+# update_schedule_run through _route_status_change/update_status), on a
+# schema without this change. `id`, `schedule_id`, and `created_at` are
+# caller-generated/wall-clock and excluded from the golden dict; every other
+# column produced by the existing write path must match exactly.
+
+_GOLDEN_ROW_AFTER_CREATE = {
+    "action_args": '{"prompt": "hello"}',
+    "action_kind": "agent",
+    "chain_depth": 0,
+    "chain_parent_id": None,
+    "ended_at": None,
+    "error_detail": None,
+    "exit_code": None,
+    "fired_at": 1700000000.0,
+    "invocation_id": None,
+    "status": "running",
+    "status_evidence_refs": None,
+    "status_reason_code": None,
+    "status_reason_summary": None,
+    "trigger_context": '{"trigger": "interval"}',
+}
+
+_GOLDEN_ROW_AFTER_UPDATE = {
+    "action_args": '{"prompt": "hello"}',
+    "action_kind": "agent",
+    "chain_depth": 0,
+    "chain_parent_id": None,
+    "ended_at": 1700000005.0,
+    "error_detail": None,
+    "exit_code": 0,
+    "fired_at": 1700000000.0,
+    "invocation_id": None,
+    "status": "completed",
+    "status_evidence_refs": "[]",
+    "status_reason_code": "run.completed.ok",
+    "status_reason_summary": "ok",
+    "trigger_context": '{"trigger": "interval"}',
+}
+
+_GOLDEN_TRANSITIONS = [
+    {
+        "entity_type": "schedule_run",
+        "previous_status": "running",
+        "status": "completed",
+        "reason_code": "run.completed.ok",
+        "reason_summary": "ok",
+        "source": "executor",
+        "actor": None,
+    }
+]
+
+_EXCLUDED_COLUMNS = {
+    "id",
+    "schedule_id",
+    "created_at",
+    "updated_at",
+    # ADR-0101 D2 additive columns — asserted separately (must be NULL for a
+    # schedule-spawned run); excluded here so the golden dicts captured from
+    # the pre-ADR-0101 codebase (which never had these columns) still apply.
+    "queued_at",
+    "leased_by",
+    "lease_expires_at",
+    "concurrency_key",
+    "required_capabilities",
+    "execution_target",
+    "library_ref",
+    "library_content_hash",
+}
+
+
+def _strip(row: dict) -> dict:
+    return {k: v for k, v in dict(row).items() if k not in _EXCLUDED_COLUMNS}
+
+
+async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
+    """The schedule_id-populated path (create_schedule_run + update_schedule_run,
+    i.e. an ordinary schedule fire) writes the same rows with the same column
+    values, and produces the same status_transitions sequence, as the
+    pre-ADR-0101 code — this codepath was not touched by the schema
+    generalization; new queue/task columns simply default to NULL.
+    """
+    sched_id = _uid()
+    await db.create_schedule(
+        {
+            "id": sched_id,
+            "name": f"sched-{sched_id}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+
+    run_id = _uid()
+    fired_at = 1700000000.0
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sched_id,
+            "trigger_context": {"trigger": "interval"},
+            "action_kind": "agent",
+            "action_args": {"prompt": "hello"},
+            "status": "running",
+            "fired_at": fired_at,
+        }
+    )
+
+    row_after_create = await db.fetch_one("SELECT * FROM schedule_runs WHERE id = ?", (run_id,))
+    assert _strip(row_after_create) == _GOLDEN_ROW_AFTER_CREATE
+    # New ADR-0101 queue/task columns are present on the row and default to NULL
+    # for a schedule-spawned run — they are additive, not a behavior change.
+    for col in (
+        "queued_at",
+        "leased_by",
+        "lease_expires_at",
+        "concurrency_key",
+        "required_capabilities",
+        "execution_target",
+        "library_ref",
+        "library_content_hash",
+    ):
+        assert row_after_create[col] is None
+
+    await db.update_schedule_run(
+        run_id,
+        status="completed",
+        exit_code=0,
+        ended_at=fired_at + 5,
+        reason_code=RunReasons.COMPLETED_OK,
+        reason_summary="ok",
+    )
+
+    row_after_update = await db.fetch_one("SELECT * FROM schedule_runs WHERE id = ?", (run_id,))
+    assert _strip(row_after_update) == _GOLDEN_ROW_AFTER_UPDATE
+
+    transitions = await db.fetch_all(
+        "SELECT entity_type, entity_id, previous_status, status, reason_code, "
+        "reason_summary, source, actor FROM status_transitions "
+        "WHERE entity_id = ? ORDER BY created_at",
+        (run_id,),
+    )
+    stripped_transitions = [
+        {k: v for k, v in dict(t).items() if k != "entity_id"} for t in transitions
+    ]
+    assert stripped_transitions == _GOLDEN_TRANSITIONS

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -222,6 +222,89 @@ async def test_migration_preserves_populated_pre_migration_rows(tmp_path):
         await state.close()
 
 
+async def test_migration_preserves_triggers(tmp_path):
+    """DROP TABLE drops the table's triggers, so the rebuild must capture and
+    replay them — a legacy schedule_runs trigger survives the migration."""
+    db_path = tmp_path / "legacy_with_trigger.db"
+
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute(_CURRENT_SCHEDULES_DDL)
+        await raw.execute(
+            """
+            CREATE TABLE schedule_runs (
+              id                  TEXT    PRIMARY KEY,
+              schedule_id         TEXT    NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+              invocation_id       TEXT,
+              trigger_context     JSON    NOT NULL,
+              action_kind         TEXT    NOT NULL,
+              action_args         JSON    NOT NULL,
+              status              TEXT    NOT NULL DEFAULT 'running'
+                                  CHECK(status IN ('running', 'completed', 'failed',
+                                                   'skipped', 'cancelled')),
+              exit_code           INTEGER,
+              chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+              chain_depth         INTEGER NOT NULL DEFAULT 0,
+              fired_at            REAL    NOT NULL,
+              ended_at            REAL,
+              error_detail        TEXT,
+              created_at          REAL    NOT NULL,
+              updated_at          REAL,
+              status_reason_code     TEXT,
+              status_reason_summary  TEXT,
+              status_evidence_refs   JSON
+            )
+            """
+        )
+        await raw.execute("CREATE TABLE trigger_log (run_id TEXT)")
+        await raw.execute(
+            """
+            CREATE TRIGGER schedule_runs_audit AFTER INSERT ON schedule_runs
+            BEGIN
+              INSERT INTO trigger_log (run_id) VALUES (NEW.id);
+            END
+            """
+        )
+        await raw.commit()
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        async with state._read() as conn:
+            trig = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master "
+                            "WHERE type='trigger' AND name='schedule_runs_audit'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        assert trig is not None, "trigger dropped by the schedule_runs rebuild"
+        assert "trigger_log" in trig["sql"]
+    finally:
+        await state.close()
+
+    # The replayed trigger still fires on insert.
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute(
+            "INSERT INTO schedules (id, name, trigger_type, action_kind, created_at, updated_at) "
+            "VALUES ('sched-t', 'sched-t', 'interval', 'agent', 1.0, 1.0)"
+        )
+        await raw.execute(
+            "INSERT INTO schedule_runs "
+            "(id, schedule_id, trigger_context, action_kind, action_args, status, "
+            " chain_depth, fired_at, created_at) "
+            "VALUES ('run-t', 'sched-t', '{}', 'agent', '{}', 'running', 0, 1.0, 1.0)"
+        )
+        await raw.commit()
+        cur = await raw.execute("SELECT run_id FROM trigger_log WHERE run_id = 'run-t'")
+        logged = await cur.fetchone()
+    assert logged is not None, "replayed trigger did not fire on insert"
+
+
 # ── 2. Backup before rebuild ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Slice 1 of ADR-0101 (task-application queue): the D2 schema layer only, per the approved slice plan.

- `schedule_runs`: `schedule_id` nullable, status CHECK widened to the full ADR-0062 lifecycle, additive queue columns (`queued_at`, `leased_by`, `lease_expires_at`, `concurrency_key`) plus task-application provenance columns (`required_capabilities`, `execution_target`, `library_ref`, `library_content_hash`) and the two queue indexes. `schema_meta.py` kept in parity (test-enforced).
- Migration: additive `ALTER TABLE ADD COLUMN` reconciliation for the new columns; the NOT NULL/CHECK change SQLite can't ALTER uses a rename→create→insert→drop rebuild that backs up `state.db` to a timestamped copy first (rollback = restore the backup).
- `transitions._ENTITY_TABLES` registers `schedule_run` so status movement can route through the guarded CAS store.
- Tests (9 new): migration idempotence on populated DBs, backup created only when a rebuild fires, transition-vocab enforcement, and a strict byte-identical guarantee for the existing schedule-spawned path — golden row values + transition sequence captured from the pre-change codebase.

Explicitly out of scope (later slices): TaskApplication surface, worker/lease loop, capability matching, workflow action_kind wiring. Python-side status vocab (`VALID_STATUSES_BY_ENTITY_TYPE`) intentionally not widened — no writer for the new statuses exists yet; the slice that introduces the enqueue/lease writer widens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)