### PR TITLE
fix(studio): cache the working GitHub poll token; avoid gh shell-out per tick

### DIFF
--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -72,6 +72,13 @@ class GithubPollResult(NamedTuple):
 
 _client: httpx.AsyncClient | None = None
 
+# Last token known to have actually authenticated against the GitHub API
+# (set after any non-401 response). Checked before _get_gh_token() so a
+# poll that already knows the working credential doesn't re-check
+# GITHUB_TOKEN or shell out to `gh auth token` on every tick -- only a
+# fresh 401 clears it and forces re-resolution.
+_cached_token: str | None = None
+
 # Merged-PR mode's dispatch key (merged_at) differs from the API's sort key
 # (updated_at): a page full of closed-but-never-merged PRs produces no item
 # at all (see the pr_merged branch in github_poll), so it can push an older,
@@ -276,7 +283,8 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         )
         return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
-    token = await _get_gh_token()
+    global _cached_token
+    token = _cached_token or await _get_gh_token()
     if not token:
         _log.warning("No GitHub token available for polling %s", repo)
         return GithubPollResult(items=[], scan_complete=True, poll_status="error")
@@ -317,14 +325,16 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         _log.exception("GitHub API request failed for %s", repo)
         return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
-    # A 401 means the token we used is bad — most often a GITHUB_TOKEN that was
-    # valid when the daemon launched but has since expired. Fall through to a
-    # fresh gh-CLI token (skipping the env var) and retry once, so a stale env
-    # credential can't pin the poller to a dead token and leave it silently
-    # blind on every subsequent poll.
+    # A 401 means the token we used is bad — most often a cached or
+    # GITHUB_TOKEN-env credential that was valid earlier but has since
+    # expired. Fall through to a freshly-fetched gh-CLI token (skipping the
+    # env var and any cache) and retry once, so a stale credential can't pin
+    # the poller to a dead token and leave it silently blind on every
+    # subsequent poll.
     if resp.status_code == 401:
         cli_token = await _get_gh_token(prefer_cli=True)
         if cli_token and cli_token != token:
+            token = cli_token
             headers["Authorization"] = f"Bearer {cli_token}"
             try:
                 resp = await client.get(
@@ -334,12 +344,11 @@ async def github_poll(schedule: dict) -> GithubPollResult:
                 )
             except httpx.HTTPError:
                 _log.exception("GitHub API request failed for %s", repo)
+                _cached_token = None
                 return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
-    if resp.status_code == 304:
-        return GithubPollResult(items=[], scan_complete=True, poll_status="ok")
-
     if resp.status_code == 401:
+        _cached_token = None
         _log.error(
             "GitHub API returned 401 (unauthorized) for %s polling schedule %s (%s) "
             "even after falling back to a gh-CLI token; the poller cannot see new "
@@ -349,6 +358,14 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             schedule.get("name"),
         )
         return GithubPollResult(items=[], scan_complete=True, poll_status="auth_error")
+
+    # Any non-401 response proves `token` actually authenticated -- cache it
+    # so the next poll can skip both the env-var check and a `gh auth token`
+    # shell-out, until a future 401 invalidates it again.
+    _cached_token = token
+
+    if resp.status_code == 304:
+        return GithubPollResult(items=[], scan_complete=True, poll_status="ok")
 
     if resp.status_code != 200:
         _log.warning("GitHub API returned %d for %s", resp.status_code, repo)

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -431,6 +431,11 @@ async def github_poll(schedule: dict) -> GithubPollResult:
                 scan_complete = False
                 break
             if resp.status_code != 200:
