### PR TITLE
fix(orchestrate): builder-time spawn identity + enforceable spawned artifact contracts

### DIFF
--- a/docs/adrs/ADR-0029-artifact-contract.md
+++ b/docs/adrs/ADR-0029-artifact-contract.md
@@ -112,9 +112,29 @@ mid-run does not retroactively change what was expected.
 > `_execute_dag` runs any leg — i.e. before any worker output could exist
 > — so the anti-drift guarantee ("no retroactive change of what was
 > expected") still holds; it is just anchored at "DAG built" rather than
-> "session created" for this call path. No other call site may write this
-> column after that point. See `_SESSION_COLUMNS` in `lionagi/state/db.py`
-> for the allowlist entry and rationale.
+> "session created" for this call path.
+>
+> **Reactive-spawn exception**: a node injected mid-run via `SpawnRequest`
+> (`reactive=True`) does not exist yet at `_build_dag` time, so it cannot be
+> folded in there. `_execute_dag` performs a second, append-only class of
+> write after such a node completes: it registers that node's role-declared
+> artifacts under its own subdirectory, keeping whatever `required` flag the
+> role itself declares. This is sound under the same anti-drift reading —
+> what is expected of a spawned node is fully determined *before* it runs,
+> not adjusted after the fact — because two things are frozen ahead of
+> execution and never revisited: the role's `artifact_defaults` (cached in
+> `role_artifact_defaults` at `_build_dag` time, the same source planned legs
+> draw from), and the node's own id (`spawn_id`, stamped by
+> `role_node_builder` at construction, before the node is ever queued). The
+> node is also told its own artifact directory and any `required` files via
+> its instruction (`decorate_instruction`, wired into `role_node_builder`)
+> before `Operation.invoke()` runs, so a `required: true` entry is a real,
+> satisfiable gate for it, identical in kind to a planned leg's — teardown's
+> `verify_artifact_contract` (`lionagi/state/artifact_verifier.py`) needs no
+> special case for either. No call site may write this column once a node's
+> own entries are folded, or after `_execute_dag` returns. See
+> `_SESSION_COLUMNS` in `lionagi/state/db.py` for the allowlist entry and
+> rationale.
 
 ### 2. Playbook contract shape
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -63,6 +63,45 @@ async def _persist_session_phase(env, phase: str) -> None:
             await ctx["db"].update_session(ctx["session_id"], current_phase=phase)
 
 
+# ── Artifact-contract text — shared by planned legs and spawned nodes ─────────
+# Extracted so a planned leg (_build_dag) and a reactively spawned node
+# (_execute_dag's decorate_instruction closure) mirror each other by
+# construction: one namespacing rule, one sentence of REQUIRED-file prose,
+# used from both call sites, rather than the two copies quietly drifting.
+
+
+def _leg_artifact_entries(node_id: str, role_defaults: dict | None) -> list[dict]:
+    """Namespace a role's declared artifact_defaults under *node_id*'s own subdirectory."""
+    if not role_defaults:
+        return []
+    entries: list[dict] = []
+    for entry in role_defaults.get("expected", []):
+        eid = entry.get("id", "")
+        epath = entry.get("path", "")
+        entries.append(
+            {
+                **entry,
+                "id": f"{node_id}__{eid}",
+                "path": f"{node_id}/{epath}",
+                "required": entry.get("required", True),
+                "source": "role_default",
+            }
+        )
+    return entries
+
+
+def _artifact_directive(run, node_id: str, leg_expected: list[dict]) -> str:
+    """Compose the artifact-directory (+ REQUIRED-file, when declared) instruction text."""
+    note = f"Your artifact directory: {run.agent_artifact_dir(node_id)}/ — write output files here."
+    if leg_expected:
+        required_paths = ", ".join(e["path"].split("/", 1)[1] for e in leg_expected)
+        note += (
+            f" REQUIRED: write {required_paths} in that directory — the run "
+            "is marked failed if it is missing at completion."
+        )
+    return note
+
+
 # ── Control poller (ADR-0085 part 1: session_controls transport) ─────────────
 # `li o ctl pause|resume|msg` enqueues a session_controls row from a separate
 # process; this poller — running alongside the heartbeat loop in _execute_dag,
