### PR TITLE
feat(cli): bypass agent-profile frontmatter field; codex bypass warning verbose-only

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -318,6 +318,7 @@ class AgentProfile:
     model: str | None = None
     effort: str | None = None
     yolo: bool = False
+    bypass: bool = False
     fast_mode: bool = False
     lion_system: bool = True
     artifact_defaults: dict | None = None
@@ -436,6 +437,7 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         model=frontmatter.get("model"),
         effort=frontmatter.get("effort"),
         yolo=bool(frontmatter.get("yolo", False)),
+        bypass=bool(frontmatter.get("bypass", False)),
         fast_mode=bool(frontmatter.get("fast_mode", False)),
         lion_system=lion_system,
         artifact_defaults=frontmatter.get("artifact_defaults"),
@@ -451,6 +453,7 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
                 "model",
                 "effort",
                 "yolo",
+                "bypass",
                 "fast_mode",
                 "lion_system",
                 "artifact_defaults",

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -261,6 +261,8 @@ async def _run_agent(
             effort = normalize_effort(profile.effort)
         if profile.yolo and not yolo:
             yolo = True
+        if profile.bypass and not bypass:
+            bypass = True
         if profile.fast_mode and not fast:
             fast = True
         if profile.timeout and timeout is None:
@@ -315,8 +317,9 @@ async def _run_agent(
         )
 
     if branch is None:
-        # codex sandbox blocks tool calls without bypass — warn early.
-        if provider == "codex" and not yolo and not bypass:
+        # codex sandbox blocks tool calls without bypass — surface only in
+        # verbose runs now that profiles can carry bypass/yolo themselves.
+        if verbose and provider == "codex" and not yolo and not bypass:
             from lionagi.cli._logging import warn
 
             warn(

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -165,7 +165,7 @@ async def test_run_agent_threads_bypass_to_build_chat_model(monkeypatch, tmp_pat
 
 @pytest.mark.asyncio
 async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path, capsys):
-    """Naked codex without --bypass or --yolo emits a visible warning."""
+    """Naked codex without --bypass or --yolo warns only in verbose runs."""
     captured: list = []
     _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured)
 
@@ -188,6 +188,11 @@ async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path, ca
     from lionagi.cli.agent import _run_agent
 
     await _run_agent("codex/gpt-5.3-codex-spark", "do stuff", bypass=False, yolo=False)
+    assert not warnings_emitted, f"Expected silence without verbose, got: {warnings_emitted}"
+
+    await _run_agent(
+        "codex/gpt-5.3-codex-spark", "do stuff", bypass=False, yolo=False, verbose=True
+    )
 
     assert any("--bypass" in w or "bypass" in w.lower() for w in warnings_emitted), (
         f"Expected a bypass warning, got: {warnings_emitted}"

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -687,6 +687,7 @@ async def test_run_agent_preset_and_profile_single_system_message_with_both(monk
         lion_system=True,
         artifact_defaults=None,
         timeout=None,
+        bypass=False,
         resume_on_timeout=False,
     )
     import lionagi.cli.agent as agent_mod
@@ -749,6 +750,7 @@ async def test_run_agent_profile_without_preset_system_prompt_unchanged(monkeypa
         system_prompt=PROFILE_PROMPT,
         artifact_defaults=None,
         timeout=None,
+        bypass=False,
         resume_on_timeout=False,
     )
     import lionagi.cli.agent as agent_mod

--- a/tests/cli/test_agent_profile_bypass.py
+++ b/tests/cli/test_agent_profile_bypass.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Profile frontmatter `bypass` field: parsing and precedence over the CLI flag."""
+
+from __future__ import annotations
+
+from lionagi.cli._providers import _parse_profile
+
+
+def _profile_text(frontmatter: str) -> str:
+    return f"---\n{frontmatter}\n---\nbody prompt\n"
+
+
+class TestProfileBypassParsing:
+    def test_bypass_true_parsed(self):
+        profile = _parse_profile("p", _profile_text("bypass: true"))
+        assert profile.bypass is True
+
+    def test_bypass_absent_defaults_false(self):
+        profile = _parse_profile("p", _profile_text("model: codex/gpt-5.5"))
+        assert profile.bypass is False
+
+    def test_bypass_false_parsed(self):
+        profile = _parse_profile("p", _profile_text("bypass: false"))
+        assert profile.bypass is False
+
+    def test_bypass_not_leaked_into_extra(self):
+        profile = _parse_profile("p", _profile_text("bypass: true"))
+        assert "bypass" not in profile.extra
+
+    def test_bypass_independent_of_yolo(self):
+        profile = _parse_profile("p", _profile_text("bypass: true"))
+        assert profile.yolo is False
+        profile = _parse_profile("p", _profile_text("yolo: true"))
+        assert profile.bypass is False

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -275,6 +275,7 @@ async def test_resume_mixed_case_profile_effort_reapplies_correct_agy_tier(monke
             system_prompt=None,
             artifact_defaults=None,
             timeout=None,
+            bypass=False,
             resume_on_timeout=False,
         ),
     )


### PR DESCRIPTION
## Summary
- Agent profiles gain a `bypass` frontmatter field, loaded and applied exactly like `yolo` (CLI flag still overrides). Profiles could previously set `yolo` but not `bypass`, and the two map to different provider kwargs (`PROVIDER_BYPASS_KWARGS` vs `PROVIDER_YOLO_KWARGS`), so a codex profile couldn't opt into bypass without the flag on every invocation.
- The codex no-bypass warning is demoted to verbose-only — it keeps the debugging breadcrumb but stops printing on every profile-driven run now that profiles can carry the flag.
- `bypass` added to the frontmatter exclusion list so it doesn't leak into `profile.extra`.

## Testing
- New `tests/cli/test_agent_profile_bypass.py` (parsing, default, extra-leak, independence from yolo).
- `test_run_agent_codex_no_bypass_emits_warning` updated to pin both sides of the verbose gate (silent by default, warns with `verbose=True`).
- Strict SimpleNamespace profile doubles in three test files gained the new field.
- Full `tests/cli/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)