### PR TITLE
docs(adr): bundle 2 — messages-context (0006-0008) + operations (0021-0024)

### DIFF
--- a/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
+++ b/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
@@ -1,0 +1,99 @@
+# ADR-0006: Conversational Message Envelope and Ordered History
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: messages-context
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+LionAGI uses one identifiable record shape for conversation turns and routed inter-branch traffic.
+`Message` inherits graph identity and metadata from `Node`, adds `sender`, `recipient`, and an
+optional grouping `channel`, and renders either its content object's `rendered` value or the string
+form of arbitrary content. The generic envelope is used directly by `Exchange`; conversational
+records specialize it with typed content.
+
+A message's role is fixed by its concrete class rather than accepted from serialized or caller
+input. `System`, `Instruction`, and `AssistantResponse` have the `system`, `user`, and `assistant`
+roles, while `ActionRequest` and `ActionResponse` both have the `action` role. The generic
+`Message` has the `unset` role. This prevents a caller-supplied role from changing the semantics of
+a typed message.
+
+Subtype content retains provider-neutral conversational data. Assistant responses keep normalized
+display text in content and the raw provider response in metadata. Action content keeps the
+function, arguments, output or error, and counterpart identifier; responses created through
+`MessageManager`'s new-response factory establish links in both directions. Instruction content
+also carries rendering and current-call configuration, a boundary addressed by ADR-0007.
+
+Each `Branch` owns one `MessageManager`. The manager owns a `Pile[Message]`, its ordered
+`Progression`, the optional canonical system message, construction factories, typed history views,
+and message-added callbacks. The branch exposes the manager and its records as facade properties
+while retaining ownership of turn execution.
+
+Two public labels are weaker than their names suggest. `Sendable` is an empty marker and does not
+enforce sender or recipient fields. `RoledMessage` is exactly an alias of `Message`, with no runtime
+or semantic distinction. Routing also distinguishes `recipient=None`, which is broadcast, from the
+default `MessageRole.UNSET`, which `is_direct` currently classifies as direct.
+
+## Decision
+
+`Message` is the single concrete identity, routing, and rendering envelope, and `MessageManager` is
+the branch-owned ordered record store. The load-bearing invariants are:
+
+- role is a read-only class-level property; construction and deserialization discard a supplied
+  `role` value;
+- `sender` and `recipient` accept a `MessageRole`, UUID, plain string, or observable identity;
+  non-null values serialize as strings, while `channel` is optional grouping metadata;
+- generic routed traffic may use `Message` directly, while conversational turns use the five typed
+  subclasses and their fixed roles;
+- assistant raw responses remain metadata, and action request/response correlation remains durable
+  message content;
+- `MessageManager` owns record membership, order, the single system record, factories, and typed
+  views; `Branch` owns operation execution and exposes those records through its facade;
+- synchronous addition rejects asynchronous callbacks before mutating history, while callback
+  failures after either synchronous or asynchronous addition are surfaced after the record has
+  been inserted; and
+- `RoledMessage` is a compatibility alias only, and `Sendable` is not the enforceable public data
+  contract.
+
+The implementation anchors are `lionagi/protocols/messages/message.py`,
+`lionagi/protocols/messages/manager.py`, the role-specific modules under
+`lionagi/protocols/messages/`, `lionagi/session/branch.py`, and `lionagi/session/exchange.py`.
+
+```mermaid
+flowchart LR
+    B[Branch] --> MM[MessageManager]
+    MM --> P[Pile plus Progression]
+    P --> M[Message envelope]
+    M --> T[Typed conversational messages]
+    E[Exchange] --> M
+```
+
+## Consequences
+
+Conversation history and inter-branch traffic share identity, serialization, routing metadata, and
+rendering without a second transport hierarchy. Fixed subtype roles prevent role spoofing through
+input data, and durable action links support tool-call correlation.
+
+The broad envelope also exposes ambiguity. `Sendable` cannot be used to type a data-bearing routing
+contract, `RoledMessage` suggests a hierarchy that does not exist, and default recipients are
+classified differently from explicit broadcasts. Callback failure is not a transaction rollback:
+a caller may receive an exception after the message is already present.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Deprecate `RoledMessage` in public exports and type annotations, migrate internal and documented uses to `Message`, and remove the alias only at a declared breaking-change boundary; acceptance requires compatibility warnings and import coverage through the deprecation window. | S | (filled at issue-open time) |
+| 2 | Define one routing state model for absent, unset, direct, and broadcast recipients; acceptance requires constructor defaults, validation, serialization, `is_direct`, and `is_broadcast` to agree under round-trip tests. | S | (filled at issue-open time) |
+| 3 | Either replace `Sendable` with a runtime-checkable structural contract for typed sender and recipient fields or document and rename it as a marker; acceptance requires public annotations and conformance tests to match the chosen meaning. | S | (filled at issue-open time) |
+| 4 | Publish message-added callback transaction semantics; acceptance requires sync and async tests to specify pre-mutation rejection, post-insertion callback failures, error aggregation, and any durable-hook retry responsibility. | S | (filled at issue-open time) |
+| 5 | Implement the canonical turn-request compiler defined by ADR-0007 and remove prompt policy from durable records and `MessageManager`; acceptance requires chat and run payload characterization tests, transient fields absent from replayed history, and every legacy preparation entry point removed or delegated. | M | (filled at issue-open time) |
+
+## Notes
+
+Alternatives considered were separate envelopes for routed traffic and conversational turns, and a
+mutable serialized role on one untyped record. The first duplicates identity and routing rules; the
+second allows record data to contradict the concrete conversational type. The existing shared
+envelope with fixed subtype roles preserves both use cases with less protocol surface.

