### PR TITLE
feat(bench): bill cache writes as a fourth cost dimension

### DIFF
--- a/benchmarks/orchestration/harness/cost.py
+++ b/benchmarks/orchestration/harness/cost.py
@@ -37,7 +37,17 @@ Token-convention difference handled in ``_norm_tokens``:
   - Anthropic: ``input_tokens`` is uncached only; ``cache_read_input_tokens`` /
     ``cache_creation_input_tokens`` are separate.
 
-Prices are USD per 1,000,000 tokens: ``(input, output, cached_input)``.
+Cache WRITES are a fourth billing dimension. Anthropic bills prompt-cache
+creation at 1.25x the input rate (5-minute TTL; 1h TTL is 2x — supply an
+explicit override for 1h-heavy workloads). OpenAI models from the 5.6
+generation onward bill cache writes at 1.25x uncached input as well (earlier
+generations bill cache writes at the plain input rate, i.e. multiplier 1.0 —
+but they also never report a cache-write token count, so the dimension stays
+zero and costs are unchanged for them). Default cache-write price is
+``1.25 x input`` unless the price entry supplies an explicit fourth value.
+
+Prices are USD per 1,000,000 tokens: ``(input, output, cached_input)`` with an
+optional fourth ``cache_write`` element (defaults to ``input * 1.25``).
 """
 
 from __future__ import annotations
@@ -77,13 +87,23 @@ _DEFAULT_PRICES: dict[str, tuple[float, float, float]] = {
 PROXY_PRICED = {"openai/gpt-5.3-codex-spark", "gpt-5.3-codex-spark", "codex"}
 
 
-def _prices() -> dict[str, tuple[float, float, float]]:
-    table = dict(_DEFAULT_PRICES)
+# Cache writes bill at a premium over uncached input (Anthropic 5m-TTL cache
+# creation and OpenAI 5.6+ both publish 1.25x). Applied whenever a price entry
+# has no explicit fourth (cache_write) element.
+CACHE_WRITE_MULT = 1.25
+
+
+def _prices() -> dict[str, tuple[float, float, float, float]]:
+    table: dict[str, tuple[float, float, float, float]] = {
+        k: (*v, v[0] * CACHE_WRITE_MULT) for k, v in _DEFAULT_PRICES.items()
+    }
     override = os.environ.get("LIONAGI_BENCH_PRICES")
     if override:
         for k, v in json.loads(override).items():
-            cached = float(v[2]) if len(v) > 2 else float(v[0]) * 0.1
-            table[k] = (float(v[0]), float(v[1]), cached)
+            pin = float(v[0])
+            cached = float(v[2]) if len(v) > 2 else pin * 0.1
+            write = float(v[3]) if len(v) > 3 else pin * CACHE_WRITE_MULT
+            table[k] = (pin, float(v[1]), cached, write)
     return table
 
 
@@ -97,27 +117,31 @@ class Usage:
     contributed (its reasoning is unbilled-here, so cost is a floor)."""
 
     input_tokens: int = 0  # uncached prompt tokens (billed at input rate)
-    cached_tokens: int = 0  # cached prompt tokens (billed at cached rate)
+    cached_tokens: int = 0  # cache-READ prompt tokens (billed at cached rate)
+    cache_write_tokens: int = 0  # cache-WRITE prompt tokens (billed at premium)
     output_tokens: int = 0  # completion (incl. reasoning for Anthropic, NOT codex)
     num_turns: int = 0  # internal CLI turns (tool calls etc.), if reported
     n_calls: int = 0  # lionagi-level model invocations seen
     source: str = "none"  # reported | estimated | mixed | none
     reasoning_disclosed: bool = True  # False if any codex call (reasoning hidden)
-    # model -> [uncached_in, cached_in, out] for exact (and mixed-model) pricing
+    # model -> [uncached_in, cached_in, out, cache_write] for exact (and
+    # mixed-model) pricing
     per_model: dict[str, list[int]] = field(default_factory=dict)
 
     @property
     def total_tokens(self) -> int:
-        return self.input_tokens + self.cached_tokens + self.output_tokens
+        return self.input_tokens + self.cached_tokens + self.cache_write_tokens + self.output_tokens
 
-    def _add(self, model: str, inp: int, cached: int, out: int) -> None:
+    def _add(self, model: str, inp: int, cached: int, out: int, cache_write: int = 0) -> None:
         self.input_tokens += inp
         self.cached_tokens += cached
+        self.cache_write_tokens += cache_write
         self.output_tokens += out
-        slot = self.per_model.setdefault(model, [0, 0, 0])
+        slot = self.per_model.setdefault(model, [0, 0, 0, 0])
         slot[0] += inp
         slot[1] += cached
         slot[2] += out
+        slot[3] += cache_write
 
     def cost_usd(self, default_model: str) -> float:
         """USD via the price table, billed per-model where tracked. For codex,
@@ -125,22 +149,42 @@ class Usage:
         lower bound when ``reasoning_disclosed`` is False."""
         table = _prices()
         models = self.per_model or {
-            default_model: [self.input_tokens, self.cached_tokens, self.output_tokens]
+            default_model: [
+                self.input_tokens,
+                self.cached_tokens,
+                self.output_tokens,
+                self.cache_write_tokens,
+            ]
         }
         total = 0.0
-        for model, (inp, cached, out) in models.items():
-            pin, pout, pcached = table.get(model, table.get(default_model, (0.0, 0.0, 0.0)))
-            total += inp / 1e6 * pin + cached / 1e6 * pcached + out / 1e6 * pout
+        for model, slot in models.items():
+            inp, cached, out = slot[0], slot[1], slot[2]
+            write = slot[3] if len(slot) > 3 else 0
+            pin, pout, pcached, pwrite = table.get(
+                model, table.get(default_model, (0.0, 0.0, 0.0, 0.0))
+            )
+            total += (
+                inp / 1e6 * pin + cached / 1e6 * pcached + out / 1e6 * pout + write / 1e6 * pwrite
+            )
         return round(total, 6)
 
 
-def cost_of(input_tokens: int, cached_tokens: int, output_tokens: int, model: str) -> float:
+def cost_of(
+    input_tokens: int,
+    cached_tokens: int,
+    output_tokens: int,
+    model: str,
+    cache_write_tokens: int = 0,
+) -> float:
     """USD for a single run's aggregate tokens at the model's published price.
     For codex this is a lower bound (reasoning excluded — see module docstring)."""
     table = _prices()
-    pin, pout, pcached = table.get(model, (0.0, 0.0, 0.0))
+    pin, pout, pcached, pwrite = table.get(model, (0.0, 0.0, 0.0, 0.0))
     return round(
-        input_tokens / 1e6 * pin + cached_tokens / 1e6 * pcached + output_tokens / 1e6 * pout,
+        input_tokens / 1e6 * pin
+        + cached_tokens / 1e6 * pcached
+        + output_tokens / 1e6 * pout
+        + cache_write_tokens / 1e6 * pwrite,
         6,
     )
 
@@ -163,24 +207,28 @@ def _dig_usage(mr: dict) -> dict | None:
     return None
 
 