+                if resp.status_code == 401:
+                    # The token authenticated the first page but has since been
+                    # rejected mid-pagination; drop it so the next poll
+                    # re-resolves instead of reusing a proven-dead credential.
+                    _cached_token = None
                 _log.warning(
                     "GitHub API returned %d for %s during merged-PR pagination; "
                     "using %d PR(s) fetched so far -- events too close to the "

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -15,8 +15,19 @@ from __future__ import annotations
 import asyncio
 
 import httpx
+import pytest
 
 from lionagi.studio.scheduler import github as gh_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_cache():
+    """github_poll caches the last working token at module scope -- reset it
+    around every test so one test's cached token can't leak into the next
+    and change which token a fresh poll tries first."""
+    gh_mod._cached_token = None
+    yield
+    gh_mod._cached_token = None
 
 
 def _pr(number, updated, *, draft=False, sha=None, state="open", merged_at=None):
@@ -648,6 +659,94 @@ def test_github_poll_401_no_retry_when_cli_token_matches_env(monkeypatch):
     result = _poll_result({"id": "s1", "github_repo": "owner/name"})
     assert result.items == []
     assert len(client.requests) == 1
+
+
+def test_github_poll_401_surviving_retry_logs_at_error_with_schedule_id_and_name(
+    monkeypatch, caplog
+):
+    """A 401 that survives the gh-CLI-token retry is logged at ERROR level and
+    names the schedule id/name, so it's visible in the daemon log rather than
+    a bare/debug line an operator would miss."""
+    _install_status(monkeypatch, [(401, []), (401, [])])
+    with caplog.at_level("ERROR", logger=gh_mod._log.name):
+        result = _poll_result(
+            {"id": "sched-123", "github_repo": "owner/name", "name": "nightly-review"}
+        )
+    assert result.poll_status == "auth_error"
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) == 1
+    msg = error_records[0].getMessage()
+    assert "sched-123" in msg
+    assert "nightly-review" in msg
+    assert "401" in msg
+
+
+# ---------------------------------------------------------------------------
+# Token caching — avoid a `gh auth token` shell-out on every poll
+# ---------------------------------------------------------------------------
+
+
+def test_github_poll_caches_working_token_across_polls(monkeypatch):
+    """Once a 401 is recovered via the gh-CLI-token retry, the *next* poll
+    reuses the cached working token directly -- it must not re-check
+    GITHUB_TOKEN or shell out to `gh auth token` again."""
+    pr1 = _pr(1, "2026-07-07T10:00:00Z")
+    pr2 = _pr(2, "2026-07-07T11:00:00Z")
+    # First poll: env token 401s, CLI fallback succeeds. Second poll: only
+    # one more response is needed since the cached token is reused directly.
+    client = _install_status(monkeypatch, [(401, []), (200, [pr1]), (200, [pr2])])
+
+    token_calls: list[bool] = []
+    # _install_status already monkeypatched _get_gh_token to a fixed fake;
+    # wrap it so we can count calls without changing its return values.
+    fake = gh_mod._get_gh_token
+
+    async def _wrapped(prefer_cli: bool = False):
+        token_calls.append(prefer_cli)
+        return await fake(prefer_cli)
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _wrapped)
+
+    first = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert [i.event["pr_number"] for i in first] == [1]
+    # First poll: initial resolve (prefer_cli=False) + the 401 retry resolve
+    # (prefer_cli=True).
+    assert token_calls == [False, True]
+
+    token_calls.clear()
+    second = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert [i.event["pr_number"] for i in second] == [2]
+    # Second poll: the cached token from the first poll is used directly --
+    # _get_gh_token is never called at all.
+    assert token_calls == []
+    assert len(client.requests) == 3
+
+
+def test_github_poll_cached_token_401_retriggers_refresh(monkeypatch):
+    """A cached working token that later 401s (it expired too) falls through
+    to a fresh CLI-token retry exactly like an uncached 401 would -- the
+    cache never permanently pins the poller to a now-dead credential."""
+    pr = _pr(1, "2026-07-07T10:00:00Z")
+    gh_mod._cached_token = "stale-cached-token"
+    client = _install_status(
+        monkeypatch, [(401, []), (200, [pr])], env_token="unused", cli_token="fresh-cli-token"
+    )
+    items = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert [i.event["pr_number"] for i in items] == [1]
+    assert client.requests[0]["auth"] == "Bearer stale-cached-token"
+    assert client.requests[1]["auth"] == "Bearer fresh-cli-token"
+    assert gh_mod._cached_token == "fresh-cli-token"
+
+
+def test_github_poll_auth_error_clears_cached_token(monkeypatch):
+    """When even the CLI-token retry 401s, the cache is cleared -- a dead
+    token doesn't linger to be reused (and silently retried without a fresh
+    resolution attempt) on the next poll."""
+    gh_mod._cached_token = "stale-cached-token"
+    _install_status(monkeypatch, [(401, []), (401, [])])
+    result = _poll_result({"id": "s1", "github_repo": "owner/name"})
+    assert result.poll_status == "auth_error"
+    assert gh_mod._cached_token is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -749,6 +749,52 @@ def test_github_poll_auth_error_clears_cached_token(monkeypatch):
     assert gh_mod._cached_token is None
 
 
+class _FakePagination401Client:
+    """Serves a full first page with a next link, then a 401 on the pagination
+    fetch -- the token authenticated page 1 but is rejected mid-scan."""
+
+    def __init__(self, page0):
+        self._page0 = page0
+        self.requests: list[dict] = []
+
+    async def get(self, url, headers=None, params=None):
+        self.requests.append({"url": url, "params": params})
+        if len(self.requests) == 1:
+            next_url = "https://api.github.com/repos/owner/name/pulls?page=2"
+            return _FakeResp(self._page0, link=f'<{next_url}>; rel="next"')
+        resp = _FakeResp([])
+        resp.status_code = 401
+        return resp
+
+
+def test_github_poll_pagination_401_clears_cached_token(monkeypatch):
+    """A 401 arriving mid-pagination (after a 200 first page cached the token)
+    still clears the cache -- GitHub has rejected the credential, so the next
+    poll must re-resolve instead of reusing a proven-dead token."""
+    cursor = "2026-06-01T00:00:00Z"
+    page1 = [
+        _pr(200 + n, f"2026-07-06T{10 - n // 10:02d}:00:00Z", state="closed", merged_at=None)
+        for n in range(20)
+    ]
+
+    async def _fake_token(prefer_cli: bool = False):
+        return "faketoken"
+
+    client = _FakePagination401Client(page1)
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: client)
+    result = _poll_result(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": cursor,
+        }
+    )
+    assert result.scan_complete is False
+    assert gh_mod._cached_token is None
+
+
 # ---------------------------------------------------------------------------
 # GithubPollResult.poll_status — observer self-health signal
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Completes #1868. Recon finding: the 401→fresh-CLI-token retry and the ERROR-level log naming the schedule were already on main from an earlier hardening PR — what was missing was the caching clause: `_get_gh_token()` ran on every poll, so an expired `GITHUB_TOKEN` meant a `gh auth token` subprocess every scheduler tick even after a successful recovery had proven the working credential.

Change: module-level `_cached_token` — any non-401 response caches the token that authenticated (a 403/304 still proves auth); a 401 surviving the CLI retry, or a network error during the retry, clears it. A cached-but-expired token re-triggers the same refresh path as the env-var case. The 304 short-circuit moved below the cache-set (still returns ok).

Tests: 4 new (401→retry→success with cache update; 401 surviving retry → ERROR log via caplog + cache cleared; cached-token fast path makes zero `_get_gh_token` calls; stale cache re-refresh), plus an autouse cache-reset fixture since the cache is process-global. Suite: 374 studio tests green (junit-verified).

Closes #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)