--- a/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
+++ b/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
@@ -1,0 +1,119 @@
+# ADR-0007: Canonical Turn-Request Compilation Boundary
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: messages-context
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0006
+
+## Context
+
+An `Instruction` currently serves two lifetimes. It is the durable user-turn record containing
+instruction text, guidance, prompt context, plain content, and images, but its content also carries
+current-call tool schemas, response-format objects, and a rendering strategy. Historical replay
+then has to remove tool schemas and response formats, while in-memory copying has special cases for
+objects that cannot survive normal serialization.
+
+Provider messages are produced by three overlapping surfaces. `MessageManager.to_chat_msgs()` is a
+raw record projection. `prepare_messages_for_chat()` folds system and action records and merges
+assistant turns but has no production caller. The active chat and run path performs a different fold
+in `_prepare_run_kwargs()`, including context-provider blocks from ADR-0008. These paths can assign
+different prompt semantics to the same history.
+
+Provider request construction is an operation concern: it selects history, applies current-turn
+options, folds action results, injects ephemeral context, and produces arguments for an `iModel`
+call. Durable record ownership remains with `MessageManager`; it must not depend on provider request
+policy.
+
+## Decision
+
+The operation layer will introduce one typed `TurnRequest` and one canonical
+`compile_chat_request(branch, request)` boundary. The minimum interface is:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ContextBlock:
+    provider_name: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledMessage:
+    role: MessageRole
+    content: str | list[dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class TurnRequest:
+    instruction: Instruction
+    progression: tuple[UUID, ...] | None
+    tool_schemas: tuple[dict[str, Any], ...]
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None
+    structure: type[Structure] | str | None
+    context_blocks: tuple[ContextBlock, ...]
+    provider_kwargs: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledChatRequest:
+    instruction: Instruction
+    messages: tuple[CompiledMessage, ...]
+    provider_kwargs: Mapping[str, Any]
+
+
+def compile_chat_request(branch: Branch, request: TurnRequest) -> CompiledChatRequest: ...
+```
+
+Provider adapters may translate `CompiledMessage` at the service boundary. The load-bearing
+invariants are:
+
+- durable `InstructionContent` retains provider-neutral user content only: instruction, stable
+  guidance and prompt context, plain content, and multimodal input;
+- tool schemas, response-format and structure objects, selected progression, context-provider
+  blocks, and model-call keyword arguments are transient `TurnRequest` data;
+- compilation does not mutate durable messages and historical turns cannot replay transient schemas
+  or current-call options;
+- one compiler owns system-policy folding, action-result correlation, consecutive-assistant
+  normalization, selected-history validation, and final role and content rendering;
+- context blocks are source-attributed and isolated in explicit data envelopes so retrieved text
+  cannot merge syntactically with system policy or user guidance;
+- chat and run use the same compiler and preserve their existing provider-visible message semantics
+  until a separately documented behavioral change is accepted;
+- `MessageManager` exposes raw ordered records only; prompt-shaping helpers migrate to the compiler;
+  and
+- the existing Branch call surface adapts arguments into `TurnRequest`, so the boundary can be
+  introduced before public call signatures change.
+
+The target implementation anchors are `lionagi/operations/types.py` and
+`lionagi/operations/chat/_prepare.py`. Migration removes independent policy from
+`lionagi/protocols/messages/prepare.py` and makes the raw nature of
+`lionagi/protocols/messages/manager.py` projections explicit.
+
+```mermaid
+flowchart LR
+    API[Branch call surface] --> TR[TurnRequest]
+    H[MessageManager raw history] --> C[Canonical compiler]
+    TR --> C
+    C --> CR[CompiledChatRequest]
+    CR --> IM[iModel boundary]
+```
+
+## Consequences
+
+One deterministic compiler becomes the regression surface for prompt history, action results,
+structured output, tools, images, and injected context. Durable messages round-trip without
+carrying objects that exist only for one model call, and provider preparation no longer leaks into
+the record manager.
+
+The migration touches a high-risk compatibility boundary. It must pin current chat and run payloads
+with characterization tests before delegating or removing legacy helpers. A typed intermediate
+model adds a small allocation and translation cost, and provider-specific payload extensions must
+pass through explicit adapter fields rather than mutating message records.
+
+## Notes
+
+Alternatives considered were retaining configuration in `InstructionContent` and stripping it on
+replay, moving all compilation into `MessageManager`, and letting each provider build payloads from
+raw history. The first preserves serialization exceptions, the second couples durable storage to
+operation policy, and the third multiplies prompt semantics. One operation-owned compiler keeps the
+record and service boundaries explicit.

--- a/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
+++ b/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
@@ -1,0 +1,110 @@
+# ADR-0008: Pre-Turn Context-Provider Execution and Attribution
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: messages-context
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+LionAGI can gather knowledge immediately before a chat or run turn without adding that knowledge to
+durable conversation history. `ContextProvider` is a structural asynchronous interface whose
+`provide(branch, instruction)` method returns a text block or no result. Each `Branch` lazily owns
+an ordered `ContextProviderRegistry`; a branch that never registers providers does no provider work.
+
+The registry invokes providers sequentially in registration order and contains provider exceptions.
+It tokenizes every non-empty successful result, applies each provider's optional maximum, and then
+selects blocks under a total token budget by descending priority. Kept blocks render in registration
+order. The budget limits rendered text, not provider invocation: all providers run before any
+total-budget result is dropped.
+
+Chat and run gather providers before compiling the model request. A branch without a system message
+does not invoke them because the current compiler has no injection target; the most recent report
+marks every registered provider as skipped. With a system message, blocks are held in a private
+per-turn slot, concatenated into the first instruction's system-guidance fold, and cleared in a
+`finally` block after compilation. The text is sent to the model but is not inserted into
+`Branch.messages`.
+
+`ProviderReport` is an in-memory last-turn diagnostic. It retains rendered blocks, provider names
+and token counts for selected results, and unclassified skipped and failed names. Empty results are
+not represented, skip reasons are not distinguished, and reports are not emitted to logs or run
+metadata. The current concatenation also supplies no guaranteed delimiter between system text, the
+joined provider blocks, and guidance.
+
+The registry is independent of `MemoryStore`. A provider may consult `branch.memory` or any external
+source, but the context contract neither requires nor adapts the memory interface. Memory backend
+and lifecycle semantics belong to the separate substrate boundary (see the substrates ADR on
+memory-store contracts). The registry also exposes a contained `gather_writeback()` hook. One
+production turn path invokes it: when providers are registered and an action-invoking turn produces
+non-empty action results, the operate pipeline calls `gather_writeback()` with those results
+(`lionagi/operations/operate/operate.py`). Turns without action results, and the chat and run
+paths, do not trigger writeback.
+
+## Decision
+
+Pre-turn context is a Branch-owned, failure-contained operational input, not a conversational
+message. The load-bearing invariants are:
+
+- providers structurally implement `async provide(Branch, Instruction) -> str | None` and run in
+  registration order;
+- provider exceptions do not fail the turn, and an empty result contributes no rendered block;
+- per-provider and total limits apply after retrieval, priority determines which successful blocks
+  fit, and retained blocks preserve registration order;
+- providers run only when a system message supplies the current render target; otherwise all
+  registered names are reported as skipped without invocation;
+- selected text exists only in the per-turn compiler input, never in durable message history, and
+  the slot is cleared even when compilation fails;
+- `last_context_report` retains only the latest in-memory report and is diagnostic rather than a
+  durable audit record;
+- context providers and memory stores remain independent structural interfaces; and
+- provider writeback fires on the operate path when action results exist, and otherwise only when
+  a caller explicitly invokes `gather_writeback()`; both follow the same exception-containment
+  policy as retrieval.
+
+The implementation anchors are `lionagi/protocols/context_providers.py`,
+`lionagi/operations/chat/_prepare.py`, `lionagi/operations/chat/chat.py`,
+`lionagi/operations/run/run.py`, and `lionagi/session/branch.py`.
+
+```mermaid
+sequenceDiagram
+    participant O as chat or run
+    participant R as ContextProviderRegistry
+    participant C as Request compiler
+    O->>R: gather(branch, instruction)
+    R-->>O: ProviderReport and selected blocks
+    O->>C: compile with ephemeral blocks
+    C-->>O: provider request
+    O->>O: clear per-turn slot
+```
+
+## Consequences
+
+Retrieval failures cannot block ordinary turns, context remains outside durable chat history, and
+priority-based selection bounds the text sent to the model. Callers can inspect immediate
+attribution without requiring a persistence backend, and providers are free to use memory, search,
+or external services.
+
+The current seam does not bound retrieval cost, cannot inject on a systemless branch, and cannot
+reconstruct attribution across turns. Raw blocks retained in the latest report may contain
+sensitive source material. Ambiguous skip outcomes and missing text boundaries make policy analysis
+and prompt inspection less reliable than the provider interface implies.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Add source-attributed data envelopes and separators between system text, each provider block, and guidance; acceptance requires retrieved text to remain syntactically isolated from instructions and exact-boundary regression tests for one and multiple providers across chat and run. | S | (filled at issue-open time) |
+| 2 | Replace loose report lists with one typed outcome per registered provider covering rendered, empty, per-provider limit, total-budget exclusion, and failure; acceptance requires stable reason codes, token counts where available, and registration-order correlation. | M | (filled at issue-open time) |
+| 3 | Define report retention and redaction, then emit a per-turn report reference to run metadata or logs; acceptance requires multi-turn attribution without persisting raw provider text unless the selected policy explicitly permits it. | M | (filled at issue-open time) |
+| 4 | Name the existing total limit as a rendered-token budget and decide whether invocation cost also needs a bound; acceptance requires documentation of the chosen semantics and preflight eligibility or cost controls if invocation must be bounded. | M | (filled at issue-open time) |
+| 5 | Decide the systemless-branch policy; acceptance requires chat and run either to compile a documented context envelope without a system message or to expose the current skip behavior as a stable public contract. | S | (filled at issue-open time) |
+| 6 | Define the lifecycle of provider writeback; acceptance requires either one documented post-turn invocation point with exactly-once-per-turn tests or renaming the hook as an explicitly caller-driven utility. | M | (filled at issue-open time) |
+
+## Notes
+
+Alternatives considered were persisting injected blocks as ordinary messages and requiring all
+providers to retrieve through `MemoryStore`. Persisted blocks would contaminate durable user and
+assistant history with operational context; a memory-only source contract cannot represent search,
+composition, or other external providers. The Branch-owned structural registry preserves ephemeral
+injection while keeping source selection pluggable.

--- a/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
+++ b/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
@@ -1,0 +1,96 @@
+# ADR-0021: Branch operation façade and turn-adapter contract
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: operations
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+`Branch` is the public verb surface for a conversation. It exposes model transport,
+structured parsing, action execution, composed operation, interpretation, and reasoning-loop
+methods while keeping most implementations in `lionagi/operations/`. The façade imports those
+implementations inside each method, which lets operation modules depend on `Branch` only for type
+checking and avoids a runtime import cycle (`lionagi/session/branch.py`,
+`lionagi/operations/types.py`).
+
+Named extensions are session-scoped. `Session` owns one `OperationManager`, shares it with every
+included branch, and registers asynchronous callables into it. `Branch.get_operation()` resolves a
+built-in branch method before consulting that registry, and `Operation` uses the same lookup when a
+graph node is invoked (`lionagi/session/session.py`, `lionagi/operations/manager.py`,
+`lionagi/operations/node.py`).
+
+The model-facing verbs have distinct state contracts. `chat()` performs an API request and logs the
+event without adding the instruction or response to branch messages. `communicate()` records an API
+instruction and response and may then parse the response. `run()` is restricted to CLI endpoints;
+it streams and records typed instruction, assistant, action-request, and action-response messages
+while owning stream cleanup and lifecycle signals. `run_and_collect()` converts that stream back to
+a single result shape (`lionagi/operations/chat/chat.py`,
+`lionagi/operations/communicate/communicate.py`, `lionagi/operations/run/run.py`).
+
+`Middle` is the structural substitution seam used by `operate()`. Its current docstring calls the
+seam one assistant turn, but its implementations do not share that cardinality: CLI collection may
+join several assistant messages, and the LNDL adapter may run several inner exchanges. The stable
+as-built contract is one logical adapter invocation that owns whatever recorded exchange or bounded
+exchange sequence it performs (`lionagi/operations/types.py`,
+`lionagi/operations/lndl_middle/lndl_middle.py`).
+
+## Decision
+
+The operation layer retains `Branch` as its public façade, the session-owned asynchronous registry
+as its named extension mechanism, and `Middle` as the typed adapter seam for a logical model
+exchange.
+
+```text
+Session-owned registry ───────┐
+                              v
+Caller ──> Branch façade ──> built-in verb implementation
+                    │
+                    └── operate() ──> Middle adapter
+                                      ├── communicate (API, recorded)
+                                      ├── run_and_collect (CLI, streamed and recorded)
+                                      └── bounded adapter (for example LNDL)
+```
+
+The load-bearing invariants are:
+
+- Built-in `Branch` methods take precedence over session-registered names. Registered operations
+  must be asynchronous and become visible to every branch included in the session.
+- Operation implementations receive a fully formed branch; they do not own branch or session
+  construction. Runtime imports from the façade remain lazy or type-only in the implementation
+  direction.
+- `chat()` is non-recording, while `communicate()`, `run()`, and any custom `Middle` own their message
+  persistence. `operate()` does not append a duplicate instruction or response around a `Middle`.
+- `run()` remains a public async-generator contract for CLI endpoints. API one-shot calls and CLI
+  stream lifecycle are not forced into one transport primitive.
+- A `Middle` accepts `branch`, `instruction`, `ChatParam`, optional `ParseParam`, `clear_messages`, and
+  `skip_validation`, and returns the logical operation result. The protocol does not guarantee one
+  provider message or prohibit a bounded internal loop.
+
+## Consequences
+
+Library callers get one discoverable branch surface, while graph nodes and custom session operations
+reuse the same dispatch path. Transport implementations retain the cleanup and persistence behavior
+their endpoint family requires, and custom adapters can replace transport-plus-turn behavior without
+replacing the branch.
+
+The façade is broader than a conventional thin interface, and lifecycle ownership is not uniform:
+`operate()` and `communicate()` use the branch wrapper, `run()` emits its own lifecycle, and `ReAct()`
+coordinates nested lifecycle suppression. The extension registry's location under `operations/`
+also obscures its session-owned lifetime.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Replace the `Middle` one-turn wording with a logical-exchange contract that states message-recording, streaming, bounded-loop, native-tool, and validation responsibilities; add conformance tests for `communicate`, `run_and_collect`, and LNDL. | M | (filled at issue-open time) |
+| 2 | Make the branch-operation vocabulary explicitly extensible or include every built-in verb, including `run`, and publish the intended registry and adapter exports from one canonical namespace. | S | (filled at issue-open time) |
+| 3 | Document the session ownership of the named-operation registry in its type and public API, preserving built-in precedence and asynchronous registration checks. | S | (filled at issue-open time) |
+| 4 | Represent lifecycle ownership for API turns, CLI streams, and nested operations in an explicit internal contract and add tests that prevent duplicate start or terminal signals. | M | (filled at issue-open time) |
+
+## Notes
+
+A single transport primitive was rejected because one-shot API calls and cancellation-sensitive CLI
+streams have different cleanup and message-order obligations. Making every verb a `Middle` was also
+rejected because parsing, action execution, and interpretation are not persisted model exchanges.

--- a/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
+++ b/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
@@ -1,0 +1,103 @@
+# ADR-0022: Composed branch operation pipeline
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: operations
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0021
+
+## Context
+
+`Branch.operate()` is the composed operation entry point. Its preparer turns public arguments into
+`ChatParam` or `RunParam`, optional `ParseParam`, and optional `ActionParam`. A CLI model or a request
+for stream persistence selects `RunParam`; action enablement carries an explicit concurrent or
+sequential strategy (`lionagi/session/branch.py`, `lionagi/operations/operate/operate.py`,
+`lionagi/operations/types.py`).
+
+Structured responses and actions require a response shape that differs between request and result.
+When a base model, additional fields, reasoning, or actions are requested, `operate()` constructs an
+internal `Operative`: action requests are exposed to the model, while action responses are excluded
+from the request schema and included in the response schema (`lionagi/operations/operate/step.py`,
+`lionagi/operations/schema/structure.py`).
+
+After one `Middle` invocation, the coordinator applies the caller's validation policy. It only
+executes tools when an `ActionParam` exists and the returned model or mapping contains
+`action_requests`. Execution uses the normal `act()` path, including authorization, hooks, event
+logging, message recording, and the selected execution strategy, then enriches the original result
+with `action_responses` (`lionagi/operations/operate/operate.py`,
+`lionagi/operations/act/act.py`).
+
+The current public contract contains accumulated seams. `skip_validation=True` returns immediately
+after the adapter and therefore also skips action execution. A caller-supplied `operative` is
+accepted but deliberately replaced with `None` by the preparer. `Structure` exists in parameter
+types and parsing internals but is not selectable through the composed branch façade.
+
+## Decision
+
+`operate()` remains the single coordinator that composes adapter selection, response-shape
+construction, validation policy, authorized action execution, and result enrichment.
+
+```text
+Caller
+  │
+  v
+Branch.operate ──> prepare parameters ──> choose or accept Middle
+                                             │
+                                             v
+                                     one adapter invocation
+                                             │
+                                  ┌──────────┴──────────┐
+                                  v                     v
+                           validation policy     early raw return
+                                  │               (skip_validation)
+                                  v
+                        action_requests present?
+                                  │ yes
+                                  v
+                     authorize + hooks + act + record
+                                  │
+                                  v
+                         enrich original result
+```
+
+The load-bearing invariants are:
+
+- Unless the caller supplies a `Middle`, `RunParam` or a CLI model selects `run_and_collect`; all
+  other calls select `communicate`.
+- When an `ActionParam` exists, `operate()` obtains the selected branch tool schemas and publishes
+  them to the adapter. The generated request model excludes `action_responses`, and its response
+  model includes them.
+- The selected `Middle` is invoked exactly once by `operate()`. The adapter owns message persistence
+  and may internally stream or loop under ADR-0021.
+- `skip_validation=True` is a raw-result short circuit. It bypasses outer type enforcement and the
+  entire outer action phase.
+- Tool execution requires both explicit action enablement and structured `action_requests`; arbitrary
+  text does not trigger an action. All accepted requests go through `act()` rather than a transport-
+  specific tool path.
+- `handle_validation` governs a returned value that is not an instance of the caller's requested
+  model: return the value, return `None`, or raise. Successful action responses augment rather than
+  replace the original structured result.
+
+## Consequences
+
+API and CLI adapters share one structured-output and tool-execution stack. Authorization and hooks
+remain effective for model-requested actions regardless of transport, and callers can inject a
+specialized adapter without duplicating response or action policy.
+
+The coordinator carries several responsibilities and depends on a generated response model that is
+not part of the public contract. The raw-result shortcut has broader effects than its name suggests,
+and currently accepted arguments can imply capabilities that the façade does not honor.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Deprecate and remove the ignored public `operative` argument, or define and implement a precedence rule that honors it while preserving generated request and response fields. | S | (filled at issue-open time) |
+| 2 | Expose `Structure` through the chosen public branch APIs and parameter builders, or mark it internal and remove it from public parameter types; add one end-to-end public-path test. | S | (filled at issue-open time) |
+| 3 | Split the raw-result shortcut into explicit validation and post-processing controls, or rename and document `skip_validation` so callers know that it also disables outer action execution. | S | (filled at issue-open time) |
+
+## Notes
+
+Separate API and CLI operation coordinators were rejected because they would duplicate structured
+validation and action policy. Moving outer action execution into every `Middle` was rejected because
+it would let adapters diverge from the common authorization, hook, logging, and enrichment path.

--- a/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
+++ b/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
@@ -1,0 +1,104 @@
+# ADR-0023: Dependency-aware operation-graph execution kernel
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: operations
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+Graph execution uses `Operation` as the executable node. An operation stores a branch-method or
+registered-operation name plus parameters, receives its branch immediately before invocation, and
+dispatches through `Branch.get_operation()`. `OperationGraphBuilder` constructs dependency,
+expansion, aggregation, and conditional graph shapes but does not execute them
+(`lionagi/operations/node.py`, `lionagi/operations/builder.py`).
+
+`Session.flow()` delegates a `Graph[Operation]` to `DependencyAwareExecutor`. The executor rejects
+cycles, validates edge conditions, preallocates branches, creates a completion event per operation,
+and starts operation coroutines under a capacity limiter. Explicitly assigned branches are reused;
+dependent or context-inheriting operations without one receive session-owned clones. Every terminal,
+failed, skipped, cancelled, or exceptional path releases its completion event
+(`lionagi/session/session.py`, `lionagi/operations/flow.py`).
+
+The executor injects predecessor results and shared flow context into operation parameters. A primary
+dependency may also supply inherited conversation messages. Successful response dictionaries with a
+`context` key are deep-merged into one shared context state. Parallel writes to the same key have no
+declared ordering or reducer and therefore resolve by completion timing (`lionagi/operations/flow.py`).
+
+`ReactiveExecutor` extends the same kernel. It observes spawn and escalation requests, schedules
+initial and injected nodes in one task group, synchronizes graph mutation, rejects cycles and
+duplicates, and enforces a spawn cap. `flow_stream()` yields a typed event per settled node through a
+memory channel, with an asyncio task driving the reactive executor. Checkpoint writing and graph
+reconstruction remain caller-owned and are not kernel capabilities (see the scheduling-control-plane
+ADR on flow checkpoint and resume semantics).
+
+## Decision
+
+`flow.py` is the execution kernel for operation graphs, not for every branch verb. Static dependency
+execution is the base contract; reactive graph growth is a constrained extension of that contract.
+
+```text
+OperationGraphBuilder ──> Graph[Operation]
+                               │
+                               v
+                  DependencyAwareExecutor
+                    │ dependency events
+                    │ branch allocation
+                    │ capacity + pause gate
+                    │ context materialization
+                    v
+                     Branch operation dispatch
+                               ^
+                               │ inherits execution semantics
+                       ReactiveExecutor
+                    spawn bus + guarded mutation
+```
+
+The load-bearing invariants are:
+
+- Execution requires an acyclic graph and valid edge-condition types. An `Operation` invokes only a
+  built-in or session-registered branch operation.
+- An explicit `branch_id` reuses that branch. Otherwise, dependent or context-inheriting nodes are
+  preallocated isolated clones; accepted reactive children receive clones when injected.
+- Dependencies are represented by per-node completion events. Every execution path sets its event,
+  so downstream waiters cannot hang solely because an upstream operation failed or was skipped.
+- The capacity limiter encloses preparation and invocation. A pause gate stops new operations at the
+  operation boundary without interrupting operations already past that boundary.
+- Predecessor results and the shared flow context state are passed as operation context. Conversation
+  inheritance is explicit metadata and follows one primary dependency.
+- Reactive injection is synchronized, capped, and cycle-checked. Dependent spawns receive an edge
+  from their emitter; independent spawns do not. Bus delivery and returned-request scanning are
+  de-duplicated by request identity.
+- Pre-marked terminal nodes may be short-circuited with restored responses, but persistence, topology
+  serialization, and branch-history reconstruction are outside the kernel.
+- The current `completed_operations` result contains every settled result except skipped nodes,
+  including failed operations. `FlowEvent.status` is the accurate completed/failed/skipped signal.
+
+## Consequences
+
+Static and reactive callers share dependency ordering, concurrency limits, pause behavior, branch
+isolation, context propagation, and operation dispatch. A fixed graph can resume from caller-restored
+terminal nodes without coupling the reusable kernel to a checkpoint format.
+
+The shared context state can be nondeterministic when parallel nodes write colliding keys. The result
+name can mislead consumers into reporting failures as successes. Reactive execution adds observer,
+mutation, streaming-driver, and branch-allocation paths to an already broad module, and its streaming
+surface is asyncio-specific.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Replace `completed_operations` with explicit completed, failed, and skipped collections, retaining a deprecated compatibility alias whose settled-not-skipped meaning is documented. | M | (filled at issue-open time) |
+| 2 | Define deterministic shared-context semantics by namespacing node outputs by default and requiring an explicit reducer for colliding shared keys; add parallel collision tests. | M | (filled at issue-open time) |
+| 3 | Pass `on_branch_created` into reactive execution and invoke it for every injected clone; add identical persistence-hook coverage for preallocated and spawned branches. | S | (filled at issue-open time) |
+| 4 | Extract reactive graph mutation and streaming-driver concerns behind internal collaborators while retaining one public executor contract; document the required async backend. | M | (filled at issue-open time) |
+| 5 | Specify durable reactive continuation with persisted spawned topology, parent edges, operation requests, branch reconstruction, context, and conversation-history policy; keep the current fail-closed refusal until all fields can be restored. | L | (filled at issue-open time) |
+
+## Notes
+
+A sequential traversal was rejected because it would discard independent-node concurrency. A second
+reactive scheduler was rejected because it would duplicate dependency, branch, pause, and context
+semantics. Checkpoint persistence inside the kernel was rejected because durability formats and
+degradation policy belong to callers rather than graph scheduling.

--- a/docs/adr/ADR-0024-lndl-operate-integration-adapter.md
+++ b/docs/adr/ADR-0024-lndl-operate-integration-adapter.md
@@ -1,0 +1,100 @@
+# ADR-0024: LNDL operate integration adapter
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: operations
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0087; extends ADR-0021 and ADR-0022
+
+## Context
+
+LNDL is integrated into operations as an opt-in `Middle`, exported from
+`lionagi.operations.lndl_middle`. It does not add a runtime or replace `operate()`; callers select it
+with `middle=lndl_middle`, and `build_lndl_middle()` creates the same adapter with a custom round
+budget. The default budget is three (`lionagi/operations/lndl_middle/__init__.py`,
+`lionagi/operations/lndl_middle/lndl_middle.py`).
+
+Each round reuses the normal API or CLI turn implementation. The first round injects the LNDL system
+prompt, a rendered target-model field specification, and caller guidance. Per-round native tool
+schemas and response-format rendering are removed because LNDL's assembler, rather than the provider
+transport, constructs and validates the target result.
+
+The adapter normalizes, lexes, parses, and assembles fenced LNDL blocks. Missing blocks or a missing
+`OUT{}` produce `Continue`; language errors produce `Retry`; and an assembled output produces a
+`Success` candidate. Retry notices are sent on the next round. Exhaustion raises `LNDLError`, while
+non-LNDL exceptions propagate rather than becoming a returned `Failed` value.
+
+The as-built action rule differs by round shape. With `OUT{}`, only action calls reachable from the
+assembled output execute. Without `OUT{}`, every declared action call executes before the next round,
+and its result is available by alias to later rounds. All calls are translated to ordinary branch
+action requests and use the concurrent, error-suppressed `act()` path, so authorization, hooks,
+logging, and message recording still apply. This eager continuation behavior conflicts with the
+prior record's statement that only `OUT{}`-referenced actions execute.
+
+## Decision
+
+The implemented LNDL behavior is a bounded-loop turn adapter under the contracts of ADR-0021 and
+ADR-0022. This record carries forward the as-built integration seam and replaces broader prior claims
+that are not enforced by the operations implementation.
+
+```text
+operate(middle=lndl_middle)
+          │
+          v
+  prompt + target specification
+          │
+          v
+ communicate or run_and_collect
+          │
+          v
+ normalize ─> lex ─> parse ─> assemble
+          │
+          ├── Retry/Continue ──> next round
+          └── Success ──> act pending calls ─> validate ─> return
+```
+
+The load-bearing invariants are:
+
+- LNDL is opt-in per `operate()` call. Non-LNDL callers and the default adapter-selection policy are
+  unchanged.
+- One LNDL adapter invocation may own several recorded inner exchanges, bounded by the configured
+  round budget. API models use `communicate`; CLI models and `RunParam` use `run_and_collect`.
+- Round-one guidance contains the LNDL prompt and, when available, the exact target-model field
+  names. Native provider tools and native response-format rendering are disabled for inner rounds.
+- Language failures are repairable retries. A valid assembled result is action-resolved and then
+  validated against the target model unless validation is skipped; budget exhaustion raises.
+- A continuation round with no `OUT{}` eagerly executes every valid declared action. A success round
+  executes only actions reachable through its assembled output. Cross-round action results are kept
+  by alias for the duration of the adapter invocation.
+- LNDL actions go through `act()` and therefore do not bypass branch authorization or hooks. Tool
+  failures are returned as action results so a later round can repair or adapt.
+
+## Consequences
+
+LNDL can reuse the established transport, message, validation, and tool-governance paths, and callers
+can choose it without affecting ordinary operations. The target model is made explicit to the prompt
+even though native structured-output rendering is disabled.
+
+One logical operation may incur several provider exchanges and action rounds. The eager continuation
+rule can cause a tool side effect before any `OUT{}` commits it. The adapter uses only
+`Continue`/`Retry`/`Success` values directly, so the package's broader round-outcome vocabulary does
+not describe the externally observed exhaustion and unexpected-failure behavior precisely.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Choose one LNDL action-commit rule for no-`OUT{}` rounds, then align the system prompt, adapter, architecture record, and tests so eager continuation actions or output-gated actions are stated consistently. | M | (filled at issue-open time) |
+| 2 | Decide whether `note.X` is supported across adapter rounds; either thread and test bounded scratchpad state or remove the cross-round promise from the prompt and public language surface. | M | (filled at issue-open time) |
+| 3 | Align the adapter's public failure contract with the round-outcome vocabulary by defining whether exhaustion and unexpected failures are typed outcomes or raised exceptions, and add end-to-end tests for the chosen policy. | S | (filled at issue-open time) |
+
+## Notes
+
+A dedicated LNDL runtime was rejected because it would duplicate branch transport, validation, and
+action governance. Direct invocation of the action manager was rejected because it would bypass the
+normal authorization and hook path. The alternative output-gated continuation rule remains viable,
+but adopting it is a behavioral change and requires the explicit resolution captured in the delta.
+
+Language-package cleanup, action-registry expansion, and quantitative measurement policy are not
+asserted as implemented operation behavior by this retrospective record; each requires a separate
+current decision if it remains desired.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,4 +44,25 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   invariants
 - 0005 — unused (intentional gap)
 
+### messages-context (0006-0010)
+
+- [ADR-0006](ADR-0006-conversational-message-envelope-and-ordered-history.md) — Conversational
+  message envelope and ordered history
+- [ADR-0007](ADR-0007-canonical-turn-request-compilation-boundary.md) — Canonical turn-request
+  compilation boundary
+- [ADR-0008](ADR-0008-pre-turn-context-provider-execution-and-attribution.md) — Pre-turn
+  context-provider execution and attribution
+- 0009-0010 — unused (intentional gaps)
+
+### operations (0021-0026)
+
+- [ADR-0021](ADR-0021-branch-operation-facade-and-turn-adapters.md) — Branch operation facade
+  and turn adapters
+- [ADR-0022](ADR-0022-composed-branch-operation-pipeline.md) — Composed branch operation
+  pipeline
+- [ADR-0023](ADR-0023-dependency-aware-operation-graph-execution-kernel.md) — Dependency-aware
+  operation graph execution kernel
+- [ADR-0024](ADR-0024-lndl-operate-integration-adapter.md) — LNDL operate integration adapter
+- 0025-0026 — unused (intentional gaps)
+
 Remaining areas land here as their records are accepted.


### PR DESCRIPTION
Second bundle of the canonical ADR corpus (follows #1943).

## Contents

**messages-context (0006-0010 block, 3 records)**
- ADR-0006 — conversational message envelope and ordered history
- ADR-0007 — canonical turn-request compilation boundary
- ADR-0008 — pre-turn context-provider execution and attribution

**operations (0021-0026 block, 4 records)**
- ADR-0021 — Branch operation facade and turn-adapter contract
- ADR-0022 — composed branch operation pipeline
- ADR-0023 — dependency-aware operation-graph execution kernel
- ADR-0024 — LNDL operate integration adapter

Plus the README index entries for both areas. Unused numbers inside each block are intentional gaps per the corpus numbering scheme.

All factual code claims in these records were adversarially verified against live source before inclusion; both areas passed review with zero blocking findings. `dispositions.yaml` (the machine-readable v0 mapping) lands with the final bundle as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)