-def _norm_tokens(u: dict) -> tuple[int, int, int, bool]:
-    """Normalize a provider usage dict to (uncached_in, cached_in, out, codex?).
+def _norm_tokens(u: dict) -> tuple[int, int, int, int, bool]:
+    """Normalize a provider usage dict to
+    (uncached_in, cached_in, out, cache_write, codex?).
 
     Handles the OpenAI vs Anthropic input-token convention difference."""
     out = int(u.get("output_tokens", u.get("completion_tokens", 0)) or 0)
     if "cached_input_tokens" in u:  # OpenAI/codex: input_tokens is TOTAL incl cached
         total_in = int(u.get("input_tokens", u.get("prompt_tokens", 0)) or 0)
         cached = int(u.get("cached_input_tokens", 0) or 0)
-        uncached = max(0, total_in - cached)
-        return uncached, cached, out, True
-    # Anthropic: input_tokens is uncached; cache_* are separate
+        # 5.6+ meters may break out cache writes; they are a subset of the
+        # input total, like the cached-read subset.
+        write = int(u.get("cache_creation_input_tokens", u.get("cache_write_tokens", 0)) or 0)
+        uncached = max(0, total_in - cached - write)
+        return uncached, cached, out, write, True
+    # Anthropic: input_tokens is uncached; cache_* are separate. Cache creation
+    # bills at a PREMIUM over input, never at the cache-read discount.
     uncached = int(u.get("input_tokens", u.get("prompt_tokens", 0)) or 0)
-    cached = int(u.get("cache_read_input_tokens", 0) or 0) + int(
-        u.get("cache_creation_input_tokens", 0) or 0
-    )
-    if not uncached and not out and u.get("total_tokens"):
+    cached = int(u.get("cache_read_input_tokens", 0) or 0)
+    write = int(u.get("cache_creation_input_tokens", 0) or 0)
+    if not uncached and not out and not cached and not write and u.get("total_tokens"):
         out = int(u["total_tokens"])  # only a total — attribute to output (conservative)
-    return uncached, cached, out, False
+    return uncached, cached, out, write, False
 
 
 def collect_usage(branches, prompts_and_outputs, default_model: str) -> Usage:
@@ -205,9 +253,9 @@ def collect_usage(branches, prompts_and_outputs, default_model: str) -> Usage:
             u = _dig_usage(mr) if mr else None
             if not u:
                 continue
-            uncached, cached, out, is_codex = _norm_tokens(u)
-            if uncached or cached or out:
-                usage._add(model_name, uncached, cached, out)
+            uncached, cached, out, write, is_codex = _norm_tokens(u)
+            if uncached or cached or out or write:
+                usage._add(model_name, uncached, cached, out, write)
                 usage.n_calls += 1
                 usage.num_turns += int(mr.get("num_turns", 0) or 0)
                 if is_codex:

--- a/benchmarks/orchestration/harness/judge.py
+++ b/benchmarks/orchestration/harness/judge.py
@@ -84,11 +84,18 @@ async def _judge_one(output: str, label: Label, model) -> JudgeVerdict:
 async def score(result: RunResult, labels: tuple[Label, ...]) -> ScoredResult:
     """Score one RunResult. Aggregates across the run's outputs (the chain's
     final synthesis dominates, but any output flagging counts)."""
-    cost = cost_of(result.input_tokens, result.cached_tokens, result.output_tokens, result.model)
+    cost = cost_of(
+        result.input_tokens,
+        result.cached_tokens,
+        result.output_tokens,
+        result.model,
+        cache_write_tokens=result.cache_write_tokens,
+    )
     compute = dict(
         input_tokens=result.input_tokens,
         output_tokens=result.output_tokens,
         cached_tokens=result.cached_tokens,
+        cache_write_tokens=result.cache_write_tokens,
         est_cost_usd=cost,
         usage_source=result.usage_source,
         reasoning_disclosed=result.reasoning_disclosed,

--- a/benchmarks/orchestration/harness/runner.py
+++ b/benchmarks/orchestration/harness/runner.py
@@ -198,6 +198,7 @@ async def _run_once_inprocess(task: Task, config: OrchestrationConfig, trial: in
             input_tokens=usage.input_tokens,
             output_tokens=usage.output_tokens,
             cached_tokens=usage.cached_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
             num_turns=usage.num_turns,
             n_calls=usage.n_calls,
             usage_source=usage.source,

--- a/benchmarks/orchestration/harness/task.py
+++ b/benchmarks/orchestration/harness/task.py
@@ -56,7 +56,8 @@ class RunResult:
     # CLI internal turns), or "mixed".
     input_tokens: int = 0  # uncached prompt tokens
     output_tokens: int = 0  # completion (incl. reasoning for Anthropic, NOT codex)
-    cached_tokens: int = 0  # cached prompt tokens (billed at cached rate)
+    cached_tokens: int = 0  # cache-read prompt tokens (billed at cached rate)
+    cache_write_tokens: int = 0  # cache-write prompt tokens (billed at premium)
     num_turns: int = 0
     n_calls: int = 0
     usage_source: str = "none"  # reported | estimated | mixed | none
@@ -86,6 +87,7 @@ class ScoredResult:
     input_tokens: int = 0
     output_tokens: int = 0
     cached_tokens: int = 0
+    cache_write_tokens: int = 0
     est_cost_usd: float = 0.0
     usage_source: str = "none"
     reasoning_disclosed: bool = True

--- a/benchmarks/orchestration/harness/test_cost.py
+++ b/benchmarks/orchestration/harness/test_cost.py
@@ -1,0 +1,92 @@
+"""Tests for cost.py's four-dimension token accounting.
+
+Cache writes bill at a premium over uncached input (1.25x by default), never
+at the cache-read discount. These tests pin the normalization split (Anthropic
+cache_creation vs cache_read, OpenAI cached/write subsets of the input total),
+the pricing rule (derived 1.25x default, explicit fourth price element,
+three-element env-override back-compat), and the per-model aggregation slots.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from harness.cost import (  # noqa: E402
+    CACHE_WRITE_MULT,
+    Usage,
+    _norm_tokens,
+    _prices,
+    cost_of,
+)
+
+_MODEL = "claude-code/sonnet"  # (3.00, 15.00, 0.30) per 1M
+
+
+def test_norm_tokens_anthropic_splits_cache_write_from_read():
+    u = {
+        "input_tokens": 100,
+        "cache_read_input_tokens": 400,
+        "cache_creation_input_tokens": 300,
+        "output_tokens": 50,
+    }
+    assert _norm_tokens(u) == (100, 400, 50, 300, False)
+
+
+def test_norm_tokens_openai_write_is_subset_of_input_total():
+    u = {
+        "input_tokens": 1000,
+        "cached_input_tokens": 600,
+        "cache_creation_input_tokens": 100,
+        "output_tokens": 20,
+    }
+    uncached, cached, out, write, is_codex = _norm_tokens(u)
+    assert (uncached, cached, out, write) == (300, 600, 20, 100)
+    assert is_codex
+
+
+def test_norm_tokens_openai_without_write_key_unchanged():
+    u = {"input_tokens": 1000, "cached_input_tokens": 600, "output_tokens": 20}
+    assert _norm_tokens(u) == (400, 600, 20, 0, True)
+
+
+def test_default_cache_write_price_is_1_25x_input():
+    pin, _pout, _pcached, pwrite = _prices()[_MODEL]
+    assert pwrite == pin * CACHE_WRITE_MULT
+
+
+def test_cost_of_bills_cache_writes_at_premium():
+    base = cost_of(0, 0, 0, _MODEL)
+    with_writes = cost_of(0, 0, 0, _MODEL, cache_write_tokens=1_000_000)
+    assert with_writes - base == 3.00 * CACHE_WRITE_MULT
+    # and the premium exceeds what the same tokens would cost as plain input
+    assert with_writes > cost_of(1_000_000, 0, 0, _MODEL)
+
+
+def test_price_override_three_elements_derives_write_price(monkeypatch):
+    monkeypatch.setenv("LIONAGI_BENCH_PRICES", json.dumps({"m": [2.0, 8.0, 0.2]}))
+    assert _prices()["m"] == (2.0, 8.0, 0.2, 2.0 * CACHE_WRITE_MULT)
+
+
+def test_price_override_fourth_element_is_explicit_write_price(monkeypatch):
+    monkeypatch.setenv("LIONAGI_BENCH_PRICES", json.dumps({"m": [2.0, 8.0, 0.2, 4.0]}))
+    assert _prices()["m"] == (2.0, 8.0, 0.2, 4.0)
+    assert cost_of(0, 0, 0, "m", cache_write_tokens=1_000_000) == 4.0
+
+
+def test_usage_add_and_cost_usd_include_cache_writes():
+    usage = Usage()
+    usage._add(_MODEL, 100, 200, 50, 300)
+    assert usage.cache_write_tokens == 300
+    assert usage.per_model[_MODEL] == [100, 200, 50, 300]
+    assert usage.total_tokens == 650
+    expected = cost_of(100, 200, 50, _MODEL, cache_write_tokens=300)
+    assert usage.cost_usd(_MODEL) == expected
+
+
+def test_usage_cost_usd_tolerates_legacy_three_slot_per_model():
+    usage = Usage(per_model={_MODEL: [100, 200, 50]})
+    assert usage.cost_usd(_MODEL) == cost_of(100, 200, 50, _MODEL)

