### PR TITLE
fix(studio): fleet page legibility — day-scale durations, labeled counts, tool-row output previews

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -1091,6 +1091,16 @@ function ToolCallBlock({
   const status = message.status || "ok";
   const exitCode = message.exit_code;
   const isError = status === "error";
+  // Collapsed-row fallback: an empty summary with non-empty output shows the
+  // output's first non-blank line instead of a bare "(no args)" — that line
+  // is usually more informative than a static placeholder.
+  const outputPreview = output
+    ? (output
+        .split("\n")
+        .find((line) => line.trim().length > 0)
+        ?.trim() ?? "")
+    : "";
+  const collapsedText = summary || outputPreview;
 
   const statusBadge = isError ? (
     <span className="rounded border border-status-error/30 bg-status-error-bg px-1.5 py-0.5 text-[length:var(--t-xs)] font-medium text-status-error">
@@ -1118,9 +1128,9 @@ function ToolCallBlock({
         </span>
         <span
           className="flex-1 truncate font-mono text-body text-content-secondary"
-          title={summary}
+          title={collapsedText || undefined}
         >
-          {summary || t("noArgs")}
+          {collapsedText || t("noArgs")}
         </span>
         {statusBadge}
         {output && (

--- a/apps/studio/frontend/src/components/fleet/FleetView.test.ts
+++ b/apps/studio/frontend/src/components/fleet/FleetView.test.ts
@@ -271,3 +271,49 @@ describe("selectedRunId validation", () => {
     expect(resolved).toBe("r1");
   });
 });
+
+// ─── Formatter helpers ────────────────────────────────────────────────────────
+
+import { formatElapsed, formatCompactCount } from "./FleetView";
+
+describe("formatElapsed", () => {
+  it("renders — for null, NaN, Infinity, and negative input", () => {
+    expect(formatElapsed(null)).toBe("—");
+    expect(formatElapsed(Number.NaN)).toBe("—");
+    expect(formatElapsed(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatElapsed(-5)).toBe("—");
+  });
+
+  it("renders sub-minute and sub-hour values unchanged", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(59)).toBe("59s");
+    expect(formatElapsed(60)).toBe("1m");
+    expect(formatElapsed(61)).toBe("1m 1s");
+    expect(formatElapsed(3599)).toBe("59m 59s");
+  });
+
+  it("renders sub-day hour values", () => {
+    expect(formatElapsed(3600)).toBe("1h");
+    expect(formatElapsed(3660)).toBe("1h 1m");
+    expect(formatElapsed(24 * 3600 - 60)).toBe("23h 59m");
+  });
+
+  it("tiers into days at exactly 24h", () => {
+    expect(formatElapsed(24 * 3600)).toBe("1d");
+    expect(formatElapsed(24 * 3600 + 3600)).toBe("1d 1h");
+    expect(formatElapsed(62 * 3600 + 34 * 60)).toBe("2d 14h");
+  });
+});
+
+describe("formatCompactCount", () => {
+  it("keeps counts under 1000 exact", () => {
+    expect(formatCompactCount(0)).toBe("0");
+    expect(formatCompactCount(999)).toBe("999");
+  });
+
+  it("abbreviates from the 1000 boundary, truncating not rounding", () => {
+    expect(formatCompactCount(1000)).toBe("1k");
+    expect(formatCompactCount(5967)).toBe("5.9k");
+    expect(formatCompactCount(999999)).toBe("999.9k");
+  });
+});

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -15,8 +15,8 @@ import { Route } from "@/routes/fleet";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function formatElapsed(sec: number | null): string {
-  if (sec == null) return "—";
+export function formatElapsed(sec: number | null): string {
+  if (sec == null || !Number.isFinite(sec) || sec < 0) return "—";
   if (sec < 60) return `${sec}s`;
   const m = Math.floor(sec / 60);
   if (m < 60) {
@@ -36,7 +36,7 @@ function formatElapsed(sec: number | null): string {
 // Compact count for a legibility-sensitive slot: under 1000 renders the exact
 // integer, at or above 1000 renders one decimal place with a "k" suffix
 // (truncated, not rounded, so the digit shown never overstates the count).
-function formatCompactCount(n: number): string {
+export function formatCompactCount(n: number): string {
   if (n < 1000) return `${n}`;
   return `${Math.floor(n / 100) / 10}k`;
 }

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -24,8 +24,21 @@ function formatElapsed(sec: number | null): string {
     return s > 0 ? `${m}m ${s}s` : `${m}m`;
   }
   const h = Math.floor(m / 60);
-  const mm = m - h * 60;
-  return mm > 0 ? `${h}h ${mm}m` : `${h}h`;
+  if (h < 24) {
+    const mm = m - h * 60;
+    return mm > 0 ? `${h}h ${mm}m` : `${h}h`;
+  }
+  const d = Math.floor(h / 24);
+  const hh = h - d * 24;
+  return hh > 0 ? `${d}d ${hh}h` : `${d}d`;
+}
+
+// Compact count for a legibility-sensitive slot: under 1000 renders the exact
+// integer, at or above 1000 renders one decimal place with a "k" suffix
+// (truncated, not rounded, so the digit shown never overstates the count).
+function formatCompactCount(n: number): string {
+  if (n < 1000) return `${n}`;
+  return `${Math.floor(n / 100) / 10}k`;
 }
 
 // ─── Agent row ────────────────────────────────────────────────────────────────
@@ -54,14 +67,21 @@ function AgentRowItem({
       <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] text-content-primary">
         {agent.name}
       </span>
-      <span className="min-w-[28px] shrink-0 font-data text-[length:var(--t-xs)] uppercase tracking-wider text-content-muted">
-        {t("agentRow.kind")}
+      <span
+        className="min-w-[28px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted"
+        title={t("agentRow.branchesTitle", { count: agent.branch_count })}
+      >
+        {agent.branch_count > 0
+          ? t("agentRow.branches", { count: formatCompactCount(agent.branch_count) })
+          : "—"}
       </span>
-      <span className="min-w-[28px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted">
-        {agent.branch_count > 0 ? t("agentRow.branches", { count: agent.branch_count }) : "—"}
-      </span>
-      <span className="min-w-[28px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted">
-        {agent.message_count > 0 ? t("agentRow.messages", { count: agent.message_count }) : "—"}
+      <span
+        className="min-w-[28px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted"
+        title={t("agentRow.messagesTitle", { count: agent.message_count })}
+      >
+        {agent.message_count > 0
+          ? t("agentRow.messages", { count: formatCompactCount(agent.message_count) })
+          : "—"}
       </span>
       <span className="min-w-[48px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-status-running">
         {formatElapsed(agent.elapsedSec)}

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -5,7 +5,7 @@
  * - LOCALES/RTL_LOCALES metadata shape (16 codes, ar/ur marked rtl).
  * - applyDocumentLocale flips <html lang>/<html dir> for rtl vs ltr locales.
  * - Every messages/*.json file has the exact same leaf-key set as en.json
- *   (700 leaves).
+ *   (701 leaves).
  * - Every locale's messages parse under a real ICU translator with no
  *   FORMATTING_ERROR, including the true {count, plural, ...} strings and
  *   the pre-existing bare-{plural} anti-pattern in prunePhantoms.
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 700 leaves", () => {
-    expect(EN_LEAVES.size).toBe(700);
+  it("en.json has 701 leaves", () => {
+    expect(EN_LEAVES.size).toBe(701);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "الوكيل {name} — فتح تفاصيل الجلسة",
-      "kind": "تشغيل",
-      "branches": "{count, plural, zero {لا فروع} one {فرع واحد} two {فرعان} few {# فروع} many {# فرعًا} other {# فرع}}",
-      "messages": "{count, plural, zero {لا رسائل} one {رسالة واحدة} two {رسالتان} few {# رسائل} many {# رسالة} other {# رسالة}}"
+      "branches": "{count} فرع",
+      "messages": "{count} رسالة",
+      "branchesTitle": "{count} فرع",
+      "messagesTitle": "{count} رسالة"
     },
     "empty": {
       "message": "لا يوجد وكلاء قيد التشغيل — يعرض أسطول الوكلاء عمليات التنسيق المباشرة فور حدوثها.",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "এজেন্ট {name} — সেশনের বিস্তারিত খুলুন",
-      "kind": "রান",
-      "branches": "{count}b",
-      "messages": "{count}m"
+      "branches": "{count} শাখা",
+      "messages": "{count} বার্তা",
+      "branchesTitle": "{count}টি শাখা",
+      "messagesTitle": "{count}টি বার্তা"
     },
     "empty": {
       "message": "কোনো এজেন্ট রানিং নেই — এজেন্ট ফ্লিট লাইভ অর্কেস্ট্রেশন ঘটার সঙ্গে সঙ্গে দেখায়।",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agent {name} — Sessiondetails öffnen",
-      "kind": "Ausführung",
-      "branches": "{count}b",
-      "messages": "{count}m"
+      "branches": "{count} Zwg",
+      "messages": "{count} Nchr",
+      "branchesTitle": "{count} Zweige",
+      "messagesTitle": "{count} Nachrichten"
     },
     "empty": {
       "message": "Keine Agenten laufen — die Flotte zeigt Live-Orchestrierungen, während sie passieren.",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agent {name} — open session detail",
-      "kind": "run",
-      "branches": "{count}b",
-      "messages": "{count}m"
+      "branches": "{count} br",
+      "messages": "{count} msg",
+      "branchesTitle": "{count} branches",
+      "messagesTitle": "{count} messages"
     },
     "empty": {
       "message": "No agents running — Fleet shows live orchestrations as they happen.",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agente {name} — abrir detalle de sesión",
-      "kind": "ejecución",
-      "branches": "{count}r",
-      "messages": "{count}m"
+      "branches": "{count} ram",
+      "messages": "{count} msj",
+      "branchesTitle": "{count} ramas",
+      "messagesTitle": "{count} mensajes"
     },
     "empty": {
       "message": "No hay agentes en ejecución — Flota muestra las orquestaciones en vivo a medida que ocurren.",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agent {name} — ouvrir le détail de session",
-      "kind": "exécution",
-      "branches": "{count, plural, one {# branche} other {# branches}}",
-      "messages": "{count, plural, one {# message} other {# messages}}"
+      "branches": "{count} br",
+      "messages": "{count} msg",
+      "branchesTitle": "{count} branches",
+      "messagesTitle": "{count} messages"
     },
     "empty": {
       "message": "Aucun agent en cours — la Flotte affiche les orchestrations en direct au fur et à mesure.",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "एजेंट {name} — सेशन विवरण खोलें",
-      "kind": "रन",
-      "branches": "{count, plural, one {# ब्रांच} other {# ब्रांच}}",
-      "messages": "{count, plural, one {# मैसेज} other {# मैसेज}}"
+      "branches": "{count} शाखा",
+      "messages": "{count} संदेश",
+      "branchesTitle": "{count} शाखाएँ",
+      "messagesTitle": "{count} संदेश"
     },
     "empty": {
       "message": "कोई एजेंट नहीं चल रहा — फ़्लीट लाइव ऑर्केस्ट्रेशन होते ही दिखाता है।",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agen {name} — buka detail sesi",
-      "kind": "eksekusi",
-      "branches": "{count}b",
-      "messages": "{count}m"
+      "branches": "{count} cab",
+      "messages": "{count} psn",
+      "branchesTitle": "{count} cabang",
+      "messagesTitle": "{count} pesan"
     },
     "empty": {
       "message": "Tidak ada agen berjalan — armada agen menampilkan orkestrasi live saat terjadi.",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "エージェント{name} — セッション詳細を開く",
-      "kind": "実行",
-      "branches": "{count, plural, other {# ブランチ}}",
-      "messages": "{count, plural, other {# メッセージ}}"
+      "branches": "{count}分岐",
+      "messages": "{count}件",
+      "branchesTitle": "{count} 件のブランチ",
+      "messagesTitle": "{count} 件のメッセージ"
     },
     "empty": {
       "message": "実行中のエージェントはありません — エージェントフリートはライブのオーケストレーションを発生時に表示します。",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "에이전트 {name} — 세션 세부 정보 열기",
-      "kind": "실행",
-      "branches": "{count, plural, other {브랜치 #개}}",
-      "messages": "{count, plural, other {메시지 #개}}"
+      "branches": "브랜치 {count}",
+      "messages": "메시지 {count}",
+      "branchesTitle": "브랜치 {count}개",
+      "messagesTitle": "메시지 {count}개"
     },
     "empty": {
       "message": "실행 중인 에이전트 없음 — 에이전트 플릿은 라이브 오케스트레이션을 발생 즉시 보여줍니다.",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Agente {name} — abrir detalhes da sessão",
-      "kind": "execução",
-      "branches": "{count}b",
-      "messages": "{count}m"
+      "branches": "{count} ram",
+      "messages": "{count} msg",
+      "branchesTitle": "{count} ramificações",
+      "messagesTitle": "{count} mensagens"
     },
     "empty": {
       "message": "Nenhum agente em execução — a frota mostra orquestrações ao vivo conforme elas acontecem.",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "Агент {name} — открыть сведения о сессии",
-      "kind": "запуск",
-      "branches": "{count} в.",
-      "messages": "{count} сообщ."
+      "branches": "{count} ветв",
+      "messages": "{count} сообщ",
+      "branchesTitle": "{count} ветвей",
+      "messagesTitle": "{count} сообщений"
     },
     "empty": {
       "message": "Запущенных агентов нет — пул агентов показывает живые оркестрации по мере их появления.",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "ajan {name} — oturum ayrıntısını aç",
-      "kind": "çalıştırma",
-      "branches": "{count, plural, one {# dal} other {# dal}}",
-      "messages": "{count, plural, one {# mesaj} other {# mesaj}}"
+      "branches": "{count} dal",
+      "messages": "{count} msj",
+      "branchesTitle": "{count} dal",
+      "messagesTitle": "{count} mesaj"
     },
     "empty": {
       "message": "çalışan ajan yok — ajan filosu canlı orkestrasyonları gerçekleşirken gösterir.",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "ایجنٹ ⁨{name}⁩ — سیشن تفصیل کھولیں",
-      "kind": "رن",
-      "branches": "{count, plural, one {# برانچ} other {# برانچز}}",
-      "messages": "{count, plural, one {# پیغام} other {# پیغامات}}"
+      "branches": "{count} شاخ",
+      "messages": "{count} پیغام",
+      "branchesTitle": "{count} شاخیں",
+      "messagesTitle": "{count} پیغامات"
     },
     "empty": {
       "message": "کوئی ایجنٹ نہیں چل رہا — ایجنٹ فلیٹ لائیو آرکیسٹریشنز دکھاتا ہے۔",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "tác nhân {name} — mở chi tiết phiên",
-      "kind": "lần chạy",
-      "branches": "{count, plural, other {# nhánh}}",
-      "messages": "{count, plural, other {# tin nhắn}}"
+      "branches": "{count} nh",
+      "messages": "{count} tn",
+      "branchesTitle": "{count} nhánh",
+      "messagesTitle": "{count} tin nhắn"
     },
     "empty": {
       "message": "không có tác nhân nào đang chạy — nhóm tác nhân hiển thị các điều phối live khi chúng diễn ra.",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -555,9 +555,10 @@
     },
     "agentRow": {
       "ariaLabel": "智能体 {name} — 打开会话详情",
-      "kind": "运行",
       "branches": "{count}分支",
-      "messages": "{count}条"
+      "messages": "{count}消息",
+      "branchesTitle": "{count} 个分支",
+      "messagesTitle": "{count} 条消息"
     },
     "empty": {
       "message": "当前没有运行中的智能体 — 这里会实时显示进行中的编排任务。",


### PR DESCRIPTION
## What

Ocean flagged the Fleet page as hard to read (screenshot review). Four targeted legibility fixes, no layout changes:

1. **Day-scale elapsed times** — `formatElapsed` gains a days tier: a 62-hour session now renders `2d 14h` instead of `5967m` / `62h 34m`.
2. **Compact counts with labels** — large branch/message counts render as `5.9k` via `formatCompactCount`, and both counts carry tooltips (`branchesTitle`/`messagesTitle` i18n keys) so the bare numbers are identifiable.
3. **Dropped the static kind column** — the agent row's `kind` cell was always the same static value; removed as noise.
4. **Tool-row output previews** — `ToolCallBlock` falls back to the first non-empty output line when a call has no args, replacing the unhelpful `(no args)` on e.g. Bash rows.

All 16 `messages/*.json` locales updated for the two new keys; locale leaf-count test 700 → 701.

## Gates

- `npm run test` — 750 passed
- `npm run build` — green
- Generated `routeTree.gen.ts` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)