### PR TITLE
docs(adr): bundle 3 — actions-tools (0011-0013) + session-branch (0016-0018) + service-providers (0027-0030)

### DIFF
--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -1,0 +1,86 @@
+# ADR-0011: Function Tool Descriptor and Branch Registry
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: actions-tools
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+Model providers need a portable function schema, while local execution needs a Python
+callable and optional processing behavior. `Tool` keeps those concerns in one `Element`:
+the callable and processors remain live Python objects excluded from serialization, while
+the generated function schema and derived function name are serializable. Arbitrary
+deserialization is deliberately unsupported because a serialized record cannot recreate
+the callable (`lionagi/protocols/action/tool.py`).
+
+Supplying a Pydantic request model through `request_options` is the practical schema and
+validation contract used by the built-in tools. Without one, `function_to_schema()` is a
+convenience adapter: it recognizes a small set of primitive annotations and advertises
+every signature parameter as required. At invocation, non-strict validation instead
+requires only signature parameters without defaults, while strict validation compares the
+argument-key set with the schema's `required` set. Provider schema, strict validation, and
+Python default semantics therefore do not agree for every raw callable
+(`lionagi/libs/schema/function_to_schema.py`,
+`lionagi/protocols/action/function_calling.py`).
+
+Each `Branch` owns an `ActionManager` whose registry maps a branch-visible function name to
+one `Tool`. Registration accepts a `Tool`, a raw callable, or a one-entry MCP configuration;
+duplicate names require `update=True`. The manager resolves action requests, exposes
+provider schemas, and can invoke the resulting event. This makes tool availability local
+to a branch even when the underlying callable is reusable (`lionagi/protocols/action/manager.py`,
+`lionagi/session/branch.py`).
+
+MCP loading is also implemented in this registry layer. `Tool` and `ActionManager` lazily
+import the MCP service adapter, discovery copies a server's input schema into a regular
+function schema, and discovered tools are stored under their unqualified remote names.
+The service connection pool is fail-closed when used directly, but the manager's config
+loaders treat an explicitly loaded config as trusted for command and URL transports when
+no policy is supplied (`lionagi/protocols/action/manager.py`,
+`lionagi/service/connections/mcp_wrapper.py`).
+
+## Decision
+
+The current tool declaration contract has these load-bearing invariants:
+
+- `Tool` is a callable descriptor, not a restorable executable artifact. Its callable and
+  processors are excluded from serialization; its schema and function name are retained.
+- A Pydantic `request_options` model is the supported path for typed input schema,
+  normalization, and validation. Raw signature derivation is a limited keyword-callable
+  convenience and currently marks all parameters as provider-required.
+- `ActionManager` is the branch-local name registry and schema resolver. A registered
+  function name is unique within that manager unless replacement is explicit.
+- MCP tools are normalized into ordinary `Tool` descriptors, but discovery, transport
+  trust defaults, and connection-pool access currently remain responsibilities of the
+  protocol registry rather than a service-owned factory.
+- Invocation lifecycle and branch transaction semantics are defined separately in
+  ADR-0012.
+
+## Consequences
+
+Provider-facing schemas and Python callables share a small, reusable descriptor, and
+branches can expose different tool sets without changing the callables themselves.
+Pydantic-backed tools receive rich schemas and normalized keyword arguments with little
+adapter code.
+
+Raw callable registration is easy but can advertise a contract different from runtime
+behavior. Custom or remote schemas that omit `required` can fail because
+`Tool.required_fields` assumes the key exists. Registry code also knows about MCP config,
+transport policy, discovery, and process-global pooling, creating an upward dependency
+from a foundational protocol package into the service layer. Unqualified remote names can
+collide within a branch registry.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Version and narrow raw-callable schema derivation so Python defaults remain optional, unsupported positional-only and variadic signatures require an explicit adapter, schemas without `required` are accepted, and tests prove provider schema and runtime validation agree. | M | (filled at issue-open time) |
+| 2 | Move MCP configuration, discovery, namespacing, and pool lifecycle into a service-owned factory that returns ready `Tool` descriptors; acceptance requires `protocols.action` to have no service-layer import and remote identities to be collision-free. | M | (filled at issue-open time) |
+| 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | (filled at issue-open time) |
+
+## Notes
+
+Correcting the all-parameters-required schema is a compatibility change because existing
+tests and provider payloads preserve that behavior. It should not be shipped as an
+unversioned cleanup.

--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -8,79 +8,596 @@
 
 ## Context
 
-Model providers need a portable function schema, while local execution needs a Python
-callable and optional processing behavior. `Tool` keeps those concerns in one `Element`:
-the callable and processors remain live Python objects excluded from serialization, while
-the generated function schema and derived function name are serializable. Arbitrary
-deserialization is deliberately unsupported because a serialized record cannot recreate
-the callable (`lionagi/protocols/action/tool.py`).
+LionAGI presents Python callables to model providers as function schemas and later
+executes provider-selected calls locally. Four concrete problems shaped the shipped
+tool layer.
 
-Supplying a Pydantic request model through `request_options` is the practical schema and
-validation contract used by the built-in tools. Without one, `function_to_schema()` is a
-convenience adapter: it recognizes a small set of primitive annotations and advertises
-every signature parameter as required. At invocation, non-strict validation instead
-requires only signature parameters without defaults, while strict validation compares the
-argument-key set with the schema's `required` set. Provider schema, strict validation, and
-Python default semantics therefore do not agree for every raw callable
-(`lionagi/libs/schema/function_to_schema.py`,
+**P1 — A provider descriptor and a Python executable have different persistence
+properties.** A provider needs a JSON-compatible function name, description, and
+parameter schema. Local execution needs a live callable plus optional pre- and
+postprocessors. Python callables and closures cannot be reconstructed safely from a
+serialized record, so treating a tool as a restorable data object would promise more
+than the runtime can deliver (`lionagi/protocols/action/tool.py`;
+`lionagi/protocols/generic/element.py`).
+
+**P2 — Python signatures, provider schemas, and invocation validation are three
+distinct contracts.** A Pydantic request model supplies the practical typed path used
+by built-ins: its JSON Schema is advertised and its constructor normalizes arguments.
+Without one, `function_to_schema()` recognizes only a small primitive annotation map
+and advertises every signature parameter as required, including parameters with Python
+defaults. At invocation, non-strict validation requires only signature parameters that
+have no defaults, while strict validation compares the argument-key set with the
+schema's `required` set. The three views therefore diverge for some raw callables
+(`lionagi/libs/schema/function_to_schema.py`;
 `lionagi/protocols/action/function_calling.py`).
 
-Each `Branch` owns an `ActionManager` whose registry maps a branch-visible function name to
-one `Tool`. Registration accepts a `Tool`, a raw callable, or a one-entry MCP configuration;
-duplicate names require `update=True`. The manager resolves action requests, exposes
-provider schemas, and can invoke the resulting event. This makes tool availability local
-to a branch even when the underlying callable is reusable (`lionagi/protocols/action/manager.py`,
-`lionagi/session/branch.py`).
+**P3 — Tool visibility is conversation-local.** Different branches can expose
+different subsets of the same reusable Python callables. A branch consequently needs a
+name-indexed registry that owns its provider schema list, resolves an action request,
+and constructs the invocation event without making tools process-global
+(`lionagi/protocols/action/manager.py`; `lionagi/session/branch.py`).
 
-MCP loading is also implemented in this registry layer. `Tool` and `ActionManager` lazily
-import the MCP service adapter, discovery copies a server's input schema into a regular
-function schema, and discovered tools are stored under their unqualified remote names.
-The service connection pool is fail-closed when used directly, but the manager's config
-loaders treat an explicitly loaded config as trusted for command and URL transports when
-no policy is supplied (`lionagi/protocols/action/manager.py`,
+**P4 — Remote MCP tools must look ordinary after discovery, but their transport is
+not ordinary.** The registry currently accepts a one-entry MCP configuration, discovers
+remote schemas, builds a local async proxy, remembers transport policy, and reaches a
+process-global client pool. Direct pool use is fail-closed for command and URL
+transports. The two explicit config-loading helpers instead install a per-load policy
+with both transport classes allowed when the caller omits a policy. Discovered tools
+use the remote tool's unqualified name in the branch registry, so remote servers can
+collide with each other or with local tools (`lionagi/protocols/action/manager.py`;
 `lionagi/service/connections/mcp_wrapper.py`).
+
+| Concern | Decision |
+|---|---|
+| Executable descriptor | D1: `Tool` combines a serializable provider schema with excluded live callables and is intentionally not deserializable. |
+| Input contract | D2: Pydantic `request_options` is the typed path; raw signature derivation and strict/non-strict validation retain their shipped, non-equivalent semantics. |
+| Branch visibility | D3: each `Branch` owns an `ActionManager` keyed by provider-visible function name. |
+| Remote normalization | D4: the action registry normalizes MCP discoveries into ordinary `Tool` values while using the service-owned process-global connection pool. |
+
+This ADR does **not** decide:
+
+- Invocation, authorization, hooks, event status, or history ordering; those are the
+  execution transaction recorded in ADR-0012.
+- How built-in providers obtain branch context or behave when a branch is cloned; that
+  construction boundary is recorded in ADR-0013.
+- Provider-specific outer request envelopes. This ADR fixes the portable function
+  object stored in `tool_schema`, not each model service's surrounding payload.
+- Session-level governance policy. The registry resolves names; the normal branch
+  execution path decides whether a resolved call is authorized.
 
 ## Decision
 
-The current tool declaration contract has these load-bearing invariants:
+### D1 — `Tool` is a live callable descriptor, not a restorable executable
 
-- `Tool` is a callable descriptor, not a restorable executable artifact. Its callable and
-  processors are excluded from serialization; its schema and function name are retained.
-- A Pydantic `request_options` model is the supported path for typed input schema,
-  normalization, and validation. Raw signature derivation is a limited keyword-callable
-  convenience and currently marks all parameters as provider-required.
-- `ActionManager` is the branch-local name registry and schema resolver. A registered
-  function name is unique within that manager unless replacement is explicit.
-- MCP tools are normalized into ordinary `Tool` descriptors, but discovery, transport
-  trust defaults, and connection-pool access currently remain responsibilities of the
-  protocol registry rather than a service-owned factory.
-- Invocation lifecycle and branch transaction semantics are defined separately in
-  ADR-0012.
+`Tool` is a Pydantic `Element`. Its shipped field contract is:
+
+```python
+# lionagi/protocols/action/tool.py
+class Tool(Element):
+    func_callable: Callable[..., Any] = Field(..., exclude=True)
+    mcp_config: dict[str, dict[str, Any]] | None = None
+    tool_schema: dict[str, Any] | None = None
+    request_options: type | None = None
+    preprocessor: Callable[[Any], Any] | None = Field(None, exclude=True)
+    preprocessor_kwargs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    postprocessor: Callable[[Any], Any] | None = Field(None, exclude=True)
+    postprocessor_kwargs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    strict_func_call: bool = False
+
+    @property
+    def function(self) -> str: ...
+
+    @property
+    def required_fields(self) -> set[str]: ...
+
+    @property
+    def minimum_acceptable_fields(self) -> set[str]: ...
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]): ...
+
+    def to_dict(
+        self,
+        mode: Literal["python", "json", "db"] = "python",
+        **kw,
+    ) -> dict[str, Any]: ...
+```
+
+The inherited `Element` fields are `id: UUID`, `created_at: float`, and
+`metadata: dict`; `Element` forbids unknown fields and permits arbitrary Python types
+(`lionagi/protocols/generic/element.py`). `Tool.to_dict()` delegates to that element
+serialization and adds a derived top-level `function` string. The callable,
+preprocessor, postprocessor, and both processor-kwargs dictionaries are excluded by
+their fields. `tool_schema`, `mcp_config`, `request_options`, and
+`strict_func_call` remain model fields; the live execution object is not recreated from
+them.
+
+The public reference aliases retain the accepted input vocabulary:
+
+```python
+FuncTool: TypeAlias = Tool | Callable[..., Any] | dict
+FuncToolRef: TypeAlias = FuncTool | str
+ToolRef: TypeAlias = FuncToolRef | list[FuncToolRef] | bool
+```
+
+**Exact semantics**
+
+- **Local construction:** with no `mcp_config`, the before-validator requires a
+  callable with a usable name. A non-callable is rejected during model validation.
+- **MCP construction:** `mcp_config` and `func_callable` are mutually exclusive.
+  `mcp_config` must be a dictionary with exactly one entry. Its key becomes the proxy
+  callable's name; its value is passed to `create_mcp_tool()`.
+- **Missing schema:** when `tool_schema is None`, the after-validator calls
+  `function_to_schema(func_callable, request_options=request_options)` exactly once at
+  construction.
+- **Supplied schema:** a caller-provided schema is retained without a second schema
+  normalization pass. Later properties assume the OpenAI-style
+  `tool_schema["function"]` shape.
+- **Function identity:** `Tool.function` is
+  `tool_schema["function"]["name"]`; registry identity follows the schema name, not
+  necessarily `func_callable.__name__` when a custom schema is supplied.
+- **Serialization:** `to_dict()` retains descriptor data and adds `function`; excluded
+  callables and processors do not appear. Serialization is a record of the declaration,
+  not an executable snapshot. `mcp_config` is not redacted, so configured environment or
+  transport values remain in the record and must be handled as configuration-sensitive
+  data.
+- **Deserialization:** `Tool.from_dict(...)` always raises `NotImplementedError`.
+  Arbitrary data cannot recreate the callable or its closure.
+- **Mutation:** `Tool` is not frozen. Factory code can attach processors after
+  construction, and a registry holds the same object by reference.
+
+**Why this way**
+
+One object keeps the provider declaration adjacent to the exact callable it describes,
+which makes local registration and schema lookup small. Excluding live objects avoids
+pretending closures are portable. The cost is that serialized tool data is diagnostic or
+presentational only; restoring executable behavior always requires code-driven
+construction.
+
+### D2 — Pydantic request models are the typed contract; raw derivation is limited
+
+The schema adapter is Python-native and emits an OpenAI-format function object:
+
+```python
+# lionagi/libs/schema/function_to_schema.py
+class FunctionSchema(SchemaModel):
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] | None = Field(
+        None,
+        validation_alias="request_options",
+    )
+    strict: bool | None = None
+
+def function_to_schema(
+    f_,
+    style: Literal["google", "rest"] = "google",
+    *,
+    request_options: dict[str, Any] | None = None,
+    strict: bool = None,
+    func_description: str = None,
+    parametert_description: dict[str, str] = None,
+    return_obj: bool = False,
+) -> dict: ...
+```
+
+For the request-model path, the `FunctionSchema.parameters` validator converts a
+Pydantic model type with `model_json_schema()`. Built-in tools pass model classes such
+as `ReaderRequest` and `BashRequest`, even though the helper's annotation says
+`dict[str, Any] | None`; runtime validation accepts the model type.
+
+The resulting provider payload has this shape:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "callable_name",
+    "description": "docstring-derived or supplied text",
+    "parameters": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  }
+}
+```
+
+When `strict` is truthy, `function_to_schema()` also adds
+`function.strict`. That provider-schema flag is distinct from
+`Tool.strict_func_call`, which controls LionAGI's local key-set check.
+
+Invocation normalization occurs when a `FunctionCalling` is constructed:
+
+```python
+# lionagi/protocols/action/function_calling.py
+class FunctionCalling(Event):
+    func_tool: Tool = Field(..., exclude=True)
+    arguments: dict[str, Any] | BaseModel
+
+    # before validation: BaseModel -> model_dump(exclude_unset=True)
+    # after validation:
+    #   request_options(**arguments) -> model_dump(exclude_unset=True)
+    #   strict=True  -> keys(arguments) == tool.required_fields
+    #   strict=False -> minimum_acceptable_fields <= keys(arguments)
+```
+
+**Exact semantics**
+
+- **Pydantic path:** `request_options(**arguments)` performs the request model's
+  coercion, constraints, defaults, and extra-field policy. The normalized arguments are
+  dumped with `exclude_unset=True`, so a model default not supplied by the caller is not
+  automatically forwarded to the Python function.
+- **Empty request-options value:** `function_to_schema()` tests `request_options` by
+  truthiness. `None` and an empty dictionary both select raw signature derivation; a
+  Pydantic model type selects the typed path.
+- **Raw schema types:** without `request_options`, only `str`, `int`, `float`, `list`,
+  `tuple`, `bool`, and `dict` have an explicit Python-to-JSON map. Both `int` and
+  `float` map to JSON Schema `number`. An unannotated parameter defaults to `string`;
+  other annotations contribute their `__name__` as the schema type.
+- **Raw required set:** every signature parameter is appended to provider
+  `required`, whether or not the Python signature gives it a default. Positional-only,
+  `*args`, and `**kwargs` are not represented specially.
+- **Non-strict local check:** the minimum set is computed with
+  `inspect.signature()` from parameters having no default, then parameters literally
+  named `kw`, `kwargs`, or `args` are removed. Empty arguments are accepted when all
+  ordinary parameters have Python defaults. Extra keys pass this set check and can fail
+  later when expanded as `func_callable(**arguments)`.
+- **Signature-inspection failure:** raw schema construction propagates an
+  `inspect.signature()` failure unless the caller supplies `tool_schema`. During later
+  non-strict validation, `minimum_acceptable_fields` catches inspection failure and
+  returns an empty set, so the key-presence check accepts any argument dictionary and
+  leaves failure to callable invocation.
+- **Strict local check:** the normalized argument keys must equal the schema's
+  `required` set exactly. Missing required keys and supplied optional keys both fail.
+  A schema without a `required` key can raise `KeyError` through
+  `Tool.required_fields`.
+- **Validation failure:** request-model construction or either key-set check raises
+  before the callable starts. The higher execution layer decides whether that exception
+  becomes a response or propagates (ADR-0012).
+- **Callable invocation:** all arguments are eventually expanded as keyword arguments.
+  Positional-only parameters and `*args` therefore require an explicit adapter even if
+  schema generation succeeds. A raw `**kwargs` callable can execute in non-strict mode,
+  but derivation advertises one required `kwargs` string property rather than the open
+  keyword object the callable accepts; provider-correct use therefore needs an explicit
+  schema or request model.
+
+**Why this way**
+
+Pydantic provides one artifact for provider schema, coercion, and field constraints, so
+it is the reliable path for maintained tools. Raw derivation keeps simple keyword
+callables convenient. The shipped raw behavior was retained because tests and existing
+provider payloads assert that even defaulted parameters are advertised as required; a
+correction is a compatibility change, not a formatting cleanup.
+
+### D3 — `ActionManager` is the branch-local name registry and resolver
+
+The manager's public contract is:
+
+```python
+# lionagi/protocols/action/manager.py
+class ActionManager(Manager):
+    def __init__(self, *args: FuncTool, **kwargs) -> None: ...
+    def __contains__(self, tool: FuncToolRef) -> bool: ...
+    def register_tool(self, tool: FuncTool, update: bool = False) -> None: ...
+    def register_tools(
+        self,
+        tools: list[FuncTool] | FuncTool,
+        update: bool = False,
+    ) -> None: ...
+    def match_tool(
+        self,
+        action_request: ActionRequest | BaseModel | dict,
+    ) -> FunctionCalling: ...
+    async def invoke(
+        self,
+        func_call: BaseModel | ActionRequest,
+    ) -> FunctionCalling: ...
+
+    @property
+    def schema_list(self) -> list[dict[str, Any]]: ...
+
+    def get_tool_schema(
+        self,
+        tools: ToolRef = False,
+        auto_register: bool = True,
+        update: bool = False,
+    ) -> dict: ...
+```
+
+Its concrete store is `registry: dict[str, Tool]`. Every `Branch` constructs a new
+empty manager, registers its constructor-supplied tools into that manager, and exposes
+the same object as `branch.acts`; `branch.tools` exposes the registry dictionary
+(`lionagi/session/branch.py`).
+
+**Exact semantics**
+
+- **Constructor input:** positional arguments and keyword values are flattened with
+  `to_list(..., dropna=True, flatten=True)` and registered with `update=True`.
+- **Callable registration:** a raw callable becomes `Tool(func_callable=callable)`.
+- **Descriptor registration:** a `Tool` is stored as-is under `tool.function`.
+- **MCP dictionary registration:** a dictionary becomes `Tool(mcp_config=dict)` and
+  must therefore contain exactly one entry.
+- **Unsupported registration:** any other value raises `TypeError`.
+- **Duplicate local name:** for a `Tool`, callable, or string membership check, an
+  existing name raises `ValueError` unless `update=True`; with update, the registry
+  entry is replaced.
+- **Dictionary duplicate edge:** `ActionManager.__contains__` has no dictionary arm.
+  A second one-entry MCP dictionary with the same derived name therefore bypasses the
+  pre-conversion duplicate check and overwrites the entry even when `update=False`.
+- **Request matching:** dictionaries must contain `function` and `arguments` keys.
+  `ActionRequest` and other Pydantic models are read through attributes. Unsupported
+  envelope types raise `TypeError`; an absent registry name raises `ValueError`.
+- **Resolution result:** a successful match returns an uninvoked
+  `FunctionCalling(func_tool=tool, arguments=args)`.
+- **Manager invocation:** `invoke()` matches, awaits `FunctionCalling.invoke()`, and
+  returns the event regardless of its terminal status. It does not raise an ordinary
+  callable exception captured by `Event.invoke()`.
+- **Schema selection:** `get_tool_schema(True)` returns
+  `{"tools": schema_list}`; `False` returns the empty list `[]`. A specific registered
+  name or descriptor returns `{"tools": schema}`. A list returns
+  `{"tools": [schema, ...]}`. A one-item list or tuple is collapsed first.
+- **Empty selection:** `get_tool_schema([])` is distinct from `False` and returns
+  `{"tools": []}`. Constructing an empty manager likewise produces an empty registry and
+  empty `schema_list`.
+- **Auto-registration:** requesting the schema for an unregistered raw callable
+  registers it when `auto_register=True`; otherwise it raises. A dictionary supplied to
+  schema selection is returned directly and is not registered.
+- **Schema references:** `schema_list` and specific lookups return the dictionaries held
+  by each `Tool`, not defensive copies. Mutating a returned schema mutates what that
+  manager will advertise on later calls.
+- **Ordering:** `schema_list` follows dictionary insertion order. Replacing an existing
+  key retains Python dictionary key position.
+- **Branch locality:** registering or replacing a tool affects that manager only. The
+  underlying `Tool` object can still be shared by reference across managers.
+
+**Why this way**
+
+The registry keeps branch-visible capability selection separate from callable
+definition. Function name is the provider's lookup key, so the same key naturally
+resolves the model request and provider schema. The design deliberately keeps
+`ActionManager` small, but MCP loading in D4 stretches it beyond pure registry duties.
+
+### D4 — MCP discoveries are normalized into ordinary tools in the registry layer
+
+The MCP-facing manager signatures are:
+
+```python
+async def ActionManager.register_mcp_server(
+    self,
+    server_config: dict[str, Any],
+    tool_names: list[str] | None = None,
+    request_options: dict[str, type] | None = None,
+    update: bool = False,
+    security: MCPSecurityConfig | None = None,
+) -> list[str]: ...
+
+async def ActionManager.load_mcp_config(
+    self,
+    config_path: str,
+    server_names: list[str] | None = None,
+    update: bool = False,
+    mcp_security: MCPSecurityConfig | None = None,
+) -> dict[str, list[str]]: ...
+
+async def load_mcp_tools(
+    config_path: str | None = None,
+    server_names: list[str] | None = None,
+    request_options_map: dict[str, dict[str, type]] | None = None,
+    update: bool = False,
+    mcp_security: MCPSecurityConfig | None = None,
+) -> list[Tool]: ...
+```
+
+The service-layer security dataclass and pool state are:
+
+```python
+# lionagi/service/connections/mcp_wrapper.py
+@dataclass(frozen=True)
+class MCPSecurityConfig:
+    allow_commands: bool = False
+    command_allowlist: frozenset[str] | None = None
+    allow_urls: bool = False
+    url_allowlist: frozenset[str] | None = None
+    env_denylist_patterns: frozenset[str] = <sensitive-name defaults>
+    filter_sensitive_env: bool = True
+    max_connections_per_server: int = 5
+
+class MCPConnectionPool:
+    _clients: dict[str, Any] = {}
+    _configs: dict[str, dict] = {}
+    _security: MCPSecurityConfig | None = None
+    _server_security: dict[str, MCPSecurityConfig] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        server_config: dict[str, Any],
+        security: MCPSecurityConfig | None = None,
+    ) -> Any: ...
+
+    @classmethod
+    async def cleanup(cls): ...
+```
+
+Auto-discovery projects the remote schema into the same descriptor form as a local
+tool:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "remote_tool_name",
+    "description": "remote description or null",
+    "parameters": { "...": "remote inputSchema copied verbatim" }
+  }
+}
+```
+
+**Exact semantics**
+
+- **Explicit tool names:** the manager creates a proxy without calling
+  `list_tools()`. `_original_tool_name` is placed in the config. If no request model or
+  schema is supplied, schema generation sees the proxy's `**kwargs` signature. This loop
+  has no per-tool exception isolation: the first construction or duplicate-registration
+  error aborts the method and later explicit names are not attempted.
+- **Request-model lookup:** before either explicit registration or discovery, the
+  manager mutates each `request_options` key that does not start with
+  `"<server_name>_"` by adding that prefix. It later looks up the model by the actual
+  `tool_name`/`tool.name`, without applying the same prefix. An ordinary unqualified
+  remote name therefore misses an unqualified caller mapping after it is renamed. A
+  mapping attaches only when the remote name already equals the retained or rewritten
+  key; the manager performs no alias reconciliation.
+- **Discovery:** with no `tool_names`, the manager obtains a pooled client, awaits
+  `client.list_tools()`, and creates one `Tool` per returned item. A dictionary
+  `inputSchema` is copied verbatim into `function.parameters`. Client acquisition or
+  `list_tools()` failure occurs before the per-tool loop and propagates from
+  `register_mcp_server()`.
+- **Discovery degradation:** an exception while reading one remote schema logs a warning
+  and falls back to proxy signature derivation. An absent, `None`, or non-dictionary
+  `inputSchema` falls back without that warning. Failure to construct or register one
+  tool logs a warning and continues discovering siblings.
+- **Names:** discovered descriptors are registered under `tool.name`, unqualified by
+  server. `_original_tool_name` preserves the remote call target but does not prevent a
+  registry collision.
+- **Proxy call:** the proxy removes underscore-prefixed metadata before acquiring the
+  client, then calls `client.call_tool(actual_tool_name, kwargs)`.
+- **Proxy response:** a single text content item is unwrapped to its text; other
+  `result.content` values are returned as content; a one-item list containing a text
+  dictionary is also unwrapped; all other results pass through.
+- **Direct pool trust:** command and URL transports are denied by default. Commands
+  require `allow_commands=True`; an allowlist, when present, accepts bare command names
+  only. URLs require `allow_urls=True`, an `https` or `wss` scheme, and an optional host
+  allowlist.
+- **Loader trust:** `load_mcp_config()` and top-level `load_mcp_tools()` replace an
+  omitted policy with `MCPSecurityConfig(allow_commands=True, allow_urls=True)`. That
+  per-load policy is threaded to registration without mutating the process-global
+  default. A transport `PermissionError` is logged and re-raised; other server failures
+  become an empty registered-name list or a warning.
+- **Loader input failure:** config-file existence, JSON shape, and parsing errors occur
+  before the per-server recovery loop and propagate. Top-level `load_mcp_tools()` also
+  raises `ValueError` when neither `server_names` nor a config path supplies a server
+  set.
+- **Policy reuse:** an explicit policy is remembered under a content-derived server key,
+  allowing the proxy's later `get_client()` call to recover the same authorization.
+- **Pool identity:** named configs use `server:<name>` and therefore reuse a connected
+  client by server name. Inline configs use the command plus the Python dictionary's
+  object identity, so reuse occurs only when the same dictionary object is passed again;
+  the MCP proxy creates a fresh metadata-stripped dictionary for each call and has no
+  stable inline reuse key. A disconnected cached client is dropped, and `cleanup()`
+  attempts every client exit before clearing the map.
+- **Environment:** command transport starts with the parent environment plus configured
+  values, removes variables whose names contain sensitive patterns by default, and adds
+  quiet logging defaults unless debug mode is active.
+- **Declared connection cap:** `max_connections_per_server` defaults to `5`, but the
+  current pool stores one client per cache key and never reads that field. The value is
+  inherited configuration with no enforced budget or recorded rationale in this path.
+
+**Why this way**
+
+Normalizing remote calls to `Tool` lets every downstream resolver and provider-schema
+path ignore transport. Lazy imports keep the foundational action modules importable
+without FastMCP installed. The tradeoff is architectural: the protocol registry knows
+about service configuration, transport trust, discovery, and global pool lifecycle, and
+unqualified names make collision handling a branch-registration concern.
 
 ## Consequences
 
-Provider-facing schemas and Python callables share a small, reusable descriptor, and
-branches can expose different tool sets without changing the callables themselves.
-Pydantic-backed tools receive rich schemas and normalized keyword arguments with little
-adapter code.
-
-Raw callable registration is easy but can advertise a contract different from runtime
-behavior. Custom or remote schemas that omit `required` can fail because
-`Tool.required_fields` assumes the key exists. Registry code also knows about MCP config,
-transport policy, discovery, and process-global pooling, creating an upward dependency
-from a foundational protocol package into the service layer. Unqualified remote names can
-collide within a branch registry.
+- Local and remote callables share one provider descriptor and one branch resolver.
+- Excluding executable objects does not make a serialized descriptor public-safe:
+  `mcp_config` remains visible and may carry transport or environment configuration.
+- Branches can expose different tool sets while reusing descriptor objects and
+  callables.
+- Pydantic-backed tools get provider schema, normalization, constraints, and keyword
+  payloads from one request model.
+- Raw callable registration is concise, but provider-required keys can disagree with
+  Python defaults and non-strict runtime validation.
+- Custom schemas that omit `required` remain usable until strict validation asks
+  `Tool.required_fields`; that access can fail with `KeyError`.
+- Registry lookup is deterministic by function name, but MCP dictionary registration
+  has a duplicate-check hole and remote unqualified names can collide.
+- MCP per-tool request-model selection is key-fragile: the manager can rename a caller's
+  mapping key and then miss it, silently falling back to the proxy's raw `**kwargs`
+  schema rather than the intended typed model.
+- Reversing D1 requires a new code-address or factory identity contract; serialized
+  callables cannot be made restorable by changing `from_dict()` alone.
+- Reversing D3 requires changing the provider-selection boundary because Branch,
+  `operate()`, and model request construction consume manager-local schema sets.
+- Contributors adding a maintained tool must decide whether it is a raw convenience
+  callable or publish a Pydantic request model; only the latter aligns the advertised
+  and normalized contracts reliably.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Version and narrow raw-callable schema derivation so Python defaults remain optional, unsupported positional-only and variadic signatures require an explicit adapter, schemas without `required` are accepted, and tests prove provider schema and runtime validation agree. | M | (filled at issue-open time) |
-| 2 | Move MCP configuration, discovery, namespacing, and pool lifecycle into a service-owned factory that returns ready `Tool` descriptors; acceptance requires `protocols.action` to have no service-layer import and remote identities to be collision-free. | M | (filled at issue-open time) |
+| 1 | Version and narrow raw-callable schema derivation so Python defaults remain optional, positional-only and `*args` signatures require an explicit adapter, open `**kwargs` callables require an explicit schema, schemas without `required` are accepted, and tests prove provider schema and runtime validation agree. | M | (filled at issue-open time) |
+| 2 | Move MCP configuration, discovery, namespacing, and pool lifecycle into a service-owned factory that returns ready `Tool` descriptors; acceptance requires `protocols.action` to have no service-layer import, remote identities to be collision-free, and per-tool request models to resolve by that canonical identity without key mutation or silent fallback. | M | (filled at issue-open time) |
 | 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A. Serialize and restore arbitrary callables
+
+This would have made `Tool` a conventional persisted `Element` and allowed branch state
+to reconstruct tools from data alone. It lost because closures, bound methods, imported
+code versions, and security-sensitive execution context have no stable data-only
+representation. The shipped `from_dict()` rejection makes the limitation explicit.
+
+### B. Split declaration and executable into unrelated objects
+
+A pure `FunctionSchema` registry plus a separate callable map would make the persistence
+boundary cleaner. It lost for the local-first implementation because every registration,
+replacement, and invocation would need to keep two name-indexed stores synchronized.
+`Tool` instead keeps the schema adjacent to the callable while excluding live fields
+from serialization.
+
+### C. Require Pydantic request models for every tool
+
+This would eliminate the raw schema/default mismatch and give every tool a rich
+validation contract. It lost because registration of small ordinary callables is a core
+convenience and existing tests rely on it. The system adopted Pydantic as the maintained
+built-in path without removing the raw adapter.
+
+### D. Treat Python signature inspection as the only contract
+
+This would avoid request-model duplication and derive provider schema and validation
+from a callable alone. It lost because Python annotations do not express the same
+constraints, descriptions, discriminated choices, and JSON Schema details as Pydantic
+models, and positional or variadic signatures do not map cleanly to provider keyword
+calls.
+
+### E. Use a process-global tool registry
+
+A global catalog would reduce per-branch setup and avoid copying registry entries. It
+lost because model-visible capability selection is branch-specific; a shared global map
+would make isolation and per-branch replacement indirect policy rather than explicit
+state.
+
+### F. Qualify every MCP name as `server.tool`
+
+Qualification would prevent remote/local collisions and preserve source identity in the
+registry. It lost in the shipped path because discovery copied server-provided schemas
+and names directly into the existing function interface. The collision cost is now
+recorded as a delta rather than hidden.
+
+### G. Keep all MCP construction in the connection service
+
+A service factory returning ready `Tool` descriptors would preserve the dependency
+direction and centralize transport policy and pool lifecycle. It was not the organic
+shape: MCP support was added at the registry's existing normalization point, using lazy
+imports to soften the dependency. Delta 2 retains the service-factory design for a
+future correction.
+
+### H. Preserve fail-closed defaults in explicit config loaders
+
+This would make an omitted policy deny every command and URL just as direct pool use
+does. It lost because selecting and loading a config file was treated as an implicit
+trust act. That convenience creates an important semantic split, so Delta 3 requires a
+named and observable trust choice rather than leaving the implication unstated.
 
 ## Notes
 
-Correcting the all-parameters-required schema is a compatibility change because existing
-tests and provider payloads preserve that behavior. It should not be shipped as an
+Correcting the all-parameters-required raw schema is a compatibility change because
+tests and provider payloads preserve that behavior. It cannot be shipped as an
 unversioned cleanup.

--- a/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
+++ b/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
@@ -8,92 +8,638 @@
 
 ## Context
 
-`FunctionCalling` is the low-level invocation record for a `Tool`. It normalizes arguments
-through the optional request model, runs a preprocessor, invokes a sync or async callable,
-and then runs a postprocessor. As an `Event`, it records status, duration, response, and
-errors. Ordinary exceptions from any of those three stages are captured as `FAILED` rather
-than re-raised; cancellation-class failures are recorded as `CANCELLED` and re-raised
-(`lionagi/protocols/action/function_calling.py`,
+The descriptor and registry in ADR-0011 answer which function a branch can expose.
+Execution crosses more boundaries: argument normalization, governance, hook emission,
+callable invocation, event persistence, observer emission, and conversation history.
+Five concrete problems define the shipped transaction.
+
+**P1 — A failed callable must leave an inspectable execution record.** Tool bodies,
+preprocessors, and postprocessors can fail after request validation. `FunctionCalling`
+therefore inherits the generic `Event` lifecycle and records terminal status, response,
+duration, and error. Ordinary exceptions become `FAILED` data; cancellation-class
+`BaseException` values become `CANCELLED` and continue propagating
+(`lionagi/protocols/action/function_calling.py`;
 `lionagi/protocols/generic/event.py`).
 
-The conversation-level transaction is `Branch.act()`, implemented by
-`operations.act`. It validates the request envelope, asks the branch's session observer to
-authorize the raw invocation, emits a blocking `TOOL_PRE` hook, invokes the manager, emits
-`TOOL_POST`, persists and emits the event, and appends linked action request and response
-messages. Denial stops before hooks and invocation and is returned as an error-shaped tool
-result. Standalone branches without an observer authorize every call
-(`lionagi/operations/act/act.py`, `lionagi/session/branch.py`,
-`lionagi/session/observer.py`, `lionagi/hooks/bus.py`).
-
-The branch action operation supports concurrent and sequential batches. Structured
-`operate()` calls and the LNDL action bridge route model-generated requests through that
-operation, so the common model-facing paths receive session authorization, hooks, event
-logging, and message history (`lionagi/operations/operate/operate.py`,
+**P2 — A model-facing call is a conversation transaction, not only a function call.**
+The normal `Branch.act()` path authorizes the proposed call, emits lifecycle hooks,
+invokes through the branch registry, logs and emits the event, and writes a linked
+`ActionRequest`/`ActionResponse` pair. Structured `operate()` and the LNDL action bridge
+route generated requests through this operation, so these model-facing paths receive the
+same transaction (`lionagi/operations/act/act.py`;
+`lionagi/operations/operate/operate.py`;
 `lionagi/operations/lndl_middle/lndl_middle.py`).
 
-The two layers do not yet share an unambiguous outcome contract. `ActionManager.invoke()`
-returns a `FunctionCalling` even when its callable failed, and the branch action operation
-does not inspect the returned status. It emits `TOOL_POST` and writes the event response,
-usually `None`, to history. `TOOL_ERROR` and the `suppress_errors` response path run only
-when matching, validation, or invocation raises before a `FunctionCalling` is returned.
-A failed tool body is therefore indistinguishable in conversation history from a
-successful tool that returned `None` (`lionagi/protocols/action/manager.py`,
-`lionagi/operations/act/act.py`, `lionagi/protocols/messages/action_response.py`).
+**P3 — Captured execution failure and branch response construction disagree.**
+`ActionManager.invoke()` returns a `FunctionCalling` after `Event.invoke()` even when its
+status is `FAILED`. The branch transaction does not inspect that status. It emits
+`TOOL_POST`, persists the failed event, and writes `func_call.response`—normally
+`None`—as the attempted action output. `MessageManager.a_add_message()` removes
+`None`-valued keyword arguments before dispatch, so this call re-adds the existing
+`ActionRequest` rather than creating an `ActionResponse`. Conversation history therefore
+cannot distinguish a failed tool body from a successful tool returning `None`: both
+leave an unresponded request, even though the event record can distinguish them
+(`lionagi/protocols/action/manager.py`; `lionagi/operations/act/act.py`;
+`lionagi/protocols/messages/manager.py`;
+`lionagi/protocols/messages/action_response.py`).
 
-Authorization and preprocessing are separate seams. Session authorization sees the raw
-argument dictionary before request-model normalization. Permission policies and coding
-guards are attached as `Tool` preprocessors and run later inside `FunctionCalling`; a
-configured security preprocessor runs before user preprocessors and again afterward when
-user preprocessors exist. Public access to `branch.acts.invoke()` and
-`Tool.func_callable` also permits deliberate low-level calls that bypass session policy,
-HookBus events, action messages, and branch event logging (`lionagi/agent/factory.py`,
+**P4 — Governance and intrinsic tool policy observe different call shapes.** The
+session observer authorizes a raw `ToolInvocation` before request-model normalization.
+Agent permission hooks are attached later as `Tool.preprocessor` callables and see the
+normalized dictionary. When user preprocessors exist, security preprocessors run before
+and after them. These are separate seams rather than one authoritative phase model
+(`lionagi/session/observer.py`; `lionagi/agent/factory.py`;
 `lionagi/agent/permissions.py`).
+
+**P5 — Batch and Python callable behavior introduce concurrency edges.** The branch
+operation can run request transactions concurrently or sequentially. Inside each
+`FunctionCalling`, coroutine functions are awaited and declared synchronous functions
+run inline on the current event-loop thread. Awaitability is classified from the
+callable declaration, not the returned value (`lionagi/operations/act/act.py`;
+`lionagi/ln/_async_call.py`; `lionagi/ln/concurrency/utils.py`).
+
+| Concern | Decision |
+|---|---|
+| Invocation record | D1: `FunctionCalling` executes preprocessor → callable → postprocessor inside the generic failure-capturing `Event` lifecycle. |
+| Conversation transaction | D2: `Branch.act()` delegates each request to `_act()`, which orders authorization, hooks, invocation, event handling, and linked messages. |
+| Outcome projection | D3: branch responses currently project `FunctionCalling.response` without interpreting terminal event status. |
+| Batch behavior | D4: action batches use explicit concurrent or sequential strategy, preserving one `_act()` transaction per input. |
+| Policy boundary | D5: session authorization, tool processors, and direct low-level invocation remain distinct public seams. |
+| Sync/async behavior | D6: coroutine declarations are awaited; synchronous declarations and processors execute inline. |
+
+This ADR does **not** decide:
+
+- Tool schema generation, registry identity, or MCP discovery; ADR-0011 owns those
+  contracts.
+- Construction and clone scope of built-in providers; ADR-0013 owns that lifecycle.
+- The complete session observer or hook vocabulary. This ADR records only behavior on
+  the action execution path.
+- Retry policy for arbitrary tool side effects. The default action batch does not retry;
+  callers can supply `AlcallParams`, but idempotency remains tool-specific.
 
 ## Decision
 
-The current execution contract has these load-bearing invariants:
+### D1 — `FunctionCalling` is a failure-capturing execution event
 
-- `FunctionCalling` is a failure-capturing execution `Event`; callers must inspect its
-  status to distinguish completion, failure, and cancellation.
-- `Branch.act()` and `operations.act` form the normal conversation transaction. The order
-  is request-envelope normalization, session authorization, `TOOL_PRE`, manager
-  resolution and event invocation, `TOOL_POST` for any returned event, event emission and
-  logging, then action request and response history.
-- A session denial is a tool result and history entry, not an exception. An exception that
-  escapes manager invocation emits `TOOL_ERROR` and is either re-raised or converted to an
-  error-shaped response according to `suppress_errors`.
-- Returned event status is currently not mapped into the action response. In particular,
-  a captured tool failure follows the same post-call path as a completed event.
-- Sequential and concurrent batches preserve the same per-call transaction, while direct
-  manager or callable access remains an explicitly possible but ungoverned low-level path.
-- Sync callables and sync processors execute inline on the event loop; awaitability is
-  determined from the callable declaration, so an awaitable returned by a sync declaration
-  is not awaited.
+The invocation type and its generic execution state are:
+
+```python
+# lionagi/protocols/action/function_calling.py
+class FunctionCalling(Event):
+    func_tool: Tool = Field(..., exclude=True)
+    arguments: dict[str, Any] | BaseModel
+
+    @property
+    def function(self): ...
+
+    async def _invoke(self) -> Any: ...
+
+    def to_dict(self, *args, **kw) -> dict[str, Any]: ...
+
+# lionagi/protocols/generic/event.py
+class EventStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"
+    ABORTED = "aborted"
+
+class Execution:
+    __slots__ = ("status", "duration", "response", "error", "retryable")
+
+    def __init__(
+        self,
+        duration: float | None | UnsetType = Unset,
+        response: Any = None,
+        status: EventStatus = EventStatus.PENDING,
+        error: str | BaseException | None = None,
+        retryable: bool | None | UnsetType = Unset,
+    ) -> None: ...
+
+class Event(Element):
+    execution: Execution = Field(default_factory=Execution)
+    streaming: bool = Field(False, exclude=True)
+
+    async def invoke(self) -> None: ...
+```
+
+The successful callable pipeline is:
+
+```text
+validated arguments
+  → optional preprocessor(arguments, **preprocessor_kwargs)
+  → func_callable(**arguments)
+  → optional postprocessor(response, **postprocessor_kwargs)
+  → execution.response
+```
+
+`FunctionCalling.to_dict()` adds `function` and normalized `arguments` to the generic
+event serialization. The live `func_tool` remains excluded.
+
+**Exact semantics**
+
+- **Construction:** an input `BaseModel` is dumped with `exclude_unset=True`. If the
+  tool has `request_options`, that model is then instantiated and dumped the same way.
+  Strict or minimum-key validation runs before an event reaches `invoke()` (ADR-0011
+  D2); construction errors are not captured in this event.
+- **First invocation:** an event in `PENDING` changes to `PROCESSING`, samples a UTC
+  timestamp for duration measurement, and enters `_invoke()`. The start sample is not a
+  persisted execution field; `created_at` remains the event-construction timestamp.
+- **Preprocessor:** its return value replaces `self.arguments`. No second request-model
+  validation follows the transform.
+- **Callable:** the current arguments are expanded as keyword arguments.
+- **Postprocessor:** its return value becomes the eventual response.
+- **Coroutine declaration:** a callable or processor for which `is_coro_func(...)` is
+  true is awaited.
+- **Synchronous declaration:** a callable or processor classified as sync is called
+  directly. If it returns an awaitable, that awaitable is treated as the ordinary
+  response and is not awaited.
+- **Successful completion:** the final result is stored in `execution.response`, status
+  becomes `COMPLETED`, and duration is always recorded in seconds.
+- **Ordinary exception:** any `Exception` raised by the preprocessor, callable, or
+  postprocessor sets status to `FAILED`, adds the exception to `execution.error`, leaves
+  the pre-existing response value unchanged (normally `None`), records duration, and is
+  not re-raised.
+- **Cancellation-class failure:** a `BaseException` outside `Exception` is added to the
+  error, status becomes `CANCELLED`, duration is recorded, and the exception is re-raised.
+- **Repeated invocation:** `Event.invoke()` returns immediately whenever status is not
+  `PENDING`. A completed, failed, processing, or cancelled `FunctionCalling` is not
+  executed again.
+- **Terminal notification:** setting `COMPLETED`, `FAILED`, `CANCELLED`, `ABORTED`, or
+  `SKIPPED` signals the lazily created `completion_event`.
+- **Error accumulation cap:** `Execution.add_error()` retains at most 100 members once
+  the error becomes an `ExceptionGroup`. The cap bounds serialized error growth; the
+  value is inherited from the generic event layer and has no action-specific recorded
+  rationale. One ordinary `FunctionCalling.invoke()` normally contributes one error.
+- **Serialization:** exceptions become `{ "error": <type>, "message": <text> }`;
+  unserializable responses fall back through recursive conversion and finally the
+  string `"<unserializable>"`.
+
+**Why this way**
+
+Failure as event data lets callers inspect and persist a complete attempt without using
+exceptions as the only control channel. It also allows independent concurrent calls to
+finish. Cancellation remains exceptional because swallowing task cancellation would
+break structured concurrency. The design requires every caller above `Event` to inspect
+status; D3 records where the branch layer currently fails to do so.
+
+### D2 — `_act()` is the normal branch conversation transaction
+
+The public and internal signatures are:
+
+```python
+# lionagi/session/branch.py
+async def Branch.act(
+    self,
+    action_request: list | ActionRequest | BaseModel | dict,
+    *,
+    strategy: Literal["concurrent", "sequential"] = "concurrent",
+    verbose_action: bool = False,
+    suppress_errors: bool = True,
+    call_params: AlcallParams = None,
+) -> list[ActionResponse]: ...
+
+# lionagi/operations/act/act.py
+async def _act(
+    branch: Branch,
+    action_request: BaseModel | dict | ActionRequest,
+    suppress_errors: bool = False,
+    verbose_action: bool = False,
+): ...
+```
+
+The accepted proposal passed to session governance is:
+
+```python
+# lionagi/session/control.py
+@dataclass(frozen=True, slots=True)
+class ToolInvocation:
+    function: str
+    arguments: dict = field(default_factory=dict)
+    branch_id: str | None = None
+```
+
+The immediate return value is not the persisted message type:
+
+```python
+# lionagi/operations/fields.py
+class ActionResponseModel(HashableModel):
+    function: str = Field(default_factory=str)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    output: Any = None
+```
+
+The persisted message pair uses these content shapes:
+
+```python
+# lionagi/protocols/messages/action_request.py
+@dataclass(slots=True)
+class ActionRequestContent:
+    function: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    action_response_id: str | None = None
+
+# lionagi/protocols/messages/action_response.py
+@dataclass(slots=True)
+class ActionResponseContent:
+    function: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    output: Any = None
+    action_request_id: str | None = None
+    error: str | None = None
+```
+
+For an allowed call that returns a `FunctionCalling`, the transaction order is:
+
+```text
+normalize envelope
+  → branch.authorize(ToolInvocation from raw arguments)
+  → TOOL_PRE
+  → ActionManager.invoke()
+  → TOOL_POST
+  → branch.emit_and_log(FunctionCalling)
+  → ensure ActionRequest message
+  → add linked ActionResponse only when response is not None
+  → return ActionResponseModel
+```
+
+The message-manager discriminator responsible for the `None` edge is:
+
+```python
+# lionagi/protocols/messages/manager.py
+async def MessageManager.a_add_message(self, **kwargs):
+    # None-valued entries are removed before create_message().
+    _msg = self.create_message(**{k: v for k, v in kwargs.items() if v is not None})
+    ...
+
+def MessageManager.create_message(
+    *,
+    action_output: Any = None,
+    action_request: ActionRequest | None = None,
+    action_response: ActionResponse | Any = None,
+    ...,
+):
+    if action_request and action_output is None and action_response is None:
+        ...  # select ActionRequest
+    elif action_response is not None or action_output is not None:
+        ...  # select ActionResponse
+```
+
+**Exact semantics**
+
+- **Accepted envelopes:** an `ActionRequest`; a `BaseModel` whose class declares at
+  least `function` and `arguments`; or a dictionary containing both keys. Any other
+  shape raises `ValueError` before authorization.
+- **Raw gate arguments:** if the envelope's `arguments` value is not already a
+  dictionary, governance receives `{}`. Pydantic request-model normalization has not yet
+  run.
+- **Standalone branch:** `Branch.authorize()` returns `True` when no session observer is
+  bound.
+- **Bound observer:** no installed gate allows. A falsy gate result or an exception from
+  the gate denies and adds a `GateDenied` signal to the observer flow.
+- **Denied call:** no tool hook, function event, or tool callable runs. `_act()` ensures
+  an `ActionRequest`, adds an action response whose output is
+  `{"error": "denied by governance gate", "function": <name>}`, and returns an
+  `ActionResponseModel`. Denial is a value regardless of `suppress_errors`.
+- **Correlation and summaries:** an allowed call gets a random UUID string `call_id`.
+  `TOOL_PRE` receives `tool_name`, `call_id`, and the first 200 characters of
+  `str(raw_arguments)`. When verbose logging is enabled, its argument preview is capped
+  at 50 characters. Both are inherited observability budgets; no recorded rationale
+  explains the exact lengths.
+- **Blocking pre-hook:** `_act()` calls `HookBus.emit(TOOL_PRE, ...)`; the bus routes
+  that point through `blocking_emit()`, runs handlers sequentially, and propagates
+  ordinary handler exceptions. Because pre-emission sits outside `_act()`'s invocation
+  `try`, such an exception bypasses `TOOL_ERROR`, `suppress_errors`, event logging, and
+  action history. `StopHook` stops remaining pre-handlers but does not prevent the tool
+  invocation itself.
+- **Returned event:** `TOOL_POST` receives the same `call_id`, `tool_name`, the first
+  200 characters of `str(func_call.response)`, and the recorded duration. Non-pre hook
+  handler exceptions are logged and isolated by `HookBus`.
+- **Event handling:** `branch.emit_and_log()` logs the complete event and emits it to the
+  session observer. The observer stores the event before applying routes and
+  subscriptions; a gate denial at this emission stage suppresses dispatch but not
+  storage.
+- **Observer failure after invocation:** `emit_and_log()` is outside `_act()`'s
+  invocation `try`, and it uses `Branch.emit()`, not the failure-isolating
+  `_safe_emit()`. An observer route, predicate, or subscriber exception can therefore
+  propagate after the event is durably logged but before request/response history is
+  created.
+- **Message linking for non-`None` output:** a dictionary or generic model becomes an
+  `ActionRequest` whose recipient is the tool descriptor id. The response message copies
+  function and arguments from that request and stores its id as `action_request_id`;
+  message-manager linking writes the reciprocal response id. Falsy outputs other than
+  `None` (`0`, `""`, `[]`, `{}`) still create and link an `ActionResponse` because the
+  discriminator uses `is not None`.
+- **Message linking for `None` output:** `a_add_message()` filters out the
+  `action_output` entry, selects the ActionRequest construction path, and re-includes the
+  same request at its existing progression position. No `ActionResponse` is created and
+  `ActionRequest.action_response_id` remains `None`.
+- **Message callback failure:** `a_add_message()` mutates the message pile before firing
+  its `on_message_added` callbacks. It runs all callbacks, then re-raises one failure or
+  an exception group. `_act()` does not roll back the already-inserted request/response,
+  so the caller can receive an exception after history changed.
+- **Successful return:** the immediate `ActionResponseModel` contains the request's
+  function and arguments and `func_call.response` as output, including `None`; its
+  existence does not imply that an `ActionResponse` message was persisted.
+- **Cancellation:** cancellation re-raised by `FunctionCalling.invoke()` is not caught
+  by `_act()`'s `except Exception`; it propagates before `TOOL_POST`, event logging, and
+  history creation.
+
+**Why this way**
+
+The transaction gives model-visible calls a consistent audit and history path while
+keeping denial readable by the next reasoning turn. The hook positions support guards
+and observability without moving callable-specific transforms out of `Tool`. The order
+also exposes two weaknesses: raw authorization and normalized processors do not see the
+same payload, and a status-blind projection can contradict the event truth.
+
+### D3 — Branch response projection is status-blind
+
+There are two failure channels after authorization.
+
+| Failure channel | Example | Does manager raise? | Hook path | History output |
+|---|---|---:|---|---|
+| Pre-invocation exception | unknown function, request-model validation, strict key mismatch | Yes | `TOOL_ERROR` | structured error dictionary when suppressed; no history when re-raised |
+| Captured event failure | preprocessor, callable, or postprocessor raises ordinary `Exception` | No | `TOOL_POST` | no `ActionResponse` when `func_call.response` remains `None`; request remains unresponded |
+
+**Exact semantics**
+
+- **Manager exception:** `_act()` emits `TOOL_ERROR` with `call_id`, `tool_name`, the
+  exception object, and `duration=None`, then logs a dictionary containing error,
+  function, arguments, and branch id.
+- **Suppressed manager exception:** with `suppress_errors=True`, `_act()` ensures request
+  and response history. Persisted output contains `error`, `function`, and `arguments`;
+  the immediate output contains `error` and a formatted `message`. The original
+  exception does not propagate.
+- **Unsuppressed manager exception:** with `suppress_errors=False`, the exception is
+  re-raised after hook emission and logging; no request/response messages are added by
+  that path.
+- **Captured callable failure:** `ActionManager.invoke()` returns the failed event.
+  `_act()` does not branch on `func_call.status` or read `func_call.execution.error`.
+  It follows `TOOL_POST`, emits/logs the event, and passes the response value to the
+  message manager. When the value is `None`, no response message is constructed.
+- **Successful `None`:** the same immediate output (`None`) and history state (an
+  unresponded `ActionRequest`, with no `ActionResponse`) is produced for a completed
+  callable that intentionally returns `None`.
+- **Unused message error field:** `ActionResponseContent.error` and its `success`
+  property can distinguish failure, but `_act()` populates errors inside `output` only
+  on the raised-and-suppressed path and never maps a failed event into that field.
+
+**Why this way**
+
+The mismatch arose because the low-level event deliberately captures ordinary
+exceptions, while the branch code was organized around exceptions escaping manager
+invocation. Both pieces are internally coherent but their composition drops the status
+discriminant. The existing `ActionResponseContent.error` field provides a correction
+path without changing successful output values; the shipped behavior remains recorded
+here until that delta lands.
+
+### D4 — Batches preserve one transaction per call under two strategies
+
+Batch configuration is a frozen parameter object:
+
+```python
+# lionagi/operations/types.py
+@dataclass(slots=True, frozen=True, init=False)
+class ActionParam(MorphParam):
+    action_call_params: AlcallParams = None
+    tools: ToolRef = None
+    strategy: Literal["concurrent", "sequential"] = "concurrent"
+    suppress_errors: bool = True
+    verbose_action: bool = False
+```
+
+`prepare_act_kw()` supplies `AlcallParams(output_dropna=True)` when callers do not pass
+`call_params` (`lionagi/operations/_defaults.py`).
+
+**Exact semantics**
+
+- **Input normalization:** both strategies wrap a single request in a one-element list.
+- **Empty input:** an empty list returns an empty list. Concurrent mode creates no task;
+  sequential mode performs no iteration. No hooks, events, or messages are produced.
+- **Concurrent:** the configured `AlcallParams` applies `_act()` to every request. The
+  generic `alcall` implementation stores results by input index, so the returned list
+  preserves input order rather than completion order.
+- **Default concurrent budget:** the default action parameters set no retry, timeout,
+  throttle, or `max_concurrent` value. All input calls may start concurrently, and each
+  call is attempted once. `output_dropna=True` is the only action-specific override; it
+  removes null-like results from the collected output. No recorded rationale explains an
+  unbounded default beyond inheritance from the generic call helper.
+- **Caller-supplied controls:** `AlcallParams` can add retry attempts, timeout,
+  concurrency cap, throttle, and exception-return behavior. Applying retries to
+  side-effecting `_act()` calls can duplicate tool effects and history; the action layer
+  does not add an idempotency key or rollback.
+- **Concurrent raised failure:** with `return_exceptions=False`, an unsuppressed
+  exception from one `_act()` task is re-raised (a single grouped exception is unwrapped)
+  and the task group cancels outstanding siblings. `suppress_errors=True` converts the
+  ordinary manager-exception path to values, but cancellation-class failures still
+  propagate. `return_exceptions=True` retains raised failures in their input slots.
+- **Sequential:** `_act()` is awaited in list order and every result is appended. A
+  raised unsuppressed exception stops the loop; an error returned because suppression is
+  enabled does not.
+- **Invalid strategy:** any value other than `concurrent` or `sequential` raises
+  `ConfigurationError`.
+- **Per-call lifecycle:** authorization, hook ids, event records, and message pairs are
+  independent for every item under either strategy.
+
+**Why this way**
+
+The strategy switch gives callers ordering when effects depend on prior branch state and
+parallelism when calls are independent. Reusing `AlcallParams` makes operational controls
+available without a second batch framework. It also means callers, not the action layer,
+own the safety of retries and high concurrency.
+
+### D5 — Governance, processors, and low-level access are separate seams
+
+The session gate accepts `ToolInvocation` before the manager constructs a
+`FunctionCalling`. Agent permission policy is converted to a tool preprocessor:
+
+```python
+# lionagi/agent/permissions.py
+@dataclass
+class PermissionPolicy:
+    mode: str = "allow_all"
+    allow: dict[str, list[str]] = field(default_factory=dict)
+    deny: dict[str, list[str]] = field(default_factory=dict)
+    escalate: dict[str, list[str]] = field(default_factory=dict)
+    on_escalate: Callable | None = None
+
+    def check(self, tool_name: str, action: str, args: dict) -> PermissionDecision: ...
+    def to_pre_hook(self) -> Callable: ...
+```
+
+Factory hook composition is:
+
+```text
+security_pre:* and security_pre:<tool>
+  → pre:* and pre:<tool>
+  → security hooks again, but only when user pre-hooks exist
+  → callable
+  → post hooks
+```
+
+**Exact semantics**
+
+- **Session authorization payload:** function, raw dictionary arguments (or `{}` for a
+  non-dictionary), and branch id.
+- **Request-model validation:** runs only after authorization, when the manager builds
+  `FunctionCalling`.
+- **Tool processor payload:** the Pydantic-normalized argument dictionary. A processor
+  may replace it with another dictionary before invocation.
+- **Security revalidation:** `_chain_pre_hooks()` appends the same security hooks after
+  user hooks only when at least one user hook exists. With no user pre-hook, security
+  runs once.
+- **Permission errors:** a permission preprocessor raises `PermissionError`; because it
+  occurs inside `Event.invoke()`, it becomes a captured `FAILED` event rather than the
+  session gate's denial-shaped value. D3 then projects it as a post-call `None` output.
+- **Public low-level manager:** `branch.acts` returns the manager. A caller can invoke it
+  directly, receiving request-model validation and event capture but bypassing session
+  authorization, `HookBus`, branch logging/emission, and messages.
+- **Public callable:** `Tool.func_callable` can be called directly, bypassing manager
+  validation, tool processors, event lifecycle, governance, hooks, logging, and history.
+- **Normal model paths:** `operate()` and LNDL call the branch action operation, so their
+  model-generated requests use the governed transaction.
+
+**Why this way**
+
+The seams were added for different scopes: session gates govern a conversation,
+processors adapt or protect one tool, and manager/callable access supports testing and
+low-level composition. Their coexistence is useful but not substitutable. A future
+authoritative executor must name bypass APIs explicitly and present every policy phase
+with one normalized call context.
+
+### D6 — Sync execution is inline and awaitability follows declarations
+
+`FunctionCalling._invoke()` calls `is_coro_func()` separately for the preprocessor,
+tool callable, and postprocessor.
+
+**Exact semantics**
+
+- An `async def` function is awaited on the current event loop.
+- A declared synchronous function is executed directly on the event-loop thread; it is
+  not sent through `run_sync()` by the generic action executor.
+- A sync pre- or postprocessor has the same inline behavior.
+- A callable object or decorator whose declaration is classified as sync but whose
+  return value is awaitable produces that awaitable as data; the executor does not call
+  `inspect.isawaitable()` on results.
+- Blocking sync CPU or I/O stalls other calls sharing the event loop, including a
+  nominally concurrent action batch.
+- Built-in tools that know they perform blocking work explicitly use `run_sync()` inside
+  their async wrappers; this is a provider implementation convention, not enforcement by
+  `FunctionCalling`.
+
+**Why this way**
+
+Direct sync support makes ordinary Python functions easy to register and avoids imposing
+thread handoff on tiny pure functions. The absence of an explicit blocking policy leaves
+latency and decorator edge cases to individual tool authors, which is retained as a
+delta rather than presented as an ideal contract.
 
 ## Consequences
 
-Tool failures can be retained as data, allowing a concurrent batch or iterative reasoning
-loop to continue without abandoning the whole branch. The event record, hook bus, branch
-log, and message history provide distinct integration points, and session denial can be
-shown to the model so it can adapt.
-
-The status-blind boundary loses the most important distinction in the event record and can
-mislead the next model turn. Policy behavior also depends on which public entry point a
-caller chooses and whether it reasons about raw or normalized arguments. Inline sync work
-can stall the event loop, while a sync wrapper that returns an awaitable produces a sharp
-edge for decorators and callable objects.
+- Ordinary callable failures survive as queryable event records and do not inherently
+  abort sibling calls in a concurrent batch.
+- Session denial is model-visible and occurs before hook and callable side effects.
+- The normal branch transaction provides separate integration points for pre-guards,
+  post/error observation, durable logs, reactive observer handlers, and conversation
+  messages.
+- Captured tool failures are truthful in the event but absent from action-response
+  history when the response remains `None`; a successful `None` and a failed call are
+  conversation-equivalent unresponded requests today.
+- A blocking `TOOL_PRE` exception bypasses suppression and history, while a permission
+  preprocessor exception is captured and then misprojected by D3. Policy location changes
+  user-visible semantics.
+- An observer exception after invocation can leave a durable function event without the
+  linked action response in conversation history. Recovery and debugging must compare
+  both records rather than assuming they advance atomically.
+- Direct manager and callable entry points are useful escape hatches but are not governed
+  equivalents of `Branch.act()`.
+- Concurrent batches have no default cap or retry; caller-supplied retries can repeat
+  non-idempotent effects, while an unsuppressed failure can cancel outstanding siblings.
+- Reversing D1 from captured failures to raised failures would change manager and batch
+  control flow. Reversing D2 requires migrating every model-facing operation that relies
+  on action history and hooks.
+- Contributors must inspect `FunctionCalling.status` whenever invoking through the
+  manager and must explicitly offload blocking work inside async tool adapters.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Make the branch action transaction inspect `FunctionCalling.status`, emit `TOOL_ERROR` for captured failures, persist an error-bearing `ActionResponse`, and reserve `TOOL_POST` for completed calls; acceptance must distinguish successful `None` from failure in sequential and concurrent regression tests. | M | (filled at issue-open time) |
-| 2 | Publish one authoritative branch action executor and reduce `ActionManager` to registry and resolution responsibilities; acceptance requires Branch, operate, iterative reasoning, and LNDL paths to use the executor while any no-history invocation is explicitly named and documents its bypass semantics. | M | (filled at issue-open time) |
+| 1 | Make the branch action transaction inspect `FunctionCalling.status`, emit `TOOL_ERROR` for captured failures, persist an error-bearing `ActionResponse`, and reserve `TOOL_POST` for completed calls; acceptance must define and persist a linked response for successful `None` and distinguish it from failure in sequential and concurrent regression tests. | M | (filled at issue-open time) |
+| 2 | Publish one authoritative branch action executor and reduce `ActionManager` to registry and resolution responsibilities; acceptance requires Branch, operate, iterative reasoning, and LNDL paths to use the executor, any no-history invocation to be explicitly named, and observer/message-callback failures to have a tested policy that cannot silently split event logging from action history. | M | (filled at issue-open time) |
 | 3 | Define one normalized call context and explicit authorization, intrinsic-policy, agent-policy, transform, and revalidation phases; acceptance requires every phase to receive the same normalized arguments and security revalidation not to depend on whether a user preprocessor exists. | M | (filled at issue-open time) |
 | 4 | Define and enforce a sync-tool execution policy; acceptance requires blocking sync work either to be offloaded by the executor or to require an explicit inline opt-in, with returned awaitables handled consistently. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A. Let callable exceptions propagate instead of recording failed events
+
+This would make failure impossible to overlook and align with conventional Python call
+semantics. It lost because event status, duration, and error are durable execution data,
+and independent action batches benefit from a returned attempt record. Cancellation
+still propagates because it belongs to task control rather than business failure.
+
+### B. Return only values from `ActionManager.invoke()`
+
+This would simplify callers and hide the event abstraction below the manager. It lost
+because callers need status, duration, and error for logging and reactive observation;
+the branch transaction persists the full `FunctionCalling`, not only its response.
+
+### C. Treat any returned `FunctionCalling` as success
+
+This is the organic shape currently shipped: exceptions escaping the manager enter the
+error path, while a returned object enters the post path. It bought simple exception-led
+control flow. It loses the event's status discriminant, creating the successful-`None`
+ambiguity. Delta 1 retains the status-aware alternative as the required correction.
+
+### D. Raise session denial as `PermissionError`
+
+This would make authorization failure match ordinary Python access-control behavior and
+stop the current operation immediately. It lost because reasoning loops need to see the
+denial as a tool result and adapt, and denial is expected policy output rather than an
+executor malfunction.
+
+### E. Put all policy in the session gate
+
+One gate would give authorization a single location and avoid processor-dependent
+failure semantics. It lost because intrinsic tool policies and transforms travel with a
+tool even outside one session, while session governance needs branch and conversation
+scope. The unresolved requirement is a shared normalized call context, not deletion of
+either scope.
+
+### F. Put all policy in tool preprocessors
+
+This would keep tools self-contained and make direct manager invocation policy-aware. It
+lost because preprocessors run after request construction and cannot represent the
+session observer's pre-invocation audit/denial contract. Direct callable access would
+still bypass them.
+
+### G. Execute every sync callable in a worker thread
+
+This would protect the event loop from blocking I/O and CPU work. It lost in the shipped
+generic executor because it imposes thread handoff and thread-safety constraints on
+small pure functions and bound objects. Built-ins offload known blocking operations
+manually; Delta 4 requires an explicit policy instead of relying on convention.
+
+### H. Detect and await any returned awaitable
+
+This would make decorated sync wrappers and callable objects behave like coroutine
+functions. It lost because the implementation uses declaration classification uniformly
+for processors and callables. The current behavior is simple but sharp; changing it
+requires tests for nested awaitables and postprocessor ordering.
+
+### I. Make a batch transactional
+
+An all-or-nothing batch could roll back earlier tool effects when one call fails. It lost
+because arbitrary tools cross files, processes, networks, and conversation state with no
+shared transaction manager. Sequential ordering and per-call results are honest; atomic
+multi-step behavior belongs inside a purpose-built tool.
 
 ## Notes
 
 The existing `ActionResponseContent.error` field can carry a structured failure without
-changing successful output values. Whether branch execution returns failures as values or
-raises them is separable from whether history represents the failure truthfully.
+changing successful output values. Whether branch execution returns failures as values
+or raises them is separable from whether history represents the failure truthfully.

--- a/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
+++ b/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
@@ -1,0 +1,99 @@
+# ADR-0012: Branch Action Execution and Event Lifecycle
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: actions-tools
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0011
+
+## Context
+
+`FunctionCalling` is the low-level invocation record for a `Tool`. It normalizes arguments
+through the optional request model, runs a preprocessor, invokes a sync or async callable,
+and then runs a postprocessor. As an `Event`, it records status, duration, response, and
+errors. Ordinary exceptions from any of those three stages are captured as `FAILED` rather
+than re-raised; cancellation-class failures are recorded as `CANCELLED` and re-raised
+(`lionagi/protocols/action/function_calling.py`,
+`lionagi/protocols/generic/event.py`).
+
+The conversation-level transaction is `Branch.act()`, implemented by
+`operations.act`. It validates the request envelope, asks the branch's session observer to
+authorize the raw invocation, emits a blocking `TOOL_PRE` hook, invokes the manager, emits
+`TOOL_POST`, persists and emits the event, and appends linked action request and response
+messages. Denial stops before hooks and invocation and is returned as an error-shaped tool
+result. Standalone branches without an observer authorize every call
+(`lionagi/operations/act/act.py`, `lionagi/session/branch.py`,
+`lionagi/session/observer.py`, `lionagi/hooks/bus.py`).
+
+The branch action operation supports concurrent and sequential batches. Structured
+`operate()` calls and the LNDL action bridge route model-generated requests through that
+operation, so the common model-facing paths receive session authorization, hooks, event
+logging, and message history (`lionagi/operations/operate/operate.py`,
+`lionagi/operations/lndl_middle/lndl_middle.py`).
+
+The two layers do not yet share an unambiguous outcome contract. `ActionManager.invoke()`
+returns a `FunctionCalling` even when its callable failed, and the branch action operation
+does not inspect the returned status. It emits `TOOL_POST` and writes the event response,
+usually `None`, to history. `TOOL_ERROR` and the `suppress_errors` response path run only
+when matching, validation, or invocation raises before a `FunctionCalling` is returned.
+A failed tool body is therefore indistinguishable in conversation history from a
+successful tool that returned `None` (`lionagi/protocols/action/manager.py`,
+`lionagi/operations/act/act.py`, `lionagi/protocols/messages/action_response.py`).
+
+Authorization and preprocessing are separate seams. Session authorization sees the raw
+argument dictionary before request-model normalization. Permission policies and coding
+guards are attached as `Tool` preprocessors and run later inside `FunctionCalling`; a
+configured security preprocessor runs before user preprocessors and again afterward when
+user preprocessors exist. Public access to `branch.acts.invoke()` and
+`Tool.func_callable` also permits deliberate low-level calls that bypass session policy,
+HookBus events, action messages, and branch event logging (`lionagi/agent/factory.py`,
+`lionagi/agent/permissions.py`).
+
+## Decision
+
+The current execution contract has these load-bearing invariants:
+
+- `FunctionCalling` is a failure-capturing execution `Event`; callers must inspect its
+  status to distinguish completion, failure, and cancellation.
+- `Branch.act()` and `operations.act` form the normal conversation transaction. The order
+  is request-envelope normalization, session authorization, `TOOL_PRE`, manager
+  resolution and event invocation, `TOOL_POST` for any returned event, event emission and
+  logging, then action request and response history.
+- A session denial is a tool result and history entry, not an exception. An exception that
+  escapes manager invocation emits `TOOL_ERROR` and is either re-raised or converted to an
+  error-shaped response according to `suppress_errors`.
+- Returned event status is currently not mapped into the action response. In particular,
+  a captured tool failure follows the same post-call path as a completed event.
+- Sequential and concurrent batches preserve the same per-call transaction, while direct
+  manager or callable access remains an explicitly possible but ungoverned low-level path.
+- Sync callables and sync processors execute inline on the event loop; awaitability is
+  determined from the callable declaration, so an awaitable returned by a sync declaration
+  is not awaited.
+
+## Consequences
+
+Tool failures can be retained as data, allowing a concurrent batch or iterative reasoning
+loop to continue without abandoning the whole branch. The event record, hook bus, branch
+log, and message history provide distinct integration points, and session denial can be
+shown to the model so it can adapt.
+
+The status-blind boundary loses the most important distinction in the event record and can
+mislead the next model turn. Policy behavior also depends on which public entry point a
+caller chooses and whether it reasons about raw or normalized arguments. Inline sync work
+can stall the event loop, while a sync wrapper that returns an awaitable produces a sharp
+edge for decorators and callable objects.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Make the branch action transaction inspect `FunctionCalling.status`, emit `TOOL_ERROR` for captured failures, persist an error-bearing `ActionResponse`, and reserve `TOOL_POST` for completed calls; acceptance must distinguish successful `None` from failure in sequential and concurrent regression tests. | M | (filled at issue-open time) |
+| 2 | Publish one authoritative branch action executor and reduce `ActionManager` to registry and resolution responsibilities; acceptance requires Branch, operate, iterative reasoning, and LNDL paths to use the executor while any no-history invocation is explicitly named and documents its bypass semantics. | M | (filled at issue-open time) |
+| 3 | Define one normalized call context and explicit authorization, intrinsic-policy, agent-policy, transform, and revalidation phases; acceptance requires every phase to receive the same normalized arguments and security revalidation not to depend on whether a user preprocessor exists. | M | (filled at issue-open time) |
+| 4 | Define and enforce a sync-tool execution policy; acceptance requires blocking sync work either to be offloaded by the executor or to require an explicit inline opt-in, with returned awaitables handled consistently. | S | (filled at issue-open time) |
+
+## Notes
+
+The existing `ActionResponseContent.error` field can carry a structured failure without
+changing successful output values. Whether branch execution returns failures as values or
+raises them is separable from whether history represents the failure truthfully.

--- a/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
+++ b/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
@@ -8,82 +8,815 @@
 
 ## Context
 
-Most standalone built-ins pair a Pydantic request model with an async handler and expose a
-cached `Tool` through `to_tool()`. Reader, editor, search, shell, diagnostics, navigation,
-and syntax-search adapters use this shape. Their concrete implementations own operational
-constraints such as workspace path resolution, subprocess limits, and typed response
-models (`lionagi/tools/file/reader.py`, `lionagi/tools/file/editor.py`,
-`lionagi/tools/code/bash.py`, `lionagi/tools/code/search.py`,
-`lionagi/tools/code/check.py`, `lionagi/tools/code/nav.py`,
-`lionagi/tools/code/ast_search.py`).
+ADR-0011 defines the executable `Tool` descriptor and branch registry. Built-in tools
+still need a construction boundary: some adapters are reusable objects with no branch
+dependency, while others close over a branch, exchange, history, or mutable per-branch
+state. Five concrete problems shaped the shipped provider layer.
 
-`LionTool` is the common marker for those adapters. Its only behavioral requirement is
-`to_tool()`, and `Branch.register_tools()` handles a `LionTool` by calling that method
-before registry insertion. The same base module also contains resource and prompt graph
-types that do not participate in tool registration (`lionagi/tools/base.py`,
-`lionagi/session/branch.py`).
+**P1 — Maintained built-ins need a richer input contract than raw signature
+inspection.** The file reader/editor, shell, search, diagnostics, navigation, and
+syntax-search adapters pair Pydantic request/response models with async handlers. Their
+request models become provider schemas and their handlers enforce workspace containment,
+timeouts, caps, and typed failure values (`lionagi/tools/file/reader.py`;
+`lionagi/tools/file/editor.py`; `lionagi/tools/code/`).
 
-Three built-in providers require runtime context instead of satisfying that generic path.
-`ContextTool` closes over a branch's messages and progression, `LionMessenger` closes over
-a branch and exchange roster, and `CodingToolkit` builds a list of tools around branch
-state. Each exposes `bind(...)` and intentionally raises from `to_tool()`. Agent construction
-therefore special-cases coding-tool binding rather than passing the provider through generic
-branch registration (`lionagi/tools/context/context.py`,
-`lionagi/tools/communication/messenger.py`, `lionagi/tools/coding.py`,
-`lionagi/agent/factory.py`).
+**P2 — The common marker describes only the stateless case.** `LionTool` requires a
+single synchronous `to_tool() -> Tool`. `Branch.register_tools()` recognizes that
+marker, instantiates marker classes without arguments, calls `to_tool()`, and registers
+the result. The interface has no construction context, multi-tool output, lifecycle, or
+clone contract (`lionagi/tools/base.py`; `lionagi/session/branch.py`).
 
-`CodingToolkit` adds genuinely branch-scoped behavior: read-before-edit state, context
-curation, and optional nudges based on branch history. It also implements local reader,
-editor, shell, search, diagnostics, navigation, and syntax-search callables alongside the
-standalone adapters with the same responsibilities. Those paths share request models and
-some helpers but produce their own response dictionaries and execution behavior
+**P3 — Three providers are factories despite inheriting from the marker.**
+`ContextTool` needs branch messages and progression. `LionMessenger` needs a branch,
+exchange, and roster. `CodingToolkit` builds multiple tools around branch history and
+mutable file state. Each exposes `bind(...)` and deliberately raises from `to_tool()`;
+generic branch registration therefore cannot consume the declared hierarchy uniformly
+(`lionagi/tools/context/context.py`;
+`lionagi/tools/communication/messenger.py`; `lionagi/tools/coding.py`).
+
+**P4 — The coding toolkit adds stateful value but duplicates basic adapters.** Its
+read-before-edit guard, context-aware invalidation, nudge integration, sandbox session,
+and subagent construction are branch-scoped. At the same time it implements reader,
+editor, shell, search, diagnostics, navigation, and syntax search again, using shared
+request models and selected helpers but returning independently assembled dictionaries.
+Defaults and failure shapes can therefore drift from standalone adapters
 (`lionagi/tools/coding.py`).
 
-Branch cloning copies registered `Tool` descriptors into the clone's manager. It does not
-rebuild or rebind their callables. A descriptor produced by `CodingToolkit.bind()`,
-`ContextTool.bind()`, or `LionMessenger.bind()` can consequently retain a closure over the
-source branch after being registered on the clone (`lionagi/session/branch.py`).
+**P5 — Branch cloning copies descriptors, not provider intent.** `Branch.clone()`
+creates a new manager and passes it the original registry's `Tool` objects. The
+descriptors and callable closures are reused without a scope or rebinding check. A tool
+created by `ContextTool.bind()`, `LionMessenger.bind()`, or `CodingToolkit.bind()` can
+remain closed over the source branch after registration on the clone
+(`lionagi/session/branch.py`).
+
+| Concern | Decision |
+|---|---|
+| Provider marker | D1: `LionTool` is a minimal one-tool adapter marker, and generic branch registration calls `to_tool()`. |
+| Stateless built-ins | D2: maintained standalone adapters cache one Pydantic-backed `Tool` and return typed result dictionaries. |
+| Context-bound factories | D3: context and messenger providers expose explicit `bind(...)` methods and reject generic `to_tool()`. |
+| Stateful toolkit | D4: `CodingToolkit.bind(branch)` returns a configurable list of branch-bound tools with local state and parallel basic implementations. |
+| Clone behavior | D5: branch cloning copies registered `Tool` descriptors by reference and performs no provider rebinding. |
+
+This ADR does **not** decide:
+
+- Function-schema derivation, registry duplicate handling, or remote MCP normalization;
+  ADR-0011 owns those contracts.
+- Authorization, event status, hooks, and action-message ordering; ADR-0012 owns the
+  execution transaction.
+- The internal implementation of sandbox or subagent orchestration. This ADR records
+  only that those optional tool factories are part of the coding provider's output.
+- Resource and prompt graph behavior. Their current co-location with `LionTool` is
+  recorded because it affects module cohesion, not because this ADR governs them.
 
 ## Decision
 
-The current built-in provider model has these load-bearing invariants:
+### D1 — `LionTool` is a minimal single-tool adapter marker
 
-- Stateless built-ins adapt their concrete implementation and Pydantic request model into
-  one regular `Tool`, which the branch can register generically.
-- `LionTool` advertises `to_tool()` but does not model construction context, multiple-tool
-  output, lifecycle, or clone behavior.
-- Context, messenger, and coding providers are branch-bound factories despite inheriting
-  from `LionTool`; their supported construction path is `bind(...)`, not `to_tool()`.
-- `CodingToolkit.bind()` returns the configured tool set and owns branch-local read state,
-  context operations, and nudge integration. Its basic tool operations remain a parallel
-  implementation to the standalone adapters.
-- Branch cloning reuses registered descriptors as-is. No provider scope, rebinding, or
-  cloneability contract is consulted.
+The complete provider interface is:
+
+```python
+# lionagi/tools/base.py
+class LionTool(ABC):
+    is_lion_system_tool: bool = True
+    system_tool_name: str
+
+    @abstractmethod
+    def to_tool(self) -> Tool:
+        pass
+```
+
+The same module also defines graph-resource types unrelated to registration:
+
+```text
+lionagi/tools/base.py
+├── LionTool
+├── ResourceCategory
+├── ResourceMeta(BaseModel)
+├── Resource(Node)
+└── Prompt(Resource)
+```
+
+Branch registration is:
+
+```python
+# lionagi/session/branch.py
+def _register_tool(
+    self,
+    tools: FuncTool | LionTool,
+    update: bool = False,
+): ...
+
+def register_tools(
+    self,
+    tools: FuncTool | list[FuncTool] | LionTool,
+    update: bool = False,
+): ...
+```
+
+**Exact semantics**
+
+- A class object that is a `LionTool` subclass is instantiated with no arguments.
+- A `LionTool` instance is converted by calling `to_tool()` synchronously.
+- The result is handed to `ActionManager.register_tool()`, so it must be one
+  registry-acceptable `Tool`, raw callable, or one-entry MCP dictionary.
+- A top-level list is iterated and each element follows the same path. The marker
+  contract itself cannot return multiple tools; if `to_tool()` returns a list, manager
+  registration rejects it.
+- `update` is forwarded to each registry insertion.
+- A provider whose constructor requires context cannot be passed as a class to generic
+  registration; zero-argument instantiation fails before `to_tool()`.
+- A branch-bound provider instance reaches `to_tool()` and receives that provider's
+  deliberate `NotImplementedError`.
+- `is_lion_system_tool` and `system_tool_name` are conventions used by built-ins; the
+  abstract base enforces neither value nor uniqueness.
+
+**Why this way**
+
+The marker made the common stateless case concise: a provider object can own setup and
+cache while the branch receives an ordinary `Tool`. It deliberately avoided a larger
+factory framework. Once providers required branch context or multiple outputs, the
+single-method shape stopped satisfying substitutability but remained the inherited base.
+
+### D2 — Standalone built-ins cache one Pydantic-backed tool
+
+The stateless provider modules are:
+
+```text
+lionagi/tools/
+├── _subprocess.py
+├── file/
+│   ├── reader.py       ReaderTool
+│   └── editor.py       EditorTool
+└── code/
+    ├── bash.py         BashTool
+    ├── search.py       SearchTool
+    ├── check.py        CodeCheckTool
+    ├── nav.py          NavTool
+    └── ast_search.py   AstSearchTool
+```
+
+Every class owns `_tool`, initializes it to `None`, and constructs the descriptor only
+on the first `to_tool()` call. Subsequent calls return the same `Tool` object. Each
+wrapper is async, reconstructs its request model from `**kwargs`, awaits
+`handle_request()`, and returns `response.model_dump()`.
+
+The provider-visible request contracts are:
+
+```python
+# reader.py
+class ReaderRequest(BaseModel):
+    action: ReaderAction                   # read | open | list_dir
+    path: str
+    offset: int | None = None
+    limit: int | None = None
+    recursive: bool | None = None
+    file_types: list[str] | None = None
+
+class ReaderResponse(BaseModel):
+    success: bool
+    content: str | None = None
+    error: str | None = None
+
+# editor.py
+class EditorRequest(BaseModel):
+    action: EditorAction                   # write | edit
+    file_path: str
+    content: str | None = None
+    old_string: str | None = None
+    new_string: str | None = None
+    replace_all: bool = False
+
+class EditorResponse(BaseModel):
+    success: bool
+    content: str | None = None
+    error: str | None = None
+
+# bash.py
+class BashRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    command: str
+    timeout: int | None = None              # milliseconds
+    cwd: str | None = None
+
+class BashResponse(BaseModel):
+    stdout: str = ""
+    stderr: str = ""
+    return_code: int
+    timed_out: bool = False
+```
+
+```python
+# search.py
+class SearchRequest(BaseModel):
+    action: SearchAction                    # grep | find
+    pattern: str
+    path: str | None = "."
+    include: str | None = None
+    max_results: int | None = 50
+
+class SearchResponse(BaseModel):
+    success: bool
+    content: str | None = None
+    count: int = 0
+    error: str | None = None
+
+# check.py
+class CodeCheckRequest(BaseModel):
+    paths: list[str]
+    tool: Literal["ruff"] = "ruff"
+    max_diagnostics: int = Field(50, ge=1, le=500)
+
+class CodeCheckResponse(BaseModel):
+    status: Literal["ok", "diagnostics", "unavailable", "error"]
+    diagnostics: list[CodeDiagnostic] = Field(default_factory=list)
+    summary: str = ""
+    tool: str = "ruff"
+
+# nav.py
+class NavRequest(BaseModel):
+    action: str                             # outline | find_definition | find_references
+    path: str
+    symbol: str | None = None
+
+class NavResponse(BaseModel):
+    success: bool
+    items: list[NavItem] = Field(default_factory=list)
+    error: str | None = None
+```
+
+```python
+# ast_search.py
+class AstSearchRequest(BaseModel):
+    pattern: str
+    path: str = "."
+    lang: Literal[
+        "python", "rust", "typescript", "javascript", "go", "c", "cpp"
+    ] = "python"
+    max_results: int = Field(50, ge=1, le=500)
+
+class AstSearchResponse(BaseModel):
+    status: Literal["ok", "matches", "unavailable", "error"]
+    matches: list[AstSearchMatch] = Field(default_factory=list)
+    summary: str = ""
+    total: int = 0
+```
+
+The response item shapes used by diagnostics and navigation are:
+
+```python
+class CodeDiagnostic(BaseModel):
+    file: str
+    line: int
+    col: int
+    end_line: int | None = None
+    end_col: int | None = None
+    severity: Literal["error", "warning", "info"] = "warning"
+    code: str = ""
+    message: str
+    source: str = "ruff"
+    fixable: bool = False
+
+class NavItem(BaseModel):
+    kind: str
+    name: str
+    line: int
+    col: int
+    signature: str | None = None
+
+class AstSearchMatch(BaseModel):
+    file: str
+    line: int
+    col: int
+    text: str
+```
+
+**Exact shared semantics**
+
+- Reader, editor, diagnostics, navigation, and syntax-search constructors resolve
+  `workspace_root or Path.cwd()` once to an absolute path. Search freezes an explicitly
+  supplied root once; `workspace_root=None` leaves standalone search uncontained and
+  resolves paths against the current process.
+- The shared path resolver rejects a direct symlink, paths escaping the workspace, and
+  protected final names such as `.env`, `.netrc`, and private-key filenames
+  (`lionagi/libs/path_safety.py`).
+- Expected operational failures are returned inside typed response objects rather than
+  raised. Pydantic request validation can still raise before the handler returns.
+- Known blocking file, subprocess, and AST work is sent through `run_sync()` by the async
+  handlers, avoiding the generic inline-sync behavior in ADR-0012 D6.
+
+**Reader semantics and budgets**
+
+- `read` rejects missing/non-files, symlinks, and files whose first 8192 bytes contain a
+  NUL. The prefix bounds binary sniffing before the full read; the exact 8192-byte value
+  is inherited with no recorded tuning rationale. It decodes UTF-8 with replacement and
+  returns `<one-based-line-number>\t<text>` rows.
+- Negative offsets clamp to zero. Missing, zero, or negative `limit` becomes 2000 lines.
+  The 2000-line window is inherited; no source comment records why that exact value was
+  selected.
+- `list_dir` uses `recursive` and extension filters, truncating the file list to 1,000.
+  The cap bounds returned context; no recorded rationale explains the exact 1,000 value.
+- `open` accepts local `.pdf`, `.pptx`, `.docx`, `.html`, and `.htm` files up to
+  50 MiB. The size protects document conversion from an unbounded input; the exact
+  50 MiB choice has no recorded rationale.
+- Remote `open` accepts only `https` URLs whose host is explicitly configured and still
+  resolves to a public, SSRF-safe address. The coding toolkit supplies an empty host set,
+  so its bound reader rejects all remote URLs.
+- Converted text is cached by the original path and read through the same numbered-line
+  window. Cache expiry is hard-coded at 300 seconds (documented as five minutes).
+  `ReaderTool(cache_ttl=...)` stores the caller value, but `_read_cached()` and
+  `_evict_expired()` read the module constant, so the constructor value does not alter
+  expiry.
+- Missing `docling` returns an actionable `success=False` response; conversion exceptions
+  are returned as errors.
+
+**Editor semantics**
+
+- `write` requires non-`None` content, creates parent directories, and overwrites the
+  target. The standalone adapter's instruction to read first is advisory; no standalone
+  read-state check exists.
+- `edit` requires both strings, rejects a missing file, and requires an exact match. Zero
+  matches returns whitespace/line-prefix hints. Multiple matches fail unless
+  `replace_all=True`.
+- The edit write opens the already resolved file with `O_NOFOLLOW` when the platform
+  supports it. Success returns a bounded nearby snippet; the 40-character context on
+  each side and 200-character fallback are inherited presentation values with no
+  recorded rationale.
+
+**Shell and search semantics and budgets**
+
+- Bash uses `shlex.split()`, `shell=False`, and rejects `;`, `&&`, `||`, pipes,
+  redirects, newlines, backticks, and `$()` before process launch.
+- Bash timeout defaults to 30,000 ms when omitted and clamps supplied values into
+  1–300,000 ms; an explicit zero or negative value therefore becomes 1 ms. The default
+  targets ordinary commands and the five-minute maximum bounds long-running calls. No
+  source note records evidence for the exact values.
+- The subprocess starts a new process group and terminates that group on timeout. It
+  drains both streams and stores at most 100,000 bytes per stream while continuing to
+  drain to avoid child-process deadlock. After a timeout, each drain thread gets a
+  one-second join window. The output cap protects model context; the exact byte and join
+  values are inherited without recorded tuning evidence.
+- Grep and find each use fixed argv with `shell=False` and a fixed 30-second timeout.
+  Grep exit codes `0` and `1` are success (`1` is an empty match); every other grep code
+  is an error. Find reports a nonzero code as an error only when stderr is non-empty; a
+  nonzero code with empty stderr falls through to a successful result.
+- Standalone search defaults to 50 results for both actions because the model field and
+  handler both use 50. Its field description says find defaults to 100, but that value is
+  not the standalone runtime behavior.
+- `SearchRequest.max_results` has no numeric constraint. `None` or zero becomes 50;
+  a negative value remains truthy and is passed to Python's `lines[:max_results]` slice,
+  dropping that many trailing rows rather than raising a validation error.
+
+**Diagnostics and navigation semantics and budgets**
+
+- Code check supports only the `ruff` binary. Missing `ruff` is `unavailable`, findings
+  are `diagnostics`, and no findings are `ok`. Ruff gets 30 seconds. An exit code of 2 or
+  greater becomes `error` when stdout is empty; non-empty stdout is still parsed and
+  classified by its contents. Malformed non-empty JSON becomes `error`.
+- Diagnostics are sliced to `max_diagnostics`, default 50 and validated within 1–500.
+  The bound limits response noise; no source record justifies the exact ceiling.
+- An unexpected Ruff or ast-grep exit includes at most 300 characters of stderr in its
+  summary. This is an inherited diagnostic-presentation cap with no recorded rationale.
+- Navigation uses the Python standard-library AST for one contained file. Omitting the
+  `symbol` argument fails the two symbol actions; a supplied but absent symbol returns a
+  successful empty item list. Syntax/read errors become `success=False`.
+- `outline` reports class, function, and method nodes. `find_definition` matches classes,
+  sync/async functions, and simple name assignments/annotated assignments; it is not an
+  import or attribute resolver. `find_references` reports every matching `ast.Name`
+  regardless of load/store context and every `ast.Attribute` whose final attribute
+  matches, so its results are syntactic occurrences rather than semantic references.
+- AST search locates `sg` or `ast-grep`, returns `unavailable` if absent, uses a
+  30-second subprocess timeout, and accepts 1–500 results with default 50. It accepts JSON
+  arrays or NDJSON and converts zero-based tool lines to one-based response lines.
+
+**Why this way**
+
+Pydantic-backed adapters make model schema and runtime validation share a source, while
+typed response dictionaries keep expected operational failure visible to a reasoning
+loop. Per-provider caching avoids rebuilding descriptors. The repeated wrapper pattern
+is straightforward, but it leaves operational constants distributed across modules and
+does not by itself solve branch-bound construction.
+
+### D3 — Context and messenger are explicit branch-bound factories
+
+The context factory contract is:
+
+```python
+# lionagi/tools/context/context.py
+class ContextAction(str, Enum):
+    status = "status"
+    get_messages = "get_messages"
+    evict = "evict"
+    evict_action_results = "evict_action_results"
+    restore = "restore"
+    compact = "compact"
+
+class ContextRequest(BaseModel):
+    action: ContextAction
+    start: int | None = None
+    end: int | None = None
+    keep_last: int | None = None
+    summary: str | None = None
+    mode: str | None = None
+    scope: str | None = None
+    auto: bool = False
+
+class ContextTool(LionTool):
+    def bind(self, branch: Branch) -> Tool: ...
+    def to_tool(self) -> Tool: ...  # raises NotImplementedError
+```
+
+`bind()` captures `branch.msgs` and returns one tool whose callable mutates or reports
+the branch's active progression.
+
+**Context exact semantics**
+
+- The active progression is copied lazily into `branch.metadata["current_progression"]`
+  on the first mutating action; the full message pile and progression remain intact.
+- `status` reports active/total/evicted counts, role counts, and an estimated token sum.
+- `get_messages` defaults to active scope. Full scope marks every preview active or
+  evicted. Previews retain at most 120 characters; the cap is a presentation budget with
+  no recorded rationale for the exact value.
+- `evict` clamps its start to at least index 1, preserving the system message, and removes
+  `[start:end)` from the active progression only.
+- `evict_action_results` keeps the most recent five action responses by default. Five is
+  a context-retention heuristic stated in the request schema; no measurement is recorded.
+- `restore` indexes the full record and reinserts messages in chronological order.
+- `get_messages` and `restore` clamp ranges and return successful empty results when the
+  clamped range contains nothing. `evict` and `compact` instead return `success=False`
+  when their clamped start is not before the end. `evict_action_results` treats zero or
+  negative `keep_last` as keeping none.
+- `compact` defaults to `tool_io`, collapsing only action request/response messages;
+  `mode="all"` collapses the whole selected span except index 0. It inserts one assistant
+  summary message and excludes originals only from the active view.
+- `mode` and `scope` are unconstrained strings: only the exact `"tool_io"` value selects
+  tool-only compaction, so any other mode string follows the all-message branch; only
+  exact `scope="all"` selects the full record, and every other scope uses the active
+  view.
+- Automatic compaction concatenates at most 6,000 source characters before one direct
+  model call and returns a normal failure dictionary if the call fails or yields no text.
+  The cap bounds the auxiliary prompt; its exact value has no recorded rationale.
+
+The messenger factory contract is:
+
+```python
+# lionagi/tools/communication/messenger.py
+class MessengerRequest(BaseModel):
+    action: MessengerAction                 # send | done | finished | wakeup
+    to: str | list[str] | None = None
+    content: str | None = None
+
+class LionMessenger(LionTool):
+    def __init__(self, exchange: Exchange): ...
+    def on(self, event: str, callback): ...
+    def bind(
+        self,
+        branch: Branch,
+        roster: dict[str, UUID],
+        sender_name: str | None = None,
+        channel: str = "team",
+    ) -> Tool: ...
+    def to_tool(self) -> Tool: ...           # raises NotImplementedError
+```
+
+**Messenger exact semantics**
+
+- The bound callable captures the branch id as sender, the roster, channel, exchange,
+  and callback dispatcher. Default sender display is the first eight characters of the
+  branch id; eight is an inherited display convention with no recorded collision policy.
+- `send` requires recipients and content, sends once per known roster name, includes each
+  returned message in the branch pile if absent, and returns semicolon-joined text.
+  Unknown recipients are per-target text results rather than exceptions.
+- `done` and `finished` fire optional synchronous callbacks and return status text.
+- `wakeup` uses only the first item when `to` is a list, sends content prefixed with
+  `[WAKEUP]`, tracks the message, and fires the callback.
+- Unknown actions and missing fields are returned as strings beginning with an error or
+  unknown-action message; there is no typed messenger response model.
+- Exceptions from `Exchange.send()` or a registered synchronous callback are not
+  converted to those strings. They leave the messenger callable and, on the normal
+  branch path, become a failed `FunctionCalling` event under ADR-0012 D1.
+- `ContextTool.to_tool()` and `LionMessenger.to_tool()` always raise with instructions to
+  call `bind(...)`.
+
+**Why this way**
+
+Explicit binding makes captured context visible at construction and keeps ordinary
+`Tool` execution unaware of branch internals. It also allowed context and communication
+features to ship without changing the `LionTool` base. The cost is that instances claim
+an abstract method they intentionally cannot fulfill, and generic registration fails at
+runtime rather than expressing required context in the type.
+
+### D4 — `CodingToolkit.bind()` returns a branch-scoped tool set
+
+The toolkit's selection and construction contract is:
+
+```python
+# lionagi/tools/coding.py
+ALL_CODING_TOOLS = (
+    "reader", "editor", "bash", "search", "code_check",
+    "code_nav", "ast_search", "context", "sandbox", "subagent",
+)
+
+DEFAULT_CODING_TOOLS = (
+    "reader", "editor", "bash", "search", "code_check",
+    "code_nav", "ast_search", "context",
+)
+
+class CodingToolkit(LionTool):
+    def __init__(
+        self,
+        notify: bool = True,
+        notify_threshold: float = 0.7,
+        notify_max_tokens: int = 200_000,
+        workspace_root: str | Path | None = None,
+        tools: Sequence[str] | None = None,
+        nudge_engine: NudgeEngine | None = None,
+        nudge_rules: Sequence[NudgeRule] | None = None,
+    ): ...
+
+    def security_pre(self, tool_name: str, handler: Callable) -> CodingToolkit: ...
+    def pre(self, tool_name: str, handler: Callable) -> CodingToolkit: ...
+    def post(self, tool_name: str, handler: Callable) -> CodingToolkit: ...
+    def on_error(self, tool_name: str, handler: Callable) -> CodingToolkit: ...
+    def bind(self, branch: Branch) -> list[Tool]: ...
+    def to_tool(self) -> Tool: ...            # raises NotImplementedError
+```
+
+Sandbox and subagent add their own request models:
+
+```python
+class SandboxRequest(BaseModel):
+    action: SandboxAction                    # create | diff | commit | merge | discard
+    message: str | None = None
+
+class SubagentRequest(BaseModel):
+    instruction: str
+    permissions: str = "read_only"
+    max_turns: int = 20
+    cwd: str | None = None
+```
+
+`bind()` constructs local functions, pairs each with its canonical request model, attaches
+tool-specific preprocessors/postprocessors, filters by `enabled_tools`, and returns a
+list in `ALL_CODING_TOOLS` order.
+
+Agent construction treats this provider as a special case rather than sending it
+through generic `LionTool.to_tool()` registration: `_register_coding_tools()` constructs
+the toolkit, installs configured hooks, calls `toolkit.bind(branch)`, and registers the
+returned list (`lionagi/agent/factory.py`).
+
+**Exact branch-scoped semantics**
+
+- **Selection:** omitted `tools` selects the eight defaults. Unknown names raise
+  `ValueError` during toolkit construction. Sandbox and subagent are opt-in.
+- **Workspace:** the root is resolved once. The bound functions close over that root and
+  the supplied branch.
+- **File-state population:** a successful filesystem text read records resolved path and
+  modification time in `file_state` and marks the path in `read_tracked`. Image reads and
+  reads served from the converted-document cache return before that metadata is added.
+  A successful write or edit also refreshes `file_state`, but removes the path from
+  `read_tracked`.
+- **Mutation guard:** an existing-file write and an edit require a `file_state` entry and
+  compare the current mtime with the stored value. A new-file write needs no entry. Once
+  a toolkit write/edit succeeds, its refreshed entry authorizes a later mutation without
+  another read. An external mtime change forces a re-read; failure to `stat()` during the
+  guard returns no error and allows the mutation attempt to continue.
+- **Context coupling:** after successful eviction or compaction, invalidation examines
+  only paths still in `read_tracked` and drops those whose reader response is no longer
+  active. Mutation-derived entries have been removed from `read_tracked`, so they remain
+  in `file_state` even when the original read evidence leaves active context.
+- **Tool hooks:** security/user preprocessors and postprocessors use the same composition
+  helpers as agent factory registration. Registered `error` hooks are stored on the
+  toolkit but are not attached to the returned `Tool` values in `bind()`.
+- **Nudges:** when `notify=True`, `bind()` uses a caller-supplied `nudge_engine` unchanged
+  or constructs `NudgeEngine(branch, rules=...)`, stores it as
+  `_bound_nudge_engine`, and adds a wildcard post-hook that can add a `system` field to
+  dictionary results. Evaluation failure logs a warning and preserves the original
+  result.
+- **Repeated binding:** the notify hook is appended to the toolkit's persistent
+  `_post_hooks` map inside every `bind()` call. Reusing one `CodingToolkit` instance for
+  another branch therefore attaches both the new hook and prior bind hooks to the new
+  descriptors; those older closures retain their earlier engine and file-state maps.
+- **Declared nudge numbers:** `notify_threshold=0.7` and
+  `notify_max_tokens=200_000` are stored on the toolkit but not read by `bind()` or
+  passed to the constructed nudge engine in this module. They are inherited inactive
+  settings here; no runtime budget or rationale can be claimed from them.
+- **Sandbox state:** one mutable session slot is captured per bind. A second create is
+  rejected until merge or discard. A successful merge clears the slot. A discard that
+  returns clears it regardless of the returned success flag; an exception from
+  `sandbox_discard()` propagates before the clear and leaves the slot populated.
+- **Subagent budget:** `max_turns` defaults to 20 and clamps to 1–50 before becoming
+  `max_extensions`. Successful text is truncated to 5,000 characters in the parent
+  result. The request text identifies 20/50 as reasoning bounds, and the response cap
+  bounds parent-context growth; no measurement for the exact values is recorded.
+
+**Parallel implementation semantics**
+
+- The toolkit imports the standalone request models and selected blocking helpers, so
+  provider schemas share field names and constraints.
+- The bound reader additionally returns images as base64 data URLs; the standalone reader
+  treats NUL-bearing binary content as unsupported. Toolkit document opening allows no
+  remote hosts.
+- Toolkit editor enforces a `file_state` prerequisite for an existing-file write and an
+  edit; the first mutation normally requires a successful text read, while successful
+  mutations refresh the state for later calls. Standalone editor only instructs the
+  caller to read first.
+- Toolkit search defaults to 50 results for grep and 100 for find when the field is
+  omitted or null. Standalone search uses 50 for both. Toolkit responses use
+  `total_matches`/`total_found` and `shown`; standalone uses `count`.
+- Toolkit search shares the unconstrained `SearchRequest`: zero selects its per-action
+  default, while a negative limit reaches slicing and can produce a negative `shown`
+  count. Its grep handler treats only return code `2` as failure and does not inspect the
+  shared helper's `timed_out` flag, whereas standalone grep rejects every code outside
+  `{0, 1}` and handles timeout explicitly.
+- Toolkit code check calls the shared Ruff helper but does not pass the standalone
+  workspace cwd. Toolkit navigation and AST search call the same low-level helpers and
+  assemble their own dictionaries.
+- Toolkit bash implements the same operator rejection and output cap through shared
+  subprocess code, then renames `returncode` to `return_code`. It computes the timeout as
+  `timeout or 30000` before clamping, so an explicit zero means 30 seconds rather than the
+  standalone adapter's 1 ms; negative values still clamp to 1 ms and values above five
+  minutes clamp to 300,000 ms.
+- Expected failures remain dictionaries, but not every dictionary has the corresponding
+  standalone response model's complete fields or wording.
+
+**Why this way**
+
+Binding once provides a natural home for read state, active-context checks, optional
+nudge state, and sandbox lifecycle. Reusing request models retains provider-schema
+compatibility. Reimplementing the handlers made stateful behavior easy to add around
+each operation, but it created two semantic sources of truth. The accepted delta is to
+compose canonical standalone operations and layer only branch state and policy.
+
+### D5 — Branch cloning copies registered descriptors without rebinding
+
+The clone path is:
+
+```python
+# lionagi/session/branch.py
+def clone(self, sender: ID.Ref = None) -> Branch:
+    tools = (
+        list(self._action_manager.registry.values())
+        if self._action_manager.registry
+        else None
+    )
+    branch_clone = Branch(
+        system=<cloned system>,
+        user=self.user,
+        messages=[msg.clone() for msg in self.msgs.messages],
+        tools=tools,
+        chat_model=<copied or shared model>,
+        parse_model=<copied or shared model>,
+        metadata={"clone_from": self},
+    )
+    ...
+    return branch_clone
+```
+
+**Exact semantics**
+
+- The clone constructs a new `ActionManager` and registry dictionary.
+- The values passed into that manager are the original `Tool` objects. Registration of
+  a `Tool` stores it as-is, so source and clone registries point to identical descriptor
+  objects and callable objects.
+- Stateless cached descriptors are consequently shared too; mutation of processors or
+  schema through either reference is visible to both branches.
+- A callable returned by `ContextTool.bind(source)` retains the source `branch`, message
+  manager, and metadata in its closure after clone registration.
+- A messenger callable retains the source branch id and source message pile used by its
+  tracking closure.
+- Every `CodingToolkit.bind(source)` function retains the source branch, source
+  progression, source message manager, local file-state dictionaries, nudge engine, and
+  optional sandbox slot.
+- The clone operation has no provider identity, scope enum, rebind callback, or
+  cloneability check, so it cannot distinguish these descriptors from reusable stateless
+  tools.
+- Message objects themselves are cloned and recipients are rewritten; this does not
+  affect the callable closures already copied.
+
+**Why this way**
+
+Copying registry values preserves the visible tool set and is sufficient for stateless
+functions. It also avoids requiring every third-party descriptor to implement cloning.
+Once providers captured branch state, descriptor reuse became semantically unsafe. The
+current code has no metadata from which clone could infer a repair, so rebinding must be
+an explicit provider contract or cloning must reject non-cloneable bindings.
 
 ## Consequences
 
-Standalone tools remain easy to construct, test, register, and use directly, while
-branch-scoped behavior can be assembled once during agent construction. Pydantic request
-models give both modes a useful common input vocabulary.
-
-Not every `LionTool` is substitutable through its declared method, so generic registration
-cannot reliably consume the hierarchy. Parallel standalone and coding implementations can
-drift in response shape, defaults, containment, timeout, and error behavior. Copying a
-branch-bound closure into a clone can direct context mutation or persistence at the source
-branch. Resource and prompt types in the base module also obscure the boundary of the tool
-provider abstraction.
+- Maintained standalone tools are easy to construct, test, cache, and register through
+  one generic path.
+- Pydantic request models give standalone and toolkit variants a shared provider input
+  vocabulary.
+- Expected file and subprocess failures are model-visible typed values rather than
+  exceptions, and known blocking operations are offloaded deliberately.
+- `LionTool` is not substitutable across its current subclasses: three implementations
+  deliberately raise from the only abstract method.
+- Operational caps are dispersed across adapters; several exact values are inherited
+  without recorded evidence, and one reader cache setting is exposed but inactive.
+- CodingToolkit's parallel handlers already diverge in search defaults, response keys,
+  subprocess exit/timeout classification, explicit-zero timeout behavior, image
+  behavior, and read-before-edit enforcement.
+- CodingToolkit's context invalidation applies only while state remains tagged as
+  read-derived; a successful mutation converts it to mutation-derived state that can
+  outlive the active reader response.
+- Rebinding the same notifying `CodingToolkit` instance accumulates branch-scoped nudge
+  closures, so provider instances are single-bind in practice even though the interface
+  does not enforce that lifecycle.
+- A cloned registry has independent name membership but shared descriptor identity. For
+  bound closures, calls through the clone can mutate, message from, or inspect the source
+  branch.
+- Reversing D1 requires a provider result that can represent one or many tools plus
+  explicit construction context. Reversing D5 requires retaining provider provenance at
+  registration time; a bare closure cannot be reliably rebound after the fact.
+- Contributors must not assume a `LionTool` instance is generically registerable or a
+  registered `Tool` is safe to copy across branch scope.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Replace the partial `LionTool.to_tool()` contract with a provider build contract that returns one or more tools from an explicit context; acceptance requires stateless and branch-bound built-ins to use the same construction path without raising from the advertised interface. | M | (filled at issue-open time) |
+| 1 | Replace the partial `LionTool.to_tool()` contract with a provider build contract that returns one or more tools from an explicit context; acceptance requires stateless and branch-bound built-ins to use the same construction path without raising from the advertised interface and to declare whether provider instances are reusable, single-bind, or cloneable. | M | (filled at issue-open time) |
 | 2 | Make branch cloning rebuild branch-bound providers for the clone or reject non-cloneable bindings; acceptance requires context, coding, and messenger callables registered on a clone to reference only the clone's state. | S | (filled at issue-open time) |
-| 3 | Refactor `CodingToolkit` to compose canonical standalone operations and add only branch-scoped state and policy; acceptance requires response-schema and failure-semantic parity tests for every operation exposed in both modes. | M | (filled at issue-open time) |
+| 3 | Refactor `CodingToolkit` to compose canonical standalone operations and add only branch-scoped state and policy; acceptance requires response-schema and failure-semantic parity tests for every operation exposed in both modes, plus a tested file-state lifecycle that either requires active read evidence for each mutation or explicitly defines when a prior mutation substitutes for a read. | M | (filled at issue-open time) |
 | 4 | Move resource and prompt graph types out of the tool-provider base module; acceptance requires the tool base module to contain only registration and construction abstractions with unchanged public compatibility aliases. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A. Keep `LionTool.to_tool()` as the universal provider interface
+
+This is sufficient for cached stateless adapters and keeps branch registration tiny. It
+lost as a universal abstraction because context and messenger need inputs and coding
+returns multiple descriptors. Their `NotImplementedError` implementations are direct
+evidence that the method cannot express the shipped provider set.
+
+### B. Remove `LionTool` and use ordinary factories
+
+Plain functions returning `Tool | list[Tool]` would remove the broken inheritance and
+make branch-bound inputs explicit without a new framework. It remains viable and is the
+seed recorded in the original draft. It loses if third-party providers need a stable,
+typed construction and clone contract discoverable by generic branch code; that product
+requirement decides factory functions versus a provider protocol.
+
+### C. Introduce a context-aware provider protocol
+
+A protocol such as `build(context) -> list[Tool]` could support stateless and bound
+providers uniformly and carry clone scope. It was not the organic implementation because
+the original built-ins each returned one tool and no branch context was needed. Delta 1
+retains this design direction without selecting its final public type prematurely.
+
+### D. Put branch context directly on `Tool`
+
+Adding a `branch` field or generic context object to every descriptor would let one
+`to_tool()` path construct bound behavior. It lost because most tools are reusable and
+the callable already captures only what it needs; putting session state on the core
+descriptor would couple ADR-0011's portable declaration to Branch.
+
+### E. Reuse standalone tools unchanged inside CodingToolkit
+
+This would guarantee response and default parity and remove duplicated subprocess/file
+logic. It did not satisfy the initial stateful needs by itself: read-before-edit requires
+observing successful reads, context eviction must invalidate that state, and nudges need
+post-call information. The retained design is composition plus explicit state/policy
+wrappers, not simple list concatenation.
+
+### F. Keep the parallel coding implementations
+
+This bought direct access to branch-local state in each closure and allowed operation-
+specific response additions. It lost as the long-term shape because standalone and bound
+semantics already differ in defaults, fields, and supported content. Every bug fix must
+be reasoned about twice.
+
+### G. Deep-copy tool descriptors during branch clone
+
+Deep-copying would separate mutable schema and processor fields. It lost as a fix for
+branch binding because copying a Python closure does not rewrite its captured branch,
+message manager, exchange sender id, or nudge engine. The result would look independent
+while retaining the same scope bug.
+
+### H. Drop all tools when cloning
+
+This would avoid stale closures and force callers to register a safe set explicitly. It
+lost because branch splitting expects visible capabilities to carry forward and existing
+tests assert cloned stateless tools remain registered. A scope-aware provider contract
+can preserve safe tools and rebuild or reject unsafe ones.
+
+### I. Mark bound tools non-cloneable and reject cloning
+
+This is the smallest safe correction: registration records scope and clone fails loudly
+when a provider offers no rebinding function. It gives up transparent branch splitting
+for context/coding/messenger users. Delta 2 keeps it as the fallback when a provider
+cannot build against the clone.
+
+### J. Keep resource and prompt graph types in `tools.base`
+
+Co-location reduces module count and preserves old imports. It lost on cohesion: those
+types do not implement registration or callable construction, so the module name no
+longer identifies one responsibility. Delta 4 preserves compatibility aliases while
+moving their implementation boundary.
 
 ## Notes
 
-Removing `LionTool` in favor of ordinary factories is a viable alternative to introducing a
-provider protocol. The deciding constraint is whether third-party providers need a stable,
-typed construction interface for branch context and multiple-tool output.
+Removing `LionTool` in favor of ordinary factories remains a viable alternative to a
+provider protocol. The deciding constraint is whether third-party providers need a
+stable, typed construction interface for branch context, multiple-tool output, and clone
+scope.

--- a/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
+++ b/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
@@ -1,0 +1,89 @@
+# ADR-0013: Built-in Tool Provider and Branch Binding
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: actions-tools
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0011
+
+## Context
+
+Most standalone built-ins pair a Pydantic request model with an async handler and expose a
+cached `Tool` through `to_tool()`. Reader, editor, search, shell, diagnostics, navigation,
+and syntax-search adapters use this shape. Their concrete implementations own operational
+constraints such as workspace path resolution, subprocess limits, and typed response
+models (`lionagi/tools/file/reader.py`, `lionagi/tools/file/editor.py`,
+`lionagi/tools/code/bash.py`, `lionagi/tools/code/search.py`,
+`lionagi/tools/code/check.py`, `lionagi/tools/code/nav.py`,
+`lionagi/tools/code/ast_search.py`).
+
+`LionTool` is the common marker for those adapters. Its only behavioral requirement is
+`to_tool()`, and `Branch.register_tools()` handles a `LionTool` by calling that method
+before registry insertion. The same base module also contains resource and prompt graph
+types that do not participate in tool registration (`lionagi/tools/base.py`,
+`lionagi/session/branch.py`).
+
+Three built-in providers require runtime context instead of satisfying that generic path.
+`ContextTool` closes over a branch's messages and progression, `LionMessenger` closes over
+a branch and exchange roster, and `CodingToolkit` builds a list of tools around branch
+state. Each exposes `bind(...)` and intentionally raises from `to_tool()`. Agent construction
+therefore special-cases coding-tool binding rather than passing the provider through generic
+branch registration (`lionagi/tools/context/context.py`,
+`lionagi/tools/communication/messenger.py`, `lionagi/tools/coding.py`,
+`lionagi/agent/factory.py`).
+
+`CodingToolkit` adds genuinely branch-scoped behavior: read-before-edit state, context
+curation, and optional nudges based on branch history. It also implements local reader,
+editor, shell, search, diagnostics, navigation, and syntax-search callables alongside the
+standalone adapters with the same responsibilities. Those paths share request models and
+some helpers but produce their own response dictionaries and execution behavior
+(`lionagi/tools/coding.py`).
+
+Branch cloning copies registered `Tool` descriptors into the clone's manager. It does not
+rebuild or rebind their callables. A descriptor produced by `CodingToolkit.bind()`,
+`ContextTool.bind()`, or `LionMessenger.bind()` can consequently retain a closure over the
+source branch after being registered on the clone (`lionagi/session/branch.py`).
+
+## Decision
+
+The current built-in provider model has these load-bearing invariants:
+
+- Stateless built-ins adapt their concrete implementation and Pydantic request model into
+  one regular `Tool`, which the branch can register generically.
+- `LionTool` advertises `to_tool()` but does not model construction context, multiple-tool
+  output, lifecycle, or clone behavior.
+- Context, messenger, and coding providers are branch-bound factories despite inheriting
+  from `LionTool`; their supported construction path is `bind(...)`, not `to_tool()`.
+- `CodingToolkit.bind()` returns the configured tool set and owns branch-local read state,
+  context operations, and nudge integration. Its basic tool operations remain a parallel
+  implementation to the standalone adapters.
+- Branch cloning reuses registered descriptors as-is. No provider scope, rebinding, or
+  cloneability contract is consulted.
+
+## Consequences
+
+Standalone tools remain easy to construct, test, register, and use directly, while
+branch-scoped behavior can be assembled once during agent construction. Pydantic request
+models give both modes a useful common input vocabulary.
+
+Not every `LionTool` is substitutable through its declared method, so generic registration
+cannot reliably consume the hierarchy. Parallel standalone and coding implementations can
+drift in response shape, defaults, containment, timeout, and error behavior. Copying a
+branch-bound closure into a clone can direct context mutation or persistence at the source
+branch. Resource and prompt types in the base module also obscure the boundary of the tool
+provider abstraction.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Replace the partial `LionTool.to_tool()` contract with a provider build contract that returns one or more tools from an explicit context; acceptance requires stateless and branch-bound built-ins to use the same construction path without raising from the advertised interface. | M | (filled at issue-open time) |
+| 2 | Make branch cloning rebuild branch-bound providers for the clone or reject non-cloneable bindings; acceptance requires context, coding, and messenger callables registered on a clone to reference only the clone's state. | S | (filled at issue-open time) |
+| 3 | Refactor `CodingToolkit` to compose canonical standalone operations and add only branch-scoped state and policy; acceptance requires response-schema and failure-semantic parity tests for every operation exposed in both modes. | M | (filled at issue-open time) |
+| 4 | Move resource and prompt graph types out of the tool-provider base module; acceptance requires the tool base module to contain only registration and construction abstractions with unchanged public compatibility aliases. | S | (filled at issue-open time) |
+
+## Notes
+
+Removing `LionTool` in favor of ordinary factories is a viable alternative to introducing a
+provider protocol. The deciding constraint is whether third-party providers need a stable,
+typed construction interface for branch context and multiple-tool output.

--- a/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
+++ b/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
@@ -1,0 +1,91 @@
+# ADR-0016: Branch Conversation Aggregate and Attachment Boundary
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: session-branch
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+`Branch` is the stateful aggregate for one conversation. It constructs and exposes a
+`MessageManager`, `ActionManager`, `iModelManager`, `DataLogger`, and `OperationManager`. The
+message manager owns the message pile and active progression; the other managers own registered
+tools, model selection, logs, and named-operation lookup rather than parallel copies of those
+resources (`lionagi/session/branch.py`).
+
+Conversation state and invocation state have different lifetimes. Messages, progression, tool and
+model configuration, logs, memory, identity, and metadata belong to the branch. Context-provider
+blocks, the latest provider report, pending loop control, and background signal tasks are currently
+held on the same object even though they describe an invocation in progress. Provider behavior and
+request compilation are specified separately (see the messages-context ADR on pre-turn context
+providers and the messages-context ADR on canonical turn-request compilation).
+
+The public verb methods are adapters over implementations in `lionagi/operations/`. `Branch` keeps
+the stable caller surface and supplies the aggregate those implementations mutate; it is not a
+second operation engine. Recording, streaming, parsing, action, and `Middle` semantics belong to the
+operation layer (see the operations ADR on the Branch operation facade and turn adapters).
+
+A standalone branch lazily creates private in-memory storage and a private operation registry. A
+session may attach an observer and hook bus, replace the operation registry with its shared registry,
+and supply shared memory when the branch has not already adopted a store. Capability grants remain
+branch-local: granting replaces one marked system-prompt block, and observed assistant messages are
+validated against that grant before structured-output or rejection signals are emitted
+(`lionagi/session/capabilities.py`, `lionagi/operations/_observe.py`).
+
+## Decision
+
+`Branch` remains the aggregate and facade for exactly one durable conversation. Its load-bearing
+invariants are:
+
+- branch identity, message history and progression, registered tools, selected models, logs,
+  metadata, and an adopted memory store have branch lifetime;
+- the manager properties are the authoritative access paths to those resources; callers do not
+  maintain shadow registries or message collections alongside them;
+- context providers and capability grants are branch-scoped extensions, while provider results and
+  lifecycle bookkeeping are invocation-scoped data rather than durable conversation records;
+- an explicitly supplied or previously adopted memory store is retained when a branch joins a
+  session; only a branch without a store adopts the session store;
+- observer, hook, session-ownership, and shared-operation references are coordination attachments,
+  not serialized conversation content, and removal from a session detaches them without deleting
+  messages, memory, or logs; and
+- public verb methods delegate to the operation layer. The Branch boundary owns state and API
+  continuity, while operation modules own execution algorithms and transport semantics.
+
+```text
+                  Branch
+       conversation state and identity
+          /       |       |       \
+   messages    actions   models    logs
+          \       |       |       /
+        memory, providers, capabilities
+                       |
+          session coordination attachments
+       observer, hooks, shared operation registry
+```
+
+## Consequences
+
+Operations receive one coherent object instead of a bundle of loosely related managers, and a
+branch can operate alone or be attached to a session without changing its conversation identity.
+Manager replacement and attachment remain internal implementation details, so callers retain one
+public surface.
+
+The aggregate has a broad dependency set and currently mixes durable conversation state with
+invocation-local state. Private attributes are therefore not interchangeable: moving or serializing
+one without classifying its lifetime can introduce cross-turn leakage or silently persist runtime
+coordination objects.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Implement the turn-scoped execution context and same-Branch serialization contract from ADR-0018; acceptance requires two overlapping top-level turns to neither overwrite provider data, consume each other's control, drain each other's signal tasks, nor change the branch's configured model. | M | (filled at issue-open time) |
+| 2 | Remove the deprecated no-op `system_template` and `system_template_context` constructor arguments under the public deprecation policy, and classify `Branch.connect()` as supported or deprecated after a repository-wide consumer inventory; acceptance requires updated API documentation and compatibility tests for the selected outcome. | S | (filled at issue-open time) |
+
+## Notes
+
+Splitting every manager into a separately passed operation dependency was rejected because the
+managers jointly define one conversation's state. Treating session attachments as durable branch
+state was rejected because a branch must be detachable and reparentable without carrying the prior
+session's observer, hooks, or operation registry.

--- a/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
+++ b/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
@@ -8,73 +8,438 @@
 
 ## Context
 
-`Branch` is the stateful aggregate for one conversation. It constructs and exposes a
-`MessageManager`, `ActionManager`, `iModelManager`, `DataLogger`, and `OperationManager`. The
-message manager owns the message pile and active progression; the other managers own registered
-tools, model selection, logs, and named-operation lookup rather than parallel copies of those
-resources (`lionagi/session/branch.py`).
+`Branch` is the stateful aggregate for one conversation. The class is both the place where
+conversation resources are assembled and the stable caller-facing facade for operations implemented
+under `lionagi/operations/`. Five concrete problems shape that boundary.
 
-Conversation state and invocation state have different lifetimes. Messages, progression, tool and
-model configuration, logs, memory, identity, and metadata belong to the branch. Context-provider
-blocks, the latest provider report, pending loop control, and background signal tasks are currently
-held on the same object even though they describe an invocation in progress. Provider behavior and
-request compilation are specified separately (see the messages-context ADR on pre-turn context
-providers and the messages-context ADR on canonical turn-request compilation).
+**P1 — one conversation needs one authoritative state owner.** Message history and active
+progression, registered tools, selected chat and parse models, logs, identity, metadata, memory, and
+named operations otherwise become a bag of independently passed managers. That makes it possible for
+an operation to receive a message collection from one conversation and a model or tool registry from
+another. `Branch.__init__()` constructs the five managers that jointly define the conversation
+(`lionagi/session/branch.py`).
 
-The public verb methods are adapters over implementations in `lionagi/operations/`. `Branch` keeps
-the stable caller surface and supplies the aggregate those implementations mutate; it is not a
-second operation engine. Recording, streaming, parsing, action, and `Middle` semantics belong to the
-operation layer (see the operations ADR on the Branch operation facade and turn adapters).
+**P2 — branch lifetime and serialization lifetime are not identical.** A tool may contain a live
+callable, a memory store may be an external backend, and an observer or hook bus belongs to a running
+session. Those objects can remain attached for the lifetime of a branch without being valid
+conversation-file content. `Branch.to_dict()` therefore exports a deliberate subset rather than all
+private state.
 
-A standalone branch lazily creates private in-memory storage and a private operation registry. A
-session may attach an observer and hook bus, replace the operation registry with its shared registry,
-and supply shared memory when the branch has not already adopted a store. Capability grants remain
-branch-local: granting replaces one marked system-prompt block, and observed assistant messages are
-validated against that grant before structured-output or rejection signals are emitted
-(`lionagi/session/capabilities.py`, `lionagi/operations/_observe.py`).
+**P3 — a branch must work both alone and inside a session.** A standalone branch creates its own
+operation registry and lazily creates private in-memory storage. Session inclusion replaces selected
+coordination references and may supply a shared memory default. Removal must undo the session-owned
+references without deleting the conversation.
+
+**P4 — optional context and capability features must not become parallel conversation stores.**
+Context providers inject ephemeral text into one provider request; they do not append that text to
+message history. Capability grants affect prompt instructions and interpretation of assistant output;
+they do not replace the action registry or session gate.
+
+**P5 — the public operation surface must not duplicate execution algorithms.** `chat`, `parse`,
+`operate`, `communicate`, `act`, `interpret`, `ReAct`, `ReActStream`, and `run` are methods on the
+aggregate, but their algorithms live under `lionagi/operations/`. Recording, streaming, parsing,
+action, and `Middle` semantics are owned by the operations area (see the operations ADR on the Branch
+operation facade and turn adapters).
+
+| Concern | Decision |
+|---------|----------|
+| Conversation composition | D1: `Branch` owns one authoritative set of managers and selected resources. |
+| Persistence boundary | D2: serialization exports conversation data, not live private attachments. |
+| Optional branch extensions | D3: memory, context providers, and capability grants are branch-scoped with distinct persistence semantics. |
+| Session attachment | D4: observer, hooks, ownership, and the shared operation registry are detachable coordination references; adopted memory is retained. |
+| Operation and clone behavior | D5: public verbs delegate to operation modules, and cloning creates a new conversation aggregate from an explicit subset. |
+
+This ADR deliberately does **not** decide:
+
+- provider request compilation; that belongs to the messages-context ADR on canonical turn-request
+  compilation;
+- provider selection, retry, timeout, parsing, action, streaming, or `Middle` algorithms; those
+  belong to the operations and service-provider areas;
+- Session membership, observer dispatch, hook execution, Exchange routing, or graph scheduling;
+  ADR-0017 records the session side of those contracts;
+- the target isolation mechanism for overlapping turns; ADR-0018 defines that aspirational change;
+- durable encoding for callables, memory backends, providers, or capability models; no such portable
+  encoding is shipped.
 
 ## Decision
 
-`Branch` remains the aggregate and facade for exactly one durable conversation. Its load-bearing
-invariants are:
+### D1 — Branch is the authoritative conversation aggregate
 
-- branch identity, message history and progression, registered tools, selected models, logs,
-  metadata, and an adopted memory store have branch lifetime;
-- the manager properties are the authoritative access paths to those resources; callers do not
-  maintain shadow registries or message collections alongside them;
-- context providers and capability grants are branch-scoped extensions, while provider results and
-  lifecycle bookkeeping are invocation-scoped data rather than durable conversation records;
-- an explicitly supplied or previously adopted memory store is retained when a branch joins a
-  session; only a branch without a store adopts the session store;
-- observer, hook, session-ownership, and shared-operation references are coordination attachments,
-  not serialized conversation content, and removal from a session detaches them without deleting
-  messages, memory, or logs; and
-- public verb methods delegate to the operation layer. The Branch boundary owns state and API
-  continuity, while operation modules own execution algorithms and transport semantics.
+`Branch` remains the owner of exactly one conversation's identity and manager set. The shipped model
+and constructor are (`lionagi/session/branch.py`):
+
+```python
+class Branch(Element, Relational):
+    user: SenderRecipient | None = None
+    name: str | None = None
+
+    _message_manager: MessageManager | None = PrivateAttr(None)
+    _action_manager: ActionManager | None = PrivateAttr(None)
+    _imodel_manager: iModelManager | None = PrivateAttr(None)
+    _log_manager: DataLogger | None = PrivateAttr(None)
+    _operation_manager: OperationManager | None = PrivateAttr(None)
+
+    def __init__(
+        self,
+        *,
+        user: SenderRecipient = None,
+        name: str | None = None,
+        messages: Pile[RoledMessage] = None,
+        system: System | JsonValue = None,
+        system_sender: SenderRecipient = None,
+        chat_model: iModel | dict | str = None,
+        parse_model: iModel | dict | str = None,
+        tools: FuncTool | list[FuncTool] = None,
+        log_config: DataLoggerConfig | dict = None,
+        system_datetime: bool | str = None,
+        system_template=None,
+        system_template_context: dict = None,
+        logs: Pile[Log] = None,
+        use_lion_system_message: bool = False,
+        memory: MemoryStore | None = None,
+        **kwargs,
+    ): ...
+```
+
+Construction creates this object graph:
 
 ```text
-                  Branch
-       conversation state and identity
-          /       |       |       \
-   messages    actions   models    logs
-          \       |       |       /
-        memory, providers, capabilities
-                       |
-          session coordination attachments
-       observer, hooks, shared operation registry
+Branch
+├── MessageManager(messages) ── messages + progression + system
+├── ActionManager() ─────────── registered Tool objects
+├── iModelManager(chat, parse) ─ selected model access points
+├── DataLogger(...) ─────────── logs + logger configuration
+└── OperationManager() ──────── named async-operation registry
 ```
+
+The manager properties are the authoritative access paths:
+
+| Property | Returned object | Exact current behavior |
+|----------|-----------------|------------------------|
+| `system` | `System \| None` | Delegates to `MessageManager.system`. |
+| `msgs` | `MessageManager` | Returns the sole message manager. |
+| `messages` | `Pile[RoledMessage]` | Returns `MessageManager.messages`; no copy is made. |
+| `progression` | `Progression` | Uses `metadata["current_progression"]` when present, otherwise the manager progression. |
+| `acts` / `tools` | `ActionManager` / `dict[str, Tool]` | `tools` exposes the action registry. |
+| `mdls` | `iModelManager` | Returns the sole model manager. |
+| `chat_model` / `parse_model` | `iModel` | Setters re-register the named model in the manager. |
+| `logs` | `Pile[Log]` | Returns the data logger's pile. |
+
+**Exact construction semantics:**
+
+- If no chat model is supplied, an `iModel` is built from
+  `settings.LIONAGI_CHAT_PROVIDER` and `settings.LIONAGI_CHAT_MODEL`.
+- If no parse model is supplied, the parse model is the selected chat-model object. Dictionary
+  inputs use `iModel.from_dict`; string inputs use `iModel(model=value)`.
+- Tools are registered into the new `ActionManager`; duplicate and update behavior is delegated to
+  that manager.
+- A truthy dictionary log configuration is validated as `DataLoggerConfig`; otherwise, including
+  for `None` or `{}`, the default logger uses `settings.LOG_CONFIG`. Supplied logs initialize that
+  logger rather than a second pile.
+- A system message is added only when at least one of `system`, `system_datetime`, or
+  `use_lion_system_message` is truthy. An explicitly supplied empty string or `False` values alone
+  do not create one. The Lion system message is prepended when requested.
+- `system_template` and `system_template_context` are accepted only for compatibility. A non-`None`
+  value emits `DeprecationWarning` and has no effect.
+- The message manager's synchronous `on_message_added` callback list receives
+  `Branch._schedule_emit`, so later message additions can be projected onto an attached observer.
+
+These choices make the branch broad by design: the managers are cohesive around one conversation,
+not independently replaceable public services.
+
+### D2 — Serialization exports a selected conversation projection
+
+The serialized contract is the output of `Branch.to_dict()` rather than the full in-memory object
+graph (`lionagi/session/branch.py`):
+
+```python
+def to_dict(
+    self,
+    mode: Literal["python", "json", "db"] = "python",
+    db_meta_key: str | None = None,
+    include_request_options: bool = False,
+    include_logs: bool = True,
+    include_log_config: bool = False,
+    include_processor_config: bool = False,
+    **kw,
+) -> dict: ...
+```
+
+After the inherited `Element` fields, the branch adds this projection:
+
+```text
+messages     always present; empty form is
+             {"collections": [], "progression": {"order": []}}
+logs         present only when include_logs=True and logs are non-empty
+system       present when a system message exists
+log_config   present only when include_log_config=True
+chat_model   always present
+parse_model  present only when it is not the same object as chat_model
+```
+
+Request-option and processor configuration inclusion is forwarded to each model's `to_dict()`.
+Tools, the operation registry, memory, provider registry, provider report, capability grant,
+pending control, pending signal tasks, observer, hooks, and owning-session reference are not added
+to the projection. All are private attributes; they are not made persistent merely because some of
+them have branch lifetime.
+
+`from_dict()` consumes the serialized keys `messages`, `logs`, `chat_model`, `parse_model`,
+`system`, and `log_config` and passes the remaining compatible values into the constructor. When
+both serialized messages and a top-level system are present, it suppresses the top-level system so
+the system message already in the pile is not re-added. The method uses `pop()` on the supplied
+dictionary, so callers that need the input unchanged must pass a copy.
+
+**Exact edge cases:**
+
+- Empty messages still produce the explicit empty pile shape; absence is not used to mean empty.
+- Empty logs are omitted even when `include_logs=True`.
+- A distinct parse model is serialized; an aliased chat/parse model is represented once.
+- Session coordination references never survive a round trip. A deserialized branch is standalone.
+- A serialized branch does not reconstruct live tools, providers, capabilities, memory, or named
+  operations because those contracts have no portable representation here.
+
+### D3 — Optional memory, provider, and capability extensions remain branch-scoped
+
+These extensions all belong to a branch, but their lifetimes and error policies differ.
+
+#### Memory contract
+
+```python
+@property
+def memory(self) -> MemoryStore:
+    if self._memory is None:
+        self._memory = InMemoryStore()
+    return self._memory
+```
+
+- An explicit constructor store is retained by identity.
+- First property access on a standalone branch creates one private `InMemoryStore`; later access
+  returns the same instance.
+- There is no public setter. Session adoption uses the private attachment protocol in D4.
+- Memory is not included in `Branch.to_dict()` and is not copied by `Branch.clone()`.
+
+#### Context-provider contract
+
+`providers` lazily creates one `ContextProviderRegistry`. The registry and report shapes are
+(`lionagi/protocols/context_providers.py`):
+
+```python
+class ContextProvider(Protocol):
+    async def provide(self, branch: Branch, instruction: Instruction) -> str | None: ...
+
+@dataclass(frozen=True)
+class ProviderReport:
+    blocks: list[str] = field(default_factory=list)
+    fired: list[dict] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+class ContextProviderRegistry:
+    def __init__(self, budget: int = 2000): ...
+    def register(
+        self,
+        provider: ContextProvider,
+        *,
+        priority: int = 0,
+        max_tokens: int | None = None,
+        name: str | None = None,
+    ) -> None: ...
+    async def gather(self, branch: Branch, instruction: Instruction) -> ProviderReport: ...
+    async def gather_writeback(self, branch: Branch, action_responses: list) -> None: ...
+```
+
+The total default injection budget is **2,000 tokens**. The code records the purpose—bound the
+ephemeral injection—but no historical rationale for the exact value. A truthy per-provider
+`max_tokens` imposes a lower independent bound. The registry performs no range validation:
+`max_tokens=0` disables that check because the implementation tests truthiness, while a negative
+value skips every non-empty output. A non-positive total `budget` admits no positive-token output.
+Callers are responsible for supplying sensible non-negative limits.
+
+Provider semantics are exact:
+
+- An untouched registry is falsy and the operation path returns without constructing an
+  instruction or report.
+- Providers run in registration order. A provider exception is logged, its name is appended to
+  `failed`, and the turn continues.
+- `None` or empty text produces no block and is not recorded as fired.
+- Text over that provider's `max_tokens` is recorded as skipped.
+- Successful outputs are ranked by descending priority for budget admission; equal priorities keep
+  registration order. Retained blocks are rendered back in original registration order.
+- A branch without a system message does not invoke providers because there is no injection target;
+  the current operation path creates a report with every registered name under `skipped`.
+- Rendered blocks are folded into the first system-guidance request and cleared from the branch slot
+  immediately after request preparation. They are never appended as durable messages.
+- `last_context_report` returns the last report reference held by the branch. In current code the
+  zero-provider path does not clear an older report; ADR-0018 defines the target turn-scoped repair.
+- After `operate()` has actually executed actions and retained at least one non-`None` action
+  response, it calls `gather_writeback()` on the registry
+  (`lionagi/operations/operate/operate.py`). Providers are visited sequentially in registration
+  order. A provider with no `writeback` attribute, or one set to `None`, is skipped. A present hook
+  must be async; a non-callable or synchronous hook fails at `await`, is logged and contained like
+  any other provider exception, and later providers still run. No writeback occurs when action
+  invocation is disabled, yields no responses, or every response is `None`.
+- Writeback is an optional provider side effect, not part of `ProviderReport`, Branch serialization,
+  or the pre-turn token budget. The registry supplies the hook; each provider decides whether and
+  where to persist.
+
+#### Capability contract
+
+The grant and rejection payloads are (`lionagi/session/capabilities.py`):
+
+```python
+class CapabilityViolation(BaseModel):
+    offending: list[str]
+    allowed: list[str]
+    block: dict | None = None
+
+class EmissionRejected(BaseModel):
+    branch_name: str = ""
+    error: str
+    block: dict | None = None
+
+CAP_BEGIN = "<!-- lionagi:capabilities -->"
+CAP_END = "<!-- /lionagi:capabilities -->"
+```
+
+- `grant_capabilities(operable, prompt=True)` stores the runtime grant. With prompt enabled, it
+  removes one balanced, previously marked block and appends a freshly rendered schema block to the
+  current system prompt. Re-granting therefore replaces rather than stacks a well-formed block.
+- Unbalanced markers are left untouched instead of risking prompt corruption.
+- `prompt=False` installs only the runtime grant. `revoke_capabilities()` clears the grant and
+  removes a balanced prompt block.
+- Every observed assistant message first emits `MessageAdded`. Fenced JSON extraction then ignores
+  blocks with no granted key, emits `CapabilityViolation` when a block mixes granted and ungranted
+  keys, validates wholly granted blocks against a generated Pydantic model, and emits
+  `EmissionRejected` on validation failure (`lionagi/operations/_observe.py`).
+- Valid bundles are emitted concurrently as `StructuredOutput`; violations and rejections are
+  emitted as ordinary `Signal` payloads. These are observation semantics, not action execution or
+  authorization.
+
+### D4 — Session references attach and detach without taking conversation ownership
+
+The branch-side coordination fields are:
+
+```python
+_observer: Any = PrivateAttr(None)
+_hooks: Any = PrivateAttr(None)
+_owning_session_id: Any = PrivateAttr(None)
+_operation_manager: OperationManager | None = PrivateAttr(None)
+_memory: MemoryStore | None = PrivateAttr(None)
+```
+
+ADR-0017 owns the membership algorithm. From the branch boundary, the contract is:
+
+| Resource | Standalone | On session inclusion | On removal |
+|----------|------------|----------------------|------------|
+| ownership | `None` | session id | reset to `None` |
+| observer | `None`; `emit()` returns `[]`; `authorize()` returns `True` | session observer | reset to `None` |
+| hooks | `None` | session bus only if that bus is already initialized | reset to `None` |
+| operation registry | fresh private manager | session's manager by identity | new empty private manager |
+| memory | explicit, adopted, lazy private, or `None` before access | session store only when `_memory is None` | retained unchanged |
+
+Consequently, reading `branch.memory` before inclusion counts as adopting a store: later inclusion
+does not replace it. A previously session-adopted store also stays with the branch after removal and
+reparenting. This first-claim behavior prevents silent replacement of a backend that may already
+contain conversation data.
+
+Attachments are excluded from serialization and cloning. Removing a branch does not delete its
+messages, progression, selected models, tools, logs, metadata, provider registry, capabilities, or
+adopted memory. It does remove access to session-registered operations because the shared registry
+is replaced.
+
+### D5 — Public verbs delegate; registry lookup and cloning have explicit precedence
+
+The public Branch methods are adapters. Representative shipped forms are:
+
+```python
+async def chat(...) -> tuple[Instruction, AssistantResponse]:
+    from lionagi.operations.chat.chat import ChatParam, chat
+    return await chat(self, ...)
+
+async def operate(...) -> list | BaseModel | None | dict | str:
+    from lionagi.operations.operate.operate import operate, prepare_operate_kw
+    return await self._observed_run(operate(self, **prepare_operate_kw(self, ...)))
+
+async def run(...) -> AsyncGenerator[RoledMessage, None]:
+    from lionagi.operations.run.run import run
+    async for msg in run(self, instruction, RunParam(...)):
+        yield msg
+```
+
+Branch owns parameter adaptation, resource selection, and API continuity. The imported operation
+modules own execution. This separation is why operation algorithms are not copied into this ADR.
+
+Named operation lookup is attribute-first (`lionagi/session/branch.py`,
+`lionagi/operations/manager.py`):
+
+```python
+def get_operation(self, operation: str) -> Callable | None:
+    if hasattr(self, operation):
+        return getattr(self, operation)
+    return self._operation_manager.registry.get(operation)
+
+class OperationManager(Manager):
+    registry: dict[str, Callable]
+
+    def register(self, operation: str, func: Callable, update: bool = False): ...
+```
+
+A registered name cannot override any existing Branch attribute. Duplicate registry names fail
+unless `update=True`, and non-async functions are rejected. The registry is described as
+experimental in its module and is not serialized.
+
+`clone()` creates a distinct Branch rather than copying the whole object:
+
+- the system and every message are cloned; cloned message sender/recipient values are rewritten for
+  the new branch;
+- registered tools are passed into the new action manager;
+- CLI models are copied where needed, while non-CLI model objects are reused; a distinct parse model
+  remains distinct;
+- the clone receives `metadata={"clone_from": source}` and the source `user`;
+- logs, log configuration, memory, providers, provider report, capabilities, pending runtime state,
+  named operations, observer, hooks, and session ownership are not copied.
+
+The `clone_from` serializer reduces the source reference to its id, user, creation time, and message
+progression. Clone registration into a session is a Session or flow-executor responsibility.
+
+Branch also fixes several numeric facade defaults even though the operation modules own their
+algorithms:
+
+| Facade parameter | Default | Current rationale record |
+|------------------|---------|--------------------------|
+| `parse(max_retries=...)` | `3` | Inherited parse retry default; no Branch-level rationale recorded. |
+| `parse(similarity_threshold=...)` | `0.85` | Inherited fuzzy-match threshold; no calibration evidence recorded here. |
+| `communicate(num_parse_retries=...)` | `3` | Inherited structured-parse retry default; no Branch-level rationale recorded. |
+| `ReAct(max_extensions=...)` / `ReActStream(max_extensions=...)` | `3` | Inherited reasoning-loop extension cap; no Branch-level rationale recorded. |
+
+The adapters forward these values. This ADR records them so callers can distinguish a stable facade
+default from an operation implementation detail; changing their policy still belongs to the owning
+operation ADR.
+
+`Branch.connect()` remains a facade-adjacent compatibility method. Its queue capacity default is
+**100** and capacity refresh default is **60 seconds**; those values are forwarded to `iModel` and
+have no recorded Branch-level rationale. Whether the method remains supported is an explicit delta
+below rather than a new architectural commitment.
 
 ## Consequences
 
-Operations receive one coherent object instead of a bundle of loosely related managers, and a
-branch can operate alone or be attached to a session without changing its conversation identity.
-Manager replacement and attachment remain internal implementation details, so callers retain one
-public surface.
-
-The aggregate has a broad dependency set and currently mixes durable conversation state with
-invocation-local state. Private attributes are therefore not interchangeable: moving or serializing
-one without classifying its lifetime can introduce cross-turn leakage or silently persist runtime
-coordination objects.
+- An operation receives one coherent conversation object instead of separately coordinated
+  managers. The cost is a broad aggregate with many imports and private lifetime classes.
+- A branch can run standalone, join a session, leave it, and join another without changing message
+  identity. An adopted memory backend deliberately survives that lifecycle.
+- Serialization is useful for conversation reconstruction but is not a process checkpoint. Live
+  tools, memory, providers, grants, operations, and coordination wiring require explicit setup.
+- Attribute-first operation lookup preserves built-in method meaning but prevents a session registry
+  from overriding or shadowing any Branch attribute.
+- Provider injections and capability instructions remain visibly attached to one branch while their
+  transient results are not durable messages. Optional provider writeback can persist derived
+  action-response knowledge outside the Branch, so reconstructing a Branch does not undo or replay
+  that side effect.
+- Contributors moving a private field must first classify it as conversation state, serializable
+  projection, branch-scoped live extension, session attachment, or per-turn state. Treating those
+  categories as interchangeable is the principal maintenance hazard.
+- Reversing D1 or D5 would change almost every operation signature. Reversing D2–D4 is narrower but
+  requires a migration format for objects that currently have no stable encoding.
 
 ## Current-vs-ideal delta
 
@@ -83,9 +448,83 @@ coordination objects.
 | 1 | Implement the turn-scoped execution context and same-Branch serialization contract from ADR-0018; acceptance requires two overlapping top-level turns to neither overwrite provider data, consume each other's control, drain each other's signal tasks, nor change the branch's configured model. | M | (filled at issue-open time) |
 | 2 | Remove the deprecated no-op `system_template` and `system_template_context` constructor arguments under the public deprecation policy, and classify `Branch.connect()` as supported or deprecated after a repository-wide consumer inventory; acceptance requires updated API documentation and compatibility tests for the selected outcome. | S | (filled at issue-open time) |
 
+## Alternatives considered
+
+### Pass every manager separately to every operation
+
+This would make dependencies locally explicit and could reduce the apparent size of `Branch`.
+It loses because the managers jointly describe one conversation and must share identity,
+progression, and attachment lifecycle. Passing them independently makes cross-conversation mixtures
+representable and expands every operation signature.
+
+### Make Session the durable owner of branch messages, models, logs, and memory
+
+This would centralize persistence and simplify some multi-branch reporting. It loses the standalone
+Branch contract and makes removal or reparenting a data migration. The shipped behavior instead
+retains conversation data on the branch and treats Session references as attachments.
+
+### Serialize every private field as a complete process checkpoint
+
+This would make a single `to_dict()` appear sufficient for restart. It loses because tool callables,
+backend handles, observer subscriptions, tasks, and registries do not have stable portable encodings.
+A partial encoding would be more dangerous than the current explicit projection because it would
+look complete while silently restoring different behavior.
+
+### Put execution algorithms directly on Branch
+
+This would remove the import-and-delegate adapters. It loses because recording, streaming, parsing,
+and action logic would become inseparable from aggregate construction and serialization. The shipped
+modules allow operation behavior to evolve while the caller-facing object remains stable.
+
+### Let registered operations override built-in attributes
+
+Registry-first lookup would permit local replacement of `chat`, `run`, or even non-operation
+attributes. It buys extensibility but makes the meaning of a core Branch method depend on session
+attachment. The current attribute-first lookup preserves the built-in surface. No historical design
+note records whether that precedence was initially deliberate; this ADR records the shipped contract.
+
+### Eagerly allocate memory and the provider registry
+
+This would remove lazy branches from the accessors. It loses because a branch that never uses memory
+or context injection would still allocate those facilities, and eager private memory would prevent a
+new branch from adopting the session default. Lazy construction is also the mechanism behind the
+current first-claim memory rule.
+
+### Treat context providers as read-only pre-turn injectors
+
+This would keep provider behavior one-directional and make operation completion free of provider
+side effects. It loses the existing opt-in post-action feedback seam: providers that can extract a
+deterministic lesson from action responses would need a second registry or operation-specific hook.
+The shipped registry therefore owns both ordered pre-turn gathering and contained post-action
+writeback, while keeping writeback absent unless a provider implements it and `operate()` produced
+action responses.
+
+### Clone the complete live Branch object
+
+This would carry providers, capability grants, logs, memory, tasks, observer subscriptions, and
+session ownership into the clone. It buys superficial behavioral similarity but creates shared
+backend and task ownership without an explicit policy, and it can make a clone appear owned before
+Session has registered it. The explicit-subset clone keeps a new conversation operationally clean.
+
+### Store capability output directly as actions
+
+This would turn structured assistant blocks into immediate side effects. It loses the separation
+between observation, validation, authorization, and action execution. The shipped path emits typed
+signals so a session policy can decide what, if anything, follows.
+
 ## Notes
 
-Splitting every manager into a separately passed operation dependency was rejected because the
-managers jointly define one conversation's state. Treating session attachments as durable branch
-state was rejected because a branch must be detachable and reparentable without carrying the prior
-session's observer, hooks, or operation registry.
+The aggregate diagram is intentionally asymmetric: durable and live branch-scoped resources are
+reachable through Branch, while session resources are detachable references.
+
+```text
+                      Branch
+          conversation identity and public facade
+               /       |       |       \
+        messages    actions   models    logs
+             \         |       |        /
+              memory, providers, capabilities
+                         |
+               detachable coordination
+          observer, hooks, ownership, operations
+```

--- a/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
+++ b/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
@@ -8,82 +8,557 @@
 
 ## Context
 
-`Session` is the coordination owner for a pile of branches and one default branch. It also owns a
-shared operation registry, a lazily created observer and hook bus, a shared memory-store default, and
-an `Exchange`. These resources give member branches a common coordination context without making
-the session the owner of their messages, logs, or explicit memory backends
-(`lionagi/session/session.py`).
+`Session` coordinates a set of conversation branches. It gives those branches shared operations,
+observation, hooks, a default memory store, and mailboxes without becoming a second owner of their
+messages or logs. Six concrete problems define the boundary.
 
-Membership is exclusive. `include_branches()` preflights the whole batch, rejects a branch owned by
-another session, then records ownership and attaches the shared operation registry, observer, hooks
-when initialized, memory when absent, and an Exchange mailbox. `remove_branch()` reverses the
-session-owned attachments and installs a fresh private operation registry while preserving branch
-conversation data. Reparenting is therefore an explicit remove-then-include operation.
+**P1 — membership must have one owner.** Two sessions attaching different observers, operation
+registries, or mailboxes to one Branch would make behavior depend on the last write to private
+fields. Membership therefore has an explicit owner id, batch preflight, removal protocol, and
+remove-then-include reparenting path (`lionagi/session/session.py`).
 
-The session observer is the in-process event transport. Emission applies the optional gate, stores
-the event in its `Flow`, adds matching routes, and then invokes matching subscribers; asynchronous
-subscribers are awaited concurrently. HookBus uses the observer as an integration seam, while the
-observer's current database-binding helper also contains StateDB-specific serialization and
-best-effort persistence policy (`lionagi/session/observer.py`, `lionagi/hooks/bus.py`).
+**P2 — defaults must be shared without replacing explicit branch resources.** A session needs one
+default branch and one default memory store, while a branch constructed with its own backend must
+keep that backend. Constructor validation and post-validation memory rewiring make those rules hold
+even when branches are supplied during model construction.
 
-`Session.flow()` and `flow_stream()` resolve a branch and delegate graph execution to
-`lionagi/operations/flow.py`. The executor registers any clones through `include_branches()` so they
-receive the same coordination attachments. Session is therefore the membership and resource
-boundary, not the DAG execution kernel (see the operations ADR on dependency-aware operation-graph
-execution and the orchestration ADR on the operation-graph boundary).
+**P3 — in-process events need a deterministic dispatch order.** Governance checks, event history,
+named routes, and subscribers have different effects. `SessionObserver.emit()` fixes their order as
+gate, store, route, dispatch so denied events remain observable without reaching routes or handlers
+(`lionagi/session/observer.py`).
 
-`Exchange` is constructed for every session and exposes explicit send, receive, collect, and sync
-operations. Routing does not run automatically and the Exchange is excluded from Session
-serialization. The only adjacent messenger adapter requires explicit construction and binding, so
-the default mailbox does not establish a durable or end-to-end interbranch messaging contract
-(`lionagi/session/exchange.py`, `lionagi/tools/communication/messenger.py`).
+**P4 — lifecycle hooks and signal persistence are related but not the same transport.** HookBus
+executes closed hook points with handler-specific failure policy and records most hook emissions on
+the observer. The observer's database-binding helper currently embeds StateDB serialization,
+payload bounds, connection handling, and best-effort persistence; that is shipped behavior but an
+identified layering delta.
+
+**P5 — graph execution needs membership but is not membership.** Flow execution clones branches,
+schedules dependencies, limits concurrency, and supports reactive mutation. Session resolves a
+starting branch and delegates to `lionagi/operations/flow.py`; the executor registers clones through
+Session so the membership invariants remain centralized.
+
+**P6 — a default mailbox must not imply delivery guarantees it does not implement.** Every Session
+constructs an `Exchange`, but messages move only when `collect`, `sync`, or the explicit `run` loop is
+called. Exchange is process-local, excluded from serialization, and not automatically paired with a
+Messenger tool.
+
+| Concern | Decision |
+|---------|----------|
+| Membership and default branch | D1: Session exclusively owns membership and performs explicit attach/detach. |
+| Shared operation and memory defaults | D2: member branches share the Session operation registry and adopt Session memory only when empty. |
+| Event observation | D3: `SessionObserver` is the canonical in-process gate, history, router, and subscriber dispatcher. |
+| Hooks and signal persistence | D4: HookBus remains a distinct hook executor; current DB binding is best-effort observer integration. |
+| Graph execution | D5: `flow()` and `flow_stream()` are convenience delegates, not the execution kernel. |
+| Branch mailboxes | D6: Exchange is explicitly pumped, non-durable, and non-serialized. |
+
+This ADR deliberately does **not** decide:
+
+- operation-graph scheduling, dependency, spawning, pause/resume, or reactive-mutation algorithms;
+  those belong to the operations and orchestration areas;
+- persistent signal-table schemas, recovery, or streaming delivery; those belong to persistence and
+  Studio-facing contracts;
+- action authorization policy; this ADR records only how the optional observer gate is consulted;
+- provider, model, message, log, capability, or per-turn execution semantics owned by Branch and the
+  adjacent areas;
+- a durable interbranch communication product; D6 records the compatibility facility that exists
+  today, and the delta records the unresolved posture.
 
 ## Decision
 
-`Session` remains the exclusive membership and shared-coordination boundary for branches. Its
-load-bearing invariants are:
+### D1 — Session owns exclusive membership and default-branch selection
 
-- one branch belongs to at most one session at a time, batch inclusion is all-or-nothing with
-  respect to ownership checks, and reparenting requires removal from the current owner;
-- inclusion installs the session's observer, operation registry, optional hook bus, memory default,
-  and Exchange registration; removal detaches ownership, observer, hooks, the shared operation
-  registry, and the mailbox while leaving the branch's adopted memory and other conversation data
-  intact;
-- a branch-supplied memory store wins over the session default, while branches without one share the
-  session's single store instance;
-- `SessionObserver` is the canonical in-process gate, event store, router, and subscriber dispatcher;
-  lifecycle calls using safe emission and the bound database subscriber treat observation and
-  persistence failures as best-effort diagnostics;
-- `Session.flow()` and `flow_stream()` are convenience delegates, and scheduling, dependency,
-  branch-cloning, and reactive-mutation algorithms remain in the operation graph kernel; and
-- the default `Exchange` is an explicitly pumped, non-serialized compatibility facility. Its
-  presence does not promise automatic delivery, durability, recovery, or a provisioned Messenger.
+The shipped model fields are (`lionagi/session/session.py`):
+
+```python
+class Session(Node, Relational):
+    branches: Pile[Branch] = Field(
+        default_factory=lambda: Pile(item_type={Branch}, strict_type=False)
+    )
+    exchange: Exchange = Field(default_factory=Exchange, exclude=True)
+    default_branch: Any = Field(default=None, exclude=True)
+    name: str = Field(default="Session")
+    user: SenderRecipient | None = None
+
+    _operation_manager: OperationManager = PrivateAttr(default_factory=OperationManager)
+    _observer: Any = PrivateAttr(default=None)
+    _hooks: Any = PrivateAttr(default=None)
+    _memory: MemoryStore | None = PrivateAttr(default=None)
+
+    def __init__(self, *, memory: MemoryStore | None = None, **kwargs: Any): ...
+```
+
+The after-model validator fabricates a fresh empty Branch as `default_branch` whenever the
+`default_branch=` argument itself is absent — supplying `branches=[...]` alone does not suppress
+it, so `Session(branches=[my_branch])` ends up with two branches and the auto-created one as the
+default; only an explicit `default_branch=my_branch` yields a single-branch Session with the
+caller's branch as default. The validator then includes the default in `branches` and passes the
+complete pile through `include_branches()`. The `observer` accessor is lazy as an accessor, but ordinary
+Session construction immediately forces it because inclusion assigns `branch._observer =
+self.observer`. HookBus remains genuinely lazy until `Session.hooks` is read.
+
+Membership entry points are:
+
+```python
+async def ainclude_branches(self, branches: ID[Branch].ItemSeq): ...
+def include_branches(self, branches: ID[Branch].ItemSeq): ...
+
+def new_branch(
+    self,
+    system: System | JsonValue = None,
+    system_sender: SenderRecipient = None,
+    system_datetime: bool | str = None,
+    user: SenderRecipient = None,
+    name: str | None = None,
+    messages: Pile[RoledMessage] = None,
+    tools: Tool | Callable | list = None,
+    as_default_branch: bool = False,
+    **kwargs,
+) -> Branch: ...
+
+def remove_branch(self, branch: ID.Ref, delete: bool = False): ...
+def split(self, branch: ID.Ref) -> Branch: ...
+def get_branch(self, branch: ID.Ref | str, default: Any = ..., /) -> Branch: ...
+def change_default_branch(self, branch: ID.Ref): ...
+```
+
+`include_branches()` first materializes the supplied Branch objects and checks the whole batch. If
+any candidate has a non-`None` `_owning_session_id` different from this Session id, it raises
+`ValueError` before changing any candidate. The all-or-nothing guarantee is specifically for this
+ownership preflight; the method is not a general transaction across arbitrary failures in later
+attachment code.
+
+For every accepted branch, inclusion performs this exact sequence:
+
+1. Include it in `branches` when absent.
+2. Set `_owning_session_id` to the Session id and set `branch.user` to the Session id.
+3. Replace the branch operation manager with the Session manager.
+4. Attach the Session observer.
+5. Attach HookBus only when `_hooks` has already been initialized.
+6. Assign Session memory only when `branch._memory is None`.
+7. Register an Exchange mailbox when one is absent.
+8. Make the branch default only when no default exists.
+
+Including an already owned member in the same Session is permitted and repairs missing attachments
+or mailbox registration. It does not duplicate the Branch in the pile.
+
+`get_branch()` first attempts id normalization and pile lookup. If that fails and the input is a
+string, it scans branch names in pile order and returns the first exact match. A miss raises
+`ItemNotFoundError` unless the positional `default` argument was supplied, in which case that value
+is returned. `change_default_branch()` accepts only a reference already resolvable through the pile;
+a missing reference fails at pile lookup rather than implicitly including a new branch.
+
+Removal performs the inverse coordination teardown:
 
 ```text
-                         Session
-              membership and shared resources
-                  /          |          \
-            Branches     Observer      Memory
-               |          + Hooks       default
-               |              |
-               +---- shared operations ----+
-               |
-          flow()/flow_stream()
-               |
-               v
-       operation graph execution kernel
+branches.exclude(branch)
+exchange.unregister(branch.id)
+branch._owning_session_id = None
+branch._observer = None
+branch._hooks = None
+branch._operation_manager = OperationManager()
+branch.user = None                 # only when it still equals this Session id
 ```
+
+If the removed branch was default, the first remaining branch becomes default or the default becomes
+`None` when the pile is empty. Messages, progression, models, tools, logs, metadata, providers,
+capabilities, and adopted memory stay on the branch. `delete=True` only deletes the method's local
+reference after detachment; it cannot destroy an object retained by another Python reference.
+
+Inclusion also overwrites `branch.user` with the Session id. Removal clears that field only when it
+still equals the removing Session id; it does not retain and restore an earlier conversational user
+value. Code that needs a durable end-user identity must therefore keep it outside this attachment
+field or restore it explicitly after detachment.
+
+An absent id raises `ItemNotFoundError`. Reparenting is deliberately remove from the old Session,
+then include in the new one. `split()` clones the selected Branch and includes the clone in the same
+Session, so clone coordination uses this same attachment path.
+
+The serialized Session includes the public branch pile, name, user, and inherited Node fields.
+`exchange` and `default_branch` are explicitly excluded; private operation, observer, hook, and
+memory objects are also absent. Deserialization reconstructs coordination through validation rather
+than restoring live references.
+
+### D2 — Shared operations and memory are defaults with different detach behavior
+
+#### Operation registry
+
+Session operation methods are:
+
+```python
+def register_operation(
+    self,
+    operation: str,
+    func: Callable,
+    *,
+    update: bool = False,
+): ...
+
+def operation(self, name: str = None, *, update: bool = False): ...
+
+async def run_operation(
+    self,
+    operation: str,
+    *,
+    branch: Branch | ID.Ref | None = None,
+    **kwargs: Any,
+) -> Any: ...
+```
+
+The decorator uses the explicit name or the function's `__name__`. `OperationManager.register()`
+rejects non-async functions and duplicate names unless `update=True`
+(`lionagi/operations/manager.py`). `run_operation()` selects the supplied Branch or Session default,
+resolves string/UUID references through the branch pile, and calls `branch.get_operation()`. Branch
+attributes take precedence over registry entries; an unknown name raises `ValueError`.
+
+All current members share the one manager by identity. A branch included before registration sees a
+later registration immediately. Removal installs a fresh empty manager, so session-registered names
+do not leak into standalone or reparented operation lookup.
+
+#### Memory default
+
+```python
+@property
+def memory(self) -> MemoryStore:
+    if self._memory is None:
+        self._memory = InMemoryStore()
+    return self._memory
+```
+
+The Session has no public memory setter. Inclusion gives this one instance to every branch whose
+private memory slot is still `None`. An explicit or previously adopted branch store wins.
+
+Pydantic after-validation runs before the custom `Session.__init__()` body. A constructor-supplied
+branch can therefore cause the validator to lazily create a temporary Session store and attach it.
+When the caller also supplies `memory=explicit_store`, the constructor replaces `_memory` and
+rewires only branches still pointing to that temporary object. Branches with independent stores are
+not rewritten.
+
+Removal does not clear memory. A default adopted from one Session therefore remains the branch's
+store during standalone use and after reparenting. This is the same first-claim rule recorded from
+the Branch side in ADR-0016.
+
+### D3 — SessionObserver dispatches gate, store, route, then subscribers
+
+The observer's concrete state and public surface are (`lionagi/session/observer.py`):
+
+```python
+Handler = Callable[[Any, SessionObserver], Any]
+Predicate = Callable[[Any], bool]
+Gate = Callable[[Any], Any]
+
+class SessionObserver(Observer):
+    def __init__(self, session: Any = None) -> None:
+        self.session = session
+        self.flow: Flow = Flow(name="session-events")
+        self._subs: list[tuple[Filter, Handler]] = []
+        self._routes: list[tuple[Predicate, str]] = []
+        self._gate: Gate | None = None
+
+    def observe(self, *keys, handler=None, role: str | None = None) -> Any: ...
+    def unobserve(self, handler: Handler) -> int: ...
+    def route(self, condition: Predicate, *, into: str) -> SessionObserver: ...
+    def gate(self, check: Gate) -> SessionObserver: ...
+    async def authorize(self, action: Any) -> bool: ...
+    async def emit(self, event: Any) -> list[Any]: ...
+    def stream(self, name: str) -> list[Any]: ...
+    def by_type(self, event_type: type) -> list[Any]: ...
+```
+
+#### Emission semantics
+
+1. A non-`Observable` input is wrapped as `Signal(data=input)`. Filters and the gate normally see
+   `Signal.data`; role filters inspect the envelope.
+2. If a gate exists, it is awaited when necessary and coerced to `bool`. A gate exception is treated
+   as denial.
+3. The event is added to `flow` whether allowed or denied.
+4. Denial returns `[]`; no named route or subscriber runs.
+5. Allowed route predicates run in registration order. Matching events are appended to a lazily
+   created named `Progression`.
+6. Subscribers run in registration order. Synchronous results are collected immediately;
+   awaitables are then awaited concurrently. The return shape is synchronous results followed by
+   asynchronous results.
+
+Raw route and subscriber exceptions are not globally swallowed by `emit()`. Isolation belongs to
+the caller that needs it: Branch lifecycle paths use `_safe_emit()` so observer failures cannot
+change an operation result, HookBus records best-effort, and the bound DB subscriber swallows its
+own persistence failures.
+
+`observe()` AND-composes multiple conditions. With `role=`, the payload condition and envelope role
+must both match. With no condition and no role, it raises `TypeError`. `unobserve()` removes all
+registrations of the exact handler object and returns the removal count. An absent named stream is
+read as `[]`.
+
+#### Authorization semantics
+
+`authorize(action)` returns `True` when no gate is installed. A falsy result or gate exception is a
+denial: it stores `GateDenied(data=action)` directly in observer history and returns `False`.
+Authorization does not route or dispatch that `GateDenied` through subscribers. Branches call this
+method before guarded actions; standalone Branch authorization returns `True` without an observer.
+
+The observer is process-local. Its `Flow` is an in-memory event history, not a restart or delivery
+guarantee.
+
+### D4 — HookBus is distinct; observer DB persistence is best-effort
+
+`Session.hooks` constructs one bus with `build_session_bus(observer=self.observer)` and caches it
+(`lionagi/hooks/loader.py`). The closed hook vocabulary is (`lionagi/hooks/bus.py`):
+
+```python
+class HookPoint(str, Enum):
+    SESSION_START = "session.start"
+    SESSION_END = "session.end"
+    BRANCH_CREATE = "branch.create"
+    API_PRE_CALL = "api.pre_call"
+    API_POST_CALL = "api.post_call"
+    API_STREAM_CHUNK = "api.stream_chunk"
+    TOOL_PRE = "tool.pre"
+    TOOL_POST = "tool.post"
+    TOOL_ERROR = "tool.error"
+    MESSAGE_ADD = "message.add"
+    ARTIFACT_CREATED = "artifact.created"
+
+class HookSignal(Signal):
+    point: HookPoint | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+```
+
+Declaration does not imply automatic emission. The current wiring is:
+
+| Hook point | Production emission path | Default handler |
+|------------|--------------------------|-----------------|
+| `SESSION_START` | CLI run-persistence setup | `persist_session_start` |
+| `SESSION_END` | CLI run-persistence teardown | `persist_session_end` |
+| `BRANCH_CREATE` | CLI run-persistence setup | `persist_branch_provenance` |
+| `TOOL_PRE` / `TOOL_POST` / `TOOL_ERROR` | action invocation | none |
+| `MESSAGE_ADD` | `route_message_persistence()` attaches `Branch._persist_via_bus()` as an async message callback | `persist_message` |
+| `API_PRE_CALL` / `API_POST_CALL` / `API_STREAM_CHUNK` | no production emitter | none |
+| `ARTIFACT_CREATED` | no production emitter | none |
+
+The no-emitter points remain valid registration and manual-emission values; they are not promises
+that provider or artifact code fires them. String inputs to `on()`, `off()`, `handlers_for()`, and
+`emit()` are normalized through `HookPoint(value)` and an unknown string raises `ValueError`.
+Merely assigning or constructing a HookBus does not emit `MESSAGE_ADD`; the persistence router in
+`lionagi/hooks/persist.py` must also append the async Branch callback. That router removes the
+generic default `persist_message` handler and installs a branch-demultiplexed handler for the
+supplied persistence callback.
+
+Once that async callback is installed, the synchronous `MessageManager.add_message()` path rejects
+the call with `RuntimeError` before mutating the message pile; callers must use
+`a_add_message()`, which awaits registered callbacks. This constraint is enforced by
+`lionagi/protocols/messages/manager.py` and is why persistence wiring happens only in an async
+lifecycle after construction-time synchronous system-message setup.
+
+`TOOL_PRE` uses `blocking_emit`: handlers run sequentially, ordinary exceptions propagate, and
+`StopHook` skips remaining handlers. Other points run sequentially, log and isolate ordinary handler
+exceptions, and also honor `StopHook`. Most emissions record a best-effort `HookSignal` on the
+observer after handlers. `MESSAGE_ADD` omits that record because `MessageAdded` already represents
+the same message on the signal bus.
+
+The default bus installs persistence-related handlers, but bus creation does not retroactively set
+`branch._hooks` on branches already included. Later inclusion does attach the initialized bus. Other
+persistence setup code may explicitly bind a bus and message callback; merely reading
+`Session.hooks` is not a complete persistence lifecycle. This asymmetry is retained as a delta rather
+than described as an intentional guarantee.
+
+The observer also ships this direct persistence seam:
+
+```python
+def bind_db_persistence(self, session_id: str, db: Any = None) -> None: ...
+def unbind_db_persistence(self) -> None: ...
+```
+
+For every `Signal`, the subscriber writes `session_id`, concrete signal class name, optional
+`op_id`, current epoch timestamp, and a sanitized payload through
+`StateDB.insert_session_signal()`. When a DB is supplied it is reused. Otherwise the subscriber opens
+`DEFAULT_DB_PATH` per event only if that path exists. All persistence exceptions are swallowed.
+
+Payload sanitization has these exact rules:
+
+- base Signal identity/timestamp/data/role fields are not blindly promoted;
+- `MessageAdded.data` becomes a compact `message_ref` containing available id, role, sender, and
+  recipient;
+- other data becomes `model_dump()` for Pydantic models or a string/repr fallback;
+- JSON serialization uses safe fallback and produces JSON-native values;
+- if that serialization gate still raises, the payload becomes
+  `{sanitize_error: repr(signal)[:256]}`;
+- the stored payload column is capped at **16,384 bytes**; oversized data becomes
+  `{truncated: true, original_bytes: N, data: clipped_text}`;
+- fitting uses at most **8** measured shrink iterations, then falls back to an empty data string.
+
+Cap enforcement itself is best-effort: an unexpected exception in the measurement/truncation block
+is swallowed and returns the already JSON-safe payload, which may then exceed 16,384 bytes. The
+256-character fallback bounds a last-resort diagnostic and the source records no historical reason
+for exactly 256. The recorded reason for 16,384 bytes is to bound the normal payload column while
+leaving a truncation marker; the source records no historical evidence for choosing exactly 16 KiB.
+The eight-iteration guard is a termination bound; its exact value also has no recorded empirical
+rationale. The cap is not an SSE-frame cap because transport envelope bytes are added later.
+
+### D5 — Flow methods delegate to the operation graph kernel
+
+Session exposes (`lionagi/session/session.py`):
+
+```python
+async def flow(
+    self,
+    graph: Graph,
+    *,
+    context: dict[str, Any] | None = None,
+    parallel: bool = True,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    default_branch: Branch | ID.Ref | None = None,
+    alcall_params: Any = None,
+    on_progress: Any = None,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+    executor_ref: dict[str, Any] | None = None,
+    on_branch_created: Callable[[Any], None] | None = None,
+    spawn_branch_setup: Callable[[Any, Any], None] | None = None,
+) -> dict[str, Any]: ...
+
+async def flow_stream(
+    self,
+    graph: Graph,
+    *,
+    context: dict[str, Any] | None = None,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    default_branch: Branch | ID.Ref | None = None,
+    alcall_params: Any = None,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+): ...
+```
+
+Both select the supplied default or Session default and resolve string/UUID references through the
+branch pile. `flow()` returns the operation module's result; `flow_stream()` yields its events.
+Scheduling, dependency validation, capacity limiting, branch preallocation, and reactive spawn
+remain in `lionagi/operations/flow.py`.
+
+The executor uses `session.include_branches(clone)` for preallocated and reactive clones, so every
+clone receives ownership, observer, operation registry, memory default, mailbox, and any already
+initialized HookBus through D1. The Session methods do not reproduce that wiring.
+
+The default concurrency limit is **5** and default reactive spawn limit is **50**. These values are
+forwarded unchanged and have no rationale recorded in the Session module; their tuning belongs to
+the operation-graph contract. The `parallel` flag exists only on the non-streaming convenience
+method.
+
+### D6 — Exchange is an explicit, process-local mailbox router
+
+Every Session constructs one excluded `Exchange`. Its state and public routing surface are
+(`lionagi/session/exchange.py`):
+
+```python
+OUTBOX = "outbox"
+
+class Exchange(Element):
+    flows: Pile[Flow[Message, Progression]] = None
+    _owner_index: dict[UUID, UUID] = PrivateAttr(default_factory=dict)
+    _stop: bool = PrivateAttr(default=False)
+
+    def register(self, owner_id: UUID) -> Flow[Message, Progression]: ...
+    def unregister(self, owner_id: UUID) -> Flow[Message, Progression] | None: ...
+    def get(self, owner_id: UUID) -> Flow[Message, Progression] | None: ...
+    def has(self, owner_id: UUID) -> bool: ...
+    @property
+    def owner_ids(self) -> list[UUID]: ...
+    def send(
+        self,
+        sender: UUID,
+        recipient: UUID | None,
+        content: Any,
+        channel: str | None = None,
+    ) -> Message: ...
+    async def collect(self, owner_id: UUID) -> int: ...
+    async def collect_all(self) -> int: ...
+    async def sync(self) -> int: ...
+    async def run(self, interval: float = 1.0) -> None: ...
+    def stop(self) -> None: ...
+    def receive(self, owner_id: UUID, sender: UUID | None = None) -> list[Message]: ...
+    def pop_message(self, owner_id: UUID, sender: UUID) -> Message | None: ...
+```
+
+Session exposes only the explicit-pump subset as direct delegates
+(`lionagi/session/session.py`):
+
+```python
+def register_participant(self, entity_id: UUID) -> Flow[Message, Progression]: ...
+def send(
+    self,
+    sender: UUID,
+    recipient: UUID | None,
+    content: Any,
+    channel: str | None = None,
+) -> Message: ...
+def receive(self, owner_id: UUID, sender: UUID | None = None) -> list[Message]: ...
+def pop_message(self, owner_id: UUID, sender: UUID) -> Message | None: ...
+async def collect(self, owner_id: UUID) -> int: ...
+async def sync(self) -> int: ...
+```
+
+There is no Session delegate for `Exchange.run()` or `stop()` and Session never starts the loop.
+
+Each owner gets one Flow with an `outbox` progression. Delivered messages enter a progression named
+`inbox_<sender-uuid>` in the recipient Flow.
+
+**Exact routing semantics:**
+
+- Duplicate registration raises `ValueError`; unregistering an unknown owner returns `None`.
+- Unregistering a known owner removes its entire Flow, including queued outbox and delivered inbox
+  messages; re-registering the UUID creates a new empty mailbox.
+- `send()` queues one `Message` in the sender outbox and raises `ValueError` when the sender is not
+  registered. It does not deliver immediately; the optional channel is stored on the Message but
+  does not change Exchange routing.
+- `collect(owner)` removes queued messages under the Exchange lock, then performs recipient
+  deliveries concurrently outside that lock.
+- A direct message to a currently registered recipient is delivered. A direct message to an
+  unregistered recipient is removed from the outbox and dropped.
+- A broadcast creates a model copy for every registered owner except the sender. Delivery to an
+  owner unregistered between collection and delivery is a no-op.
+- Per-delivery exceptions are gathered as results and not re-raised. The returned count is the
+  number of unique source message ids scheduled for delivery, not a confirmation count, so one
+  broadcast counts as one even with many copies.
+- An empty outbox, a direct message whose recipient is no longer registered, or a broadcast with no
+  other registered owners returns zero after consuming any queued source message involved.
+- `collect_all()` iterates a snapshot of owner ids and skips owners that disappear. `sync()` is an
+  alias for `collect_all()`.
+- `receive()` is non-destructive and optionally filters by sender. Unknown owners return `[]`.
+  `pop_message()` is FIFO for one sender and returns `None` for an unknown owner, absent inbox, or
+  empty inbox.
+- `run()` is an opt-in polling loop; `stop()` only sets its in-memory flag. Its default **1.0-second**
+  interval has no recorded rationale. Session does not start this loop.
+
+The adjacent `LionMessenger` requires explicit `LionMessenger(exchange)` construction and
+`bind(branch, roster, ...)` before it yields a Tool (`lionagi/tools/communication/messenger.py`).
+The default Session does not provision or bind it. Exchange state, pending mail, the owner index, and
+the pump are not serialized, recovered, or acknowledged durably.
 
 ## Consequences
 
-Branch ownership, shared extensions, observation, and graph-created clone wiring have one lifecycle.
-Standalone branches remain usable, and orchestration code can rely on Session membership without
-moving the graph executor into the session package.
-
-The Session surface exposes facilities with different maturity and durability. Observer history and
-Exchange mailboxes are process-local, Exchange requires explicit pumping, and direct database
-binding couples the observer to persistence policy. Consumers must not infer recovery guarantees
-from in-memory coordination APIs.
+- Branch ownership, shared operations, observer wiring, memory adoption, and mailbox registration
+  have one lifecycle. Reparenting is explicit and testable.
+- Membership currently reuses `Branch.user` as Session identity and does not restore its prior
+  value. This is observable after detachment and must be accounted for by callers that separately
+  track a conversational user.
+- Branch conversation data remains usable after removal, but session operation names, subscriptions,
+  routes, hooks, and mailbox contents do not follow it automatically.
+- Observer history makes denied and allowed emissions inspectable in process. It does not make raw
+  subscriber failures best-effort; callers must choose the appropriate isolation boundary.
+- HookBus and SessionObserver can interoperate without pretending to be the same abstraction. The
+  cost is two related registration surfaces and current persistence wiring in the wrong layer.
+  Several declared HookPoints are extension vocabulary only and have no production emitter.
+- Flow-created clones obey normal membership rules, while Session stays independent of graph
+  scheduling algorithms.
+- Exchange is useful for explicitly coordinated in-process mail, but callers must pump it and accept
+  loss on restart, removal, unknown recipients, or ignored delivery errors.
+- Reversing D1–D2 would require a branch-ownership and backend migration. D3–D4 would affect event
+  ordering and integrations. D5 is cheap to move mechanically but would increase Session coupling.
+  Reversing D6 requires a separate delivery and recovery protocol, not an internal refactor.
 
 ## Current-vs-ideal delta
 
@@ -92,9 +567,87 @@ from in-memory coordination APIs.
 | 1 | Extract StateDB signal persistence from `SessionObserver` into a persistence-owned subscription adapter; acceptance requires the observer module to contain no StateDB construction or payload-size policy while CLI and Studio retain best-effort writes, payload bounds, and unbind behavior. | S | (filled at issue-open time) |
 | 2 | Move versioned signal and loop-control vocabulary to a neutral low-level module with compatibility re-exports from `lionagi.session`; acceptance requires unchanged schema versions, serialized payloads, `lane_for()` results, dispatch envelopes, and public import behavior throughout the relocation. | M | (filled at issue-open time) |
 | 3 | Choose and implement one Exchange product posture: provision Messenger, collection, durability, and recovery as an end-to-end supported path, or make Exchange opt-in and deprecate the default Session mailbox; acceptance requires documentation and integration tests that demonstrate the selected lifecycle. | M | (filled at issue-open time) |
+| 4 | Define and implement HookBus initialization for existing members; acceptance requires either retroactive attachment to every current branch or an explicit non-attachment contract, plus tests covering branches included both before and after first access to `Session.hooks`. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Allow one Branch to belong to multiple Sessions
+
+This would let several coordinators observe or operate on one conversation without cloning. It loses
+because the Branch has one observer, one hook reference, one owning id, and one operation-manager
+slot. Multi-membership would make attachment order semantic or require replacing those fields with a
+new multiplexing layer.
+
+### Mutate a batch as each branch passes ownership validation
+
+This is simpler than preflight. It loses because a later owned branch would leave earlier candidates
+partially claimed. Whole-batch ownership validation buys a clear retry boundary with little cost.
+
+### Always replace branch memory with the Session store
+
+This would make every member share one backend and simplify cross-branch reads. It loses because an
+explicit or already-used backend may contain branch data. Silent replacement would disconnect that
+data and make reparenting destructive. The first-claim rule gives callers an explicit choice at
+Branch construction or before first memory access.
+
+### Clear adopted memory on removal
+
+This would make detached branches return to a uniform empty standalone state. It loses because the
+adopted store may now contain the branch's durable data and may be intentionally shared. Coordination
+attachments are reversible; adopted storage is treated as branch state once assigned.
+
+### Move graph execution into Session
+
+This would make `Session.flow()` self-contained. It loses because dependency scheduling, capacity
+limits, reactive mutation, and operation execution would combine with ownership, observer, and
+mailbox lifecycle. The delegate retains a narrow integration point: branch resolution in, normal
+membership for clones, result out.
+
+### Merge Observer, HookBus, and Exchange into one transport
+
+One bus would reduce the number of names. It loses because the three have incompatible contracts:
+Observer matches typed payloads and stores history, HookBus executes closed lifecycle points with
+ordered failure policies, and Exchange holds addressed messages until an explicit pump. A common
+class would hide rather than remove those distinctions.
+
+### Dispatch before storing the observer event
+
+This would avoid retaining events that handlers never consume. It loses diagnostic history on gate
+denial and makes reentrant handlers observe an event stream that does not yet contain the event they
+are processing. Store-before-route fixes that ordering.
+
+### Fail open when an observer gate raises
+
+This would keep event delivery running through gate defects. It loses the meaning of a governance
+check: a broken check would silently permit the action or event. Current observer gates treat raised
+checks as denial, while lifecycle-observer failures after authorization remain best-effort.
+
+### Make Exchange delivery automatic and durable inside Session
+
+This would make the default mailbox an end-to-end communication system. It requires pump ownership,
+restart recovery, acknowledgements, recipient lifecycle, and a persistent schema that do not exist.
+The shipped Exchange stays explicit; the product-level choice is retained in the delta instead of
+being implied by construction.
+
+### Keep StateDB serialization inside SessionObserver permanently
+
+This buys a one-call binding API and is the organic shape currently shipped. It loses layering:
+observer code now owns a database path, row payload policy, size cap, and connection lifecycle. The
+retrospective contract records the behavior so extraction can preserve it; the delta assigns the
+adapter to persistence rather than silently rewriting the current truth.
 
 ## Notes
 
-Moving graph execution into `Session` was rejected because it would combine membership lifecycle
-with scheduling and reactive graph mutation. Treating Observer, HookBus, and Exchange as one
-transport was rejected because they have different delivery, persistence, and invocation contracts.
+```text
+                         Session
+              membership and shared defaults
+                  /          |          \
+            Branches     Observer      Memory
+               |          + Hooks       default
+               +---- shared operations ----+
+               |                            |
+          flow delegates                Exchange
+               |                      explicit pump
+               v
+       operation graph execution kernel
+```

--- a/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
+++ b/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
@@ -1,0 +1,100 @@
+# ADR-0017: Session Membership and Coordination Boundary
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: session-branch
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+`Session` is the coordination owner for a pile of branches and one default branch. It also owns a
+shared operation registry, a lazily created observer and hook bus, a shared memory-store default, and
+an `Exchange`. These resources give member branches a common coordination context without making
+the session the owner of their messages, logs, or explicit memory backends
+(`lionagi/session/session.py`).
+
+Membership is exclusive. `include_branches()` preflights the whole batch, rejects a branch owned by
+another session, then records ownership and attaches the shared operation registry, observer, hooks
+when initialized, memory when absent, and an Exchange mailbox. `remove_branch()` reverses the
+session-owned attachments and installs a fresh private operation registry while preserving branch
+conversation data. Reparenting is therefore an explicit remove-then-include operation.
+
+The session observer is the in-process event transport. Emission applies the optional gate, stores
+the event in its `Flow`, adds matching routes, and then invokes matching subscribers; asynchronous
+subscribers are awaited concurrently. HookBus uses the observer as an integration seam, while the
+observer's current database-binding helper also contains StateDB-specific serialization and
+best-effort persistence policy (`lionagi/session/observer.py`, `lionagi/hooks/bus.py`).
+
+`Session.flow()` and `flow_stream()` resolve a branch and delegate graph execution to
+`lionagi/operations/flow.py`. The executor registers any clones through `include_branches()` so they
+receive the same coordination attachments. Session is therefore the membership and resource
+boundary, not the DAG execution kernel (see the operations ADR on dependency-aware operation-graph
+execution and the orchestration ADR on the operation-graph boundary).
+
+`Exchange` is constructed for every session and exposes explicit send, receive, collect, and sync
+operations. Routing does not run automatically and the Exchange is excluded from Session
+serialization. The only adjacent messenger adapter requires explicit construction and binding, so
+the default mailbox does not establish a durable or end-to-end interbranch messaging contract
+(`lionagi/session/exchange.py`, `lionagi/tools/communication/messenger.py`).
+
+## Decision
+
+`Session` remains the exclusive membership and shared-coordination boundary for branches. Its
+load-bearing invariants are:
+
+- one branch belongs to at most one session at a time, batch inclusion is all-or-nothing with
+  respect to ownership checks, and reparenting requires removal from the current owner;
+- inclusion installs the session's observer, operation registry, optional hook bus, memory default,
+  and Exchange registration; removal detaches ownership, observer, hooks, the shared operation
+  registry, and the mailbox while leaving the branch's adopted memory and other conversation data
+  intact;
+- a branch-supplied memory store wins over the session default, while branches without one share the
+  session's single store instance;
+- `SessionObserver` is the canonical in-process gate, event store, router, and subscriber dispatcher;
+  lifecycle calls using safe emission and the bound database subscriber treat observation and
+  persistence failures as best-effort diagnostics;
+- `Session.flow()` and `flow_stream()` are convenience delegates, and scheduling, dependency,
+  branch-cloning, and reactive-mutation algorithms remain in the operation graph kernel; and
+- the default `Exchange` is an explicitly pumped, non-serialized compatibility facility. Its
+  presence does not promise automatic delivery, durability, recovery, or a provisioned Messenger.
+
+```text
+                         Session
+              membership and shared resources
+                  /          |          \
+            Branches     Observer      Memory
+               |          + Hooks       default
+               |              |
+               +---- shared operations ----+
+               |
+          flow()/flow_stream()
+               |
+               v
+       operation graph execution kernel
+```
+
+## Consequences
+
+Branch ownership, shared extensions, observation, and graph-created clone wiring have one lifecycle.
+Standalone branches remain usable, and orchestration code can rely on Session membership without
+moving the graph executor into the session package.
+
+The Session surface exposes facilities with different maturity and durability. Observer history and
+Exchange mailboxes are process-local, Exchange requires explicit pumping, and direct database
+binding couples the observer to persistence policy. Consumers must not infer recovery guarantees
+from in-memory coordination APIs.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Extract StateDB signal persistence from `SessionObserver` into a persistence-owned subscription adapter; acceptance requires the observer module to contain no StateDB construction or payload-size policy while CLI and Studio retain best-effort writes, payload bounds, and unbind behavior. | S | (filled at issue-open time) |
+| 2 | Move versioned signal and loop-control vocabulary to a neutral low-level module with compatibility re-exports from `lionagi.session`; acceptance requires unchanged schema versions, serialized payloads, `lane_for()` results, dispatch envelopes, and public import behavior throughout the relocation. | M | (filled at issue-open time) |
+| 3 | Choose and implement one Exchange product posture: provision Messenger, collection, durability, and recovery as an end-to-end supported path, or make Exchange opt-in and deprecate the default Session mailbox; acceptance requires documentation and integration tests that demonstrate the selected lifecycle. | M | (filled at issue-open time) |
+
+## Notes
+
+Moving graph execution into `Session` was rejected because it would combine membership lifecycle
+with scheduling and reactive graph mutation. Treating Observer, HookBus, and Exchange as one
+transport was rejected because they have different delivery, persistence, and invocation contracts.

--- a/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
+++ b/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
@@ -1,0 +1,97 @@
+# ADR-0018: Turn-Scoped Branch Execution State
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: session-branch
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0016
+
+## Context
+
+Branch currently stores provider injection blocks, the latest provider report, one loop-control
+directive, and pending signal tasks in branch-global mutable attributes. Chat and run populate and
+clear the same provider slot, control polling consumes the same directive, and signal draining takes
+the whole branch task list. The CLI run path also installs a per-call model override as the branch's
+configured chat model (`lionagi/session/branch.py`, `lionagi/operations/chat/_prepare.py`,
+`lionagi/operations/chat/chat.py`, `lionagi/operations/run/run.py`).
+
+Those fields describe an invocation, not a conversation. Top-level operations are asynchronous and
+the Branch API does not reject overlap, so two turns on one branch can overwrite or clear each
+other's provider state, consume the wrong control, drain unrelated signals, or retain a temporary
+model. The latest provider report also lacks a stable turn identity. This is separate from the
+immutable provider request proposed for compilation (see the messages-context ADR on canonical
+turn-request compilation): a compiled request is model input, while execution state owns lifecycle
+and runtime resources.
+
+Lifecycle ownership is also distributed. Ordinary recorded operations use `Branch._observed_run()`,
+`ReAct()` repeats start and terminal emission while suppressing nested signals through a task-local
+flag, and the CLI async generator owns its own abandonment and finalization path. Exact-once
+terminal behavior is required, but adding another execution path currently requires reproducing
+that policy (`lionagi/session/branch.py`, `lionagi/session/_lifecycle_ctx.py`,
+`lionagi/operations/run/run.py`). Adapter and transport responsibilities remain separately governed
+(see the operations ADR on the Branch operation facade and turn adapters).
+
+## Decision
+
+Every top-level model turn will create one internal, typed `TurnExecutionContext`. The minimum
+contract is:
+
+```python
+@dataclass(slots=True)
+class TurnExecutionContext:
+    turn_id: UUID
+    model: iModel
+    provider_blocks: tuple[str, ...]
+    provider_report: ProviderReport | None
+    control: LoopControl | None
+    signal_tasks: set[asyncio.Task[Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class TurnScope:
+    context: TurnExecutionContext
+    owns_lifecycle: bool
+```
+
+The context is runtime state and is never serialized as conversation history. The target type lives
+with operation parameter contracts in `lionagi/operations/types.py`; one internal lifecycle driver
+in the operation layer owns its entry, completion, failure, stream-close, and cleanup behavior.
+
+The load-bearing invariants are:
+
+- top-level model turns on the same Branch are serialized for their full lifetime, including the
+  lifetime of a returned async generator; turns on distinct branches remain concurrent;
+- nested operations receive a new `TurnScope` over the active context with
+  `owns_lifecycle=False`, so only the top-level scope emits start and terminal events and releases
+  the branch turn lock;
+- a per-call model is resolved into the context and never mutates the branch's configured model;
+- provider blocks, provider report, control, and signal tasks are read and cleared only through the
+  active context; no turn may observe or drain another turn's runtime state;
+- every started turn receives a stable `turn_id`, and its start and exactly one end-or-failed event
+  carry that identity; `turn_id` supplements rather than replaces graph-node `op_id`, and stream
+  abandonment and cancellation are terminal paths rather than silent leaks;
+- pending message signals for the turn are drained before its terminal event, and observer failures
+  remain best-effort diagnostics that do not change the operation result; and
+- lock acquisition cancellation emits no start event, while any failure after start releases the
+  lock and emits exactly one failed terminal event.
+
+## Consequences
+
+Provider attribution, controls, model overrides, signal draining, and lifecycle events become
+unambiguous per turn. The single driver gives ordinary calls, reasoning loops, and streams the same
+failure and cleanup contract, and conversation-level objects no longer carry transient execution
+slots.
+
+One Branch deliberately gives up overlapping top-level model turns. Work that requires parallel
+model calls must use separate branches or graph-created clones, which matches the existing
+conversation-isolation model but can reduce throughput for callers that previously overlapped calls
+on one branch. Migration must preserve async-generator close behavior and coordinate the new turn
+identity with signal consumers and persistence adapters.
+
+## Notes
+
+Fully concurrent recorded turns on one Branch were rejected because isolated temporary fields would
+not define deterministic history snapshots or append order. A branch-global lock without an
+explicit context was rejected because nested ownership, model overrides, signal attribution, and
+stream cleanup would remain implicit. The context is intentionally separate from `TurnRequest`:
+one governs execution lifetime, the other governs compiled provider input.

--- a/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
+++ b/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
@@ -8,43 +8,104 @@
 
 ## Context
 
-Branch currently stores provider injection blocks, the latest provider report, one loop-control
-directive, and pending signal tasks in branch-global mutable attributes. Chat and run populate and
-clear the same provider slot, control polling consumes the same directive, and signal draining takes
-the whole branch task list. The CLI run path also installs a per-call model override as the branch's
-configured chat model (`lionagi/session/branch.py`, `lionagi/operations/chat/_prepare.py`,
-`lionagi/operations/chat/chat.py`, `lionagi/operations/run/run.py`).
+Branch currently stores several values that describe an invocation in progress rather than the
+conversation itself:
 
-Those fields describe an invocation, not a conversation. Top-level operations are asynchronous and
-the Branch API does not reject overlap, so two turns on one branch can overwrite or clear each
-other's provider state, consume the wrong control, drain unrelated signals, or retain a temporary
-model. The latest provider report also lacks a stable turn identity. This is separate from the
-immutable provider request proposed for compilation (see the messages-context ADR on canonical
-turn-request compilation): a compiled request is model input, while execution state owns lifecycle
-and runtime resources.
+```python
+# lionagi/session/branch.py — current state, not the target
+_loop_control: LoopControl | None = PrivateAttr(None)
+_signal_tasks: list = PrivateAttr(default_factory=list)
+_context_injection_slot: list[str] | None = PrivateAttr(None)
+_last_context_report: Any = PrivateAttr(None)
+```
 
-Lifecycle ownership is also distributed. Ordinary recorded operations use `Branch._observed_run()`,
-`ReAct()` repeats start and terminal emission while suppressing nested signals through a task-local
-flag, and the CLI async generator owns its own abandonment and finalization path. Exact-once
-terminal behavior is required, but adding another execution path currently requires reproducing
-that policy (`lionagi/session/branch.py`, `lionagi/session/_lifecycle_ctx.py`,
-`lionagi/operations/run/run.py`). Adapter and transport responsibilities remain separately governed
-(see the operations ADR on the Branch operation facade and turn adapters).
+The public async API neither rejects nor serializes overlapping calls. Five concrete problems follow.
+
+**P1 — provider state can be overwritten across turns.** `chat` and CLI `run` gather providers into
+the same `_context_injection_slot`, request preparation reads that slot, and a `finally` block clears
+it (`lionagi/operations/chat/_prepare.py`, `lionagi/operations/chat/chat.py`,
+`lionagi/operations/run/run.py`). Two overlapping calls can replace or clear each other's blocks.
+`_last_context_report` also identifies only a branch-global latest report and the zero-provider path
+can leave an older report visible.
+
+**P2 — loop control has no turn identity.** `Branch.control()` overwrites one `_loop_control`, while
+`poll_control()` consumes and clears it. A directive can therefore be consumed by whichever
+overlapping stream reaches a poll point first, not necessarily the invocation that caused the
+observer to issue it (`lionagi/session/control.py`, `lionagi/operations/_observe.py`).
+
+**P3 — message-signal drainage is branch-global.** Every message callback appends an asyncio task to
+one list. `drain_signals()` swaps and awaits the whole list. A terminal boundary can drain another
+turn's emissions, and a later terminal can run before its own message signal if the earlier turn
+took the task list.
+
+**P4 — a CLI model override mutates durable configuration.** Current `run()` assigns
+`branch.chat_model = param.imodel` before endpoint validation and never restores the prior model.
+A one-call override can therefore become the model for later turns, including after a failing call
+(`lionagi/operations/run/run.py`).
+
+**P5 — lifecycle ownership is duplicated.** Ordinary recorded operations use
+`Branch._observed_run()`. `ReAct()` repeats start, failure, end, timing, signal-drain, and observer
+isolation while setting `suppress_lifecycle_var`. CLI `run()` implements a third path with additional
+async-generator abandonment and stream cleanup logic (`lionagi/session/branch.py`,
+`lionagi/session/_lifecycle_ctx.py`, `lionagi/operations/run/run.py`). The paths are individually
+careful, but a new adapter must reproduce the same terminal policy and nested calls depend on a
+suppression flag rather than explicit ownership.
+
+These failures cannot be repaired by moving provider blocks alone. A same-Branch conversation also
+has one ordered progression and no merge rule for simultaneous turns. The target therefore combines
+typed invocation state with full-lifetime serialization of top-level model turns.
+
+| Concern | Decision |
+|---------|----------|
+| Runtime state shape | D1: every top-level model turn owns one typed `TurnExecutionContext`, wrapped by a `TurnScope`. |
+| Overlap and nesting | D2: top-level turns serialize on one Branch lock; task-local nested calls reuse the active context without owning lifecycle. |
+| Model, provider, control, and signal state | D3: all four are resolved or stored through the active context and never through independent branch-global slots. |
+| Lifecycle and stream cleanup | D4: one operation-layer driver owns start, one terminal, signal drain, cancellation, generator close, and lock release. |
+| Compatibility surface | D5: lifecycle signals gain additive turn identity and `last_context_report` becomes a last-terminal compatibility view. |
+
+This ADR deliberately does **not** decide:
+
+- how a provider request is compiled from messages, guidance, tools, images, and response schemas;
+  that belongs to the messages-context ADR on canonical turn-request compilation;
+- provider retry, timeout, subprocess, parsing, action, or tool-authorization policy;
+- graph-node scheduling or `op_id` allocation; a turn id supplements graph identity rather than
+  replacing it;
+- cross-Branch concurrency; distinct branches remain independently schedulable;
+- direct message-manager mutation or a top-level `act()` invoked outside a model turn; those paths
+  can still interleave with a model turn and remain caller-coordinated under this ADR;
+- persistence or restart recovery for an in-flight context; execution contexts are runtime-only;
+- a transactional rollback of messages, logs, API events, or tool effects after a failed turn;
+- per-turn usage accounting; existing usage projection remains governed by the signal and operation
+  contracts.
 
 ## Decision
 
-Every top-level model turn will create one internal, typed `TurnExecutionContext`. The minimum
-contract is:
+### D1 — One typed context owns one top-level turn's runtime state
+
+The target types live with operation parameter contracts in `lionagi/operations/types.py`:
 
 ```python
+from asyncio import Task
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from uuid import UUID
+
+from lionagi.protocols.context_providers import ProviderReport
+from lionagi.service.imodel import iModel
+from lionagi.session.control import LoopControl
+
+
 @dataclass(slots=True)
 class TurnExecutionContext:
     turn_id: UUID
     model: iModel
-    provider_blocks: tuple[str, ...]
-    provider_report: ProviderReport | None
-    control: LoopControl | None
-    signal_tasks: set[asyncio.Task[Any]]
+    owner_task: Task[Any]
+    phase: Literal["active", "finalizing", "closed"] = "active"
+    provider_blocks: tuple[str, ...] = ()
+    provider_report: ProviderReport | None = None
+    control: LoopControl | None = None
+    signal_tasks: set[Task[Any]] = field(default_factory=set)
+    nested_tasks: set[Task[Any]] = field(default_factory=set)
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,45 +114,505 @@ class TurnScope:
     owns_lifecycle: bool
 ```
 
-The context is runtime state and is never serialized as conversation history. The target type lives
-with operation parameter contracts in `lionagi/operations/types.py`; one internal lifecycle driver
-in the operation layer owns its entry, completion, failure, stream-close, and cleanup behavior.
+```python
+# lionagi/operations/turn.py
+class TurnFinalizingError(RuntimeError):
+    """A task inherited this Branch's turn binding after finalization began."""
+```
 
-The load-bearing invariants are:
+`TurnExecutionContext` is mutable because providers, controls, and scheduled signal tasks arrive
+during execution. `TurnScope` is frozen because ownership must not change after entry. The context is
+not a Pydantic model and is never added to Branch or Session serialization.
 
-- top-level model turns on the same Branch are serialized for their full lifetime, including the
-  lifetime of a returned async generator; turns on distinct branches remain concurrent;
-- nested operations receive a new `TurnScope` over the active context with
-  `owns_lifecycle=False`, so only the top-level scope emits start and terminal events and releases
-  the branch turn lock;
-- a per-call model is resolved into the context and never mutates the branch's configured model;
-- provider blocks, provider report, control, and signal tasks are read and cleared only through the
-  active context; no turn may observe or drain another turn's runtime state;
-- every started turn receives a stable `turn_id`, and its start and exactly one end-or-failed event
-  carry that identity; `turn_id` supplements rather than replaces graph-node `op_id`, and stream
-  abandonment and cancellation are terminal paths rather than silent leaks;
-- pending message signals for the turn are drained before its terminal event, and observer failures
-  remain best-effort diagnostics that do not change the operation result; and
-- lock acquisition cancellation emits no start event, while any failure after start releases the
-  lock and emits exactly one failed terminal event.
+The minimum module boundary is:
+
+```text
+lionagi/
+├── operations/
+│   ├── types.py          TurnExecutionContext, TurnScope
+│   └── turn.py           scope entry, coroutine driver, stream driver,
+│                         signal scheduling/drain, terminal finalization,
+│                         TurnFinalizingError
+├── session/
+│   ├── branch.py         _turn_lock, _active_turn_context, facade adapters
+│   └── signal.py         additive turn_id lifecycle fields
+└── operations/chat/
+    └── _prepare.py       reads provider_blocks from TurnScope
+```
+
+The Branch carries only the synchronization primitive and an out-of-band pointer to the one active
+context:
+
+```python
+_turn_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
+_active_turn_context: TurnExecutionContext | None = PrivateAttr(None)
+```
+
+The pointer is not an alternate state store. It exists so an observer callback running outside the
+turn's task-local context can address the active turn through `Branch.control()`. All mutable turn
+data remains inside `TurnExecutionContext`.
+
+**Exact construction semantics:**
+
+- `turn_id` is a new `uuid4()` for every top-level entry that acquires the lock.
+- `model` is resolved after lock acquisition from the call-specific override or the appropriate
+  current Branch model. Waiting turns therefore see configuration as it exists when they start.
+- `owner_task` is `asyncio.current_task()` at top-level entry. Driver entry is async, so a missing
+  current task is an invariant failure rather than a supported context shape.
+- `phase` starts as `"active"`, becomes `"finalizing"` exactly once after the operation result or
+  primary exception is fixed, and becomes `"closed"` before the lock is released. It never moves
+  backward.
+- `provider_blocks` starts empty and is immutable as a tuple once provider gathering assigns it.
+- `provider_report` and `control` start as `None`; the signal-task and nested-task sets start empty.
+- A nested scope references the same context object; it does not copy fields or create a second id.
+
+### D2 — Same-Branch top-level turns serialize; nested work reuses scope
+
+`lionagi/operations/turn.py` owns a task-local binding:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _ActiveTurnBinding:
+    branch_id: UUID
+    scope: TurnScope
+
+
+_active_turn_var: ContextVar[_ActiveTurnBinding | None] = ContextVar(
+    "lionagi_active_turn",
+    default=None,
+)
+```
+
+The target drivers have separate coroutine and iterator shapes so the stream wrapper can retain the
+lock across every `yield`:
+
+```python
+async def run_in_turn(
+    branch: Branch,
+    *,
+    model: iModel | None,
+    invoke: Callable[[TurnScope], Awaitable[T]],
+) -> T: ...
+
+
+async def stream_in_turn(
+    branch: Branch,
+    *,
+    model: iModel | None,
+    invoke: Callable[[TurnScope], AsyncIterator[T]],
+) -> AsyncIterator[T]: ...
+```
+
+Entry follows this state machine:
+
+```text
+call adapter
+  |
+  +-- binding has this Branch id, points to Branch._active_turn_context,
+  |   and phase == "active" -----------------> nested TurnScope
+  |                                               owns_lifecycle=False
+  |                                               no lock acquisition / no lifecycle signals
+  |
+  +-- same live binding is "finalizing" -----> raise TurnFinalizingError
+  |                                               no lock wait / no signals
+  |
+  +-- no matching live binding, including a stale closed binding
+                            --> await Branch._turn_lock
+                                |
+                                +-- cancelled while waiting --> propagate
+                                |                              no context/event
+                                |
+                                +-- acquired --> create context
+                                                  set Branch active pointer
+                                                  bind task-local scope
+                                                  owns_lifecycle=True
+                                                  emit RunStart
+                                                  invoke body
+```
+
+The lock covers provider gathering, request construction, provider invocation, message recording,
+actions and parsing that belong to the top-level adapter, signal drainage, terminal emission, and
+stream finalization. For an async generator, merely constructing the generator acquires nothing;
+entry occurs on first iteration. Once started, the lock remains held until normal exhaustion,
+`aclose()`/`GeneratorExit`, cancellation, or failure finalization completes.
+
+ContextVar inheritance makes a child task created inside an active turn part of that turn when it
+calls the same Branch. It receives a nested scope that shares the context but explicitly does not
+own lifecycle. This is intentional: work spawned from an active turn is not a second top-level
+conversation turn while the parent context is active.
+
+When nested entry occurs from a task other than `owner_task`, the driver adds the current task to
+`context.nested_tasks` once and installs a done callback that removes it and observes/logs any task
+failure. The owning operation is expected to await its child work. If the owner body returns or
+raises while nested tasks remain, finalization cancels unfinished tasks and awaits a snapshot with
+`return_exceptions=True` before draining message-signal tasks. A child failure changes the operation
+result only when the owner awaited and received it; an unawaited child failure is diagnostic.
+Detached nested model work therefore cannot continue into the next turn, and cancellation of it is
+cleanup rather than a second lifecycle failure signal.
+
+Inheritance alone is not proof of liveness. A child task can outlive its parent and retain a copied
+binding after the parent releases the Branch. Scope entry therefore also requires pointer identity
+with `Branch._active_turn_context` and `phase == "active"`. A closed or displaced binding is stale
+and the child enters as a new top-level contender. A same-binding call during `"finalizing"` fails
+with `TurnFinalizingError` instead of waiting on the lock its own task lineage is helping release;
+this prevents a terminal observer handler from deadlocking by synchronously re-entering the Branch.
+The handler may schedule independent work after terminal completion or handle and retry the error.
+
+Distinct branches have distinct locks and remain concurrent. Same-Branch contenders queue rather
+than fail. No lock-wait timeout is introduced; the exact queuing/fairness properties are those of
+`asyncio.Lock`.
+
+The top-level adapters that invoke models enter the driver. Direct `chat`, `chat_and_record`,
+`parse`, `operate`, `communicate`, `interpret`, `ReAct`, `ReActStream`, and `run` calls therefore
+participate. `act` alone does not acquire the turn lock because it is not a model turn; when called
+inside a composed turn it runs within the owning scope. A direct top-level `act()` can append action
+messages while a model turn is active; this ADR does not serialize that caller-managed path.
+Internal operation functions accept or retrieve `TurnScope` instead of creating independent
+lifecycle wrappers.
+
+### D3 — Model, provider, control, and signal state is isolated by context
+
+#### Model resolution
+
+A call-specific model is stored as `scope.context.model`. CLI `run()` uses that local object for
+endpoint validation, session resume, event construction, streaming, and temporary stream callbacks.
+It does not assign `branch.chat_model` and does not need a restore step.
+
+For a composed operation, `context.model` is the primary generation model selected at top-level
+entry. Explicit parse or interpretation submodels remain parameters to those nested operation calls;
+they also must not mutate the Branch model manager. A later top-level turn without an override uses
+the configured Branch model, not the previous context's model.
+
+**Error cases:**
+
+- An invalid CLI endpoint fails the current turn and leaves Branch configuration untouched.
+- Provider failure or cancellation leaves the context eligible for terminal cleanup but never
+  publishes its model back to Branch.
+- Changing Branch configuration while another turn is waiting affects the waiting turn when it
+  starts; changing it during an active turn does not replace that turn's snapshot.
+
+#### Provider gathering and report visibility
+
+The target provider helper receives the active scope:
+
+```python
+async def _apply_context_providers(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    param: ChatParam,
+    scope: TurnScope,
+) -> Instruction | None: ...
+```
+
+- With no registered providers, `provider_report` remains `None` and `provider_blocks` remains `()`.
+- With providers but no system message, providers are not invoked; the context receives
+  `ProviderReport(skipped=list(registry.names))` and no blocks.
+- With a system message, `ContextProviderRegistry.gather()` supplies the report and the context stores
+  `tuple(report.blocks)`.
+- Request preparation reads only `scope.context.provider_blocks`. It never reads or clears a Branch
+  injection slot.
+- Provider exceptions retain the registry's current containment semantics: names appear under
+  `failed` and the turn continues with remaining blocks.
+- The context report is available throughout nested work. At top-level terminal finalization it
+  becomes the compatibility view described in D5.
+
+This ADR retains the provider registry's **2,000-token** default total budget and optional
+per-provider cap from ADR-0016. It does not add a second turn-level budget.
+
+#### Loop control
+
+The target public compatibility surface becomes:
+
+```python
+def control(
+    self,
+    directive: LoopDirective,
+    *,
+    reason: str | None = None,
+    turn_id: UUID | None = None,
+) -> bool: ...
+
+def poll_control(
+    self,
+    *,
+    turn_id: UUID | None = None,
+) -> LoopControl | None: ...
+```
+
+`control()` reads `_active_turn_context`. It returns `False` and stores nothing when no context is in
+the `"active"` phase or when a supplied `turn_id` does not match. Otherwise it writes one
+`LoopControl` into that context and returns `True`. Omitting `turn_id` addresses the sole active turn
+and preserves existing observer-callback ergonomics under same-Branch serialization. A control
+arriving during finalization is rejected rather than being applied to the completed result or queued
+for the next turn.
+
+`poll_control()` uses the same optional identity check, returns the active context's directive, and
+sets only that context's field to `None`. Multiple writes before a poll retain current last-write-wins
+behavior. A directive is never queued for a future turn.
+
+`check_control()` keeps its existing meanings: no directive or `CONTINUE` is a no-op, `BREAK` raises
+`LoopBreak`, and `CANCEL` raises the clean `StopStream` control signal. The change is attribution, not
+directive vocabulary.
+
+#### Message-signal tasks
+
+Message scheduling consults both the task-local binding and the Branch active pointer:
+
+```text
+message added while binding, pointer identity, and active phase agree
+  -> create emit_message task
+  -> add task to context.signal_tasks
+  -> done callback removes it and consumes/logs task failure
+
+message added without that live triple, including from a stale child binding
+  -> create detached best-effort task
+  -> done callback consumes/logs task failure
+  -> no future turn adopts or drains it
+```
+
+As today, no task is scheduled when no observer exists or no event loop is running. Top-level
+finalization repeatedly drains the active context's current task set with
+`return_exceptions=True` until it is empty, then emits the terminal lifecycle event. It never swaps
+or drains another context's tasks.
+
+There is no signal-drain timeout or retry budget in this ADR. Preserving “message signals before
+terminal” means a non-completing observer task can delay terminal emission and lock release. Adding a
+timeout would require a separate loss and cancellation policy rather than an unexplained number.
+
+### D4 — One driver owns start, terminal, cancellation, and stream close
+
+Only a scope with `owns_lifecycle=True` emits lifecycle signals, updates the compatibility report,
+or releases the lock. Nested operation paths receive `owns_lifecycle=False` and must not call a
+second wrapper.
+
+Once the body result or primary exception is known, the owner changes the context phase to
+`"finalizing"` before draining signals. That closes nested entry and control attribution while
+leaving the context available to the finalizer. It then cancels and awaits unfinished nested tasks,
+drains the context signal-task set, attempts the single terminal signal, publishes the compatibility
+report, marks the context `"closed"`, clears the Branch pointer, resets the ContextVar token, and
+releases the lock. An independently scheduled caller without the inherited binding may wait
+throughout finalization; a caller with the same live binding receives `TurnFinalizingError` as
+specified in D2.
+
+The target terminal matrix is normative:
+
+| Path after lock acquisition | Terminal signal | Operation result | Cleanup |
+|-----------------------------|-----------------|------------------|---------|
+| normal coroutine return | `RunEnd(turn_id=...)` | return unchanged | cancel/await unfinished nested tasks, drain signals, clear binding/pointer, release lock |
+| normal stream exhaustion | `RunEnd(turn_id=...)` | iteration ends | same |
+| `StopStream` clean control | `RunEnd(turn_id=...)` | stream ends without error | same |
+| consumer `aclose()` / `GeneratorExit` after start | `RunEnd(turn_id=...)` | `GeneratorExit` is not converted | same; underlying stream is closed |
+| provider, parse, action, or other `Exception` | `RunFailed(turn_id=..., data=exc)` | original exception re-raised | same |
+| `LoopBreak` | `RunFailed(turn_id=..., data=exc)` | original exception re-raised | same |
+| cancellation after start | `RunFailed(turn_id=..., data=exc)` | cancellation re-raised | cancellation-shielded terminal cleanup, then release |
+| cancellation while waiting for lock | none | cancellation re-raised | no context or lock ownership |
+| generator created but never iterated | none | no yielded value | no context or lock ownership |
+
+The driver sets one local `terminal_emitted` guard before attempting terminal observation. Cleanup is
+performed in a cancellation-shielded scope so cancellation cannot strand `_active_turn_context` or
+the lock. Observer exceptions during start or terminal are logged and do not replace the operation
+result or exception. A terminal observer failure is not retried and does not permit a second terminal
+attempt.
+
+Pending message signals are drained before terminal emission. The active task-local binding and
+Branch pointer are cleared after terminal attempt and before lock release. The ContextVar token is
+reset rather than assigned blindly, so an outer context is restored if different-Branch work was
+nested.
+
+The stream driver also retains the current deterministic close requirement: its `finally` closes the
+underlying async generator, restores any temporary `streaming_process_func`, and performs configured
+stream-persistence cleanup before the turn terminal is emitted. An ordinary `Exception` raised by
+close is logged and suppressed. A close-time `BaseException` is re-raised only when no other
+exception is already unwinding; otherwise it is logged as secondary and suppressed. This preserves
+the existing provider-stream behavior while moving lifecycle selection to one owner.
+
+Started work is not rolled back. Messages or external effects committed before failure remain; the
+terminal event describes the outcome and releases serialization for the next turn.
+
+### D5 — Turn identity is additive and the provider report has a compatibility view
+
+Run lifecycle signals gain an optional UUID field in `lionagi/session/signal.py`:
+
+```python
+class RunStart(Signal):
+    turn_id: UUID | None = None
+
+
+class RunEnd(Signal):
+    turn_id: UUID | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_cost_usd: float = 0.0
+    num_turns: int = 0
+    duration_ms: float = 0.0
+
+
+class RunFailed(Signal):
+    turn_id: UUID | None = None
+```
+
+The field is optional for compatibility with manual signal construction and non-turn projections,
+but the D4 driver always supplies it. UUID JSON serialization produces the stable string form used
+by persistence payloads. This is an additive nullable field under the current signal version policy,
+so it does not by itself bump `SIGNAL_SCHEMA_VERSION`. `op_id` remains graph-node identity; consumers
+must not substitute one id for the other.
+
+`build_run_end()` accepts and forwards `turn_id`. Existing usage and duration fields retain their
+current defaults and calculation policy; this ADR does not claim that branch-history usage is
+already isolated per turn.
+
+```python
+def build_run_end(
+    branch: Any,
+    *,
+    turn_id: UUID | None = None,
+    duration_ms: float = 0.0,
+    result: Any = None,
+) -> RunEnd: ...
+```
+
+`Branch.last_context_report` remains as a read-only compatibility property, with clarified target
+meaning: report from the **last terminal top-level turn**, including failed, cancelled, or abandoned
+turns. Finalization copies the active context's report into one private compatibility slot after
+signal drainage. A currently running turn never publishes a partial report there. A no-provider turn
+publishes `None`, so an older report cannot remain falsely current.
+
+No unbounded `turn_id -> ProviderReport` map is added. The shipped compatibility surface therefore
+retains only the last terminal report; durable report history would require a separately specified
+observation or persistence contract. The execution context itself is released after terminal
+cleanup.
+
+Migration removes direct reads and writes of `_context_injection_slot`, `_loop_control`, and
+`_signal_tasks`, and removes lifecycle suppression through `suppress_lifecycle_var`. Temporary
+compatibility shims may exist during implementation, but the completed target has one lifecycle owner
+and no operation path may use those branch-global slots.
 
 ## Consequences
 
-Provider attribution, controls, model overrides, signal draining, and lifecycle events become
-unambiguous per turn. The single driver gives ordinary calls, reasoning loops, and streams the same
-failure and cleanup contract, and conversation-level objects no longer carry transient execution
-slots.
+- Provider blocks, provider reports, controls, model overrides, and message-signal tasks have an
+  unambiguous turn owner. No top-level turn can clear, consume, or drain another's context.
+- One Branch deliberately gives up overlapping top-level model turns. Work needing parallel model
+  calls uses distinct branches or graph-created clones. Same-Branch callers wait instead of receiving
+  a new conflict error.
+- Child work created inside a turn shares that turn through ContextVar propagation. Contributors must
+  treat it as nested work and must not emit lifecycle signals independently. Child tasks that
+  outlive the owner body are cancelled and awaited before terminal emission; they cannot reuse a
+  stale context. A finalizer-time re-entry fails fast and a post-close re-entry contends as a new
+  top-level turn.
+- A stream holds the Branch lock for its full active lifetime. Consumers that start iteration are
+  responsible for exhausting or closing the iterator; the wrapper makes close deterministic once it
+  receives `aclose()` or `GeneratorExit`.
+- Observer failures remain diagnostic. Cancellation requires shielded cleanup, which slightly
+  increases cancellation latency but prevents a permanently locked Branch.
+- Out-of-band control can target a known turn id and safely rejects stale controls. The compatibility
+  no-id form is safe only because one Branch has at most one active top-level turn.
+- Reversing D2 is expensive because deterministic progression and lifecycle would need a merge
+  protocol. D1, D3, and D5 are internal or additive contracts; D4 consolidates existing behavior but
+  touches every model-turn adapter.
 
-One Branch deliberately gives up overlapping top-level model turns. Work that requires parallel
-model calls must use separate branches or graph-created clones, which matches the existing
-conversation-isolation model but can reduce throughput for callers that previously overlapped calls
-on one branch. Migration must preserve async-generator close behavior and coordinate the new turn
-identity with signal consumers and persistence adapters.
+## Alternatives considered
+
+### Allow fully concurrent turns with separate temporary contexts
+
+This would isolate provider blocks and model overrides while preserving maximum throughput. It loses
+because Branch still has one message progression, one append sequence, and one configured snapshot.
+Two turns can build from different histories and append in completion order, producing a conversation
+neither model saw. A merge policy would be a different architecture, not a context-field fix.
+
+### Add only a branch-global lock
+
+A lock alone would prevent overlap and is the smallest race fix. It loses because lifecycle
+ownership, temporary model selection, provider attribution, signal-task grouping, and stale control
+remain implicit private-field conventions. The typed context makes those contracts inspectable and
+testable.
+
+### Reject overlap instead of queueing
+
+Fail-fast `TurnAlreadyActive` would make contention visible and avoid unbounded wait. It loses
+compatibility with async callers that reasonably submit work before a prior stream closes and forces
+retry policy into every caller. Serialization already defines a deterministic safe order; queuing is
+the narrower behavior change.
+
+### Clone Branch automatically for every overlapping call
+
+This would preserve concurrency and give each call a separate progression. It loses conversation
+identity: results would need an explicit merge, tools and memory have nontrivial clone semantics, and
+the caller asked to continue one Branch rather than create graph fan-out. Explicit clones remain the
+parallelism mechanism.
+
+### Use ContextVar alone with no Branch active pointer
+
+This would keep all state task-local and remove a Branch private field. It loses out-of-band control:
+observer handlers or external control pollers can run in tasks that do not inherit the invocation's
+ContextVar. The narrow `_active_turn_context` pointer makes that seam explicit while the context
+retains the state.
+
+### Trust an inherited ContextVar binding until the child task exits
+
+This would avoid a phase field and pointer-identity check. It loses because asyncio copies context
+into child tasks: a detached child can retain the parent's binding after terminal cleanup, bypass
+the Branch lock, and mutate a later conversation turn through a closed context. Treating a
+same-lineage finalizer call as an ordinary lock contender is also unsafe because a terminal observer
+can await that call while the driver awaits the observer, producing self-deadlock. The explicit
+active/finalizing/closed phases make both cases decidable.
+
+### Keep one branch-global pending control for compatibility
+
+This would preserve controls issued before a turn starts. It loses attribution: a stale cancel could
+silently terminate the next unrelated turn. The target returns `False` when there is no matching
+active context, making the race observable to the controller.
+
+### Mutate the Branch model and restore it in `finally`
+
+This is a smaller change to CLI `run()`. It loses because cancellation and overlap make restoration
+order meaningful: one call can restore a model over a newer configuration. Resolving a local model
+snapshot has no shared rollback problem.
+
+### Retain separate lifecycle wrappers plus a suppression flag
+
+This would minimize movement of working code. It loses because exact-once behavior remains a
+convention copied among coroutine, reasoning-loop, and async-generator paths. A task-local boolean
+answers only “suppress?”; it does not identify the owning turn or centralize terminal cleanup.
+
+### Fold execution context into the compiled `TurnRequest`
+
+One type would reduce names. It loses the boundary between immutable provider input and mutable
+runtime resources. Controls and asyncio tasks are not request fields, while rendered messages and
+tool schemas are not lifecycle ownership. Separate types allow request compilation to remain pure.
+
+### Persist execution contexts for restart
+
+This would appear to support resuming in-flight turns. It loses because locks, Tasks, provider stream
+objects, and live callbacks cannot be reconstructed from a data record, and external effects may
+already have occurred. Durable checkpoints require a separate operation-specific recovery protocol.
+
+### Keep a report map for every completed turn
+
+This would give direct random access by `turn_id`. It loses because retention, eviction, and
+persistence policy are undefined and would make Branch an observability database. An additive id on
+events supplies correlation without unbounded Branch memory.
 
 ## Notes
 
-Fully concurrent recorded turns on one Branch were rejected because isolated temporary fields would
-not define deterministic history snapshots or append order. A branch-global lock without an
-explicit context was rejected because nested ownership, model overrides, signal attribution, and
-stream cleanup would remain implicit. The context is intentionally separate from `TurnRequest`:
-one governs execution lifetime, the other governs compiled provider input.
+The target sequence for two independent calls on one Branch is:
+
+```text
+caller A            Branch / turn driver             caller B
+   |                         |                           |
+   | first iteration/call    |                           |
+   |------------------------>| acquire lock              |
+   |                         | RunStart(A)               |
+   |                         | execute + message signals |
+   |                         |<--------------------------| call waits
+   |                         | drain(A)                  |
+   |                         | RunEnd/RunFailed(A)       |
+   |                         | release                   |
+   |                         | acquire for B             |
+   |                         | RunStart(B)               |
+   |                         | execute + drain(B)        |
+   |                         | RunEnd/RunFailed(B)       |
+```
+
+The ContextVar replaces the current lifecycle-suppression boolean with an explicit scope. It is not
+a substitute for the Branch lock: task-local isolation alone cannot order shared conversation
+history.

--- a/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
+++ b/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
@@ -1,0 +1,107 @@
+# ADR-0027: Model-service façade and endpoint resolution
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: service-providers
+- **Date**: 2026-07-09
+- **Relations**: none
+
+## Context
+
+`iModel` is the caller-facing service façade for API and agentic model providers. It derives a
+provider from a `provider/model` specification when needed, resolves an endpoint, creates
+`APICalling` events, owns a per-model `RateLimitedAPIExecutor`, applies service-call hooks, and
+retains resumable provider session state. `iModelManager` is a named registry of these façades and
+shuts them down concurrently with per-model isolation (`lionagi/service/imodel.py`,
+`lionagi/service/manager.py`).
+
+`EndpointRegistry` is the sole endpoint resolver. Provider modules decorate concrete endpoint
+classes, and the decorator materializes an immutable, typed `EndpointMeta` record on each class.
+Provider authors still supply most metadata through positional `ProviderConfig` enum tuples. On
+first resolution, the registry imports a fixed module list, ignores `ImportError`, and selects the
+first provider and endpoint key or alias that matches (`lionagi/service/connections/registry.py`,
+`lionagi/service/connections/provider_config.py`).
+
+`Endpoint` owns generic payload validation, authentication headers, SSRF checks, HTTP transport,
+retry, circuit-breaking, and generic stream projection. `AgenticEndpoint` inherits the same
+configuration and event boundary but prevents use of the HTTP helpers; concrete subprocess,
+in-process, and remote-agent adapters provide their own call and stream implementations. Both
+families are exposed through `APICalling`, while provider-specific schemas, request mappings, and
+event grammars remain under `lionagi/providers/` (`lionagi/service/connections/endpoint.py`,
+`lionagi/service/connections/agentic_endpoint.py`, `lionagi/service/connections/api_calling.py`).
+
+Resolution is deliberately permissive. An unknown provider or endpoint becomes a generic endpoint
+with an OpenAI-compatible request shape, and a single-endpoint provider accepts any endpoint name.
+Provider matching itself is case-sensitive even though `EndpointConfig` later lowercases the stored
+provider. Consequently a misspelling, a failed bundled-provider import, and an intentional custom
+OpenAI-compatible provider can reach the same fallback path.
+
+## Decision
+
+The shipped service boundary consists of one `iModel` façade, one `EndpointRegistry`, two endpoint
+families, and provider-owned adapters:
+
+```text
+Caller / Branch
+      │
+      v
+   iModel ─────> RateLimitedAPIExecutor + service-call hooks
+      │
+      v
+EndpointRegistry ──> EndpointMeta ──> Endpoint | AgenticEndpoint
+                                      ^              ^
+                                      │              │
+                               API adapters    agentic adapters
+                                      └──── lionagi/providers ────┘
+```
+
+The load-bearing invariants are:
+
+- `iModel` remains the model-facing lifecycle façade. It owns endpoint selection, one executor,
+  service-call hook attachment, and provider session state; callers do not select provider classes
+  directly.
+- `EndpointRegistry` remains the only provider-and-endpoint resolver. Decorator registration and
+  the class-bound `EndpointMeta` record are the current registration mechanism; no parallel
+  executor registry exists.
+- `Endpoint` centralizes provider-neutral HTTP security, request validation, transport, and
+  resilience. `AgenticEndpoint` is the non-HTTP specialization. Both execute as `APICalling` events
+  and stream provider-neutral `StreamChunk` values.
+- Provider adapters own vendor request schemas, defaults, payload adaptations, and event grammar.
+  The generic endpoint base does not select a vendor, although the registry currently owns the
+  fixed bootstrap list that imports bundled adapters.
+- Service hooks observe the `APICalling` boundary. They do not make the provider registry or the
+  service package a general event bus (see the hooks ADR on call-boundary hooks).
+- The generic fallback, first-match alias resolution, positional provider declarations, and
+  differing `invoke()` and `stream()` scheduling paths are recorded as current behavior, not
+  endorsed as target contracts.
+
+## Consequences
+
+API, subprocess, in-process, and remote-agent providers share one public façade and event model.
+Cross-provider HTTP security and resilience remain centralized, while vendors can override payload
+or transport behavior without changing callers. The existing public `iModel`, `Endpoint`,
+`AgenticEndpoint`, `APICalling`, and `StreamChunk` names remain stable.
+
+The boundary is not fully dependency-inverted. Provider modules depend on service registration and
+base classes, while the service registry imports a fixed list of provider modules at runtime.
+Permissive fallback and first-match resolution also make catalog defects observable only after a
+request is misrouted or a provider silently disappears.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Replace positional provider declarations with typed authoring records; canonicalize and validate every provider, endpoint, and alias key; report failed bundled imports; and require explicit opt-in for generic OpenAI-compatible fallback, with compatibility coverage for existing custom-provider callers. | M | (filled at issue-open time) |
+| 2 | Route `invoke()` and `stream()` through one bounded admission lifecycle that applies request, token, and concurrency limits before provider work; propagate one deadline through queueing, retries, and transport; and prove that cancellation leaves no queued or active orphan. | L | (filled at issue-open time) |
+| 3 | Apply retry and circuit policy to HTTP stream establishment before the first emitted chunk, prohibit automatic replay after output begins, and add tests for pre-first-byte failure, mid-stream failure, normal EOF, and caller cancellation. | M | (filled at issue-open time) |
+| 4 | Publish an agentic-adapter conformance contract for request construction, normalized chunks, error classification, resume identifiers, and transport cleanup; run it against every subprocess, in-process, and remote adapter while retaining vendor parsers beside their vendors. | M | (filled at issue-open time) |
+| 5 | Move named-vendor identity, effort, bypass, and safety tables out of generic service ownership while preserving `parse_model_spec()` as a compatibility façade and testing every existing provider alias. | M | (filled at issue-open time) |
+| 6 | Freeze neutral interfaces for token estimation and MCP client security, then move them below protocol callers with compatibility re-exports and unchanged action-layer tool-registration behavior. | M | (filled at issue-open time) |
+
+## Notes
+
+Direct provider construction was rejected as the public model API because it would duplicate
+selection, executor, hook, and session-state behavior. A separate executor-provider registry was
+rejected because the implemented endpoint registry already resolves both endpoint families. A
+single concrete endpoint class was rejected because HTTP and agentic transports have incompatible
+connection and cancellation mechanics.

--- a/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
+++ b/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
@@ -8,84 +8,626 @@
 
 ## Context
 
-`iModel` is the caller-facing service façade for API and agentic model providers. It derives a
-provider from a `provider/model` specification when needed, resolves an endpoint, creates
-`APICalling` events, owns a per-model `RateLimitedAPIExecutor`, applies service-call hooks, and
-retains resumable provider session state. `iModelManager` is a named registry of these façades and
-shuts them down concurrently with per-model isolation (`lionagi/service/imodel.py`,
-`lionagi/service/manager.py`).
+LionAGI presents one model-facing object even though the work behind that object may be an HTTP
+request, a local subprocess, an in-process agent, or a remote agent. The current service package
+grew around four concrete problems.
 
-`EndpointRegistry` is the sole endpoint resolver. Provider modules decorate concrete endpoint
-classes, and the decorator materializes an immutable, typed `EndpointMeta` record on each class.
-Provider authors still supply most metadata through positional `ProviderConfig` enum tuples. On
-first resolution, the registry imports a fixed module list, ignores `ImportError`, and selects the
-first provider and endpoint key or alias that matches (`lionagi/service/connections/registry.py`,
-`lionagi/service/connections/provider_config.py`).
+**P1 — Callers need one lifecycle owner.** A caller should not have to derive a provider from a
+model string, select an endpoint class, create a call event, configure rate limiting, attach hooks,
+retain a provider session identifier, and stop background tasks separately. `iModel` performs all
+of those jobs; `iModelManager` provides named ownership for multiple `iModel` instances
+(`lionagi/service/imodel.py`; `iModel`, and `lionagi/service/manager.py`; `iModelManager`).
 
-`Endpoint` owns generic payload validation, authentication headers, SSRF checks, HTTP transport,
-retry, circuit-breaking, and generic stream projection. `AgenticEndpoint` inherits the same
-configuration and event boundary but prevents use of the HTTP helpers; concrete subprocess,
-in-process, and remote-agent adapters provide their own call and stream implementations. Both
-families are exposed through `APICalling`, while provider-specific schemas, request mappings, and
-event grammars remain under `lionagi/providers/` (`lionagi/service/connections/endpoint.py`,
-`lionagi/service/connections/agentic_endpoint.py`, `lionagi/service/connections/api_calling.py`).
+**P2 — Provider and endpoint selection needs one authority.** Provider packages register endpoint
+classes, but callers select them by strings such as `openai/chat`, `codex/cli`, or
+`ag2/groupchat`. `EndpointRegistry` is the only resolver and materializes a typed, immutable
+`EndpointMeta` record on each registered class
+(`lionagi/service/connections/registry.py`; `EndpointRegistry`, `EndpointMeta`).
 
-Resolution is deliberately permissive. An unknown provider or endpoint becomes a generic endpoint
-with an OpenAI-compatible request shape, and a single-endpoint provider accepts any endpoint name.
-Provider matching itself is case-sensitive even though `EndpointConfig` later lowercases the stored
-provider. Consequently a misspelling, a failed bundled-provider import, and an intentional custom
-OpenAI-compatible provider can reach the same fallback path.
+**P3 — HTTP and agentic transports share a call boundary but not transport mechanics.** HTTP
+adapters need headers, payload validation, SSRF checks, sessions, status handling, retry, circuit
+breaking, and SSE/NDJSON projection. Subprocess and in-process adapters need process or agent
+lifecycle control instead. Both still need the same `APICalling` event, hook boundary, normalized
+`StreamChunk` output, and executor ownership
+(`lionagi/service/connections/endpoint.py`; `Endpoint`,
+`lionagi/service/connections/agentic_endpoint.py`; `AgenticEndpoint`, and
+`lionagi/service/connections/api_calling.py`; `APICalling`).
 
-## Decision
+**P4 — Vendor grammar must remain vendor-owned.** Request models, endpoint defaults, payload
+adaptation, command flags, event parsing, and provider safety settings change at provider cadence.
+They live under `lionagi/providers/`; moving them into the generic service layer would make the
+service layer a vendor switch statement.
 
-The shipped service boundary consists of one `iModel` façade, one `EndpointRegistry`, two endpoint
-families, and provider-owned adapters:
+**P5 — The organic resolver is permissive and order-sensitive.** A provider lookup is
+case-sensitive even though the resulting `EndpointConfig` lowercases `provider`. Bundled modules
+are imported from a fixed list and an `ImportError` is ignored. An unmatched single-endpoint
+provider accepts any endpoint string. Any remaining miss becomes a generic endpoint with an
+OpenAI-compatible request shape, but `openai_compatible` remains its default `False`. A misspelling,
+an unavailable bundled adapter, and an intentional custom compatible service therefore converge on
+the same fallback path (`lionagi/service/connections/registry.py`; `EndpointRegistry.match`,
+`_import_all_providers`, and `lionagi/service/connections/endpoint_config.py`;
+`EndpointConfig._validate_provider`).
+
+The shipped spine is:
 
 ```text
 Caller / Branch
-      │
+      |
       v
-   iModel ─────> RateLimitedAPIExecutor + service-call hooks
-      │
+   iModel ---------> RateLimitedAPIExecutor + service-call hooks
+      |
       v
-EndpointRegistry ──> EndpointMeta ──> Endpoint | AgenticEndpoint
-                                      ^              ^
-                                      │              │
-                               API adapters    agentic adapters
-                                      └──── lionagi/providers ────┘
+EndpointRegistry ---> EndpointMeta ---> Endpoint | AgenticEndpoint
+                                         ^              ^
+                                         |              |
+                                  HTTP adapters   agentic adapters
+                                         +--- lionagi/providers ---+
 ```
 
-The load-bearing invariants are:
+| Concern | Decision |
+|---------|----------|
+| Caller-facing lifecycle and model registry | D1: `iModel` owns one resolved endpoint, executor, hook registry, and provider session; `iModelManager` owns named façades. |
+| Provider/endpoint discovery | D2: `EndpointRegistry` is the sole resolver, populated by provider decorators and a fixed lazy bootstrap list. |
+| Generic execution boundary | D3: `Endpoint` and `AgenticEndpoint` execute through `APICalling` and normalize streams as `StreamChunk`; HTTP-only mechanics stay on `Endpoint`. |
+| Vendor ownership | D4: provider packages own request schemas, defaults, mappings, event grammars, and agentic mechanics. |
 
-- `iModel` remains the model-facing lifecycle façade. It owns endpoint selection, one executor,
-  service-call hook attachment, and provider session state; callers do not select provider classes
-  directly.
-- `EndpointRegistry` remains the only provider-and-endpoint resolver. Decorator registration and
-  the class-bound `EndpointMeta` record are the current registration mechanism; no parallel
-  executor registry exists.
-- `Endpoint` centralizes provider-neutral HTTP security, request validation, transport, and
-  resilience. `AgenticEndpoint` is the non-HTTP specialization. Both execute as `APICalling` events
-  and stream provider-neutral `StreamChunk` values.
-- Provider adapters own vendor request schemas, defaults, payload adaptations, and event grammar.
-  The generic endpoint base does not select a vendor, although the registry currently owns the
-  fixed bootstrap list that imports bundled adapters.
-- Service hooks observe the `APICalling` boundary. They do not make the provider registry or the
-  service package a general event bus (see the hooks ADR on call-boundary hooks).
-- The generic fallback, first-match alias resolution, positional provider declarations, and
-  differing `invoke()` and `stream()` scheduling paths are recorded as current behavior, not
-  endorsed as target contracts.
+This retrospective ADR deliberately does **not** decide:
+
+- Validated catalog authoring, collision policy, import diagnostics, or explicit compatible fallback;
+  ADR-0028 owns that target.
+- Bounded admission, unified deadlines, cancellation ownership, or stream retry; ADR-0029 owns that
+  target.
+- The normalized agentic conformance suite and transport capability vocabulary; ADR-0030 owns that
+  target.
+- General hook composition or event-bus behavior; the hooks ADR owns call-boundary hook policy.
+- Final package ownership for token estimation or MCP client security. Their consumers and failure
+  contracts differ, so they remain migration deltas rather than part of this façade decision.
+
+## Decision
+
+### D1 — `iModel` is the model-service lifecycle façade
+
+`iModel` is the object callers construct, invoke, stream, copy, serialize, and close. Callers do not
+instantiate provider classes as the normal model API. The shipped constructor is
+(`lionagi/service/imodel.py`; `iModel.__init__`):
+
+```python
+class iModel:
+    def __init__(
+        self,
+        provider: str = None,
+        base_url: str = None,
+        endpoint: str | Endpoint = "chat",
+        api_key: str = None,
+        queue_capacity: int | None = None,
+        capacity_refresh_time: float = 60,
+        interval: float | None = None,
+        limit_requests: int = None,
+        limit_tokens: int = None,
+        concurrency_limit: int | None = None,
+        streaming_process_func: Callable = None,
+        provider_metadata: dict | None = None,
+        hook_registry: HookRegistry | dict | None = None,
+        exit_hook: bool = False,
+        id: UUID | str = None,
+        created_at: float | None = None,
+        **kwargs,
+    ) -> None: ...
+
+    async def create_event(
+        self,
+        create_event_type: type[Event] = APICalling,
+        create_event_exit_hook: bool = None,
+        create_event_hook_timeout: float = 10.0,
+        create_event_hook_params: dict = None,
+        pre_invoke_event_exit_hook: bool = None,
+        pre_invoke_event_hook_timeout: float = 30.0,
+        pre_invoke_event_hook_params: dict = None,
+        post_invoke_event_exit_hook: bool = None,
+        post_invoke_event_hook_timeout: float = 30.0,
+        post_invoke_event_hook_params: dict = None,
+        **kwargs,
+    ) -> tuple[HookEvent | None, APICalling]: ...
+
+    def create_api_calling(
+        self, include_token_usage_to_model: bool = False, **kwargs
+    ) -> APICalling: ...
+
+    async def invoke(self, api_call: APICalling = None, **kw) -> APICalling: ...
+    async def stream(self, api_call=None, **kw) -> AsyncGenerator: ...
+    async def close(self) -> None: ...
+    def copy(self, share_session: bool = False) -> iModel: ...
+```
+
+The `create_event()` annotation currently claims a two-tuple, but every successful implementation
+path returns the `APICalling` alone. That mismatch is part of the shipped source, not a second
+supported result shape.
+
+`iModelManager` is a string-keyed registry with two conventional keys and isolated concurrent
+shutdown (`lionagi/service/manager.py`; `iModelManager`):
+
+```python
+class iModelManager(Manager):
+    def __init__(self, *args: iModel, **kwargs): ...
+    @property
+    def chat(self) -> iModel | None: ...
+    @property
+    def parse(self) -> iModel | None: ...
+    def register_imodel(self, name: str, model: iModel): ...
+    async def shutdown(self, *, per_model_timeout: float = 10.0) -> None: ...
+```
+
+**Exact semantics**
+
+- **Model specification.** If `kwargs["model"]` contains `/` and no provider was supplied, the
+  prefix becomes the provider and is removed from the model. If the model has no `/`, the configured
+  default chat provider is used. An explicit `provider` wins.
+- **Endpoint object.** Passing an `Endpoint` instance bypasses string resolution. Otherwise
+  `match_endpoint(provider, endpoint, **kwargs)` is the only selection path. An explicit `provider`
+  and `base_url` overwrite the resolved configuration after construction.
+- **Identity.** `id` is normalized through `ID.get_id`; otherwise a new UUID is generated.
+  `created_at` must be a float timestamp when supplied; otherwise current UTC time is stored.
+- **Executor ownership.** Each façade creates exactly one `RateLimitedAPIExecutor`; copies receive a
+  fresh façade id and executor. The endpoint config is deep-copied, while the existing retry and
+  circuit-breaker objects are passed to the copied endpoint. Provider runtime handlers are copied
+  through `Endpoint.copy_runtime_state_to()`.
+- **Event construction.** `create_event()` optionally runs a pre-create hook, builds an
+  `APICalling`, and attaches pre/post invocation hooks. A pre-create exit raises its cause before
+  the call event is returned. Event types other than `HookedEvent` subclasses are rejected; the
+  error text states that only `APICalling` is supported.
+- **Resume injection.** For an `AgenticEndpoint`, `create_api_calling()` injects the stored endpoint
+  session id as `resume` only when neither `resume` nor `session_id` was supplied. Runtime transport
+  arguments declared by the endpoint are removed from provider data and stored in
+  `APICalling.call_kwargs`.
+- **One-shot invocation.** `invoke()` starts the executor if necessary, appends the event, forwards
+  pending work through the processor, and waits at most 10 seconds if the event remains pending or
+  processing. Timeout is swallowed. The event is then removed from executor ownership even if it is
+  still non-terminal. A returned agentic response dict containing `session_id` updates endpoint
+  state. Any exception escaping this sequence is wrapped as `ValueError("Failed to invoke API
+  call: ...")`.
+- **Streaming invocation.** `stream()` appends only calls it creates itself. It starts the executor,
+  acquires the processor semaphore if one exists, and calls `api_call.stream()` directly; it does
+  not enqueue through `forward()` and therefore does not ask the rate/token permission method. Each
+  yielded item passes through the hook registry or `streaming_process_func`. The event is removed
+  from the executor pile in `finally`. Ordinary exceptions are wrapped as `ValueError`; cancellation
+  is a `BaseException`, so it reaches `finally` and propagates.
+- **Chunk processing.** A registered chunk hook takes priority over `streaming_process_func`. A hook
+  exit raises its supplied cause or a `RuntimeError`. With no handler, the original chunk is yielded.
+- **Serialization.** `to_dict()` stores id, creation time, provider metadata, endpoint state, and by
+  default processor config. Request schemas are omitted unless explicitly requested. `from_dict()`
+  reconstructs an endpoint, resolves a fresh registered endpoint to recover environment-backed API
+  key state, overlays serialized config, and restores executor config.
+- **Close and manager shutdown.** `close()` stops the executor. Manager shutdown closes all models
+  concurrently, gives each model an independent timeout, logs and swallows timeout, exception, and
+  cancellation failures, and returns immediately for an empty registry.
+- **Name conflict.** Registering the same manager key again replaces the prior model. There is no
+  duplicate-name error and no automatic close of the displaced model.
+
+Current numeric defaults are recorded rather than rationalized after the fact:
+
+| Value | Shipped meaning | Recorded rationale |
+|-------|-----------------|--------------------|
+| `capacity_refresh_time=60` seconds | Default fixed-window replenishment cadence. | Inherited; no design rationale is recorded in source. |
+| API `queue_capacity=100` | Processor cycle capacity and fallback executor concurrency property; it is not a physical queue bound. | Inherited; no design rationale is recorded. |
+| Agentic `queue_capacity=10`, `concurrency_limit=3` | Defaults from `AgenticEndpoint`; individual adapters may override. | Inherited; no numeric rationale is recorded. |
+| Hook timeouts `10/30/30` seconds | Pre-create, pre-invocation, and post-invocation local caps. | The split is shipped; no numeric rationale is recorded. |
+| `invoke()` wait `10` seconds | Safety wait before the event is popped and returned. | Inherited; source records the behavior but no numeric rationale. |
+| Manager close `10` seconds per model | Prevents one close from blocking all other closes. | Isolation is documented; the exact number is inherited. |
+
+**Why this way.** A single façade keeps provider selection, event creation, hook attachment,
+executor lifetime, serialization, and session state from being reimplemented by Branch and every
+operation. `iModelManager` adds only named ownership and shutdown rather than another dispatch
+abstraction. The cost is a broad façade: admission defects and provider-session details can leak
+into an object that callers otherwise treat as a model client.
+
+### D2 — `EndpointRegistry` is the sole endpoint resolver
+
+Provider classes register by decorator. Registration attaches `_ENDPOINT_META` to the class and
+appends a registry entry. The shipped metadata contract is
+(`lionagi/service/connections/registry.py`; `EndpointType`, `EndpointMeta`):
+
+```python
+class EndpointType(Enum):
+    API = "api"
+    AGENTIC = "agentic"
+
+@dataclass(frozen=True, slots=True)
+class EndpointMeta:
+    provider: str
+    endpoint: str
+    endpoint_type: EndpointType
+    aliases: tuple[str, ...] = ()
+    provider_aliases: tuple[str, ...] = ()
+    options: type[BaseModel] | None = None
+    base_url: str | None = None
+    auth_type: str | None = None
+    content_type: str | None = None
+    api_key_env: str | None = None
+
+    def create_config(self, **overrides: Any): ...
+```
+
+The registration and lookup surface is:
+
+```python
+class EndpointRegistry:
+    @classmethod
+    def register(
+        cls,
+        provider: str,
+        endpoint: str,
+        aliases: list[str] | None = None,
+        endpoint_type: EndpointType = EndpointType.API,
+        provider_aliases: list[str] | None = None,
+        options: type[BaseModel] | None = None,
+        base_url: str | None = None,
+        auth_type: str | None = None,
+        content_type: str | None = None,
+        api_key_env: str | None = None,
+    ): ...
+
+    @classmethod
+    def match(cls, provider: str, endpoint: str = "", **kwargs) -> Any: ...
+
+    @classmethod
+    def list_providers(cls) -> list[dict[str, Any]]: ...
+
+# defined in lionagi/service/connections/match_endpoint.py, not registry.py
+def match_endpoint(provider: str, endpoint: str, **kwargs) -> Endpoint: ...
+```
+
+`EndpointMeta.create_config()` supplies these registration-derived defaults:
+
+```python
+{
+    "name": f"{provider}_{endpoint}",
+    "provider": provider,
+    "base_url": declared_base_url or ("internal" if agentic else ""),
+    "endpoint": endpoint,
+    # agentic -> "internal"; declared api_key_env -> settings value, or the
+    # "dummy-key-for-testing" sentinel when the env var is unset; no declared
+    # api_key_env (e.g. Ollama) -> None
+    "api_key": api_key,
+    "request_options": options,
+    "timeout": 3600 if agentic else 600,
+    "auth_type": declared_auth_type or "bearer",
+    "content_type": declared_content_type or "application/json",
+    "method": "POST",
+}
+```
+
+The 3,600-second agentic cap, 600-second registered API cap, and 300-second generic
+`EndpointConfig` default are inherited values with no recorded numeric rationale. They are
+transport caps, not a propagated request deadline.
+
+The fixed bootstrap currently materializes the following source-owned catalog; the scripted row is
+test support but is imported through the same bootstrap
+(`lionagi/service/connections/registry.py`; `_import_all_providers`):
+
+| Provider family | Registered endpoints | Family |
+|-----------------|----------------------|--------|
+| `openai` | chat, speech, transcription, image generation/edit, embeddings, responses | API |
+| `anthropic` | messages | API |
+| `ollama` | chat, embeddings, generate | API |
+| `tavily`, `exa`, `firecrawl` | search/extract, search/contents/similar, scrape/map/crawl | API |
+| `perplexity`, `deepseek`, `gemini`, `openrouter` | chat | API |
+| `nvidia_nim` | chat, embeddings | API |
+| `groq` | chat, transcription | API |
+| `codex`, `claude_code`, `gemini_code`, `pi` | one CLI endpoint each | Agentic |
+| `ag2` | group chat, in-process agent, remote NLIP | Agentic |
+| `scripted` | chat/CLI aliases | Agentic test support |
+
+**Exact semantics**
+
+- **Lazy bootstrap.** The first `match()` or `list_providers()` call imports the fixed modules under
+  a process-local lock. `_loaded` is set after the loop. Later calls do not rescan modules.
+- **Import failure.** Each `ImportError` is ignored without a diagnostic. Other exception types
+  escape and prevent `_loaded` from being set.
+- **Registration order.** Entries are appended. There is no canonical-key, alias, endpoint-class,
+  or metadata validation and no duplicate detection.
+- **Provider match.** The raw provider must equal the canonical string or one of its aliases. The
+  comparison is case-sensitive and does not trim. Normalization in `EndpointConfig` happens only
+  after a class or fallback has already been chosen.
+- **Endpoint match.** Empty endpoint selects the first entry for the provider. Otherwise canonical
+  endpoint or alias selects the first match. Punctuation is literal.
+- **Single-endpoint provider.** If a provider has exactly one canonical registration, any unmatched
+  non-empty endpoint selects it. The requested endpoint string is not retained as a mismatch.
+- **Miss.** Every other miss creates the base `Endpoint` with provider as supplied, endpoint or
+  `chat/completions`, bearer JSON POST settings, `requires_tokens=True`, and name
+  `openai_compatible_chat`. It does not set `openai_compatible=True`.
+- **Instantiation.** A match instantiates `entry.cls(None, **kwargs)`; class metadata creates a fresh
+  `EndpointConfig`. Registry entries store classes and immutable metadata, not shared endpoint
+  instances.
+- **Inspection.** `list_providers()` returns one dict per entry with exactly `provider`, `endpoint`,
+  `aliases`, `type`, `class`, and `options`. Provider aliases, URLs, auth, availability, and ignored
+  imports are absent.
+- **Restart.** Registry state is process-local. A restart resets entries and `_loaded`; imports
+  reconstruct the catalog.
+
+**Why this way.** Decorator registration keeps each concrete adapter beside its schema and avoids a
+large construction switch. A single registry prevents caller-specific routing rules. The lazy fixed
+bootstrap makes built-in discovery deterministic, but it creates a dependency from generic service
+code back to every bundled provider module and makes ignored imports indistinguishable from absent
+providers. ADR-0028 retains the single resolver while replacing the unvalidated inputs.
+
+### D3 — `Endpoint`, `AgenticEndpoint`, and `APICalling` share one event boundary
+
+The base configuration is a Pydantic model. Unknown constructor keys are moved into `kwargs` before
+validation (`lionagi/service/connections/endpoint_config.py`; `EndpointConfig`):
+
+```python
+class EndpointConfig(BaseModel):
+    name: str
+    provider: str
+    base_url: str | None = None
+    endpoint: str
+    endpoint_params: list[str] | None = None
+    method: str = "POST"
+    params: dict[str, str] = Field(default_factory=dict)
+    content_type: str | None = "application/json"
+    auth_type: Literal["bearer", "x-api-key", "none"] = "bearer"
+    default_headers: dict = {}
+    request_options: type[BaseModel] | None = None
+    api_key: str | SecretStr | None = Field(None, exclude=True)
+    timeout: int = 300
+    max_retries: int = 3
+    openai_compatible: bool = False
+    requires_tokens: bool = False
+    context_window: int | None = None
+    kwargs: dict = Field(default_factory=dict)
+    client_kwargs: dict = Field(default_factory=dict)
+    allow_local_network: bool = False
+    serialize_by_alias: bool = False
+```
+
+The generic method boundary is (`lionagi/service/connections/endpoint.py`; `Endpoint`):
+
+```python
+class Endpoint:
+    is_cli: ClassVar[bool] = False
+    transport_arg_keys: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        config: dict | EndpointConfig | None = None,
+        circuit_breaker: CircuitBreaker | None = None,
+        retry_config: RetryConfig | None = None,
+        **kwargs,
+    ): ...
+
+    def create_payload(
+        self,
+        request: dict | BaseModel,
+        extra_headers: dict | None = None,
+        **kwargs,
+    ): ...  # unannotated in source; returns (payload, headers)
+
+    async def call(
+        self,
+        request: dict | BaseModel,
+        cache_control: bool = False,
+        skip_payload_creation: bool = False,
+        **kwargs,
+    ): ...
+
+    async def stream(
+        self,
+        request: dict | BaseModel,
+        extra_headers: dict | None = None,
+        **kwargs,
+    ): ...
+```
+
+Agentic endpoints reuse the config and event interface but block the base HTTP helpers
+(`lionagi/service/connections/agentic_endpoint.py`; `AgenticEndpoint`):
+
+```python
+class AgenticEndpoint(Endpoint):
+    is_cli: ClassVar[bool] = True
+    DEFAULT_CONCURRENCY_LIMIT: ClassVar[int] = 3
+    DEFAULT_QUEUE_CAPACITY: ClassVar[int] = 10
+
+    def __init__(self, config: dict | EndpointConfig = None, **kwargs): ...
+    @property
+    def provider_session_id(self) -> str | None: ...
+    @property
+    def session_id(self) -> str | None: ...
+```
+
+`APICalling` is the Pydantic event envelope
+(`lionagi/service/connections/api_calling.py`; `APICalling`):
+
+```python
+class APICalling(HookedEvent):
+    endpoint: Endpoint = Field(..., exclude=True)
+    payload: dict
+    headers: dict = Field(default_factory=dict, exclude=True)
+    call_kwargs: dict = Field(default_factory=dict, exclude=True)
+    cache_control: bool = Field(default=False, exclude=True)
+    include_token_usage_to_model: bool = Field(default=False, exclude=True)
+
+    @property
+    def required_tokens(self) -> int | None: ...
+    async def _core_invoke(self): ...
+    async def _core_stream(self): ...
+```
+
+All endpoint streams project to this dataclass
+(`lionagi/service/types/stream_chunk.py`; `StreamChunk`):
+
+```python
+ChunkType = Literal[
+    "system", "thinking", "text", "tool_use",
+    "tool_result", "result", "error",
+]
+
+@dataclass(slots=True)
+class StreamChunk:
+    type: ChunkType
+    content: str | None = None
+    tool_name: str | None = None
+    tool_id: str | None = None
+    tool_input: dict[str, Any] | None = None
+    tool_output: Any | None = None
+    is_error: bool = False
+    is_delta: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+**Exact payload and execution semantics**
+
+- **Configuration input.** A dict is validated as `EndpointConfig`; an existing config is deep
+  copied and updated; `None` requires class-bound `_ENDPOINT_META`. Any other type raises
+  `ValueError`.
+- **Unknown config keys.** The pre-validator moves unknown keys into `EndpointConfig.kwargs`. These
+  keys become provider request defaults during `create_payload()`. This is why a misspelled control
+  field can cross into provider data.
+- **Request schema.** With `request_options`, payload keys are filtered to model fields and the model
+  validates them. Alias serialization returns a validated `model_dump`; otherwise the original
+  filtered values are returned after validation. Without a schema, a fixed list of LionAGI control
+  keys is removed and other values pass through.
+- **Headers and keys.** `HeaderFactory` constructs bearer, x-api-key, or no-auth headers. API key
+  config accepts a secret, settings key, environment key, literal, or special local/testing value;
+  it is excluded from serialization.
+- **URL and SSRF.** `full_url` is base plus endpoint, with format parameters when declared. Both
+  call and stream assert that the hostname is safe unless `allow_local_network=True`.
+- **One-shot HTTP status.** Status 200 returns JSON. Status 429 and status 500 or above are retryable
+  transport failures. Other non-200 statuses are wrapped in an internal non-retryable sentinel so the
+  retry layer gives up immediately. Only the native path (no explicit `RetryConfig`) unwraps the
+  sentinel and re-raises the original `aiohttp.ClientResponseError`; with an explicit `RetryConfig`
+  the sentinel is neither excluded by default (`RetryConfig.exclude_exceptions` defaults empty) nor
+  unwrapped, so the caller sees the internal sentinel exception rather than the original — a
+  current-behavior asymmetry, recorded as-is.
+- **One-shot resilience.** An explicit `RetryConfig` wraps `_call`; an explicit circuit breaker
+  wraps the resulting attempt function when caching is off. With no `RetryConfig`, native aiohttp
+  retry uses `EndpointConfig.max_retries` as a total-attempt cap. Cached calls apply the same chosen
+  wrappers inside the cached function.
+- **HTTP stream.** `stream()` creates a payload then calls `_stream_aiohttp()` directly. It applies
+  neither the endpoint retry config nor the circuit breaker. The transport sets `stream=True`,
+  requires status 200, parses SSE framing and plain JSON lines, ignores comments and SSE metadata,
+  recognizes `[DONE]`, and maps unrecognized JSON objects to a `system` chunk containing raw data.
+- **Agentic transport.** `AgenticEndpoint` raises `NotImplementedError` from session, aiohttp call,
+  and aiohttp stream helpers. Concrete adapters override `_call()` and/or `stream()`.
+- **Token estimation.** `APICalling.required_tokens` returns `None` when the endpoint does not
+  require tokens. Otherwise it estimates messages, Responses-style input, or embedding input. A
+  caller-requested usage annotation is appended to the final message before dispatch.
+- **Event state.** `Event` begins `PENDING`, becomes `PROCESSING`, and terminalizes as `COMPLETED`,
+  `FAILED`, or `CANCELLED`; `SKIPPED` and `ABORTED` are also terminal states. Terminal transitions
+  set a lazily created completion event. Ordinary exceptions from event invoke/stream are captured
+  on the event and are not re-raised by `Event`; `BaseException` marks cancellation and is re-raised.
+- **Hook order.** `HookedEvent` runs pre-invocation, core work, then post-invocation. A one-shot post
+  hook runs even after core failure but cannot replace that core failure. A post-stream hook runs
+  only after normal stream exhaustion; once data has been sent, its failure is logged rather than
+  re-raised.
+- **Empty stream.** A transport that produces no chunks and no exception reaches normal EOF and the
+  event becomes `COMPLETED`; the generic layer does not require a result chunk.
+
+The shipped resilience values are:
+
+| Value | Meaning | Recorded rationale |
+|-------|---------|--------------------|
+| `EndpointConfig.max_retries=3` | Native HTTP path makes at most three total attempts. | Inherited; no numeric rationale is recorded. |
+| `RetryConfig.max_retries=3` | Explicit retry path makes one initial attempt plus three retries. | Inherited; the different interpretation is current behavior. |
+| Backoff `1s`, cap `60s`, factor `2.0`, jitter `0.2` | Defaults in `RetryConfig`/`retry_with_backoff`. | Exponential jitter is intentional; exact values are inherited. |
+| Native HTTP jitter `0.5` | Used when no explicit `RetryConfig` exists. | Inherited; no reason for differing from `0.2` is recorded. |
+| Circuit threshold `5`, recovery `30s`, half-open probes `1` | Default circuit transition policy. | Pattern intent is clear; exact values are inherited. |
+
+**Why this way.** A stable event and chunk boundary lets operations consume both transport families
+without vendor selection logic. HTTP security and response framing benefit from one implementation.
+Agentic transports cannot safely share HTTP session or cancellation mechanics, so inheritance is
+limited to configuration, event, and normalized output. The current `is_cli=True` marker on every
+agentic endpoint is an overloaded routing signal; ADR-0030 names the capability split.
+
+### D4 — Provider adapters own vendor request and event grammar
+
+The package boundary is:
+
+```text
+lionagi/service/
+├── imodel.py                         façade and session ownership
+├── manager.py                        named façade lifecycle
+├── rate_limited_processor.py         current admission/executor
+├── resilience.py                     generic retry and circuit policy
+└── connections/
+    ├── registry.py                   selection authority and metadata
+    ├── endpoint_config.py            generic endpoint configuration
+    ├── endpoint.py                   generic HTTP transport/projection
+    ├── agentic_endpoint.py           non-HTTP base
+    └── api_calling.py                event boundary
+
+lionagi/providers/
+├── <vendor>/_config.py               provider identity and endpoint tuples
+├── <vendor>/<endpoint>.py            request models and adapter behavior
+├── _cli_subprocess.py                shared subprocess mechanics
+├── _agentic_handlers.py              shared runtime callback handling
+└── _provider_errors.py               provider error classification
+```
+
+Provider declarations currently use four-to-seven-position enum tuples
+(`lionagi/service/connections/provider_config.py`; `ProviderConfig`):
+
+```python
+(
+    endpoint_path,       # index 0
+    aliases,             # index 1
+    endpoint_type,       # index 2
+    request_options,     # index 3, optional; type or LazyType
+    base_url,            # index 4, optional
+    auth_type,           # index 5, optional
+    content_type,        # index 6, optional; default application/json
+)
+```
+
+`LazyType("module:Class")` defers request-model import and caches the resolved type. Each enum class
+adds `_PROVIDER`, `_PROVIDER_ALIASES`, and optionally `_API_KEY_ENV`; its member's `.register`
+decorator forwards named values into the generic registry.
+
+**Exact ownership semantics**
+
+- API providers own their Pydantic request models, metadata tuples, any provider header additions,
+  payload remapping, multipart transport arguments, and response normalization.
+- Subprocess providers own command grammars, model defaults, permission modes, event parsers, UX
+  callbacks, and session synthesis. Shared NDJSON/process mechanics remain generic only where at
+  least two adapters use them.
+- In-process and remote agent adapters own their request objects and agent/network calls while still
+  yielding `StreamChunk`.
+- `lionagi/service/providers.py` currently remains a second vendor-identity table for model aliases,
+  effort mapping, fast mode, bypass, and safety kwargs. `parse_model_spec()` is a public compatibility
+  surface consumed outside provider packages.
+- A provider adapter depends on the service registry decorator and base endpoint. Conversely the
+  service registry imports a fixed list of provider modules at runtime. This is a real two-way
+  package dependency, not full dependency inversion.
+- Provider-specific failures may arrive as raised exceptions, error chunks, or a final session with
+  `is_error`; the generic base does not currently enforce one adapter conformance contract.
+
+**Why this way.** Request and event grammars change with provider releases and are easiest to test
+beside their fixtures. Pulling those grammars into `Endpoint` would make the generic transport
+select vendors. Conversely, leaving subprocess framing, SSRF checks, or error taxonomy duplicated
+would cause security and cleanup drift. The boundary therefore centralizes mechanics, not vendor
+meaning. ADR-0028 removes generic ownership of the bootstrap/vendor tables, and ADR-0030 tightens
+the shared agentic output and cleanup contract.
 
 ## Consequences
 
-API, subprocess, in-process, and remote-agent providers share one public façade and event model.
-Cross-provider HTTP security and resilience remain centralized, while vendors can override payload
-or transport behavior without changing callers. The existing public `iModel`, `Endpoint`,
-`AgenticEndpoint`, `APICalling`, and `StreamChunk` names remain stable.
-
-The boundary is not fully dependency-inverted. Provider modules depend on service registration and
-base classes, while the service registry imports a fixed list of provider modules at runtime.
-Permissive fallback and first-match resolution also make catalog defects observable only after a
-request is misrouted or a provider silently disappears.
+- API, subprocess, in-process, and remote-agent providers share one public `iModel` façade and one
+  `APICalling`/`StreamChunk` event model. Existing public `iModel`, `Endpoint`, `AgenticEndpoint`,
+  `APICalling`, and `StreamChunk` names remain stable.
+- Provider selection and construction are inspectable at one resolver. A new provider must still
+  coordinate its local registration with the generic bootstrap list and, where model aliases or
+  effort behavior apply, the second table in `service/providers.py`.
+- HTTP adapters inherit one SSRF and transport implementation. Agentic adapters cannot accidentally
+  use the HTTP helpers because those helpers fail explicitly.
+- Reversing D1 would require changing Branch, operation, serialization, and lifecycle call sites;
+  it is high cost. Replacing D2's registration mechanism is medium cost if `match_endpoint()` remains
+  the façade. Splitting D3's event model is high cost because operations consume `APICalling` and
+  `StreamChunk`. Moving a vendor grammar under service is mechanically easy but raises ongoing
+  coupling.
+- Maintainers must know that `queue_capacity` is not a physical queue limit, `stream()` bypasses
+  rate/token permission, `invoke()` may return a non-terminal event after ten seconds, and HTTP
+  stream setup does not use retry/circuit policy. ADR-0029 exists because these are one lifecycle
+  problem, not independent tuning defects.
+- The resolver can silently hide an unavailable or mistyped adapter behind a generic endpoint.
+  Catalog failure becomes visible only when a later call is misrouted or fails.
 
 ## Current-vs-ideal delta
 
@@ -98,10 +640,60 @@ request is misrouted or a provider silently disappears.
 | 5 | Move named-vendor identity, effort, bypass, and safety tables out of generic service ownership while preserving `parse_model_spec()` as a compatibility façade and testing every existing provider alias. | M | (filled at issue-open time) |
 | 6 | Freeze neutral interfaces for token estimation and MCP client security, then move them below protocol callers with compatibility re-exports and unchanged action-layer tool-registration behavior. | M | (filled at issue-open time) |
 
+## Alternatives considered
+
+### Direct provider construction as the public API
+
+Callers could import `OpenaiChatEndpoint`, `CodexCLIEndpoint`, or another concrete class and manage
+it directly. This would make provider behavior explicit and remove one lookup. It lost because each
+caller would then need to reproduce provider/model parsing, API-key restoration, executor creation,
+hook attachment, transport-argument separation, session resume, copy, serialization, and close.
+Those responsibilities already converge in `iModel`; duplicating them would create behaviorally
+different clients for the same provider.
+
+### Separate executor-provider registry
+
+A second registry could select executor implementations independently of endpoints. It would make
+transport scheduling replaceable. It lost because the live endpoint registry already resolves both
+HTTP and agentic endpoint families, and each `iModel` already owns its executor. A second string
+authority would need collision, alias, fallback, and lifecycle rules while still depending on the
+endpoint selection result.
+
+### One concrete endpoint class for every transport
+
+One class could branch internally on provider or transport type. That would reduce the number of
+base classes. It lost because HTTP sessions/status/retry and subprocess/process-group cleanup have
+incompatible resource and cancellation mechanics. The current `AgenticEndpoint` makes accidental
+HTTP use fail immediately while retaining the shared event/config boundary.
+
+### Put all provider schemas and event parsers in `service/connections`
+
+This would make the full catalog visible from one directory and remove provider-to-service
+registration imports. It lost because generic service code would then own vendor releases, flags,
+event grammars, and fixtures. Provider-local request models and parsers are the evidence-bearing
+units; only generic transport and normalized output belong in service.
+
+### Resolve by direct import path instead of a registry
+
+Callers could pass `module:Class` and bypass aliases and bootstrap. That would support arbitrary
+extensions without a central list. It lost for the primary API because model specs and public aliases
+would become Python package paths, provider availability could not be inspected uniformly, and every
+caller would become responsible for validating the imported type. A validated catalog can accept
+declarative external inventory later without changing the resolver façade.
+
+### Make resolution strict immediately
+
+Unknown providers and endpoints could have raised from the first registry version. That would have
+made typos visible. It was not the shape the code grew: the generic fallback supports custom
+OpenAI-compatible services, and single-endpoint aliases were treated permissively. ADR-0028 keeps
+that use case but makes compatibility an explicit selection mode with a staged migration.
+
 ## Notes
 
-Direct provider construction was rejected as the public model API because it would duplicate
-selection, executor, hook, and session-state behavior. A separate executor-provider registry was
-rejected because the implemented endpoint registry already resolves both endpoint families. A
-single concrete endpoint class was rejected because HTTP and agentic transports have incompatible
-connection and cancellation mechanics.
+This ADR records current behavior, including the permissive fallback, first-match alias resolution,
+positional provider declarations, and different `invoke()`/`stream()` scheduling paths. It does not
+endorse them as target contracts. The principal source anchors are `lionagi/service/imodel.py`,
+`lionagi/service/manager.py`, `lionagi/service/rate_limited_processor.py`,
+`lionagi/service/connections/{registry,provider_config,endpoint_config,endpoint,agentic_endpoint,api_calling}.py`,
+`lionagi/protocols/generic/{event,processor}.py`, and the provider modules under
+`lionagi/providers/`.

--- a/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
+++ b/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
@@ -1,0 +1,104 @@
+# ADR-0028: Validated provider-adapter catalog
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: service-providers
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0027
+
+## Context
+
+The resolver already creates typed `EndpointMeta` records, but provider authors declare them
+indirectly through positional enum tuples with four to seven slots. The representation is compact,
+yet field meaning depends on index position and a deferred type may import the module currently
+being registered. Unknown `EndpointConfig` constructor keys are also retained as request defaults,
+so a misspelled configuration field can cross the boundary as payload data
+(`lionagi/service/connections/provider_config.py`,
+`lionagi/service/connections/endpoint_config.py`).
+
+Registration is local to an adapter, but discovery is central and unvalidated. The generic registry
+contains every bundled provider module name, suppresses all `ImportError`, and resolves the first
+matching canonical name or alias. It does not reject a canonical key repeated as its own alias,
+collisions across registrations, or case variants that fall through to the generic endpoint
+(`lionagi/service/connections/registry.py`).
+
+The fallback is useful for custom OpenAI-compatible services, but it is currently implicit. The
+resulting `EndpointConfig` does not mark `openai_compatible=True`, and the same branch handles an
+unknown provider, an unknown endpoint, and a provider that failed to import. Catalog inspection
+therefore cannot explain whether an adapter is absent, invalid, unavailable, or deliberately
+generic.
+
+Provider identity policy is split as well. Endpoint metadata lives with provider packages, while
+CLI aliases, effort translation, and bypass settings live in `lionagi/service/providers.py`. That
+makes generic service code a second source of vendor truth and requires vendor additions to touch
+both sides of the package boundary.
+
+## Decision
+
+Retain `EndpointRegistry` as the sole resolver and make its inputs a validated catalog. Provider
+authors declare a named record rather than a positional tuple; registration materializes the
+existing `EndpointMeta` shape and associates it with the concrete endpoint class.
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProviderEndpointSpec:
+    provider: str
+    endpoint: str
+    endpoint_type: EndpointType
+    endpoint_class: type[Endpoint]
+    provider_aliases: tuple[str, ...] = ()
+    endpoint_aliases: tuple[str, ...] = ()
+    request_options: type[BaseModel] | Callable[[], type[BaseModel]] | None = None
+    base_url: str | None = None
+    auth_type: str | None = None
+    content_type: str = "application/json"
+    api_key_env: str | None = None
+```
+
+The catalog contract has these invariants:
+
+- Provider and endpoint identifiers are trimmed and case-folded before indexing. Punctuation is not
+  rewritten; hyphen and underscore variants require declared aliases. Canonical names and aliases
+  are unique in their scope, and a redundant self-alias is invalid.
+- Catalog construction validates the complete key space before serving a lookup. Duplicate keys,
+  invalid metadata, and unresolved request-option types produce typed diagnostics and cannot win by
+  registration order.
+- Bundled provider inventory moves to the provider package and is passed into the registry through
+  one bootstrap boundary. A failed bundled import records provider, module, and cause. Other valid
+  providers remain usable, while selection of the failed provider raises `ProviderUnavailable`.
+- Registered lookup is fail-closed. An absent provider or endpoint raises `EndpointNotFound` with
+  available keys. Generic OpenAI-compatible construction occurs only when the caller passes an
+  explicit `openai_compatible=True` selection mode, and the resulting configuration carries that
+  value.
+- The transition first warns on implicit fallback and identifies the explicit replacement, then
+  removes implicit fallback under the repository deprecation policy. Existing public imports and
+  `match_endpoint()` remain compatibility façades during the transition.
+- `list_providers()` reports canonical identifiers, aliases, endpoint type, request schema,
+  availability, and diagnostics from the same catalog snapshot used for resolution.
+- Provider-specific identity, effort, fast-mode, bypass, and safety policy moves beside the provider
+  catalog declaration. `parse_model_spec()` retains its public import path and delegates to that
+  catalog so existing aliases and normalization behavior do not change accidentally.
+
+Bundled declarative inventory is the required discovery mechanism for this decision. Third-party
+entry-point discovery may feed the same validation API later, but this ADR does not require a plugin
+system or a second resolver.
+
+## Consequences
+
+Provider metadata becomes reviewable by field name, and every lookup has deterministic resolution
+or a typed failure. Custom OpenAI-compatible services remain supported through an explicit contract
+rather than an error-shaped fallback. Catalog inspection can explain unavailable optional adapters
+without disabling unrelated providers.
+
+Catalog construction becomes a startup validation step, and previously tolerated aliases or
+misspellings may fail. The staged fallback migration and compatibility façade add temporary code,
+but they keep the behavioral change visible. Moving vendor policy out of service requires parity
+tests because model-spec normalization is consumed outside the provider packages.
+
+## Notes
+
+Keeping positional tuples was rejected because static type checking cannot express slot meaning or
+catalog-wide uniqueness. Immediate dynamic entry-point discovery was rejected because bundled
+inventory and deterministic validation solve the present problem with less mechanism. A separate
+executor-provider registry was rejected because it would duplicate the selection authority retained
+by `EndpointRegistry`.

--- a/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
+++ b/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
@@ -8,38 +8,73 @@
 
 ## Context
 
-The resolver already creates typed `EndpointMeta` records, but provider authors declare them
-indirectly through positional enum tuples with four to seven slots. The representation is compact,
-yet field meaning depends on index position and a deferred type may import the module currently
-being registered. Unknown `EndpointConfig` constructor keys are also retained as request defaults,
-so a misspelled configuration field can cross the boundary as payload data
-(`lionagi/service/connections/provider_config.py`,
-`lionagi/service/connections/endpoint_config.py`).
+ADR-0027 records the shipped resolver as a useful single authority with unvalidated and permissive
+inputs. This ADR defines the target catalog without changing that authority.
 
-Registration is local to an adapter, but discovery is central and unvalidated. The generic registry
-contains every bundled provider module name, suppresses all `ImportError`, and resolves the first
-matching canonical name or alias. It does not reject a canonical key repeated as its own alias,
-collisions across registrations, or case variants that fall through to the generic endpoint
-(`lionagi/service/connections/registry.py`).
+**P1 — Positional declarations hide field meaning.** Provider authors currently declare endpoints
+through enum tuples with four to seven positions. Index 3 may be a deferred `LazyType` that imports
+the module being registered. Type checking can confirm that a value is a tuple but cannot name the
+slots or prove catalog-wide uniqueness
+(`lionagi/service/connections/provider_config.py`; `ProviderConfig`, `LazyType`).
 
-The fallback is useful for custom OpenAI-compatible services, but it is currently implicit. The
-resulting `EndpointConfig` does not mark `openai_compatible=True`, and the same branch handles an
-unknown provider, an unknown endpoint, and a provider that failed to import. Catalog inspection
-therefore cannot explain whether an adapter is absent, invalid, unavailable, or deliberately
-generic.
+**P2 — Configuration typos can become request data.** `EndpointConfig` moves every unknown
+constructor key into `kwargs`, and `Endpoint.create_payload()` merges those values into provider
+payload defaults. A misspelled endpoint-control field is therefore accepted at configuration time
+and may cross the provider boundary
+(`lionagi/service/connections/endpoint_config.py`; `EndpointConfig._validate_kwargs`, and
+`lionagi/service/connections/endpoint.py`; `Endpoint.create_payload`).
 
-Provider identity policy is split as well. Endpoint metadata lives with provider packages, while
-CLI aliases, effort translation, and bypass settings live in `lionagi/service/providers.py`. That
-makes generic service code a second source of vendor truth and requires vendor additions to touch
-both sides of the package boundary.
+**P3 — Discovery is central but cannot explain failure.** The registry owns a fixed module list,
+suppresses every `ImportError`, appends entries in import order, and selects the first canonical key
+or alias that matches. It does not reject a canonical key repeated as its own alias, collisions
+between registrations, inconsistent provider aliases, or case variants that later normalize to the
+same `EndpointConfig.provider`
+(`lionagi/service/connections/registry.py`; `EndpointRegistry`, `_import_all_providers`).
+
+**P4 — Compatible fallback is useful but error-shaped.** An unknown provider, unknown endpoint,
+failed provider import, and intentional custom OpenAI-compatible service all reach the same generic
+fallback. The resulting config retains `openai_compatible=False`, so inspection cannot distinguish
+intent from accident.
+
+**P5 — Provider identity has two owners.** Endpoint metadata lives with provider packages, while
+model aliases, effort translation, fast-mode, bypass, and safety kwargs live in
+`lionagi/service/providers.py`. Adding a provider can require coordinated edits on both sides of the
+generic/provider boundary.
+
+| Concern | Decision |
+|---------|----------|
+| Provider authoring | D1: provider endpoints are declared as named, immutable `ProviderEndpointSpec` records and request defaults are explicit. |
+| Key identity and validation | D2: provider, endpoint, and alias keys are canonicalized and the complete key space is validated before snapshot publication. |
+| Bootstrap and availability | D3: bundled inventory is provider-owned; import failures are retained as typed diagnostics while unrelated valid providers remain usable. |
+| Lookup and compatible fallback | D4: registered lookup is fail-closed; generic OpenAI-compatible selection requires an explicit flag and produces a marked config. |
+| Inspection and model policy | D5: inspection and `parse_model_spec()` read the same immutable catalog snapshot, with vendor policy declared beside provider inventory. |
+
+This ADR deliberately does **not** decide:
+
+- Dynamic package entry-point discovery or a general plugin lifecycle. Such inventory may feed the
+  same validation API later; it must not create a second resolver.
+- Request admission, deadlines, retries, or circuit policy; ADR-0029 owns execution lifecycle.
+- Agentic chunk, session, and cleanup conformance; ADR-0030 owns adapter behavior after selection.
+- Provider-specific request fields, command flags, event parsers, model defaults, or safety policy
+  values. The catalog locates those vendor-owned contracts but does not standardize them.
+- Automatic hyphen/underscore or punctuation rewriting. Only case and surrounding whitespace are
+  canonicalized; spelling variants remain explicit aliases.
 
 ## Decision
 
-Retain `EndpointRegistry` as the sole resolver and make its inputs a validated catalog. Provider
-authors declare a named record rather than a positional tuple; registration materializes the
-existing `EndpointMeta` shape and associates it with the concrete endpoint class.
+### D1 — Provider authors publish named endpoint specifications
+
+Replace enum tuple authoring with an immutable record under the provider package. The catalog
+materializes the existing `EndpointMeta` from this record and binds it to the concrete class. The
+target contract is:
 
 ```python
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+RequestOptionsFactory = Callable[[], type[BaseModel]]
+
 @dataclass(frozen=True, slots=True)
 class ProviderEndpointSpec:
     provider: str
@@ -48,57 +83,426 @@ class ProviderEndpointSpec:
     endpoint_class: type[Endpoint]
     provider_aliases: tuple[str, ...] = ()
     endpoint_aliases: tuple[str, ...] = ()
-    request_options: type[BaseModel] | Callable[[], type[BaseModel]] | None = None
+    request_options: type[BaseModel] | RequestOptionsFactory | None = None
     base_url: str | None = None
     auth_type: str | None = None
     content_type: str = "application/json"
     api_key_env: str | None = None
+    request_defaults: Mapping[str, Any] = field(default_factory=dict)
+
+@dataclass(frozen=True, slots=True)
+class ProviderModuleSpec:
+    provider: str
+    module: str
 ```
 
-The catalog contract has these invariants:
+`request_defaults` is the only catalog field whose contents become provider payload defaults.
+Unknown endpoint-control kwargs no longer acquire that meaning implicitly.
 
-- Provider and endpoint identifiers are trimmed and case-folded before indexing. Punctuation is not
-  rewritten; hyphen and underscore variants require declared aliases. Canonical names and aliases
-  are unique in their scope, and a redundant self-alias is invalid.
-- Catalog construction validates the complete key space before serving a lookup. Duplicate keys,
-  invalid metadata, and unresolved request-option types produce typed diagnostics and cannot win by
-  registration order.
-- Bundled provider inventory moves to the provider package and is passed into the registry through
-  one bootstrap boundary. A failed bundled import records provider, module, and cause. Other valid
-  providers remain usable, while selection of the failed provider raises `ProviderUnavailable`.
-- Registered lookup is fail-closed. An absent provider or endpoint raises `EndpointNotFound` with
-  available keys. Generic OpenAI-compatible construction occurs only when the caller passes an
-  explicit `openai_compatible=True` selection mode, and the resulting configuration carries that
-  value.
-- The transition first warns on implicit fallback and identifies the explicit replacement, then
-  removes implicit fallback under the repository deprecation policy. Existing public imports and
-  `match_endpoint()` remain compatibility façades during the transition.
-- `list_providers()` reports canonical identifiers, aliases, endpoint type, request schema,
-  availability, and diagnostics from the same catalog snapshot used for resolution.
-- Provider-specific identity, effort, fast-mode, bypass, and safety policy moves beside the provider
-  catalog declaration. `parse_model_spec()` retains its public import path and delegates to that
-  catalog so existing aliases and normalization behavior do not change accidentally.
+The compatibility construction surface remains:
 
-Bundled declarative inventory is the required discovery mechanism for this decision. Third-party
-entry-point discovery may feed the same validation API later, but this ADR does not require a plugin
-system or a second resolver.
+```python
+def match_endpoint(
+    provider: str,
+    endpoint: str,
+    *,
+    openai_compatible: bool = False,
+    request_defaults: Mapping[str, Any] | None = None,
+    **config_overrides: Any,
+) -> Endpoint: ...
+```
+
+`config_overrides` accepts only declared `EndpointConfig.model_fields`. `request_defaults` accepts
+only fields in the selected request model when one exists; for a deliberately schema-less compatible
+endpoint it accepts arbitrary JSON-serializable values. `iModel` remains a compatibility façade:
+it classifies its legacy `**kwargs` against endpoint-config fields and the selected request model,
+warns during the deprecation window when an unclassified value would previously have entered
+`EndpointConfig.kwargs`, and then requires the caller to use `request_defaults` explicitly.
+
+**Exact semantics**
+
+- **Named fields.** Every author-supplied value is named. A provider module may construct specs
+  directly or use a provider-local helper, but positional tuple interpretation is not a catalog API.
+- **Deferred request model.** A request-options factory is called exactly once while building a
+  snapshot. The result must be a `BaseModel` subclass. Factory failure becomes a validation
+  diagnostic and prevents snapshot publication; lookup never triggers a new import.
+- **Endpoint class.** `endpoint_class` must subclass `Endpoint`. An API spec must not name an
+  `AgenticEndpoint` subclass. An agentic spec must name an `AgenticEndpoint` subclass.
+- **Defaults.** `request_defaults` is copied into the immutable snapshot. Mutable caller mappings
+  are not retained by reference. Each endpoint instance receives a fresh dict.
+- **Config typo.** An unknown `config_overrides` key raises `EndpointConfigurationError` before
+  endpoint construction. It is never silently moved into request data.
+- **Request typo.** When a request model exists, an unknown request-default key raises
+  `EndpointConfigurationError` during catalog build or explicit call configuration. Runtime request
+  validation remains the provider model's responsibility.
+- **Existing metadata.** `_ENDPOINT_META` remains attached to each endpoint class for compatibility,
+  but it is derived from the validated snapshot rather than being the source of truth.
+
+**Why this way.** Named immutable records make declarations reviewable and allow static tools to
+check field types. Keeping `EndpointMeta` as the class-bound projection avoids an unnecessary change
+to endpoint construction. Separating request defaults from endpoint control closes the current typo
+channel without forcing provider payload fields into generic service configuration.
+
+### D2 — Canonicalize keys and validate the complete catalog atomically
+
+One key function is used by registration, lookup, inspection, diagnostics, and model-spec policy:
+
+```python
+def canonical_provider_key(value: str) -> str:
+    return value.strip().casefold()
+
+def canonical_endpoint_key(value: str) -> str:
+    return value.strip().casefold()
+```
+
+No other punctuation transformation occurs. `claude-code` and `claude_code`, or `findSimilar` and
+`find_similar`, are equivalent only when both are explicitly declared through canonical name plus
+alias.
+
+Validation reports stable typed diagnostics:
+
+```python
+CatalogDiagnosticCode = Literal[
+    "empty_key",
+    "self_alias",
+    "duplicate_provider_key",
+    "duplicate_endpoint_key",
+    "inconsistent_provider_aliases",
+    "invalid_endpoint_class",
+    "invalid_request_options",
+    "invalid_request_default",
+    "import_error",
+]
+
+@dataclass(frozen=True, slots=True)
+class ProviderDiagnostic:
+    code: CatalogDiagnosticCode
+    provider: str
+    endpoint: str | None
+    module: str | None
+    key: str | None
+    message: str
+    cause_type: str | None = None
+
+class ProviderCatalogError(RuntimeError): ...
+
+class CatalogValidationError(ProviderCatalogError):
+    diagnostics: tuple[ProviderDiagnostic, ...]
+
+class ProviderUnavailable(ProviderCatalogError):
+    provider: str
+    diagnostic: ProviderDiagnostic
+
+class EndpointNotFound(ProviderCatalogError):
+    provider: str
+    endpoint: str
+    available: tuple[str, ...]
+
+class EndpointConfigurationError(ProviderCatalogError):
+    field: str
+```
+
+**Exact semantics**
+
+- **Empty values.** A canonical provider or endpoint key that becomes empty is invalid. Empty
+  aliases are invalid rather than ignored.
+- **Self alias.** An alias canonicalizing to its own canonical key is invalid. It is not silently
+  deduplicated because the redundant declaration usually signals author confusion.
+- **Provider scope.** Canonical provider names and aliases share one global key space. One key may
+  identify exactly one canonical provider.
+- **Endpoint scope.** Canonical endpoint names and aliases share one key space within a canonical
+  provider. The same endpoint spelling may be used by different providers.
+- **Repeated provider declarations.** Multiple endpoint specs for one provider must declare the
+  same canonical provider-alias set. Disagreement is an error; registration order does not choose a
+  winner.
+- **Duplicate class.** The same endpoint class may appear only once in a snapshot. Reusing a class
+  for another key requires an explicit new subclass so its class-bound metadata is unambiguous.
+- **Validation order.** All modules are collected, then every key and metadata record is validated.
+  Indexes are built only if the successfully imported specification set has no validation error.
+- **Atomic publication.** A valid `CatalogSnapshot` replaces the prior snapshot in one assignment.
+  If a refresh fails validation, the prior valid snapshot remains active. On first build, a
+  validation failure leaves no resolvable catalog and raises `CatalogValidationError`.
+- **No first-match behavior.** A valid snapshot contains no ambiguous keys, so resolution is a map
+  lookup and cannot depend on import or registration order.
+- **Restart.** A process restart rebuilds and revalidates the snapshot. No catalog state is persisted.
+
+**Why this way.** Case-folding aligns resolver identity with `EndpointConfig.provider` and accepts
+case variants without multiplying aliases. Refusing punctuation rewriting keeps public spellings
+auditable. Whole-set validation is necessary because uniqueness is a property of the catalog, not
+of one decorator call; an incremental last-writer-wins map would preserve the current order bug.
+
+### D3 — Provider-owned bootstrap records availability and import diagnostics
+
+The bundled module inventory moves under `lionagi/providers/` and is passed through one bootstrap
+boundary. Generic service code receives an iterable of `ProviderModuleSpec`; it no longer names
+every bundled module.
+
+```text
+lionagi/providers/
+├── _catalog.py                  bundled ProviderModuleSpec inventory
+├── <vendor>/_config.py          ProviderEndpointSpec records
+└── <vendor>/<endpoint>.py       concrete endpoint classes and request models
+
+lionagi/service/connections/
+├── catalog.py                   validation + immutable CatalogSnapshot
+├── registry.py                  EndpointRegistry façade over snapshot
+└── match_endpoint.py            public compatibility façade
+```
+
+**Exact semantics**
+
+- **Import unit.** Each inventory row names the canonical provider expected from that module. The
+  loader imports every row and collects its specs before validation.
+- **Failed import.** Any `Exception` raised while importing a bundled module is captured as an
+  `import_error` diagnostic with provider, module, exception type, and sanitized message.
+  `BaseException` control signals are never swallowed.
+- **Partial availability.** Import failure marks that inventory provider unavailable but does not
+  prevent unrelated successfully imported providers from being validated and published.
+- **Selection of failed provider.** A canonical provider key known from inventory but lacking a
+  loaded spec raises `ProviderUnavailable`; it does not fall through to `EndpointNotFound` or a
+  compatible endpoint.
+- **Validation failure.** Invalid metadata or collisions among successfully imported specs are not
+  partial failures. They prevent snapshot publication because serving a subset could make an alias
+  silently change owner.
+- **Repeated lookup.** A failed provider is not re-imported per request. Availability is fixed for
+  the snapshot. A deliberate catalog refresh or process restart performs another import attempt.
+- **Unknown provider.** A provider absent from both inventory and indexes is `EndpointNotFound`, not
+  `ProviderUnavailable`.
+- **Thread safety.** Lazy first-build remains lock-protected. Lookups after publication are immutable
+  snapshot reads and need no registry mutation.
+
+**Why this way.** Provider-owned inventory removes the reverse list dependency from generic service
+code while keeping deterministic bundled discovery. Capturing imports lets inspection distinguish
+"not registered" from "registered package unavailable." Import failures are isolated because they
+do not create key ambiguity; validation collisions are global and therefore fail publication.
+
+### D4 — Registered resolution fails closed; compatible fallback is explicit
+
+Resolution uses the validated snapshot first. The target lookup state machine is:
+
+```text
+canonicalize provider
+        |
+        +-- known unavailable --------------------> ProviderUnavailable
+        |
+        +-- unknown -------------------------------+-- openai_compatible=False
+        |                                          |      -> EndpointNotFound
+        |                                          +-- openai_compatible=True
+        |                                                 -> marked generic endpoint
+        v
+resolve canonical provider
+        |
+        +-- endpoint key matches -----------------> instantiate registered class
+        |
+        +-- endpoint empty + exactly one endpoint -> instantiate that endpoint
+        |
+        +-- miss ----------------------------------+-- openai_compatible=False
+                                                   |      -> EndpointNotFound
+                                                   +-- openai_compatible=True
+                                                          -> marked generic endpoint
+```
+
+The compatible construction result is explicit:
+
+```python
+EndpointConfig(
+    name="openai_compatible_chat",
+    provider=canonical_provider,
+    base_url=required_base_url,
+    endpoint=endpoint or "chat/completions",
+    method="POST",
+    auth_type="bearer",
+    content_type="application/json",
+    request_options=OpenAIChatCompletionsRequest,
+    openai_compatible=True,
+    requires_tokens=True,
+    kwargs=dict(request_defaults or {}),
+)
+```
+
+**Exact semantics**
+
+- **Known match wins.** If provider and endpoint resolve to a registered entry, that entry is used
+  even when `openai_compatible=True`; the flag authorizes fallback, not replacement of a valid
+  registration.
+- **Multiple endpoints with empty selection.** Empty endpoint is accepted only for a provider with
+  exactly one endpoint. A provider with multiple endpoints raises `EndpointNotFound` with sorted
+  canonical endpoint keys. There is no first-entry default hidden in registration order.
+- **Known provider, unknown endpoint.** The miss raises unless compatible fallback was explicitly
+  authorized. The old single-endpoint "accept any string" behavior is removed through the same
+  staged deprecation as implicit fallback.
+- **Compatible URL.** Explicit compatible construction requires a non-empty `base_url`; absence is
+  `EndpointConfigurationError("base_url")`. The generic service does not guess a vendor URL.
+- **Failed bundled provider.** `openai_compatible=True` does not mask `ProviderUnavailable` for a
+  provider key owned by bundled inventory. A caller intending a separate compatible service must use
+  a distinct provider key.
+- **Diagnostics.** `EndpointNotFound` carries canonical provider, requested canonical endpoint, and
+  sorted available canonical endpoint keys. It does not include secrets or request defaults.
+- **Migration.** The first compatibility release preserves implicit fallback with a deprecation
+  warning naming `openai_compatible=True` and the explicit `base_url` requirement. After the
+  repository deprecation window, implicit fallback raises. Public imports and `match_endpoint()`
+  remain available throughout.
+
+**Why this way.** Custom compatible services remain supported, but intent becomes observable in
+configuration and inspection. Registered lookup fails closed because a typo should not select a
+different transport. Requiring a URL prevents a marked compatible endpoint from deferring an
+obvious configuration error until transport construction.
+
+### D5 — Inspection and provider model policy share the snapshot
+
+Inspection returns a stable typed dict projection of the same snapshot used for lookup:
+
+```python
+class EndpointCatalogItem(TypedDict):
+    endpoint: str
+    aliases: list[str]
+    endpoint_type: Literal["api", "agentic"]
+    endpoint_class: str
+    request_options: str | None
+    base_url: str | None
+
+class ProviderCatalogItem(TypedDict):
+    provider: str
+    aliases: list[str]
+    availability: Literal["available", "unavailable"]
+    endpoints: list[EndpointCatalogItem]
+    diagnostics: list[dict[str, str | None]]
+
+class EndpointRegistry:
+    @classmethod
+    def list_providers(cls) -> list[ProviderCatalogItem]: ...
+```
+
+Rows and nested endpoints are sorted by canonical key. Diagnostics come from the same snapshot and
+are sorted by `(provider, endpoint or "", code, key or "")`. No API key, request default, or secret
+value is exposed.
+
+Vendor model identity moves beside provider inventory:
+
+```python
+EffortMode = Literal["none", "kwarg", "model_name"]
+
+@dataclass(frozen=True, slots=True)
+class ProviderModelPolicy:
+    provider: str
+    provider_aliases: tuple[str, ...] = ()
+    model_aliases: Mapping[str, str] = field(default_factory=dict)
+    effort_mode: EffortMode = "none"
+    effort_kwarg: str | None = None
+    effort_levels: tuple[str, ...] = ()
+    yolo_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    bypass_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    fast_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+def parse_model_spec(spec: str) -> ModelSpec: ...
+```
+
+**Exact semantics**
+
+- The provider key and aliases in `ProviderModelPolicy` must resolve to the same catalog provider.
+  Conflicts are catalog validation errors.
+- Model aliases are canonicalized by surrounding whitespace and case only for lookup; the expanded
+  provider/model string retains the provider package's declared spelling.
+- Effort policy has exactly one mode. `kwarg` requires `effort_kwarg`; `model_name` forbids it;
+  `none` rejects an effort suffix as current `parse_model_spec()` does for providers without effort.
+- `parse_model_spec()` retains its public import path and returns the existing frozen
+  `ModelSpec(model: str, effort: str | None)`. It delegates provider aliases, model aliases, and
+  effort classification to the snapshot.
+- Existing aliases and normalization are parity-tested before the service-owned tables are removed.
+  The move changes ownership, not accepted public spellings.
+- Inspection of an unavailable provider includes its import diagnostic and an empty endpoint list.
+  Inspection of a valid provider contains no historical diagnostics from prior snapshots.
+
+**Why this way.** Lookup, inspection, and model parsing must not answer provider identity from
+different tables. Provider-local policy keeps vendor additions local; the registry remains the
+validator and projection point. Keeping the `parse_model_spec()` façade prevents a package move from
+becoming an unrelated public API break.
 
 ## Consequences
 
-Provider metadata becomes reviewable by field name, and every lookup has deterministic resolution
-or a typed failure. Custom OpenAI-compatible services remain supported through an explicit contract
-rather than an error-shaped fallback. Catalog inspection can explain unavailable optional adapters
-without disabling unrelated providers.
+- Provider metadata becomes reviewable by field name. Every lookup either selects exactly one
+  validated entry, raises a typed failure, or follows an explicit compatible path.
+- Catalog construction becomes a startup or refresh gate. A collision stops publication instead of
+  letting import order decide. This makes adapter defects visible earlier at the cost of stricter
+  startup.
+- A failed optional provider no longer disables unrelated providers and no longer disappears
+  silently. The unavailable row remains inspectable with a sanitized cause.
+- Existing callers relying on implicit fallback, arbitrary endpoint strings for single-endpoint
+  providers, or unknown config keys receive a staged warning and then a typed failure. Compatibility
+  work is concentrated in `match_endpoint()` and `iModel`, not spread through adapters.
+- Custom OpenAI-compatible services remain supported. They must state intent, URL, and request
+  defaults; their config carries `openai_compatible=True`.
+- Provider additions stop requiring a generic bootstrap edit and, after policy migration, stop
+  requiring changes to `service/providers.py`.
+- Reversing D1/D2 is medium cost because provider declarations must be rewritten, but the resolver
+  façade remains stable. Reversing D4 after warnings ship is high cost because callers will rely on
+  typed failure. Adding a future inventory source is low cost if it emits the same two spec types.
+- Maintainers must treat snapshot validation as a closed-world operation: local registration success
+  is insufficient until global provider and endpoint key spaces validate.
 
-Catalog construction becomes a startup validation step, and previously tolerated aliases or
-misspellings may fail. The staged fallback migration and compatibility façade add temporary code,
-but they keep the behavioral change visible. Moving vendor policy out of service requires parity
-tests because model-spec normalization is consumed outside the provider packages.
+## Alternatives considered
+
+### Keep positional `ProviderConfig` tuples
+
+This preserves compact declarations and avoids a migration. It lost because slot meaning remains
+implicit, factories and types cannot be validated by field name, and tuple-local checks cannot prove
+catalog-wide uniqueness. The current four-to-seven-slot shape is exactly the ambiguity this ADR is
+removing.
+
+### Incrementally validate decorators as modules import
+
+Each decorator could reject collisions against entries already seen. That would catch some errors
+with little new machinery. It lost because the first imported registration would still win the
+diagnostic framing, inconsistent provider-alias sets are only visible across multiple modules, and a
+partially mutated registry would remain after a later failure. Atomic snapshots make serving state
+all-valid or previously-valid.
+
+### Last-writer-wins maps
+
+A dictionary assignment could make lookup fast and deterministic within one import order. It would
+also make overrides easy. It lost because changing module order would change the selected adapter,
+and inspection could not reveal the displaced definition. Duplicate public identity is a catalog
+error, not an extension mechanism.
+
+### Automatic punctuation normalization
+
+The resolver could treat hyphens, underscores, dots, and slashes as interchangeable. This would
+reduce explicit aliases. It lost because punctuation is meaningful in endpoint paths and public
+provider spellings; broad rewriting can collapse distinct keys. Explicit aliases are more verbose
+but auditable.
+
+### Remove generic compatible fallback entirely
+
+Strict registered-only lookup would make every miss obvious and simplify selection. It lost because
+the existing fallback supports custom OpenAI-compatible services without a dedicated adapter. The
+problem is implicit intent, not compatibility itself; the explicit flag and marked config retain the
+valid use case.
+
+### Immediate dynamic entry-point discovery
+
+Package entry points could remove the fixed bundled list and enable external adapters at once. They
+would also require package precedence, refresh, trust, diagnostics, and conflict rules. It lost for
+this decision because provider-owned bundled inventory plus deterministic validation solves the
+present dependency and observability defects. A future entry-point source must emit the same specs
+and pass the same validator.
+
+### Keep vendor policy tables in generic service code
+
+This avoids moving `BACKENDS`, effort, bypass, and fast-mode mappings and keeps one familiar module.
+It lost because it preserves a second provider identity authority. Parity tests and the retained
+`parse_model_spec()` façade make ownership movement safer than continued split truth.
+
+### Add a separate executor-provider registry
+
+An executor catalog could model HTTP, subprocess, in-process, and remote execution separately. It
+lost because `EndpointRegistry` already resolves concrete endpoint families and ADR-0029 places
+admission behind `iModel`. A second registry would duplicate provider keys, aliases, availability,
+and diagnostics without removing the endpoint catalog.
 
 ## Notes
 
-Keeping positional tuples was rejected because static type checking cannot express slot meaning or
-catalog-wide uniqueness. Immediate dynamic entry-point discovery was rejected because bundled
-inventory and deterministic validation solve the present problem with less mechanism. A separate
-executor-provider registry was rejected because it would duplicate the selection authority retained
-by `EndpointRegistry`.
+This is a target-state ADR. It does not claim that `ProviderEndpointSpec`, atomic snapshots, typed
+catalog errors, or explicit fallback are shipped. The existing source contracts that constrain the
+migration are `lionagi/service/connections/{provider_config,registry,endpoint_config,endpoint,match_endpoint}.py`,
+the provider declarations in `lionagi/providers/*/_config.py`, and the compatibility tables and
+`ModelSpec` in `lionagi/service/providers.py`.

--- a/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
+++ b/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
@@ -8,48 +8,110 @@
 
 ## Context
 
-Non-streaming `iModel.invoke()` appends an `APICalling`, forwards it to
-`RateLimitedAPIProcessor`, and waits for a terminal event. The processor atomically checks request
-and estimated-token capacity, defers denied work until replenishment, and uses a semaphore for
-concurrency. The caller wait is nevertheless fixed at ten seconds: it then removes and returns the
-event even if a longer refresh interval left it queued and pending (`lionagi/service/imodel.py`,
-`lionagi/service/rate_limited_processor.py`).
+ADR-0027 records one public model façade but two materially different execution lifecycles. This
+ADR defines one target lifecycle for both result shapes.
 
-`iModel.stream()` follows a different path. It appends the event and uses the processor semaphore,
-but calls `APICalling.stream()` directly instead of forwarding it through permission checks. A
-configured request or token limit therefore does not gate a stream before provider work starts.
-Generator cleanup removes the event from the executor, but there is no shared deadline contract for
-queued work, an active provider stream, and caller cancellation.
+**P1 — `invoke()` can detach pending work.** Non-streaming `iModel.invoke()` appends an
+`APICalling`, forwards it through `RateLimitedAPIProcessor`, and waits for a terminal signal. If the
+event remains pending or processing after ten seconds, the timeout is swallowed and the event is
+removed and returned anyway. A refresh interval longer than that fixed wait can leave a pending call
+outside executor ownership (`lionagi/service/imodel.py`; `iModel.invoke`).
 
-Resilience also differs by path. `Endpoint.call()` composes circuit breaking with configured retry
-and otherwise supplies a native HTTP retry policy. `Endpoint.stream()` invokes the HTTP stream
-transport directly, so connection establishment and response-header failures do not use the same
-policy. Retrying after a chunk has reached the caller would be unsafe because most provider streams
-do not expose a replay cursor (`lionagi/service/connections/endpoint.py`,
-`lionagi/service/resilience.py`).
+**P2 — `stream()` bypasses request and token admission.** Streaming appends the event and acquires
+the processor semaphore, but calls `APICalling.stream()` directly instead of forwarding through
+`RateLimitedAPIProcessor.request_permission()`. Configured request and token limits therefore do not
+gate provider work before a stream starts (`lionagi/service/imodel.py`; `iModel.stream`, and
+`lionagi/service/rate_limited_processor.py`; `RateLimitedAPIProcessor.request_permission`).
 
-`Event` already provides pending, processing, completed, failed, skipped, cancelled, and aborted
-states plus a completion signal. The missing contract is ownership: who admits the work, how long a
-caller is willing to wait, which scope holds scarce capacity, and who terminalizes or cancels the
-event when that scope ends (`lionagi/protocols/generic/event.py`).
+**P3 — `queue_capacity` is not a bounded queue.** The base `Processor` constructs
+`asyncio.Queue(maxsize=0)` unless `max_queue_size` is separately supplied. The rate-limited
+processor does not supply it. Its `queue_capacity` limits a processing cycle and participates in a
+permission check; it does not bound queued memory
+(`lionagi/protocols/generic/processor.py`; `Processor.__init__`, and
+`lionagi/service/rate_limited_processor.py`; `RateLimitedAPIProcessor.__init__`).
 
-The CLI run operation already converts its relative timeout to a monotonic deadline, bounds each
-stream read by the remaining time, and explicitly closes the generator. That protects one operation
-caller but does not cover admission or define the service-wide contract. The service budget must
-accept that existing deadline rather than stack a fresh timeout around it
-(`lionagi/operations/run/run.py`).
+**P4 — Relative timeouts are stacked instead of propagated.** The service has endpoint transport
+timeouts, hook timeouts, a ten-second `invoke()` wait, replenishment sleeps, and retry delays, but no
+single owner for total elapsed time. The CLI run operation already converts a positive relative
+timeout to an absolute `anyio.current_time()` deadline, bounds each stream read by remaining time,
+and explicitly closes the generator. That protects one caller after the call event is created; it
+does not include admission, and the service cannot currently accept the inherited deadline
+(`lionagi/operations/run/run.py`; `_stream_with_deadline`, `run`).
+
+**P5 — HTTP stream resilience diverges from one-shot calls.** `Endpoint.call()` combines configured
+retry and circuit policy or supplies a native aiohttp retry path. `Endpoint.stream()` calls
+`_stream_aiohttp()` directly. Connection establishment and response-header failures therefore do
+not receive the same policy. Replaying after a chunk reaches a caller is unsafe because generic
+provider streams have no replay cursor
+(`lionagi/service/connections/endpoint.py`; `Endpoint.call`, `Endpoint.stream`).
+
+**P6 — Terminal state and cleanup have multiple owners.** `Event` already has `PENDING`,
+`PROCESSING`, `COMPLETED`, `FAILED`, `SKIPPED`, `CANCELLED`, and `ABORTED` states plus a completion
+signal. The processor, façade, event, endpoint, and operation nevertheless each own part of queueing,
+cancellation, error capture, or generator close. No invariant currently prevents an event from being
+removed while non-terminal (`lionagi/protocols/generic/event.py`; `Event`, `EventStatus`).
+
+| Concern | Decision |
+|---------|----------|
+| Admission and capacity | D1: `invoke()` and `stream()` acquire the same FIFO bounded-queue, request, token, and concurrency lease before hooks or provider work. |
+| Deadline and cancellation ownership | D2: one optional absolute monotonic deadline covers every stage; the lease supervisor alone terminalizes deadline, cancellation, and shutdown paths. |
+| Public invoke/stream lifecycle | D3: both methods retain executor ownership until terminal cleanup; one-shot returns only a terminal event and stream failures propagate as typed exceptions. |
+| Retry and circuit behavior | D4: HTTP call and stream establishment share one deadline-aware attempt policy; replay is prohibited after the first user-visible chunk. |
+| Verification and observability | D5: a conformance matrix proves terminal state, capacity release, and absence of orphaned work for every exit path. |
+
+This ADR deliberately does **not** decide:
+
+- A durable job queue or persistence of deferred requests. Admission is process-local; restart does
+  not resume queued calls.
+- Provider-specific stream resume or replay cursors. An adapter with a real cursor needs an explicit
+  policy under ADR-0030; generic replay remains prohibited after output.
+- Consolidation of hook registries or a general event bus. Existing pre/post call hooks remain the
+  service observation points.
+- Provider request schemas or error grammar. ADR-0030 normalizes agentic errors; API adapters remain
+  vendor-owned.
+- Cross-model global quotas. One `iModel` owns one controller. A shared quota service would require a
+  separate scope and fairness decision.
 
 ## Decision
 
-Introduce one internal admission operation used by both `invoke()` and `stream()`. It returns an
-async lease only after queue capacity, request budget, estimated-token budget, and concurrency
-capacity have been acquired. The lease begins before hooks or provider work and ends only after the
-event reaches a terminal state or cancellation cleanup completes.
+### D1 — One admission controller issues an async lease
+
+Both public methods use one internal controller. The target Python contract is:
 
 ```python
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+MonotonicClock = Callable[[], float]
+AsyncSleep = Callable[[float], Awaitable[None]]
+
 @dataclass(frozen=True, slots=True)
 class RequestBudget:
-    deadline: float | None  # absolute event-loop monotonic time
+    # Absolute event-loop monotonic time. None means no caller deadline.
+    deadline: float | None = None
+
+    def remaining(self, clock: MonotonicClock) -> float | None:
+        if self.deadline is None:
+            return None
+        return max(0.0, self.deadline - clock())
+
+@dataclass(frozen=True, slots=True)
+class AdmissionConfig:
+    queue_capacity: int
+    capacity_refresh_time: float = 60.0
+    interval: float | None = None
+    limit_requests: int | None = None
+    limit_tokens: int | None = None
+    concurrency_limit: int | None = None
+
+class AdmissionLease(Protocol):
+    call: APICalling
+    budget: RequestBudget
+
+    async def __aenter__(self) -> AdmissionLease: ...
+    async def __aexit__(self, exc_type, exc, tb) -> bool: ...
+    async def release(self) -> None: ...
 
 class AdmissionController(Protocol):
     async def acquire(
@@ -58,79 +120,506 @@ class AdmissionController(Protocol):
         *,
         budget: RequestBudget,
     ) -> AdmissionLease: ...
+
+    async def close(self) -> None: ...
 ```
 
-The lifecycle is the same for both result shapes:
+The controller uses a physical `asyncio.Queue(maxsize=config.queue_capacity)` or an equivalent
+bounded AnyIO queue. `AdmissionLease.release()` is idempotent. `__aexit__()` always releases
+concurrency and active-call bookkeeping, but it does not suppress exceptions.
+
+Admission failures are typed:
+
+```python
+class AdmissionError(RuntimeError): ...
+class AdmissionClosed(AdmissionError): ...
+class AdmissionConflict(AdmissionError): ...
+class TokenEstimateUnavailable(AdmissionError): ...
+class RequestExceedsTokenWindow(AdmissionError): ...
+
+class RequestDeadlineExceeded(AdmissionError):
+    call_id: UUID
+    phase: Literal[
+        "enqueue", "rate", "concurrency", "hook",
+        "retry_delay", "transport", "stream",
+    ]
+```
+
+The acquisition sequence is normative:
 
 ```text
-create APICalling
-       │
-       v
-bounded enqueue ──> rate + token admission ──> concurrency lease
-       │                         │                      │
-       │                         │                      v
-       │                         │                pre-call hooks
-       │                         │                      │
-       │                         │             endpoint call / stream
-       │                         │                      │
-       │                         │                post-call hooks
-       │                         │                      │
-       └──── deadline/cancel ────┴────────────> terminalize + release
+validate event + token estimate
+            |
+            v
+bounded FIFO enqueue  -- full --> wait under same RequestBudget
+            |
+            v
+head-of-line rate/token reservation under one lock
+            |
+            v
+concurrency acquisition under same RequestBudget
+            |
+            v
+remove from waiting queue; return AdmissionLease
+            |
+            v
+pre-hook -> provider call/stream -> post-hook -> terminalize -> release
 ```
 
-The load-bearing invariants are:
+**Exact semantics**
 
-- Queueing is bounded and happens before expensive provider work. Request and estimated-token units
-  are checked and debited atomically. Concurrency is a lease over active hook and provider work, not
-  merely a semaphore used by one public method. A full queue applies producer backpressure until
-  capacity is available, the request deadline expires, or the caller cancels.
-- A stream is fully admitted before its pre-invocation hook runs or its endpoint starts. No chunk may
-  be produced by work that bypassed configured request, token, or concurrency policy.
-- One optional absolute deadline, measured on the event loop's monotonic clock, covers queue wait,
-  admission wait, all retry delays, provider transport, and stream consumption. Nested stages derive
-  remaining time; they do not reset a relative timeout.
-- Caller cancellation removes queued work or cancels active work, closes an active stream, and
-  re-raises cancellation after cleanup. Deadline expiry at any phase cancels underlying work, sets
-  the event to `ABORTED`, and raises `RequestDeadlineExceeded`; caller cancellation sets
-  `CANCELLED`; transport or provider failure sets `FAILED`. An `APICalling` is never removed from
-  executor ownership while pending or processing.
-- `invoke()` returns only a terminal `APICalling`. Stream setup and transport failures terminalize
-  the same event and surface as typed exceptions rather than normal end-of-stream; normal EOF marks
-  completion.
-- Retry and circuit policy cover HTTP stream establishment through receipt of valid response
-  headers and the first provider event. Automatic retry is allowed only before a user-visible chunk
-  is emitted and only within the remaining deadline and retry budget. A mid-stream failure is
-  recorded and raised as `ProviderStreamError` without generic replay. The circuit gates stream
-  start, records normal EOF as success, and records any transport failure even when replay is
-  prohibited. Provider-specific resumability requires a separate explicit adapter policy.
-- Service hooks remain observation and policy points around the admitted call. This ADR does not
-  consolidate hook systems or introduce another event bus (see the hooks ADR on call-boundary
-  hooks).
+- **Configuration validation.** `queue_capacity`, `capacity_refresh_time`, and a non-`None`
+  `interval` must be greater than zero. Request, token, and concurrency limits must be `None` or a
+  positive integer. Zero and negative values are configuration errors rather than ambiguous
+  "unlimited" values; `None` is the sole unlimited spelling.
+- **FIFO.** Waiting calls are admitted in enqueue order. A later small request does not bypass an
+  earlier large request. This trades maximum utilization for a stable starvation-free rule.
+- **Full queue.** Producers wait for a queue slot. They are neither dropped nor admitted around the
+  queue. Deadline expiry or cancellation removes the waiting producer without leaving a queue item.
+- **Duplicate event.** Acquiring a call id that is already queued or active raises
+  `AdmissionConflict`. A terminal event cannot be reacquired; callers use `as_fresh_event()` for a
+  new attempt.
+- **Token estimate.** If token limiting is configured and `APICalling.required_tokens is None`,
+  acquisition raises `TokenEstimateUnavailable`; unmetered provider work is not silently admitted.
+  A required token count greater than the whole window raises `RequestExceedsTokenWindow`
+  immediately rather than waiting forever.
+- **Atomic reservation.** Request and token availability are checked under one lock. Both are
+  provisionally decremented or neither is. A deadline/cancellation before concurrency acquisition
+  restores both under that lock. Once a lease is returned, the units are consumed even if hooks or
+  provider work later fail; the dependency attempt used the admitted request budget.
+- **Fixed window.** At each refresh, available request/token counters reset to configured limits.
+  `interval=None` means `capacity_refresh_time`; an explicit interval is used as written. This ADR
+  does not change the algorithm to a sliding window or token bucket.
+- **Concurrency.** `concurrency_limit=None` means no semaphore. Otherwise the lease holds one permit
+  from before the pre-invocation hook until terminal state and cleanup. Long-lived streams therefore
+  consume concurrency for their entire lifetime.
+- **Queue accounting.** `queue_capacity` counts waiting calls. Active calls have left the queue and
+  are bounded by `concurrency_limit`. Executor inspection reports the two populations separately.
+- **Empty controller.** Closing a controller with no queued or active work is a no-op. Repeated close
+  is idempotent.
+- **Refresh failure.** An unexpected replenisher failure closes admission, terminalizes queued work
+  as `ABORTED`, cancels active work, and is observable. It is not logged and ignored while calls wait
+  forever.
 
-An operation that already computed a monotonic deadline passes that absolute value into
-`RequestBudget`; the service never starts a second full-duration timeout. Conformance tests use a
-refresh interval longer than the caller budget, a full queue, a rate-limited stream, a cancelled
-queued call, a cancelled active stream, pre-first-chunk transport failure, mid-stream failure, and
-circuit-open behavior. They assert terminal state, provider call count, queue removal, lease release,
-and absence of background work after the caller scope exits.
+The default values retain current surface behavior where it is coherent:
+
+| Endpoint class | Queue bound | Active concurrency | Reason |
+|----------------|-------------|--------------------|--------|
+| API endpoint | `100` | `None` unless configured | Inherited API defaults; no recorded numeric rationale. The target changes `100` from cycle capacity into an actual waiting bound. |
+| Base agentic endpoint | `10` | `3` | Inherited from `AgenticEndpoint`; no recorded numeric rationale. |
+| AG2 in-process agent/group chat | `3` | `1` | Inherited adapter overrides; serialization avoids concurrent mutation of adapter-owned agent state, while the exact values have no recorded rationale. |
+| AG2 remote NLIP | `10` | `3` | Inherited adapter defaults; no recorded numeric rationale. |
+
+The default refresh window remains 60 seconds. It is inherited from `iModel`; the source records no
+reason for that exact duration. Callers that need a different provider window must configure it.
+
+**Why this way.** A lease makes ownership visible: admission is not complete until every scarce
+capacity has been acquired, and capacity is not released until cleanup is complete. A physical bound
+makes overload backpressure explicit instead of hiding it in memory. Atomic provisional reservation
+prevents a cancelled concurrency waiter from leaking quota. FIFO is deliberately simple and
+testable; a weighted scheduler would be a separate fairness decision.
+
+### D2 — One absolute monotonic deadline owns every stage
+
+A relative timeout is converted exactly once, at the outermost caller that introduces it:
+
+```python
+def request_budget_from_timeout(
+    timeout: float | None,
+    *,
+    clock: MonotonicClock,
+) -> RequestBudget:
+    # Compatibility: None, zero, and negative values mean no caller deadline.
+    if timeout is None or timeout <= 0:
+        return RequestBudget()
+    return RequestBudget(deadline=clock() + float(timeout))
+```
+
+If an operation already owns an absolute deadline, it passes `RequestBudget(deadline=deadline)`
+directly. The service never adds the original relative duration again.
+
+**Exact semantics**
+
+- **Clock.** Deadline arithmetic uses the running event loop's monotonic clock (`loop.time()` or
+  `anyio.current_time()`), never UTC or `time.time()`. The clock is injected into the controller for
+  deterministic tests.
+- **Scope.** The budget begins before bounded enqueue and covers queue wait, rate wait, concurrency
+  wait, pre-hook, retry delay, every transport attempt, stream consumption, post-hook, and mandatory
+  cleanup.
+- **Remaining time.** Before every wait, sleep, hook, and transport attempt, the stage computes
+  remaining time. A local stage cap is `min(local_cap, remaining)`; it never receives a fresh full
+  duration.
+- **Past deadline.** A non-`None` deadline at or before current monotonic time expires immediately in
+  the current phase. No provider work starts.
+- **No deadline.** `None` removes only the caller deadline. Local hook and endpoint transport caps
+  still apply.
+- **Deadline expiry.** The supervisor cancels queued or active work, closes an active stream,
+  performs cleanup, sets `EventStatus.ABORTED`, releases all reservations/permits, removes the event
+  from ownership only after it is terminal, and raises `RequestDeadlineExceeded` with the phase.
+- **External cancellation.** Caller cancellation is not translated into a deadline. Cleanup runs,
+  the event becomes `CANCELLED`, and the original cancellation is re-raised.
+- **Consumer close.** If a stream consumer calls `aclose()` or abandons iteration before normal EOF,
+  the supervisor treats it as caller cancellation for event state: cleanup completes and the event
+  becomes `CANCELLED`, but no new exception is injected into an otherwise clean `aclose()`.
+- **Shutdown.** Controller close rejects new acquisition with `AdmissionClosed`, marks queued and
+  active events `ABORTED`, cancels active scopes, awaits their cleanup, and then stops replenishment.
+- **Race.** A terminal provider result that wins the race with cancellation remains terminal. A
+  cancellation observed first owns the result; late provider completion is discarded inside the
+  cancelled scope and cannot overwrite status.
+- **Restart.** Admission state, reservations, and queued events are process-local. A restart begins
+  empty; there is no replay or recovery scan.
+
+Local caps remain useful inside the one deadline:
+
+| Cap | Shipped default carried forward | Target interpretation | Numeric rationale |
+|-----|---------------------------------|-----------------------|-------------------|
+| Registered API transport | `600s` | Maximum one transport attempt when no shorter caller remainder exists. | Inherited; no recorded rationale. |
+| Generic endpoint transport | `300s` | Same, for explicitly constructed generic config. | Inherited; no recorded rationale. |
+| Registered agentic config | `3600s` | Adapter-level maximum only when the adapter uses it; caller remainder still wins. | Inherited; long-running agent intent is evident, exact value is not justified in source. |
+| Pre-create/pre/post hook | `10s/30s/30s` | Effective hook cap is the lesser of local cap and caller remainder. | Inherited; no exact numeric rationale. |
+| Model-manager shutdown | `10s` per model | Independent close cap outside any completed request budget. | Prevents one model blocking peers; exact value is inherited. |
+
+**Why this way.** Absolute deadlines compose. A stage that receives only "ten seconds" cannot tell
+whether nine seconds were already spent queueing; a monotonic deadline can. Deadline and external
+cancellation remain distinct because they carry different caller meaning and terminal states.
+Cleanup is inside the supervised lifetime so a timeout cannot return while provider work continues.
+
+### D3 — `invoke()` and `stream()` use the same supervised lifecycle
+
+The public surface accepts an internal budget without forcing ordinary callers to construct one:
+
+```python
+class iModel:
+    async def invoke(
+        self,
+        api_call: APICalling | None = None,
+        *,
+        request_budget: RequestBudget | None = None,
+        **request: Any,
+    ) -> APICalling: ...
+
+    async def stream(
+        self,
+        api_call: APICalling | None = None,
+        *,
+        request_budget: RequestBudget | None = None,
+        **request: Any,
+    ) -> AsyncGenerator[StreamChunk, None]: ...
+```
+
+`request_budget=None` means `RequestBudget(deadline=None)`. Existing public `timeout` values are
+adapted at the caller boundary during migration; nested code passes `RequestBudget`.
+
+The shared sequence is:
+
+```text
+create or accept APICalling
+          |
+          v
+append to executor ownership
+          |
+          v
+AdmissionController.acquire(call, budget)
+          |
+          v
+pre-invocation hook
+          |
+          +------------------+
+          |                  |
+          v                  v
+    endpoint.call       endpoint.stream
+          |                  |
+          v                  v
+    store response       yield chunks
+          |                  |
+          +--------+---------+
+                   v
+             post-invocation hook
+                   |
+                   v
+         terminal state -> cleanup -> release -> remove
+```
+
+**Exact semantics**
+
+- **Creation failure.** Payload/config validation before append raises its typed validation error and
+  creates no executor-owned event. Hook-enabled pre-create behavior remains as specified by the
+  hooks contract.
+- **Append.** A successfully created event is appended before acquisition so inspection can see
+  queued state. Failure after append must terminalize and remove it through the supervisor.
+- **Pre-hook ordering.** Pre-invocation hooks run only after all admission resources are acquired.
+  A rate-limited or queued call cannot execute policy or provider work early.
+- **One-shot success.** The endpoint response is stored, post-hook runs, status becomes `COMPLETED`,
+  the lease is released, and the terminal `APICalling` is returned.
+- **One-shot ordinary failure.** Hook/provider `Exception` is retained in `execution.error`, status
+  becomes `FAILED`, the lease is released, and the terminal `APICalling` is returned. The method no
+  longer wraps every error as a generic `ValueError`. Admission/deadline/cancellation failures keep
+  their typed control-flow behavior.
+- **One-shot invariant.** `invoke()` never returns `PENDING` or `PROCESSING`. It does not use an
+  independent ten-second safety wait and never removes a non-terminal event.
+- **Stream success.** A stream is fully admitted before the first provider call. Normal EOF runs the
+  post-stream hook, marks `COMPLETED`, releases, and removes. A result chunk is permitted but not
+  required for normal EOF.
+- **Provider-declared stream error.** An adapter error chunk must have `type="error"` and
+  `is_error=True`. The supervisor yields that normalized chunk at most once, records it, prohibits
+  further output, marks the event `FAILED`, and raises `ProviderStreamError` after the chunk boundary
+  so direct and operation consumers observe failure.
+- **Transport/parser stream failure.** The event becomes `FAILED`; the original typed provider or
+  transport exception escapes after cleanup. `Event.stream()` is adapted so ordinary stream
+  exceptions are not silently converted into normal EOF.
+- **Mid-stream hook failure.** A pre-hook failure emits no provider output and fails the event. A
+  chunk-processing hook failure after provider start fails the event and propagates. Existing
+  post-stream hook behavior remains: once output has been sent, its failure is logged and does not
+  replace a successful provider stream.
+- **Session state.** A system chunk with a provider session identifier may update the endpoint during
+  streaming; a one-shot response may update it after completion. Cancellation or failure does not
+  erase the last confirmed identifier. ADR-0030 defines which adapters are resumable.
+- **Ownership removal.** Removal from the executor pile occurs after terminal state and cleanup on
+  every path. Inspection may retain a separate bounded history snapshot, but active ownership never
+  drops a non-terminal event.
+
+**Why this way.** Method-dependent quotas are not meaningful quotas. Running the same supervisor on
+both result shapes makes status, capacity, deadline, hook, and cleanup behavior citeable. One-shot
+keeps the existing event-return style for ordinary provider failures; streaming must propagate
+because there is no terminal event return value for the caller to inspect.
+
+### D4 — Retry and circuit policy cover stream establishment, never observed output
+
+The internal policy uses total attempts, avoiding the current ambiguity where one `max_retries=3`
+path means three total attempts and another means one plus three retries:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AttemptPolicy:
+    max_attempts: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    backoff_factor: float = 2.0
+    jitter_factor: float = 0.2
+    retry_statuses: frozenset[int] = frozenset({429})
+    retry_server_errors: bool = True
+
+@dataclass(frozen=True, slots=True)
+class CircuitPolicy:
+    failure_threshold: int = 5
+    recovery_time: float = 30.0
+    half_open_max_calls: int = 1
+```
+
+`retry_server_errors=True` means every HTTP status at or above 500 is retryable. A non-429 4xx is
+never retried. `max_attempts` includes the first call and must be at least one. Delays and circuit
+values must be non-negative, the backoff factor must be at least one, and half-open calls and failure
+threshold must be positive.
+
+The HTTP stream attempt boundary is:
+
+```text
+circuit gate
+    |
+    v
+attempt: connect -> receive headers -> validate status -> parse first provider event
+    | failure before emitted StreamChunk
+    +---- retryable + attempts/time remain ----> deadline-clipped backoff -> next attempt
+    |
+    v
+emit first StreamChunk  ===== replay boundary closes permanently =====
+    |
+    v
+continue stream -> normal EOF | failure (record, never generic-retry)
+```
+
+**Exact semantics**
+
+- **Retryable setup failures.** Connection/timeouts, HTTP 429, and HTTP status 500 or above may retry
+  before any `StreamChunk` is yielded. Non-429 4xx, payload validation, authentication classification,
+  parser contract errors, cancellation, and circuit-open errors are not generic retry candidates
+  unless a provider adapter explicitly classifies them before output.
+- **First-output boundary.** The retry flag closes immediately before the first normalized chunk is
+  yielded from the endpoint. It never reopens, including if the first chunk is `system` or
+  `thinking` rather than text.
+- **Mid-stream failure.** Any transport or parser failure after that boundary records circuit
+  failure, marks the event `FAILED`, and raises `ProviderStreamError` or the more specific provider
+  error. No automatic replay occurs.
+- **Normal EOF.** EOF records circuit success even when the stream yielded no chunks. A
+  provider-declared error chunk is failure, not normal EOF.
+- **Circuit unit.** The circuit gates one logical request, not each internal retry. Exhausted setup
+  retries count as one circuit failure. A normal one-shot response or normal stream EOF counts as one
+  success. A rejected open-circuit request makes no transport attempt.
+- **Half-open stream.** A half-open permit remains in use until stream EOF or failure; receiving one
+  chunk does not close the circuit early.
+- **Deadline.** Before every attempt and sleep, remaining caller time is checked. Attempt transport
+  timeout is `min(endpoint_local_timeout, remaining)`. Backoff sleep is clipped to remaining time and
+  cannot start if no useful budget remains.
+- **Retry-After.** A valid HTTP `Retry-After` delay is a floor for the next 429/5xx retry. If that
+  delay cannot fit in remaining time, the last provider error is raised without sleeping past the
+  deadline. Invalid header values are ignored in favor of client backoff.
+- **Jitter.** Jitter randomizes only the computed client delay. An injected async sleep and monotonic
+  clock make the schedule testable without real waiting.
+- **Cancellation.** Cancellation during an attempt or delay propagates immediately after cleanup and
+  is never caught by retry classification.
+- **Caching.** Cache control remains a one-shot concern. A stream is never replayed from the generic
+  call cache.
+- **Provider resume.** A resumable adapter may define an application-level continuation after
+  failure, but that is a new explicit request using a confirmed cursor. It is not an automatic
+  retry hidden inside this policy.
+
+The target carries forward these defaults with clarified meaning:
+
+| Value | Target meaning | Reason |
+|-------|----------------|--------|
+| `max_attempts=3` | Three total transport attempts for one logical request. | Preserves the native `EndpointConfig.max_retries=3` attempt count; the exact number is inherited. Explicit `RetryConfig(max_retries=3)` callers require migration because that path currently permits four attempts. |
+| `base_delay=1s`, `max_delay=60s`, factor `2.0`, jitter `0.2` | Deadline-clipped exponential backoff with jitter. | Pattern choice avoids synchronized retries; exact values are inherited from `RetryConfig` (whose `jitter_factor` default is 0.2 — the native no-`RetryConfig` aiohttp path currently hardcodes 0.5), with no recorded tuning evidence. |
+| Circuit `5` failures, `30s` recovery, `1` half-open call | Logical-request circuit thresholds. | Inherited current defaults; no measured tuning rationale is recorded. |
+
+**Why this way.** A retry boundary is safe only before output becomes observable. Total attempts are
+easier to reason about than a field whose meaning changes by path. The circuit measures logical
+dependency health rather than magnifying one caller's retry sequence into several failures. Deadline
+checks before attempts and sleeps prevent resilience policy from violating the caller's budget.
+
+### D5 — Conformance proves resource and terminal-state invariants
+
+The controller exposes a redacted inspection snapshot:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AdmissionSnapshot:
+    queued: int
+    active: int
+    available_requests: int | None
+    available_tokens: int | None
+    queue_capacity: int
+    concurrency_limit: int | None
+    closed: bool
+```
+
+No request payload, header, API key, prompt, or provider response appears in this snapshot. Retry and
+circuit telemetry records call id, provider, endpoint, attempt number, phase, delay, remaining
+budget, terminal status, and exception class; it does not log secret-bearing payloads.
+
+The conformance suite is normative:
+
+| Case | Required assertions |
+|------|---------------------|
+| Refresh interval longer than budget | Call becomes `ABORTED`; deadline error escapes; queue and active counts return to zero; provider count is zero. |
+| Physically full queue | Next producer waits; on slot release it proceeds FIFO; on cancellation it leaves no queue item. |
+| Request and token conflict | Neither counter is debited when either check fails. |
+| Token estimate unavailable | Typed admission error; no provider/hook call. |
+| Token request larger than window | Immediate typed error; no refresh wait. |
+| Rate-limited stream | No pre-hook or provider work before rate admission. |
+| Cancelled queued call | `CANCELLED`; provisional units restored; no active task. |
+| Cancelled active one-shot | Provider scope cancelled and awaited; `CANCELLED`; semaphore released. |
+| Cancelled or closed active stream | Generator closed; transport/process cleanup awaited; `CANCELLED`; no later chunks. |
+| Pre-first-chunk retryable failure | Retry count and delays match policy and remaining deadline. |
+| Permanent 4xx | One attempt; `FAILED`; no retry delay. |
+| Mid-stream transport failure | Prior chunks appear once; `FAILED`; typed error; provider count remains one logical request with no replay. |
+| Provider error chunk | Exactly one normalized error chunk with `is_error=True`; then typed failure, no result chunk. |
+| Normal empty EOF | `COMPLETED`; circuit success; lease released. |
+| Circuit open | No provider attempt; typed open error; lease cleanup complete. |
+| Controller close | Queued/active work becomes `ABORTED`; close waits for cleanup and is idempotent. |
+
+Every test asserts the event is terminal before it disappears from active executor ownership. The
+suite also checks task enumeration or adapter-specific probes so "counts returned to zero" cannot
+hide a detached background task.
+
+**Why this way.** Async lifecycle bugs often pass return-value tests while leaking a task, queue
+item, semaphore permit, socket, or process. The snapshot and conformance matrix make cleanup and
+terminal state first-class outputs. Injected clock and sleep collaborators keep deadline/retry tests
+deterministic.
 
 ## Consequences
 
-Quotas and overload behavior apply consistently to one-shot and streaming calls. A caller deadline
-has one meaning across queueing, retries, and transport, and cancellation cannot detach work that the
-executor later runs. Stream retry behavior becomes safe to reason about because no generic replay
-occurs after observable output.
+- Quotas and overload behavior apply equally to one-shot and streaming calls. A full waiting queue
+  becomes caller-visible backpressure instead of unbounded memory growth.
+- One caller deadline has one meaning across admission, hooks, retries, transport, and stream
+  consumption. Nested layers cannot silently reset it.
+- A call remains owned until it is terminal and cleanup has completed. Detached pending work and
+  post-timeout provider calls are contract violations detectable by conformance tests.
+- Long streams hold concurrency for their lifetime. This can reduce throughput, but it represents
+  actual scarce provider work rather than undercounting it.
+- FIFO can cause head-of-line blocking when a large token request waits for refresh. Replacing FIFO
+  with size-aware scheduling would require a fairness ADR and starvation proof.
+- Zero and negative quota values become invalid rather than ambiguous. Existing configurations that
+  used them must switch to `None` for unlimited.
+- Explicit retry config semantics change from "retries after first" to total attempts through the
+  internal policy. Compatibility adaptation and release notes are required.
+- Stream setup gains safe retries; mid-stream failures become more visible because they raise typed
+  errors instead of looking like normal EOF. Consumers that inferred failure only from content must
+  migrate.
+- Reversing D1/D2 is high cost once operations rely on one lease and deadline. Tuning numeric
+  defaults is low cost if semantics remain fixed. Adding durable admission is a separate large
+  design because restart and acknowledgement contracts would change.
 
-Long-lived streams hold concurrency for their lifetime, which is the honest accounting model but
-may reduce throughput. Bounded queues and deadlines can reject work that the current implementation
-waits on indefinitely or returns while pending. Typed failure propagation may expose failures that
-were previously visible only through event state, so the migration requires release notes and
-compatibility tests.
+## Alternatives considered
+
+### Keep separate `invoke()` and `stream()` schedulers
+
+This minimizes code movement and lets streams remain low-latency by taking only the semaphore. It
+lost because request and token limits would remain method-dependent, queue ownership would still
+diverge, and a provider call could bypass policy merely by asking for streaming output.
+
+### Treat the current `queue_capacity` as sufficient overload control
+
+This preserves `Processor` unchanged. It lost because the actual `asyncio.Queue` is unbounded and
+`queue_capacity` is a cycle/permission value, not a memory bound. A name cannot provide
+backpressure; the queue primitive must be bounded.
+
+### Fixed per-stage relative timeouts
+
+Admission, hooks, retries, and transport could each keep a local duration. This is easy to configure
+and reason about in isolation. It lost because durations add: each stage can consume its full limit
+after earlier stages already spent the caller's budget. One absolute monotonic deadline composes
+without budget inflation.
+
+### Keep the ten-second `invoke()` safety wait
+
+The fixed wait prevents a caller from waiting forever and is already deployed. It lost because it is
+independent of provider refresh and transport budgets and returns a non-terminal event after removing
+ownership. A caller deadline plus supervised cleanup provides an actual bound.
+
+### Drop when the queue is full
+
+Immediate rejection protects memory and avoids waiting. It lost as the default because current
+callers expect work to wait for provider capacity. Bounded producer backpressure preserves that
+behavior while respecting cancellation/deadline. A future explicit fail-fast admission mode can be
+added without changing the default.
+
+### Refund quota after every provider failure
+
+Refunding would maximize successful work per fixed window. It lost because a failed provider attempt
+still consumed dependency capacity and automatic refund can amplify an outage. Only reservations
+cancelled before the lease begins are restored.
+
+### Retry an entire stream after output begins
+
+This could hide transient disconnects and improve completion rates. It lost because replay can
+duplicate text, tool requests, or side effects, and generic streams expose no cursor or idempotency
+proof. Only an explicit provider continuation request may resume.
+
+### Mark circuit success on the first chunk
+
+This would release half-open probes early and improve circuit throughput for long streams. It lost
+because a dependency that disconnects after one chunk is not healthy for the promised stream. Normal
+EOF is the success boundary; mid-stream transport failure is circuit failure.
+
+### Persist every deferred request
+
+A durable queue would survive restart and allow later replay. It lost because persistence introduces
+serialization, acknowledgement, duplicate suppression, credential lifetime, and recovery semantics
+far beyond an in-process model client. This ADR intentionally aborts queued work on shutdown.
+
+### Use wall-clock timestamps for deadlines
+
+UTC deadlines are easy to log and pass across processes. They lost inside this process because clock
+adjustments can make remaining time jump. The caller may translate an external timestamp once, but
+all service budget arithmetic uses monotonic time.
 
 ## Notes
 
-Keeping separate stream and invoke schedulers was rejected because it makes quota configuration
-method-dependent. Retrying an entire stream after output begins was rejected because it can duplicate
-text, tool requests, or side effects. A fixed caller wait independent of the rate window was rejected
-because it permits detached pending work. Persisting every deferred request was not selected; this is
-an in-process service admission contract, not a durable job queue.
+This is a target-state ADR. The current source constraints are
+`lionagi/service/{imodel,rate_limited_processor,resilience}.py`,
+`lionagi/service/connections/{endpoint,api_calling,agentic_endpoint}.py`,
+`lionagi/protocols/generic/{processor,event}.py`, and `lionagi/operations/run/run.py`. The design
+retains the existing event vocabulary and service hook boundary while replacing split scheduling
+and unpropagated timeouts. The composed architecture domains reinforced four choices already forced
+by source evidence: a physical queue bound, one absolute deadline, immediate cancellation
+propagation, and a replay boundary at first observable output.

--- a/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
+++ b/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
@@ -1,0 +1,136 @@
+# ADR-0029: Unified request admission, deadline, and resilience policy
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: service-providers
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0027
+
+## Context
+
+Non-streaming `iModel.invoke()` appends an `APICalling`, forwards it to
+`RateLimitedAPIProcessor`, and waits for a terminal event. The processor atomically checks request
+and estimated-token capacity, defers denied work until replenishment, and uses a semaphore for
+concurrency. The caller wait is nevertheless fixed at ten seconds: it then removes and returns the
+event even if a longer refresh interval left it queued and pending (`lionagi/service/imodel.py`,
+`lionagi/service/rate_limited_processor.py`).
+
+`iModel.stream()` follows a different path. It appends the event and uses the processor semaphore,
+but calls `APICalling.stream()` directly instead of forwarding it through permission checks. A
+configured request or token limit therefore does not gate a stream before provider work starts.
+Generator cleanup removes the event from the executor, but there is no shared deadline contract for
+queued work, an active provider stream, and caller cancellation.
+
+Resilience also differs by path. `Endpoint.call()` composes circuit breaking with configured retry
+and otherwise supplies a native HTTP retry policy. `Endpoint.stream()` invokes the HTTP stream
+transport directly, so connection establishment and response-header failures do not use the same
+policy. Retrying after a chunk has reached the caller would be unsafe because most provider streams
+do not expose a replay cursor (`lionagi/service/connections/endpoint.py`,
+`lionagi/service/resilience.py`).
+
+`Event` already provides pending, processing, completed, failed, skipped, cancelled, and aborted
+states plus a completion signal. The missing contract is ownership: who admits the work, how long a
+caller is willing to wait, which scope holds scarce capacity, and who terminalizes or cancels the
+event when that scope ends (`lionagi/protocols/generic/event.py`).
+
+The CLI run operation already converts its relative timeout to a monotonic deadline, bounds each
+stream read by the remaining time, and explicitly closes the generator. That protects one operation
+caller but does not cover admission or define the service-wide contract. The service budget must
+accept that existing deadline rather than stack a fresh timeout around it
+(`lionagi/operations/run/run.py`).
+
+## Decision
+
+Introduce one internal admission operation used by both `invoke()` and `stream()`. It returns an
+async lease only after queue capacity, request budget, estimated-token budget, and concurrency
+capacity have been acquired. The lease begins before hooks or provider work and ends only after the
+event reaches a terminal state or cancellation cleanup completes.
+
+```python
+@dataclass(frozen=True, slots=True)
+class RequestBudget:
+    deadline: float | None  # absolute event-loop monotonic time
+
+class AdmissionController(Protocol):
+    async def acquire(
+        self,
+        call: APICalling,
+        *,
+        budget: RequestBudget,
+    ) -> AdmissionLease: ...
+```
+
+The lifecycle is the same for both result shapes:
+
+```text
+create APICalling
+       │
+       v
+bounded enqueue ──> rate + token admission ──> concurrency lease
+       │                         │                      │
+       │                         │                      v
+       │                         │                pre-call hooks
+       │                         │                      │
+       │                         │             endpoint call / stream
+       │                         │                      │
+       │                         │                post-call hooks
+       │                         │                      │
+       └──── deadline/cancel ────┴────────────> terminalize + release
+```
+
+The load-bearing invariants are:
+
+- Queueing is bounded and happens before expensive provider work. Request and estimated-token units
+  are checked and debited atomically. Concurrency is a lease over active hook and provider work, not
+  merely a semaphore used by one public method. A full queue applies producer backpressure until
+  capacity is available, the request deadline expires, or the caller cancels.
+- A stream is fully admitted before its pre-invocation hook runs or its endpoint starts. No chunk may
+  be produced by work that bypassed configured request, token, or concurrency policy.
+- One optional absolute deadline, measured on the event loop's monotonic clock, covers queue wait,
+  admission wait, all retry delays, provider transport, and stream consumption. Nested stages derive
+  remaining time; they do not reset a relative timeout.
+- Caller cancellation removes queued work or cancels active work, closes an active stream, and
+  re-raises cancellation after cleanup. Deadline expiry at any phase cancels underlying work, sets
+  the event to `ABORTED`, and raises `RequestDeadlineExceeded`; caller cancellation sets
+  `CANCELLED`; transport or provider failure sets `FAILED`. An `APICalling` is never removed from
+  executor ownership while pending or processing.
+- `invoke()` returns only a terminal `APICalling`. Stream setup and transport failures terminalize
+  the same event and surface as typed exceptions rather than normal end-of-stream; normal EOF marks
+  completion.
+- Retry and circuit policy cover HTTP stream establishment through receipt of valid response
+  headers and the first provider event. Automatic retry is allowed only before a user-visible chunk
+  is emitted and only within the remaining deadline and retry budget. A mid-stream failure is
+  recorded and raised as `ProviderStreamError` without generic replay. The circuit gates stream
+  start, records normal EOF as success, and records any transport failure even when replay is
+  prohibited. Provider-specific resumability requires a separate explicit adapter policy.
+- Service hooks remain observation and policy points around the admitted call. This ADR does not
+  consolidate hook systems or introduce another event bus (see the hooks ADR on call-boundary
+  hooks).
+
+An operation that already computed a monotonic deadline passes that absolute value into
+`RequestBudget`; the service never starts a second full-duration timeout. Conformance tests use a
+refresh interval longer than the caller budget, a full queue, a rate-limited stream, a cancelled
+queued call, a cancelled active stream, pre-first-chunk transport failure, mid-stream failure, and
+circuit-open behavior. They assert terminal state, provider call count, queue removal, lease release,
+and absence of background work after the caller scope exits.
+
+## Consequences
+
+Quotas and overload behavior apply consistently to one-shot and streaming calls. A caller deadline
+has one meaning across queueing, retries, and transport, and cancellation cannot detach work that the
+executor later runs. Stream retry behavior becomes safe to reason about because no generic replay
+occurs after observable output.
+
+Long-lived streams hold concurrency for their lifetime, which is the honest accounting model but
+may reduce throughput. Bounded queues and deadlines can reject work that the current implementation
+waits on indefinitely or returns while pending. Typed failure propagation may expose failures that
+were previously visible only through event state, so the migration requires release notes and
+compatibility tests.
+
+## Notes
+
+Keeping separate stream and invoke schedulers was rejected because it makes quota configuration
+method-dependent. Retrying an entire stream after output begins was rejected because it can duplicate
+text, tool requests, or side effects. A fixed caller wait independent of the rate window was rejected
+because it permits detached pending work. Persisting every deferred request was not selected; this is
+an in-process service admission contract, not a durable job queue.

--- a/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
+++ b/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
@@ -8,97 +8,753 @@
 
 ## Context
 
-`AgenticEndpoint` represents providers whose work is not a normal HTTP request. Codex, Claude Code,
-Pi, and Gemini adapters launch command-line processes; AG2 adapters run in-process or connect to a
-remote agent. They share `APICalling`, `StreamChunk`, and resumable session state with API endpoints,
-which lets operations consume them through `iModel` without vendor selection logic
-(`lionagi/service/connections/agentic_endpoint.py`, `lionagi/service/types/`).
+`AgenticEndpoint` represents providers whose work is not a normal LionAGI HTTP request. Codex,
+Claude Code, Gemini, and Pi launch local command-line processes; AG2 adapters run agents in process
+or call a remote agent. They already share `APICalling`, `StreamChunk`, provider-session storage,
+and the `iModel` lifecycle with API endpoints. That common boundary lets operations consume them
+without selecting a vendor (`lionagi/service/connections/agentic_endpoint.py`;
+`AgenticEndpoint`, and `lionagi/service/imodel.py`; `iModel`).
 
-The subprocess adapters already share meaningful mechanics. `lionagi/providers/_cli_subprocess.py`
-owns NDJSON framing, bounded stderr capture, process-group isolation and termination, workspace
-validation, prompt extraction, and declarative flag emission.
-`lionagi/providers/_agentic_handlers.py` validates callbacks and constructs typed requests. Vendor
-modules correctly retain their own flag grammars, safety settings, event parsers, UX callbacks, and
-session synthesis.
+The implementation has also converged on reusable mechanics. The four subprocess adapters call the
+same NDJSON reader, bounded stderr drain, and process-group terminator. Three use the shared
+declarative flag builder; Codex, Claude Code, and Gemini use the shared workspace resolver while Pi
+uses the same containment library for its file-bearing fields. Codex, Claude Code, Gemini, and Pi
+all use the same callback-validation mixin.
+The provider modules still correctly own their request models, command grammar, safety flags, event
+parsers, defaults, and presentation callbacks (`lionagi/providers/_cli_subprocess.py`;
+`ndjson_from_cli`, `lionagi/providers/_agentic_handlers.py`; `AgenticHandlersMixin`).
 
-The common result contract is less explicit than the common machinery. Each adapter decides how to
-map provider events, end-of-stream, errors, final sessions, and resume identifiers. Some streams
-convert a final session to a result chunk while others suppress it; provider error chunks do not
-uniformly set `is_error`; and the `is_cli` flag is also true for non-CLI agentic adapters because
-operations use it as the general streaming-path selector.
+Six concrete problems remain.
 
-These differences are not a reason to centralize vendor parsers. They are a reason to name the
-boundary, distinguish transport capability from operation routing, and test the normalized contract
-that every adapter promises.
+**P1 — `is_cli` names two different facts.** `AgenticEndpoint.is_cli` is `True`, so it is inherited
+by subprocess, in-process, remote, and scripted endpoints. `iModel`, `Branch`, and the run operation
+read it as “use the agentic streaming path,” not “launches a CLI.” Code that needs actual process
+behavior cannot use the same flag honestly (`lionagi/service/imodel.py`; `iModel.is_cli`,
+`lionagi/session/branch.py`; `Branch.clone`, and `lionagi/operations/run/run.py`; `run`).
+
+**P2 — The public stream contract ends at different layers.** The low-level Codex, Claude Code,
+Gemini, and Pi parsers yield an internal session accumulator after their chunks. Endpoint wrappers
+then suppress it, translate it into a result chunk, or use it to synthesize an error. Codex and
+Claude Code normally expose no terminal result chunk; Gemini does; Pi exposes the accumulated final
+text again as a result, even after text chunks. AG2 adapters synthesize their own result chunks.
+Consumers therefore cannot assign one meaning to normal EOF or a result chunk
+(`lionagi/service/types/cli_session.py`; `CLISession`, and the adapter `stream()` methods under
+`lionagi/providers/`).
+
+**P3 — Provider-declared failure is not normalized.** Gemini emits an error chunk with both
+`type="error"` and `is_error=True`. Codex can emit the same chunk type with `is_error=False`,
+including its endpoint-level fallback. Claude Code can finish with `CLISession.is_error=True` but
+the endpoint suppresses the session without emitting an error chunk. Pi parser errors can be
+represented only on an internal `PiChunk` that the endpoint does not map to an error chunk.
+Operations currently infer failure from `type="error"`; other consumers may inspect `is_error`.
+Both fields must agree (`lionagi/providers/openai/codex.py`,
+`lionagi/providers/anthropic/claude_code.py`, `lionagi/providers/google/gemini_code.py`, and
+`lionagi/providers/pi/cli.py`).
+
+**P4 — Session observation is mistaken for resumability.** `iModel` injects its stored agentic
+session as `resume` for every `AgenticEndpoint`. Claude Code and Gemini have typed `resume` fields;
+Pi has no resume field and defaults to `no_session=True`; Codex emits a thread id but its current
+`CodexCodeRequest` has no resume field. The shared layer needs a declared capability before it can
+safely inject a provider identifier (`lionagi/service/imodel.py`; `iModel.create_api_calling`, and
+the provider request models).
+
+**P5 — Subprocess safety is shared but not stated as an adapter contract.** The helper already uses
+argument-vector process creation, `start_new_session=True`, a 256 KiB stderr capture, concurrent
+stderr drainage, a five-second process-group termination grace, and workspace containment. Those
+properties are load-bearing: changing one adapter back to shell-string execution or failing to
+close its generator can reintroduce injection, deadlock, or orphan-process failures
+(`lionagi/providers/_cli_subprocess.py`; `ndjson_from_cli`, and `lionagi/ln/_proc.py`;
+`aterminate_process_group`).
+
+**P6 — Transport cleanup cannot be made identical.** Subprocess adapters terminate and reap a
+process group. The AG2 beta adapter owns an `asyncio.Task` and stream subscriptions. Group chat owns
+an in-process async iterator. NLIP owns an HTTP client and SSRF validation. A useful common boundary
+must normalize observable results without pretending these resource mechanics are interchangeable.
+
+The current and target boundary is:
+
+```text
+Branch / operations
+        |
+        v
+      iModel ---------------------> admission + deadline supervisor (ADR-0029)
+        |
+        v
+  AgenticEndpoint ----------------> APICalling ----------------> StreamChunk
+        |
+        +-- subprocess support ---- argv + NDJSON + process-group teardown
+        +-- in-process support ---- task / iterator cancellation
+        +-- remote support -------- SSRF-safe client lifetime
+        |
+        +-- vendor adapter -------- typed request + flags/events/defaults
+```
+
+| Concern | Decision |
+|---------|----------|
+| Capability and routing identity | D1: every adapter declares immutable transport/output capabilities; `is_agentic` becomes the operation-routing fact. |
+| Request construction | D2: provider request models are validated before transport and runtime handlers are separated from serializable provider data. |
+| Output, error, and session contract | D3: endpoints yield only normalized `StreamChunk` values and return one typed result mapping for supported one-shot calls. |
+| Subprocess mechanics | D4: a shared support module owns argv execution, NDJSON framing, bounded stderr, workspace validation, and deterministic group teardown. |
+| Non-subprocess lifecycle | D5: in-process and remote adapters implement the same observable contract while retaining transport-specific cancellation and safety. |
+| Verification | D6: one capability-driven conformance suite runs against every agentic adapter, with additional process tests for subprocess transports. |
+
+This ADR deliberately does **not** decide:
+
+- Provider-specific request fields, model names, flags, permission modes, event grammars, or UX
+  callbacks. They remain vendor-owned because the upstream interfaces change independently.
+- Admission ordering, total request deadlines, event terminalization, or retry after stream setup.
+  ADR-0029 owns the supervisor and the no-replay-after-first-output boundary.
+- Provider catalog keys, aliases, bootstrap, or availability diagnostics. ADR-0028 owns selection.
+- A universal agent protocol or remote-agent wire format. NLIP remains one adapter, not the generic
+  shape every in-process or subprocess provider must implement.
+- Durable provider sessions. This ADR moves confirmed identifiers between requests in one façade;
+  persistence and cross-process recovery require a separate state contract.
+- Whether thinking content is shown to end users. The boundary transports normalized thinking
+  chunks; presentation belongs to the consuming operation.
 
 ## Decision
 
-Retain `AgenticEndpoint` as the implemented extension boundary and establish an internal
-`lionagi/providers/_agentic/` support lane. Move the existing generic subprocess and handler helpers
-into that lane with compatibility re-exports. Vendor request models, command grammars, event parsers,
-and provider-specific safety policy remain under their vendor packages.
+### D1 — Declare agentic capabilities and route operations by `is_agentic`
 
-Every `AgenticEndpoint` declares immutable capabilities:
+`AgenticEndpoint` remains the extension boundary. It gains an immutable class-level capability
+record and a precise operation-routing marker:
 
 ```python
+from dataclasses import dataclass
+from typing import ClassVar, Literal
+
+AgenticTransport = Literal["subprocess", "in_process", "remote"]
+
 @dataclass(frozen=True, slots=True)
 class AgenticCapabilities:
-    transport: Literal["subprocess", "in_process", "remote"]
+    transport: AgenticTransport
     resumable: bool
     emits_tool_events: bool
     reports_usage: bool
+
+class Endpoint:
+    is_agentic: ClassVar[bool] = False
+
+class AgenticEndpoint(Endpoint):
+    is_agentic: ClassVar[bool] = True
+    capabilities: ClassVar[AgenticCapabilities]
+    resume_field: ClassVar[str | None] = None
+
+    # Deprecated compatibility spelling for “uses the agentic stream path”.
+    # New code must use is_agentic or capabilities.transport.
+    is_cli: ClassVar[bool] = True
 ```
 
-The adapter conformance contract is:
+`AgenticCapabilities` and `AgenticTransport` live in
+`lionagi/providers/_agentic/capabilities.py` and are re-exported from the provider support package.
+`AgenticEndpoint` remains in `lionagi/service/connections/agentic_endpoint.py`; the generic service
+layer knows the vocabulary but not the vendor inventory.
 
-- `create_payload()` constructs the provider's typed request and separates runtime handlers from
-  serializable provider data. Unknown handler names and invalid request fields fail before transport
-  starts.
-- `stream()` yields only provider-neutral `StreamChunk` values. Text, reasoning, tool use, tool
-  result, final result, and error use the closed chunk vocabulary; a provider-declared error sets
-  both `type="error"` and `is_error=True`.
-- A resumable adapter publishes the provider session identifier in a system chunk as soon as it is
-  known and in the non-streaming result mapping. `iModel` owns the stored identifier and injects it
-  on the next request through the provider's typed resume field. Non-resumable adapters do not
-  synthesize an identifier.
-- Text is carried only by text chunks. A successful stream emits at most one result chunk after
-  content, containing terminal metadata and any non-duplicated final result; an internal
-  `CLISession` is not exposed as a chunk. Normal EOF is not an error. Transport or parser failure
-  raises a provider-classified exception; cancellation propagates after resource cleanup. ADR-0029
-  owns admission, terminal event state, and whether an HTTP stream may retry before its first chunk.
-- Subprocess adapters use argument-vector process creation, validate the working directory before
-  launch, isolate the process group, drain bounded stderr concurrently, and terminate and reap the
-  group on normal close, failure, timeout, or cancellation. Shell-string execution is not part of
-  the common lane.
-- Shared code is admitted only when at least two adapters use the same semantics. Provider event
-  interpretation, model defaults, flags, permission modes, and fallback grammar stay vendor-owned.
+The initial capability inventory is fixed as follows. “One-shot” records whether `_call()` returns
+a result mapping; it is method behavior rather than a fifth capability flag because all agentic
+operation routing uses `stream()`.
 
-Add `is_agentic` as the canonical operation-routing capability. Preserve `is_cli` as a deprecated
-compatibility alias during migration; `transport="subprocess"` is the precise test for CLI-specific
-behavior. This naming change must not alter which endpoints use the streaming operation path.
+| Endpoint | Transport | Resumable | Tool events | Usage | One-shot |
+|----------|-----------|-----------|-------------|-------|----------|
+| `CodexCLIEndpoint` | subprocess | no | yes | yes | yes |
+| `ClaudeCodeCLIEndpoint` | subprocess | yes, through request field `resume` | yes | yes | yes |
+| `GeminiCLIEndpoint` | subprocess | yes, through request field `resume` | no | yes | yes |
+| `PiCLIEndpoint` | subprocess | no | yes | yes | yes |
+| `AG2BetaEndpoint` | in_process | no | yes | yes | stream-only |
+| `AG2GroupChatEndpoint` | in_process | no | yes | no | stream-only |
+| `AG2NlipEndpoint` | remote | no | no | no | stream-only |
+| `ScriptedEndpoint` | in_process | no | yes | no | yes |
 
-One conformance suite runs against every agentic adapter. All adapters cover request construction,
-normalized chunk order, declared capability behavior, provider error classification, cancellation,
-and session identifiers. Subprocess adapters additionally cover workspace containment, argument
-emission, stderr saturation, process-group teardown, and missing executable behavior. Vendor parser
-fixtures remain beside their adapters.
+Codex is intentionally `resumable=False` in this contract. Its parser observes a `thread_id`, but
+the shipped `CodexCodeRequest` has no typed resume input and filters unknown fields before model
+construction. Observation alone is not a usable resume contract. A provider-local change may set
+the capability to `True` only when it adds a typed field, command mapping, and round-trip test.
+Pi is non-resumable because its request has no resume field and defaults `no_session=True`.
+
+**Exact semantics**
+
+- **Operation selection.** `iModel`, `Branch`, and run/communicate routing read `is_agentic`.
+  Transport-specific code reads `capabilities.transport`. No new code branches on `is_cli`.
+- **Compatibility.** `is_cli` continues to return `True` for every agentic endpoint during the
+  deprecation window, so in-process and remote adapters do not change operation path while call
+  sites migrate. It is then removed under the repository deprecation policy; it is never redefined
+  as the precise subprocess test.
+- **Missing capabilities.** Registering an `AgenticEndpoint` subclass without an
+  `AgenticCapabilities` instance is a catalog validation error under ADR-0028. Lookup never returns
+  a partially declared adapter.
+- **False capability.** An adapter may omit an optional output only when the corresponding field is
+  `False`. It must not synthesize tool or usage events merely to satisfy a common shape.
+- **True capability.** Fixtures must exercise the declared behavior. A `reports_usage=True` adapter
+  places provider-reported usage on its terminal result metadata; an `emits_tool_events=True`
+  adapter maps at least one provider fixture to tool-use and tool-result chunks.
+- **Copy and restart.** Capabilities are immutable class data. Copying an endpoint does not copy
+  active transport resources. Process restart reconstructs the same declaration through catalog
+  import.
+- **Unsupported one-shot.** Calling `invoke()` on a stream-only endpoint raises
+  `AgenticOperationUnsupported(operation="invoke")` before starting a task, process, or connection.
+
+**Why this way.** The present inheritance seam is already the correct extension point; the missing
+piece is an honest vocabulary. A transport enum prevents an in-process agent from masquerading as a
+CLI while `is_agentic` preserves the behavior operations actually need. The matrix is conservative:
+capabilities describe normalized output that an adapter can prove, not everything its upstream
+provider might support in another client.
+
+### D2 — Validate typed requests and separate runtime arguments before transport
+
+Every adapter names one Pydantic request type and the runtime-only keys it accepts. The generic
+payload envelope stays compatible with `APICalling`:
+
+```python
+from collections.abc import AsyncIterator, Callable
+from typing import Any, ClassVar, TypedDict
+
+class AgenticPayload(TypedDict):
+    request: BaseModel
+
+class AgenticEndpoint(Endpoint):
+    request_type: ClassVar[type[BaseModel]]
+    runtime_arg_keys: ClassVar[frozenset[str]] = frozenset()
+
+    def create_payload(
+        self,
+        request: dict[str, Any] | BaseModel,
+        extra_headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> tuple[AgenticPayload, dict[str, str]]: ...
+
+    async def stream(
+        self,
+        request: dict[str, Any] | AgenticPayload,
+        extra_headers: dict[str, str] | None = None,
+        **runtime_args: Any,
+    ) -> AsyncIterator[StreamChunk]: ...
+```
+
+The agentic envelope contains exactly `{"request": <validated provider model>}` and an empty
+generic-header mapping. Remote adapters may build transport headers internally from their typed
+configuration; secrets do not become payload fields.
+
+`AgenticHandlersMixin` moves to `lionagi/providers/_agentic/handlers.py` with its existing runtime
+surface preserved:
+
+```python
+class AgenticHandlersMixin:
+    _handler_params: ClassVar[tuple[str, ...]]
+    _handler_kwarg: ClassVar[str]
+    request_type: ClassVar[type[BaseModel]]
+
+    def update_handlers(self, **kwargs: Callable | None) -> None: ...
+    def copy_runtime_state_to(self, other: Endpoint) -> None: ...
+    def _runtime_handlers(self, kwargs: dict[str, Any]) -> dict[str, Callable]: ...
+```
+
+The compatibility names `transport_arg_keys`, `_request_model`,
+`lionagi.providers._agentic_handlers`, and the vendor-specific handler properties remain re-exports
+or aliases during migration. Their values are derived from `runtime_arg_keys` and `request_type`;
+they are not second authorities.
+
+**Exact semantics**
+
+- **Classification order.** `iModel.create_api_calling()` removes declared runtime keys from the
+  request mapping first and stores them in `APICalling.call_kwargs`. Remaining keys are provider
+  request candidates. No callable is present in `APICalling.payload` or serialization.
+- **Request model.** A dict is validated by `request_type`. A supplied `BaseModel` must already be an
+  instance of `request_type` or is revalidated from its `model_dump`; it is never passed to another
+  provider unchanged.
+- **Unknown request field.** Any key left after runtime classification that is not accepted by the
+  provider request model raises `AgenticRequestValidationError` before a subprocess, task, or HTTP
+  client is created. The shared layer does not silently filter it.
+- **Unknown handler.** A runtime handler name outside `runtime_arg_keys` raises
+  `AgenticHandlerError`. A handler value must be callable or `None`; `None` explicitly disables a
+  configured handler for that call.
+- **Precedence.** Per-call handlers override endpoint-configured handlers. Missing per-call keys use
+  the configured value. Handler mappings are copied on endpoint copy; callable objects themselves
+  are shared deliberately.
+- **Prompt construction.** Provider request models own messages-to-prompt conversion, system prompt
+  placement, resume grammar, and empty-prompt rejection. The generic layer only guarantees that
+  validation completes before transport.
+- **Mutable values.** Request models and runtime mappings are new per call. An endpoint does not
+  retain a caller-owned mutable request dict.
+- **Error path.** Validation and handler errors are not provider failures, are not retried, and
+  produce no stream chunks. ADR-0029 terminalizes the owning `APICalling` if it was already
+  appended.
+- **Headers.** `extra_headers` is rejected for subprocess and in-process adapters unless a concrete
+  adapter documents a safe mapping. It is not forwarded into a command environment or model data.
+
+**Why this way.** The current `{"request": BaseModel}` envelope is already the narrow seam used by
+all agentic providers. Making classification explicit closes the silent-drop and callable-leak
+paths without inventing another provider protocol. Request meaning remains beside vendor models;
+the shared code decides only when input is valid enough to start work.
+
+### D3 — Normalize chunks, terminal results, errors, and resumable sessions
+
+The public stream item remains the existing dataclass
+(`lionagi/service/types/stream_chunk.py`; `StreamChunk`):
+
+```python
+ChunkType = Literal[
+    "system", "thinking", "text", "tool_use",
+    "tool_result", "result", "error",
+]
+
+@dataclass(slots=True)
+class StreamChunk:
+    type: ChunkType
+    content: str | None = None
+    tool_name: str | None = None
+    tool_id: str | None = None
+    tool_input: dict[str, Any] | None = None
+    tool_output: Any | None = None
+    is_error: bool = False
+    is_delta: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+Supported one-shot adapters return one stable mapping. All keys are present; unavailable values use
+`None` or an empty mapping rather than disappearing:
+
+```python
+class AgenticCallResult(TypedDict):
+    result: str
+    session_id: str | None
+    model: str | None
+    usage: dict[str, Any]
+    metadata: dict[str, Any]
+
+class AgenticResultMetadata(TypedDict, total=False):
+    session_id: str
+    model: str
+    usage: dict[str, Any]
+    total_cost_usd: float
+    num_turns: int
+    duration_ms: int
+    duration_api_ms: int
+```
+
+Provider parsers may retain an internal accumulator with the shipped `CLISession` fields—session
+id, model, chronological chunks, thinking/messages/tool views, result, usage, cost, turns,
+durations, error flag, and summary—but neither `CLISession`, `PiChunk`, raw provider event dicts,
+nor AG2 event objects are yielded by `AgenticEndpoint.stream()`.
+
+The common error hierarchy extends the shipped `ProviderError` family in
+`lionagi/providers/_agentic/errors.py`:
+
+```python
+class ProviderError(RuntimeError):
+    stderr_tail: str
+    raw: str
+
+class ProviderQuotaError(ProviderError): ...
+class ProviderAuthError(ProviderError): ...
+class ProviderContextError(ProviderError): ...
+class ProviderTransportError(ProviderError): ...
+class ProviderExecutableNotFound(ProviderTransportError): ...
+
+class ProviderProcessError(ProviderTransportError):
+    returncode: int
+
+class ProviderProtocolError(ProviderError): ...
+class ProviderStreamError(ProviderError): ...
+class AgenticRequestValidationError(ValueError): ...
+class AgenticHandlerError(ValueError): ...
+class AgenticOperationUnsupported(RuntimeError): ...
+```
+
+Compatibility imports from `lionagi.providers._provider_errors` continue to resolve to these
+classes. `classify_provider_error()` retains its quota, authentication, and context classifiers and
+falls back to `ProviderError`.
+
+**Exact stream semantics**
+
+- **System.** A system chunk carries provider/session/model/capability metadata. It does not carry
+  assistant text. Multiple vendor system events may be projected when their metadata changes.
+- **Thinking.** Reasoning trace appears only in thinking chunks. Missing reasoning is represented by
+  no chunk, not an empty synthetic chunk.
+- **Text.** User-visible assistant text appears only in text chunks. `is_delta=True` means content
+  must be concatenated in order; `False` means the chunk is a complete text unit.
+- **Tool use.** A tool-use chunk carries the provider id when one exists, the provider tool name,
+  and parsed input. An adapter must not invent an id. Tool results preserve the matching id and set
+  `is_error=True` only when that tool execution failed; a failed tool result is not automatically a
+  failed provider stream.
+- **Result.** A successful stream emits at most one result chunk, after all content chunks. Its
+  `content` contains only terminal text not already emitted as text; otherwise it is `None`.
+  `metadata` contains the fields from `AgenticResultMetadata` that the provider actually reported.
+  A result chunk is permitted but not required for normal EOF.
+- **Normal empty EOF.** A provider that produces no semantic output and raises no error completes
+  normally. The adapter does not invent text, a result, or an error merely to make the stream
+  non-empty.
+- **Provider-declared error.** The adapter yields exactly one
+  `StreamChunk(type="error", is_error=True, content=<safe message>)`, records the provider class in
+  metadata when known, and yields nothing afterward. ADR-0029's supervisor marks the event failed
+  and raises `ProviderStreamError` after the observable error-chunk boundary.
+- **Transport or parser error.** A failure that has no provider error event raises the most specific
+  `ProviderTransportError` or `ProviderProtocolError`; it does not synthesize normal EOF. The
+  supervisor owns terminal event state and propagation.
+- **Unknown vendor event.** A provider parser may ignore an explicitly allowlisted telemetry-only
+  event. Any other unknown event that can contain text, tool activity, result, or error raises
+  `ProviderProtocolError`; it is not projected as a raw system chunk.
+- **Cancellation.** Cancellation yields no synthetic error/result chunk. It propagates after the
+  transport-specific cleanup in D4 or D5; ADR-0029 marks the event `CANCELLED`.
+- **Consumer close.** `aclose()` follows the cancellation cleanup path but returns cleanly after
+  resources are reaped. No chunk is yielded from `finally`.
+
+**Exact session semantics**
+
+- **Capability gate.** `iModel` injects stored state only when `capabilities.resumable=True` and
+  `resume_field` names a field present on `request_type`. A mismatch is catalog validation failure.
+- **Publication.** A resumable adapter publishes the canonical provider identifier as
+  `metadata["session_id"]` on a system chunk as soon as it is confirmed. It also returns it in
+  `AgenticCallResult` and terminal result metadata when those outputs exist.
+- **Storage.** `iModel` stores only a non-empty confirmed identifier. A later empty value does not
+  erase the last confirmed id.
+- **Injection.** Explicit caller values in `resume_field` or a provider-supported `session_id` field
+  win. Otherwise `iModel` injects the stored identifier into `resume_field` before request-model
+  validation.
+- **Non-resumable adapters.** They do not receive automatic `resume`. An observational upstream id
+  may be retained as vendor metadata under `provider_session_id`, but not under the canonical
+  resumable `session_id` key.
+- **Failure.** Failure or cancellation does not erase a confirmed id. An id seen only in an invalid
+  or unparseable event is not stored.
+- **Copy.** `iModel.copy(share_session=False)` starts without session state;
+  `share_session=True` copies a confirmed id only for resumable adapters.
+
+**Why this way.** `StreamChunk` is already the consumer contract; the defect is inconsistent
+projection at its edges. Keeping `CLISession` internal lets parsers accumulate vendor state without
+making a second public stream type. Explicit error and resume semantics remove inference from
+content, final accumulator state, or the presence of any provider identifier.
+
+### D4 — Centralize subprocess framing, safety, and deterministic teardown
+
+The generic subprocess and handler helpers move under one internal support package with
+compatibility re-exports:
+
+```text
+lionagi/providers/_agentic/
+├── __init__.py          AgenticCapabilities and error re-exports
+├── capabilities.py      D1 capability vocabulary
+├── handlers.py          D2 runtime-handler validation/copying
+├── subprocess.py        D4 argv, NDJSON, workspace, stderr, teardown
+└── errors.py            D3 provider/transport/protocol error hierarchy
+
+lionagi/providers/
+├── _agentic_handlers.py  compatibility re-export
+├── _cli_subprocess.py    compatibility re-export
+└── _provider_errors.py   compatibility re-export
+```
+
+The subprocess entry point remains Python-native and provider-neutral:
+
+```python
+STDERR_CAPTURE_LIMIT = 256 * 1024
+STDERR_DRAIN_TIMEOUT = 2.0
+PROCESS_TERMINATE_GRACE = 5.0
+READ_SIZE = 4096
+
+async def ndjson_from_cli(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    stdin: Any = asyncio.subprocess.DEVNULL,
+    tail_repair: Callable[[str], dict[str, Any] | None] | None = None,
+) -> AsyncIterator[dict[str, Any]]: ...
+
+def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path: ...
+def build_declarative_cli_args(model_instance: BaseModel) -> list[str]: ...
+def discover_cli(binary: str) -> tuple[bool, str | None]: ...
+```
+
+**Exact semantics**
+
+- **Argument vector.** The helper calls `asyncio.create_subprocess_exec(*cmd, ...)`. It never
+  invokes a shell or accepts a prejoined command string. Provider request models place flags and
+  values into distinct argv elements.
+- **Working directory.** An absent repository uses `Path.cwd()`. An absent/empty workspace returns
+  the repository. An absolute workspace or lexical traversal is rejected; the resolved path must
+  remain contained by the repository. Provider-specific file fields receive their own containment
+  validation before argv construction.
+- **Process group.** Every process starts with `start_new_session=True`. The helper captures stdout
+  and stderr and uses `DEVNULL` stdin by default. Pi may explicitly request inherited stdin through
+  the compatibility sentinel; other adapters do not inherit it accidentally.
+- **Framing.** Incremental UTF-8 decoding accepts newline-delimited or directly concatenated JSON
+  values. Leading whitespace is ignored. Each parsed value must be a mapping; a scalar/array is
+  `ProviderProtocolError`.
+- **Tail.** A complete final JSON object is yielded. Claude Code may supply its existing JSON repair
+  callback. If repair produces one mapping it is yielded; no repair, a `None` repair, or a repair
+  failure raises `ProviderProtocolError` instead of silently dropping a potentially semantic tail.
+- **Stderr.** Stderr drains concurrently with stdout so a full pipe cannot block the child. At most
+  `STDERR_CAPTURE_LIMIT` leading bytes are retained for diagnostics; excess bytes are drained and
+  discarded. Captured text is decoded with replacement and never treated as stdout events.
+- **Exit zero.** Normal stdout EOF plus exit code zero ends the iterator. The `finally` path still
+  reaps resources and the stderr task.
+- **Exit nonzero.** The helper waits up to `STDERR_DRAIN_TIMEOUT` for the drain, classifies the
+  bounded content, and raises a typed `ProviderProcessError` or the more specific
+  quota/auth/context error. It never returns a successful result because stdout contained earlier
+  chunks; already yielded chunks remain observable before the error.
+- **Missing binary.** Discovery failure raises `ProviderExecutableNotFound` before process creation
+  with the provider's installation hint. It is not retried.
+- **Cancellation/close.** In `finally`, send SIGTERM to the process group and direct child, wait up
+  to `PROCESS_TERMINATE_GRACE`, then SIGKILL the group and child if still alive, and await reaping.
+  The stderr task is cancelled and awaited. `CancelledError` propagates after cleanup.
+- **Primary error.** A secondary close/reap failure is logged and cannot replace an exception or
+  cancellation already in flight. With no primary error, a cleanup failure remains visible.
+
+The inherited numeric values are part of the record:
+
+| Value | Meaning | Recorded rationale |
+|-------|---------|--------------------|
+| 256 KiB | Maximum retained stderr per subprocess; draining continues after the cap. | Bounds diagnostic memory while preventing pipe deadlock. The exact cap is inherited; no tuning evidence is recorded. |
+| 4 KiB | Stdout/stderr read size. | Inherited implementation value; no design rationale is recorded. It is not a total-output cap. |
+| 2 seconds | Extra wait for stderr drain after nonzero process exit. | Inherited; prevents diagnostics from blocking failure forever. The exact duration is not justified in source. |
+| 5 seconds | SIGTERM-to-SIGKILL grace for the process group. | Inherited; gives cooperative cleanup a chance before preventing an orphan. The exact duration is not justified in source. |
+
+**Why this way.** These mechanics are identical across four adapters and have dedicated regression
+coverage. Centralizing them avoids four independent security and cancellation implementations.
+The helper deliberately stops below command grammar and event meaning: Codex workspace flags,
+Claude tail repair, Gemini model resolution, and Pi stdin behavior remain explicit provider choices.
+
+### D5 — Retain transport-specific lifecycle below the normalized boundary
+
+Subprocess, in-process, and remote adapters satisfy D2/D3 but own different resource cleanup. The
+target does not insert a generic executor-provider protocol between `AgenticEndpoint` and these
+mechanics.
+
+**In-process adapters**
+
+- `AG2BetaEndpoint` retains the current `run_beta_agent()` task/queue/subscription design. On normal
+  completion it drains queued events before the response. On error, cancellation, or consumer close
+  it unsubscribes both stream callbacks; if the agent task is unfinished it cancels and awaits it.
+- Its current 0.1-second queue poll remains an internal responsiveness interval. The value is
+  inherited with no recorded numeric rationale; it is not a request timeout and the caller deadline
+  from ADR-0029 still governs the task.
+- A pre-built agent continues to take precedence over `AgentConfig`. Without a pre-built agent,
+  both a valid config and model configuration are required before the task starts. Unknown observer
+  and policy names remain vendor-owned validation behavior until their provider model is tightened.
+- `AG2GroupChatEndpoint` retains event mapping beside the AG2 module. The default `max_round=15`
+  remains a provider request limit with Pydantic `gt=0` validation. It is inherited; source records
+  no rationale for fifteen. Consumer close closes the AG2 iterator before releasing admission.
+- Base AG2 agent/group-chat queue and concurrency defaults remain `3` waiting and `1` active, as
+  recorded in ADR-0029. Serial active execution protects adapter-owned mutable agent state; the
+  exact queue value is inherited.
+
+**Remote adapter**
+
+- `AG2NlipEndpoint` validates that its URL uses `http` or `https` and that the hostname passes the
+  shared SSRF check before creating a client. Missing URL or prompt fails before connection.
+- The HTTP client is scoped to one logical request and closes on success, exception, deadline, or
+  cancellation. SDK and direct-HTTP paths return the same mapping:
+
+  ```python
+  {
+      "content": str,
+      "context": Any | None,
+      "input_required": Any | None,
+  }
+  ```
+
+- Its current local transport cap is 60 seconds and its current total attempt count is three.
+  Both are inherited without recorded tuning rationale. Under ADR-0029 they become the endpoint
+  local cap and `AttemptPolicy.max_attempts`; the adapter must not wrap that policy in a second
+  hidden retry loop. Only timeout/connect failures are retryable before output; status and response
+  validation failures propagate on their first occurrence.
+- `max_attempts <= 0` is invalid target configuration. The shipped helper currently interprets
+  `max_retries <= 0` as “make no request and return an empty result”; migration replaces that silent
+  success with validation failure.
+- Base NLIP queue/concurrency defaults remain `10` waiting and `3` active, as recorded in ADR-0029.
+
+**Vendor ownership**
+
+```text
+lionagi/providers/
+├── openai/codex.py             Codex request, flags, event mapping
+├── anthropic/claude_code.py    Claude request, flags, tail repair, events
+├── google/gemini_code.py       Gemini request, model mapping, terminal JSON
+├── pi/cli.py                   Pi request, env/argv, incremental events
+├── ag2/agent.py                in-process beta-agent construction/events
+├── ag2/groupchat.py            group-chat models/event mapping
+└── ag2/nlip.py                 remote NLIP request/wire adaptation
+```
+
+Provider request fields, permission/sandbox modes, model aliases, event allowlists, callbacks, and
+fallback parsing remain in those modules. Shared code enters `_agentic/` only after at least two
+adapters use the same semantics.
+
+**Why this way.** Observable sameness does not require identical internals. Process signals cannot
+cancel an in-process task, and an HTTP client has neither a process group nor an AG2 subscription.
+Keeping cleanup beside the resource makes it testable while D2/D3 give operations one request and
+output contract.
+
+### D6 — Run one capability-driven conformance suite for every adapter
+
+The suite lives under `tests/providers/agentic/` and parametrizes every registered
+`AgenticEndpoint`, including scripted test support. Vendor parser fixtures stay beside their
+providers; the conformance layer consumes adapter-level fakes rather than duplicating raw grammars.
+
+| Case | Required assertions |
+|------|---------------------|
+| Capability declaration | Frozen record exists; transport is one closed value; resume field agrees with request model; catalog inventory matches the matrix in D1. |
+| Request validation | Valid dict produces exactly `{"request": request_type(...)}` and empty headers; unknown request/runtime key and non-callable handler fail before transport. |
+| Runtime separation | Callables appear only in `APICalling.call_kwargs`; payload serialization contains none; per-call handler override does not mutate endpoint defaults. |
+| Stream type | Every yielded public item is `StreamChunk`; no `CLISession`, `PiChunk`, raw dict, or AG2 event escapes. |
+| Chunk order | System/semantic chunks precede at most one result; nothing follows result or error; text is not duplicated into result content. |
+| Empty success | Empty adapter fixture reaches normal EOF without a synthetic result or error. |
+| Provider error | Exactly one error chunk has `type="error"` and `is_error=True`; no result/later chunk; supervisor observes typed failure. |
+| Transport/parser error | Specific typed exception propagates; event fails; no conversion to normal EOF. |
+| Resumable adapter | System chunk publishes confirmed id; one-shot/result mapping carries it; next request injects it unless caller supplied a value. |
+| Non-resumable adapter | No automatic resume injection; observational ids do not use canonical `session_id`. |
+| Tool capability | `True` adapters map fixture use/result with ids and error bit; `False` adapters do not fabricate tool events. |
+| Usage capability | `True` adapters expose provider usage in terminal metadata/result; `False` adapters may omit it and do not synthesize zeros. |
+| One-shot adapter | Returns all `AgenticCallResult` keys; ordinary failure follows ADR-0029 event semantics. |
+| Stream-only adapter | `invoke()` raises `AgenticOperationUnsupported` before task/process/client creation. |
+| Caller cancellation | Original cancellation propagates after cleanup; no result/error chunk is synthesized; no active resource remains. |
+| Consumer close | `aclose()` reaps the transport and returns without a yield from `finally`. |
+| Endpoint copy | Runtime handlers copy; active resource does not; session copies only when requested and resumable. |
+
+Subprocess adapters additionally prove:
+
+- argv elements are passed to `create_subprocess_exec` without shell joining;
+- workspace traversal, absolute workspace, and symlink escape are rejected before launch;
+- stdout supports split and concatenated JSON; invalid/non-mapping tail fails unless Claude's repair
+  returns a mapping;
+- stderr beyond 256 KiB is drained without being retained and cannot deadlock stdout;
+- missing executable and nonzero exit produce typed errors with bounded stderr;
+- normal EOF, parser failure, timeout, caller cancellation, and early consumer close all terminate
+  and reap the process group, escalating after the five-second grace when required; and
+- a cleanup exception never masks an already propagating provider or cancellation exception.
+
+The suite preserves the existing focused provider tests for command arguments, path safety, Codex
+benign end-of-stream classification, Gemini terminal JSON, Claude tail repair, Pi event mapping,
+AG2 agent task teardown, group-chat event projection, NLIP SSRF/retry behavior, and scripted output.
+Conformance tests add cross-adapter invariants; they do not replace grammar fixtures.
+
+**Why this way.** Per-provider tests can all pass while adapters disagree at the shared boundary.
+One suite pins the properties operations rely on, and capability predicates prevent it from forcing
+fake tool, usage, or resume behavior on providers that do not have it.
 
 ## Consequences
 
-Operations receive a stable stream and session contract without learning vendor event formats.
-Subprocess safety and teardown behavior evolve once, while provider owners can change flags or event
-grammar locally. In-process and remote agent adapters no longer need to masquerade as command-line
-transports merely to select the streaming path.
+- Operations select agentic streaming without confusing transport type. Subprocess-only behavior
+  becomes explicit through `capabilities.transport == "subprocess"`.
+- `APICalling` and `StreamChunk` remain the public service boundary. Existing endpoint/provider
+  names remain stable, and helper moves retain compatibility re-exports.
+- Provider errors become observable the same way from every adapter. Tightening `is_error` and
+  raising parser/transport failures can change consumers that currently treat malformed or empty
+  streams as success.
+- Resumability becomes opt-in and provable. Codex no longer receives a silently filtered `resume`;
+  adding real Codex continuation later is a provider-local typed change plus a matrix update.
+- Internal `CLISession` remains useful for summaries and one-shot aggregation but is no longer a
+  second public stream union member. Adapters must project its terminal data explicitly.
+- Subprocess teardown and stderr behavior evolve once. A regression in the shared helper affects
+  four providers, so its conformance coverage is a release gate.
+- In-process and remote adapters keep their correct resource mechanics. The shared abstraction does
+  not require subprocess concepts or duplicate ADR-0029 retry/deadline ownership.
+- The target adds stricter validation: unknown request keys, handler keys, non-mapping provider
+  events, silent malformed tails, and NLIP nonpositive attempts become typed failures. Compatibility
+  warnings are required where a public caller previously relied on silent filtering.
+- Reversing D1/D3 after consumers migrate is high cost because routing and error/session semantics
+  become cross-operation contracts. Moving support files is low cost because compatibility imports
+  remain. Adding a new adapter is medium cost: it must declare capabilities and pass conformance.
+- Maintainers must know which layer owns each failure: adapter input validation (D2), provider event
+  projection (D3), transport cleanup (D4/D5), or admission/deadline terminalization (ADR-0029).
 
-The conformance boundary deliberately permits provider-specific capabilities, so not every stream
-will contain tool or usage events. Moving shared helpers and introducing `is_agentic` require
-compatibility exports and a staged deprecation. Tightening error chunks may change consumers that
-currently infer failure from content instead of `is_error`.
+## Alternatives considered
+
+### Introduce a separate executor-provider protocol and registry
+
+A new protocol could select a subprocess, in-process, or remote executor independently of endpoint
+selection. It would make scheduling replaceable and give transport families their own registry. It
+lost because `AgenticEndpoint` and `EndpointRegistry` are already the live extension and resolution
+seams. A second registry would duplicate provider keys, aliases, availability, fallback, and
+lifecycle rules while still needing the selected endpoint's request/event grammar.
+
+### Keep `is_cli` as the permanent operation-routing flag
+
+This avoids changing consumers and accurately describes the original CLI adapters. It lost because
+AG2 in-process and remote endpoints already inherit `True`; new code cannot know whether the flag
+means process transport or agentic execution. A deprecated alias preserves migration behavior while
+`is_agentic` and `transport` name the two facts separately.
+
+### Move every agentic adapter into one package
+
+One directory would make the inventory easy to scan and could centralize all request and parser
+types. It lost because it separates vendor request/flag/event grammar from the provider packages
+that own API endpoints, aliases, fixtures, and release changes. The target centralizes only mechanics
+already shared by multiple adapters.
+
+### Force one universal request model or command schema
+
+A single `AgenticRequest` could expose prompt, model, tools, sandbox, resume, and timeout for every
+provider. It would make construction look uniform. It lost because permission modes, file grants,
+session commands, model identifiers, and even transport inputs differ materially. Unsupported
+fields would either be ignored—a recurrence of P2—or falsely promise capability. The invariant is
+validated provider-owned input, not identical input.
+
+### Yield `CLISession` as a public final stream item
+
+Keeping the existing low-level union would expose summaries and usage without projection work and
+would let callbacks consume the same object. It lost because operations are written against
+`StreamChunk` and each endpoint currently treats the accumulator differently. A private accumulator
+plus typed result metadata keeps useful state without requiring every consumer to branch on a second
+type.
+
+### Require exactly one result chunk from every successful stream
+
+This would give EOF a visible terminal record and a uniform place for usage. It lost because some
+providers have no terminal metadata and normal empty EOF is already valid under ADR-0029. Requiring
+a chunk would create synthetic content. At most one result provides a stable ordering rule without
+inventing data.
+
+### Treat any provider identifier as resumable
+
+The shared layer could continue storing every `session_id`/`thread_id` and injecting `resume`. This
+would make continuation automatic for providers that add support incidentally. It lost because a
+returned identifier does not prove a request field or command grammar; Codex demonstrates the
+failure by publishing a thread id while filtering the injected field. Resumability requires an
+explicit round trip.
+
+### Use shell-string process execution
+
+Shell execution would simplify command logging, quoting, and pipelines. It lost because prompts,
+paths, model names, and provider arguments are caller-controlled. Argument-vector execution avoids
+shell interpretation and matches the existing implementation and cancellation tests.
+
+### Let every adapter own subprocess reading and teardown
+
+Vendor-local process code would allow different framing and termination behavior. It lost because
+the adapters already use the same NDJSON/process-group helper, and the shared properties prevent
+deadlock and orphan processes. Provider-specific tail repair, stdin, cwd, and argv remain extension
+points without duplicating the safety core.
+
+### Normalize all failures as error chunks and never raise
+
+Pure data-plane errors would make streams easy to record and avoid exception classification. It lost
+because connection, parser, cancellation, and setup failures may occur before any valid chunk and
+must remain typed control flow. Provider-declared errors get one observable error chunk; ADR-0029
+then raises after the boundary so direct and operation consumers cannot mistake failure for EOF.
+
+### Test adapters only with vendor-specific fixtures
+
+Local fixtures are best at detecting event-grammar drift and require no abstraction. They lost as
+the only test layer because each adapter can be locally correct while disagreeing on error flags,
+terminal result duplication, session injection, or cleanup. The conformance suite asserts only the
+shared boundary and leaves parser fixtures in place.
 
 ## Notes
 
-A new executor-provider protocol was rejected because `AgenticEndpoint` and `EndpointRegistry`
-already provide the live extension and resolution seams. Moving every agentic adapter into one
-package was rejected because it would separate request and event grammar from vendor ownership.
-Forcing one universal parser or command schema was rejected because the shared invariant is the
-normalized output and lifecycle contract, not identical vendor inputs.
+This is a target-state ADR. `AgenticCapabilities`, `is_agentic`, the `_agentic/` support package,
+strict request classification, the unified result mapping, and the conformance suite are not
+shipped. The source contracts constraining migration are:
+
+- `lionagi/service/connections/{agentic_endpoint,endpoint,api_calling}.py` and
+  `lionagi/service/types/{stream_chunk,cli_session}.py`;
+- `lionagi/service/imodel.py`, `lionagi/session/branch.py`, and
+  `lionagi/operations/run/run.py`;
+- `lionagi/providers/{_agentic_handlers,_cli_subprocess,_provider_errors}.py` and
+  `lionagi/ln/_proc.py`;
+- `lionagi/providers/openai/codex.py`, `anthropic/claude_code.py`,
+  `google/gemini_code.py`, `pi/cli.py`, and `ag2/{agent,groupchat,nlip}.py`; and
+- `lionagi/testing/_endpoint.py` plus the existing provider/service tests named in D6.
+
+The compatibility migration order is: publish capabilities and aliases; update operation routing to
+`is_agentic`; move helpers behind compatibility re-exports; normalize each adapter and make it pass
+conformance; then deprecate and remove `is_cli` under repository policy.

--- a/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
+++ b/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
@@ -1,0 +1,104 @@
+# ADR-0030: Agentic provider-adapter boundary
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: service-providers
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0027, ADR-0029
+
+## Context
+
+`AgenticEndpoint` represents providers whose work is not a normal HTTP request. Codex, Claude Code,
+Pi, and Gemini adapters launch command-line processes; AG2 adapters run in-process or connect to a
+remote agent. They share `APICalling`, `StreamChunk`, and resumable session state with API endpoints,
+which lets operations consume them through `iModel` without vendor selection logic
+(`lionagi/service/connections/agentic_endpoint.py`, `lionagi/service/types/`).
+
+The subprocess adapters already share meaningful mechanics. `lionagi/providers/_cli_subprocess.py`
+owns NDJSON framing, bounded stderr capture, process-group isolation and termination, workspace
+validation, prompt extraction, and declarative flag emission.
+`lionagi/providers/_agentic_handlers.py` validates callbacks and constructs typed requests. Vendor
+modules correctly retain their own flag grammars, safety settings, event parsers, UX callbacks, and
+session synthesis.
+
+The common result contract is less explicit than the common machinery. Each adapter decides how to
+map provider events, end-of-stream, errors, final sessions, and resume identifiers. Some streams
+convert a final session to a result chunk while others suppress it; provider error chunks do not
+uniformly set `is_error`; and the `is_cli` flag is also true for non-CLI agentic adapters because
+operations use it as the general streaming-path selector.
+
+These differences are not a reason to centralize vendor parsers. They are a reason to name the
+boundary, distinguish transport capability from operation routing, and test the normalized contract
+that every adapter promises.
+
+## Decision
+
+Retain `AgenticEndpoint` as the implemented extension boundary and establish an internal
+`lionagi/providers/_agentic/` support lane. Move the existing generic subprocess and handler helpers
+into that lane with compatibility re-exports. Vendor request models, command grammars, event parsers,
+and provider-specific safety policy remain under their vendor packages.
+
+Every `AgenticEndpoint` declares immutable capabilities:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AgenticCapabilities:
+    transport: Literal["subprocess", "in_process", "remote"]
+    resumable: bool
+    emits_tool_events: bool
+    reports_usage: bool
+```
+
+The adapter conformance contract is:
+
+- `create_payload()` constructs the provider's typed request and separates runtime handlers from
+  serializable provider data. Unknown handler names and invalid request fields fail before transport
+  starts.
+- `stream()` yields only provider-neutral `StreamChunk` values. Text, reasoning, tool use, tool
+  result, final result, and error use the closed chunk vocabulary; a provider-declared error sets
+  both `type="error"` and `is_error=True`.
+- A resumable adapter publishes the provider session identifier in a system chunk as soon as it is
+  known and in the non-streaming result mapping. `iModel` owns the stored identifier and injects it
+  on the next request through the provider's typed resume field. Non-resumable adapters do not
+  synthesize an identifier.
+- Text is carried only by text chunks. A successful stream emits at most one result chunk after
+  content, containing terminal metadata and any non-duplicated final result; an internal
+  `CLISession` is not exposed as a chunk. Normal EOF is not an error. Transport or parser failure
+  raises a provider-classified exception; cancellation propagates after resource cleanup. ADR-0029
+  owns admission, terminal event state, and whether an HTTP stream may retry before its first chunk.
+- Subprocess adapters use argument-vector process creation, validate the working directory before
+  launch, isolate the process group, drain bounded stderr concurrently, and terminate and reap the
+  group on normal close, failure, timeout, or cancellation. Shell-string execution is not part of
+  the common lane.
+- Shared code is admitted only when at least two adapters use the same semantics. Provider event
+  interpretation, model defaults, flags, permission modes, and fallback grammar stay vendor-owned.
+
+Add `is_agentic` as the canonical operation-routing capability. Preserve `is_cli` as a deprecated
+compatibility alias during migration; `transport="subprocess"` is the precise test for CLI-specific
+behavior. This naming change must not alter which endpoints use the streaming operation path.
+
+One conformance suite runs against every agentic adapter. All adapters cover request construction,
+normalized chunk order, declared capability behavior, provider error classification, cancellation,
+and session identifiers. Subprocess adapters additionally cover workspace containment, argument
+emission, stderr saturation, process-group teardown, and missing executable behavior. Vendor parser
+fixtures remain beside their adapters.
+
+## Consequences
+
+Operations receive a stable stream and session contract without learning vendor event formats.
+Subprocess safety and teardown behavior evolve once, while provider owners can change flags or event
+grammar locally. In-process and remote agent adapters no longer need to masquerade as command-line
+transports merely to select the streaming path.
+
+The conformance boundary deliberately permits provider-specific capabilities, so not every stream
+will contain tool or usage events. Moving shared helpers and introducing `is_agentic` require
+compatibility exports and a staged deprecation. Tightening error chunks may change consumers that
+currently infer failure from content instead of `is_error`.
+
+## Notes
+
+A new executor-provider protocol was rejected because `AgenticEndpoint` and `EndpointRegistry`
+already provide the live extension and resolution seams. Moving every agentic adapter into one
+package was rejected because it would separate request and event grammar from vendor ownership.
+Forcing one universal parser or command schema was rejected because the shared invariant is the
+normalized output and lifecycle contract, not identical vendor inputs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,26 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   context-provider execution and attribution
 - 0009-0010 — unused (intentional gaps)
 
+### actions-tools (0011-0015)
+
+- [ADR-0011](ADR-0011-function-tool-descriptor-and-branch-registry.md) — Function tool
+  descriptor and Branch registry
+- [ADR-0012](ADR-0012-branch-action-execution-and-event-lifecycle.md) — Branch action
+  execution and event lifecycle
+- [ADR-0013](ADR-0013-built-in-tool-provider-and-branch-binding.md) — Built-in tool provider
+  and Branch binding
+- 0014-0015 — unused (intentional gaps)
+
+### session-branch (0016-0020)
+
+- [ADR-0016](ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md) — Branch
+  conversation aggregate and attachment boundary
+- [ADR-0017](ADR-0017-session-membership-and-coordination-boundary.md) — Session membership
+  and coordination boundary
+- [ADR-0018](ADR-0018-turn-scoped-branch-execution-state.md) — Turn-scoped Branch execution
+  state
+- 0019-0020 — unused (intentional gaps)
+
 ### operations (0021-0026)
 
 - [ADR-0021](ADR-0021-branch-operation-facade-and-turn-adapters.md) — Branch operation facade
@@ -64,5 +84,17 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   operation graph execution kernel
 - [ADR-0024](ADR-0024-lndl-operate-integration-adapter.md) — LNDL operate integration adapter
 - 0025-0026 — unused (intentional gaps)
+
+### service-providers (0027-0032)
+
+- [ADR-0027](ADR-0027-model-service-facade-and-endpoint-resolution.md) — Model-service facade
+  and endpoint resolution
+- [ADR-0028](ADR-0028-validated-provider-adapter-catalog.md) — Validated provider-adapter
+  catalog
+- [ADR-0029](ADR-0029-unified-request-admission-deadline-and-resilience-policy.md) — Unified
+  request admission, deadline, and resilience policy
+- [ADR-0030](ADR-0030-agentic-provider-adapter-boundary.md) — Agentic provider-adapter
+  boundary
+- 0031-0032 — unused (intentional gaps)
 
 Remaining areas land here as their records are accepted.


### PR DESCRIPTION
Third bundle of the canonical ADR corpus (follows #1943, #1947).

## Contents

**actions-tools (0011-0015 block, 3 records)**
- ADR-0011 — function tool descriptor and Branch registry
- ADR-0012 — Branch action execution and event lifecycle
- ADR-0013 — built-in tool provider and Branch binding

**session-branch (0016-0020 block, 3 records)**
- ADR-0016 — Branch conversation aggregate and attachment boundary
- ADR-0017 — Session membership and coordination boundary
- ADR-0018 — turn-scoped Branch execution state

**service-providers (0027-0032 block, 4 records)**
- ADR-0027 — model-service facade and endpoint resolution
- ADR-0028 — validated provider-adapter catalog
- ADR-0029 — unified request admission, deadline, and resilience policy
- ADR-0030 — agentic provider-adapter boundary

Plus the README index entries for all three areas. Unused numbers inside each block are intentional gaps per the corpus numbering scheme.

All factual code claims verified against live source pre-inclusion; all three areas passed adversarial review with zero blocking findings. dispositions.yaml lands with the final bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)