### PR TITLE
feat(state): task application submit surface writing durable queued rows

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -281,7 +281,11 @@ EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
 VALID_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": VALID_SESSION_STATUSES,
     "invocation": VALID_SESSION_STATUSES,  # shared vocabulary
-    "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES | frozenset({"pending", "running"}),
+    # ADR-0101 D1/D2 slice 2: "queued" is the durable status a task
+    # application (or a schedule fire) now starts in before a worker leases
+    # it. Lease/running vocab beyond the existing "running" stays as-is —
+    # this slice does not add a worker/lease loop.
+    "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES | frozenset({"pending", "running", "queued"}),
     # Shows live in {active, completed, aborted} and carry an "imported" marker
     # for records reconstructed from an on-disk manifest — update_show() already
     # validates against this same set before routing here.

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -72,6 +72,16 @@ _ENTITY_TABLES: dict[str, str] = {
     "schedule_run": "schedule_runs",
 }
 
+# ADR-0101 slice 2: the task-application submit surface only needs a task to
+# be cancellable while still queued (unleased). This is NOT a full transition
+# graph — it only narrows the single edge set leaving "queued" for entities
+# listed here; any other current status (e.g. "running") is governed by CAS
+# alone, same as before this slice. Lease/running edges are deliberately not
+# modeled yet (D3/D4 worker loop is out of scope for this slice).
+_QUEUED_STATE_ALLOWED_TARGETS: dict[str, frozenset[str]] = {
+    "schedule_run": frozenset({"cancelled"}),
+}
+
 
 async def transition(
     db: Any,
@@ -120,6 +130,18 @@ async def transition(
                 f"{request.entity_type} {request.entity_id!r} not found (table={table})"
             )
         previous_status = row["status"]
+
+        allowed_from_queued = _QUEUED_STATE_ALLOWED_TARGETS.get(request.entity_type)
+        if (
+            allowed_from_queued is not None
+            and previous_status == "queued"
+            and request.to_state not in allowed_from_queued
+        ):
+            raise ValueError(
+                f"transition(): {request.entity_type} queued -> {request.to_state!r} "
+                "is not in the declared transition vocabulary for this slice "
+                f"(allowed: {sorted(allowed_from_queued)})"
+            )
 
         if request.from_state is not None and previous_status != request.from_state:
             return TransitionResult(

--- a/lionagi/studio/services/task_applications.py
+++ b/lionagi/studio/services/task_applications.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0101 D1: the task-application submit surface.
+
+``TaskApplication`` is the frozen submit shape every binding shares. This
+module wires only the in-process binding (``submit_task`` /
+``cancel_task``) — ``li task submit`` and ``POST /api/tasks`` are later,
+separate bindings that call the same functions.
+
+``submit_task`` validates the application and writes a durable ``queued``
+row into ``schedule_runs`` (the ADR-0101 D2 generalized task entity,
+``schedule_id`` NULL). That first write is a plain INSERT — there is no
+prior CAS state to guard. Every status move after it routes through
+``lionagi.state.transitions.transition()``; this module never writes
+``schedule_runs.status`` directly again.
+
+No worker/lease loop, no capability matching, and no remote execution live
+here — ``execution_target``/``required_capabilities``/``library_ref`` are
+stored as provenance for a later slice (D3/D4, ADR-0102).
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import bindparam, text
+from sqlalchemy.types import JSON
+
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
+
+from ..scheduler.subprocess import _ALIAS_ACTION_KINDS, _VALID_ACTION_KINDS
+
+__all__ = ("TaskApplication", "cancel_task", "submit_task")
+
+# ADR-0101 D1: this ADR pair adds "workflow" (ADR-0102 registry-resolved
+# definitions) to the existing launcher vocabulary — a CHECK widen, not a
+# rename of any existing kind. Reuses the launcher's own closed set +
+# "playbook" alias rather than declaring a second copy.
+_TASK_APPLICATION_ACTION_KINDS: frozenset[str] = _VALID_ACTION_KINDS | {"workflow"}
+
+_VALID_EXECUTION_TARGETS: frozenset[str] = frozenset(
+    {"host", "local_worktree", "daytona", "remote_agent", "process"}
+)
+
+
+@dataclass(frozen=True)
+class TaskApplication:
+    """D1's frozen submit shape."""
+
+    action_kind: str
+    args: dict[str, Any]
+    execution_target: str
+    required_capabilities: list[str] = field(default_factory=list)
+    library_ref: str | None = None
+    library_content_hash: str | None = None
+    # Optional, per ADR-0062 dedup — carried on the contract but not wired to
+    # any dedup logic yet; ADR-0062's transition() is itself proposed and
+    # unbuilt (see transitions.py's module docstring).
+    idempotency_key: str | None = None
+
+
+def _validate(app: TaskApplication) -> str:
+    """Validate *app*; return the normalized (alias-resolved) action_kind."""
+    normalized_kind = _ALIAS_ACTION_KINDS.get(app.action_kind, app.action_kind)
+    if normalized_kind not in _TASK_APPLICATION_ACTION_KINDS:
+        valid = sorted(_TASK_APPLICATION_ACTION_KINDS | set(_ALIAS_ACTION_KINDS))
+        raise ValueError(f"unknown action_kind {app.action_kind!r}. Valid kinds: {valid}")
+    if app.execution_target not in _VALID_EXECUTION_TARGETS:
+        raise ValueError(
+            f"unknown execution_target {app.execution_target!r}. "
+            f"Valid targets: {sorted(_VALID_EXECUTION_TARGETS)}"
+        )
+    if not isinstance(app.required_capabilities, list) or not all(
+        isinstance(tok, str) and tok for tok in app.required_capabilities
+    ):
+        raise ValueError(
+            "required_capabilities must be a list of non-empty strings, got "
+            f"{app.required_capabilities!r}"
+        )
+    if not isinstance(app.args, dict):
+        raise ValueError(f"args must be a dict, got {type(app.args).__name__}")
+    return normalized_kind
+
+
+def _derive_concurrency_key(required_capabilities: list[str]) -> str | None:
+    """D4's host-scoped rule: a task carrying capability tokens gets a
+    concurrency_key scoped to this host, so ADR-0061 admission can later
+    serialize same-host claims. Which tokens actually demand serialization
+    (D4's eligibility/serialization/affinity classes) is a worker-side
+    capability-class concern out of scope for this slice — here the key is
+    only derived and stored, never matched or admitted against.
+    """
+    if not required_capabilities:
+        return None
+    return f"{socket.gethostname()}:{'+'.join(sorted(required_capabilities))}"
+
+
+async def submit_task(db: StateDB, app: TaskApplication) -> str:
+    """Validate *app* and write a durable ``queued`` row. Returns the new
+    ``schedule_runs.id``."""
+    normalized_kind = _validate(app)
+    run_id = str(uuid.uuid4())
+    now = time.time()
+    concurrency_key = _derive_concurrency_key(app.required_capabilities)
+
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO schedule_runs
+                   (id, schedule_id, invocation_id, trigger_context,
+                    action_kind, action_args, status, chain_depth,
+                    fired_at, created_at, queued_at, concurrency_key,
+                    required_capabilities, execution_target,
+                    library_ref, library_content_hash)
+                   VALUES (:id, NULL, NULL, :trigger_context,
+                           :action_kind, :action_args, 'queued', 0,
+                           :fired_at, :created_at, :queued_at, :concurrency_key,
+                           :required_capabilities, :execution_target,
+                           :library_ref, :library_content_hash)"""
+            ).bindparams(
+                bindparam("trigger_context", type_=JSON),
+                bindparam("action_args", type_=JSON),
+                bindparam("required_capabilities", type_=JSON),
+            ),
+            {
+                "id": run_id,
+                "trigger_context": {},
+                "action_kind": normalized_kind,
+                "action_args": app.args,
+                "fired_at": now,
+                "created_at": now,
+                "queued_at": now,
+                "concurrency_key": concurrency_key,
+                "required_capabilities": app.required_capabilities,
+                "execution_target": app.execution_target,
+                "library_ref": app.library_ref,
+                "library_content_hash": app.library_content_hash,
+            },
+        )
+    return run_id
+
+
+async def cancel_task(db: StateDB, run_id: str, *, actor: Actor) -> bool:
+    """Cancel a still-``queued`` task application via the CAS transition
+    store. Only ``queued -> cancelled`` is permitted in this slice
+    (transitions.py's ADR-0101 vocab gate rejects anything else, e.g. a
+    lease/running move, out from a queued row).
+    """
+    result = await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=run_id,
+            from_state="queued",
+            to_state="cancelled",
+            reason=StateReason(
+                code=RunReasons.CANCELLED_ORCHESTRATOR,
+                summary="task application cancelled before lease",
+            ),
+            actor=actor,
+            idempotency_key=str(uuid.uuid4()),
+        ),
+    )
+    return result.applied

--- a/lionagi/studio/services/task_applications.py
+++ b/lionagi/studio/services/task_applications.py
@@ -59,14 +59,20 @@ class TaskApplication:
     required_capabilities: list[str] = field(default_factory=list)
     library_ref: str | None = None
     library_content_hash: str | None = None
-    # Optional, per ADR-0062 dedup — carried on the contract but not wired to
-    # any dedup logic yet; ADR-0062's transition() is itself proposed and
-    # unbuilt (see transitions.py's module docstring).
+    # Part of the submit contract per ADR-0062 dedup, but submit-level
+    # deduplication is not built yet — submit_task rejects a non-None value
+    # rather than silently double-enqueueing a retried application.
     idempotency_key: str | None = None
 
 
 def _validate(app: TaskApplication) -> str:
     """Validate *app*; return the normalized (alias-resolved) action_kind."""
+    if app.idempotency_key is not None:
+        raise ValueError(
+            "idempotency_key is not supported yet: submit-level deduplication "
+            "is unimplemented, and accepting the key would silently enqueue a "
+            "duplicate task on retry instead of returning the existing one"
+        )
     normalized_kind = _ALIAS_ACTION_KINDS.get(app.action_kind, app.action_kind)
     if normalized_kind not in _TASK_APPLICATION_ACTION_KINDS:
         valid = sorted(_TASK_APPLICATION_ACTION_KINDS | set(_ALIAS_ACTION_KINDS))

--- a/tests/studio/services/test_task_applications.py
+++ b/tests/studio/services/test_task_applications.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0101 D1 slice 2: the task-application submit surface.
+
+Covers submit_task's round-trip write, the CAS-governed queued -> cancelled
+cancel path, rejection of a malformed TaskApplication, and the negative vocab
+test proving transitions.transition() actively rejects queued -> running for
+schedule_run in this slice (not merely unexercised).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
+from lionagi.studio.services.task_applications import TaskApplication, cancel_task, submit_task
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _actor() -> Actor:
+    return Actor(type="operator", id="test")
+
+
+# ── 1. Submit round-trip ─────────────────────────────────────────────────
+
+
+async def test_submit_task_writes_queued_row_with_every_field(db: StateDB) -> None:
+    app = TaskApplication(
+        action_kind="agent",
+        args={"prompt": "hello"},
+        execution_target="host",
+        required_capabilities=["gpu-exclusive", "lean-toolchain"],
+        library_ref="ns/name@1.0.0",
+        library_content_hash="deadbeef",
+        idempotency_key="idem-1",
+    )
+
+    run_id = await submit_task(db, app)
+
+    row = await db.fetch_one("SELECT * FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row is not None
+    assert row["schedule_id"] is None
+    assert row["status"] == "queued"
+    assert row["queued_at"] is not None
+    assert row["action_kind"] == "agent"
+    assert row["action_args"] == '{"prompt": "hello"}'
+    assert row["execution_target"] == "host"
+    assert row["library_ref"] == "ns/name@1.0.0"
+    assert row["library_content_hash"] == "deadbeef"
+    assert row["leased_by"] is None
+    assert row["lease_expires_at"] is None
+    assert json.loads(row["required_capabilities"]) == ["gpu-exclusive", "lean-toolchain"]
+
+    expected_key = f"{socket.gethostname()}:gpu-exclusive+lean-toolchain"
+    assert row["concurrency_key"] == expected_key
+
+
+async def test_submit_task_normalizes_playbook_alias(db: StateDB) -> None:
+    app = TaskApplication(
+        action_kind="playbook",
+        args={},
+        execution_target="host",
+    )
+    run_id = await submit_task(db, app)
+    row = await db.fetch_one("SELECT action_kind FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["action_kind"] == "play"
+
+
+async def test_submit_task_workflow_kind_accepted(db: StateDB) -> None:
+    app = TaskApplication(action_kind="workflow", args={}, execution_target="host")
+    run_id = await submit_task(db, app)
+    row = await db.fetch_one("SELECT action_kind FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["action_kind"] == "workflow"
+
+
+async def test_submit_task_no_capabilities_no_concurrency_key(db: StateDB) -> None:
+    app = TaskApplication(action_kind="agent", args={}, execution_target="host")
+    run_id = await submit_task(db, app)
+    row = await db.fetch_one("SELECT concurrency_key FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["concurrency_key"] is None
+
+
+# ── 2. CAS-governed queued -> cancelled ──────────────────────────────────
+
+
+async def test_cancel_task_succeeds_via_transition_store(db: StateDB) -> None:
+    app = TaskApplication(action_kind="agent", args={}, execution_target="host")
+    run_id = await submit_task(db, app)
+
+    applied = await cancel_task(db, run_id, actor=_actor())
+    assert applied is True
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "cancelled"
+
+    audit = await db.fetch_all(
+        "SELECT previous_status, status, entity_type FROM status_transitions WHERE entity_id = ?",
+        (run_id,),
+    )
+    assert len(audit) == 1
+    assert audit[0]["previous_status"] == "queued"
+    assert audit[0]["status"] == "cancelled"
+    assert audit[0]["entity_type"] == "schedule_run"
+
+
+async def test_cancel_task_twice_is_not_applied_second_time(db: StateDB) -> None:
+    app = TaskApplication(action_kind="agent", args={}, execution_target="host")
+    run_id = await submit_task(db, app)
+
+    assert await cancel_task(db, run_id, actor=_actor()) is True
+    # Second cancel: the row is no longer "queued" (it's "cancelled"), so the
+    # CAS guard's from_state="queued" mismatch reports a conflict rather than
+    # re-applying — ordinary CAS behavior, unchanged by this slice's vocab gate.
+    assert await cancel_task(db, run_id, actor=_actor()) is False
+
+
+# ── 3. Rejection paths ───────────────────────────────────────────────────
+
+
+async def test_submit_task_rejects_unknown_action_kind(db: StateDB) -> None:
+    app = TaskApplication(action_kind="not_a_real_kind", args={}, execution_target="host")
+    with pytest.raises(ValueError, match="unknown action_kind"):
+        await submit_task(db, app)
+
+
+async def test_submit_task_rejects_malformed_required_capabilities_not_a_list(
+    db: StateDB,
+) -> None:
+    app = TaskApplication(
+        action_kind="agent",
+        args={},
+        execution_target="host",
+        required_capabilities={"gpu-exclusive": True},  # type: ignore[arg-type]
+    )
+    with pytest.raises(ValueError, match="required_capabilities"):
+        await submit_task(db, app)
+
+
+async def test_submit_task_rejects_malformed_required_capabilities_non_string_element(
+    db: StateDB,
+) -> None:
+    app = TaskApplication(
+        action_kind="agent",
+        args={},
+        execution_target="host",
+        required_capabilities=["gpu-exclusive", 7],  # type: ignore[list-item]
+    )
+    with pytest.raises(ValueError, match="required_capabilities"):
+        await submit_task(db, app)
+
+
+async def test_submit_task_rejects_unknown_execution_target(db: StateDB) -> None:
+    app = TaskApplication(action_kind="agent", args={}, execution_target="mars")
+    with pytest.raises(ValueError, match="execution_target"):
+        await submit_task(db, app)
+
+
+# ── 4. Negative vocab test — queued -> running is actively rejected ─────
+
+
+async def test_transition_store_rejects_queued_to_running_for_schedule_run(
+    db: StateDB,
+) -> None:
+    """The declared vocabulary is actively narrow, not merely unexercised:
+    attempting queued -> running through transitions.transition() must fail
+    even though the CAS guard itself would otherwise happily apply it."""
+    app = TaskApplication(action_kind="agent", args={}, execution_target="host")
+    run_id = await submit_task(db, app)
+
+    with pytest.raises(ValueError, match="not in the declared transition vocabulary"):
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="queued",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=_actor(),
+                idempotency_key="idem-reject",
+            ),
+        )
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "queued"  # untouched — the rejected write never landed

--- a/tests/studio/services/test_task_applications.py
+++ b/tests/studio/services/test_task_applications.py
@@ -44,7 +44,6 @@ async def test_submit_task_writes_queued_row_with_every_field(db: StateDB) -> No
         required_capabilities=["gpu-exclusive", "lean-toolchain"],
         library_ref="ns/name@1.0.0",
         library_content_hash="deadbeef",
-        idempotency_key="idem-1",
     )
 
     run_id = await submit_task(db, app)
@@ -165,6 +164,22 @@ async def test_submit_task_rejects_unknown_execution_target(db: StateDB) -> None
     app = TaskApplication(action_kind="agent", args={}, execution_target="mars")
     with pytest.raises(ValueError, match="execution_target"):
         await submit_task(db, app)
+
+
+async def test_submit_task_rejects_idempotency_key_until_dedup_exists(db: StateDB) -> None:
+    """Accepting a key without dedup would silently double-enqueue on retry,
+    so a non-None idempotency_key must fail fast — and enqueue nothing."""
+    app = TaskApplication(
+        action_kind="agent",
+        args={},
+        execution_target="host",
+        idempotency_key="idem-1",
+    )
+    with pytest.raises(ValueError, match="idempotency_key"):
+        await submit_task(db, app)
+
+    row = await db.fetch_one("SELECT COUNT(*) AS n FROM schedule_runs")
+    assert row["n"] == 0
 
 
 # ── 4. Negative vocab test — queued -> running is actively rejected ─────


### PR DESCRIPTION
Slice 2 of ADR-0101: the D1 TaskApplication submit surface, building on the generalized task entity that landed in the previous slice.

- `TaskApplication` frozen dataclass — the shared submit shape (action_kind incl. the new `workflow` kind, args, `execution_target`, `required_capabilities`, `library_ref`/`library_content_hash`, `idempotency_key`). Vocabulary reused from the scheduler's existing action-kind source, `playbook` alias normalized to `play`.
- `submit_task()` validates and writes a durable `queued` row into `schedule_runs` (`schedule_id` NULL, `queued_at` stamped, `concurrency_key` derived host-scoped and stored — no matching logic). Every status move after the initial insert routes through the CAS transition store; `cancel_task()` is `queued→cancelled` through that store.
- Python status vocab widened to exactly what this slice writes: `queued`, with `queued→cancelled` permitted. Lease/running transitions remain narrow; the negative test proves `queued→running` is actively rejected by the transition store, not merely unexercised.

**Deliberate fence: no CLI exposure in this slice.** No user-visible verb exists until a worker exists, so nothing can be submitted into a void that silently never executes. The submit surface is an importable internal API only; `li task submit` arrives with the worker/lease slice.

Out of scope (later slices): worker/lease loop, capability matching, remote execution, workflow-library registry integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)