--- a/benchmarks/orchestration/suites/swebench/_sandbox_entry.py
+++ b/benchmarks/orchestration/suites/swebench/_sandbox_entry.py
@@ -160,7 +160,7 @@ def _collect_usage(branch) -> dict:
 
     Mirrors harness/cost.py's normalization but inline (host has the full
     price table; here we only need raw token counts)."""
-    inp = cached = out = calls = 0
+    inp = cached = write = out = calls = 0
     try:
         messages = list(branch.msgs.messages)
     except Exception:
@@ -176,16 +176,25 @@ def _collect_usage(branch) -> dict:
         if "cached_input_tokens" in u:  # OpenAI/codex: input incl cached
             total_in = int(u.get("input_tokens", u.get("prompt_tokens", 0)) or 0)
             c = int(u.get("cached_input_tokens", 0) or 0)
-            i = max(0, total_in - c)
-        else:  # Anthropic / generic
+            w = int(u.get("cache_creation_input_tokens", u.get("cache_write_tokens", 0)) or 0)
+            i = max(0, total_in - c - w)
+        else:  # Anthropic / generic: cache writes bill at a premium, not the read rate
             i = int(u.get("input_tokens", u.get("prompt_tokens", 0)) or 0)
             c = int(u.get("cache_read_input_tokens", 0) or 0)
-        if i or c or o:
+            w = int(u.get("cache_creation_input_tokens", 0) or 0)
+        if i or c or w or o:
             inp += i
             cached += c
+            write += w
             out += o
             calls += 1
-    return {"input_tokens": inp, "cached_tokens": cached, "output_tokens": out, "n_calls": calls}
+    return {
+        "input_tokens": inp,
+        "cached_tokens": cached,
+        "cache_write_tokens": write,
+        "output_tokens": out,
+        "n_calls": calls,
+    }
 
 
 async def _control_poller(branch, control_path: Path, stop: asyncio.Event) -> None:


### PR DESCRIPTION
## Summary
- Adds a cache-WRITE token dimension to the orchestration bench cost meter. Cache writes bill at a premium over uncached input (Anthropic prompt-cache creation and OpenAI 5.6+ both publish 1.25x); previously Anthropic `cache_creation_input_tokens` were billed at the ~0.1x cache-READ discount in the host collector and dropped entirely in the sandbox collector — a real undercount on cache-heavy runs.
- `Usage` gains `cache_write_tokens` + a fourth `per_model` slot (legacy three-slot entries still price correctly); `cost_of` gains an optional `cache_write_tokens` kwarg.
- `_norm_tokens` splits writes from reads on both provider shapes; on the OpenAI shape, write keys are treated as a subset of the input total (like the cached-read subset).
- Price entries grow an optional fourth cache-write element; default derives `1.25 x input`; existing three-element `LIONAGI_BENCH_PRICES` overrides keep working.
- The dimension is threaded through `RunResult`/`ScoredResult`, the runner, the judge, and the sandbox usage collector so it prices instead of vanishing at a seam.

## Testing
- New `benchmarks/orchestration/harness/test_cost.py` (9 tests): normalization split on both provider shapes, 1.25x default pricing, explicit fourth-element and three-element override back-compat, per-model aggregation incl. legacy slots.
- Full `benchmarks/orchestration/harness/` suite green (16 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)