### PR TITLE
fix(studio): fleet tooltip plurals, tool-preview test coverage, scheduler-engine DB isolation

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.test.ts
+++ b/apps/studio/frontend/src/components/RunStepCard.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { runMessageMemoKey, runMessagesEqualForMemo, stepPropsEqual } from "./RunStepCard";
+import {
+  runMessageMemoKey,
+  runMessagesEqualForMemo,
+  stepPropsEqual,
+  collapsedTextFor,
+} from "./RunStepCard";
 import type { RunMessage, RunStep } from "@/lib/types";
 
 function toolMessage(overrides: Partial<RunMessage> = {}): RunMessage {
@@ -90,6 +95,32 @@ describe("runMessagesEqualForMemo", () => {
 
   it("treats undefined as an empty array", () => {
     expect(runMessagesEqualForMemo(undefined, [])).toBe(true);
+  });
+});
+
+describe("collapsedTextFor (ToolCallBlock output-preview fallback)", () => {
+  it("prefers summary when present, even if output is also present", () => {
+    expect(collapsedTextFor("ls -la", "a.txt\nb.txt")).toBe("ls -la");
+  });
+
+  it("falls back to the first non-blank output line when summary is empty", () => {
+    expect(collapsedTextFor("", "line one\nline two")).toBe("line one");
+  });
+
+  it("skips leading blank/whitespace-only lines to find the first real content", () => {
+    expect(collapsedTextFor("", "\n   \n\nreal content\nmore")).toBe("real content");
+  });
+
+  it("returns empty string when output is entirely whitespace", () => {
+    expect(collapsedTextFor("", "\n   \n\t\n")).toBe("");
+  });
+
+  it("returns empty string when output is undefined/empty and summary is empty", () => {
+    expect(collapsedTextFor("", "")).toBe("");
+  });
+
+  it("trims surrounding whitespace from the selected output line", () => {
+    expect(collapsedTextFor("", "   padded line   \nnext")).toBe("padded line");
   });
 });
 

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -91,6 +91,16 @@ function summarizeOutput(out: string, more: (n: number) => string): string {
   return `${first.slice(0, 80)}${first.length > 80 ? "…" : ""} · ${more(lines.length - 1)}`;
 }
 
+export function collapsedTextFor(summary: string, output: string): string {
+  if (summary) return summary;
+  if (!output) return "";
+  const firstLine = output
+    .split("\n")
+    .find((line) => line.trim().length > 0)
+    ?.trim();
+  return firstLine ?? "";
+}
+
 function formatBytes(n: number): string {
   if (n < 1024) return `${n}B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
@@ -1094,13 +1104,7 @@ function ToolCallBlock({
   // Collapsed-row fallback: an empty summary with non-empty output shows the
   // output's first non-blank line instead of a bare "(no args)" — that line
   // is usually more informative than a static placeholder.
-  const outputPreview = output
-    ? (output
-        .split("\n")
-        .find((line) => line.trim().length > 0)
-        ?.trim() ?? "")
-    : "";
-  const collapsedText = summary || outputPreview;
+  const collapsedText = collapsedTextFor(summary, output);
 
   const statusBadge = isError ? (
     <span className="rounded border border-status-error/30 bg-status-error-bg px-1.5 py-0.5 text-[length:var(--t-xs)] font-medium text-status-error">

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -557,8 +557,8 @@
       "ariaLabel": "الوكيل {name} — فتح تفاصيل الجلسة",
       "branches": "{count} فرع",
       "messages": "{count} رسالة",
-      "branchesTitle": "{count} فرع",
-      "messagesTitle": "{count} رسالة"
+      "branchesTitle": "{count, plural, zero {لا فروع} one {فرع واحد} two {فرعان} few {# فروع} many {# فرعًا} other {# فرع}}",
+      "messagesTitle": "{count, plural, zero {لا رسائل} one {رسالة واحدة} two {رسالتان} few {# رسائل} many {# رسالة} other {# رسالة}}"
     },
     "empty": {
       "message": "لا يوجد وكلاء قيد التشغيل — يعرض أسطول الوكلاء عمليات التنسيق المباشرة فور حدوثها.",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -557,8 +557,8 @@
       "ariaLabel": "Agent {name} — open session detail",
       "branches": "{count} br",
       "messages": "{count} msg",
-      "branchesTitle": "{count} branches",
-      "messagesTitle": "{count} messages"
+      "branchesTitle": "{count, plural, one {# branch} other {# branches}}",
+      "messagesTitle": "{count, plural, one {# message} other {# messages}}"
     },
     "empty": {
       "message": "No agents running — Fleet shows live orchestrations as they happen.",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -557,8 +557,8 @@
       "ariaLabel": "Agent {name} — ouvrir le détail de session",
       "branches": "{count} br",
       "messages": "{count} msg",
-      "branchesTitle": "{count} branches",
-      "messagesTitle": "{count} messages"
+      "branchesTitle": "{count, plural, one {# branche} other {# branches}}",
+      "messagesTitle": "{count, plural, one {# message} other {# messages}}"
     },
     "empty": {
       "message": "Aucun agent en cours — la Flotte affiche les orchestrations en direct au fur et à mesure.",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -557,8 +557,8 @@
       "ariaLabel": "एजेंट {name} — सेशन विवरण खोलें",
       "branches": "{count} शाखा",
       "messages": "{count} संदेश",
-      "branchesTitle": "{count} शाखाएँ",
-      "messagesTitle": "{count} संदेश"
+      "branchesTitle": "{count, plural, one {# ब्रांच} other {# ब्रांच}}",
+      "messagesTitle": "{count, plural, one {# मैसेज} other {# मैसेज}}"
     },
     "empty": {
       "message": "कोई एजेंट नहीं चल रहा — फ़्लीट लाइव ऑर्केस्ट्रेशन होते ही दिखाता है।",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -557,8 +557,8 @@
       "ariaLabel": "ایجنٹ ⁨{name}⁩ — سیشن تفصیل کھولیں",
       "branches": "{count} شاخ",
       "messages": "{count} پیغام",
-      "branchesTitle": "{count} شاخیں",
-      "messagesTitle": "{count} پیغامات"
+      "branchesTitle": "{count, plural, one {# برانچ} other {# برانچز}}",
+      "messagesTitle": "{count, plural, one {# پیغام} other {# پیغامات}}"
     },
     "empty": {
       "message": "کوئی ایجنٹ نہیں چل رہا — ایجنٹ فلیٹ لائیو آرکیسٹریشنز دکھاتا ہے۔",

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1143,7 +1143,9 @@ async def test_startup_missed_fire_run_once_recovers_and_advances(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_startup_missed_fire_run_once_not_double_fired_by_immediate_tick(monkeypatch):
+async def test_startup_missed_fire_run_once_not_double_fired_by_immediate_tick(
+    monkeypatch, tmp_path
+):
     """Reproduces the exact _tick_loop() startup ordering: _check_missed_fires()
     runs, then _tick() runs immediately after with no sleep in between (the
     tick loop only sleeps *between* iterations of the while-loop, not before
@@ -1153,11 +1155,18 @@ async def test_startup_missed_fire_run_once_not_double_fired_by_immediate_tick(m
     following _tick() does not see the same stale past-due next_fire_at and
     queue a second, duplicate fire for it."""
     pytest.importorskip("croniter", reason="studio extra not installed")
+    import lionagi.state.db as state_db_mod
     import lionagi.studio.config as studio_config
     import lionagi.studio.scheduler.engine as engine_mod
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
     monkeypatch.setattr(studio_config, "SCHEDULER_TZ", "America/New_York")
+    # _tick() also runs the dispatch-outbox scan and the D3 task-worker tick
+    # (_deliver_due_dispatches / _run_task_worker_tick), both of which open a
+    # StateDB() at the default path — redirect it so this test never touches
+    # the real ~/.lionagi/state.db.
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     fixed_now = datetime(2026, 7, 2, 10, 0, 0, tzinfo=NY).timestamp()
     monkeypatch.setattr(engine_mod.time, "time", lambda: fixed_now)
@@ -1223,10 +1232,16 @@ async def test_startup_missed_fire_run_once_not_double_fired_by_immediate_tick(m
         f"fires: {[c[1].get('trigger_context') for c in tracked_calls]}"
     )
     assert tracked_calls[0][1]["trigger_context"]["missed_recovery"] is True
+    assert fake_db.exists(), (
+        "_tick() must have opened/schema-applied the redirected StateDB "
+        "(dispatch-outbox scan + D3 task-worker tick), proving isolation "
+        "from the real ~/.lionagi/state.db rather than the tick silently "
+        "no-op'ing on the fake path"
+    )
 
 
 @pytest.mark.asyncio
-async def test_startup_missed_fire_run_once_reserve_failure_skips_recovery(monkeypatch):
+async def test_startup_missed_fire_run_once_reserve_failure_skips_recovery(monkeypatch, tmp_path):
     """Failure path of the synchronous reserve: if update_schedule raises
     while reserving next_fire_at, storage still holds the past-due value
     and the immediately-following _tick() will fire the schedule normally.
@@ -1235,11 +1250,15 @@ async def test_startup_missed_fire_run_once_reserve_failure_skips_recovery(monke
     result: exactly one fire total, and it is the normal scheduled one,
     not a missed_recovery fire."""
     pytest.importorskip("croniter", reason="studio extra not installed")
+    import lionagi.state.db as state_db_mod
     import lionagi.studio.config as studio_config
     import lionagi.studio.scheduler.engine as engine_mod
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
     monkeypatch.setattr(studio_config, "SCHEDULER_TZ", "America/New_York")
+    # Same real-DB hazard as the sibling test above: _tick() opens StateDB()
+    # at the default path via _deliver_due_dispatches / _run_task_worker_tick.
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", tmp_path / "state.db")
 
     fixed_now = datetime(2026, 7, 2, 10, 0, 0, tzinfo=NY).timestamp()
     monkeypatch.setattr(engine_mod.time, "time", lambda: fixed_now)


### PR DESCRIPTION
Batch of three regression-watch closures.

- **Fleet tooltip plurals**: the `branchesTitle`/`messagesTitle` tooltip keys get ICU `{count, plural, ...}` forms restored for the locales that had plural marking before the regression (ar, fr, ur, hi) plus en; compact labels stay flat by design. Locale leaf counts unchanged.
- **Tool-preview coverage**: the collapsed-row fallback in `RunStepCard.tsx` is extracted as a pure `collapsedTextFor(summary, output)` and covered by 6 unit tests (summary precedence, first non-blank line, blank-skipping, whitespace-only, empty, trimming). Truncation is CSS-only, so no JS truncation test.
- **Scheduler-engine DB isolation**: the two `_tick()`-driving tests in `tests/studio/test_scheduler_engine.py` now monkeypatch `DEFAULT_DB_PATH` to `tmp_path` (the repo's established convention), so the worker tick never touches the real `~/.lionagi/state.db`; an assertion proves the isolated DB is actually the one engaged.

Closes #1911, closes #1912, closes #1914.

## Gates
- `npm run test` — 762 passed; `npm run build` green
- `uv run --extra studio pytest tests/studio/ tests/apps_studio_server/ -q` — 1229 tests, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)