@@ -440,32 +479,11 @@ async def _build_dag(
                 with contextlib.suppress(ValueError):
                     role_defaults = _Role.load(ta.assignee).artifact_defaults
             role_artifact_defaults[ta.assignee] = role_defaults
-        leg_expected: list[dict] = []
-        if role_defaults:
-            for entry in role_defaults.get("expected", []):
-                eid = entry.get("id", "")
-                epath = entry.get("path", "")
-                leg_expected.append(
-                    {
-                        **entry,
-                        "id": f"{agent_ids[i]}__{eid}",
-                        "path": f"{agent_ids[i]}/{epath}",
-                        "source": "role_default",
-                    }
-                )
-            role_artifact_entries.extend(leg_expected)
+        leg_expected = _leg_artifact_entries(agent_ids[i], role_defaults)
+        role_artifact_entries.extend(leg_expected)
 
         ctx: list = [{"original_task": prompt}]
-        artifact_note = (
-            f"Your artifact directory: {env.run.agent_artifact_dir(agent_ids[i])}/ — "
-            "write output files here."
-        )
-        if leg_expected:
-            required_paths = ", ".join(e["path"].split("/", 1)[1] for e in leg_expected)
-            artifact_note += (
-                f" REQUIRED: write {required_paths} in that directory — the run "
-                "is marked failed if it is missing at completion."
-            )
+        artifact_note = _artifact_directive(env.run, agent_ids[i], leg_expected)
         if dep_indices[i]:
             ups = "; ".join(
                 f"step {j + 1} ({agent_ids[j]}): {env.run.agent_artifact_dir(agent_ids[j])}/"
@@ -538,12 +556,17 @@ async def _build_dag(
     # should fail loudly here, not be silently dropped.
     #
     # ADR-0029 extension (see db.py _SESSION_COLUMNS comment): this is the
-    # one allowed post-creation write to artifact_contract_json, happening
-    # once here at DAG-build time, before _execute_dag runs any leg. It must
-    # reach the session row (not just env._live_persist) — a crash or
-    # orphan exit before teardown should still leave the DB row showing what
-    # was actually expected, matching what Studio/`li state show-session`
-    # read directly from artifact_contract_json.
+    # planned-leg write to artifact_contract_json, happening once here at
+    # DAG-build time, before _execute_dag runs any leg. It must reach the
+    # session row (not just env._live_persist) — a crash or orphan exit
+    # before teardown should still leave the DB row showing what was
+    # actually expected, matching what Studio/`li state show-session` read
+    # directly from artifact_contract_json. A SECOND, append-only write class
+    # exists for reactively spawned nodes (_execute_dag, after a spawned
+    # node completes) — see the "Reactive-spawn exception" paragraph in
+    # ADR-0029, which explains why folding a spawned node's entries in after
+    # it runs is still sound: what is expected of it was frozen (role
+    # defaults + spawn_id) before it was ever queued.
     if role_artifact_entries and ctx_lp is not None:
         from lionagi.state.artifact_verifier import validate_artifact_contract
 
@@ -924,6 +947,16 @@ async def _execute_dag(
     env.session.observe(NodeFailed, handler=_on_node_failed)
     eng_run = PlanningEngine().new_run(session=env.session)
 
+    def _decorate_spawn_instruction(req: SpawnRequest, spawn_id: str) -> str:
+        """Give a reactively spawned node the same artifact-dir + REQUIRED
+        text a planned leg gets (env.run.agent_artifact_dir + this leg's
+        role_defaults) — the mirror of the ctx["artifact_instructions"]
+        block _build_dag composes above, via the shared helpers."""
+        role_defaults = dag_state.role_artifact_defaults.get(req.assignee) if req.assignee else None
+        leg_expected = _leg_artifact_entries(spawn_id, role_defaults)
+        note = _artifact_directive(env.run, spawn_id, leg_expected)
+        return f"{req.instruction}\n\n{note}"
+
     t_exec = time.monotonic()
     _hb_task = _asyncio.ensure_future(_heartbeat_loop())
     _ctl_task = _asyncio.ensure_future(_control_poll_loop())
@@ -932,7 +965,11 @@ async def _execute_dag(
             env.builder.get_graph(),
             reactive=reactive,
             spawn_type=SpawnRequest if reactive else None,
-            node_builder=role_node_builder(role_base) if reactive else None,
+            node_builder=(
+                role_node_builder(role_base, decorate_instruction=_decorate_spawn_instruction)
+                if reactive
+                else None
+            ),
             max_spawn=max_spawn,
             max_concurrent=conc,
             verbose=env.verbose,
@@ -1013,21 +1050,60 @@ async def _execute_dag(
         )
 
     # Reactively spawned nodes are in the result map but not in our plan. Their
-    # graph node still carries the assignee role_node_builder stamped on it
-    # (role_node_builder in lionagi/orchestration/patterns.py) and the branch
-    # the executor ultimately ran it on, so both are recovered here — plan-
-    # time arrays (agent_ids/worker_models) are fixed-size and can't cover
-    # nodes injected mid-run via SpawnRequest.
+    # graph node still carries the spawn_id + assignee role_node_builder
+    # stamped on it at construction time (lionagi/orchestration/patterns.py)
+    # and the branch the executor ultimately ran it on, so all three are
+    # recovered here — plan-time arrays (agent_ids/worker_models) are
+    # fixed-size and can't cover nodes injected mid-run via SpawnRequest.
     graph_nodes = getattr(env.builder.get_graph(), "internal_nodes", {}) or {}
     spawned_contract_entries: list[dict] = []
-    spawn_idx = 0
+
+    # Pre-scan every builder-stamped spawn_id BEFORE assigning any fallback —
+    # a node injected without going through role_node_builder (escalation
+    # children, public Session.flow inject()) carries no spawn_id and needs a
+    # synthesized one, but that synthesis must never collide with (or, worse,
+    # race ahead of and steal) an id role_node_builder already allocated at
+    # construction time. Completion order alone is exactly the bug this whole
+    # change fixes, so it can no longer be trusted to hand out spawn-1.
+    stamped_spawn_ids: set[str] = set()
+    for nid in op_results:
+        if nid in known_nodes:
+            continue
+        graph_node = graph_nodes.get(nid)
+        stamped = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        if stamped:
+            stamped_spawn_ids.add(stamped)
+
+    _fallback_seq = 0
+
+    def _next_fallback_spawn_id() -> str:
+        nonlocal _fallback_seq
+        while True:
+            _fallback_seq += 1
+            candidate = f"spawn-{_fallback_seq}"
+            if candidate not in stamped_spawn_ids:
+                return candidate
+
     for nid, res in op_results.items():
         if nid in known_nodes:
             continue
-        spawn_idx += 1
-        sid = f"spawn-{spawn_idx}"
         graph_node = graph_nodes.get(nid)
         assignee = graph_node.metadata.get("assignee") if graph_node is not None else None
+        sid = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        if not sid:
+            if assignee:
+                # role_node_builder stamps spawn_id unconditionally, whether
+                # or not the request carried an assignee — a role-attributed
+                # node reaching here without one means that invariant broke
+                # upstream. Fail loudly instead of silently minting a fresh
+                # id that would hide the defect behind a plausible-looking
+                # contract entry.
+                raise RuntimeError(
+                    f"spawned node {nid!r} carries role assignee {assignee!r} "
+                    "but no spawn_id — role_node_builder must stamp spawn_id "
+                    "before the executor runs the node"
+                )
+            sid = _next_fallback_spawn_id()
         spawn_model = ""
         if graph_node is not None and graph_node.branch_id is not None:
             with contextlib.suppress(Exception):
@@ -1054,25 +1130,14 @@ async def _execute_dag(
 
         # Record the spawned node's role-declared artifacts in the session
         # contract for post-run visibility (synthesis, Studio), namespaced
-        # under the node's own subdir. These are folded as non-required: a
-        # reactively spawned node is built with only its instruction and is
-        # never told its artifact dir, so it has no path to satisfy a required
-        # entry — enforcing one would flip an otherwise-completed run to failed.
+        # under the node's own subdir. Required entries now stay required:
+        # decorate_instruction (wired into role_node_builder above) tells the
+        # spawned node its own artifact dir + REQUIRED files before it runs,
+        # the same way a planned leg is told — so an explicitly-required
+        # declaration is enforceable here, not just observability.
         if assignee:
             role_defaults = dag_state.role_artifact_defaults.get(assignee)
-            if role_defaults:
-                for entry in role_defaults.get("expected", []):
-                    eid = entry.get("id", "")
-                    epath = entry.get("path", "")
-                    spawned_contract_entries.append(
-                        {
-                            **entry,
-                            "id": f"{sid}__{eid}",
-                            "path": f"{sid}/{epath}",
-                            "required": False,
-                            "source": "role_default",
-                        }
-                    )
+            spawned_contract_entries.extend(_leg_artifact_entries(sid, role_defaults))
 
     ctx_lp = getattr(env, "_live_persist", None)
     if spawned_contract_entries and ctx_lp is not None:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -11,6 +11,8 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
 from lionagi._errors import LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
@@ -957,6 +959,30 @@ async def _execute_dag(
         note = _artifact_directive(env.run, spawn_id, leg_expected)
         return f"{req.instruction}\n\n{note}"
 
+    def _spawn_branch_setup(operation: Any, branch: Any) -> None:
+        """A reactively-spawned node's cloned branch inherits the emitting
+        leg's CLI workspace (chat_model.endpoint.config.kwargs["repo"]) via
+        Branch.clone — but the artifact contract this leg is told about in
+        _decorate_spawn_instruction points at its own spawn_id subdir, a
+        sibling of the emitter's. Without retargeting, the spawned CLI child
+        can only write inside the emitter's directory, not its own, unless
+        running fully unsandboxed. Only CLI-backed chat models carry a
+        writable-root concept; anything else is a no-op."""
+        spawn_id = operation.metadata.get("spawn_id") if operation is not None else None
+        if not spawn_id:
+            return
+        chat_model = getattr(branch, "chat_model", None)
+        if chat_model is None or not getattr(chat_model, "is_cli", False):
+            return
+        artifact_dir = env.run.agent_artifact_dir(spawn_id)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        kwargs = chat_model.endpoint.config.kwargs
+        kwargs["repo"] = artifact_dir
+        project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
+        add_dir = kwargs.setdefault("add_dir", [])
+        if project_root not in add_dir:
+            add_dir.append(project_root)
+
     t_exec = time.monotonic()
     _hb_task = _asyncio.ensure_future(_heartbeat_loop())
     _ctl_task = _asyncio.ensure_future(_control_poll_loop())
@@ -975,6 +1001,7 @@ async def _execute_dag(
             verbose=env.verbose,
             executor_ref=_executor_ref,
             context=checkpoint_flow_context,
+            spawn_branch_setup=_spawn_branch_setup if reactive else None,
         )
     finally:
         _hb_task.cancel()
@@ -1010,6 +1037,7 @@ async def _execute_dag(
     # agent_ids (those are fixed-size arrays built once from the initial
     # assignments), so they must be checked separately against known_nodes
     # rather than only via the plan-time index walk below.
+    graph_nodes = getattr(env.builder.get_graph(), "internal_nodes", {}) or {}
     escalated_op_ids = {str(x) for x in dag_result.get("escalated_operations", [])}
     escalated_evidence = [
         {"kind": "escalated_operation", "id": agent_ids[i], "label": assignments[i].assignee}
@@ -1017,8 +1045,15 @@ async def _execute_dag(
         if node_ids[i] in escalated_op_ids
     ]
     for spawned_nid in sorted(escalated_op_ids - known_nodes):
+        # Spawned nodes carry role_node_builder's stamped spawn_id (e.g.
+        # "spawn-3") in their graph node metadata — surface that instead of
+        # the internal Operation UUID so evidence reads the same as the
+        # artifact dirs/contract entries the run actually produced.
+        graph_node = graph_nodes.get(spawned_nid)
+        spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        evidence_id = spawn_id or spawned_nid
         escalated_evidence.append(
-            {"kind": "escalated_operation", "id": spawned_nid, "label": spawned_nid}
+            {"kind": "escalated_operation", "id": evidence_id, "label": evidence_id}
         )
     escalated_agent_ids = [entry["id"] for entry in escalated_evidence]
     if escalated_evidence:
@@ -1055,7 +1090,7 @@ async def _execute_dag(
     # and the branch the executor ultimately ran it on, so all three are
     # recovered here — plan-time arrays (agent_ids/worker_models) are
     # fixed-size and can't cover nodes injected mid-run via SpawnRequest.
-    graph_nodes = getattr(env.builder.get_graph(), "internal_nodes", {}) or {}
+    # (graph_nodes computed above, ahead of the escalation-evidence block.)
     spawned_contract_entries: list[dict] = []
 
     # Pre-scan every builder-stamped spawn_id BEFORE assigning any fallback —

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -489,6 +489,7 @@ class EngineRun:
         verbose: bool = False,
         executor_ref: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
+        spawn_branch_setup: Any = None,
     ) -> dict[str, Any]:
         """Execute a prebuilt operation DAG on the run's session and return operation results."""
         from .flow_signals import flow_progress_signals  # noqa: PLC0415
@@ -505,6 +506,7 @@ class EngineRun:
                 verbose=verbose,
                 on_progress=on_progress,
                 executor_ref=executor_ref,
+                spawn_branch_setup=spawn_branch_setup,
             )
         return result
 

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -639,6 +639,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -649,6 +650,14 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.spawn_type = spawn_type
         self.node_builder = node_builder
         self.max_spawn = max_spawn
+        # CLI-workspace seam: a caller (cli/orchestrate/flow.py) can pass a
+        # sync callback invoked with (spawned_operation, cloned_branch) right
+        # after a reactively-spawned node's branch is cloned, so it can
+        # retarget a CLI-backed chat_model's writable workspace (endpoint
+        # kwargs["repo"]) to that spawn's own artifact dir instead of the
+        # planned leg's — the clone otherwise inherits the emitter's repo,
+        # which sits outside the spawned node's own artifact directory.
+        self.spawn_branch_setup = spawn_branch_setup
         self._spawn_count = 0
         self._dropped_spawns: list[dict[str, Any]] = []
         self._running = False
@@ -1014,6 +1023,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
         # as _preallocate_all_branches to pick up mid-run spawned branches.
         # Not wired: workflow_run (the only caller threading on_branch_created
         # today) never runs with reactive=True.
+        if self.spawn_branch_setup is not None:
+            self.spawn_branch_setup(child, clone)
         self.operation_branches[child.id] = clone
         child.branch_id = clone.id
 
@@ -1042,6 +1053,7 @@ async def flow(
     max_spawn: int = 50,
     executor_ref: dict[str, Any] | None = None,
     on_branch_created: Callable[[Any], None] | None = None,
+    spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
 ) -> dict[str, Any]:
     """Execute a graph with dependency management and optional reactive self-expansion.
 
@@ -1051,6 +1063,9 @@ async def flow(
     (emitter ids), and ``dropped_spawns`` (rejected spawn/inject attempts as
     ``{reason, assignee, emitter_id, ...}``; reasons: builder_error,
     null_child, cycle, max_spawn_exceeded, duplicate).
+
+    ``spawn_branch_setup``, when given, runs after each reactively-spawned
+    node's branch is cloned (reactive mode only) — see ``ReactiveExecutor``.
     """
 
     if not parallel:
@@ -1069,6 +1084,7 @@ async def flow(
             node_builder=node_builder,
             max_spawn=max_spawn,
             executor_ref=executor_ref,
+            spawn_branch_setup=spawn_branch_setup,
         )
     else:
         executor = DependencyAwareExecutor(

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import itertools
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from lionagi import FieldModel
@@ -57,8 +59,30 @@ def grant_spawn(branch: Branch, *, prompt: bool = True) -> None:
     branch.grant_capabilities(build_emission_operable((SpawnRequest,), name="spawn"), prompt=prompt)
 
 
-def role_node_builder(roles: dict[str, Branch]):
-    """Return a node_builder closure that routes SpawnRequests to role branches."""
+def role_node_builder(
+    roles: dict[str, Branch],
+    *,
+    decorate_instruction: Callable[[SpawnRequest, str], str] | None = None,
+):
+    """Return a node_builder closure that routes SpawnRequests to role branches.
+
+    *decorate_instruction*, when given, is called with the request and the
+    node's freshly allocated ``spawn_id`` and must return the full instruction
+    text the child operation runs with — CLI callers use it to inject the
+    same artifact-directory + REQUIRED-file text a planned leg gets (see
+    ``lionagi.cli.orchestrate.flow``); library/engine callers that pass
+    nothing keep the plain no-artifact instruction.
+    """
+    # Closure-scoped monotonic sequence: the ONLY correct source of a spawned
+    # node's stable id. It must be allocated here, at construction time,
+    # because this is the sole point that sees the SpawnRequest before the
+    # child Operation is ever queued — by the time _execute_dag looks at
+    # completed results, completion order (not spawn order) is all that is
+    # left, and that is unrelated to which child actually is "the first
+    # spawn". Minting the id at completion-time let an unrelated node "steal"
+    # spawn-1 depending on which sibling happened to finish first — that is
+    # the bug this closure exists to fix.
+    _next_spawn_seq = itertools.count(1)
 
     def build(req: SpawnRequest, emitter: Operation) -> Operation:
         # Defense-in-depth: validate the operation at the routing boundary even
@@ -75,10 +99,8 @@ def role_node_builder(roles: dict[str, Branch]):
                 sorted(SPAWN_ALLOWED_OPERATIONS),
             )
             op = "operate"
-        node = create_operation(
-            op,
-            parameters={"instruction": req.instruction},
-        )
+
+        target = None
         if req.assignee:
             target = roles.get(req.assignee)
             if target is None:
@@ -86,11 +108,34 @@ def role_node_builder(roles: dict[str, Branch]):
                     f"SpawnRequest assignee {req.assignee!r} is not a "
                     f"recognized role (known: {sorted(roles)})"
                 )
+
+        # Allocate only after assignee validation succeeds — an unknown
+        # assignee raises above and never consumes a sequence number, so the
+        # ids handed to real children stay dense modulo only genuine
+        # post-build rejections (cycle/cap) downstream, which are acceptable
+        # gaps per the executor's own bookkeeping.
+        spawn_id = f"spawn-{next(_next_spawn_seq)}"
+        instruction = req.instruction
+        if decorate_instruction is not None:
+            instruction = decorate_instruction(req, spawn_id)
+
+        node = create_operation(
+            op,
+            parameters={"instruction": instruction},
+        )
+        # Stamped so post-run callers (artifact contracts, DAG metadata) can
+        # attribute a reactively spawned node back to the role that ran it —
+        # the node otherwise carries no trace of its assignee once its
+        # branch_id is overwritten by the executor's per-spawn branch clone.
+        # spawn_id survives that clone too (metadata, not branch state) and
+        # is the stable correlation key every downstream surface must use.
+        # reference_id mirrors it for the executor's own display path
+        # (DependencyAwareExecutor._run_tracked reads metadata["reference_id"]
+        # for its progress/log line).
+        node.metadata["spawn_id"] = spawn_id
+        node.metadata["reference_id"] = spawn_id
+        if target is not None:
             node.branch_id = target.id
-            # Stamped so post-run callers (artifact contracts, DAG metadata) can
-            # attribute a reactively spawned node back to the role that ran it —
-            # the node otherwise carries no trace of its assignee once its
-            # branch_id is overwritten by the executor's per-spawn branch clone.
             node.metadata["assignee"] = req.assignee
         return node
 

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -372,6 +372,7 @@ class Session(Node, Relational):
         max_spawn: int = 50,
         executor_ref: dict[str, Any] | None = None,
         on_branch_created: Callable[[Any], None] | None = None,
+        spawn_branch_setup: Callable[[Any, Any], None] | None = None,
     ) -> dict[str, Any]:
         """Execute a graph-based DAG workflow, optionally reactive (self-expanding)."""
         from lionagi.operations.flow import flow
@@ -396,6 +397,7 @@ class Session(Node, Relational):
             max_spawn=max_spawn,
             executor_ref=executor_ref,
             on_branch_created=on_branch_created,
+            spawn_branch_setup=spawn_branch_setup,
         )
 
     async def flow_stream(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -123,13 +123,18 @@ _SESSION_COLUMNS = frozenset(
         # DAG flows break that assumption: which role runs which leg is only
         # known once planning finishes, which happens after create_session
         # (see _build_dag in cli/orchestrate/flow.py). This column is
-        # allowlisted here so that ONE extension write is possible — folding
-        # resolved per-leg role artifact_defaults into the flow-wide
-        # contract, done once at DAG-build time, strictly before any leg
-        # starts executing. No writer may touch it after that point; the
-        # anti-drift intent of ADR-0029 (no changes once work is underway)
-        # still holds, it is just anchored at "DAG built" instead of
-        # "session created" for this call path.
+        # allowlisted here for two writer classes, both append-only and both
+        # frozen before the work they describe ever runs: (1) _build_dag
+        # folds each planned leg's resolved role artifact_defaults in once,
+        # at DAG-build time, strictly before any leg starts executing; (2)
+        # _execute_dag folds a reactively spawned node's own entries in after
+        # that node completes, but what is expected of it (role defaults +
+        # its builder-stamped spawn_id) was frozen before it was ever
+        # queued, so this is still a "before work starts" declaration in
+        # substance — see the ADR-0029 "Reactive-spawn exception" paragraph.
+        # No other writer may touch this column; the anti-drift intent of
+        # ADR-0029 (no changes once what was expected has been acted on)
+        # still holds.
         "artifact_contract_json",
     }
 )

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -364,10 +365,9 @@ async def test_execute_dag_tags_spawned_nodes(tmp_path):
 async def test_execute_dag_spawned_node_registers_artifact_contract(tmp_path):
     """A spawned node running under a role with artifact_defaults must be
     attributed back to that role and get its own contract entry folded into
-    the live-persist context for post-run visibility — folded non-required,
-    since a spawned node is never told its artifact dir and so has no path to
-    satisfy a required entry (enforcing one would fail an otherwise-complete
-    run)."""
+    the live-persist context for post-run visibility, keeping the role's own
+    required flag (decorate_instruction tells the spawned node its artifact
+    dir + REQUIRED files before it runs, the same as a planned leg)."""
     env = _make_env(tmp_path)
     db = _FakeDB()
     env._live_persist = {
@@ -397,10 +397,13 @@ async def test_execute_dag_spawned_node_registers_artifact_contract(tmp_path):
         },
     )
 
-    # The spawned node's graph entry carries the assignee role_node_builder
-    # stamped on it (patterns.py) — that's how a post-run surface recovers
-    # which role a reactively-injected node ran under.
-    spawned_node = SimpleNamespace(metadata={"assignee": "implementer"}, branch_id=None)
+    # The spawned node's graph entry carries the spawn_id + assignee
+    # role_node_builder stamps on it at construction time (patterns.py) —
+    # that's how a post-run surface recovers which role a reactively-injected
+    # node ran under, and its stable correlation id.
+    spawned_node = SimpleNamespace(
+        metadata={"assignee": "implementer", "spawn_id": "spawn-1"}, branch_id=None
+    )
     env.builder.get_graph = lambda: SimpleNamespace(
         nodes=[], internal_nodes={"node-spawn-1": spawned_node}
     )
@@ -425,6 +428,7 @@ async def test_execute_dag_spawned_node_registers_artifact_contract(tmp_path):
 
     spawned = next(r for r in exec_result.agent_results if r.get("spawned"))
     assert spawned["assignee"] == "implementer"
+    assert spawned["id"] == "spawn-1"
 
     contract = env._live_persist["artifact_contract"]
     assert contract is not None
@@ -432,10 +436,10 @@ async def test_execute_dag_spawned_node_registers_artifact_contract(tmp_path):
     assert "spawn-1__report" in ids
     paths = {e["path"] for e in contract["expected"]}
     assert "spawn-1/report.md" in paths
-    # Folded non-required even though the role default declares required=True —
-    # a spawned node can't be held to an artifact it was never told to write.
+    # Stays required — the role default declares required=True and the
+    # spawned node was told its artifact dir before it ran (decorate_instruction).
     spawned_entry = next(e for e in contract["expected"] if e["id"] == "spawn-1__report")
-    assert spawned_entry["required"] is False
+    assert spawned_entry["required"] is True
 
 
 @pytest.mark.asyncio
@@ -467,7 +471,9 @@ async def test_execute_dag_spawned_node_without_role_defaults_no_contract(tmp_pa
         worker_models=["codex/gpt-5.5"],
         role_artifact_defaults={"implementer": None},
     )
-    spawned_node = SimpleNamespace(metadata={"assignee": "implementer"}, branch_id=None)
+    spawned_node = SimpleNamespace(
+        metadata={"assignee": "implementer", "spawn_id": "spawn-1"}, branch_id=None
+    )
     env.builder.get_graph = lambda: SimpleNamespace(
         nodes=[], internal_nodes={"node-spawn-1": spawned_node}
     )
@@ -491,6 +497,312 @@ async def test_execute_dag_spawned_node_without_role_defaults_no_contract(tmp_pa
         await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
 
     assert env._live_persist["artifact_contract"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_dag_spawned_ids_independent_of_completion_order(tmp_path):
+    """Two role-built spawned nodes must keep their builder-stamped spawn_id
+    regardless of which one appears FIRST in op_results — completion order
+    (dict insertion order here) must never override the stamped id. Reversing
+    the dict's insertion order relative to construction order is exactly the
+    scenario that let an unrelated node "steal" spawn-1 under the old
+    completion-order-derived minting."""
+    env = _make_env(tmp_path)
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    # Node built SECOND (spawn-2) completes and is recorded FIRST; node built
+    # FIRST (spawn-1) completes and is recorded SECOND.
+    node_a = SimpleNamespace(
+        metadata={"assignee": "implementer", "spawn_id": "spawn-1"}, branch_id=None
+    )
+    node_b = SimpleNamespace(
+        metadata={"assignee": "researcher", "spawn_id": "spawn-2"}, branch_id=None
+    )
+    env.builder.get_graph = lambda: SimpleNamespace(
+        nodes=[], internal_nodes={"node-b": node_b, "node-a": node_a}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {
+                    "node-0": "planned result",
+                    # insertion order: node-b (spawn-2) BEFORE node-a (spawn-1)
+                    "node-b": "b result",
+                    "node-a": "a result",
+                },
+                "spawned_operations": 2,
+            }
+        )
+    )
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        exec_result = await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    spawned_by_id = {r["id"]: r for r in exec_result.agent_results if r.get("spawned")}
+    assert spawned_by_id["spawn-2"]["response"] == "b result"
+    assert spawned_by_id["spawn-2"]["assignee"] == "researcher"
+    assert spawned_by_id["spawn-1"]["response"] == "a result"
+    assert spawned_by_id["spawn-1"]["assignee"] == "implementer"
+
+
+@pytest.mark.asyncio
+async def test_execute_dag_unstamped_node_fallback_skips_stamped_ids(tmp_path):
+    """A node injected WITHOUT going through role_node_builder (no spawn_id
+    in its metadata — e.g. an escalation child or a raw inject()) must fall
+    back to a synthesized id, but that fallback must never collide with an
+    id a role-built sibling already carries."""
+    env = _make_env(tmp_path)
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    # role-built sibling already owns "spawn-1"; the unstamped node has no
+    # spawn_id and no assignee (a raw injected node carries neither).
+    stamped_node = SimpleNamespace(
+        metadata={"assignee": "researcher", "spawn_id": "spawn-1"}, branch_id=None
+    )
+    unstamped_node = SimpleNamespace(metadata={}, branch_id=None)
+    env.builder.get_graph = lambda: SimpleNamespace(
+        nodes=[],
+        internal_nodes={"node-stamped": stamped_node, "node-unstamped": unstamped_node},
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {
+                    "node-0": "planned result",
+                    "node-unstamped": "unstamped result",
+                    "node-stamped": "stamped result",
+                },
+                "spawned_operations": 2,
+            }
+        )
+    )
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        exec_result = await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    spawned_ids = {r["id"] for r in exec_result.agent_results if r.get("spawned")}
+    # spawn-1 is already taken by the stamped node — the fallback must skip
+    # it and mint spawn-2, never a second "spawn-1".
+    assert spawned_ids == {"spawn-1", "spawn-2"}
+
+
+@pytest.mark.asyncio
+async def test_execute_dag_role_attributed_node_missing_spawn_id_fails_loud(tmp_path):
+    """A node carrying a role assignee (the role_node_builder trail) but no
+    spawn_id indicates the stamping invariant broke upstream — this must
+    raise, not silently mint a fresh id that hides the defect."""
+    env = _make_env(tmp_path)
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    broken_node = SimpleNamespace(metadata={"assignee": "researcher"}, branch_id=None)
+    env.builder.get_graph = lambda: SimpleNamespace(
+        nodes=[], internal_nodes={"node-broken": broken_node}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {
+                    "node-0": "planned result",
+                    "node-broken": "broken result",
+                },
+                "spawned_operations": 1,
+            }
+        )
+    )
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        with pytest.raises(RuntimeError, match="no spawn_id"):
+            await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+
+# ── Reactive spawn artifact enforcement through REAL teardown ─────────────────
+# Replaces the old interim regression test that pinned spawned artifacts as
+# permanently non-required (a spawned node used to have no way to learn its
+# own artifact dir before running). decorate_instruction now tells it that
+# dir before execution, so a role's required:True declaration is a real,
+# enforceable gate for a reactively spawned node too — exercised here through
+# the actual teardown path (start_live_persist / stop_live_persist / StateDB),
+# not just the in-memory contract dict.
+
+
+@pytest.fixture
+def _flow_phase_state_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["reviewer", "critic"])
+@pytest.mark.parametrize(
+    "outcome, file_content",
+    [
+        ("pass", "## Verdict\nAPPROVE\n"),
+        ("missing", None),
+        ("zero_byte", ""),
+    ],
+)
+async def test_reactive_spawn_required_artifact_persistence_matrix(
+    _flow_phase_state_db, tmp_path, role, outcome, file_content
+):
+    """A spawned node running under reviewer/critic (both declare a required
+    review.md) must flip the run to failed at teardown when that artifact is
+    missing OR present-but-empty, and stay completed only when a real
+    non-empty file is written — the actual enforcement the role declaration
+    exists for, now that the spawned node is told its artifact dir up front."""
+    from lionagi import Branch, Session
+    from lionagi.casts.pattern import Role
+    from lionagi.cli._runs import allocate_run
+    from lionagi.cli.orchestrate._orchestration import (
+        OrchestrationEnv,
+        start_live_persist,
+        stop_live_persist,
+    )
+    from lionagi.engines import PlanningEngine
+    from lionagi.state.db import StateDB
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+    run = allocate_run(save_dir=str(tmp_path / "artifacts"))
+
+    env = OrchestrationEnv(
+        run=run,
+        session=session,
+        orc_branch=orc_branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        default_model_spec="claude",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(run.artifact_root))
+
+    assignments = [TaskAssignment(task="review it", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    role_defaults = Role.load(role).artifact_defaults
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+        role_artifact_defaults={role: role_defaults},
+    )
+
+    spawned_node = SimpleNamespace(
+        metadata={"assignee": role, "spawn_id": "spawn-1"}, branch_id=None
+    )
+    env.builder.get_graph = lambda: SimpleNamespace(
+        nodes=[], internal_nodes={"node-spawn-1": spawned_node}
+    )
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {
+                    "node-0": "planned result",
+                    "node-spawn-1": "spawned result",
+                },
+                "spawned_operations": 1,
+            }
+        )
+    )
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    # Simulate the spawned worker itself writing (or not writing) the file it
+    # was told about via decorate_instruction, at the exact path the contract
+    # entry expects (namespaced under its own stamped spawn_id).
+    if file_content is not None:
+        artifact_path = run.agent_artifact_dir("spawn-1") / "review.md"
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(file_content)
+
+    session_id = env._live_persist["session_id"]
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(session_id)
+    assert s is not None
+    if outcome == "pass":
+        assert s["status"] == "completed"
+    else:
+        assert s["status"] == "failed"
+        assert s["status_reason_code"] == "run.failed.missing_artifact"
 
 
 # ── Tests for _synthesize ─────────────────────────────────────────────────────

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -362,6 +362,128 @@ async def test_execute_dag_tags_spawned_nodes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_execute_dag_reactive_wires_spawn_branch_setup_for_cli_workspace(tmp_path):
+    """Reactive execution must pass a spawn_branch_setup callback into
+    run_dag that retargets a CLI-backed spawned branch's writable workspace
+    (chat_model.endpoint.config.kwargs['repo']) to that spawn's own artifact
+    dir. Branch.clone() otherwise carries the emitting leg's repo forward
+    unchanged — a sibling directory outside the spawned artifact contract —
+    so without this seam a spawned CLI child can only write where its
+    emitter can, not where its own artifact contract expects. Non-CLI
+    branches (no writable-root concept) must be left untouched."""
+    env = _make_env(tmp_path)
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {"operation_results": {"node-0": "planned result"}, "spawned_operations": 0}
+        )
+    )
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    call_kwargs = fake_engine_run.run_dag.call_args.kwargs
+    spawn_branch_setup = call_kwargs["spawn_branch_setup"]
+    assert spawn_branch_setup is not None
+
+    operation = SimpleNamespace(metadata={"spawn_id": "spawn-1"})
+    cli_branch = SimpleNamespace(
+        chat_model=SimpleNamespace(
+            is_cli=True,
+            endpoint=SimpleNamespace(config=SimpleNamespace(kwargs={})),
+        )
+    )
+    spawn_branch_setup(operation, cli_branch)
+
+    expected_dir = env.run.agent_artifact_dir("spawn-1")
+    assert cli_branch.chat_model.endpoint.config.kwargs["repo"] == expected_dir
+    assert expected_dir.exists()
+
+    non_cli_branch = SimpleNamespace(
+        chat_model=SimpleNamespace(
+            is_cli=False,
+            endpoint=SimpleNamespace(config=SimpleNamespace(kwargs={})),
+        )
+    )
+    spawn_branch_setup(operation, non_cli_branch)
+    assert "repo" not in non_cli_branch.chat_model.endpoint.config.kwargs
+
+
+@pytest.mark.asyncio
+async def test_execute_dag_escalated_spawned_node_evidence_uses_spawn_id(tmp_path):
+    """An escalated node that was reactively spawned (not in the plan) must
+    surface its role_node_builder-stamped spawn_id in the escalation
+    evidence, not the internal Operation UUID — so a reviewer reading the
+    teardown evidence sees the same 'spawn-N' label the artifact dirs and
+    contract entries already use."""
+    env = _make_env(tmp_path)
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    escalated_node = SimpleNamespace(
+        metadata={"assignee": "critic", "spawn_id": "spawn-7"}, branch_id=None
+    )
+    env.builder.get_graph = lambda: SimpleNamespace(
+        nodes=[], internal_nodes={"node-escalated": escalated_node}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {"node-0": "planned result"},
+                "spawned_operations": 1,
+                "escalated_operations": ["node-escalated"],
+            }
+        )
+    )
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert env._escalated_evidence == [
+        {"kind": "escalated_operation", "id": "spawn-7", "label": "spawn-7"}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_execute_dag_spawned_node_registers_artifact_contract(tmp_path):
     """A spawned node running under a role with artifact_defaults must be
     attributed back to that role and get its own contract entry folded into

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1689,6 +1689,7 @@ async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(
     `escalated_operations` but absent from `node_ids`/`known_nodes` — and
     confirm it still surfaces past the backstop.
     """
+    from types import SimpleNamespace
     from unittest.mock import MagicMock, patch
 
     from lionagi.casts.emission import TaskAssignment
@@ -1717,6 +1718,14 @@ async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(
         role_base={},
         worker_models=["codex/gpt-5.5"],
     )
+
+    # This node was injected directly (e.g. an EscalationRequest child, or a
+    # raw Session.flow inject()) rather than through role_node_builder, so it
+    # carries no stamped spawn_id in the graph — the evidence must fall back
+    # to its raw node id, same as the artifact-recovery loop's own unstamped
+    # fallback. env.builder defaults to a bare MagicMock() (_minimal_env),
+    # whose auto-attributes would otherwise look like a "found" node.
+    env.builder.get_graph = lambda: SimpleNamespace(nodes=[], internal_nodes={})
 
     from lionagi.engines import PlanningEngine
 

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -146,6 +146,54 @@ async def test_dependent_spawn_runs_after_emitter():
     assert result["spawned_operations"] == 1
 
 
+@pytest.mark.asyncio
+async def test_spawn_branch_setup_fires_with_operation_and_cloned_branch():
+    """spawn_branch_setup(operation, cloned_branch) must run for every
+    reactively-spawned node right after its branch clone is created — the
+    seam cli/orchestrate/flow.py uses to retarget a CLI-backed chat_model's
+    writable workspace to the spawn's own artifact dir instead of silently
+    inheriting the emitter's. The stamped spawn_id (set by node_builder,
+    mirroring role_node_builder in production) must already be on the
+    operation's metadata by the time the callback fires."""
+    from lionagi.session.branch import Branch
+
+    async def spawner(**kw):
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        return "did the follow-up work"
+
+    session = _session_with_ops(spawner=spawner, follow_up=follow_up)
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        op = create_operation("follow_up", parameters={})
+        op.metadata["spawn_id"] = "spawn-1"
+        return op
+
+    seen: list[tuple[str | None, Branch]] = []
+
+    def spawn_branch_setup(operation: Operation, branch: Branch) -> None:
+        seen.append((operation.metadata.get("spawn_id"), branch))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    result = await flow(
+        session,
+        graph,
+        reactive=True,
+        node_builder=node_builder,
+        spawn_branch_setup=spawn_branch_setup,
+    )
+
+    assert result["spawned_operations"] == 1
+    assert len(seen) == 1
+    spawn_id, branch = seen[0]
+    assert spawn_id == "spawn-1"
+    assert isinstance(branch, Branch)
+
+
 def test_inject_rejected_when_not_running():
     """inject() is a no-op (returns False) outside an active flow."""
     from lionagi.operations.flow import ReactiveExecutor

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -80,6 +80,75 @@ class TestRoleNodeBuilder:
         )
         assert node.operation == "ReAct"
 
+    def test_stamps_stable_spawn_id_and_reference_id(self):
+        """Builder-time identity: spawn_id (and reference_id, the executor's
+        display-path key) must be allocated at construction, not left for a
+        completion-order-derived id downstream."""
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        node = nb(SpawnRequest(instruction="dig", assignee="researcher"), None)
+        assert node.metadata.get("spawn_id") == "spawn-1"
+        assert node.metadata.get("reference_id") == "spawn-1"
+
+    def test_spawn_id_stamped_even_without_assignee(self):
+        """A spawn_id is allocated regardless of whether the request carries
+        an assignee — only the metadata["assignee"]/branch_id routing is
+        conditional on that."""
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        node = nb(SpawnRequest(instruction="x"), None)
+        assert node.metadata.get("spawn_id") == "spawn-1"
+
+    def test_spawn_id_monotonic_across_calls_from_one_closure(self):
+        """Multiple SpawnRequests routed through the SAME role_node_builder
+        closure get distinct, increasing ids — the closure-scoped sequence is
+        the only correct source of the id (completion order is not spawn
+        order)."""
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        n1 = nb(SpawnRequest(instruction="a", assignee="researcher"), None)
+        n2 = nb(SpawnRequest(instruction="b", assignee="researcher"), None)
+        n3 = nb(SpawnRequest(instruction="c", assignee="researcher"), None)
+        assert [n.metadata["spawn_id"] for n in (n1, n2, n3)] == [
+            "spawn-1",
+            "spawn-2",
+            "spawn-3",
+        ]
+
+    def test_unknown_assignee_does_not_consume_a_sequence_number(self):
+        """A rejected (unknown-assignee) request must not burn an id — the
+        next successfully built node still gets spawn-1, not spawn-2."""
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        with pytest.raises(ValueError, match="not a recognized role"):
+            nb(SpawnRequest(instruction="x", assignee="ghost"), None)
+        node = nb(SpawnRequest(instruction="ok", assignee="researcher"), None)
+        assert node.metadata["spawn_id"] == "spawn-1"
+
+    def test_decorate_instruction_receives_request_and_spawn_id(self):
+        """decorate_instruction is called with (req, spawn_id) and its return
+        value becomes the child operation's instruction — the seam the CLI
+        uses to inject the artifact-directory + REQUIRED text."""
+        session, roles = _roles("researcher")
+        seen: list[tuple[str, str]] = []
+
+        def decorate(req: SpawnRequest, spawn_id: str) -> str:
+            seen.append((req.instruction, spawn_id))
+            return f"{req.instruction}\n\nWrite to {spawn_id}/."
+
+        nb = role_node_builder(roles, decorate_instruction=decorate)
+        node = nb(SpawnRequest(instruction="dig deeper", assignee="researcher"), None)
+        assert seen == [("dig deeper", "spawn-1")]
+        assert node.parameters["instruction"] == "dig deeper\n\nWrite to spawn-1/."
+
+    def test_no_decorate_instruction_keeps_plain_instruction(self):
+        """Library/engine callers that pass nothing keep the bare instruction
+        — no artifact prose leaks into non-CLI callers."""
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        node = nb(SpawnRequest(instruction="dig deeper", assignee="researcher"), None)
+        assert node.parameters["instruction"] == "dig deeper"
+
 
 class TestBuildFanoutGraph:
     def test_parallel_workers_are_independent(self):


### PR DESCRIPTION
Closes #1666.

Implements the builder-time spawn-identity plan from the issue:

- `role_node_builder` allocates a stable `spawn-N` at node construction (after assignee validation, so rejects don't burn IDs) and stamps `spawn_id`/`reference_id` into operation metadata, which survives the executor's branch clone. New keyword-only `decorate_instruction` callback keeps CLI path knowledge out of the patterns layer.
- The CLI wires a decorator that gives spawned nodes the same artifact-directory + REQUIRED text planned legs get, via one shared helper (`_leg_artifact_entries` / `_artifact_directive`) so planned/spawned mirroring is a code invariant.
- `_execute_dag` consumes the stamped ID everywhere (results, response dirs, contract entries, synthesis, Studio metadata); unstamped injected nodes (escalation children, `inject()`) get collision-free fallbacks that pre-scan stamped IDs; a role-built node missing its stamp fails loudly.
- Spawned contract entries restore `required: entry.get("required", True)` — reviewer/critic quality gates enforce again.
- ADR-0029 amended with the reactive-spawn append-only exception; stale contract comments updated.

Tests: builder-identity suite, completion-order independence (reversed result order), fallback-collision, fail-loud invariant, and a parameterized reviewer/critic × pass/missing/zero-byte persistence matrix through real teardown asserting `run.failed.missing_artifact` on the failure legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
