### PR TITLE
feat(bench): GPT-5.6 tier pricing rows (sol/terra/luna)

### DIFF
--- a/benchmarks/orchestration/harness/cost.py
+++ b/benchmarks/orchestration/harness/cost.py
@@ -75,6 +75,15 @@ _DEFAULT_PRICES: dict[str, tuple[float, float, float]] = {
     "codex/gpt-5.3-codex-spark": (0.75, 4.50, 0.075),
     "gpt-5.3-codex-spark": (0.75, 4.50, 0.075),
     "codex": (0.75, 4.50, 0.075),
+    # OpenAI GPT-5.6 tiers — published launch pricing, 2026-07-09. Cache reads
+    # keep the 90% discount; cache writes bill at 1.25x input (the derived
+    # default, so no fourth element needed).
+    "codex/gpt-5.6-sol": (5.00, 30.00, 0.50),
+    "gpt-5.6-sol": (5.00, 30.00, 0.50),
+    "codex/gpt-5.6-terra": (2.50, 15.00, 0.25),
+    "gpt-5.6-terra": (2.50, 15.00, 0.25),
+    "codex/gpt-5.6-luna": (1.00, 6.00, 0.10),
+    "gpt-5.6-luna": (1.00, 6.00, 0.10),
     # Anthropic via claude_code CLI. Output_tokens INCLUDES thinking (accurate).
     # cached = cache-read rate (~0.1x input). VERIFY against current Anthropic
     # pricing before external quotes.


### PR DESCRIPTION
## Summary
- Adds the three live GPT-5.6 tiers to the bench price table at published launch pricing (per 1M tokens): sol 5.00/30.00, terra 2.50/15.00, luna 1.00/6.00, cache reads at the 90% discount.
- Cache writes bill at 1.25x input via the derived default from #1932 — no fourth element needed.
- Availability verified empirically on codex CLI 0.144.0: sol/terra/luna resolve; bare gpt-5.6 and the -codex variants are still account-gated and are deliberately NOT added until they resolve.

## Testing
- `benchmarks/orchestration/harness/test_cost.py` green (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)