### PR TITLE
fix(studio): apply chat node config.model, reject bare model strings

### DIFF
--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -298,6 +298,23 @@ async def compile_workflow_def(
             prompt = config.get("prompt")
             if not prompt or not isinstance(prompt, str):
                 raise WorkflowCompileError("chat node requires config.prompt", node_id=node_id)
+            chat_kwargs: dict[str, Any] = {}
+            model = config.get("model")
+            if model is not None:
+                if not isinstance(model, str) or "/" not in model:
+                    raise WorkflowCompileError(
+                        f"node {node_id!r} config.model must be provider-prefixed "
+                        f"(provider/name, e.g. openai/gpt-4.1-mini); got {model!r}. "
+                        "Use provider/model, e.g. openai/gpt-4.1-mini.",
+                        node_id=node_id,
+                    )
+                # Built here at compile time rather than passed through as a bare
+                # string: chat_and_record forwards its kwargs straight into
+                # Branch.chat(), whose model-override parameter is `imodel` (an
+                # iModel instance), not a string.
+                from lionagi.service.imodel import iModel
+
+                chat_kwargs["imodel"] = iModel(model=model)
             # "chat_and_record", not the native "chat" operation: Branch.chat()
             # does not add messages to the branch (by design — see its
             # docstring), so a plain "chat" node would run through the
@@ -306,7 +323,9 @@ async def compile_workflow_def(
             # the turn through the same hooked a_add_message path communicate()
             # uses, and returns the assistant response text for downstream
             # routing/context.
-            op_id = builder.add_operation("chat_and_record", node_id=node_id, instruction=prompt)
+            op_id = builder.add_operation(
+                "chat_and_record", node_id=node_id, instruction=prompt, **chat_kwargs
+            )
         elif kind == "engine":
             engine_def_id = config.get("engine_def_id")
             if not engine_def_id or not isinstance(engine_def_id, str):

--- a/lionagi/studio/services/workflow_defs.py
+++ b/lionagi/studio/services/workflow_defs.py
@@ -107,8 +107,15 @@ def _validate_chat_config(node_id: str, config: Any) -> None:
     if not isinstance(config["prompt"], str):
         raise ValueError(f"node {node_id!r} config.prompt must be a string")
     model = config.get("model")
-    if model is not None and not isinstance(model, str):
-        raise ValueError(f"node {node_id!r} config.model must be a string")
+    if model is not None:
+        if not isinstance(model, str):
+            raise ValueError(f"node {node_id!r} config.model must be a string")
+        if "/" not in model:
+            raise ValueError(
+                f"node {node_id!r} config.model must be provider-prefixed "
+                f"(provider/name, e.g. openai/gpt-4.1-mini); got {model!r}. "
+                "Use provider/model, e.g. openai/gpt-4.1-mini."
+            )
 
 
 def _find_gate_node_ids(spec: dict[str, Any] | None) -> list[str]:

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -368,6 +368,54 @@ async def test_compile_missing_chat_prompt_raises():
     assert exc_info.value.node_id == "n2"
 
 
+async def test_compile_chat_node_applies_config_model():
+    """A chat node's config.model must reach the compiled operation as an
+    iModel bound to that provider/model — not be silently dropped."""
+    spec = _make_spec()
+    spec["nodes"][1]["config"]["model"] = "openai/gpt-4.1-mini"
+    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+
+    from lionagi.operations.node import Operation
+    from lionagi.service.imodel import iModel
+
+    chat_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "chat_and_record"
+    )
+    imodel = chat_op.parameters["imodel"]
+    assert isinstance(imodel, iModel)
+    assert imodel.endpoint.config.provider == "openai"
+    assert imodel.endpoint.config.kwargs.get("model") == "gpt-4.1-mini"
+
+
+async def test_compile_chat_node_bare_model_rejected_with_node_id():
+    """A bare (non provider-prefixed) config.model must fail loudly at
+    compile — it otherwise silently binds to the default provider."""
+    spec = _make_spec()
+    spec["nodes"][1]["config"]["model"] = "gpt-4.1-mini"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n2"
+    assert "n2" in str(exc_info.value)
+    assert "provider/model" in str(exc_info.value) or "provider-prefixed" in str(exc_info.value)
+
+
+async def test_compile_chat_node_no_model_keeps_default_behavior():
+    """A chat node that omits config.model compiles with no imodel override,
+    so it runs on the branch's default chat model exactly as before."""
+    graph, _id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
+
+    from lionagi.operations.node import Operation
+
+    chat_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "chat_and_record"
+    )
+    assert "imodel" not in chat_op.parameters
+
+
 async def test_compile_bad_condition_raises_with_edge_id():
     spec = _make_spec()
     spec["edges"][1]["condition"] = "__import__('os')"

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -251,10 +251,27 @@ async def test_chat_node_non_string_model_raises(patched_svc):
         await svc.create_workflow_def({"name": "badmodel", "spec_json": spec})
 
 
