### PR TITLE
test(studio): app factory + entered TestClients to kill xdist worker crash

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -186,76 +186,6 @@ async def lifespan(app_instance):
     await scheduler.stop()
 
 
-app = FastAPI(title="Lion Studio Server", lifespan=lifespan)
-
-
-@app.exception_handler(LionError)
-async def _lion_error_handler(request: Request, exc: LionError) -> JSONResponse:
-    """Translate domain errors raised by service logic into HTTP responses."""
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={"detail": exc.message},
-    )
-
-
-@app.middleware("http")
-async def require_studio_bearer_token(request: Request, call_next):
-    # CORS preflight requests arrive without an Authorization header by design.
-    # Let them pass through so CORSMiddleware can respond with the correct
-    # Allow-* headers; blocking them here would prevent browsers from ever
-    # reaching authenticated endpoints from a separate frontend origin.
-    if request.method == "OPTIONS":
-        return await call_next(request)
-    token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
-    path = request.url.path
-    if token and request.headers.get("authorization") != f"Bearer {token}":
-        # All /api/* paths (any method) and the FastAPI schema/docs endpoints
-        # are protected when a token is configured.  Non-API GET/HEAD — the
-        # SPA shell, hashed assets, and liveness probes — stay public: browsers
-        # navigate without an Authorization header, so gating the shell would
-        # make the UI unloadable in authed mode.  Every byte behind those paths
-        # is the static frontend bundle; all data lives under /api.
-        is_api = path == "/api" or path.startswith("/api/")
-        is_guarded_non_api = path in _GUARDED_NON_API_PATHS
-        is_public_static = (
-            request.method in ("GET", "HEAD") and not is_api and not is_guarded_non_api
-        )
-        if path not in _PUBLIC_PATHS and not is_public_static:
-            return JSONResponse({"detail": "Unauthorized"}, status_code=401)
-    return await call_next(request)
-
-
-@app.middleware("http")
-async def require_json_content_type(request: Request, call_next):
-    """Reject state-changing /api requests that don't declare a JSON body.
-
-    FastAPI parses request bodies as JSON regardless of the declared
-    Content-Type, so a cross-site "simple request" (text/plain, no CORS
-    preflight) carrying a JSON-shaped body would otherwise reach route
-    handlers unchecked -- the classic form-based JSON CSRF vector. The SPA
-    always sends `application/json` on requests that carry a body (see
-    apps/studio/frontend/src/lib/api.ts `fetchJson`) and sends no body at all
-    for the handful of routes that need none, so this only rejects traffic
-    the frontend itself never produces.
-    """
-    if request.method in ("GET", "HEAD", "OPTIONS"):
-        return await call_next(request)
-    path = request.url.path
-    if not (path == "/api" or path.startswith("/api/")):
-        return await call_next(request)
-    content_length = request.headers.get("content-length")
-    has_body = content_length not in (None, "0") or "transfer-encoding" in request.headers
-    if has_body:
-        content_type = request.headers.get("content-type", "")
-        media_type = content_type.split(";", 1)[0].strip().lower()
-        if media_type != "application/json":
-            return JSONResponse(
-                {"detail": "Content-Type must be application/json"},
-                status_code=415,
-            )
-    return await call_next(request)
-
-
 # Strict Host-header authority grammar: `host` or `host:port` (1-5 digit
 # port), or a bracketed IPv6 literal `[addr]` with an optional `:port` after
 # the closing bracket -- nothing else. Deliberately stricter than
@@ -310,31 +240,38 @@ async def validate_host_header(request: Request, call_next):
     return await call_next(request)
 
 
-# Mount routes registered via the @studio_route decorator. Area modules listed
-# in _STUDIO_ROUTE_MODULES are imported here so their @studio_route decorators
-# fire and populate _ROUTES before the loop below adds each route to the app.
-load_studio_route_modules()
-for _route in iter_studio_routes():
-    app.add_api_route(
-        f"/api{_route.path}",
-        _route.handler,
-        methods=[_route.method],
-        **({"response_model": _route.response_model} if _route.response_model is not None else {}),
-        dependencies=list(_route.dependencies),
-        status_code=_route.status_code,
-        tags=list(_route.tags),
-        name=_route.name,
-        summary=_route.summary,
-        description=_route.description,
-        **({"response_class": _route.response_class} if _route.response_class is not None else {}),
-        responses=dict(_route.responses) if _route.responses is not None else None,
-        include_in_schema=_route.include_in_schema,
-    )
+def _mount_studio_routes(application: FastAPI) -> None:
+    """Add every route registered via the @studio_route decorator to `application`.
 
-
-@app.get("/health")
-async def health() -> dict[str, Any]:
-    return {"status": "ok"}
+    Area modules listed in _STUDIO_ROUTE_MODULES are imported here so their
+    @studio_route decorators fire and populate _ROUTES; import_module caches
+    modules, so calling this once per app instance is cheap and idempotent.
+    """
+    load_studio_route_modules()
+    for _route in iter_studio_routes():
+        application.add_api_route(
+            f"/api{_route.path}",
+            _route.handler,
+            methods=[_route.method],
+            **(
+                {"response_model": _route.response_model}
+                if _route.response_model is not None
+                else {}
+            ),
+            dependencies=list(_route.dependencies),
+            status_code=_route.status_code,
+            tags=list(_route.tags),
+            name=_route.name,
+            summary=_route.summary,
+            description=_route.description,
+            **(
+                {"response_class": _route.response_class}
+                if _route.response_class is not None
+                else {}
+            ),
+            responses=dict(_route.responses) if _route.responses is not None else None,
+            include_in_schema=_route.include_in_schema,
+        )
 
 
 def _resolve_frontend_dist() -> Path | None:
@@ -383,31 +320,121 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
         )
 
 
-# Mount the SPA if a dist/ exists.  Assets mount must happen BEFORE
-# CORSMiddleware is added so _collect_cors_methods sees the Mount entry.
-# The 404 exception handler is registered on the app object and takes effect
-# after all route resolution — CORSMiddleware position doesn't affect it.
-_dist = _resolve_frontend_dist()
-if _dist is not None:
-    _mount_spa(app, _dist)
+def create_app() -> FastAPI:
+    """Build and return a fresh Studio FastAPI app instance.
 
-# Middleware registration order (Starlette wraps LIFO: the most-recently-added
-# middleware is the first to see an incoming request). CORSMiddleware is added
-# after every router, the direct @app.get endpoint, and the optional SPA mount
-# so its method allowlist is derived from the complete route table (see
-# _collect_cors_methods). Host validation is added AFTER CORSMiddleware and so
-# runs OUTERMOST: every request -- including CORS preflight OPTIONS -- has its
-# Host header checked before CORS can answer, closing the window where an
-# invalid-Host request could still receive a successful preflight response.
-# Execution order for an incoming request is therefore: Host validation ->
-# CORS (answers valid-Host preflight) -> Content-Type/CSRF check -> bearer-token
-# gate -> route. The bearer-token and Content-Type middlewares let every
-# OPTIONS through; a real preflight never reaches them because CORSMiddleware
-# answers it first.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=CORS_ORIGINS,
-    allow_methods=_collect_cors_methods(app),
-    allow_headers=["*"],
-)
-app.add_middleware(BaseHTTPMiddleware, dispatch=validate_host_header)
+    Everything the module used to do at import time (construct FastAPI,
+    register exception handlers/middleware/routes, mount the SPA) lives here
+    instead, so a caller that needs a clean app -- most notably tests that
+    monkeypatch service module globals before the app captures them -- can
+    get one without `importlib.reload`-ing this module and mutating the
+    shared singleton every other importer holds a reference to.
+    """
+    application = FastAPI(title="Lion Studio Server", lifespan=lifespan)
+
+    @application.exception_handler(LionError)
+    async def _lion_error_handler(request: Request, exc: LionError) -> JSONResponse:
+        """Translate domain errors raised by service logic into HTTP responses."""
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.message},
+        )
+
+    @application.middleware("http")
+    async def require_studio_bearer_token(request: Request, call_next):
+        # CORS preflight requests arrive without an Authorization header by
+        # design. Let them pass through so CORSMiddleware can respond with
+        # the correct Allow-* headers; blocking them here would prevent
+        # browsers from ever reaching authenticated endpoints from a
+        # separate frontend origin.
+        if request.method == "OPTIONS":
+            return await call_next(request)
+        token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
+        path = request.url.path
+        if token and request.headers.get("authorization") != f"Bearer {token}":
+            # All /api/* paths (any method) and the FastAPI schema/docs
+            # endpoints are protected when a token is configured. Non-API
+            # GET/HEAD — the SPA shell, hashed assets, and liveness probes —
+            # stay public: browsers navigate without an Authorization
+            # header, so gating the shell would make the UI unloadable in
+            # authed mode. Every byte behind those paths is the static
+            # frontend bundle; all data lives under /api.
+            is_api = path == "/api" or path.startswith("/api/")
+            is_guarded_non_api = path in _GUARDED_NON_API_PATHS
+            is_public_static = (
+                request.method in ("GET", "HEAD") and not is_api and not is_guarded_non_api
+            )
+            if path not in _PUBLIC_PATHS and not is_public_static:
+                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        return await call_next(request)
+
+    @application.middleware("http")
+    async def require_json_content_type(request: Request, call_next):
+        """Reject state-changing /api requests that don't declare a JSON body.
+
+        FastAPI parses request bodies as JSON regardless of the declared
+        Content-Type, so a cross-site "simple request" (text/plain, no CORS
+        preflight) carrying a JSON-shaped body would otherwise reach route
+        handlers unchecked -- the classic form-based JSON CSRF vector. The SPA
+        always sends `application/json` on requests that carry a body (see
+        apps/studio/frontend/src/lib/api.ts `fetchJson`) and sends no body at all
+        for the handful of routes that need none, so this only rejects traffic
+        the frontend itself never produces.
+        """
+        if request.method in ("GET", "HEAD", "OPTIONS"):
+            return await call_next(request)
+        path = request.url.path
+        if not (path == "/api" or path.startswith("/api/")):
+            return await call_next(request)
+        content_length = request.headers.get("content-length")
+        has_body = content_length not in (None, "0") or "transfer-encoding" in request.headers
+        if has_body:
+            content_type = request.headers.get("content-type", "")
+            media_type = content_type.split(";", 1)[0].strip().lower()
+            if media_type != "application/json":
+                return JSONResponse(
+                    {"detail": "Content-Type must be application/json"},
+                    status_code=415,
+                )
+        return await call_next(request)
+
+    _mount_studio_routes(application)
+
+    @application.get("/health")
+    async def health() -> dict[str, Any]:
+        return {"status": "ok"}
+
+    # Mount the SPA if a dist/ exists. Assets mount must happen BEFORE
+    # CORSMiddleware is added so _collect_cors_methods sees the Mount entry.
+    # The 404 exception handler is registered on the app object and takes
+    # effect after all route resolution — CORSMiddleware position doesn't
+    # affect it.
+    dist = _resolve_frontend_dist()
+    if dist is not None:
+        _mount_spa(application, dist)
+
+    # Middleware registration order (Starlette wraps LIFO: the most-recently-added
+    # middleware is the first to see an incoming request). CORSMiddleware is added
+    # after every router, the direct /health endpoint, and the optional SPA mount
+    # so its method allowlist is derived from the complete route table (see
+    # _collect_cors_methods). Host validation is added AFTER CORSMiddleware and so
+    # runs OUTERMOST: every request -- including CORS preflight OPTIONS -- has its
+    # Host header checked before CORS can answer, closing the window where an
+    # invalid-Host request could still receive a successful preflight response.
+    # Execution order for an incoming request is therefore: Host validation ->
+    # CORS (answers valid-Host preflight) -> Content-Type/CSRF check -> bearer-token
+    # gate -> route. The bearer-token and Content-Type middlewares let every
+    # OPTIONS through; a real preflight never reaches them because CORSMiddleware
+    # answers it first.
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=CORS_ORIGINS,
+        allow_methods=_collect_cors_methods(application),
+        allow_headers=["*"],
+    )
+    application.add_middleware(BaseHTTPMiddleware, dispatch=validate_host_header)
+
+    return application
+
+
+app = create_app()

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import signal
-from importlib import reload
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,7 +19,12 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 
 def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
