### PR TITLE
feat(state,studio): ADR-0101 D3 local worker/claim loop with bounded lease recovery

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1094,6 +1094,7 @@ class StateDB:
                       leased_by           TEXT,
                       lease_expires_at    REAL,
                       concurrency_key     TEXT,
+                      lease_attempts      INTEGER NOT NULL DEFAULT 0,
                       required_capabilities  JSON,
                       execution_target       TEXT,
                       library_ref             TEXT,

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -82,6 +82,9 @@ class RunReasons:
     CANCELLED_FORCE_KILL = "run.cancelled.force_kill"
     CANCELLED_STALE_AUTO = "run.cancelled.stale_auto"
     PAUSED_OPERATOR = "run.paused.operator"
+    # ADR-0101 D3: task-application worker lease outcomes.
+    QUEUED_LEASE_EXPIRED = "run.queued.lease_expired"
+    FAILED_LEASE_ATTEMPTS_EXHAUSTED = "run.failed.lease_attempts_exhausted"
 
 
 class SessionReasons:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -507,6 +507,8 @@ CREATE TABLE IF NOT EXISTS schedule_runs (
   leased_by           TEXT,
   lease_expires_at    REAL,
   concurrency_key     TEXT,
+  -- ADR-0101 D3: bounds the lease-expiry recovery loop (worker.py's reaper).
+  lease_attempts      INTEGER NOT NULL DEFAULT 0,
   -- ADR-0101 D2: task-application provenance (seam into ADR-0102).
   required_capabilities  JSON,
   execution_target       TEXT,

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -593,6 +593,8 @@ schedule_runs = Table(
     Column("leased_by", Text),
     Column("lease_expires_at", Float),
     Column("concurrency_key", Text),
+    # ADR-0101 D3: bounds the lease-expiry recovery loop (worker.py's reaper).
+    Column("lease_attempts", Integer, nullable=False, server_default="0"),
     # ADR-0101 D2: task-application provenance (seam into ADR-0102).
     Column("required_capabilities", JSON),
     Column("execution_target", Text),

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -120,6 +120,8 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("execution_target", "TEXT"),
         ("library_ref", "TEXT"),
         ("library_content_hash", "TEXT"),
+        # ADR-0101 D3: bounds the lease-expiry recovery loop (worker.py's reaper).
+        ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
     ],
     # Phase C Move 2: engine run persistence.
     # New table created via schema.sql; these columns allow ALTER TABLE on

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -73,13 +73,13 @@ _ENTITY_TABLES: dict[str, str] = {
 }
 
 # ADR-0101 slice 2/3: the declared transition vocabulary, per (entity_type,
-# from_state). This is NOT a full transition graph — only edges an ADR-0101
-# slice actually authorizes are listed; any current status that is not a key
-# for a given entity_type is governed by CAS alone, same as before this
-# vocabulary existed. "completed"/"failed" map to an empty target set,
-# closing terminal re-entry (D3 R2): no CAS write can move a schedule_run
-# back out of a terminal status even though the guard alone would happily
-# apply it.
+# from_state). This is NOT a full transition graph, but it IS closed for the
+# entity types listed: a current status with no entry has no declared
+# outgoing edges, exactly like an explicit empty set — CAS alone never
+# authorizes an undeclared move. "completed"/"failed"/"cancelled" map to an
+# empty target set, closing terminal re-entry: no CAS write can move a
+# schedule_run back out of a terminal status even though the guard alone
+# would happily apply it.
 _TRANSITION_VOCAB: dict[str, dict[str, frozenset[str]]] = {
     "schedule_run": {
         "queued": frozenset({"cancelled", "running"}),
@@ -88,6 +88,7 @@ _TRANSITION_VOCAB: dict[str, dict[str, frozenset[str]]] = {
         "running": frozenset({"completed", "failed", "queued"}),
         "completed": frozenset(),
         "failed": frozenset(),
+        "cancelled": frozenset(),
     },
 }
 
@@ -140,16 +141,9 @@ async def transition(
             )
         previous_status = row["status"]
 
-        vocab = _TRANSITION_VOCAB.get(request.entity_type)
-        if vocab is not None:
-            allowed_targets = vocab.get(previous_status)
-            if allowed_targets is not None and request.to_state not in allowed_targets:
-                raise ValueError(
-                    f"transition(): {request.entity_type} {previous_status} -> "
-                    f"{request.to_state!r} is not in the declared transition "
-                    f"vocabulary for this slice (allowed: {sorted(allowed_targets)})"
-                )
-
+        # CAS mismatch reports BEFORE the vocabulary check so an ordinary
+        # lost race (e.g. a second cancel finding the row already cancelled)
+        # stays a conflict result instead of becoming a vocabulary error.
         if request.from_state is not None and previous_status != request.from_state:
             return TransitionResult(
                 applied=False,
@@ -158,6 +152,16 @@ async def transition(
                 current_state=previous_status,
                 transition_id=transition_id,
             )
+
+        vocab = _TRANSITION_VOCAB.get(request.entity_type)
+        if vocab is not None:
+            allowed_targets = vocab.get(previous_status, frozenset())
+            if request.to_state not in allowed_targets:
+                raise ValueError(
+                    f"transition(): {request.entity_type} {previous_status} -> "
+                    f"{request.to_state!r} is not in the declared transition "
+                    f"vocabulary for this slice (allowed: {sorted(allowed_targets)})"
+                )
 
         for col, expected in guard.items():
             if row[col] != expected:

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -72,14 +72,23 @@ _ENTITY_TABLES: dict[str, str] = {
     "schedule_run": "schedule_runs",
 }
 
-# ADR-0101 slice 2: the task-application submit surface only needs a task to
-# be cancellable while still queued (unleased). This is NOT a full transition
-# graph — it only narrows the single edge set leaving "queued" for entities
-# listed here; any other current status (e.g. "running") is governed by CAS
-# alone, same as before this slice. Lease/running edges are deliberately not
-# modeled yet (D3/D4 worker loop is out of scope for this slice).
-_QUEUED_STATE_ALLOWED_TARGETS: dict[str, frozenset[str]] = {
-    "schedule_run": frozenset({"cancelled"}),
+# ADR-0101 slice 2/3: the declared transition vocabulary, per (entity_type,
+# from_state). This is NOT a full transition graph — only edges an ADR-0101
+# slice actually authorizes are listed; any current status that is not a key
+# for a given entity_type is governed by CAS alone, same as before this
+# vocabulary existed. "completed"/"failed" map to an empty target set,
+# closing terminal re-entry (D3 R2): no CAS write can move a schedule_run
+# back out of a terminal status even though the guard alone would happily
+# apply it.
+_TRANSITION_VOCAB: dict[str, dict[str, frozenset[str]]] = {
+    "schedule_run": {
+        "queued": frozenset({"cancelled", "running"}),
+        # D3: running -> queued is ONLY the lease-expiry recovery edge (the
+        # worker reaper), never a worker- or operator-initiated move.
+        "running": frozenset({"completed", "failed", "queued"}),
+        "completed": frozenset(),
+        "failed": frozenset(),
+    },
 }
 
 
@@ -131,17 +140,15 @@ async def transition(
             )
         previous_status = row["status"]
 
-        allowed_from_queued = _QUEUED_STATE_ALLOWED_TARGETS.get(request.entity_type)
-        if (
-            allowed_from_queued is not None
-            and previous_status == "queued"
-            and request.to_state not in allowed_from_queued
-        ):
-            raise ValueError(
-                f"transition(): {request.entity_type} queued -> {request.to_state!r} "
-                "is not in the declared transition vocabulary for this slice "
-                f"(allowed: {sorted(allowed_from_queued)})"
-            )
+        vocab = _TRANSITION_VOCAB.get(request.entity_type)
+        if vocab is not None:
+            allowed_targets = vocab.get(previous_status)
+            if allowed_targets is not None and request.to_state not in allowed_targets:
+                raise ValueError(
+                    f"transition(): {request.entity_type} {previous_status} -> "
+                    f"{request.to_state!r} is not in the declared transition "
+                    f"vocabulary for this slice (allowed: {sorted(allowed_targets)})"
+                )
 
         if request.from_state is not None and previous_status != request.from_state:
             return TransitionResult(

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -224,6 +224,8 @@ class SchedulerEngine:
         # closes the race a DB-only last_alert_at check can't (see
         # _maybe_fire).
         self._threshold_pending: set[str] = set()
+        # ADR-0101 D3: this daemon process is the one host worker (v1).
+        self._task_worker_id = f"host:{uuid.uuid4().hex[:8]}"
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -522,6 +524,11 @@ class SchedulerEngine:
         except Exception:
             _log.exception("Dispatch outbox delivery scan error")
 
+        try:
+            await self._run_task_worker_tick(now)
+        except Exception:
+            _log.exception("Task worker tick error")
+
         schedules = await self._svc.list_schedules(enabled=True)
 
         for s in schedules:
@@ -552,6 +559,19 @@ class SchedulerEngine:
 
         async with StateDB() as db:
             await deliver_due_dispatches(db, now=now)
+
+    async def _run_task_worker_tick(self, now: float) -> None:
+        """ADR-0101 D3: reap lapsed leases and claim/execute eligible host
+        task applications. Not interval-gated for the same reason as
+        ``_deliver_due_dispatches`` — the 30s tick is the latency floor.
+        """
+        from lionagi.state.db import StateDB
+        from lionagi.studio.scheduler import worker as _worker
+
+        if not _worker.TASK_WORKER_ENABLED:
+            return
+        async with StateDB() as db:
+            await _worker.worker_tick(db, worker_id=self._task_worker_id, now=now)
 
     async def _tick_github(self, schedule: dict, now: float) -> None:
         poll_interval = schedule.get("poll_interval_sec") or schedule.get("interval_sec") or 300

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0101 D3: the local (host-only) worker/claim loop.
+
+v1 ships ONE worker — the Studio daemon engine itself — claiming everything
+it can serve. A claim is one guarded CAS through
+``lionagi.state.transitions.transition()`` (``queued -> running``) that sets
+``leased_by``/``lease_expires_at``/``lease_attempts`` in the same guarded
+UPDATE the status move performs; there is no second write and no parallel
+CAS path (ADR-0101's scope fence). Execution resolves through the existing
+subprocess launcher (``lionagi.studio.scheduler.subprocess``) — this module
+never spawns a process itself.
+
+Capability matching, remote execution targets, workers-table heartbeats, and
+workflow-registry resolution are later slices (D4 / ADR-0102): a row this
+worker cannot serve under the D3 claim predicate is left ``queued``, never
+faked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from sqlalchemy import text
+
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
+from lionagi.studio.scheduler import subprocess as _subprocess
+
+_log = logging.getLogger(__name__)
+
+__all__ = (
+    "DEFAULT_LEASE_TTL_SECONDS",
+    "MAX_LEASE_ATTEMPTS",
+    "TASK_WORKER_ENABLED",
+    "claim_and_execute",
+    "default_execute",
+    "reap_expired_leases",
+    "worker_tick",
+)
+
+# Module-level enable flag (ADR-0101 D3 host worker), default ON. The Studio
+# daemon's scheduler tick checks this before running a worker_tick pass.
+TASK_WORKER_ENABLED = True
+
+DEFAULT_LEASE_TTL_SECONDS = 300.0
+
+# D3 R1: a running lease that lapses this many times without completing goes
+# terminal instead of re-queuing forever. Deliberately conservative — policy
+# tuning (backoff curves, per-capability bounds) belongs to the
+# capability-matching slice, not this one.
+MAX_LEASE_ATTEMPTS = 3
+
+# CLAIM PREDICATE (D3, conservative v1): only host-targeted, capability-free,
+# non-workflow, ad-hoc (schedule_id IS NULL) rows are eligible. Scheduler-fired
+# rows (schedule_id NOT NULL) are never touched — that path is governed by
+# SchedulerEngine._fire, not this worker.
+_CLAIM_SELECT_SQL = """
+    SELECT id, action_kind, action_args, lease_attempts
+    FROM schedule_runs
+    WHERE status = 'queued'
+      AND schedule_id IS NULL
+      AND execution_target = 'host'
+      AND (required_capabilities IS NULL OR required_capabilities = '[]')
+      AND action_kind != 'workflow'
+    ORDER BY queued_at ASC
+    LIMIT :limit
+"""
+
+_REAP_SELECT_SQL = """
+    SELECT id, lease_attempts, lease_expires_at
+    FROM schedule_runs
+    WHERE status = 'running'
+      AND lease_expires_at IS NOT NULL
+      AND lease_expires_at < :now
+"""
+
+ExecuteFn = Callable[[dict[str, Any]], Awaitable[tuple[int, str]]]
+
+
+async def default_execute(row: dict[str, Any]) -> tuple[int, str]:
+    """Resolve *row*'s action_kind through the existing subprocess launcher.
+
+    Reuses the scheduler's own action_kind vocabulary and argv builder
+    rather than a second launcher: the task application's ``action_args``
+    payload carries the same ``action_*``-named keys a schedule dict would
+    (``action_model``/``action_prompt``/``action_agent``/...).
+    """
+    action_args = row.get("action_args") or {}
+    schedule_like = {"action_kind": row["action_kind"], **action_args}
+    li_prefix, li_resolve_error = _subprocess.resolve_li_executable()
+    if li_prefix is None:
+        return 1, f"cannot resolve li executable: {li_resolve_error}"
+    try:
+        argv, tmp_path = _subprocess.build_argv(schedule_like, {}, executable_prefix=li_prefix)
+    except Exception as exc:  # noqa: BLE001
+        return 1, f"{type(exc).__name__}: {exc}"
+    invocation_id = uuid.uuid4().hex[:12]
+    return await _subprocess.spawn_and_wait(argv, invocation_id, tmp_path=tmp_path)
+
+
+async def reap_expired_leases(db: StateDB, *, now: float | None = None) -> dict[str, int]:
+    """Recover or fail rows whose lease has lapsed.
+
+    A row under ``MAX_LEASE_ATTEMPTS`` goes back to ``queued`` (recovery,
+    clearing the lease columns); at or beyond the bound it goes to
+    ``failed`` (terminal) — unbounded requeue is impossible by construction.
+    A live (unexpired) lease is never touched: the guard on
+    ``lease_expires_at`` closes the race between this pass's read and its
+    own guarded write.
+    """
+    now = now if now is not None else time.time()
+    counts = {"requeued": 0, "failed": 0}
+
+    async with db._read() as conn:
+        rows = (await conn.execute(text(_REAP_SELECT_SQL), {"now": now})).mappings().all()
+
+    for row in rows:
+        run_id = row["id"]
+        if row["lease_attempts"] >= MAX_LEASE_ATTEMPTS:
+            result = await transition(
+                db,
+                TransitionRequest(
+                    entity_type="schedule_run",
+                    entity_id=run_id,
+                    from_state="running",
+                    to_state="failed",
+                    reason=StateReason(
+                        code=RunReasons.FAILED_LEASE_ATTEMPTS_EXHAUSTED,
+                        summary=(
+                            f"lease expired {row['lease_attempts']} time(s); "
+                            f"bound ({MAX_LEASE_ATTEMPTS}) reached"
+                        ),
+                    ),
+                    actor=Actor(type="system", id="task_worker_reaper"),
+                    idempotency_key=f"lease_exhausted:{run_id}:{row['lease_attempts']}",
+                ),
+                guard={"lease_expires_at": row["lease_expires_at"]},
+            )
+            if result.applied:
+                counts["failed"] += 1
+        else:
+            result = await transition(
+                db,
+                TransitionRequest(
+                    entity_type="schedule_run",
+                    entity_id=run_id,
+                    from_state="running",
+                    to_state="queued",
+                    reason=StateReason(
+                        code=RunReasons.QUEUED_LEASE_EXPIRED,
+                        summary="lease expired before completion; recovered for re-claim",
+                    ),
+                    actor=Actor(type="system", id="task_worker_reaper"),
+                    idempotency_key=f"lease_expired:{run_id}:{row['lease_attempts']}",
+                ),
+                guard={"lease_expires_at": row["lease_expires_at"]},
+                patch={"leased_by": None, "lease_expires_at": None},
+            )
+            if result.applied:
+                counts["requeued"] += 1
+
+    return counts
+
+
+async def claim_and_execute(
+    db: StateDB,
+    *,
+    worker_id: str,
+    execute: ExecuteFn | None = None,
+    now: float | None = None,
+    lease_ttl: float = DEFAULT_LEASE_TTL_SECONDS,
+    limit: int = 20,
+) -> int:
+    """Claim every eligible queued row this worker can serve, then execute each.
+
+    Returns the number of rows claimed (regardless of execution outcome).
+    Each claim is one guarded CAS (``queued -> running``) that atomically
+    sets ``leased_by``/``lease_expires_at``/``lease_attempts``; a lost race
+    or a row another caller already moved (e.g. cancelled) is skipped, not
+    retried within this pass.
+    """
+    execute = execute if execute is not None else default_execute
+    now = now if now is not None else time.time()
+
+    async with db._read() as conn:
+        rows = (await conn.execute(text(_CLAIM_SELECT_SQL), {"limit": limit})).mappings().all()
+
+    claimed = 0
+    for row in rows:
+        run_id = row["id"]
+        result = await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="queued",
+                to_state="running",
+                reason=StateReason(
+                    code=RunReasons.STARTED_OK,
+                    summary=f"claimed by host worker {worker_id}",
+                ),
+                actor=Actor(type="system", id=worker_id),
+                idempotency_key=f"claim:{run_id}:{worker_id}:{now}",
+            ),
+            patch={
+                "leased_by": worker_id,
+                "lease_expires_at": now + lease_ttl,
+                "lease_attempts": row["lease_attempts"] + 1,
+            },
+        )
+        if not result.applied:
+            continue
+        claimed += 1
+        await _execute_claimed(db, run_id, row, execute)
+
+    return claimed
+
+
+async def _execute_claimed(db: StateDB, run_id: str, row: Any, execute: ExecuteFn) -> None:
+    task_row = dict(row)
+    action_args = task_row.get("action_args")
+    if isinstance(action_args, str):
+        task_row["action_args"] = json.loads(action_args) if action_args else {}
+
+    try:
+        exit_code, error_detail = await execute(task_row)
+    except Exception as exc:  # noqa: BLE001
+        exit_code, error_detail = 1, f"{type(exc).__name__}: {exc}"
+
+    completion_time = time.time()
+    if exit_code == 0:
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="running",
+                to_state="completed",
+                reason=StateReason(
+                    code=RunReasons.COMPLETED_OK, summary="task execution completed"
+                ),
+                actor=Actor(type="system", id="task_worker"),
+                idempotency_key=f"complete:{run_id}:{completion_time}",
+            ),
+        )
+    else:
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="running",
+                to_state="failed",
+                reason=StateReason(
+                    code=RunReasons.FAILED_EXIT_NONZERO,
+                    summary=(error_detail or f"exit code {exit_code}")[:500],
+                ),
+                actor=Actor(type="system", id="task_worker"),
+                idempotency_key=f"fail:{run_id}:{completion_time}",
+            ),
+        )
+
+
+async def worker_tick(
+    db: StateDB,
+    *,
+    worker_id: str,
+    execute: ExecuteFn | None = None,
+    now: float | None = None,
+    lease_ttl: float = DEFAULT_LEASE_TTL_SECONDS,
+) -> dict[str, int]:
+    """One worker tick: reaper pass then claim pass.
+
+    Split from any sleep loop so tests (and the Studio daemon's own tick)
+    can drive a single pass directly without a timer.
+    """
+    now = now if now is not None else time.time()
+    reaped = await reap_expired_leases(db, now=now)
+    claimed = await claim_and_execute(
+        db, worker_id=worker_id, execute=execute, now=now, lease_ttl=lease_ttl
+    )
+    return {**reaped, "claimed": claimed}

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -218,12 +218,20 @@ async def claim_and_execute(
         if not result.applied:
             continue
         claimed += 1
-        await _execute_claimed(db, run_id, row, execute)
+        # The claim's lease identity travels to the terminal write: if this
+        # worker's lease lapses mid-execution and the reaper hands the row to
+        # another claimant, the stale worker's completed/failed guard
+        # mismatches and its write is dropped instead of clobbering the live
+        # lease.
+        lease_guard = {"leased_by": worker_id, "lease_expires_at": now + lease_ttl}
+        await _execute_claimed(db, run_id, row, execute, lease_guard)
 
     return claimed
 
 
-async def _execute_claimed(db: StateDB, run_id: str, row: Any, execute: ExecuteFn) -> None:
+async def _execute_claimed(
+    db: StateDB, run_id: str, row: Any, execute: ExecuteFn, lease_guard: dict[str, Any]
+) -> None:
     task_row = dict(row)
     action_args = task_row.get("action_args")
     if isinstance(action_args, str):
@@ -249,6 +257,7 @@ async def _execute_claimed(db: StateDB, run_id: str, row: Any, execute: ExecuteF
                 actor=Actor(type="system", id="task_worker"),
                 idempotency_key=f"complete:{run_id}:{completion_time}",
             ),
+            guard=lease_guard,
         )
     else:
         await transition(
@@ -265,6 +274,7 @@ async def _execute_claimed(db: StateDB, run_id: str, row: Any, execute: ExecuteF
                 actor=Actor(type="system", id="task_worker"),
                 idempotency_key=f"fail:{run_id}:{completion_time}",
             ),
+            guard=lease_guard,
         )
 
 

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -305,6 +305,71 @@ async def test_migration_preserves_triggers(tmp_path):
     assert logged is not None, "replayed trigger did not fire on insert"
 
 
+async def test_migration_adds_lease_attempts_column_to_legacy_db(tmp_path):
+    """A schedule_runs table already at ADR-0101 D2 shape (all D2 columns
+    present) but pre-dating D3's lease_attempts column gains it additively —
+    no rebuild, just StateDB._reconcile_columns's ALTER TABLE ADD COLUMN."""
+    db_path = tmp_path / "legacy_no_lease_attempts.db"
+
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute(_CURRENT_SCHEDULES_DDL)
+        await raw.execute(
+            """
+            CREATE TABLE schedule_runs (
+              id                  TEXT    PRIMARY KEY,
+              schedule_id         TEXT    REFERENCES schedules(id) ON DELETE CASCADE,
+              invocation_id       TEXT,
+              trigger_context     JSON    NOT NULL,
+              action_kind         TEXT    NOT NULL,
+              action_args         JSON    NOT NULL,
+              status              TEXT    NOT NULL DEFAULT 'running'
+                                  CHECK(status IN ('queued', 'waiting_dependency', 'running',
+                                                   'retry_wait', 'completed', 'failed',
+                                                   'timed_out', 'skipped', 'cancelled')),
+              exit_code           INTEGER,
+              chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+              chain_depth         INTEGER NOT NULL DEFAULT 0,
+              fired_at            REAL    NOT NULL,
+              ended_at            REAL,
+              error_detail        TEXT,
+              created_at          REAL    NOT NULL,
+              updated_at          REAL,
+              status_reason_code     TEXT,
+              status_reason_summary  TEXT,
+              status_evidence_refs   JSON,
+              queued_at           REAL,
+              leased_by           TEXT,
+              lease_expires_at    REAL,
+              concurrency_key     TEXT,
+              required_capabilities  JSON,
+              execution_target       TEXT,
+              library_ref             TEXT,
+              library_content_hash    TEXT
+            )
+            """
+        )
+        await raw.execute(
+            "INSERT INTO schedules (id, name, trigger_type, action_kind, created_at, updated_at) "
+            "VALUES ('sched-la', 'sched-la', 'interval', 'agent', 1.0, 1.0)"
+        )
+        await raw.execute(
+            "INSERT INTO schedule_runs "
+            "(id, schedule_id, trigger_context, action_kind, action_args, status, "
+            " chain_depth, fired_at, created_at) "
+            "VALUES ('run-la', 'sched-la', '{}', 'agent', '{}', 'running', 0, 1.0, 1.0)"
+        )
+        await raw.commit()
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        row = await state.fetch_one("SELECT * FROM schedule_runs WHERE id = 'run-la'")
+        assert row is not None
+        assert row["lease_attempts"] == 0
+    finally:
+        await state.close()
+
+
 # ── 2. Backup before rebuild ─────────────────────────────────────────────────
 
 
@@ -533,6 +598,10 @@ _EXCLUDED_COLUMNS = {
     "execution_target",
     "library_ref",
     "library_content_hash",
+    # ADR-0101 D3 additive column — asserted separately (must default to 0
+    # for a schedule-spawned run); excluded here for the same reason as the
+    # D2 columns above.
+    "lease_attempts",
 }
 
 
@@ -587,6 +656,8 @@ async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
         "library_content_hash",
     ):
         assert row_after_create[col] is None
