### PR TITLE
feat(studio): per-node cwd with engine-owned containment for workflow runs

### DIFF
--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -517,6 +517,7 @@ class CodingEngine(Engine):
         export_dir: str | Path | None = None,
         session: Any = None,
         on_event: Any = None,
+        on_branch_created: Any = None,
     ) -> CodeResultRecorded:
         """Normalize *spec* exactly once before creating run state; raises ValueError/TypeError for malformed specs before session initialization."""
         task_text, experiment_ref = _normalize_spec(spec)  # raises on bad input
@@ -528,6 +529,7 @@ class CodingEngine(Engine):
             _normalized=(task_text, experiment_ref),
             session=session,
             on_event=on_event,
+            on_branch_created=on_branch_created,
         )
 
     async def _run(

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -149,14 +149,15 @@ def _resolve_node_cwd(node_id: str, raw_cwd: Any, base_dir: str | None) -> str:
     if has_traversal(raw_path):
         raise WorkflowCompileError(
             f"node {node_id!r} config.cwd {raw_cwd!r} contains directory "
-            "traversal ('..') and is rejected before any path resolution",
+            "traversal ('..') and is rejected before any path resolution "
+            f"(base_dir={base_dir!r})",
             node_id=node_id,
         )
     if base_dir is None:
         raise WorkflowCompileError(
-            f"node {node_id!r} sets config.cwd but the run supplied no "
-            "base_dir; a node cwd requires a run-level base_dir to "
-            "establish a containment root",
+            f"node {node_id!r} sets config.cwd {raw_cwd!r} but the run "
+            "supplied no base_dir; a node cwd requires a run-level "
+            "base_dir to establish a containment root",
             node_id=node_id,
         )
     base_resolved = Path(base_dir).resolve()
@@ -173,7 +174,8 @@ def _resolve_node_cwd(node_id: str, raw_cwd: Any, base_dir: str | None) -> str:
     if not resolved.exists() or not resolved.is_dir():
         raise WorkflowCompileError(
             f"node {node_id!r} config.cwd {raw_cwd!r} resolves to "
-            f"{resolved}, which does not exist or is not a directory",
+            f"{resolved} under base_dir {base_resolved}, which does not "
+            "exist or is not a directory",
             node_id=node_id,
         )
     return str(resolved)
@@ -439,7 +441,7 @@ async def compile_workflow_def(
             except ValueError as exc:
                 raise WorkflowCompileError(str(exc), node_id=node_id) from exc
 
-            # Per-node working directory (D-F1). Containment is enforced
+            # Per-node working directory. Containment is enforced
             # here (raw-string traversal check + symlink-resolving
             # relative_to(base_dir) + must-exist-and-be-a-dir); v1.1 only
             # wires the resolved cwd through to a 'coding' engine node's

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 import ast
 import json
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field, PrivateAttr
 
+from lionagi.libs.path_safety import has_traversal
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.graph.edge import Edge, EdgeCondition
 from lionagi.protocols.graph.graph import Graph
@@ -128,6 +130,53 @@ def _validate_node(node: ast.AST) -> None:
             _validate_node(element)
         return
     raise UnsafeExpressionError(f"expression construct {type(node).__name__} is not allowed")
+
+
+def _resolve_node_cwd(node_id: str, raw_cwd: Any, base_dir: str | None) -> str:
+    """Resolve and contain a node's config.cwd against the run's base_dir.
+
+    Order matters: the raw-string traversal check runs before any path
+    resolution (so a hostile '..' segment is rejected even when base_dir is
+    absent), symlinks are resolved before the containment check (so a
+    contained-looking path that resolves outside base_dir through a symlink
+    is caught), and the resolved directory must actually exist.
+    """
+    if not isinstance(raw_cwd, str) or not raw_cwd:
+        raise WorkflowCompileError(
+            f"node {node_id!r} config.cwd must be a non-empty string", node_id=node_id
+        )
+    raw_path = Path(raw_cwd)
+    if has_traversal(raw_path):
+        raise WorkflowCompileError(
+            f"node {node_id!r} config.cwd {raw_cwd!r} contains directory "
+            "traversal ('..') and is rejected before any path resolution",
+            node_id=node_id,
+        )
+    if base_dir is None:
+        raise WorkflowCompileError(
+            f"node {node_id!r} sets config.cwd but the run supplied no "
+            "base_dir; a node cwd requires a run-level base_dir to "
+            "establish a containment root",
+            node_id=node_id,
+        )
+    base_resolved = Path(base_dir).resolve()
+    joined = raw_path if raw_path.is_absolute() else base_resolved / raw_path
+    resolved = joined.resolve()
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError:
+        raise WorkflowCompileError(
+            f"node {node_id!r} config.cwd {raw_cwd!r} resolves to "
+            f"{resolved}, which escapes base_dir {base_resolved}",
+            node_id=node_id,
+        ) from None
+    if not resolved.exists() or not resolved.is_dir():
+        raise WorkflowCompileError(
+            f"node {node_id!r} config.cwd {raw_cwd!r} resolves to "
+            f"{resolved}, which does not exist or is not a directory",
+            node_id=node_id,
+        )
+    return str(resolved)
 
 
 def _parse_expr(expr: str) -> ast.Expression:
@@ -249,6 +298,7 @@ async def compile_workflow_def(
     spec: dict[str, Any],
     *,
     resolve_engine_def: Callable[[str], Awaitable[dict[str, Any] | None]],
+    base_dir: str | None = None,
 ) -> tuple[Graph, dict[str, str]]:
     """Compile a validated WorkflowDef spec into an executable Graph.
 
@@ -256,7 +306,20 @@ async def compile_workflow_def(
     internal Operation ids lionagi assigned them. Raises WorkflowCompileError
     (node_id/edge_id set) on any problem — never lets a bad expr, unknown
     engine_def_id, or a parse/fanout/gate node reach the executor.
+
+    ``base_dir`` is a run-level containment root for node ``config.cwd``
+    values — it is never read from the spec itself (a spec carrying a
+    top-level ``base_dir`` field is rejected below): a shared/contributed
+    def must not be able to pin its own containment root.
     """
+    if "base_dir" in spec:
+        raise WorkflowCompileError(
+            "spec_json must not carry a top-level 'base_dir' field — "
+            "base_dir is a run-level input supplied by the operator, never "
+            "a def-authored field (a def that could pin its own "
+            "containment root would defeat cwd containment)"
+        )
+
     nodes: list[dict[str, Any]] = spec.get("nodes", [])
     edges: list[dict[str, Any]] = spec.get("edges", [])
 
@@ -375,6 +438,28 @@ async def compile_workflow_def(
                 _validate_budget("max_agents", engine_max_agents)
             except ValueError as exc:
                 raise WorkflowCompileError(str(exc), node_id=node_id) from exc
+
+            # Per-node working directory (D-F1). Containment is enforced
+            # here (raw-string traversal check + symlink-resolving
+            # relative_to(base_dir) + must-exist-and-be-a-dir); v1.1 only
+            # wires the resolved cwd through to a 'coding' engine node's
+            # run(workspace=...) — the only engine run() signature that
+            # accepts a working directory today (research/review/planning
+            # take no such kwarg and would crash at run time, not compile,
+            # if one were smuggled in).
+            engine_workspace: str | None = None
+            node_cwd = config.get("cwd")
+            if node_cwd is not None:
+                resolved_cwd = _resolve_node_cwd(node_id, node_cwd, base_dir)
+                if defn.get("kind") != "coding":
+                    raise WorkflowCompileError(
+                        f"node {node_id!r} sets config.cwd but its engine "
+                        f"kind is {defn.get('kind')!r}; cwd is only "
+                        "supported on 'coding' engine nodes in v1.1",
+                        node_id=node_id,
+                    )
+                engine_workspace = resolved_cwd
+
             op_id = builder.add_operation(
                 "engine",
                 node_id=node_id,
@@ -383,6 +468,7 @@ async def compile_workflow_def(
                 engine_max_depth=engine_max_depth,
                 engine_max_agents=engine_max_agents,
                 engine_options=engine_options,
+                engine_workspace=engine_workspace,
             )
         else:  # pragma: no cover — unreachable, prefiltered above
             raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=node_id)
@@ -541,6 +627,7 @@ def make_engine_operation(
         engine_max_depth: int | None = None,
         engine_max_agents: int | None = None,
         engine_options: dict[str, Any] | None = None,
+        engine_workspace: str | None = None,
         **_ignored: Any,
     ) -> Any:
         from lionagi.cli.engine import _KIND_META, _import_engine_class
@@ -565,6 +652,8 @@ def make_engine_operation(
             run_kwargs["test_cmd"] = options.get("test_cmd")
         if engine_kind in ("coding", "hypothesis") and options.get("export_dir"):
             run_kwargs["export_dir"] = options["export_dir"]
+        if engine_kind == "coding" and engine_workspace:
+            run_kwargs["workspace"] = engine_workspace
 
         spec_input = _derive_engine_input(context)
 

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -143,7 +143,9 @@ def _resolve_node_cwd(node_id: str, raw_cwd: Any, base_dir: str | None) -> str:
     """
     if not isinstance(raw_cwd, str) or not raw_cwd:
         raise WorkflowCompileError(
-            f"node {node_id!r} config.cwd must be a non-empty string", node_id=node_id
+            f"node {node_id!r} config.cwd must be a non-empty string, "
+            f"got {raw_cwd!r} (base_dir={base_dir!r})",
+            node_id=node_id,
         )
     raw_path = Path(raw_cwd)
     if has_traversal(raw_path):

--- a/lionagi/studio/services/workflow_defs.py
+++ b/lionagi/studio/services/workflow_defs.py
@@ -41,6 +41,12 @@ def _validate_spec(spec: dict[str, Any] | None) -> None:
         raise ValueError("spec_json must be an object")
     if spec.get("version") != 1:
         raise ValueError(f"spec_json.version must be 1, got {spec.get('version')!r}")
+    if "base_dir" in spec:
+        raise ValueError(
+            "spec_json must not carry a top-level 'base_dir' field — base_dir "
+            "is a run-level input supplied by the operator at run time, never "
+            "a def-authored field"
+        )
 
     nodes = spec.get("nodes", [])
     edges = spec.get("edges", [])
@@ -284,6 +290,7 @@ async def delete_workflow_def_route(def_id: str) -> dict[str, Any]:
 
 class RunWorkflowDefRequest(BaseModel):
     inputs: dict[str, Any] | None = None
+    base_dir: str | None = None
 
 
 @studio_route(
@@ -303,7 +310,7 @@ async def run_workflow_def_route(def_id: str, body: RunWorkflowDefRequest) -> di
     from .workflow_run import WorkflowNotFoundError, run_workflow_def
 
     try:
-        return await run_workflow_def(def_id, body.inputs)
+        return await run_workflow_def(def_id, body.inputs, base_dir=body.base_dir)
     except WorkflowNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except WorkflowCompileError as exc:

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -117,6 +117,7 @@ async def run_workflow_def(
     def_id: str,
     inputs: dict[str, Any] | None = None,
     *,
+    base_dir: str | None = None,
     _session: Any | None = None,
 ) -> dict[str, Any]:
     """Load, compile, and execute a WorkflowDef; return ``{run_id, status}``.
@@ -126,6 +127,10 @@ async def run_workflow_def(
     shows up exactly like any other flow run. Raises WorkflowNotFoundError
     (404) or WorkflowCompileError (422, carries node_id/edge_id) on failure
     to compile; never a bare 500 for those two cases.
+
+    ``base_dir`` is a run-level containment root for node ``config.cwd``
+    values (never a spec field — see compile_workflow_def). A node with no
+    cwd runs unaffected whether or not base_dir is supplied.
 
     ``_session`` is a private testability seam (inject a Session with a
     mocked default branch to avoid real provider calls in tests); real
@@ -151,7 +156,9 @@ async def run_workflow_def(
             found = await engine_defs.get_engine_def_by_name(ref)
         return found
 
-    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_engine_def)
+    graph, _id_map = await compile_workflow_def(
+        spec, resolve_engine_def=_resolve_engine_def, base_dir=base_dir
+    )
 
     from .workflow_compile import build_early_graph
 

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -313,6 +313,20 @@ async def test_engine_node_cwd_without_base_dir_rejected_with_node_id():
     assert "'sub'" in str(exc_info.value)  # the raw cwd is named in the error
 
 
+async def test_engine_node_cwd_invalid_type_rejected_with_full_context():
+    """A non-string/empty cwd error names node id, the offending value, and
+    the supplied base_dir, like every other containment error."""
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = 42
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_coding_kind)
+    assert exc_info.value.node_id == "n3"
+    msg = str(exc_info.value)
+    assert "non-empty string" in msg
+    assert "42" in msg
+    assert "base_dir" in msg
+
+
 async def test_engine_node_cwd_traversal_rejected_before_resolution():
     """A raw '..' segment is rejected before any path resolution — even
     with no base_dir and on a non-coding engine kind."""

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -287,6 +287,162 @@ async def test_compile_null_budget_override_falls_back_to_def():
     assert engine_op.parameters["engine_max_agents"] == 5  # def value, not None
 
 
+# ─── Per-node cwd (D-F1) ──────────────────────────────────────────────────
+
+
+async def _resolve_coding_kind(ref: str) -> dict[str, Any]:
+    return {"kind": "coding", "model": None, "options": {"test_cmd": "pytest"}}
+
+
+async def test_spec_level_base_dir_rejected_at_compile():
+    """base_dir is a run-level input, never a spec field — reject even a
+    def already saved with a top-level base_dir (defense in depth, mirroring
+    the write-path check)."""
+    spec = _make_spec(base_dir="/tmp/hostile")
+    with pytest.raises(WorkflowCompileError, match="base_dir"):
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+
+
+async def test_engine_node_cwd_without_base_dir_rejected_with_node_id():
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "sub"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_coding_kind)
+    assert exc_info.value.node_id == "n3"
+    assert "base_dir" in str(exc_info.value)
+
+
+async def test_engine_node_cwd_traversal_rejected_before_resolution():
+    """A raw '..' segment is rejected before any path resolution — even
+    with no base_dir and on a non-coding engine kind."""
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "../../etc"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n3"
+    assert "traversal" in str(exc_info.value)
+
+
+async def test_engine_node_cwd_non_coding_kind_rejected(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "sub"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok, base_dir=str(tmp_path))
+    assert exc_info.value.node_id == "n3"
+    assert "coding" in str(exc_info.value)
+
+
+async def test_engine_node_relative_cwd_resolves_contained(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "sub"
+    graph, _id_map = await compile_workflow_def(
+        spec, resolve_engine_def=_resolve_coding_kind, base_dir=str(tmp_path)
+    )
+
+    from lionagi.operations.node import Operation
+
+    engine_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "engine"
+    )
+    assert engine_op.parameters["engine_workspace"] == str(sub.resolve())
+
+
+async def test_engine_node_absolute_cwd_inside_base_dir_accepted(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = str(sub)
+    graph, _id_map = await compile_workflow_def(
+        spec, resolve_engine_def=_resolve_coding_kind, base_dir=str(tmp_path)
+    )
+
+    from lionagi.operations.node import Operation
+
+    engine_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "engine"
+    )
+    assert engine_op.parameters["engine_workspace"] == str(sub.resolve())
+
+
+async def test_engine_node_absolute_cwd_outside_base_dir_rejected(tmp_path):
+    base = tmp_path / "base"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = str(outside)
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(
+            spec, resolve_engine_def=_resolve_coding_kind, base_dir=str(base)
+        )
+    assert exc_info.value.node_id == "n3"
+    assert "escapes" in str(exc_info.value)
+
+
+async def test_engine_node_cwd_nonexistent_dir_rejected(tmp_path):
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "does-not-exist"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(
+            spec, resolve_engine_def=_resolve_coding_kind, base_dir=str(tmp_path)
+        )
+    assert exc_info.value.node_id == "n3"
+    assert "does not exist" in str(exc_info.value)
+
+
+async def test_engine_node_cwd_symlink_escape_rejected(tmp_path):
+    """A relative cwd that LOOKS contained under base_dir but resolves through
+    a symlink to a directory outside base_dir must be rejected. This is why
+    containment uses Path.resolve() (symlink-resolving) rather than
+    os.path.normpath — normpath would pass the traversal check and this test
+    while missing the symlink escape."""
+    base = tmp_path / "base"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = base / "escape-link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["cwd"] = "escape-link"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(
+            spec, resolve_engine_def=_resolve_coding_kind, base_dir=str(base)
+        )
+    assert exc_info.value.node_id == "n3"
+    assert "escapes" in str(exc_info.value)
+
+
+async def test_engine_node_no_cwd_unaffected_with_base_dir(tmp_path):
+    """A def with no node cwd anywhere runs exactly as today, base_dir or not."""
+    graph, id_map = await compile_workflow_def(
+        _make_spec(), resolve_engine_def=_resolve_ok, base_dir=str(tmp_path)
+    )
+    assert set(id_map) == {"n2", "n3"}
+
+    from lionagi.operations.node import Operation
+
+    engine_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "engine"
+    )
+    assert engine_op.parameters["engine_workspace"] is None
+
+
+async def test_engine_node_no_cwd_unaffected_without_base_dir():
+    graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
+    assert set(id_map) == {"n2", "n3"}
+
+
 async def test_compile_non_mapping_engine_options_raises_with_node_id():
     """A non-mapping config.options would raise TypeError on the ** merge,
     escaping the ValueError wrapper as a 500. Reject it as a compile error.

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -287,7 +287,7 @@ async def test_compile_null_budget_override_falls_back_to_def():
     assert engine_op.parameters["engine_max_agents"] == 5  # def value, not None
 
 
-# ─── Per-node cwd (D-F1) ──────────────────────────────────────────────────
+# ─── Per-node cwd ──────────────────────────────────────────────────────
 
 
 async def _resolve_coding_kind(ref: str) -> dict[str, Any]:
@@ -310,6 +310,7 @@ async def test_engine_node_cwd_without_base_dir_rejected_with_node_id():
         await compile_workflow_def(spec, resolve_engine_def=_resolve_coding_kind)
     assert exc_info.value.node_id == "n3"
     assert "base_dir" in str(exc_info.value)
+    assert "'sub'" in str(exc_info.value)  # the raw cwd is named in the error
 
 
 async def test_engine_node_cwd_traversal_rejected_before_resolution():
@@ -321,6 +322,8 @@ async def test_engine_node_cwd_traversal_rejected_before_resolution():
         await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
     assert exc_info.value.node_id == "n3"
     assert "traversal" in str(exc_info.value)
+    assert "'../../etc'" in str(exc_info.value)
+    assert "base_dir" in str(exc_info.value)  # supplied base_dir (None here) is named
 
 
 async def test_engine_node_cwd_non_coding_kind_rejected(tmp_path):

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -102,7 +102,7 @@ async def test_bad_node_kind_raises(patched_svc):
 
 
 async def test_spec_level_base_dir_rejected_at_create(patched_svc):
-    """base_dir is a run-level input, never a spec field — see D-F5: a def
+    """base_dir is a run-level input, never a spec field: a def
     that could pin its own containment root would defeat cwd containment."""
     svc, _ = patched_svc
     spec = _spec(base_dir="/tmp/whatever")

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -101,6 +101,23 @@ async def test_bad_node_kind_raises(patched_svc):
         await svc.create_workflow_def({"name": "badkind", "spec_json": spec})
 
 
+async def test_spec_level_base_dir_rejected_at_create(patched_svc):
+    """base_dir is a run-level input, never a spec field — see D-F5: a def
+    that could pin its own containment root would defeat cwd containment."""
+    svc, _ = patched_svc
+    spec = _spec(base_dir="/tmp/whatever")
+    with pytest.raises(ValueError, match="base_dir"):
+        await svc.create_workflow_def({"name": "hostile-base-dir", "spec_json": spec})
+
+
+async def test_spec_level_base_dir_rejected_at_update(patched_svc):
+    svc, _ = patched_svc
+    created = await svc.create_workflow_def({"name": "later-hostile", "spec_json": _spec()})
+    spec = _spec(base_dir="/tmp/whatever")
+    with pytest.raises(ValueError, match="base_dir"):
+        await svc.update_workflow_def(created["id"], {"spec_json": spec})
+
+
 async def test_duplicate_node_id_raises(patched_svc):
     svc, _ = patched_svc
     spec = _spec()

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -129,6 +129,14 @@ def patched_env(tmp_path: Path, monkeypatch):
             "cls_path": ("tests.apps_studio_server.test_workflow_run", "_FakeEngine"),
         },
     )