-    """Reload app to pick up monkeypatched env vars."""
+    """Build a fresh app to pick up monkeypatched env vars.
+
+    create_app() (not importlib.reload) means a fresh app instance every
+    call, so the monkeypatched values are baked in without mutating the
+    shared lionagi.studio.app.app singleton other code still imports.
+    """
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.stats as stats_mod
 
@@ -28,8 +32,8 @@ def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
         monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
         monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-    reload(app_mod)
-    return TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    app = app_mod.create_app()
+    return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -19,8 +19,12 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 
 def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
-    from importlib import reload
+    """Build a fresh app to pick up monkeypatched env vars.
 
+    create_app() (not importlib.reload) means a fresh app instance every
+    call, so the monkeypatched values are baked in without mutating the
+    shared lionagi.studio.app.app singleton other code still imports.
+    """
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.stats as stats_mod
 
@@ -28,8 +32,8 @@ def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
         monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
         monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-    reload(app_mod)
-    return TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    app = app_mod.create_app()
+    return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
 def _stub_db_and_spawn(monkeypatch):

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -146,41 +146,30 @@ def test_leo_message_unknown_session(tmp_path, monkeypatch):
 
 def test_leo_requires_bearer_when_token_set(tmp_path, monkeypatch):
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-leo-secret")
-    from importlib import reload
 
     import lionagi.studio.app as app_mod
 
-    reload(app_mod)
-    client = TestClient(
-        app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
-    )
-    try:
-        r = client.post("/api/leo/sessions")
-        assert r.status_code == 401
-    finally:
-        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
-        reload(app_mod)
+    # create_app() bakes the monkeypatched token into a fresh app instance;
+    # unlike importlib.reload(app_mod), there is no shared singleton to
+    # restore afterwards.
+    app = app_mod.create_app()
+    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    r = client.post("/api/leo/sessions")
+    assert r.status_code == 401
 
 
 def test_leo_correct_token_not_401(tmp_path, monkeypatch):
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-leo-secret")
-    from importlib import reload
 
     import lionagi.studio.app as app_mod
 