-async def test_chat_node_valid_config_passes(patched_svc):
+async def test_chat_node_bare_model_rejected_at_write(patched_svc):
+    """A bare (non provider-prefixed) config.model must fail to save — it
+    silently binds to the default provider at runtime otherwise."""
     svc, _ = patched_svc
     spec = _spec_with_chat({"prompt": "hi", "model": "gpt-4"})
+    with pytest.raises(ValueError, match="n3") as exc_info:
+        await svc.create_workflow_def({"name": "baremodel", "spec_json": spec})
+    assert "provider/model" in str(exc_info.value) or "provider-prefixed" in str(exc_info.value)
+
+
+async def test_chat_node_valid_config_passes(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec_with_chat({"prompt": "hi", "model": "openai/gpt-4"})
     result = await svc.create_workflow_def({"name": "goodchat", "spec_json": spec})
+    assert "id" in result
+
+
+async def test_chat_node_no_model_passes(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec_with_chat({"prompt": "hi"})
+    result = await svc.create_workflow_def({"name": "nomodelchat", "spec_json": spec})
     assert "id" in result
 
 

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -366,6 +366,44 @@ async def test_run_route_returns_structured_422_on_compile_error(patched_env):
     assert exc_info.value.detail["edge_id"] == "e2"
 
 
+async def test_workflow_run_bare_chat_model_rejected_at_compile_defense_in_depth(patched_env):
+    """A row saved with a bare config.model BEFORE the write-path validation
+    existed (or written directly, bypassing it) must still be caught at
+    compile time — the write-path check alone is not sufficient defense."""
+    wf_svc, engine_defs_svc = patched_env
+    from lionagi.studio.services.workflow_compile import WorkflowCompileError
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    engine_def = await engine_defs_svc.create_engine_def({"name": "eng-c", "kind": "research"})
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["nodes"][1]["config"]["model"] = "gpt-4.1-mini"  # bare — no provider prefix
+
+    import time
+    import uuid
+
+    from lionagi.state.db import StateDB
+
+    def_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    async with StateDB() as db:
+        await db.create_workflow_def(
+            {
+                "id": def_id,
+                "name": "legacy-bare-model",
+                "description": None,
+                "spec_json": spec,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await run_workflow_def(def_id)
+    assert exc_info.value.node_id == "chat1"
+    assert "chat1" in str(exc_info.value)
+
+
 async def test_run_route_returns_404_for_missing_def(patched_env):
     from fastapi import HTTPException
 


### PR DESCRIPTION
Fixes #1922.

A chat node's `config.model` was validated and displayed but never applied at execution — `compile_workflow_def` compiled chat nodes to `chat_and_record(instruction=prompt)` and dropped the model, so every chat node silently ran on the session default while reporting green.

Per the ADR-0103 contract (D-F4):

- **Compile path** (`workflow_compile.py`): when `config.model` is present, an `iModel` is constructed at compile time and passed as `imodel=` into the operation. `chat_and_record` forwards kwargs into `Branch.chat()`, whose model-override parameter is `imodel` (an iModel instance) — this is the real seam, traced through `branch.py:696` → `chat.py:31` (`chat_param.imodel or branch.chat_model`).
- **Provider prefix is mandatory, enforced at BOTH paths**: bare strings (no `/`) raise `WorkflowCompileError` naming the node id at compile, and `ValueError` at the def write path (`_validate_chat_config`) so a bad def can't be saved. Defense in depth: a legacy row seeded past the write check still rejects at compile (covered by test).
- A chat node with no `config.model` keeps current behavior unchanged (explicit regression test).

Migration safety: since `config.model` was never applied for chat nodes, rejecting bare strings breaks no working behavior — it converts a silent mis-bind into a loud authoring error.

Tests: 8 new/updated across `test_workflow_compile.py`, `test_workflow_defs_api.py`, `test_workflow_run.py`; each load-bearing test verified to fail with the fix reverted. Full workflow suite (compile/defs/run/persist/transcript): 97 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)