+    # ADR-0101 D3 additive column — defaults to 0, not NULL.
+    assert row_after_create["lease_attempts"] == 0
 
     await db.update_schedule_run(
         run_id,

--- a/tests/studio/services/test_task_applications.py
+++ b/tests/studio/services/test_task_applications.py
@@ -4,9 +4,10 @@
 """ADR-0101 D1 slice 2: the task-application submit surface.
 
 Covers submit_task's round-trip write, the CAS-governed queued -> cancelled
-cancel path, rejection of a malformed TaskApplication, and the negative vocab
-test proving transitions.transition() actively rejects queued -> running for
-schedule_run in this slice (not merely unexercised).
+cancel path, and rejection of a malformed TaskApplication. The transition
+vocabulary's negative-boundary tests (queued -> running is now allowed by
+D3; terminal re-entry is rejected) live in test_task_worker.py alongside the
+worker that exercises the queued -> running edge.
 """
 
 from __future__ import annotations
@@ -17,7 +18,7 @@ import socket
 import pytest
 
 from lionagi.state.db import StateDB
-from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
+from lionagi.state.transitions import Actor
 from lionagi.studio.services.task_applications import TaskApplication, cancel_task, submit_task
 
 
@@ -180,33 +181,3 @@ async def test_submit_task_rejects_idempotency_key_until_dedup_exists(db: StateD
 
     row = await db.fetch_one("SELECT COUNT(*) AS n FROM schedule_runs")
     assert row["n"] == 0
-
-
-# ── 4. Negative vocab test — queued -> running is actively rejected ─────
-
-
-async def test_transition_store_rejects_queued_to_running_for_schedule_run(
-    db: StateDB,
-) -> None:
-    """The declared vocabulary is actively narrow, not merely unexercised:
-    attempting queued -> running through transitions.transition() must fail
-    even though the CAS guard itself would otherwise happily apply it."""
-    app = TaskApplication(action_kind="agent", args={}, execution_target="host")
-    run_id = await submit_task(db, app)
-
-    with pytest.raises(ValueError, match="not in the declared transition vocabulary"):
-        await transition(
-            db,
-            TransitionRequest(
-                entity_type="schedule_run",
-                entity_id=run_id,
-                from_state="queued",
-                to_state="running",
-                reason=StateReason(code="run.started.ok"),
-                actor=_actor(),
-                idempotency_key="idem-reject",
-            ),
-        )
-
-    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
-    assert row["status"] == "queued"  # untouched — the rejected write never landed

--- a/tests/studio/services/test_task_worker.py
+++ b/tests/studio/services/test_task_worker.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0101 D3: the local (host-only) worker/claim loop.
+
+Covers the claim CAS race, cancel-beats-claim, bounded lease-expiry
+recovery (R1), terminal re-entry rejection (R2), the D3 claim predicate,
+and a full submit -> claim -> execute -> completed round trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from lionagi.state.db import StateDB
+from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
+from lionagi.studio.scheduler.worker import (
+    MAX_LEASE_ATTEMPTS,
+    claim_and_execute,
+    reap_expired_leases,
+    worker_tick,
+)
+from lionagi.studio.services.task_applications import TaskApplication, submit_task
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def _submit_host_task(db: StateDB, **overrides) -> str:
+    kwargs = {"action_kind": "agent", "args": {}, "execution_target": "host"}
+    kwargs.update(overrides)
+    app = TaskApplication(**kwargs)
+    return await submit_task(db, app)
+
+
+async def _make_scheduled_queued_row(db: StateDB) -> str:
+    """A schedule-fired-shaped row (schedule_id NOT NULL) that otherwise
+    looks host-claimable in every other column — proves the worker's claim
+    predicate excludes it regardless."""
+    sched_id = str(uuid.uuid4())
+    await db.create_schedule(
+        {
+            "id": sched_id,
+            "name": f"sched-{sched_id}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    run_id = str(uuid.uuid4())
+    now = time.time()
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sched_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": {},
+            "status": "queued",
+            "fired_at": now,
+        }
+    )
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                "UPDATE schedule_runs SET execution_target = 'host', "
+                "queued_at = :now, required_capabilities = '[]' WHERE id = :id"
+            ),
+            {"now": now, "id": run_id},
+        )
+    return run_id
+
+
+async def _noop_execute(row: dict) -> tuple[int, str]:
+    return 0, ""
+
+
+async def _failing_execute(row: dict) -> tuple[int, str]:
+    return 1, "boom"
+
+
+# ── 1. Claim CAS race ────────────────────────────────────────────────────
+
+
+async def test_two_concurrent_claims_exactly_one_wins(tmp_path) -> None:
+    # A real (file-backed) StateDB, not ":memory:": genuinely concurrent
+    # transactions need the connection pool a file DB gets, matching the
+    # dispatch outbox's own concurrent-CAS test precedent
+    # (tests/dispatch/test_outbox.py's tmp_path-based StateDB).
+    async with StateDB(tmp_path / "state.db") as db:
+        run_id = await _submit_host_task(db)
+
+        claimed_counts = await asyncio.gather(
+            claim_and_execute(db, worker_id="w1", execute=_noop_execute),
+            claim_and_execute(db, worker_id="w2", execute=_noop_execute),
+        )
+        assert sorted(claimed_counts) == [0, 1]
+
+        row = await db.fetch_one(
+            "SELECT leased_by, lease_attempts, status FROM schedule_runs WHERE id = ?", (run_id,)
+        )
+    assert row["leased_by"] in ("w1", "w2")
+    assert row["lease_attempts"] == 1
+    assert row["status"] == "completed"
+
+
+# ── 2. Cancel beats claim ────────────────────────────────────────────────
+
+
+async def test_cancelled_before_claim_is_never_leased(db: StateDB) -> None:
+    from lionagi.studio.services.task_applications import cancel_task
+
+    run_id = await _submit_host_task(db)
+    assert await cancel_task(db, run_id, actor=Actor(type="operator", id="test")) is True
+
+    claimed = await claim_and_execute(db, worker_id="w1", execute=_noop_execute)
+    assert claimed == 0
+
+    row = await db.fetch_one("SELECT status, leased_by FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "cancelled"
+    assert row["leased_by"] is None
+
+
+# ── 3. Lease-expiry recovery ─────────────────────────────────────────────
+
+
+async def test_expired_lease_recovers_to_queued(db: StateDB) -> None:
+    run_id = await _submit_host_task(db)
+
+    # Claim it directly via the CAS transition (bypassing execution) so the
+    # row is left "running" with a lease, as if a worker crashed mid-task.
+    now = time.time()
+    result = await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=run_id,
+            from_state="queued",
+            to_state="running",
+            reason=StateReason(code="run.started.ok"),
+            actor=Actor(type="system", id="w1"),
+            idempotency_key=f"claim:{run_id}",
+        ),
+        patch={"leased_by": "w1", "lease_expires_at": now - 10, "lease_attempts": 1},
+    )
+    assert result.applied is True
+
+    counts = await reap_expired_leases(db, now=now)
+    assert counts == {"requeued": 1, "failed": 0}
+
+    row = await db.fetch_one(
+        "SELECT status, leased_by, lease_expires_at, lease_attempts "
+        "FROM schedule_runs WHERE id = ?",
+        (run_id,),
+    )
+    assert row["status"] == "queued"
+    assert row["leased_by"] is None
+    assert row["lease_expires_at"] is None
+    assert row["lease_attempts"] == 1  # preserved, not reset
+
+
+async def test_live_lease_is_never_reaped(db: StateDB) -> None:
+    run_id = await _submit_host_task(db)
+    now = time.time()
+    await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=run_id,
+            from_state="queued",
+            to_state="running",
+            reason=StateReason(code="run.started.ok"),
+            actor=Actor(type="system", id="w1"),
+            idempotency_key=f"claim:{run_id}",
+        ),
+        patch={"leased_by": "w1", "lease_expires_at": now + 300, "lease_attempts": 1},
+    )
+
+    counts = await reap_expired_leases(db, now=now)
+    assert counts == {"requeued": 0, "failed": 0}
+
+    row = await db.fetch_one("SELECT status, leased_by FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "running"
+    assert row["leased_by"] == "w1"
+
+
+# ── 4. Bounded re-queue (R1) ─────────────────────────────────────────────
+
+
+async def test_third_lease_expiry_fails_terminal_not_requeued(db: StateDB) -> None:
+    run_id = await _submit_host_task(db)
+    now = time.time()
+
+    # Cycle claim -> expire MAX_LEASE_ATTEMPTS times.
+    for attempt in range(1, MAX_LEASE_ATTEMPTS + 1):
+        result = await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="queued",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=Actor(type="system", id="w1"),
+                idempotency_key=f"claim:{run_id}:{attempt}",
+            ),
+            patch={
+                "leased_by": "w1",
+                "lease_expires_at": now - 1,
+                "lease_attempts": attempt,
+            },
+        )
+        assert result.applied is True
+
+        counts = await reap_expired_leases(db, now=now)
+        if attempt < MAX_LEASE_ATTEMPTS:
+            assert counts == {"requeued": 1, "failed": 0}
+        else:
+            assert counts == {"requeued": 0, "failed": 1}
+
+    row = await db.fetch_one(
+        "SELECT status, lease_attempts FROM schedule_runs WHERE id = ?", (run_id,)
+    )
+    assert row["status"] == "failed"
+    assert row["lease_attempts"] == MAX_LEASE_ATTEMPTS
+
+    # A subsequent reap pass leaves the terminal row alone (not "running").
+    counts = await reap_expired_leases(db, now=now)
+    assert counts == {"requeued": 0, "failed": 0}
+
+
+# ── 5. Terminal re-entry rejected (R2) ───────────────────────────────────
+
+
+async def test_completed_to_running_rejected(db: StateDB) -> None:
+    run_id = await _submit_host_task(db)
+    await claim_and_execute(db, worker_id="w1", execute=_noop_execute)
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed"
+
+    with pytest.raises(ValueError, match="not in the declared transition vocabulary"):
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="completed",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=Actor(type="system", id="w1"),
+                idempotency_key=f"reentry:{run_id}",
+            ),
+        )
+
+
+async def test_failed_to_running_rejected(db: StateDB) -> None:
+    run_id = await _submit_host_task(db)
+    await claim_and_execute(db, worker_id="w1", execute=_failing_execute)
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "failed"
+
+    with pytest.raises(ValueError, match="not in the declared transition vocabulary"):
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="failed",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=Actor(type="system", id="w1"),
+                idempotency_key=f"reentry:{run_id}",
+            ),
+        )
+
+
+# ── 6. Claim predicate ───────────────────────────────────────────────────
+
+
+async def test_capability_carrying_row_is_never_leased(db: StateDB) -> None:
+    run_id = await _submit_host_task(db, required_capabilities=["gpu-exclusive"])
+    claimed = await claim_and_execute(db, worker_id="w1", execute=_noop_execute)
+    assert claimed == 0
+    row = await db.fetch_one("SELECT leased_by, status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["leased_by"] is None
+    assert row["status"] == "queued"
+
+
+async def test_workflow_kind_row_is_declined_not_leased(db: StateDB) -> None:
+    run_id = await _submit_host_task(db, action_kind="workflow")
+    claimed = await claim_and_execute(db, worker_id="w1", execute=_noop_execute)
+    assert claimed == 0
+    row = await db.fetch_one("SELECT leased_by, status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["leased_by"] is None
+    assert row["status"] == "queued"
+
+
+async def test_scheduler_fired_row_is_never_leased(db: StateDB) -> None:
+    run_id = await _make_scheduled_queued_row(db)
+    claimed = await claim_and_execute(db, worker_id="w1", execute=_noop_execute)
+    assert claimed == 0
+    row = await db.fetch_one("SELECT leased_by, status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["leased_by"] is None
+    assert row["status"] == "queued"
+
+
+# ── 7. Round trip ─────────────────────────────────────────────────────────
+
+
+async def test_submit_claim_execute_completed_round_trip(db: StateDB) -> None:
+    run_id = await _submit_host_task(db, args={"action_prompt": "hello"})
+
+    executed_rows: list[dict] = []
+
+    async def _record_execute(row: dict) -> tuple[int, str]:
+        executed_rows.append(row)
+        return 0, ""
+
+    counts = await worker_tick(db, worker_id="w1", execute=_record_execute)
+    assert counts["claimed"] == 1
+    assert counts["requeued"] == 0
+    assert counts["failed"] == 0
+
+    assert len(executed_rows) == 1
+    assert executed_rows[0]["action_args"] == {"action_prompt": "hello"}
+
+    row = await db.fetch_one("SELECT status, leased_by FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed"
+    assert row["leased_by"] == "w1"
+
+    audit = await db.fetch_all(
+        "SELECT previous_status, status, reason_code FROM status_transitions "
+        "WHERE entity_id = ? ORDER BY created_at",
+        (run_id,),
+    )
+    assert [(a["previous_status"], a["status"]) for a in audit] == [
+        ("queued", "running"),
+        ("running", "completed"),
+    ]

--- a/tests/studio/services/test_task_worker.py
+++ b/tests/studio/services/test_task_worker.py
@@ -349,3 +349,78 @@ async def test_submit_claim_execute_completed_round_trip(db: StateDB) -> None:
         ("queued", "running"),
         ("running", "completed"),
     ]
+
+
+async def test_cancelled_to_running_rejected(db: StateDB) -> None:
+    """The vocabulary is closed: cancelled is terminal, and a bare CAS from
+    cancelled back to running must raise, not apply."""
+    from lionagi.studio.services.task_applications import cancel_task
+
+    run_id = await _submit_host_task(db)
+    assert await cancel_task(db, run_id, actor=Actor(type="operator", id="test")) is True
+
+    with pytest.raises(ValueError, match="not in the declared transition vocabulary"):
+        await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="cancelled",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=Actor(type="system", id="w1"),
+                idempotency_key=f"reentry:{run_id}",
+            ),
+        )
+
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "cancelled"
+
+
+async def test_stale_worker_cannot_finalize_a_reclaimed_lease(db: StateDB) -> None:
+    """A worker that outlives its lease must not complete (or fail) the row
+    after the reaper hands it to another claimant: the terminal write carries
+    the claim's lease identity as a guard, so the stale write conflicts."""
+    run_id = await _submit_host_task(db)
+    t0 = time.time()
+    w1_ttl = 5.0
+
+    async def hijacking_execute(row: dict) -> tuple[int, str]:
+        # While w1 is "executing", its lease lapses: the reaper requeues the
+        # row and a second worker claims a fresh lease.
+        counts = await reap_expired_leases(db, now=t0 + w1_ttl + 60)
+        assert counts == {"requeued": 1, "failed": 0}
+        result = await transition(
+            db,
+            TransitionRequest(
+                entity_type="schedule_run",
+                entity_id=run_id,
+                from_state="queued",
+                to_state="running",
+                reason=StateReason(code="run.started.ok"),
+                actor=Actor(type="system", id="w2"),
+                idempotency_key=f"claim:{run_id}:w2",
+            ),
+            patch={
+                "leased_by": "w2",
+                "lease_expires_at": t0 + 3600,
+                "lease_attempts": 2,
+            },
+        )
+        assert result.applied is True
+        return 0, ""
+
+    claimed = await claim_and_execute(
+        db, worker_id="w1", execute=hijacking_execute, now=t0, lease_ttl=w1_ttl
+    )
+    assert claimed == 1
+
+    # w1's stale running -> completed was dropped by the lease-identity
+    # guard: the row still belongs to w2's live claim.
+    row = await db.fetch_one(
+        "SELECT status, leased_by, lease_expires_at FROM schedule_runs WHERE id = ?",
+        (run_id,),
+    )
+    assert row["status"] == "running"
+    assert row["leased_by"] == "w2"
+    assert row["lease_expires_at"] == t0 + 3600


### PR DESCRIPTION
## What

Slice 3 of the ADR-0101 task-application queue: the local (host-only) worker/claim loop. Slices 1 (D2 schema) and 2 (D1 submit surface) are on main.

- **Vocabulary completion**: the slice-2 queued-edge gate generalizes into a per-(entity_type, from_state) `_TRANSITION_VOCAB` table. `schedule_run`: `queued -> {cancelled, running}`, `running -> {completed, failed, queued}` (`running -> queued` is only the lease-expiry recovery edge), and `completed`/`failed` map to empty sets — terminal re-entry is actively rejected.
- **Atomic claim**: `transition()` gains `guard` (extra WHERE equality constraints) and `patch` (extra SET assignments) applied inside the same guarded UPDATE as the status CAS. A claim is one write: `queued -> running` + `leased_by` + `lease_expires_at` + `lease_attempts` increment. No second UPDATE, no parallel CAS path.
- **Bounded re-queue**: new `lease_attempts` column (additive migration). The reaper re-queues a lapsed lease below `MAX_LEASE_ATTEMPTS = 3` (conservative constant; policy tuning belongs to the capability-matching slice) and fails it terminally at the bound — unbounded requeue is impossible by construction. The reaper guards on the `lease_expires_at` value it read, so a live claimant is never reaped.
- **Worker loop** (`lionagi/studio/scheduler/worker.py`): `worker_tick` = reaper pass + claim pass, hosted by `SchedulerEngine._tick()` exactly like the dispatch-outbox scan. Claim predicate is deliberately conservative: `schedule_id IS NULL` (scheduler-fired runs untouched), `execution_target='host'`, empty `required_capabilities`, `action_kind != 'workflow'` — anything else stays queued, never faked.
- **Execution** reuses the existing subprocess launcher vocabulary; outcome recorded via `transition()` `running -> completed/failed`.
- Fixed a latent legacy-rebuild bug found en route: the pre-D2 `schedule_runs` rebuild's hand-kept CREATE TABLE literal lacked the new column while `_reconcile_columns` had already added it to the legacy table, breaking the rebuild's column-list copy.

## Tests

11 new worker tests: two-claimant CAS race (exactly one wins), cancel-beats-claim, live-lease never reaped, bounded re-queue terminal at 3, terminal re-entry rejected, claim-predicate exclusions (capability rows / workflow rows / scheduler-fired rows never leased), submit->claim->execute->completed round trip with audit rows, migration adds `lease_attempts` to a legacy DB. The slice-2 negative test (`queued -> running` rejected) inverts by design and is replaced by the terminal-boundary assertions.

## Gates

- `uv run --extra studio pytest tests/studio/services/ tests/dispatch/ -q` — exit 0 (50 tests)
- `uv run --extra studio pytest tests/state/ -q` — only the 3 pre-existing asyncpg import failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)