-    reload(app_mod)
-    client = TestClient(
-        app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
+    app = app_mod.create_app()
+    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    r = client.post(
+        "/api/leo/sessions",
+        headers={"Authorization": "Bearer test-leo-secret"},
     )
-    try:
-        r = client.post(
-            "/api/leo/sessions",
-            headers={"Authorization": "Bearer test-leo-secret"},
-        )
-        assert r.status_code == 200
-    finally:
-        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
-        reload(app_mod)
+    assert r.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_security_batch1.py
+++ b/tests/apps_studio_server/test_security_batch1.py
@@ -272,8 +272,12 @@ class TestMarketplaceSourcePaths:
 @pytest.mark.integration
 class TestBearerTokenAuth:
     def _get_client(self, monkeypatch, fake_db: Path | None = None) -> TestClient:
-        from importlib import reload
+        """Build a fresh app to pick up monkeypatched env vars.
 
+        create_app() (not importlib.reload) means a fresh app instance every
+        call, so the monkeypatched values are baked in without mutating the
+        shared lionagi.studio.app.app singleton other code still imports.
+        """
         import lionagi.studio.app as app_mod
         import lionagi.studio.services.stats as stats_mod
 
@@ -281,10 +285,8 @@ class TestBearerTokenAuth:
             monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
             monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-        reload(app_mod)
-        return TestClient(
-            app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
-        )
+        app = app_mod.create_app()
+        return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
     def test_mutating_route_requires_bearer_when_token_set(self, monkeypatch):
         """POST to /api/* must return 401 when token is set and auth is missing/wrong."""

--- a/tests/apps_studio_server/test_spa_serving.py
+++ b/tests/apps_studio_server/test_spa_serving.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import os
-from importlib import reload
 from pathlib import Path
 
 import pytest
@@ -41,7 +39,13 @@ def spa_client(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
-    """TestClient with SPA serving enabled; teardown restores the API-only singleton for xdist workers."""
+    """TestClient with SPA serving enabled, backed by a fresh app instance.
+
+    create_app() (not importlib.reload) means this app is never the shared
+    lionagi.studio.app.app singleton, so there is nothing to restore for
+    other tests in the same xdist worker -- the SPA mount dies with this app
+    object at test teardown.
+    """
     fake_db = tmp_path / "state.db"
 
     import lionagi.studio.services.sessions as sessions_mod
@@ -55,15 +59,8 @@ def spa_client(
 
     import lionagi.studio.app as app_mod
 
-    reload(app_mod)
-    yield TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
-
-    # Restore the API-only module singleton so it does not leak into later
-    # tests in the same xdist worker.  Fixture finalizers run LIFO: this code
-    # executes BEFORE monkeypatch undoes setenv, so the env var must be
-    # removed explicitly here or the reload re-mounts the SPA.
-    os.environ.pop("LIONAGI_STUDIO_FRONTEND_DIST", None)
-    reload(app_mod)
+    app = app_mod.create_app()
+    yield TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
 @pytest.fixture()
@@ -71,7 +68,7 @@ def no_dist_client(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
-    """TestClient in API-only mode (no dist dir); teardown reloads the app module for xdist workers."""
+    """TestClient in API-only mode (no dist dir), backed by a fresh app instance."""
     fake_db = tmp_path / "state.db"
 
     import lionagi.studio.services.sessions as sessions_mod
@@ -82,17 +79,13 @@ def no_dist_client(
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
     # Ensure no dist is resolved (env var must be absent so _resolve_frontend_dist
-    # returns None and the 404 exception handler is not registered on reload).
+    # returns None and the 404 exception handler is not registered).
     monkeypatch.delenv("LIONAGI_STUDIO_FRONTEND_DIST", raising=False)
 
     import lionagi.studio.app as app_mod
 
-    reload(app_mod)
-    yield TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
-
-    # The env var is still absent here (finalizers run LIFO, before monkeypatch
-    # restores anything), so this reload restores the API-only singleton.
-    reload(app_mod)
+    app = app_mod.create_app()
+    yield TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +223,7 @@ class TestCORSAfterSPAMount:
         """HEAD must be in the CORS allowlist after SPA mount (_collect_cors_methods called after mount)."""
         import lionagi.studio.app as app_mod
 
-        allowlist = {m.upper() for m in app_mod._collect_cors_methods(app_mod.app)}
+        allowlist = {m.upper() for m in app_mod._collect_cors_methods(spa_client.app)}
         assert "HEAD" in allowlist, (
             f"HEAD must be in CORS allowlist after SPA mount; got {sorted(allowlist)}"
         )

--- a/tests/apps_studio_server/test_startup_warnings.py
+++ b/tests/apps_studio_server/test_startup_warnings.py
@@ -22,6 +22,7 @@ import pytest
 
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
+import anyio  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 _STUDIO_APP_LOGGER = "lionagi.studio.app"
@@ -101,8 +102,6 @@ def _lifespan_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generat
 
     Bare TestClient(app, base_url="http://127.0.0.1:8765") construction does NOT trigger the lifespan.
     """
-    from importlib import reload
-
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.stats as stats_mod
 
@@ -110,18 +109,27 @@ def _lifespan_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generat
     monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-    reload(app_mod)
+    # A fresh app instance (via create_app()) instead of importlib.reload(app_mod):
+    # reload mutates the shared module singleton every other importer holds a
+    # reference to, which is both a data race under xdist and re-executes
+    # module-level side effects (CORS regex compilation, route
+    # re-registration) on a namespace other code still imports.
+    app = app_mod.create_app()
     _neutralize_heavy_lifespan(monkeypatch)
-    with TestClient(
-        app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
-    ) as client:
+    with TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765") as client:
         yield client
 
 
-def _make_bare_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
-    """Non-lifespan client for CORS header tests."""
-    from importlib import reload
+@contextmanager
+def _bare_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[TestClient]:
+    """Non-lifespan client for CORS header tests.
 
+    Attaches the TestClient's blocking portal directly (one thread serving
+    every request in the `with` block) instead of entering the client, which
+    would drive the full lifespan -- scheduler start, DB reconciliation, WAL
+    checkpoint -- unwanted here since these tests only assert on CORS
+    response headers.
+    """
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.stats as stats_mod
 
@@ -129,8 +137,14 @@ def _make_bare_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestCl
     monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-    reload(app_mod)
-    return TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    app = app_mod.create_app()
+    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    with anyio.from_thread.start_blocking_portal(**client.async_backend) as portal:
+        client.portal = portal
+        try:
+            yield client
+        finally:
+            client.portal = None
 
 
 # ---------------------------------------------------------------------------
@@ -241,22 +255,24 @@ class TestEscalatedWarningOnWildcardBind:
 
 @pytest.mark.integration
 class TestCORSBoundedMethods:
-    def _client(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    @contextmanager
+    def _client(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[TestClient]:
         monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
-        return _make_bare_client(monkeypatch, tmp_path)
+        with _bare_client(monkeypatch, tmp_path) as client:
+            yield client
 
     def test_options_preflight_returns_200_or_204(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """CORS OPTIONS preflight to /health must succeed (200 or 204)."""
-        client = self._client(monkeypatch, tmp_path)
-        resp = client.options(
-            "/health",
-            headers={
-                "Origin": "http://localhost:3000",
-                "Access-Control-Request-Method": "GET",
-            },
-        )
+        with self._client(monkeypatch, tmp_path) as client:
+            resp = client.options(
+                "/health",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
         assert resp.status_code in (200, 204), (
             f"OPTIONS preflight must succeed; got {resp.status_code}"
         )
@@ -265,14 +281,14 @@ class TestCORSBoundedMethods:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Access-Control-Allow-Methods must not be '*'."""
-        client = self._client(monkeypatch, tmp_path)
-        resp = client.options(
-            "/health",
-            headers={
-                "Origin": "http://localhost:3000",
-                "Access-Control-Request-Method": "GET",
-            },
-        )
+        with self._client(monkeypatch, tmp_path) as client:
+            resp = client.options(
+                "/health",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
         allow_methods = resp.headers.get("access-control-allow-methods", "")
         assert allow_methods != "*", (
             f"CORS allow_methods must be an explicit list, not a wildcard; got: {allow_methods!r}"
@@ -282,14 +298,14 @@ class TestCORSBoundedMethods:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """GET, POST, PUT, PATCH, DELETE, OPTIONS must all be in the allowed set."""
-        client = self._client(monkeypatch, tmp_path)
-        resp = client.options(
-            "/health",
-            headers={
-                "Origin": "http://localhost:3000",
-                "Access-Control-Request-Method": "POST",
-            },
-        )
+        with self._client(monkeypatch, tmp_path) as client:
+            resp = client.options(
+                "/health",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
         raw = resp.headers.get("access-control-allow-methods", "")
         allowed = {m.strip().upper() for m in raw.split(",")}
         for verb in ("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"):
@@ -305,14 +321,14 @@ class TestCORSBoundedMethods:
         FastAPI auto-generates HEAD for GET routes/docs endpoints; a hardcoded
         allowlist that omits HEAD causes preflight 400 for those routes.
         """
-        client = self._client(monkeypatch, tmp_path)
-        resp = client.options(
-            "/openapi.json",
-            headers={
-                "Origin": "http://localhost:3000",
-                "Access-Control-Request-Method": "HEAD",
-            },
-        )
+        with self._client(monkeypatch, tmp_path) as client:
+            resp = client.options(
+                "/openapi.json",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "HEAD",
+                },
+            )
         assert resp.status_code in (200, 204), (
             f"HEAD preflight must succeed; got {resp.status_code}"
         )

--- a/tests/studio/test_auth.py
+++ b/tests/studio/test_auth.py
@@ -40,8 +40,6 @@ _DATA_GET_PREFIXES = [
 
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
-    from importlib import reload
-
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.invocations as inv_mod
     import lionagi.studio.services.sessions as sess_mod
@@ -56,8 +54,13 @@ def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
         if hasattr(mod, "_DB"):
             monkeypatch.setattr(mod, "_DB", str(fake_db))
 
-    reload(app_mod)
-    return TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    # A fresh app instance (via create_app()) instead of importlib.reload(app_mod):
+    # reload mutates the shared module singleton every other importer holds a
+    # reference to, which is both a data race under xdist and re-executes
+    # module-level side effects (CORS regex compilation, route
+    # re-registration) on a namespace other code still imports.
+    app = app_mod.create_app()
+    return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
 @pytest.mark.integration

--- a/tests/studio/test_hosted_hardening.py
+++ b/tests/studio/test_hosted_hardening.py
@@ -8,37 +8,80 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 
 import pytest
 
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
+import anyio  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 
-def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
-    from importlib import reload
+@contextmanager
+def _entered_client(app: FastAPI, **kwargs: object) -> Generator[TestClient]:
+    """Attach a TestClient's blocking portal directly, without driving the
+    ASGI lifespan.
 
+    ``TestClient.__enter__()`` is the only public way to get a persistent
+    portal (one background thread serving every request) instead of
+    ``_portal_factory()``'s per-request spin-up/spin-down thread, but
+    entering it also always runs the app's lifespan -- scheduler start, DB
+    reconciliation, WAL checkpoint. These hardening tests exercise
+    middleware, not startup behavior, so the lifespan is deliberately never
+    driven here; attaching the portal directly gets the one-thread-per-test
+    win without it.
+    """
+    client = TestClient(app, **kwargs)
+    with anyio.from_thread.start_blocking_portal(**client.async_backend) as portal:
+        client.portal = portal
+        try:
+            yield client
+        finally:
+            client.portal = None
+
+
+@pytest.fixture()
+def make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Factory fixture: each call builds a fresh app (via create_app(), not
+    importlib.reload) plus an entered client, all torn down when the test
+    ends. A fresh app instance, built with the monkeypatched DB path already
+    in place, replaces reloading lionagi.studio.app: reload mutates the
+    shared module singleton every other importer holds a reference to,
+    which is a data race under xdist and re-executes module-level side
+    effects (CORS regex compilation, route re-registration) on a namespace
+    other code still imports.
+    """
     import lionagi.studio.app as app_mod
     import lionagi.studio.services.invocations as inv_mod
     import lionagi.studio.services.sessions as sess_mod
     import lionagi.studio.services.stats as stats_mod
 
     fake_db = tmp_path / "state.db"
-
     for mod in (stats_mod, inv_mod, sess_mod):
         if hasattr(mod, "DEFAULT_DB_PATH"):
             monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
         if hasattr(mod, "_DB"):
             monkeypatch.setattr(mod, "_DB", str(fake_db))
 
-    reload(app_mod)
-    # base_url determines the Host header the TestClient sends for relative
-    # paths; use the real default bind address so tests exercise the same
-    # Host the daemon actually serves on (TestClient otherwise defaults to
-    # the fictitious "testserver" host, which the new Host-check would reject).
-    return TestClient(app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    stack = ExitStack()
+
+    def _factory() -> TestClient:
+        app = app_mod.create_app()
+        # base_url determines the Host header the TestClient sends for
+        # relative paths; use the real default bind address so tests
+        # exercise the same Host the daemon actually serves on (TestClient
+        # otherwise defaults to the fictitious "testserver" host, which the
+        # Host-check would reject).
+        return stack.enter_context(
+            _entered_client(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+        )
+
+    yield _factory
+    stack.close()
 
 
 @pytest.mark.integration
@@ -51,9 +94,9 @@ class TestHostedCorsOrigin:
 
         assert "https://lion-studio.khive.ai" in config_mod.CORS_ORIGINS
 
-    def test_hosted_origin_gets_cors_headers(self, monkeypatch, tmp_path):
+    def test_hosted_origin_gets_cors_headers(self, monkeypatch, tmp_path, make_client):
         monkeypatch.delenv("CORS_ORIGINS", raising=False)
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get(
             "/health",
@@ -71,12 +114,12 @@ class TestHostHeaderValidation:
     """DNS-rebinding defense: only loopback (any port) and the configured bind
     host are accepted as Host header values."""
 
-    def test_hosted_flow_host_and_origin_both_pass(self, monkeypatch, tmp_path):
+    def test_hosted_flow_host_and_origin_both_pass(self, monkeypatch, tmp_path, make_client):
         """Pin test: the exact hosted-page flow -- a request from the browser
         tab at https://lion-studio.khive.ai talking to the local daemon at
         127.0.0.1:8765 -- must be accepted by both the Host check and CORS."""
         monkeypatch.delenv("CORS_ORIGINS", raising=False)
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get(
             "/health",
@@ -88,47 +131,47 @@ class TestHostHeaderValidation:
         assert resp.status_code == 200
         assert resp.headers.get("access-control-allow-origin") == "https://lion-studio.khive.ai"
 
-    def test_localhost_any_port_accepted(self, monkeypatch, tmp_path):
-        client = _make_client(monkeypatch, tmp_path)
+    def test_localhost_any_port_accepted(self, monkeypatch, tmp_path, make_client):
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": "localhost:59999"})
         assert resp.status_code == 200
 
-    def test_bracketed_ipv6_loopback_accepted(self, monkeypatch, tmp_path):
-        client = _make_client(monkeypatch, tmp_path)
+    def test_bracketed_ipv6_loopback_accepted(self, monkeypatch, tmp_path, make_client):
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": "[::1]:8765"})
         assert resp.status_code == 200
 
-    def test_rebound_host_is_rejected(self, monkeypatch, tmp_path):
+    def test_rebound_host_is_rejected(self, monkeypatch, tmp_path, make_client):
         """A DNS-rebinding attempt (Host pointed at an attacker domain while
         the connection is actually to the local daemon) must be rejected."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": "evil.example.com"})
         assert resp.status_code == 400
         assert "Invalid Host header" in resp.json()["detail"]
 
-    def test_rebound_host_rejected_for_api_paths_too(self, monkeypatch, tmp_path):
-        client = _make_client(monkeypatch, tmp_path)
+    def test_rebound_host_rejected_for_api_paths_too(self, monkeypatch, tmp_path, make_client):
+        client = make_client()
 
         resp = client.get("/api/sessions/", headers={"Host": "evil.example.com"})
         assert resp.status_code == 400
 
-    def test_configured_non_loopback_bind_host_accepted(self, monkeypatch, tmp_path):
+    def test_configured_non_loopback_bind_host_accepted(self, monkeypatch, tmp_path, make_client):
         """When the operator explicitly binds to a routable host/hostname,
         that value (with any port) is accepted, alongside loopback."""
         monkeypatch.setenv("LIONAGI_STUDIO_HOST", "studio-box.local")
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": "studio-box.local:8765"})
         assert resp.status_code == 200
 
-    def test_wildcard_bind_host_does_not_widen_allowlist(self, monkeypatch, tmp_path):
+    def test_wildcard_bind_host_does_not_widen_allowlist(self, monkeypatch, tmp_path, make_client):
         """Binding to 0.0.0.0 (all interfaces) must not itself become an
         accepted Host value -- browsers never send Host: 0.0.0.0."""
         monkeypatch.setenv("LIONAGI_STUDIO_HOST", "0.0.0.0")
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": "0.0.0.0:8765"})
         assert resp.status_code == 400
@@ -142,20 +185,24 @@ class TestHostHeaderValidation:
             "localhost:badport",
         ],
     )
-    def test_malformed_host_authority_is_rejected(self, monkeypatch, tmp_path, malformed_host):
+    def test_malformed_host_authority_is_rejected(
+        self, monkeypatch, tmp_path, malformed_host, make_client
+    ):
         """Authorities that Python/Starlette's URL parser would normalize
         into an accepted loopback hostname must be rejected outright by the
         strict Host-header grammar."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.get("/health", headers={"Host": malformed_host})
         assert resp.status_code == 400
         assert "Invalid Host header" in resp.json()["detail"]
 
-    def test_non_preflight_options_with_bad_host_is_rejected(self, monkeypatch, tmp_path):
+    def test_non_preflight_options_with_bad_host_is_rejected(
+        self, monkeypatch, tmp_path, make_client
+    ):
         """An OPTIONS request without Origin/Access-Control-Request-Method
         is not a real CORS preflight and must still get its Host checked."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.options(
             "/api/sessions/",
@@ -164,11 +211,11 @@ class TestHostHeaderValidation:
         assert resp.status_code == 400
         assert "Invalid Host header" in resp.json()["detail"]
 
-    def test_real_cors_preflight_still_succeeds(self, monkeypatch, tmp_path):
+    def test_real_cors_preflight_still_succeeds(self, monkeypatch, tmp_path, make_client):
         """A genuine CORS preflight (Origin + Access-Control-Request-Method)
         from the hosted SPA's origin must still succeed."""
         monkeypatch.delenv("CORS_ORIGINS", raising=False)
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.options(
             "/health",
@@ -180,13 +227,13 @@ class TestHostHeaderValidation:
         assert resp.status_code in (200, 204)
         assert resp.headers.get("access-control-allow-origin") == "https://lion-studio.khive.ai"
 
-    def test_preflight_with_bad_host_is_rejected(self, monkeypatch, tmp_path):
+    def test_preflight_with_bad_host_is_rejected(self, monkeypatch, tmp_path, make_client):
         """Even a well-formed CORS preflight from an allowed origin must be
         rejected when the Host header is invalid: Host validation runs
         outside CORSMiddleware, so a rebound request can't fish a successful
         preflight response out of the daemon."""
         monkeypatch.delenv("CORS_ORIGINS", raising=False)
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.options(
             "/health",
@@ -208,12 +255,14 @@ class TestJsonContentTypeEnforcement:
     that FastAPI's own body parsing (which ignores Content-Type) leaves open.
     """
 
-    def test_text_plain_body_on_bodyless_route_is_rejected(self, monkeypatch, tmp_path):
+    def test_text_plain_body_on_bodyless_route_is_rejected(
+        self, monkeypatch, tmp_path, make_client
+    ):
         """Representative body-less, side-effecting route: enabling a
         schedule takes only a path param, so FastAPI would otherwise execute
         it regardless of Content-Type. A text/plain simple-request body must
         now be rejected before the handler runs."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.post(
             "/api/schedules/some-id/enable",
@@ -228,7 +277,6 @@ class TestJsonContentTypeEnforcement:
         must not slip past the Content-Type gate just because the middleware
         can't see a Content-Length header."""
         httpx = pytest.importorskip("httpx", reason="httpx not installed")
-        from importlib import reload
 
         import lionagi.studio.app as app_mod
         import lionagi.studio.services.invocations as inv_mod
@@ -241,12 +289,12 @@ class TestJsonContentTypeEnforcement:
                 monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
             if hasattr(mod, "_DB"):
                 monkeypatch.setattr(mod, "_DB", str(fake_db))
-        reload(app_mod)
+        app = app_mod.create_app()
 
         async def _chunks():
             yield b'{"pwn": true}'
 
-        transport = httpx.ASGITransport(app=app_mod.app)
+        transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:8765") as ac:
             resp = await ac.post(
                 "/api/schedules/some-id/enable",
@@ -256,11 +304,11 @@ class TestJsonContentTypeEnforcement:
         assert resp.status_code == 415
         assert resp.json()["detail"] == "Content-Type must be application/json"
 
-    def test_normal_json_path_still_works(self, monkeypatch, tmp_path):
+    def test_normal_json_path_still_works(self, monkeypatch, tmp_path, make_client):
         """A route with a required Pydantic body, sent the way the SPA sends
         it (application/json), must not be blocked by the new middleware --
         it should reach validation/business logic, not get stopped at 415."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.post(
             "/api/projects/",
@@ -269,19 +317,19 @@ class TestJsonContentTypeEnforcement:
         )
         assert resp.status_code != 415
 
-    def test_empty_body_post_from_spa_shape_still_works(self, monkeypatch, tmp_path):
+    def test_empty_body_post_from_spa_shape_still_works(self, monkeypatch, tmp_path, make_client):
         """The SPA sends several POSTs with no body and no Content-Type at all
         (e.g. schedule trigger/enable/disable, invocation cancel). These must
         stay reachable -- the middleware only gates requests that *carry* a
         body, so a genuinely empty POST must pass through to the handler
         (here surfacing as 404 for a nonexistent id, not 415)."""
-        client = _make_client(monkeypatch, tmp_path)
+        client = make_client()
 
         resp = client.post("/api/schedules/some-id/trigger")
         assert resp.status_code != 415
 
-    def test_get_requests_are_never_gated_by_content_type(self, monkeypatch, tmp_path):
-        client = _make_client(monkeypatch, tmp_path)
+    def test_get_requests_are_never_gated_by_content_type(self, monkeypatch, tmp_path, make_client):
+        client = make_client()
 
         resp = client.get("/api/sessions/", headers={"Content-Type": "text/plain"})
         assert resp.status_code != 415


### PR DESCRIPTION
## Summary
- Six of the last eight red main-CI runs were the same xdist worker crash ("[gw1] node down: Not properly terminated"), always at the same test in `tests/studio/test_hosted_hardening.py`, Python 3.10–3.14, linux-only (300+ local iterations could not reproduce). Issue #1440 documents an identical signature from June in `tests/apps_studio_server/test_startup_warnings.py`. Common factor in both files: mid-suite `importlib.reload(lionagi.studio.app)` rebinding the shared module singleton every other importer holds, plus TestClients used without a portal so every HTTP call spins up/tears down its own anyio blocking-portal thread. Per-worker RSS diagnostics (#1928) ruled out OOM — the dying worker was at 594 MB.
- `lionagi/studio/app.py`: all app construction moves into a `create_app()` factory; module-level `app = create_app()` preserves the existing singleton exactly. Middleware bodies, registration order, and the ordering comments are moved verbatim.
- Eight test files switch from `reload(app_mod)` to `create_app()` (monkeypatch first, then build a fresh isolated instance), and the two crash-implicated files get one directly-managed blocking portal per test instead of per-request thread churn. The old restore-the-singleton teardown in `test_spa_serving.py` is gone since nothing mutates the shared module anymore.
- Honest caveat: the crash was never reproduced locally (macOS), so this is a structural fix of the only mechanism consistent with all the evidence, not a verified-by-repro fix. If the signature reappears on main after this lands, that's signal the mechanism hunt must continue.

## Testing
- `tests/studio/ tests/apps_studio_server/`: 1311 passed (also at `-n 4 --dist loadfile --max-worker-restart=0`, mirroring CI worker counts).
- Direct `app`-singleton importer sanity: route-registry and schedule-route-drift suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)