### PR TITLE
perf(studio): session detail 250s -> 0.7s — force PK probe in action-message stats query

### DIFF
--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -83,7 +83,7 @@ def _graph_from_metadata(raw: str | None) -> dict[str, Any] | None:
     return {"nodes": nodes, "edges": edges} if nodes else None
 
 
-def _format_message(row: aiosqlite.Row) -> dict[str, Any]:
+def _format_message(row: aiosqlite.Row | dict[str, Any]) -> dict[str, Any]:
     return {
         "id": row["id"],
         "role": row["role"],
@@ -368,23 +368,37 @@ async def _fetch_action_messages(
     """
     if not msg_ids:
         return []
-    rows_by_id: dict[str, dict[str, Any]] = {}
     class_placeholders = ",".join("?" for _ in _ACTION_LION_CLASSES)
+    cur = await db.execute(
+        f"SELECT type_id, lion_class FROM message_types WHERE lion_class IN ({class_placeholders})",  # noqa: S608
+        _ACTION_LION_CLASSES,
+    )
+    lion_class_by_type_id = {row["type_id"]: row["lion_class"] for row in await cur.fetchall()}
+    if not lion_class_by_type_id:
+        return []
+
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    type_ids = list(lion_class_by_type_id)
+    type_placeholders = ",".join("?" for _ in type_ids)
     for chunk_start in range(0, len(msg_ids), 500):
         chunk = msg_ids[chunk_start : chunk_start + 500]
         placeholders = ",".join("?" for _ in chunk)
+        # `+m.lion_class` disqualifies the lion_class index so the planner probes
+        # the id primary key for the IN list; without it, SQLite drives this query
+        # from idx_messages_lion_class and rescans every action-class row in the
+        # whole table per chunk, which is minutes of I/O on a multi-GB store.
         cur = await db.execute(
             f"""
-            SELECT m.id, m.created_at, m.content, m.sender, m.role,
-                   mt.lion_class AS lion_class_str
+            SELECT m.id, m.created_at, m.content, m.sender, m.role, m.lion_class
             FROM messages m
-            JOIN message_types mt ON m.lion_class = mt.type_id
-            WHERE m.id IN ({placeholders}) AND mt.lion_class IN ({class_placeholders})
+            WHERE m.id IN ({placeholders}) AND +m.lion_class IN ({type_placeholders})
             """,  # noqa: S608
-            [*chunk, *_ACTION_LION_CLASSES],
+            [*chunk, *type_ids],
         )
         for row in await cur.fetchall():
-            rows_by_id[row["id"]] = _format_message(row)
+            data = dict(row)
+            data["lion_class_str"] = lion_class_by_type_id.get(data.pop("lion_class"))
+            rows_by_id[data["id"]] = _format_message(data)
     return [rows_by_id[mid] for mid in msg_ids if mid in rows_by_id]
 
 


### PR DESCRIPTION
## Problem

Ocean reported loading a run in Studio got very slow. Measured: `GET /api/sessions/{id}` on an 11,321-message running session took **250.66s** (a 37-message session: 1.09s). Response body was only 267KB — the time is all server-side.

## Root cause

`_fetch_action_messages` in `lionagi/studio/services/sessions.py` runs per 500-id chunk:

```sql
SELECT ... FROM messages m
JOIN message_types mt ON m.lion_class = mt.type_id
WHERE m.id IN (...500 ids...) AND mt.lion_class IN (...4 classes...)
```

EXPLAIN QUERY PLAN shows SQLite drives this from `idx_messages_lion_class` (`SEARCH m USING INDEX idx_messages_lion_class (lion_class=?)`) instead of the id primary key — i.e. it rescans **every action-class row in the whole 3.6GB messages table** once per chunk, ~23 chunks per detail view. Profiled read-only against the live db: 28.5s in this query alone; the remaining wall time is formatting/JSON-parsing overhead compounded on the event loop.

## Fix

- Resolve the action-class `type_id`s from `message_types` once up front (a handful of rows), map `type_id -> lion_class` in Python.
- Probe `messages` by the id PK, with `+m.lion_class IN (...)` — the unary `+` disqualifies `idx_messages_lion_class` so the planner uses the id lookup.

Same rows, same stats output (verified: identical `tool_call_count`/`message_count` on the live session).

## Measured

| | before | after |
|---|---|---|
| slow query pass (8.3k action rows) | 28.47s | 0.60s |
| `get_session` end-to-end, 11k-message session | 250.66s | **0.72s** |

## Gate

- `uv run --extra studio pytest tests/apps_studio_server/` — exit 0, all green (35 in test_sessions_detail.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)