+    monkeypatch.setitem(
+        cli_engine._KIND_META,
+        "coding",
+        {
+            **cli_engine._KIND_META["coding"],
+            "cls_path": ("tests.apps_studio_server.test_workflow_run", "_FakeEngine"),
+        },
+    )
     return wf_svc, engine_defs_svc
 
 
@@ -402,6 +410,176 @@ async def test_workflow_run_bare_chat_model_rejected_at_compile_defense_in_depth
         await run_workflow_def(def_id)
     assert exc_info.value.node_id == "chat1"
     assert "chat1" in str(exc_info.value)
+
+
+# ─── Per-node cwd (D-F1) end-to-end ─────────────────────────────────────────
+
+
+async def test_workflow_run_node_cwd_reaches_engine_invocation(patched_env, tmp_path):
+    """A contained, relative node cwd must resolve to an absolute path under
+    base_dir and reach the engine's run(workspace=...) call — the actual
+    provider seam (make_engine_operation._engine_op forwards it as
+    run_kwargs['workspace'] for coding engine nodes)."""
+    wf_svc, engine_defs_svc = patched_env
+    _FakeEngine.calls = []
+
+    sub = tmp_path / "worktree"
+    sub.mkdir()
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "coding-eng", "kind": "coding", "options": {"test_cmd": "pytest"}}
+    )
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["nodes"][2]["config"]["cwd"] = "worktree"
+    created = await wf_svc.create_workflow_def({"name": "cwd-flow", "spec_json": spec})
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    session = Session(default_branch=_mock_chat_branch())
+    result = await run_workflow_def(
+        created["id"], {"topic": "GQA"}, base_dir=str(tmp_path), _session=session
+    )
+
+    assert result["status"] == "completed"
+    assert len(_FakeEngine.calls) == 1
+    assert _FakeEngine.calls[0]["kwargs"]["workspace"] == str(sub.resolve())
+
+
+async def test_workflow_run_node_cwd_without_base_dir_rejected(patched_env, tmp_path):
+    wf_svc, engine_defs_svc = patched_env
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "coding-eng-2", "kind": "coding", "options": {"test_cmd": "pytest"}}
+    )
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["nodes"][2]["config"]["cwd"] = "worktree"
+    created = await wf_svc.create_workflow_def({"name": "cwd-no-basedir-flow", "spec_json": spec})
+
+    from lionagi.studio.services.workflow_compile import WorkflowCompileError
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await run_workflow_def(created["id"])
+    assert exc_info.value.node_id == "eng1"
+    assert "base_dir" in str(exc_info.value)
+
+
+async def test_workflow_run_node_absolute_cwd_outside_base_dir_rejected(patched_env, tmp_path):
+    wf_svc, engine_defs_svc = patched_env
+
+    base = tmp_path / "base"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "coding-eng-3", "kind": "coding", "options": {"test_cmd": "pytest"}}
+    )
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["nodes"][2]["config"]["cwd"] = str(outside)
+    created = await wf_svc.create_workflow_def({"name": "cwd-outside-flow", "spec_json": spec})
+
+    from lionagi.studio.services.workflow_compile import WorkflowCompileError
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await run_workflow_def(created["id"], base_dir=str(base))
+    assert exc_info.value.node_id == "eng1"
+    assert "escapes" in str(exc_info.value)
+
+
+async def test_workflow_run_node_absolute_cwd_inside_base_dir_accepted(patched_env, tmp_path):
+    wf_svc, engine_defs_svc = patched_env
+    _FakeEngine.calls = []
+
+    sub = tmp_path / "worktree"
+    sub.mkdir()
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "coding-eng-4", "kind": "coding", "options": {"test_cmd": "pytest"}}
+    )
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["nodes"][2]["config"]["cwd"] = str(sub)
+    created = await wf_svc.create_workflow_def({"name": "cwd-abs-inside-flow", "spec_json": spec})
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    session = Session(default_branch=_mock_chat_branch())
+    result = await run_workflow_def(created["id"], base_dir=str(tmp_path), _session=session)
+
+    assert result["status"] == "completed"
+    assert _FakeEngine.calls[0]["kwargs"]["workspace"] == str(sub.resolve())
+
+
+async def test_workflow_run_spec_level_base_dir_rejected(patched_env):
+    """Defense in depth: a def row that somehow carries a top-level base_dir
+    field (bypassing the write-path check, or written directly) must still be
+    caught at compile/run time — see test_workflow_run_bare_chat_model_rejected_at_compile_defense_in_depth
+    for the identical precedent with config.model."""
+    wf_svc, engine_defs_svc = patched_env
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "eng-basedir", "kind": "research"}
+    )
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["base_dir"] = "/tmp/hostile"
+
+    import time
+    import uuid
+
+    from lionagi.state.db import StateDB
+
+    def_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    async with StateDB() as db:
+        await db.create_workflow_def(
+            {
+                "id": def_id,
+                "name": "legacy-spec-base-dir",
+                "description": None,
+                "spec_json": spec,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+    from lionagi.studio.services.workflow_compile import WorkflowCompileError
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    with pytest.raises(WorkflowCompileError, match="base_dir"):
+        await run_workflow_def(def_id)
+
+
+async def test_workflow_run_no_cwd_unaffected_with_and_without_base_dir(patched_env, tmp_path):
+    """A def with no node cwd anywhere runs exactly as today, whether or not
+    the run supplies a base_dir."""
+    wf_svc, engine_defs_svc = patched_env
+    _FakeEngine.calls = []
+
+    engine_def = await engine_defs_svc.create_engine_def({"name": "no-cwd-eng", "kind": "research"})
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    created = await wf_svc.create_workflow_def({"name": "no-cwd-flow", "spec_json": spec})
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    session_a = Session(default_branch=_mock_chat_branch())
+    result_a = await run_workflow_def(created["id"], {"topic": "GQA"}, _session=session_a)
+    assert result_a["status"] == "completed"
+
+    session_b = Session(default_branch=_mock_chat_branch())
+    result_b = await run_workflow_def(
+        created["id"], {"topic": "GQA"}, base_dir=str(tmp_path), _session=session_b
+    )
+    assert result_b["status"] == "completed"
 
 
 async def test_run_route_returns_404_for_missing_def(patched_env):

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -412,7 +412,7 @@ async def test_workflow_run_bare_chat_model_rejected_at_compile_defense_in_depth
     assert "chat1" in str(exc_info.value)
 
 
-# ─── Per-node cwd (D-F1) end-to-end ─────────────────────────────────────────
+# ─── Per-node cwd end-to-end ──────────────────────────────────────────────────
 
 
 async def test_workflow_run_node_cwd_reaches_engine_invocation(patched_env, tmp_path):
@@ -445,6 +445,26 @@ async def test_workflow_run_node_cwd_reaches_engine_invocation(patched_env, tmp_
     assert result["status"] == "completed"
     assert len(_FakeEngine.calls) == 1
     assert _FakeEngine.calls[0]["kwargs"]["workspace"] == str(sub.resolve())
+
+
+def test_real_coding_engine_run_accepts_compile_invocation_kwargs():
+    """The compile layer invokes every engine as run(spec, session=...,
+    on_branch_created=..., **run_kwargs). The fake engine in these tests
+    accepts **kwargs, so it cannot catch a real signature mismatch — bind
+    the exact invocation shape against the real CodingEngine.run signature."""
+    import inspect
+
+    from lionagi.engines.coding import CodingEngine
+
+    sig = inspect.signature(CodingEngine.run)
+    sig.bind(
+        object(),  # self
+        "fix the bug",  # spec
+        session=None,
+        on_branch_created=None,
+        test_cmd="pytest",
+        workspace="/tmp/w",
+    )
 
 
 async def test_workflow_run_node_cwd_without_base_dir_rejected(patched_env, tmp_path):


### PR DESCRIPTION
Implements the per-node working-directory surface of the fixed-flow workflow contract (ADR-0103 D-F1/D-F5).

- **`base_dir` is a run-level input, never a spec field** — `run_workflow_def(..., base_dir=...)` and the run route accept it; a def spec carrying a top-level `base_dir` is rejected at BOTH the write path and compile (the load-bearing security invariant: a shared/contributed def cannot pin its own containment root).
- **Containment order matters and is engine-owned**: raw-string traversal check (reusing `has_traversal`) runs before any resolution, so a hostile `..` rejects even without a base_dir; then symlink-resolving `Path.resolve()` on the joined path (explicitly not `normpath`); then `relative_to(base_dir)`; then must-exist + must-be-dir. Failures name the node id, the offending cwd, and the base_dir.
- **Node `config.cwd` may be absolute or relative**; absolute must still resolve inside `base_dir`. A node cwd with no run `base_dir` rejects with a clear error.
- **Seam**: the resolved cwd flows through `engine_workspace` into `CodingEngine.run(workspace=...)` — the only engine `run()` signature that accepts a working directory today. `config.cwd` on other engine kinds fails loudly at compile rather than being silently dropped (forwarding blind would `TypeError` at run time on their fixed-arg signatures).
- No-cwd defs run exactly as before, with or without `base_dir` (regression tests).

Tests: 12 new across compile/defs/run, including the symlink-escape case (fails if `resolve()` is swapped for `normpath` — verified by revert-check) and end-to-end assertions on the actual `workspace` kwarg reaching the engine. Full `tests/apps_studio_server/`: 891 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)