### PR TITLE
docs(adr): deepen bundle 1-2 ADRs to full depth-contract form

### DIFF
--- a/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
+++ b/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
@@ -9,66 +9,371 @@
 ## Context
 
 LionAGI needs persisted and externally addressable model objects to retain identity across
-collections, graph edges, messages, logs, and serialization boundaries. `Element` supplies that
-shared envelope through a UUID, a creation timestamp, mutable metadata, and Pydantic validation.
-The UUID and creation timestamp are immutable after construction, while equality and hashing use
-the UUID. `lionagi/protocols/generic/element.py` is the defining module.
+collections, graph relationships, messages, logs, and serialization boundaries. Five concrete
+problems shape the shipped model.
 
-Serialization adds a fully qualified `lion_class` discriminator to metadata. Deserialization reads
-the discriminator from either `metadata` or the database-shaped `node_metadata`, resolves the
-concrete class, and delegates reconstruction to that class. Python, JSON, and database-shaped
-dictionaries are supported representations of the same envelope.
+**P1 — Addressable objects need stable identity independent of their current values.** A node can
+change content or metadata while references held by a Pile, Graph, log, or operation still need to
+identify the same object. Value equality would make identity depend on mutable fields; object
+identity would be lost at a serialization boundary.
 
-Class resolution is compatibility-oriented rather than a uniform extension registry.
-`lionagi/_class_registry.py` first checks the process registry, then permits an importable dotted
-path, then searches a fixed set of built-in modules and registered suffixes for older short class
-names. `Node` subclasses register automatically in `lionagi/protocols/graph/node.py`; other
-`Element` subclasses do not share that automatic registration contract.
+**P2 — A serialized base type must recover the concrete model.** Callers frequently hold
+`Element`, `Node`, or heterogeneous Pile references while the payload contains an Instruction,
+Graph, Event, or extension subclass. Reconstructing only the statically requested base class would
+either reject subtype fields or discard subtype behavior.
 
-The boundary is addressable or persisted framework models, not all data. Nodes, edges, events,
-graphs, collections, progressions, and logs use the envelope because they are referenced or
-round-tripped as model objects. Configuration and query value objects may remain plain Pydantic
-models. `Node` adds serializable content and a nullable embedding field; the latter is currently a
-persisted compatibility field, not evidence that every node participates in vector retrieval.
+**P3 — Several persisted shapes and naming generations must remain readable.** Normal model dumps
+use `metadata`; database adapters use `node_metadata`. Current writers store a fully qualified
+class name, while older built-in payloads may contain a short name such as `Instruction`. The
+reader therefore cannot be a single direct registry lookup.
+
+**P4 — The envelope has a trust and extension boundary.** `Node` subclasses register
+automatically, other `Element` subclasses do not, and a fully qualified discriminator may cause a
+Python module import. That behavior makes third-party recovery possible, but it also means
+deserialization is not a passive data-only operation.
+
+**P5 — Graph nodes need a stable content shape without making every value object a node.** `Node`
+adds arbitrary content and a nullable embedding to the Element envelope. Configuration and query
+objects do not become addressable merely because they are Pydantic models, and can remain plain
+models.
+
+The current implementation is defined by `lionagi/protocols/generic/element.py`,
+`lionagi/_class_registry.py`, and `lionagi/protocols/graph/node.py`.
+
+| Concern | Decision |
+|---|---|
+| Object identity and base fields | D1: Addressable framework models inherit the frozen UUID and creation timestamp plus mutable metadata from `Element`. |
+| Serialized envelope | D2: Writers place a fully qualified `lion_class` discriminator in metadata and support Python, JSON, and database dictionary shapes. |
+| Concrete-class recovery | D3: Readers resolve registry entries, importable dotted paths, and a fixed legacy built-in short-name set in that order. |
+| Node payload | D4: `Node` adds serializable arbitrary content and a nullable float-list embedding while retaining the Element envelope. |
+
+This ADR deliberately does **not** decide:
+
+- node lifecycle policy such as versioning, soft deletion, or content hashing; those features are
+  activated by per-class node configuration and are not required by the identity envelope;
+- adapter-specific database schemas; adapters consume database-mode dictionaries but own their
+  table and transport contracts;
+- vector indexing or retrieval behavior; `Node.embedding` is a stored compatibility field, not a
+  declaration that every Node is searchable by vector; or
+- a future trusted plugin-registration policy; the current asymmetric registry/import behavior is
+  recorded here, while its replacement remains an explicit delta.
 
 ## Decision
 
-`Element` is the common identity and polymorphic-serialization envelope for addressable or
-persisted LionAGI models. Its load-bearing invariants are:
+### D1 — Element supplies identity, creation time, and metadata
 
-- `id` is a UUID, is immutable after construction, and defines `Element` equality and hashing;
-- `created_at` is an immutable UTC timestamp, while `metadata` remains mutable extension data;
-- serialized forms carry the concrete, fully qualified class name in `metadata.lion_class`;
-- database serialization may rename `metadata` to `node_metadata`, and deserialization accepts
-  either name;
-- deserialization delegates to the resolved concrete type and continues to read built-in short
-  class names written by older data; and
-- inheriting from `Element` is not required for configuration, query, or other non-addressable
-  value objects.
+`Element` is the common identity envelope for addressable or persisted LionAGI models. It is a
+Pydantic model and the nominal `Observable` used by generic collections.
 
-The implementation anchors are `lionagi/protocols/generic/element.py`,
-`lionagi/_class_registry.py`, and `lionagi/protocols/graph/node.py`.
+**The contract** (`lionagi/protocols/generic/element.py`):
+
+```python
+class Element(BaseModel, Observable):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    id: UUID = Field(default_factory=uuid4, frozen=True)
+    created_at: float = Field(
+        default_factory=lambda: now_utc().timestamp(),
+        frozen=True,
+    )
+    metadata: dict = Field(default_factory=dict)
+
+    @property
+    def created_datetime(self) -> datetime: ...
+
+    @classmethod
+    def class_name(cls, full: bool = False) -> str: ...
+```
+
+**Exact semantics**:
+
+- With no input, `id` is a UUID4, `created_at` is the current UTC timestamp expressed as a float,
+  and `metadata` is a new empty dictionary.
+- `id` accepts a UUID or a string accepted by `UUID(str(value))`. Invalid values fail Pydantic
+  validation. The field cannot be assigned after construction because it is frozen.
+- `created_at=None` produces a new current timestamp. A float is retained; a `datetime` uses its
+  `.timestamp()`; a string is first parsed as ISO text after replacing a space with `T`, and a
+  timezone-naive parsed string is treated as UTC. If ISO parsing fails, a numeric string is
+  converted with `float`; failure of both string conversions becomes
+  `ValueError("Invalid datetime string: ...")`. Other numeric-like inputs use `float(value)`;
+  failures become `ValueError("Invalid created_at: ...")`. The field is frozen after construction.
+- `created_datetime` always projects the stored float as a timezone-aware UTC `datetime`.
+- Falsey metadata becomes `{}`. A non-dictionary input is passed through the recursive `to_dict`
+  utility; failure to obtain a dictionary raises `ValueError("Invalid metadata.")`.
+- If input metadata already contains `lion_class`, it must equal the concrete validating class's
+  fully qualified name. A mismatch raises `ValueError("Metadata class mismatch.")`.
+- Unknown top-level model fields are rejected (`extra="forbid"`); arbitrary values remain allowed
+  inside declared fields such as `metadata` and Node content.
+- Equality between two Elements compares only UUIDs. Comparing to a non-Element returns
+  `NotImplemented`. Hashing uses the UUID, and every Element is truthy even when a subclass also
+  represents an empty collection. Collection subclasses may deliberately override truthiness.
+
+The negation matters: without one identity field, Pile keys and Graph endpoints would each need
+their own identity convention, and equality of mutable objects would be unsuitable for references.
+
+### D2 — Serialization carries a concrete-class discriminator in metadata
+
+Element has three dictionary modes and one JSON form. The discriminator is not a separate top-level
+field; it is injected into the serialized metadata copy.
+
+**The contract** (`lionagi/protocols/generic/element.py`):
+
+```python
+def to_dict(
+    self,
+    mode: Literal["python", "json", "db"] = "python",
+    db_meta_key: str | None = None,
+    **kw,
+) -> dict: ...
+
+def to_json(self, decode: bool = True, **kw) -> str: ...
+
+@classmethod
+def from_dict(cls, data: dict) -> Element: ...
+
+@classmethod
+def from_json(cls, json_str: str) -> Element: ...
+```
+
+The canonical Python shape is:
+
+```python
+{
+    "id": "00000000-0000-0000-0000-000000000001",
+    "created_at": 1.0,
+    "metadata": {
+        "source": "example",
+        "lion_class": "lionagi.protocols.generic.element.Element",
+    },
+}
+```
+
+Database mode changes only the metadata key by default:
+
+```python
+{
+    "id": "00000000-0000-0000-0000-000000000001",
+    "created_at": 1.0,
+    "node_metadata": {
+        "source": "example",
+        "lion_class": "lionagi.protocols.generic.element.Element",
+    },
+}
+```
+
+**Exact semantics**:
+
+- Python mode uses Pydantic `model_dump(**kw)`, adds the concrete fully qualified class name to the
+  dumped metadata, and removes sentinel-valued fields. It does not intentionally add
+  `lion_class` to the live object's metadata.
+- JSON mode serializes through `orjson` and parses the bytes back to JSON-compatible Python values;
+  UUIDs therefore appear as strings.
+- Database mode follows JSON mode, removes `metadata`, and installs it under `db_meta_key` or the
+  default `node_metadata`.
+- Any mode other than `python`, `json`, or `db` raises `ValueError("Unsupported mode: ...")`.
+- `to_json(decode=True)` returns text. `decode=False` returns the underlying JSON bytes even though
+  the public annotation says `str`; callers in `to_dict` rely on those bytes.
+- `from_json` parses with `orjson` and delegates all recovery behavior to `from_dict`.
+- `from_dict` shallow-copies the top-level dictionary and separately copies the chosen metadata
+  dictionary before removing `lion_class`; the caller's input dictionaries are not mutated.
+- When both metadata keys are present, `node_metadata` is selected first. The recovered in-memory
+  metadata does not retain `lion_class`; the discriminator is regenerated on the next write.
+- If no concrete subclass delegation occurs, reconstruction ends with `cls.model_validate(data)`.
+
+The discriminator is fully qualified because short class names are ambiguous across extension
+modules. Keeping it inside metadata preserves the stable three-field base envelope and lets older
+database shapes move metadata as one unit.
+
+### D3 — Class recovery is registry-first, import-capable, and legacy-aware
+
+The resolver is deliberately compatibility-oriented rather than a uniform extension registry.
+
+**The contract** (`lionagi/_class_registry.py`):
+
+```python
+LION_CLASS_REGISTRY: dict[str, type] = {}
+
+def get_class(class_name: str) -> type: ...
+```
+
+Resolution proceeds in this exact order:
+
+1. Return an exact `LION_CLASS_REGISTRY[class_name]` hit.
+2. If the string contains `.`, split it at the last dot and attempt to import that module attribute;
+   return it only when it is a class.
+3. Import each module in the fixed `_BUILTIN_MODULES` tuple and look for an attribute matching the
+   short name.
+4. Re-scan registry keys for an exact short-name or `.<short-name>` suffix match, because importing
+   built-ins may have registered Node subclasses.
+5. Raise `ValueError("Unable to find class ...")`.
+
+`Element.from_dict` removes the discriminator, asks `get_class`, restores the remaining metadata,
+and delegates to the resolved type's `from_dict` whenever the resolved type differs from the class
+currently reconstructing or supplies a different implementation. Resolver/import errors are
+caught for a final direct dotted import attempt; an unresolved or malformed discriminator then
+propagates an import, attribute, type, or value error rather than silently constructing the wrong
+base type.
+
+`Node` provides the only automatic registration hook:
+
+```python
+class Node(Element, Relational, AsyncAdaptable, Adaptable):
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        LION_CLASS_REGISTRY[cls.class_name(full=True)] = cls
+```
+
+**Exact semantics**:
+
+- The Node base itself is not inserted by its own subclass hook; each concrete Node subclass is.
+- Registration is ordinary dictionary assignment. A second class with the same fully qualified
+  key silently replaces the first; last writer wins.
+- Non-Node Element subclasses do not auto-register. Built-in classes remain recoverable through
+  module attribute lookup; importable third-party classes remain recoverable through dotted paths.
+- A short-name suffix collision is resolved by registry insertion order, not by an explicit
+  ambiguity error.
+- Dotted-path recovery executes Python import machinery. Payloads must therefore come from a trust
+  context permitted to name importable classes; the code does not maintain an allow-list.
+
+This shape grew from two compatibility needs: qualified names for extensions and continued reads
+of older built-in short names. It buys recovery breadth at the cost of an asymmetric registration
+and trust model, which is retained as a delta rather than described as ideal.
+
+### D4 — Node adds content and a compatibility embedding field
+
+`Node` is the graph-addressable specialization of Element.
+
+**The contract** (`lionagi/protocols/graph/node.py`):
+
+```python
+class Node(Element, Relational, AsyncAdaptable, Adaptable):
+    node_config: ClassVar[Any] = None
+
+    content: Any = None
+    embedding: list[float] | None = None
+```
+
+The resulting constructor fields are `id`, `created_at`, `metadata`, `content=None`, and
+`embedding=None`.
+
+**Exact semantics**:
+
+- `content` accepts any Python value. On serialization, an Element becomes its `to_dict()` shape, a
+  Pydantic model becomes `model_dump()`, a LionAGI `DataClass` uses its configured `to_dict`, and
+  any other value passes through unchanged.
+- On input, a dictionary whose `metadata` contains `lion_class` is reconstructed with
+  `Element.from_dict`; other dictionaries remain ordinary content.
+- `embedding=None` remains null. A list is converted element-by-element with `float`; invalid list
+  contents raise `ValueError("Invalid embedding list.")`.
+- A string must decode as a JSON list and every member must convert to float; malformed JSON or a
+  non-list JSON value raises `ValueError("Invalid embedding string.")`. Other input types raise an
+  invalid-embedding-type error. An empty list is valid.
+- Sync and async adapters force `to_dict(mode="db")` on writes and `from_dict` on reads. JSON and
+  TOML adapters are registered at module import; the optional PostgreSQL adapter is checked and
+  registered lazily on first PostgreSQL adaptation, with missing extras degrading to no adapter.
+  The PostgreSQL availability check is one-shot per process: the checked marker is installed even
+  when dependencies are missing or registration raises, so later calls do not retry after the
+  environment changes.
+
+The embedding field remains on the broad Node base because it is part of the persisted shape. Its
+presence is not a vector-capability interface, and removing it safely requires an inventory and
+migration rather than a local field deletion.
 
 ## Consequences
 
-UUID references, mixed-type collections, graph relationships, and persisted model round trips use
-one interoperable envelope. Concrete model types can preserve their own reconstruction behavior,
-and existing built-in data containing short class names remains readable.
+UUID references, heterogeneous collections, graph relationships, and persisted model payloads can
+share one base envelope. Most concrete model types recover their own schema and behavior through
+the discriminator, and legacy built-in short names remain readable.
 
-The resolver has an asymmetric extension and trust boundary: automatic registration is tied to
-`Node`, while an unregistered qualified discriminator can trigger a module import. The inherited
-timestamp and metadata also appear on descendants that do not independently need them. Retaining
-`Node.embedding` preserves stored shape but leaves an optional concern on a broad base class.
+Contributors extending the model must understand three non-obvious costs:
+
+- subclass construction can violate the envelope if a custom `__init__` does not forward inherited
+  fields; `Edge` currently demonstrates this failure and is captured in the delta table;
+- the resolver's ability to import a dotted path is also a code-loading trust boundary; and
+- automatic registration is a Node behavior, not an Element behavior, with silent overwrite and
+  ambiguous short-suffix recovery.
+
+Reversing D1 would invalidate UUID-keyed stores and graph endpoints. Reversing D2 or D3 requires a
+persisted-data migration and a compatibility reader. Moving `Node.embedding` behind a capability is
+less structurally invasive but still requires a persisted-shape migration.
+
+The inherited timestamp and metadata appear on descendants that may not independently need them.
+This is accepted for addressable framework models, while configuration and query value objects stay
+outside the inheritance tree.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
-|---|-------|------|-------|
+|---|---|---|---|
 | 1 | Add an explicit polymorphic-model registration and trusted-deserialization policy; acceptance requires qualified third-party model names to round-trip without `Node` inheritance, built-in short names to remain readable, and dotted-path imports to follow the documented trust policy. | M | (filled at issue-open time) |
 | 2 | Separate `Node`'s stable content contract from optional vector capability; acceptance requires an inventory and migration plan for persisted embeddings before any base-field deprecation, plus an opt-in capability for new vector operations. | M | (filled at issue-open time) |
+| 3 | Make `Edge` reconstruction preserve the inherited Element envelope; acceptance requires `Edge.from_dict(edge.to_dict())` to retain its UUID, creation timestamp, metadata values, and properties without nesting inherited fields under `properties`, with regression coverage for direct and polymorphic reconstruction. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### No shared model envelope
+
+Each model family could define its own identifier, timestamp, metadata, and serializer. That would
+let small value objects carry only what they need, but Pile, Graph, adapters, and polymorphic
+collections would need parallel identity and reconstruction rules. The repeated reference boundary
+is concrete and already shared, so duplicated envelopes lost to the common Element contract.
+
+### Value equality or Python object identity
+
+Value equality would change identity when mutable content changes and can merge distinct records
+with equal fields. Python object identity cannot survive JSON or database storage. UUID equality is
+stable across both mutation and process boundaries, so both alternatives lost.
+
+### A top-level `type` field
+
+A dedicated top-level discriminator would make the type marker visually prominent. It would also
+change the stable base record shape and require database adapters to map another reserved column.
+Keeping `lion_class` inside metadata lets `metadata`/`node_metadata` move as one payload and remains
+compatible with already persisted data.
+
+### Short class names only
+
+Short names are compact and matched early built-in data, but they cannot distinguish two extension
+modules defining the same class name. Fully qualified names are written now; fixed built-in search
+remains only as a compatibility reader.
+
+### A closed registry with no dotted imports
+
+A closed registry would make the deserialization trust boundary explicit and would detect unknown
+extension classes before import. It would also make current importable third-party discriminators
+unreadable unless every class was registered before the payload arrived. The shipped code chose
+compatibility and extension recovery; a trusted registration policy is deferred as delta 1 rather
+than retroactively asserted.
+
+### Automatic registration for every Element subclass
+
+Moving the subclass hook to Element would make extension behavior uniform. It also changes global
+registration and collision behavior for every value in the hierarchy and does not by itself solve
+trusted import or legacy short-name ambiguity. The current Node-only hook is recorded as-is pending
+the explicit policy decision.
+
+### Make every Pydantic model an Element
+
+Uniform inheritance would simplify a few generic annotations, but it would assign UUIDs,
+timestamps, and mutable metadata to configuration and query values that are compared and moved by
+value. The boundary remains addressable or persisted framework objects, not all structured data.
+
+### Remove `Node.embedding` immediately
+
+An opt-in vector capability would narrow the base node contract. Immediate removal loses the
+persisted compatibility field and provides no migration for stored embeddings. The capability
+split remains a delta until the stored-data inventory and migration are defined.
 
 ## Notes
 
-Alternatives considered were using no shared model envelope and serializing only short class names.
-The former would duplicate identity and persistence rules across model families; the latter cannot
-uniquely identify extension types and would preserve the ambiguity that qualified names avoid.
+The Edge reconstruction delta was verified from `lionagi/protocols/graph/edge.py`: the custom
+constructor forwards only `head`, `tail`, and a newly assembled `properties` dictionary to
+`Element`, so inherited envelope keys arriving through `**kwargs` become nested properties while a
+new Element UUID and timestamp are generated. ADR-0004 records the separate Graph-level
+reconstruction failures without changing ownership of the base Edge serialization decision.

--- a/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
+++ b/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
@@ -8,76 +8,466 @@
 
 ## Context
 
-LionAGI collections need both stable identity lookup and deterministic traversal order. `Pile`
-implements those concerns with a UUID-to-item dictionary and one `Progression` containing the UUIDs
-in traversal order. Construction rejects duplicate order entries and requires the order and
-dictionary to contain exactly the same members. `lionagi/protocols/generic/pile.py` and
-`lionagi/protocols/generic/progression.py` define these structures.
+LionAGI collections need identity lookup, deterministic traversal, reusable orderings, and named
+views without copying the underlying models. The shipped Pile, Progression, and Flow types answer
+six related problems.
 
-UUID and element references address dictionary entries, while integer and slice access resolve
-through the progression. Mutators maintain both structures so that an item is not stored without a
-position and an ordered UUID does not lack a stored item. A Pile may restrict items to declared
-nominal `Observable` types, optionally excluding subclasses. This is narrower than the structural
-ID-only `Observable` protocol exported by `lionagi/protocols/contracts.py`.
+**P1 — Identity lookup and traversal order are different concerns.** A dictionary gives constant
+time UUID lookup but not an independently editable order. A sequence gives order but makes identity
+lookup linear and cannot by itself enforce that a UUID has a resident object.
 
-`Progression` is also usable independently. Its membership cache is set-based, but `append`,
-`extend`, and `insert` can preserve duplicate UUIDs in the sequence. Pile construction and its
-default ordering require uniqueness, so callers cannot infer one universal multiplicity rule from
-the shared type.
+**P2 — Construction and mutation must keep both representations aligned.** A collection becomes
+invalid if its dictionary contains an item absent from the order, if the order names an absent
+item, or if the default order contains duplicate UUIDs that address only one dictionary entry.
 
-Multiple named orderings belong to `Flow`, not to Pile. `lionagi/protocols/generic/flow.py` keeps one
-item Pile and a Pile of named Progressions, validates that every progression UUID exists in the item
-Pile, and allows the same item to appear in multiple views. Session observation and exchange
-mailboxes use this split between storage and named ordering.
+**P3 — Item admission has both nominal and structural definitions in the repository.** Pile uses
+the nominal `Observable` base and optional runtime classes. The public contracts module separately
+exports a runtime-checkable structural protocol requiring only an `id` property. Those are not the
+same contract today.
 
-Pile also exposes a synchronous reentrant lock and a separate asynchronous lock. Decorated
-synchronous and asynchronous operations use their respective locks, but several public reads and
-mutations are unlocked, and the two lock domains do not serialize against each other. The current
-model supports disciplined, cooperative use; it is not a general linearizability or cross-context
-snapshot guarantee.
+**P4 — A reusable ordering and a Pile-owned ordering do not share one multiplicity rule.** A
+standalone Progression is a sequence and several mutators preserve repeated UUIDs. A Pile's default
+Progression must be unique because it is the one-to-one traversal view of a UUID-keyed dictionary.
+
+**P5 — Some consumers need several orderings over one stored set.** Session observation and
+exchange-style mailboxes need the same item in several named sequences. Adding all named views to
+every Pile would burden the common collection, while duplicating items would create divergent
+copies.
+
+**P6 — Sync and async callers need coordination, but the current surface evolved incrementally.**
+Pile exposes a reentrant thread lock and a separate AnyIO lock. Decorated operations do not cover
+every public read and mutation, and the two locks are not one unified snapshot mechanism.
+
+The implementation anchors are `lionagi/protocols/generic/pile.py`,
+`lionagi/protocols/generic/progression.py`, `lionagi/protocols/generic/flow.py`,
+`lionagi/protocols/generic/element.py`, `lionagi/protocols/_concepts.py`, and
+`lionagi/protocols/contracts.py`.
+
+| Concern | Decision |
+|---|---|
+| Pile storage and order | D1: A Pile owns one UUID-to-item dictionary and one unique default Progression containing exactly the same UUIDs. |
+| Addressing and mutation | D2: UUID/Element references address identity; integers and slices address positions; mutators update store and order together. |
+| Item admission and wire shape | D3: Pile admission is nominal and optionally class-restricted; serialized collections are polymorphic item lists plus a serialized Progression. |
+| Reusable ordering | D4: Progression stores an ordered UUID deque with set-backed membership, while duplicate behavior remains method-dependent. |
+| Named views | D5: Flow owns one item Pile and a Pile of named Progressions, validating that every view refers only to resident items. |
+| Synchronization | D6: Pile and Flow provide method-level cooperative locks, not a general cross-context linearizability or snapshot contract. |
+
+This ADR deliberately does **not** decide:
+
+- database indexes or persistence tables for collections; adapters consume the serialized model;
+- durable queue or scheduler semantics; Progression is an ordering, not an acknowledgement queue;
+- the future choice between unique and repeated standalone sequences; the current mixed behavior is
+  retrospective truth and remains a delta; or
+- a unified sync/async concurrency design; the shipped locks and their limits are recorded, while
+  the target requires a separate design decision.
 
 ## Decision
 
-Pile is one UUID-keyed store with one default ordered view, while Flow owns multiple named ordered
-views over one Pile. The load-bearing invariants are:
+### D1 — Pile is one UUID-keyed store plus one unique default order
 
-- a Pile's dictionary keys and default Progression contain the same unique UUIDs;
-- reference access is identity-based, while integer and slice access are order-based;
-- Pile item admission follows the nominal `Observable` and optional `item_type` checks implemented
-  by Pile, not the structural ID-only protocol;
-- every Flow progression references only items resident in that Flow's item Pile;
-- standalone and Flow-owned Progressions may currently contain repeated UUIDs, even though a
-  Pile's default Progression may not; and
-- synchronous and asynchronous locking are separate facilities and do not promise safe arbitrary
-  mixing of threads, async callers, unlocked mutators, and live reads.
+**The contract** (`lionagi/protocols/generic/pile.py`):
 
-The implementation anchors are `lionagi/protocols/generic/pile.py`,
-`lionagi/protocols/generic/progression.py`, `lionagi/protocols/generic/flow.py`, and
-`lionagi/protocols/contracts.py`.
+```python
+class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
+    collections: dict[UUID, T] = Field(default_factory=dict)
+    item_type: set | None = Field(default=None, exclude=True)
+    progression: Progression = Field(default_factory=Progression)
+    strict_type: bool = Field(default=False, frozen=True)
+
+    def __init__(
+        self,
+        collections: ID.ItemSeq = None,
+        item_type: set[type[T]] = None,
+        order: ID.RefSeq = None,
+        strict_type: bool = False,
+        **kwargs,
+    ) -> None: ...
+```
+
+The invariant is:
+
+```text
+set(pile.collections.keys()) == set(pile.progression.order)
+len(pile.collections) == len(pile.progression.order)
+```
+
+**Exact construction semantics**:
+
+- Missing or falsey `collections` produces an empty dictionary, except that a falsey nominal
+  Observable such as an empty Pile or Progression is retained as one candidate item.
+- A dictionary item is reconstructed with `Element.from_dict` before admission. Other input values
+  pass through the `to_list_type` normalization helper.
+- Items are keyed by `item.id`. Repeated input items with the same UUID overwrite the earlier
+  dictionary value before the order is validated; the resulting store has one entry for that UUID.
+- With no order, Pile creates a Progression in dictionary insertion order.
+- A supplied order may be a serialized Progression dictionary, a Progression, or an accepted
+  sequence of references. It must contain no duplicate UUIDs, have the same length as the store,
+  and resolve every UUID to a dictionary key. Violations raise `ValueError` before construction.
+- An empty supplied order is treated like no order and therefore becomes dictionary insertion
+  order. An explicitly empty order cannot describe a non-empty unordered Pile.
+- `strict_type` is frozen after construction. `collections` and `progression` remain mutable, so
+  callers can bypass the invariant by mutating fields directly; supported mutation goes through the
+  Pile methods.
+
+The dictionary and Progression are both necessary: identity lookup does not have to follow display
+order, and reordering does not rebuild or duplicate the objects.
+
+### D2 — References address identity and integers/slices address order
+
+Pile's public surface deliberately has two indexing domains.
+
+**The contract** (`lionagi/protocols/generic/pile.py` and
+`lionagi/protocols/generic/element.py`):
+
+```python
+ID.Ref = UUID | Element | str
+
+def __getitem__(self, key: ID.Ref | ID.RefSeq | int | slice) -> Any | list | T: ...
+def __setitem__(self, key, item) -> None: ...
+def get(self, key, default=UNDEFINED, /) -> T | Pile | D: ...
+def pop(self, key, default=UNDEFINED, /) -> T | Pile | D: ...
+def include(self, item, /) -> None: ...
+def exclude(self, item, /) -> None: ...
+def update(self, other, /) -> None: ...
+def insert(self, index: int, item, /) -> None: ...
+def append(self, item, /) -> None: ...
+```
+
+**Exact read semantics**:
+
+- A UUID selects `collections[uuid]`. An Element or reference sequence is normalized through
+  `ID.get_id`; one match returns the item and multiple matches return a list.
+- An integer first selects a UUID from the default Progression, then returns that item. A slice
+  returns a scalar when exactly one item was selected and a list for multiple items; an empty or
+  invalid slice raises `ItemNotFoundError`.
+- Passing a Python type returns a new Pile filtered by that type. Passing another callable returns a
+  new Pile of items for which the predicate is true.
+- `get` and `pop` translate lookup/normalization failures to `ItemNotFoundError` unless a default was
+  supplied, in which case the default is returned.
+- `keys`, `values`, and `items` are materialized lists in Progression order. Despite the `keys`
+  return annotation saying `Sequence[str]`, the actual members are UUID objects.
+- Iteration snapshots the current Progression into a list, then performs live dictionary lookups.
+  It stabilizes the order list only; removal after the snapshot can still make lookup fail.
+- Pile truthiness is `not is_empty()`, overriding Element's always-true behavior.
+
+**Exact mutation semantics**:
+
+- `include` validates items, adds only missing UUIDs to the Progression, and updates dictionary
+  values. Including an existing UUID therefore replaces the stored object without moving it.
+- `update` replaces existing UUID values in place and delegates new UUIDs to `include`; `append` is
+  an alias for that upsert behavior, not an always-add duplicate operation.
+- `insert` rejects any item UUID already present, inserts new UUIDs at the requested Progression
+  position, then updates the dictionary.
+- Integer/slice assignment accepts only new item UUIDs, replaces the selected Progression segment,
+  removes the displaced dictionary entries, and installs the new entries. Other assignment requires
+  each supplied key to match one new item's UUID; it then appends those keys.
+- `pop` by integer returns one item; a multi-item slice returns a new Pile. `pop` by several UUID
+  references returns a list rather than a Pile. All popped UUIDs are removed from both structures.
+- `exclude` silently ignores missing candidates and pops only present ones. `remove` raises
+  `ItemNotFoundError` when the item is absent and rejects integer/slice arguments.
+- Set-style `|`, `^`, and `&` operations accept only another Pile and derive membership from UUID
+  identity while retaining the left Pile's type policy.
+- A valid UUID string is declared as `ID.Ref`, and `validate_order` handles it for several reads and
+  pops. The Pile-specific `to_list_type` helper instead returns a bare UUID for that string, not a
+  one-item list; construction/order and non-positional assignment paths that use this helper are
+  therefore inconsistent and are retained as delta 1.
+
+### D3 — Pile admission is nominal and its serialized constraint is not durable
+
+Pile imports `Observable` from `lionagi/protocols/_concepts.py`, an empty nominal ABC. This is
+deliberately distinguished from the exported structural convenience protocol.
+
+**The contracts**:
+
+```python
+# lionagi/protocols/_concepts.py
+class Observable(ABC):
+    """Observable entities must define 'id'."""
+
+# lionagi/protocols/contracts.py
+@runtime_checkable
+class ObservableProto(Protocol):
+    @property
+    def id(self) -> object: ...
+
+Observable = ObservableProto
+LegacyObservable = protocols._concepts.Observable
+```
+
+```python
+def _validate_item_type(value) -> set[type] | None: ...
+def _validate_collections(
+    value: Any,
+    item_type: set | None,
+    strict_type: bool,
+) -> dict[UUID, T]: ...
+```
+
+**Exact semantics**:
+
+- With no `item_type`, every item must be an instance of the nominal ABC. Merely exposing an `id`
+  property through the structural protocol is not sufficient.
+- `item_type` accepts classes and unions. A fully qualified class string is resolved when it reaches
+  validation as a member of a list, tuple, or set. A scalar non-UUID string is currently discarded
+  by Pile's `to_list_type` normalizer before the resolver sees it. Every resolved member must be a
+  nominal Observable subclass; duplicated declarations raise LionAGI `ValidationError`.
+- With `strict_type=False`, an item's concrete type may be any subclass of an allowed class. With
+  `strict_type=True`, `type(item)` must be exactly one allowed class.
+- Invalid item types and invalid items fail before the Pile dictionary/order is committed.
+- `collections` serializes as a list of each item's polymorphic `to_dict()` output. `progression`
+  serializes as its full Element dictionary. `strict_type` is serialized.
+- `item_type` is declared with `exclude=True`; despite a field serializer existing for it, the
+  normal Pile dictionary does not carry the allowed-class set. `Pile.from_dict` calls the
+  constructor with the fields present, so a standalone round trip loses the runtime admission
+  constraint while retaining `strict_type`.
+
+The nominal check is the implemented behavior because Pile needs model identity and serialization,
+not merely a property named `id`. The mismatch with the public structural alias is still a source
+of extension ambiguity and remains delta 2.
+
+### D4 — Progression is an ordered UUID sequence with method-dependent multiplicity
+
+**The contract** (`lionagi/protocols/generic/progression.py`):
+
+```python
+class Progression(Element, Ordering[T], Generic[T]):
+    order: deque[UUID] = Field(default_factory=deque)
+    name: str | None = None
+    _members: set[UUID] = PrivateAttr(default_factory=set)
+```
+
+Input is flattened by `validate_order`: Elements contribute their IDs; mappings contribute keys;
+UUIDs and UUID strings become UUIDs; nested list, tuple, and set containers are flattened; `None`
+is ignored; any other member raises `ValueError`.
+
+**Exact semantics**:
+
+- `_members` is rebuilt as `set(order)` after validation. It accelerates membership but does not
+  encode occurrence count.
+- `include` is set-like: it appends only UUIDs absent from `_members`, returns whether anything was
+  added, returns `True` for empty input, and returns `False` for invalid input.
+- `append`, `extend`, `insert`, `+=`, construction, and slice/integer assignment do not reject a UUID
+  already in the deque. Repetitions remain visible to iteration, length, `count`, serialization, and
+  positional access.
+- Membership asks whether every normalized reference occurs at least once. An empty normalized input
+  therefore returns `True` by Python's `all([])` behavior; invalid input returns `False`.
+- `exclude`, `remove`, and subtraction remove every occurrence of each selected UUID. For empty
+  normalized input, `exclude` returns true as a successful no-op; otherwise it returns whether
+  length decreased. `remove` also returns normally for empty input and raises if any non-empty
+  requested UUID is absent.
+- `pop`/`popleft` remove one occurrence and remove the UUID from `_members` only after its last
+  occurrence leaves the deque.
+- Integer lookup returns a UUID. Slice lookup returns a new Progression and rejects an empty slice.
+  Out-of-range lookup raises `ItemNotFoundError`.
+- Integer assignment uses only the first normalized UUID, silently ignoring additional UUIDs;
+  empty input raises `IndexError`. An integer beyond the deque inserts that first UUID according to
+  `deque.insert`; slice assignment consumes every normalized UUID and rebuilds the deque. `move`,
+  `swap`, and `reverse` preserve membership and multiplicity.
+- Progression equality compares ordered UUID contents and `name`, not inherited Element UUID. This
+  intentionally differs from Element equality.
+
+Pile construction imposes uniqueness on its default Progression; standalone and Flow-owned
+Progressions do not. No caller can safely infer a universal duplicate rule from the type alone.
+
+### D5 — Flow owns multiple referentially valid views over one item Pile
+
+**The contract** (`lionagi/protocols/generic/flow.py`):
+
+```python
+class Flow(Element, Generic[E, P]):
+    name: str | None = None
+    items: Pile[E] = Field(default_factory=Pile)
+    progressions: Pile[P] = Field(default_factory=Pile)
+    _progression_names: dict[str, UUID] = PrivateAttr(default_factory=dict)
+    _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
+
+    def add_progression(self, progression: P) -> None: ...
+    def remove_progression(self, key: UUID | str | P) -> None: ...
+    def get_progression(self, key: UUID | str | P) -> P: ...
+    def add_item(self, item: E, progressions=...) -> None: ...
+    def remove_item(self, item_id: UUID | str | Element) -> None: ...
+```
+
+**Exact semantics**:
+
+- Construction and `from_dict` compute `item_ids = set(items.keys())` and reject any Progression
+  containing a UUID outside that set. An empty Flow is valid.
+- `_progression_names` indexes only truthy names. During normal `add_progression`, a duplicate name
+  raises `ItemExistsError`; UUID identity remains enforced by the Progressions Pile. Construction
+  does not separately reject duplicate names, so rebuilding the private index leaves the last
+  Progression with a repeated name addressable by that name.
+- `add_progression` validates all references before modifying the Pile. Unnamed Progressions are
+  valid and can be addressed only by UUID or instance.
+- Name lookup wins for a string key. If no name matches, Flow tries to parse the string as a UUID.
+  A missing non-UUID name is translated to `ItemNotFoundError`.
+- `add_item` resolves UUID and name references against the Flow before inserting the item. A
+  Progression instance is accepted directly without checking that it is resident in
+  `flow.progressions`; the method can therefore upsert the item into the Flow and append its UUID to
+  an external Progression that the Flow does not own. For every resolved or directly accepted view,
+  repeated calls can append the same UUID repeatedly.
+- `remove_item` removes every occurrence of the UUID from every Progression, then removes the item
+  from the item Pile. `clear` clears both Piles and the private name index.
+- Python-mode serialization explicitly calls nested `Pile.to_dict()` so concrete item classes are
+  preserved. `from_dict` accepts a Pile, serialized dictionary, or item list for each Pile, manually
+  validates referential integrity, uses `model_construct`, then rebuilds private fields.
+- The same stored item may appear in several Progressions without copying the item object.
+
+Flow, rather than Pile, owns the cost of multiple views because only the consumers that need named
+orders should carry their lifecycle and referential-integrity rules.
+
+### D6 — Synchronization is method-level and cooperative
+
+Pile owns two independent private locks:
+
+```python
+_lock: threading.RLock
+_async_lock: lionagi.ln.concurrency.Lock  # wraps anyio.Lock
+```
+
+The `synchronized` decorator acquires only `_lock`; `async_synchronized` acquires only
+`_async_lock`.
+
+**Exact semantics**:
+
+- Sync `pop`, `include`, `exclude`, `clear`, `update`, `insert`, `append`, and `get` acquire the
+  RLock. Direct `__setitem__`, `remove`'s membership test, `__getitem__`, iteration, key/value/item
+  snapshots, filtering, and direct public-field mutation are not uniformly protected.
+- Async mutation/read wrappers acquire the AnyIO lock. Several then call a sync decorated method,
+  acquiring the RLock inside the async lock; `asetitem`, `apop`, `aclear`, and `aget` call private
+  helpers directly and do not all share that nested locking shape.
+- The sync and async locks do not exclude each other by themselves. A sync caller holding only the
+  RLock and an async caller on a helper guarded only by the AnyIO lock can overlap.
+- Sync iteration snapshots only Progression order. Async iteration snapshots order while holding the
+  async lock, releases it, and then performs live dictionary lookups.
+- Pickle restoration and deep copy create fresh lock instances; locks are not serialized or shared
+  with the copy.
+- `adump` snapshots dictionary UUIDs and a DataFrame under the async lock, writes outside the lock,
+  and, when `clear=True`, later removes only the snapshotted UUIDs. Items added during the write are
+  retained.
+- Synchronous `dump(clear=True)` is format-dependent in the shipped control flow: Parquet reaches
+  the final `clear()` call, while JSON-lines and CSV return immediately after their writer and do
+  not clear. Async `adump(clear=True)` applies the snapshot removal after all three supported
+  writers.
+- Flow uses a separate RLock around its own named-view and item-management methods. External
+  mutation of its public Piles or Progressions bypasses that lock and can violate referential or
+  name-index invariants.
+
+These facilities support disciplined cooperative use and individually serialized common mutations.
+They do not promise a linearizable mixed thread/async collection, immutable snapshots, or atomic
+multi-method transactions.
 
 ## Consequences
 
-Identity lookup remains independent from presentation or processing order, and a single stored item
-can participate in several named sequences without duplication. Pile can round-trip heterogeneous
-`Element` subclasses while preserving one deterministic default order.
+Identity lookup remains independent from traversal order, and one stored object can participate in
+several named sequences without duplication. Pile construction rejects the most damaging split-
+brain states between dictionary and default order. Flow centralizes the additional cost and
+integrity rules of multiple views.
 
-The public surface carries real ambiguity. Structural observability does not imply Pile admission,
-valid UUID strings are declared references but are normalized incorrectly on some Pile paths,
-Progression multiplicity depends on its owner, and callers today must know which lock and mutation
-discipline protects a compound operation. These limitations constrain safe extension and concurrent
-use until their contracts are made explicit.
+The design also carries concrete maintenance costs:
+
+- contributors must choose the correct identity or positional access domain and account for scalar
+  versus list/Pile return shapes;
+- Progression multiplicity depends on the mutator and owner;
+- Pile's nominal admission rule differs from the exported structural protocol and is not fully
+  preserved in its wire payload;
+- valid UUID strings do not normalize consistently on every Pile path;
+- Flow can mutate a Progression instance that is not one of its owned named views;
+- synchronous dump-and-clear behavior differs by selected file format; and
+- callers currently need to know which lock and mutation discipline protects a compound operation.
+
+Reversing D1 or D2 affects nearly every collection consumer. Replacing D4's multiplicity behavior
+requires a data and caller audit because serialized repeated sequences already exist. Replacing D6
+is mechanically local to collection methods but semantically broad: it changes blocking,
+reentrancy, async scheduling, and snapshot guarantees.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
-|---|-------|------|-------|
-| 1 | Fix Pile UUID-string reference normalization; acceptance requires valid UUID strings to work as one-item references for get, set, pop, and construction paths with regression coverage. | S | (filled at issue-open time) |
+|---|---|---|---|
+| 1 | Fix Pile UUID-string reference normalization in `to_list_type`; acceptance requires valid UUID strings to work as one-item references on the paths that fail today — `__getitem__`, `__setitem__`, `exclude`, and `order=` at construction — with regression coverage (`get` and `pop` already route through `validate_order` and work). | S | (filled at issue-open time) |
 | 2 | Define one public Pile-item contract and align the exported Observable protocol with it; acceptance requires structural or nominal admission to be stated once and enforced by item-type validation and extension tests. | M | (filled at issue-open time) |
 | 3 | Decide and enforce Progression multiplicity semantics for standalone Progressions, Pile default order, and Flow named views; acceptance requires append, extend, insert, serialization, and membership behavior to match the documented rule. | M | (filled at issue-open time) |
 | 4 | Publish and enforce Pile synchronization and snapshot semantics; acceptance requires every public mutator and read API to be audited against a stated sync, async, and mixed-context contract, with stable snapshot APIs where live traversal is unsafe. | M | (filled at issue-open time) |
+| 5 | Define and enforce Progression ownership in `Flow.add_item`; acceptance requires instance, UUID, and name references to follow one documented residency rule, reject invalid ownership before item insertion, and never mutate an external view accidentally. | S | (filled at issue-open time) |
+| 6 | Make `Pile.dump(clear=True)` consistent across JSON-lines, CSV, and Parquet; acceptance requires every format either to clear the same documented pre-write snapshot after success or to retain it, with failure-path tests. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Dictionary insertion order as the only order
+
+Python dictionaries preserve insertion order, so Pile could omit Progression. That would make
+initial traversal deterministic, but arbitrary reordering, positional replacement, and multiple
+views would require rebuilding dictionaries or copying items. An explicit UUID sequence keeps
+storage identity independent from current processing order.
+
+### A list of items with linear identity lookup
+
+A list would unify storage and order and remove the split-representation invariant. UUID lookup,
+membership, replacement, and graph endpoint resolution would become linear scans, and duplicate
+identity behavior would remain ambiguous. The dictionary plus Progression pays one extra structure
+for direct lookup and explicit order.
+
+### Several Progressions inside every Pile
+
+This would make named views directly available on the common collection. Most Piles need only one
+order, and every Pile would then need naming, referential integrity, and view-removal rules. Flow
+keeps that complexity in the consumers that need it.
+
+### Copy each item into every named sequence
+
+Independent lists would avoid reference validation, but a content change in one list would not
+update the others and UUID identity would no longer select one authoritative object. Flow stores
+objects once and sequences only UUIDs.
+
+### Structural `id`-only admission
+
+Accepting `ObservableProto` would make lightweight third-party objects easy to store. Pile also
+serializes every item with `to_dict` and reconstructs dictionaries through Element, so an `id`
+property alone is not the full operational contract. The current code retains nominal admission;
+delta 2 requires choosing and documenting the complete extension surface rather than pretending the
+structural alias is sufficient.
+
+### Unique Progressions everywhere
+
+A universal set-like order would simplify membership and align standalone Progression with Pile.
+It would remove the ability to represent repeated sequence visits and would change `append`,
+`extend`, `insert`, and already serialized data. The code has not made that choice; the fork remains
+delta 3.
+
+### Duplicate-preserving Pile default order
+
+Allowing repeated UUIDs in Pile's default Progression would represent the same dictionary item at
+several positions, but Pile length, pop, replacement, and dictionary/order equality would become
+occurrence-sensitive. Construction deliberately rejects this even though standalone Progression can
+represent it.
+
+### One cross-context lock for all operations
+
+A unified lock and snapshot API could provide a stronger contract to mixed sync/async callers. A
+threading lock cannot be awaited safely as the only async primitive, while an AnyIO lock is not a
+drop-in synchronous lock; changing all methods also risks deadlock and event-loop blocking. The
+current separate locks remain retrospective truth pending the explicit concurrency design in delta
+4.
+
+### Require every Progression instance passed to Flow to be resident
+
+`add_item` could resolve a Progression instance through its UUID exactly as it resolves UUID and
+name inputs. That would make the Flow the sole owner of every mutated view and reject an external
+Progression before inserting the item. The shipped method treats an instance as already resolved,
+which avoids one lookup but bypasses the Flow's residency boundary. No stronger rationale for that
+shortcut is recorded; delta 5 retains the ownership correction.
+
+### One dump-and-clear path for every file format
+
+All synchronous writers could fall through to one post-write `clear()` block, matching async
+`adump`. That would make `clear=True` independent of the selected format. JSON-lines and CSV
+currently return their adapter result from inside the format branch, so only Parquet reaches the
+shared clear block. No format-specific retention rationale is recorded; delta 6 treats the split as
+a control-flow defect rather than a deliberate storage policy.
 
 ## Notes
 
-Alternatives considered were relying only on dictionary insertion order and storing several orders
-inside every Pile. The first couples identity storage to every reordering operation; the second adds
-unused state to the common collection and does not match the existing Flow abstraction.
+`Pile.dump` and `adump` support JSON-lines, CSV, and Parquet through DataFrame adapters. Those file
+formats are transport conveniences, not a second collection identity model. Parquet requires
+`pyarrow`; DataFrame conversion requires pandas and raises an installation-oriented `ImportError`
+when unavailable.

--- a/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
+++ b/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
@@ -9,74 +9,500 @@
 ## Context
 
 API calls and executable operations need a shared in-process representation of pending work and its
-outcome. `Event` provides mutable execution state containing status, duration, response, error, and
-retryability. Its seven statuses are `pending`, `processing`, `completed`, `failed`, `skipped`,
-`cancelled`, and `aborted`. `lionagi/protocols/generic/event.py` defines this lifecycle.
+outcome. Six concrete problems determine the shipped Event, Processor, and Executor lifecycle.
 
-Invocation begins only from `pending`, changes the event to `processing`, and then records
-`completed`, `failed`, or `cancelled` according to the outcome. Streaming uses the same result
-contract. The terminal set is `completed`, `failed`, `skipped`, `cancelled`, and `aborted`; assigning
-one of those states signals a lazily created process-local completion event. Execution state can be
-serialized for observation, but `Event.from_dict()` deliberately rejects reconstruction.
+**P1 — Work needs one inspectable outcome shape.** Callers need to distinguish work that has not
+started, is running, succeeded, failed, was denied, was cancelled, or was aborted, while retaining
+duration, response, error, and retryability information on the work item.
 
-`Processor` and `Executor` in `lionagi/protocols/generic/processor.py` are lightweight runtime
-facilities around this lifecycle. Processor queues events, applies permission and capacity checks,
-and invokes them; permission denial is terminal `skipped` unless a processor explicitly defers it.
-Executor stores live events in a Pile and their pending UUIDs in a Progression.
+**P2 — Business failures and cancellation do not have the same propagation contract.** Ordinary
+operation and provider errors should be captured on the Event so a batch processor can continue.
+Cancellation, keyboard interruption, and other base exceptions must still unwind the controlling
+task after recording state.
 
-`APICalling` uses Event for endpoint work, and `iModel` waits on the process-local completion signal
-before removing the call from its executor. `Operation` combines `Node` and `Event`, so executable
-graph nodes use the same outcome vocabulary. The anchors are
+**P3 — Waiters need a completion signal without eagerly binding Events to one loop.** Events are
+often created before a waiter exists. A lazily created process-local signal avoids allocating an
+`asyncio.Event` until needed while still waking waiters for every terminal status.
+
+**P4 — Queueing needs capacity, optional concurrency limits, and explicit denial behavior.** A
+processor may admit, terminally reject, or temporarily defer an Event. Deferred events must not be
+dropped or busy-spin, and a bounded queue needs a non-blocking enqueue path.
+
+**P5 — Live ownership must be separate from the Event's state fields.** Executor retains live Event
+objects by UUID and a pending order, lazily creates the configured Processor, and exposes status
+views without turning Event into a durable scheduler record.
+
+**P6 — Durable delivery has a different state machine.** The outbox persists delivery attempts,
+acknowledgements, expiry, retries, and dead-letter outcomes. It does not rehydrate or resume Event
+objects, whose completion primitive and arbitrary response values are process-local (see the
+persistence-state ADR on durable dispatch lifecycle).
+
+The defining modules are `lionagi/protocols/generic/event.py` and
+`lionagi/protocols/generic/processor.py`. Current consumers include
 `lionagi/service/connections/api_calling.py`, `lionagi/service/imodel.py`, and
 `lionagi/operations/node.py`.
 
-Durable dispatch is a different contract. The outbox persists delivery attempts, acknowledgements,
-expiry, retries, and dead-letter outcomes with its own state machine. It does not rehydrate or drive
-Event execution state (see the persistence-state ADR on durable dispatch lifecycle). Reactive flow
-also exposes a smaller completion projection; its current mapping does not preserve every Event
-terminal state.
+| Concern | Decision |
+|---|---|
+| Outcome vocabulary and payload | D1: Event owns mutable Execution state with seven statuses and five terminal statuses. |
+| Invocation and streaming | D2: The Event wrapper captures ordinary exceptions as failed, re-raises base exceptions as cancelled, and records duration in all started paths. |
+| Completion, observation, and reuse | D3: Terminal assignment signals a lazy local event; state serializes for observation, cannot rehydrate, and can be cloned as fresh work. |
+| Queue processing | D4: Processor applies capacity, optional semaphore concurrency, permission, terminal denial, and deferral policy in memory. |
+| Live event ownership | D5: Executor stores Events in a typed Pile and pending UUIDs in a Progression, forwarding them to a lazily created Processor. |
+| Persistence boundary | D6: Durable delivery keeps its own persisted lifecycle rather than adopting EventStatus. |
+
+This ADR deliberately does **not** decide:
+
+- provider rate-limit numbers, retry policy, or endpoint payloads; Processor accepts policy inputs
+  and provider-specific processors own those values;
+- operation-graph dependency scheduling; Operation reuses Event state, while the operations area
+  owns graph execution;
+- durable acknowledgement, expiry, retry, or dead-letter transitions; those belong to the
+  persistence-state durable-dispatch contract; or
+- hook execution and hook timeout behavior; HookedEvent layers that concern above Event.
 
 ## Decision
 
-Event is the common in-process execution lifecycle for API calls and executable Operations. Its
-load-bearing invariants are:
+### D1 — Event owns a seven-state mutable Execution payload
 
-- execution begins in `pending`, active work is `processing`, and the complete seven-value status
-  vocabulary remains available to runtime consumers;
-- `completed`, `failed`, `skipped`, `cancelled`, and `aborted` are terminal and signal the local
-  completion primitive;
-- normal results populate `response`, ordinary exceptions produce `failed` with captured error
-  state, and cancellation-class base exceptions produce `cancelled` and are re-raised;
-- Event execution records may be serialized for observation but are not durable, rehydratable work
-  items;
-- Processor and Executor coordinate live Event instances in memory; and
-- durable dispatch retains an independent delivery state machine rather than adopting EventStatus.
+**The contracts** (`lionagi/protocols/generic/event.py`):
 
-The defining implementation anchors are `lionagi/protocols/generic/event.py` and
-`lionagi/protocols/generic/processor.py`.
+```python
+class EventStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"
+    ABORTED = "aborted"
+```
+
+```python
+class Execution:
+    __slots__ = ("status", "duration", "response", "error", "retryable")
+
+    def __init__(
+        self,
+        duration: float | None | UnsetType = Unset,
+        response: Any = None,
+        status: EventStatus = EventStatus.PENDING,
+        error: str | BaseException | None = None,
+        retryable: bool | None | UnsetType = Unset,
+    ) -> None: ...
+
+class Event(Element):
+    execution: Execution = Field(default_factory=Execution)
+    streaming: bool = Field(False, exclude=True)
+```
+
+The terminal set is exactly:
+
+```python
+frozenset({
+    EventStatus.COMPLETED,
+    EventStatus.FAILED,
+    EventStatus.SKIPPED,
+    EventStatus.CANCELLED,
+    EventStatus.ABORTED,
+})
+```
+
+**Exact semantics**:
+
+- A new Event is `pending`; duration and retryability use the internal `Unset` sentinel, response
+  and error are `None`, and `streaming` is false.
+- `Event.status` returns `execution.status`. Its setter accepts an EventStatus or one of the seven
+  legal strings; an unknown string or other type raises `ValueError`.
+- The setter validates membership but does not enforce a transition graph. Callers can assign any
+  legal status from any other status. Direct assignment to `execution.status` bypasses both setter
+  validation and completion signalling.
+- `response` is a direct property proxy to `execution.response`. Base `request` returns `{}`;
+  subclasses provide the permission/request metadata used by processors.
+- `retryable` is descriptive state only. Event and Processor do not automatically retry based on
+  it.
+- `Event.q.status`, `.duration`, `.response`, `.error`, and `.retryable` produce field references to
+  the nested `execution.*` paths for query expressions.
+
+Execution is a mutable slot object rather than a second Pydantic model because it is updated
+throughout one live invocation and serialized through Event's dedicated field serializer.
+
+### D2 — Invoke and stream wrap subclass work with total ordinary-failure capture
+
+Subclasses implement `_invoke` and optionally `_stream`; the base wrapper owns state transitions.
+
+**The contract** (`lionagi/protocols/generic/event.py`):
+
+```python
+async def invoke(self) -> None: ...
+async def _invoke(self) -> Any: ...
+
+async def stream(self): ...
+async def _stream(self): ...
+```
+
+Invoke transitions are:
+
+```text
+pending -> processing -> completed   (_invoke returned)
+pending -> processing -> failed      (_invoke raised Exception)
+pending -> processing -> cancelled   (_invoke raised BaseException outside Exception)
+non-pending -> unchanged             (invoke is a no-op)
+```
+
+**Exact invoke semantics**:
+
+- Only `pending` starts. Every other status, including `processing`, returns immediately without
+  changing response, error, duration, or completion state.
+- Start assigns `execution.status = processing` and records the current UTC timestamp.
+- A normal `_invoke` return is stored as response and status is assigned `completed` through the
+  property setter.
+- An ordinary `Exception` is not re-raised. Status becomes `failed` and the exception is accumulated
+  by `Execution.add_error`.
+- A `BaseException` not caught by `Exception` is accumulated, status becomes `cancelled`, and the
+  same exception is re-raised. This includes asyncio/AnyIO cancellation classes and process-control
+  exceptions on the running Python version.
+- Duration is overwritten in `finally` with elapsed wall-clock seconds for every started path,
+  including failure and cancellation. A no-op invocation retains its earlier duration.
+- Calling the bare Event's `_invoke` captures its `NotImplementedError` as a failed Event rather than
+  raising to the caller.
+
+**Exact stream semantics**:
+
+- Stream returns without yielding when status is any terminal value. Unlike invoke, a non-terminal
+  `processing` status does not block a new stream attempt; the wrapper assigns `processing` again.
+- Every `_stream` chunk is yielded unchanged. Chunks are not accumulated into `response` by the base
+  class.
+- Exhausting the async generator assigns `completed`. An ordinary exception after any yielded
+  chunks is captured as `failed` and iteration ends without re-raising it. A base exception records
+  `cancelled` and is re-raised.
+- Duration is recorded when generator execution closes through normal completion, captured failure,
+  or cancellation.
+- Subclasses that override `invoke` or `stream` directly bypass these guarantees. Compatibility
+  tests retain that extension shape, so the wrapper cannot enforce duration or completion
+  signalling for a direct override.
+
+This split lets batch processing treat ordinary business failure as data while preserving
+cancellation as control flow.
+
+### D3 — Completion is local and one-shot; serialization is observational
+
+**The contract** (`lionagi/protocols/generic/event.py`):
+
+```python
+_completion_event: asyncio.Event | None = PrivateAttr(default=None)
+
+@property
+def completion_event(self) -> asyncio.Event: ...
+
+@classmethod
+def from_dict(cls, data: dict) -> Event:
+    raise NotImplementedError("Cannot recreate an event once it's done.")
+
+def assert_completed(self) -> None: ...
+def as_fresh_event(self, copy_meta: bool = False) -> Event: ...
+```
+
+The serialized execution payload is always five keys:
+
+```python
+{
+    "status": "pending",
+    "duration": None,
+    "response": None,
+    "error": None,
+    "retryable": None,
+}
+```
+
+**Exact completion semantics**:
+
+- The asyncio.Event is created on first access. If status is already terminal, it is immediately
+  set; otherwise it starts unset.
+- Assigning a terminal value through `Event.status` sets an already-created signal. Assigning a
+  non-terminal value does not clear it. Completion is therefore a one-shot signal for the live Event,
+  not a reusable condition variable.
+- Directly mutating `execution.status` or overriding lifecycle methods can bypass signalling.
+- `assert_completed` succeeds only for `completed`. Every other status raises `RuntimeError` with
+  the serialized execution fields except response.
+
+**Exact observation semantics**:
+
+- Simple response values serialize directly. Complex responses are first tested with JSON dumping,
+  then recursively converted to a dictionary when possible; values still not serializable become
+  the string `"<unserializable>"`.
+- A normal exception serializes as `{"error": <class name>, "message": <text>}`. An ExceptionGroup
+  recursively serializes nested exceptions.
+- `Execution.add_error` stores the first exception, groups the second, and appends later exceptions
+  to the group. It caps a group at **100 errors**; further errors are ignored. The value is inherited
+  from the implementation and has no recorded design rationale beyond bounding diagnostic growth.
+- ExceptionGroup serialization stops only after depth **100** and emits a max-depth marker; it also
+  detects a repeated object identity and emits a circular-reference marker. This numeric limit is
+  likewise inherited with no recorded rationale.
+- `Unset` duration and retryability serialize as `None`. `streaming` is excluded from the payload.
+- Event state may be serialized through Element for logs and inspection, but `from_dict` always
+  raises. A payload is not a resumable Event.
+
+`as_fresh_event` is the supported reuse mechanism. It constructs the same concrete class while
+excluding old `execution`, `id`, `created_at`, and metadata, reattaches other excluded fields with a
+best-effort deep copy, and receives a fresh identity and pending Execution. Optional metadata copy
+is best-effort deep; the new metadata always gains:
+
+```python
+{"original": {"id": str(old.id), "created_at": old.created_at}}
+```
+
+### D4 — Processor performs bounded in-process queue cycles
+
+**The contract** (`lionagi/protocols/generic/processor.py`):
+
+```python
+class Processor(Observer):
+    event_type: ClassVar[type[Event]]
+
+    def __init__(
+        self,
+        queue_capacity: int,
+        capacity_refresh_time: float,
+        concurrency_limit: int,
+        max_queue_size: int = 0,
+    ) -> None: ...
+
+    async def enqueue(self, event: Event) -> None: ...
+    def try_enqueue(self, event: Event) -> bool: ...
+    async def process(self) -> None: ...
+    async def join(self) -> None: ...
+    async def execute(self) -> None: ...
+    async def request_permission(self, **kwargs: Any) -> bool: ...
+    async def handle_denied(self, event: Event) -> bool: ...
+```
+
+**Parameter semantics**:
+
+- `queue_capacity` must be at least 1 and bounds the number of capacity-consuming events (accepted,
+  or terminally denied) handled in one processing cycle. It is not a cap on total dequeue
+  operations: a deferred event is re-enqueued without decrementing `available_capacity`, so total
+  queue traffic in one `process()` call can exceed `queue_capacity` when accepted, denied, and
+  deferred events interleave. The generic class has no default; a caller or subclass owns the
+  chosen number.
+- `capacity_refresh_time` must be greater than zero and is the sleep interval for the long-running
+  loop and for a `join` cycle that made no queue-size progress. The generic class does not choose a
+  value or rationale.
+- A truthy `concurrency_limit` creates an AnyIO semaphore; zero or `None` means no semaphore. A
+  negative truthy value is rejected by the semaphore constructor.
+- `max_queue_size=0` uses asyncio.Queue's unbounded convention. A positive value bounds queued
+  Events. This zero default is intentional compatibility with the underlying queue API; no finite
+  generic queue budget is imposed.
+- A negative `max_queue_size` is not rejected. `asyncio.Queue` treats it as unbounded, but
+  Processor's `queue_full` property compares the current size to the negative number and therefore
+  reports true even for an empty queue. Negative values are accepted but internally inconsistent.
+- Despite its name, `capacity_refresh_time` does not replenish `available_capacity`; it controls
+  only the sleep interval in `join` and `execute`. Capacity resets only through the dispatched-work
+  path described below.
+
+**Exact queue and processing semantics**:
+
+- `enqueue` waits for space. `try_enqueue` returns false rather than waiting on `QueueFull`.
+  `queue_full` is always false for the unbounded zero case and otherwise compares current size to
+  the configured maximum.
+- `process` dequeues while cycle capacity remains and the queue is non-empty. It calls
+  `request_permission(**event.request)` before dispatch.
+- Default permission always allows. Default denial assigns `skipped` and returns true, meaning a
+  terminal denial. A subclass can return false from `handle_denied` to defer instead.
+- A terminal denial consumes one unit of available cycle capacity and leaves the Event out of the
+  queue. A deferral re-enqueues the still-pending Event and consumes no capacity.
+- The cycle stops after a full lap of deferrals, detected by deferred count reaching current queue
+  size; this prevents a permanently denied queue from busy-spinning inside one call.
+- Non-streaming Events run `invoke`; streaming Events are fully consumed through `stream`. When a
+  semaphore exists, each task holds one permit around the entire invoke or stream.
+- Scheduled tasks run in a task group, so `process` waits for all work selected in that cycle before
+  returning. Ordinary Event failures normally remain captured state rather than task errors.
+- If at least one Event was dispatched, available capacity resets to `queue_capacity` after the task
+  group completes. A cycle containing only terminal denials decrements capacity without this reset;
+  that is the current implementation, not a general token-bucket contract.
+- If terminal denials consume all available capacity while denied Events remain queued, later
+  `process` calls cannot dequeue them. `join` and `execute` continue sleeping at
+  `capacity_refresh_time`, but no timer restores capacity; the remaining queue stalls until code
+  outside Processor changes `available_capacity` or the caller cancels the loop.
+- `join` repeats until the queue is empty. If a cycle leaves queue size unchanged, it sleeps
+  `capacity_refresh_time`; permanently deferred work therefore keeps `join` alive until external
+  policy changes or the caller cancels it.
+- `execute` sets `execution_mode`, clears a prior stop signal, runs process/sleep cycles until
+  stopped, and then clears `execution_mode`.
+
+Processor is a live scheduling facility. Its queue and stop signal do not persist across restart.
+
+### D5 — Executor owns live Events and pending order
+
+**The contract** (`lionagi/protocols/generic/processor.py`):
+
+```python
+class Executor(Observer):
+    processor_type: ClassVar[type[Processor]]
+
+    def __init__(
+        self,
+        processor_config: dict[str, Any] | None = None,
+        strict_event_type: bool = False,
+    ) -> None:
+        self.pending = Progression()
+        self.processor: Processor | None = None
+        self.pile = Pile(
+            item_type=self.processor_type.event_type,
+            strict_type=strict_event_type,
+        )
+```
+
+**Exact semantics**:
+
+- `append` asynchronously includes the live Event in the typed Pile and set-like includes its UUID
+  in `pending`; appending the same Event again replaces the Pile value and does not duplicate the
+  pending UUID.
+- `start` lazily creates the configured Processor and resets its stop signal. `stop` is a no-op when
+  no Processor has been created.
+- `forward` removes every pending UUID from the left of the Progression, retrieves the corresponding
+  Event, awaits queue insertion, then calls one Processor cycle. It expects a Processor to have been
+  created by `start`.
+- Completed, pending, failed, cancelled, and skipped properties construct new filtered Piles.
+  `aborted` and `processing` have no dedicated property but remain visible in `status_counts`.
+- `cleanup_completed` removes only completed Events and returns the count. Other terminal states
+  remain owned until a consumer removes them.
+- `inspect_state` reports total events, a string-keyed status histogram, pending UUID count, and
+  processor running/stopped flags. It is a live snapshot assembled from current objects.
+
+`APICalling` uses Event for endpoint work; `Operation` combines Node and Event so graph-addressable
+operations share the same execution payload. `iModel.invoke` waits only while a call is pending or
+processing, using the completion event with a **10-second** timeout before it removes and returns the
+live call. That timeout replaced an earlier polling bound in the consumer; no stronger completion
+guarantee is provided by Event itself, and timeout ownership stays in the service layer.
+
+### D6 — Durable delivery remains a separate lifecycle
+
+Event serialization is diagnostic and Event reconstruction is forbidden. Processor and Executor
+hold live objects, local locks/signals, arbitrary response values, and in-memory queues. They cannot
+provide restart recovery.
+
+The durable outbox instead persists delivery identifiers, attempts, acknowledgement state, expiry,
+retry timing, and dead-letter disposition. Those states answer whether a payload was delivered, not
+whether an in-process operation's `_invoke` returned, failed, was skipped by permission, or was
+cancelled by its task.
+
+**Exact boundary semantics**:
+
+- no outbox row is an Event snapshot;
+- no Event `from_dict` path resumes an outbox delivery;
+- Event `retryable` does not schedule a durable retry; and
+- integrations must translate outcomes explicitly when they connect execution to delivery (see the
+  persistence-state ADR on durable dispatch lifecycle).
+
+Keeping the vocabularies separate prevents a delivery acknowledgement from being confused with a
+successful operation response or a process-local cancellation.
 
 ## Consequences
 
-API calls and graph operations share one outcome shape, completion signal, and processor model.
-Failures and cancellations remain observable on the live object, while processors can apply
-capacity, concurrency, and permission policy without embedding durable delivery semantics in the
-generic event type.
+API calls and graph Operations share one outcome shape, completion signal, error capture rule, and
+processor model. Ordinary failures remain inspectable on the live Event without aborting sibling
+work, while cancellation retains task-control semantics. Processors can apply capacity,
+concurrency, queue, and permission policy without placing durable delivery concepts in Event.
 
-Live Events cannot resume after process loss, and serialized Event state is diagnostic rather than
-an executable record. Consumers that expose a smaller status vocabulary today must define a total
-projection or risk reporting cancellation or abort as success. Systems needing retries,
-acknowledgements, or dead-letter handling currently integrate with the durable dispatch contract instead.
+The costs are concrete:
+
+- legal status assignments are not a validated state machine, and direct `execution.status`
+  mutation can bypass completion signalling;
+- the completion primitive is tied to the process and is one-shot;
+- direct lifecycle overrides can bypass duration, signalling, and failure capture;
+- Processor denial/deferral policy and capacity values must be understood by each subclass;
+- negative queue bounds produce contradictory queue-state reporting, and terminal-only denial can
+  exhaust capacity without a refresh path; and
+- serialized Event state cannot resume after process loss.
+
+Today, consumers that expose a smaller status vocabulary risk projecting `cancelled` or `aborted`
+as success. Reactive flow's completion record currently has only `completed`, `failed`, and
+`skipped`, and its fallback maps any non-failed, non-explicitly-skipped Event to completed (see the
+operations ADR on operation-flow completion projection).
+
+Reversing D1 or D2 breaks all Event consumers. Replacing the local completion primitive requires an
+async-runtime compatibility audit. Merging D6 with the outbox would require a migration and a new
+definition of execution versus delivery success, not an enum rename.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
-|---|-------|------|-------|
+|---|---|---|---|
 | 1 | Make the flow completion projection total over every terminal EventStatus; acceptance requires `cancelled` and `aborted` to remain non-success outcomes through status or reason fields, with tests for all five terminal states. | S | (filled at issue-open time) |
 | 2 | Document the translation boundary between in-process Event execution and durable dispatch delivery; acceptance requires each integration point to identify ownership of retry, acknowledgement, expiry, and terminal-outcome mapping without merging the two state machines. | M | (filled at issue-open time) |
+| 3 | Validate Processor queue bounds; acceptance requires negative `max_queue_size` to be rejected or assigned one coherent queue and `queue_full` meaning, with zero and positive-bound regression tests. | S | (filled at issue-open time) |
+| 4 | Restore progress after terminal denial exhausts cycle capacity; acceptance requires more than `queue_capacity` terminally denied Events to reach `skipped` under `join` and `execute`, with the capacity-refresh rule stated and tested. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Raise every invocation error to the processor
+
+This would use ordinary coroutine exception semantics and reduce mutable error state. A task-group
+failure could then cancel sibling Events and force every batch caller to reconstruct which work
+completed. Capturing ordinary `Exception` as `failed` keeps per-Event outcomes independent;
+BaseException still unwinds control flow.
+
+### Swallow cancellation as a failed Event
+
+Treating cancellation like a business failure would make invocation total, but the controlling task
+could not reliably stop work. The wrapper records `cancelled`, records duration and error, then
+re-raises so structured concurrency remains authoritative.
+
+### One terminal status
+
+A single `done` value would simplify waiters. It would erase success, business failure, permission
+skip, cancellation, and abort distinctions that processors and operation flows already need.
+Completion signalling uses a shared terminal set without collapsing the externally inspected status.
+
+### Eagerly allocate the completion event
+
+Eager allocation makes the field simpler but binds every Event to an asyncio primitive whether or
+not anything waits. Lazy allocation supports pre-loop construction and immediately sets the signal
+when a waiter first arrives after terminal completion.
+
+### Rehydrate serialized Events
+
+Persisted Events could appear to support restart recovery. Their arbitrary response/error objects,
+private completion primitive, subclass runtime dependencies, and possible in-flight side effects do
+not form a durable replay contract. `from_dict` rejects the operation explicitly; callers create a
+fresh Event or use durable dispatch.
+
+### One status enum for Event and durable dispatch
+
+This would reduce vocabulary count but collapse different questions: execution outcome versus
+delivery attempt/acknowledgement/expiry. Retry and dead-letter transitions do not correspond to
+`processing`, `skipped`, or task cancellation. The outbox retains its independent state machine.
+
+### Drop denied Events
+
+Dequeuing a temporarily rate-limited Event without requeueing loses work. Processor distinguishes
+terminal denial (`skipped`) from deferral (requeue pending) and stops after a full deferred lap.
+
+### Busy-wait deferred work
+
+Immediately retrying a queue whose permission state has not changed consumes CPU and starves other
+tasks. `process` returns after a full lap and `join` sleeps the configured refresh interval before
+trying again.
+
+### Time-based capacity replenishment
+
+Processor could restore `available_capacity` after each `capacity_refresh_time` window regardless
+of whether the prior cycle dispatched work. That would make the parameter a true capacity window
+and would allow a terminal-denial-only queue to keep draining. The shipped implementation resets
+capacity only when at least one Event was dispatched; no recorded rationale explains why terminal
+denials are excluded. Delta 4 retains the required progress correction without retroactively
+claiming a particular rate-limit algorithm.
+
+### Persist Processor and Executor directly
+
+Persisting queue order and live Event objects would couple generic execution to one storage and
+recovery model. Their process-local task groups, semaphores, locks, and response objects do not
+round-trip safely. Durable delivery remains a separate integration.
 
 ## Notes
 
-Alternatives considered were making Event a durable workflow record and sharing one status enum with
-the dispatch outbox. The first conflicts with process-local completion primitives and arbitrary
-runtime response objects; the second would collapse execution outcomes and delivery guarantees that
-have different transition and retry semantics.
+The generic Processor intentionally does not assign provider capacity numbers. Service consumers
+currently choose values such as queue capacity and refresh intervals; their rationales belong to
+the service-provider area. The only numeric safety caps owned by this ADR are the two inherited
+Execution diagnostic caps of 100, for which no recorded rationale was found.

--- a/docs/adr/ADR-0004-directed-graph-structural-invariants.md
+++ b/docs/adr/ADR-0004-directed-graph-structural-invariants.md
@@ -8,68 +8,446 @@
 
 ## Context
 
-LionAGI represents dependency-aware work as a directed graph. `Graph` stores Nodes and Edges in
-typed Piles and maintains a derived adjacency mapping with separate incoming and outgoing edge maps
-for every resident node. An edge can be added only when both endpoint UUIDs are already present, and
-removing a node removes its incident edges. `lionagi/protocols/graph/graph.py` and
-`lionagi/protocols/graph/edge.py` define this structure.
+LionAGI represents relationships and dependency-aware work with a mutable directed graph. The
+generic Graph owns structure, not execution. Five problems determine its shipped contract.
 
-Graph supports predecessor and successor lookup, cycle detection via `is_acyclic`, and topological
-sorting. Its mutating methods use a reentrant lock, but traversal and adjacency reads do not take
-that lock. The public `add_node` annotation admits any nominal `Relational`, while the backing Pile
-accepts `Node` subclasses; the storage boundary is therefore narrower than the method signature.
+**P1 — Edges must not point outside the resident graph.** A graph traversal cannot resolve an
+endpoint that is absent from node storage. Endpoint checks therefore happen before an edge is added,
+and removing a node must remove every incident edge.
 
-The primary consumer of this structure is operation-flow execution, which schedules content-bearing
-Operation nodes over a Graph and relies on its acyclicity check, adjacency mapping, and mutation
-methods (see the operations ADR on operation-graph execution). That consumer imposes stronger
-transactional requirements than any single Graph mutation provides — it coordinates graph changes
-with its own runtime state under its own lock — which is why Graph deliberately exposes composable
-mutation primitives rather than an execution-shaped transaction API.
+**P2 — Relationship lookup must not scan every edge.** Predecessor, successor, head, tail, and path
+queries are frequent. Graph maintains a derived per-node adjacency map with separate incoming and
+outgoing edge maps in addition to the canonical Node and Edge Piles.
+
+**P3 — Structural edits need reusable primitives.** Consumers need to add/remove nodes and edges,
+replace a node while preserving incident relationships, and insert a new node after an anchor while
+rewiring the anchor's outgoing relationships. These are graph operations, independent of any
+execution state machine.
+
+**P4 — Cycles are valid graph data but must be detectable.** A generic directed graph may contain a
+self-loop or longer cycle. Execution consumers need an explicit acyclicity query or topological-sort
+failure before using the graph as a dependency plan; Graph does not silently outlaw cycles for every
+consumer.
+
+**P5 — Mutation coordination and traversal coordination have different scope.** Each shipped Graph
+mutation holds a reentrant thread lock. Traversal, serialization, and direct access to public Piles
+and the adjacency dictionary are unlocked, so Graph is not an immutable snapshot or a multi-step
+transaction.
+
+The primary execution consumer schedules content-bearing Operation nodes over a Graph and applies
+stronger dependency and transaction rules above these primitives (see the operations ADR on
+operation-graph execution). The defining modules for this ADR remain
+`lionagi/protocols/graph/graph.py` and `lionagi/protocols/graph/edge.py`; Node identity and
+serialization are defined by ADR-0001.
+
+| Concern | Decision |
+|---|---|
+| Node and edge representation | D1: Graph stores Node subclasses and directed Edge models; Edge keeps endpoints as UUIDs and condition/label/custom values in a properties dictionary. |
+| Adjacency and residency | D2: Every resident node has `in` and `out` maps, and an edge is admitted only when both endpoints are resident. |
+| Structural mutation | D3: Add/remove, node replacement, and splice-after update Piles and adjacency together under one mutation lock. |
+| Structural queries | D4: Graph exposes adjacency queries, cycle detection, topological sorting, and condition-aware directed BFS over the current live structure. |
+| Serialization and concurrency boundary | D5: Node/Edge Piles serialize; adjacency is excluded and rebuilt; mutation locks are method-level and traversal remains unlocked. |
+
+This ADR deliberately does **not** decide:
+
+- whether an executable operation graph may run with cycles, how predecessors complete, or how a
+  blocked operation is marked; those are operation-scheduler decisions;
+- transactional coordination between Graph mutations and consumer runtime state; consumers that
+  need a compound transaction own it above Graph;
+- graph database persistence, distributed traversal, or durable graph locking; Graph is an in-memory
+  model; or
+- a domain ontology for edge labels and properties; generic Edge accepts caller-defined properties.
 
 ## Decision
 
-`Graph` is a mutable directed-graph model whose load-bearing structural invariants are:
+### D1 — Graph stores Nodes and directed property-bearing Edges
 
-- graph storage contains Nodes and directed Edges in typed Piles, and every edge head and tail
-  refers to a resident node — insertion of an edge with a non-resident endpoint fails;
-- the derived adjacency mapping (incoming and outgoing edge maps per node) agrees with the node and
-  edge Piles at all times, including cascade removal of incident edges when a node is removed;
-- cycle detection (`is_acyclic`) and topological sorting are structural queries over the current
-  graph state, available to any consumer before or during use;
-- each mutating method is individually serialized by a reentrant lock; compound multi-step changes
-  are the caller's responsibility to coordinate.
+**The model contracts** (`lionagi/protocols/graph/graph.py` and
+`lionagi/protocols/graph/edge.py`):
 
-Graph's mutation lock protects individual graph mutations. It does not establish a general guarantee
-for arbitrary concurrent mutation and unlocked traversal, and it does not provide multi-mutation
-transactions — consumers needing atomic compound changes (for example, reactive node insertion
-coordinated with runtime completion state) build their own transaction above Graph (see the
-operations ADR on operation-graph execution). The implementation anchors are
-`lionagi/protocols/graph/graph.py` and `lionagi/protocols/graph/edge.py`.
+```python
+class Graph(Element, Relational, Generic[T]):
+    internal_nodes: Pile[T] = Field(
+        default_factory=lambda: Pile(item_type={Node}, strict_type=False)
+    )
+    internal_edges: Pile[Edge] = Field(
+        default_factory=lambda: Pile(item_type={Edge}, strict_type=False)
+    )
+    node_edge_mapping: dict = Field(default_factory=dict, exclude=True)
+    _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
+```
+
+```python
+class EdgeCondition(BaseModel, Condition):
+    source: Any = None
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,
+    )
+
+class Edge(Element):
+    head: UUID
+    tail: UUID
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    def __init__(
+        self,
+        head: ID[Relational].Ref,
+        tail: ID[Relational].Ref,
+        condition: Condition | None = None,
+        label: list[str] | None = None,
+        **kwargs,
+    ): ...
+```
+
+**Exact Edge semantics**:
+
+- `head` and `tail` accept a UUID, Element reference, or UUID string and are normalized by
+  `ID.get_id`. Direction is head to tail.
+- The constructor places every extra keyword in `properties`. A truthy `condition` is also placed
+  under `properties["condition"]` after a nominal `Condition` check. A duck-typed object that only
+  exposes an async `apply` method is rejected.
+- A truthy string label becomes a one-element list. A truthy list must contain one homogeneous
+  string type; other values raise `ValueError`. An omitted or falsey constructor label does not add a
+  label property.
+- The `label` setter differs slightly: `None` or an empty list writes `[]`; a string is wrapped; a
+  homogeneous string list is retained. The `condition` setter accepts `None` or a nominal Condition
+  and always writes the property.
+- `check_condition(*args, **kwargs)` awaits the condition's `apply` when present and otherwise
+  returns true. Condition exceptions propagate to the caller.
+- `update_property` overwrites one property. `update_condition_source` changes `.source` only when
+  the current condition value is truthy; Graph does not interpret the source.
+- Parallel edges, reverse-direction pairs, and self-loops are structurally valid because every Edge
+  has its own UUID and the graph imposes no endpoint-pair uniqueness rule.
+
+The custom Edge constructor has an important inherited-envelope consequence: serialized `id`,
+`created_at`, `metadata`, and an existing `properties` dictionary arrive through `**kwargs` and are
+then nested into a newly assembled properties dictionary while Element generates a new UUID and
+timestamp. Direct Edge reconstruction therefore changes identity. In a containing Graph, that new
+UUID also disagrees with the old UUID retained by the serialized Edge Pile's Progression, causing
+Pile reconstruction to fail. ADR-0001 delta 3 owns the Edge envelope correction; this ADR records
+the additional Graph reconstruction contract in delta 4.
+
+### D2 — Derived adjacency mirrors every resident node and edge
+
+The adjacency shape is:
+
+```python
+node_edge_mapping = {
+    node_id: {
+        "in":  {edge_id: edge.head, ...},
+        "out": {edge_id: edge.tail, ...},
+    },
+    ...,
+}
+```
+
+For an edge `A -> B`, `mapping[A]["out"][edge.id] == B` and
+`mapping[B]["in"][edge.id] == A`.
+
+**The mutation entry points**:
+
+```python
+def add_node(self, node: Relational) -> None: ...
+def add_edge(self, edge: Edge, /) -> None: ...
+def remove_node(self, node: ID[Node].Ref, /) -> Node: ...
+def remove_edge(self, edge: Edge | str, /) -> Edge: ...
+```
+
+The source annotations for `remove_node` and `remove_edge` say `None`, but the implementations
+return the removed Node or Edge from their backing Piles.
+
+**Exact semantics**:
+
+- A new Graph has empty typed Piles and an empty mapping.
+- `add_node` first checks nominal `Relational`, then inserts through the Node-typed Pile and creates
+  an empty adjacency entry. Reusing a UUID becomes `RelationError` through the caught
+  `ItemExistsError`.
+- The public `add_node` annotation/check is broader than storage: a nominal Relational that is not a
+  Node passes the first check and then fails Pile's Node admission. This mismatch remains delta 1.
+- `add_edge` requires an Edge instance and checks both endpoint UUIDs against the node Pile before
+  mutating any structure. A missing endpoint raises `RelationError`. A repeated Edge UUID is
+  translated from `ItemExistsError` to `RelationError`.
+- A valid add inserts the Edge, then records one outgoing and one incoming adjacency entry. A
+  self-loop records the same Edge ID in both maps for the same node.
+- `remove_edge` rejects an absent Edge UUID, removes both adjacency entries, and removes/returns the
+  Edge.
+- `remove_node` rejects an absent UUID. It removes all incoming edges from predecessor `out` maps and
+  edge storage, then all remaining outgoing edges from successor `in` maps and edge storage. For a
+  self-loop, removing it during the incoming pass also removes it from the same node's outgoing map,
+  so it is not removed twice. Finally the node mapping and Node are removed.
+- Direct writes to `internal_nodes`, `internal_edges`, or `node_edge_mapping` bypass these operations
+  and can violate residency and mirror invariants.
+
+The redundant mapping is retained because the common predecessor/successor queries become local to
+one node rather than scans over all Edges.
+
+### D3 — Replacement preserves edges; splice-after replaces outgoing edge identities
+
+Graph provides two compound structural edits in addition to add/remove.
+
+**The contracts** (`lionagi/protocols/graph/graph.py`):
+
+```python
+def replace_node(self, old: Any, new_node: Node) -> Node: ...
+def splice_after(self, anchor: Any, new_node: Node) -> list[Edge]: ...
+```
+
+**`replace_node` semantics**:
+
+1. Normalize the old reference. Missing old UUID raises `RelationError`.
+2. Reject a replacement UUID already resident in the graph.
+3. Insert the replacement Node at the end of the Node Pile and create empty adjacency maps.
+4. For every incoming Edge, mutate `edge.tail` to the new UUID and update the predecessor's outgoing
+   target and the replacement's incoming entry.
+5. For every outgoing Edge, mutate `edge.head` to the new UUID and update the successor's incoming
+   source and the replacement's outgoing entry.
+6. Remove the old adjacency entry and remove/return the old Node.
+
+Existing Edge objects, UUIDs, conditions, labels, custom properties, and relative Edge order are
+preserved. Node order is not preserved: the replacement is appended and the old node is removed
+from its prior position.
+
+**`splice_after` semantics**:
+
+1. Normalize and require the anchor; reject a new UUID already resident.
+2. Append the new Node and snapshot the anchor's outgoing `(edge_id, tail_id)` entries.
+3. For every former outgoing Edge, create a new Edge from the new Node to the old tail. Reuse the
+   same condition object and any truthy label value, and copy all other properties except the
+   separately passed `condition` and `label` keys. An explicitly stored empty label is not
+   preserved: `old_edge.label` supplies `[]`, the Edge constructor treats that value as omitted, and
+   the replacement has no label property and reads back `None`.
+4. Insert each replacement Edge and adjacency, then remove the original Edge and its adjacency.
+5. Create a new unconditioned Edge from anchor to new Node.
+6. Return a list with the anchor-to-new link first, followed by replacement outgoing Edges.
+
+With no original successors, splice creates only the anchor-to-new Edge. Unlike `replace_node`, it
+deliberately creates new identities and timestamps for every rewired outgoing Edge; old Edge
+metadata is not copied because only condition, label, and other property entries are forwarded.
+
+Both methods hold the Graph RLock for their full sequence, but neither has rollback. An unexpected
+validation or insertion failure after earlier steps can leave partial mutation; the lock prevents
+another decorated mutation from interleaving, not transaction failure.
+
+These primitives stay execution-agnostic. A consumer coordinating Graph structure with running or
+completed operations must add its own higher-level transaction (see the operations ADR on reactive
+operation insertion).
+
+### D4 — Queries inspect the current directed structure
+
+**The contracts** (`lionagi/protocols/graph/graph.py`):
+
+```python
+def find_node_edge(
+    self,
+    node: Any,
+    /,
+    direction: Literal["both", "in", "out"] = "both",
+) -> Pile[Edge]: ...
+
+def get_heads(self) -> Pile[Node]: ...
+def get_tails(self) -> Pile[Node]: ...
+def get_predecessors(self, node: Node, /) -> Pile[Node]: ...
+def get_successors(self, node: Node, /) -> Pile[Node]: ...
+def is_acyclic(self) -> bool: ...
+def topological_sort(self) -> list[Node]: ...
+async def find_path(
+    self,
+    start: Any,
+    end: Any,
+    check_conditions: bool = False,
+) -> list[Edge] | None: ...
+```
+
+**Adjacency-query semantics**:
+
+- `find_node_edge` accepts only `both`, `in`, or `out`; other strings raise `ValueError`. An absent
+  node raises `RelationError`. Incoming edges are emitted before outgoing edges for `both`. The
+  source annotation says list, but the method returns an Edge-typed Pile.
+- `get_heads` returns nodes with no incoming Edge; `get_tails` returns nodes with no outgoing Edge.
+  An isolated node is both a head and a tail. A cyclic component may contribute neither.
+- Predecessors are the heads of incoming Edges; successors are the tails of outgoing Edges. Return
+  Piles preserve adjacency insertion order and accept Node subclasses.
+- `Graph.__contains__` returns true for a UUID/Element present in either the Node or Edge Pile.
+
+**Cycle and ordering semantics**:
+
+- `is_acyclic` runs depth-first marking over every node and returns true for an empty graph, false
+  for self-loops and longer cycles, and true for disconnected acyclic components. It does not mutate
+  or reject the graph.
+- `topological_sort` uses Kahn's algorithm. Empty graph returns `[]`; otherwise zero-in-degree nodes
+  and outgoing edges follow current dictionary insertion order. If fewer nodes are emitted than are
+  resident, it raises `ValueError("Cannot topologically sort graph with cycles")`.
+
+**Path semantics**:
+
+- `find_path` normalizes and separately checks both endpoints, raising `RelationError` for a missing
+  start or end. Equal resident endpoints return `[]`.
+- Directed breadth-first search returns a shortest-hop list of Edge objects in head-to-tail order.
+  No path returns `None`. A visited set makes search terminate on cyclic graphs.
+- With `check_conditions=False`, conditions are ignored. With true, each candidate Edge condition is
+  awaited with no arguments before its target is visited; false omits that Edge, and an exception
+  from condition code propagates.
+- Edge construction accepts any nominal `Condition`, while the executable operation consumer
+  currently narrows its accepted conditions further. Generic graph validity therefore does not by
+  itself guarantee operation-graph executability; delta 2 owns contract alignment.
+
+`to_networkx` is an optional projection to `networkx.DiGraph`; absent NetworkX raises an
+installation-oriented ImportError. Node/Edge IDs become strings and their remaining serialized
+fields become attributes. Because the target is `DiGraph` rather than `MultiDiGraph`, parallel
+Edges with the same head and tail collapse to one projected NetworkX edge even though canonical
+Graph storage retains them as distinct UUID-bearing Edges. `display` additionally requires
+matplotlib and draws a spring layout. These helpers do not change Graph's canonical storage and are
+not a lossless export format.
+
+### D5 — Adjacency is derived state and locking is mutation-only
+
+Graph serializes `internal_nodes` and `internal_edges` through their Pile dictionaries.
+`node_edge_mapping` is excluded. If both Pile fields validate, Graph clears the mapping, creates an
+empty `in`/`out` entry for every resident Node, then replays every Edge into the two maps.
+
+**Exact reconstruction semantics**:
+
+- The serialized payload has Element envelope fields plus `internal_nodes` and `internal_edges`;
+  it does not contain the adjacency map or lock.
+- Field validators call `Pile.from_dict` for both stores. The output of even an empty Graph currently
+  fails this step: default stores serialize `lion_class` as the concrete non-parameterized `Pile`,
+  while Graph's field validation binds parameterized `Pile[T]` and `Pile[Edge]` classes whose
+  metadata validator expects their own generated qualified names. The result is a metadata-class-
+  mismatch ValidationError.
+- With resident Edges there is a second independent failure reason: Edge reconstruction generates a
+  new UUID, while the serialized Edge Pile Progression still names the old UUID, so Pile rejects the
+  dictionary/order mismatch. Both reasons surface together in the same pydantic validation pass (one
+  ValidationError), not as two temporally separate failures.
+- If those Pile failures are repaired, Graph then trusts that every Edge endpoint exists; malformed
+  serialized input with an absent endpoint fails while indexing the mapping rather than through the
+  friendly `add_edge` RelationError path.
+- Because Pile excludes `item_type` from serialization, reconstructed stores do not carry their
+  original runtime type constraint inside the nested Pile payload. Graph's mapping rebuild still
+  assumes Node and Edge contents.
+- Because validation fails before the model validator, `Graph.from_dict(graph.to_dict())` does not
+  currently return a rebuilt Graph. Delta 4 defines the self-round-trip contract.
+
+The RLock is acquired by `add_node`, `add_edge`, `remove_node`, `remove_edge`, `replace_node`, and
+`splice_after`. It is reentrant and per Graph instance.
+
+**Concurrency semantics**:
+
+- Each decorated mutation excludes other decorated mutations on the same Graph and updates Piles
+  and adjacency within that critical section.
+- Query methods, algorithms, serialization, `__contains__`, and optional projections do not acquire
+  the Graph lock.
+- The backing Piles have their own locks, but direct Pile mutation is not coordinated with the Graph
+  lock or adjacency updates.
+- A traversal concurrent with mutation has no stable-snapshot guarantee and can observe changing
+  dictionaries or missing entries.
+- Multiple decorated mutations are not one transaction when invoked as separate calls. Callers
+  needing atomic compound changes own a lock/transaction above Graph.
 
 ## Consequences
 
-Dependency lookup is direct, invalid endpoint references fail at insertion, and node removal cannot
-leave incident edges behind. Structural queries (acyclicity, topological order) let consumers
-validate a graph before committing to execute it, and the primitive-mutation design keeps Graph
-reusable for non-executable graphs.
+Endpoint validation and mirrored adjacency make predecessor/successor lookup direct, and supported
+node removal cannot leave incident edges behind. Generic callers can represent cycles while
+execution-oriented consumers can preflight with `is_acyclic` or `topological_sort`. Replacement and
+splice primitives keep graph-editing logic in one reusable model rather than duplicating adjacency
+updates in each consumer.
 
-Graph remains a mutable structure rather than an immutable execution plan. Callers cannot safely
-assume concurrent traversal during arbitrary mutation, and the method-level `Relational` type is
-broader than actual storage. Edge construction accepts a general Condition, while downstream
-executable-graph validation narrows conditions further (see the operations ADR on operation-graph
-execution), so generic graph validity does not by itself guarantee executability.
+The costs are concrete:
+
+- every supported mutation must update canonical Piles and derived adjacency consistently;
+- direct public-field mutation can bypass invariants;
+- Graph is mutable and unlocked traversal is not a snapshot;
+- `replace_node` preserves Edge identity but changes Node order, whereas `splice_after` replaces
+  outgoing Edge identities and metadata and drops an explicit empty label;
+- the method-level Relational annotation is broader than actual Node storage;
+- generic Condition admission is broader than executable-operation validation; and
+- current Edge and parameterized-Pile reconstruction defects prevent a Graph from round-tripping its
+  own serialized output.
+
+Reversing D2 requires replacing every adjacency query with scans or another index. Reversing D3
+changes consumer-visible Edge identities and ordering. Strengthening D5 to snapshot isolation or
+transactions requires closing direct mutation paths and coordinating Graph and Pile locks.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
-|---|-------|------|-------|
+|---|---|---|---|
 | 1 | Align `Graph.add_node` with its storage boundary; acceptance requires the public type contract and backing Pile to admit the same node family, with tests for accepted and rejected types. | S | (filled at issue-open time) |
 | 2 | Align Edge condition admission with downstream executable-graph validation; acceptance requires construction and execution to accept the same documented condition protocol, with tests for custom conditions or an explicit construction-time rejection. | S | (filled at issue-open time) |
 | 3 | Publish graph traversal snapshot semantics; acceptance requires supported concurrent read and mutation patterns to be documented and traversal APIs to return stable results under those supported patterns. | M | (filled at issue-open time) |
+| 4 | Restore Graph self-round-trip reconstruction; acceptance requires empty and populated `Graph.from_dict(graph.to_dict())` calls to succeed, preserve every Node and Edge UUID and property, rebuild equivalent adjacency, and handle parameterized Pile discriminators without metadata mismatch, after the Edge envelope repair in ADR-0001 delta 3. | M | (filled at issue-open time) |
+| 5 | Preserve Edge label semantics through `Graph.splice_after`; acceptance requires omitted, empty, scalar, and non-empty-list labels to retain their documented presence and value on replacement Edges, with custom-property coverage. | S | (filled at issue-open time) |
+
+The inherited Edge envelope repair is not duplicated in row 4; ADR-0001 delta 3 owns direct Edge
+reconstruction, while row 4 owns Graph's parameterized nested-Pile and adjacency round trip.
+
+## Alternatives considered
+
+### Permit non-resident endpoints
+
+This would support partially loaded or externally resolved graphs and make edge-first construction
+possible. Every adjacency and path query would then need a missing-node result, and node removal
+could not define a complete local cascade. The in-memory Graph chooses closed endpoint residency;
+external/distributed references require a different graph contract.
+
+### Scan the Edge Pile for every query
+
+One canonical list would remove the risk of adjacency drift. Predecessor, successor, head, tail,
+cycle, and BFS operations would repeatedly scan all Edges. The derived mapping trades memory and
+mutation complexity for direct local adjacency, which matches the query-heavy consumers.
+
+### Store adjacency only in the executing consumer
+
+Operation scheduling could derive a private dependency map and leave generic Graph as two Piles.
+Non-executable graph users would lose efficient structural queries, and each consumer would
+reimplement endpoint validation and cascade cleanup. Graph owns reusable structural integrity;
+execution state remains above it.
+
+### Reject cycles at `add_edge`
+
+Insertion-time cycle prevention would make every Graph a DAG and give operation consumers a strong
+invariant. Generic relationship graphs may legitimately contain cycles and each insertion would need
+a reachability check. Graph permits cycles, exposes explicit detection, and leaves DAG enforcement
+to consumers that require it.
+
+### Allow cycles and rely only on runtime deadlock detection
+
+Omitting `is_acyclic` and topological-sort failure would simplify the model but make dependency
+failure diagnosable only after execution stalls. The shipped structural queries let consumers detect
+the problem before committing to execution without banning cycles globally.
+
+### Immutable graph values
+
+Persistent immutable Graph versions would give traversal stable snapshots and make concurrent reads
+simple. Each edit would copy or structurally share Piles and adjacency, while current consumers rely
+on in-place insertion and reactive changes. The shipped model remains mutable; stable snapshot
+semantics are delta 3.
+
+### One graph-wide transaction API
+
+A transaction object could compose several edits with rollback and a single lock. Graph does not
+know the consumer state that often needs to commit with those edits, and rollback for arbitrary
+mutable Node/Edge properties is broader than adjacency. It exposes composable primitives; consumers
+own higher-level transactions.
+
+### Replace outgoing Edges in place during splice
+
+Mutating each original Edge's head from anchor to new Node would preserve Edge identity and metadata.
+It would change the meaning of an existing relationship without a new record and still require a
+new anchor link. The current splice treats rewired relationships as new Edges, while `replace_node`
+is the explicit identity-preserving primitive.
+
+### Restrict Edge conditions to EdgeCondition
+
+Requiring the Pydantic EdgeCondition base would align serialization and its `source` helper. The
+generic `Condition` ABC deliberately permits custom async conditions, and tests pin that acceptance.
+The narrower executable-operation contract is not silently imposed here; delta 2 requires the two
+owners to choose one documented boundary.
 
 ## Notes
 
-Alternatives considered were allowing cycles and relying on runtime deadlock detection, or moving
-all adjacency ownership into the graph's executing consumer. The first makes dependency completion
-impossible to reason about before execution; the second duplicates a reusable directed-graph model
-and weakens Graph's own integrity guarantees.
+Graph's structural contract is intentionally narrower than operation-flow execution. Cycle refusal
+at execution, predecessor waiting, path-condition scheduling, skip propagation, and reactive
+runtime-state rollback are not Graph invariants and remain behind cross-references to the operations
+area.

--- a/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
+++ b/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
@@ -8,78 +8,495 @@
 
 ## Context
 
-LionAGI uses one identifiable record shape for conversation turns and routed inter-branch traffic.
-`Message` inherits graph identity and metadata from `Node`, adds `sender`, `recipient`, and an
-optional grouping `channel`, and renders either its content object's `rendered` value or the string
-form of arbitrary content. The generic envelope is used directly by `Exchange`; conversational
-records specialize it with typed content.
+LionAGI uses one identifiable record shape for both conversational turns and routed inter-branch
+traffic. That shared shape solves several distinct problems.
 
-A message's role is fixed by its concrete class rather than accepted from serialized or caller
-input. `System`, `Instruction`, and `AssistantResponse` have the `system`, `user`, and `assistant`
-roles, while `ActionRequest` and `ActionResponse` both have the `action` role. The generic
-`Message` has the `unset` role. This prevents a caller-supplied role from changing the semantics of
-a typed message.
+**P1 — Conversation records need durable identity without making identity part of prompt text.**
+Messages participate in piles, progressions, cloning, serialization, and routing. They therefore
+need the `Node` identity fields (`id`, `created_at`, `metadata`) independently of their rendered
+content (`lionagi/protocols/graph/node.py`; `lionagi/protocols/generic/element.py`).
 
-Subtype content retains provider-neutral conversational data. Assistant responses keep normalized
-display text in content and the raw provider response in metadata. Action content keeps the
-function, arguments, output or error, and counterpart identifier; responses created through
-`MessageManager`'s new-response factory establish links in both directions. Instruction content
-also carries rendering and current-call configuration, a boundary addressed by ADR-0007.
+**P2 — The conversational role must not disagree with the concrete message type.** A serialized
+record that says `role="assistant"` while carrying `InstructionContent` would make replay and
+provider compilation ambiguous. The implementation fixes role on the concrete class and discards
+caller-supplied role input (`lionagi/protocols/messages/message.py`).
 
-Each `Branch` owns one `MessageManager`. The manager owns a `Pile[Message]`, its ordered
-`Progression`, the optional canonical system message, construction factories, typed history views,
-and message-added callbacks. The branch exposes the manager and its records as facade properties
-while retaining ownership of turn execution.
+**P3 — Provider-neutral content has several real shapes.** System policy, user instructions,
+assistant output, action calls, and action results do not share one useful field set. They do share
+identity, sender/recipient metadata, rendering, and serialization. Typed content dataclasses keep
+those differences explicit without making the envelope provider-specific.
 
-Two public labels are weaker than their names suggest. `Sendable` is an empty marker and does not
-enforce sender or recipient fields. `RoledMessage` is exactly an alias of `Message`, with no runtime
-or semantic distinction. Routing also distinguishes `recipient=None`, which is broadcast, from the
-default `MessageRole.UNSET`, which `is_direct` currently classifies as direct.
+**P4 — Membership and order have different mutation and lookup needs.** History needs UUID lookup
+and strict record membership, but model context needs an explicit ordered view. `Pile[Message]`
+owns the objects; its `Progression` owns UUID order. A `Branch` may expose a selected progression
+without deleting records (`lionagi/protocols/messages/manager.py`; `lionagi/session/branch.py`).
+
+**P5 — Action results must remain correlated after intervening records and serialization.** An
+action request and response cannot rely only on adjacency. Their content stores reciprocal IDs
+when the manager constructs a new response.
+
+**P6 — Message-added observers run across synchronous and asynchronous callers.** Persistence and
+session observers need a stable rule for when callbacks run, what happens when one fails, and
+whether a failed callback means the record was rolled back. The implementation deliberately
+inserts first and reports callback failures afterward, except that the synchronous path rejects an
+asynchronous callback before mutation.
+
+**P7 — Routed traffic needs direct and broadcast delivery without a second envelope.** `Exchange`
+queues the generic `Message` itself. Its routing semantics expose an existing ambiguity: explicit
+`recipient=None` is broadcast, while the constructor default is `MessageRole.UNSET`, which
+`is_direct` classifies as direct even though it is not a registered UUID.
+
+| Concern | Decision |
+|---------|----------|
+| Identity, routing, role, and rendering | D1: Use `Message(Node, Sendable)` as the shared envelope and fix role by concrete class. |
+| Provider-neutral conversational content | D2: Use five typed message classes with dataclass content and durable action correlation. |
+| Ordered branch history | D3: Let `MessageManager` own `Pile[Message]`, its `Progression`, the one system record, factories, and typed views. |
+| Observer transaction semantics | D4: Insert or replace the message before firing a callback snapshot; reject async hooks on the sync path before mutation. |
+| Inter-branch routing | D5: Route the same generic `Message` through per-owner `Exchange` flows, with `None` as broadcast. |
+| Compatibility labels | D6: Treat `RoledMessage` as an alias and `Sendable` as a marker, not as distinct enforceable contracts. |
+
+This ADR deliberately does **not** decide:
+
+- provider request compilation; ADR-0007 owns the target compilation boundary because request
+  shaping is an operation concern, not a durable-record concern;
+- pre-turn context retrieval and attribution; ADR-0008 owns that operational input;
+- tool registration, invocation strategy, or tool error policy; those are action-operation
+  concerns even though their outcomes are recorded as action messages;
+- branch persistence backends; this ADR fixes the in-memory record contract that a persistence
+  adapter serializes, not where it stores it; or
+- a repaired recipient state model. The current ambiguity is recorded in the delta table rather
+  than described as solved.
 
 ## Decision
 
-`Message` is the single concrete identity, routing, and rendering envelope, and `MessageManager` is
-the branch-owned ordered record store. The load-bearing invariants are:
+### D1 — One identifiable envelope with a class-fixed role
 
-- role is a read-only class-level property; construction and deserialization discard a supplied
-  `role` value;
-- `sender` and `recipient` accept a `MessageRole`, UUID, plain string, or observable identity;
-  non-null values serialize as strings, while `channel` is optional grouping metadata;
-- generic routed traffic may use `Message` directly, while conversational turns use the five typed
-  subclasses and their fixed roles;
-- assistant raw responses remain metadata, and action request/response correlation remains durable
-  message content;
-- `MessageManager` owns record membership, order, the single system record, factories, and typed
-  views; `Branch` owns operation execution and exposes those records through its facade;
-- synchronous addition rejects asynchronous callbacks before mutating history, while callback
-  failures after either synchronous or asynchronous addition are surfaced after the record has
-  been inserted; and
-- `RoledMessage` is a compatibility alias only, and `Sendable` is not the enforceable public data
-  contract.
+`Message` is the single concrete identity, routing, grouping, content, and rendering envelope.
+The shipped model contract is:
 
-The implementation anchors are `lionagi/protocols/messages/message.py`,
-`lionagi/protocols/messages/manager.py`, the role-specific modules under
-`lionagi/protocols/messages/`, `lionagi/session/branch.py`, and `lionagi/session/exchange.py`.
+```python
+# lionagi/protocols/generic/element.py
+class Element(BaseModel, Observable):
+    id: UUID = Field(default_factory=uuid4, frozen=True)
+    created_at: float = Field(default_factory=lambda: now_utc().timestamp(), frozen=True)
+    metadata: dict = Field(default_factory=dict)
+
+
+# lionagi/protocols/graph/node.py
+class Node(Element, Relational, AsyncAdaptable, Adaptable):
+    content: Any = None
+    embedding: list[float] | None = None
+
+
+# lionagi/protocols/messages/message.py
+class Message(Node, Sendable):
+    _role: ClassVar[MessageRole] = MessageRole.UNSET
+    _content_type: ClassVar[type] = MessageContent
+
+    content: Any = None
+    sender: MessageRole | str | UUID | None = MessageRole.UNSET
+    recipient: MessageRole | str | UUID | None = MessageRole.UNSET
+    channel: str | None = None
+
+    @property
+    def role(self) -> MessageRole: ...
+
+    @property
+    def is_broadcast(self) -> bool: ...
+
+    @property
+    def is_direct(self) -> bool: ...
+
+    @property
+    def chat_msg(self) -> dict[str, Any] | None: ...
+
+    @property
+    def rendered(self) -> str: ...
+```
+
+`MessageRole` is the closed role vocabulary used by these records:
+
+```python
+class MessageRole(str, Enum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    UNSET = "unset"
+    ACTION = "action"
+```
+
+Exact semantics:
+
+- **Construction and deserialization:** `Message.__init__` removes a supplied `role` key before
+  Pydantic validation. `role` is read from `self.__class__._role`; input cannot override it.
+- **Serialization:** `to_dict()` and `model_dump()` add the concrete role value back to output.
+  Deserializing that output ignores the role field again, so the concrete class remains
+  authoritative.
+- **Sender and recipient normalization:** a `MessageRole` remains a role, a UUID remains a UUID,
+  an observable object becomes its UUID, a known role string becomes `MessageRole`, a UUID string
+  becomes a UUID, and any other plain string remains a string. Other values raise
+  `ValueError("Invalid sender or recipient")`.
+- **Explicit null versus absent value:** the field validator preserves explicit `None`. Omission
+  uses `MessageRole.UNSET`. Serialization emits non-null values as strings and emits `None` as
+  null.
+- **Routing predicates:** `recipient is None` is broadcast; every non-null recipient—including
+  `MessageRole.UNSET`—is direct. The predicates do not validate deliverability.
+- **Channel:** `channel` is optional grouping/filtering metadata. It does not affect `Exchange`
+  delivery.
+- **Generic content:** base `Message` accepts arbitrary content without coercion. A typed subclass
+  accepts its content dataclass, converts a dictionary through `from_dict`, creates an empty
+  content instance for `None`, and rejects any other value with `TypeError`.
+- **Rendering:** if content exposes `rendered`, the envelope returns it. Otherwise non-null content
+  is converted with `str`; null content renders as `""`.
+- **Chat projection:** `chat_msg` is `{ "role": <role string>, "content": rendered }`. Any
+  exception during that projection is contained and returns `None`.
+- **Update:** `update(sender=..., recipient=..., **content_fields)` changes sender or recipient
+  only when the supplied value is truthy. It therefore cannot set either field to `None`. Content
+  updates rebuild dataclass content through `to_dict()` and `from_dict()` rather than mutating its
+  individual fields in place.
+- **Clone:** `clone()` removes `id`, `created_at`, and serialized `role`, reconstructs the same
+  concrete class, receives a new identity, and records the source UUID in
+  `metadata["clone_from"]`.
+
+The shared envelope prevents identity and routing rules from diverging between conversation and
+mailbox records. It also means that a generic routed `Message` has role `unset`; being routable is
+not the same as being a provider conversation turn.
+
+### D2 — Typed conversational content and durable action correlation
+
+Conversational records specialize the envelope with fixed roles and content dataclasses:
+
+| Message class | Fixed role | Content class |
+|---------------|------------|---------------|
+| `System` | `system` | `SystemContent` |
+| `Instruction` | `user` | `InstructionContent` |
+| `AssistantResponse` | `assistant` | `AssistantResponseContent` |
+| `ActionRequest` | `action` | `ActionRequestContent` |
+| `ActionResponse` | `action` | `ActionResponseContent` |
+
+```python
+@dataclass(slots=True)
+class SystemContent(MessageContent):
+    system_message: str = "You are a helpful AI assistant. Let's think step by step."
+    system_datetime: str | None = None
+
+
+@dataclass(slots=True)
+class InstructionContent(MessageContent):
+    instruction: str | None = None
+    guidance: str | None = None
+    prompt_context: list[Any] = field(default_factory=list)
+    plain_content: str | None = None
+    tool_schemas: list[dict[str, Any]] = field(default_factory=list)
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None
+    structure: type | str | None = None
+    _structure_instance: Any = field(default=None, repr=False)
+    images: list[str] = field(default_factory=list)
+    image_detail: Literal["low", "high", "auto"] | None = None
+
+
+@dataclass(slots=True)
+class AssistantResponseContent(MessageContent):
+    assistant_response: str = ""
+
+
+@dataclass(slots=True)
+class ActionRequestContent(MessageContent):
+    function: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    action_response_id: str | None = None
+
+
+@dataclass(slots=True)
+class ActionResponseContent(MessageContent):
+    function: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    output: Any = None
+    action_request_id: str | None = None
+    error: str | None = None
+```
+
+Anchors are the role-specific modules under `lionagi/protocols/messages/`. Mutable defaults in the
+table are per-instance factories, not shared objects.
+
+Exact semantics by subtype:
+
+- **System:** `system_datetime=True` becomes the current UTC time at minute precision;
+  `False` or `None` becomes no datetime. Rendering joins the optional `System Time: ...` prefix and
+  `system_message` with two newlines. Defaults route from `system` to `assistant`.
+- **Instruction context:** `context` is the compatibility input name for `prompt_context`.
+  Scalars become one-element lists. `handle_context="extend"` appends; `"replace"` replaces; any
+  other value raises `ValueError`.
+- **Instruction tools:** a flat schema list stays flat. A `{ "tools": [...] }` wrapper is
+  unwrapped. A single non-list schema becomes a one-element list.
+- **Instruction response format:** a dictionary, a `BaseModel` type, or a `BaseModel` instance can
+  create a rendering structure. Type and model-instance references, `structure`, and the private
+  structure instance are omitted from ordinary `to_dict()` because they cannot round-trip as
+  plain data. A dictionary response format is retained because it is serializable.
+- **Instruction structure resolution:** `None`, `"json"`, and every other string resolve to
+  `JsonStructure`; a supplied type is used directly. A structure instance is built only when a
+  response format is also present.
+- **Instruction rendering:** `plain_content`, when truthy, replaces structured text rendering.
+  Otherwise the content renders non-empty Guidance, Instruction, Context, Tools, ResponseSchema,
+  and ResponseFormat sections through the minimal-YAML renderer. Images change the rendered value
+  from a string to a provider-neutral list containing one text part followed by `image_url` parts.
+- **Instruction image safety:** HTTP and HTTPS URLs pass the URL validator; inline data accepts
+  only non-empty base64 PNG, JPEG, GIF, or WebP; other URI schemes are rejected; raw base64 is
+  wrapped as JPEG data. This is a content-format contract, not an image-fetch guarantee.
+- **Assistant normalization:** `AssistantResponse.from_response()` extracts text from supported
+  content, choices, output-message, result, or string shapes. Normalized display text goes into
+  `AssistantResponseContent`; the original provider value goes into
+  `metadata["model_response"]`. Multiple text fragments concatenate without an added delimiter.
+- **Action request parsing:** callable functions become `__name__`; objects with `.function` use
+  that value; a non-string function after normalization raises `ValueError`. Arguments are copied
+  and, when not already a dictionary, pass through fuzzy dictionary conversion.
+- **Action response state:** `success` is exactly `error is None`; `request_id` aliases
+  `action_request_id`; `result` aliases `output`. A successful null output summarizes as `"ok"`;
+  a failed response summarizes as `"error: <message>"`.
+- **New response correlation:** `MessageManager.create_action_response(action_request=..., ...)`
+  requires an `ActionRequest`, copies its function and arguments, stores the request UUID in the
+  response, then stores the new response UUID in the request. Passing an already-created
+  `ActionResponse` updates and returns it but does not establish a missing reciprocal link.
+
+The action IDs make correlation independent of progression adjacency. Raw assistant provider
+responses remain metadata so ordinary prompt rendering does not replay provider-specific payloads.
+
+### D3 — Branch-owned membership, order, system record, factories, and views
+
+Each `Branch` constructs one `MessageManager`; the manager contract is:
+
+```python
+# lionagi/protocols/messages/manager.py
+class MessageManager(Manager):
+    def __init__(
+        self,
+        messages: list[Message] | None = None,
+        progression: Progression | None = None,
+        system: System | None = None,
+        on_message_added: list | None = None,
+    ): ...
+
+    messages: Pile[Message]
+    system: System | None
+
+    @property
+    def progression(self) -> Progression: ...
+
+    def set_system(self, system: System) -> None: ...
+    def clear_messages(self) -> None: ...
+    def add_message(...) -> Message: ...
+    async def a_add_message(self, **kwargs) -> Message: ...
+    def to_chat_msgs(self, progression=None) -> list[dict]: ...
+```
+
+The manager's `Pile` is configured with `item_type={Message}`, `strict_type=False`, and the
+supplied progression. It accepts subclasses of `Message`. Its progression is the authoritative
+ordering for the full pile.
+
+Exact history semantics:
+
+- **Initialization:** list entries that are dictionaries are reconstructed through
+  `Message.from_dict`; non-message entries are ignored. A dictionary-shaped serialized pile is
+  reconstructed through `Pile.from_dict`. A separately supplied system must be a `System` or
+  construction raises `ValueError`.
+- **Single system:** setting the first system inserts it at progression index zero. Replacing it
+  inserts the new system at zero and excludes the old record. `clear_messages()` clears the pile
+  and then reinserts the current system at zero.
+- **Add or replace:** factories create or update exactly one message. If its UUID is already in
+  the pile, the manager removes and reinserts it at the same progression index. Otherwise it is
+  appended through `Pile.include`.
+- **Factory selection:** conflicting truthy instruction, assistant-response, system, or standalone
+  action-request inputs raise `ValueError("Only one message type can be added at a time.")`.
+  Action output uses an `is not None` check so falsy results such as `0`, `""`, `[]`, or `{}` still
+  create an action response. With no other selected kind, the factory creates an instruction.
+- **Typed views:** `assistant_responses`, `actions`, `action_requests`, `action_responses`, and
+  `instructions` are strict-type filtered piles. `last_response` and `last_instruction` search the
+  progression in reverse and return `None` on miss.
+- **Raw projection:** `to_chat_msgs(progression=[])` returns an empty list. Otherwise it projects
+  the supplied order, or the full manager progression when none/falsy is supplied, through each
+  record's `chat_msg`. An invalid ID is wrapped as `ValueError("One or more messages in the
+  requested progression are invalid.")`. The method does not perform action folding, system
+  folding, transient-field stripping, or empty-content filtering.
+
+`Branch` remains the operation owner and exposes the records as a facade:
+
+```python
+# lionagi/session/branch.py
+@property
+def msgs(self) -> MessageManager: ...
+
+@property
+def messages(self) -> Pile[RoledMessage]: ...
+
+@property
+def progression(self) -> Progression:
+    # metadata["current_progression"] wins when present
+    ...
+```
+
+`Branch.progression` may therefore be an agent-managed subset stored in
+`metadata["current_progression"]`; selecting that view does not remove records from
+`MessageManager.messages`. Request compilation, not the manager, decides how that selected history
+becomes provider input.
+
+### D4 — Message-added callbacks are post-insertion observers
+
+The synchronous and asynchronous add paths share insertion behavior but have different callback
+admission rules.
+
+```text
+sync add_message
+  snapshot callbacks and reject any coroutine function
+  → construct message
+  → insert or replace message
+  → call every callback in the snapshot
+  → raise collected callback failure(s), if any
+
+async a_add_message
+  lock pile
+  → construct and insert or replace message
+  → release pile lock
+  → snapshot callbacks
+  → call/await every callback
+  → raise collected callback failure(s), if any
+```
+
+Exact semantics:
+
+- **Sync preflight:** if any snapshot member is a coroutine function, `add_message()` raises a
+  `RuntimeError` before construction or pile mutation and directs the caller to `a_add_message()`.
+- **Snapshot isolation:** adding or removing callbacks during a callback does not change the
+  callbacks for that add operation. The changed list applies to the next addition.
+- **Failure continuation:** one callback failure does not prevent later callbacks in the snapshot
+  from running.
+- **Failure result:** one failure is re-raised directly. Multiple failures are raised as one
+  `BaseExceptionGroup("on_message_added hooks failed", errors)` (using the compatibility backport
+  on Python 3.10).
+- **Mutation is committed:** callback failure never removes the inserted message. A caller can
+  receive an exception while the message is already present.
+- **Re-entrant async callbacks:** callbacks run after the pile lock is released, so an async
+  callback may call `a_add_message()` again without deadlocking. The nested addition receives its
+  own callback snapshot.
+
+This is observer behavior, not a transaction boundary. Any callback providing durable side effects
+must own its retry and idempotency policy.
+
+### D5 — `Exchange` routes the generic envelope through ordered mailbox flows
+
+`Exchange` deliberately uses `Message`, not a conversational subtype:
+
+```python
+# lionagi/session/exchange.py
+class Exchange(Element):
+    flows: Pile[Flow[Message, Progression]]
+
+    def register(self, owner_id: UUID) -> Flow[Message, Progression]: ...
+    def unregister(self, owner_id: UUID) -> Flow[Message, Progression] | None: ...
+    def send(
+        self,
+        sender: UUID,
+        recipient: UUID | None,
+        content: Any,
+        channel: str | None = None,
+    ) -> Message: ...
+    async def collect(self, owner_id: UUID) -> int: ...
+    def receive(self, owner_id: UUID, sender: UUID | None = None) -> list[Message]: ...
+    def pop_message(self, owner_id: UUID, sender: UUID) -> Message | None: ...
+```
+
+Each registered owner gets one `Flow` with an `outbox` progression. Delivery creates an
+`inbox_<sender UUID>` progression on the recipient flow.
+
+Exact routing semantics:
+
+- duplicate registration and sending or collecting for an unregistered sender raise `ValueError`;
+- unregistering, getting, receiving for, or popping from an unknown owner returns `None` or `[]` as
+  appropriate;
+- `send()` creates a base `Message`, enqueues it in the sender's outbox, and does not require the
+  recipient to be registered yet;
+- `collect()` consumes outbox entries. A missing queued object is skipped;
+- explicit `recipient=None` broadcasts a model copy to every other registered owner; the sender
+  does not receive its own broadcast;
+- a direct message is delivered only when its recipient is a key in the UUID owner index. An
+  unknown recipient, a plain string, or `MessageRole.UNSET` is consumed and dropped;
+- delivery is best-effort: fan-out uses `gather(..., return_exceptions=True)`, and a recipient that
+  unregisters before delivery receives nothing. Delivery failures are not returned to the sender;
+- the return value is the number of unique message UUIDs delivered, so a broadcast delivered to
+  multiple owners counts as one message;
+- `receive()` is non-destructive and optionally filters by sender inbox; `pop_message()` removes
+  the oldest message from one sender inbox and returns `None` on an empty or missing inbox; and
+- `collect_all()` visits a snapshot of registered owner IDs sequentially and skips owners removed
+  before their turn. `sync()` is its alias.
+
+This routing contract explains why explicit `None` must remain distinguishable from the current
+unset default until the recipient state model is repaired.
+
+### D6 — `RoledMessage` and `Sendable` are compatibility surfaces only
+
+The shipped declarations are literal:
+
+```python
+# lionagi/protocols/messages/message.py
+RoledMessage = Message
+
+
+# lionagi/protocols/_concepts.py
+class Sendable(ABC):
+    pass
+```
+
+`RoledMessage` creates no subclass, validation boundary, or role guarantee. `Sendable` documents an
+intention in its docstring but has no abstract sender or recipient member. Runtime enforcement
+comes from the concrete `Message` fields and validators. New code must not infer stronger semantics
+from either label.
 
 ```mermaid
 flowchart LR
     B[Branch] --> MM[MessageManager]
-    MM --> P[Pile plus Progression]
-    P --> M[Message envelope]
-    M --> T[Typed conversational messages]
+    MM --> P[Pile of Message objects]
+    P --> PR[Progression of UUIDs]
+    M[Message envelope] --> N[Node identity and metadata]
+    M --> T[Typed conversational subclasses]
     E[Exchange] --> M
+    E --> F[Per-owner Flow and inbox progressions]
 ```
 
 ## Consequences
 
-Conversation history and inter-branch traffic share identity, serialization, routing metadata, and
-rendering without a second transport hierarchy. Fixed subtype roles prevent role spoofing through
-input data, and durable action links support tool-call correlation.
+### Positive
 
-The broad envelope also exposes ambiguity. `Sendable` cannot be used to type a data-bearing routing
-contract, `RoledMessage` suggests a hierarchy that does not exist, and default recipients are
-classified differently from explicit broadcasts. Callback failure is not a transaction rollback:
-a caller may receive an exception after the message is already present.
+- Conversation history and inter-branch traffic share identity, serialization, routing metadata,
+  and rendering without a duplicate transport hierarchy.
+- Fixed subtype roles prevent serialized data from contradicting the concrete conversational type.
+- Pile membership and progression order can evolve independently, and `Branch` can select a view
+  without deleting history.
+- Durable reciprocal IDs preserve action correlation across serialization and non-adjacent records.
+- Callback snapshot and aggregation rules are testable for sync, async, failure, and re-entrant
+  paths.
+
+### Negative
+
+- The broad envelope permits generic `Message` values that are routable but not valid provider
+  turns; compilation must filter or reject them deliberately.
+- `Sendable` and `RoledMessage` overstate their runtime meaning and can mislead type annotations.
+- `recipient=None`, `MessageRole.UNSET`, strings, and UUIDs form a routing state space that the two
+  boolean predicates do not model accurately.
+- A callback error does not roll back history. Callers must not retry blindly without checking
+  whether the message UUID already exists.
+- `Exchange` consumes messages addressed to unknown recipients and contains delivery failures,
+  providing no dead-letter or acknowledgement record.
+
+### Maintenance and reversal cost
+
+- Adding a message subtype requires a content dataclass, fixed `_role`, rendering and
+  serialization behavior, manager factory or caller construction, and compiler treatment.
+- Changing `Message` fields or role serialization affects branch snapshots, mailbox traffic, and
+  provider-history tooling simultaneously; splitting the envelope later would require a migration
+  adapter for both stored records and `Exchange` flows.
+- Replacing `Pile + Progression` with a list would simplify storage but require rebuilding UUID
+  lookup, selected views, and same-index replacement.
+- Making callbacks transactional would require a rollback protocol for in-memory membership and
+  every external side effect already performed by earlier callbacks; it is not a local reorder.
 
 ## Current-vs-ideal delta
 
@@ -91,9 +508,62 @@ a caller may receive an exception after the message is already present.
 | 4 | Publish message-added callback transaction semantics; acceptance requires sync and async tests to specify pre-mutation rejection, post-insertion callback failures, error aggregation, and any durable-hook retry responsibility. | S | (filled at issue-open time) |
 | 5 | Implement the canonical turn-request compiler defined by ADR-0007 and remove prompt policy from durable records and `MessageManager`; acceptance requires chat and run payload characterization tests, transient fields absent from replayed history, and every legacy preparation entry point removed or delegated. | M | (filled at issue-open time) |
 
+## Alternatives considered
+
+### Separate envelopes for routed traffic and conversational turns
+
+A `MailboxMessage` could carry sender, recipient, and arbitrary content while a separate
+`ConversationMessage` hierarchy carried roles and provider rendering. This would make invalid
+cross-use harder and could give mailbox delivery its own acknowledgement fields. It lost because
+identity, metadata, cloning, sender/recipient normalization, channel grouping, and serialization
+would be duplicated or require another shared base almost identical to `Message`. The shipped
+`Exchange` demonstrates that arbitrary content can use the generic base without weakening typed
+conversation content.
+
+### One untyped record with a mutable serialized role
+
+One model with `role`, `content`, and optional action fields would reduce the class count and map
+directly to common provider payloads. It lost because the data can become internally contradictory:
+role, content fields, and rendering policy can drift independently. Class-fixed roles make such a
+state unconstructable for typed conversation records and make role spoofing through deserialization
+ineffective.
+
+### A list as the sole history structure
+
+An append-only `list[Message]` would make order obvious and reduce the number of collection types.
+It lost because the manager performs UUID membership, replacement at the existing index, typed
+views, selected progressions, and serialization of identity independently from order. Rebuilding
+those operations over a list would either be linear or recreate a side index and progression under
+different names.
+
+### Infer action correlation from adjacency
+
+The compiler could pair each `ActionResponse` with the nearest preceding `ActionRequest`, avoiding
+two ID fields. It lost because filtering, selected progressions, concurrent tool calls, and
+intervening messages can break adjacency. Reciprocal identifiers survive those transformations and
+allow `ActionRequest.is_responded()` to answer without scanning history.
+
+### Fire callbacks before insertion or roll back on callback error
+
+Pre-insertion callbacks would let failure veto a record; rollback would give callers transactional
+intuition. Both lose against the observer use case. Callbacks such as session emission need the
+record to exist when observed, multiple callbacks must still run after one failure, and external
+effects from an earlier callback cannot be generally undone. The implementation instead has one
+safe preflight rule—reject an async callback on the sync path—then treats callbacks as
+post-commit observers.
+
+### Make `Sendable` and `RoledMessage` real hierarchies immediately
+
+Abstract sender/recipient members and a separate roled subclass would improve static meaning. This
+was not taken in the shipped design because it would change public imports and subclass identity
+without changing the concrete `Message` fields that already enforce actual data. The delta table
+retains the narrower migration: clarify or deprecate the labels at a declared compatibility
+boundary.
+
 ## Notes
 
-Alternatives considered were separate envelopes for routed traffic and conversational turns, and a
-mutable serialized role on one untyped record. The first duplicates identity and routing rules; the
-second allows record data to contradict the concrete conversational type. The existing shared
-envelope with fixed subtype roles preserves both use cases with less protocol surface.
+Implementation anchors: `lionagi/protocols/messages/message.py`, the role-specific modules and
+`manager.py` under `lionagi/protocols/messages/`, `lionagi/protocols/generic/element.py`,
+`lionagi/protocols/generic/pile.py`, `lionagi/protocols/generic/progression.py`,
+`lionagi/protocols/graph/node.py`, `lionagi/session/branch.py`, and
+`lionagi/session/exchange.py`.

--- a/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
+++ b/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
@@ -8,29 +8,95 @@
 
 ## Context
 
-An `Instruction` currently serves two lifetimes. It is the durable user-turn record containing
-instruction text, guidance, prompt context, plain content, and images, but its content also carries
-current-call tool schemas, response-format objects, and a rendering strategy. Historical replay
-then has to remove tool schemas and response formats, while in-memory copying has special cases for
-objects that cannot survive normal serialization.
+LionAGI currently distributes provider-request preparation across durable message content, a raw
+projection, an unused general preparation helper, and the active chat/run preparation path. The
+result works for ordinary turns but does not give one place an exact request contract.
 
-Provider messages are produced by three overlapping surfaces. `MessageManager.to_chat_msgs()` is a
-raw record projection. `prepare_messages_for_chat()` folds system and action records and merges
-assistant turns but has no production caller. The active chat and run path performs a different fold
-in `_prepare_run_kwargs()`, including context-provider blocks from ADR-0008. These paths can assign
-different prompt semantics to the same history.
+**P1 — `Instruction` currently mixes durable and one-call lifetimes.** `InstructionContent`
+contains stable user material (`instruction`, `guidance`, `prompt_context`, `plain_content`, and
+images) alongside current-call tool schemas, response-format objects, structure objects, and a
+rendering instance (`lionagi/protocols/messages/instruction.py`). Serialization conditionally strips
+the objects that cannot round-trip, and in-memory copies carry special cases to keep them alive.
+Replay therefore depends on remembering which fields are transient rather than making that
+lifetime explicit.
 
-Provider request construction is an operation concern: it selects history, applies current-turn
-options, folds action results, injects ephemeral context, and produces arguments for an `iModel`
-call. Durable record ownership remains with `MessageManager`; it must not depend on provider request
-policy.
+**P2 — Three surfaces project history with different semantics.**
+
+- `MessageManager.to_chat_msgs()` is a raw ordered `chat_msg` projection. It does no prompt
+  shaping (`lionagi/protocols/messages/manager.py`).
+- `prepare_messages_for_chat()` extracts a leading system record, folds action results, clears
+  historical schemas, merges assistant messages, and can render round notifications. It has no
+  production caller (`lionagi/protocols/messages/prepare.py`).
+- `_prepare_run_kwargs()` is the active chat and run path. It performs a different action fold,
+  assistant merge, system fold, context-provider injection, filtering, and final rendering
+  (`lionagi/operations/chat/_prepare.py`).
+
+Two helpers can therefore assign different provider-visible meanings to the same record sequence.
+
+**P3 — History selection and malformed-history behavior are implicit.** The active path chooses
+`param.progression or branch.progression`, looks up every UUID, ignores some message kinds, and
+requires the first retained item to be an instruction only when a system message exists. Invalid
+IDs surface through collection lookup; adjacent non-assistant retained records can be silently
+dropped by the current merge loop. Those are control-flow accidents, not a named contract.
+
+**P4 — Ephemeral context needs attribution and syntax boundaries.** ADR-0008 records that current
+provider blocks are joined and concatenated directly between system text and guidance. The request
+compiler needs a typed block input and an exact encoding so source attribution survives to the
+provider request and retrieved text cannot become adjacent to policy merely because delimiters
+were omitted. This is a data-boundary improvement, not a claim that retrieved text becomes trusted.
+
+**P5 — Chat and run must agree before transport-specific execution begins.** Both paths already
+call `_prepare_run_kwargs()`, but they then mutate call arguments differently: chat invokes an API
+event, while run adds streaming, resume, deadline, and persistence behavior. Compilation belongs
+before that fork so transport mechanics cannot redefine history.
+
+**P6 — Migration must preserve normal provider payloads while removing duplicate authority.** The
+existing `Branch.chat`, `communicate`, `operate`, and `run` signatures cannot all change at once.
+They need an adapter into one typed request, characterization tests for current successful
+histories, and one removal/delegation plan for legacy helpers.
+
+| Concern | Decision |
+|---------|----------|
+| Durable versus transient turn data | D1: Introduce immutable `TurnRequest`, `ContextBlock`, `CompiledMessage`, and `CompiledChatRequest` contracts. |
+| History selection and folding | D2: Make `compile_chat_request()` the sole owner of validation, action folding, assistant normalization, system placement, and rendering. |
+| Context attribution and boundaries | D3: Encode context blocks as canonical JSON in a separately delimited guidance section. |
+| Service boundary | D4: Keep compiled messages provider-neutral; adapters translate them only at model invocation. |
+| Chat/run parity | D5: Require chat and run to consume the same compiled result before adding transport-only keyword arguments. |
+| Migration and old helpers | D6: Adapt existing Branch arguments into `TurnRequest`, characterize payloads, then delegate or remove every competing preparation path. |
+
+This ADR deliberately does **not** decide:
+
+- how context providers retrieve or prioritize blocks; ADR-0008 owns provider execution and
+  supplies `ContextBlock` values to this boundary;
+- tool execution, action concurrency, or action-result writeback; compilation only represents
+  recorded results in model context;
+- response parsing or Pydantic validation after the model call;
+- provider transport, retry, rate-limit, streaming, or persistence behavior;
+- a new public `Branch.chat` or `Branch.run` signature. Existing call surfaces adapt into the new
+  contract first; or
+- a new system-role wire message. The target keeps the shipped system-into-first-user-message fold
+  so this refactor does not also change the role sequence.
 
 ## Decision
 
-The operation layer will introduce one typed `TurnRequest` and one canonical
-`compile_chat_request(branch, request)` boundary. The minimum interface is:
+### D1 — Separate record-ready instruction data from transient call data
+
+The operation layer introduces the following exact Python-native contract in
+`lionagi/operations/types.py`:
 
 ```python
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from lionagi.operations.schema.structure import Structure
+from lionagi.protocols.messages import Instruction, MessageRole
+
+
 @dataclass(frozen=True, slots=True)
 class ContextBlock:
     provider_name: str
@@ -46,12 +112,14 @@ class CompiledMessage:
 @dataclass(frozen=True, slots=True)
 class TurnRequest:
     instruction: Instruction
-    progression: tuple[UUID, ...] | None
-    tool_schemas: tuple[dict[str, Any], ...]
-    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None
-    structure: type[Structure] | str | None
-    context_blocks: tuple[ContextBlock, ...]
-    provider_kwargs: Mapping[str, Any]
+    progression: tuple[UUID, ...] | None = None
+    tool_schemas: tuple[dict[str, Any], ...] = ()
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None
+    structure: type[Structure] | str | None = None
+    context_blocks: tuple[ContextBlock, ...] = ()
+    provider_kwargs: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,59 +129,400 @@ class CompiledChatRequest:
     provider_kwargs: Mapping[str, Any]
 
 
-def compile_chat_request(branch: Branch, request: TurnRequest) -> CompiledChatRequest: ...
+def compile_chat_request(
+    branch: Branch,
+    request: TurnRequest,
+) -> CompiledChatRequest: ...
 ```
 
-Provider adapters may translate `CompiledMessage` at the service boundary. The load-bearing
-invariants are:
+The per-instance mapping factory avoids sharing mutable call state and exposes a read-only empty
+default.
 
-- durable `InstructionContent` retains provider-neutral user content only: instruction, stable
-  guidance and prompt context, plain content, and multimodal input;
-- tool schemas, response-format and structure objects, selected progression, context-provider
-  blocks, and model-call keyword arguments are transient `TurnRequest` data;
-- compilation does not mutate durable messages and historical turns cannot replay transient schemas
-  or current-call options;
-- one compiler owns system-policy folding, action-result correlation, consecutive-assistant
-  normalization, selected-history validation, and final role and content rendering;
-- context blocks are source-attributed and isolated in explicit data envelopes so retrieved text
-  cannot merge syntactically with system policy or user guidance;
-- chat and run use the same compiler and preserve their existing provider-visible message semantics
-  until a separately documented behavioral change is accepted;
-- `MessageManager` exposes raw ordered records only; prompt-shaping helpers migrate to the compiler;
-  and
-- the existing Branch call surface adapts arguments into `TurnRequest`, so the boundary can be
-  introduced before public call signatures change.
+After migration, the durable instruction content contract is reduced to provider-neutral fields:
 
-The target implementation anchors are `lionagi/operations/types.py` and
-`lionagi/operations/chat/_prepare.py`. Migration removes independent policy from
-`lionagi/protocols/messages/prepare.py` and makes the raw nature of
-`lionagi/protocols/messages/manager.py` projections explicit.
+```python
+# lionagi/protocols/messages/instruction.py
+@dataclass(slots=True)
+class InstructionContent(MessageContent):
+    instruction: str | None = None
+    guidance: str | None = None
+    prompt_context: list[Any] = field(default_factory=list)
+    plain_content: str | None = None
+    images: list[str] = field(default_factory=list)
+    image_detail: Literal["low", "high", "auto"] | None = None
+```
+
+`tool_schemas`, `response_format`, `structure`, and `_structure_instance` no longer remain fields on
+the target durable dataclass. During the compatibility window, `InstructionContent.from_dict()`
+accepts those keys from legacy serialized content and ignores them; replay cannot reconstruct a
+current-call option. The Branch call adapters continue accepting their existing arguments and place
+them on `TurnRequest`.
+
+The lifetime split is normative:
+
+| Data | Durable `CompiledChatRequest.instruction` | Transient `TurnRequest` / compiled messages |
+|------|---------------------------------------------|---------------------------------------------|
+| instruction text | yes | rendered from durable copy |
+| stable guidance and prompt context | yes | rendered from durable copy |
+| plain content and images | yes | rendered from durable copy |
+| sender, recipient, identity, metadata | yes | used only as needed for compilation |
+| tool schemas | no | `TurnRequest.tool_schemas` |
+| response format and structure | no | `TurnRequest.response_format` / `structure` |
+| selected progression | no | `TurnRequest.progression` |
+| context-provider blocks | no | `TurnRequest.context_blocks` |
+| model-call keyword arguments | no | `TurnRequest.provider_kwargs` |
+
+Exact construction semantics:
+
+- `TurnRequest.instruction` is an `Instruction`, not raw text. Existing Branch entry points first
+  build it through the current instruction factory so sender/recipient, context, images, and
+  content validation retain their public behavior.
+- The compiler makes a deep model copy of the supplied instruction, preserving its `id`,
+  `created_at`, sender, recipient, and metadata values. It replaces that copy's content with the
+  target `InstructionContent` built from only instruction, guidance, prompt context, plain content,
+  images, and image detail. The supplied `Instruction` is never mutated.
+- The compiler builds a private ephemeral rendering view for the current call. That view combines
+  durable content with `tool_schemas`, `response_format`, and `structure` from `TurnRequest` and
+  preserves the current minimal-YAML Tools, ResponseSchema, and ResponseFormat sections.
+- Historical instruction copies use only the target durable fields, so an old in-memory record
+  created before migration cannot replay a schema into a later call.
+- `CompiledChatRequest.instruction` is the only instruction object that chat/communicate/run may
+  record after compilation. It contains no context blocks or current-call model kwargs.
+- The frozen dataclasses prevent field reassignment but do not make nested dictionaries or
+  multimodal lists immutable. The compiler uses `copy.deepcopy()` for schema dictionaries,
+  provider kwargs, and rendered list content, then exposes compiled kwargs through
+  `MappingProxyType`. Caller-owned mutable containers are not retained by the compiled request.
+- `provider_kwargs` may not contain the reserved key `"messages"`. A collision raises
+  `ValueError("provider_kwargs must not contain reserved key 'messages'")` rather than silently
+  overwriting either value.
+
+This decision removes the need for serialization to be the mechanism that distinguishes durable
+from transient state. Serialization remains a compatibility safeguard, not the lifetime boundary.
+
+### D2 — One deterministic compiler owns selection, folding, and rendering
+
+`compile_chat_request()` is a pure compilation step with respect to branch history: it reads the
+branch and returns new values without mutating any stored message, progression, or content object.
+Its algorithm is normative.
+
+#### 1. Resolve and validate the history view
+
+- `request.progression is None` selects `branch.progression`, including any
+  `metadata["current_progression"]` override described by ADR-0006.
+- An explicit empty tuple selects no historical messages.
+- Existing public adapters preserve the current falsy-list behavior during migration by mapping a
+  legacy `progression=[]` argument to `None`. Direct internal `TurnRequest(progression=())` is the
+  unambiguous empty-history form.
+- Every UUID must exist in `branch.msgs.messages`. Missing IDs are collected and reported in one
+  `ValueError` before any compilation output is produced.
+- Duplicate UUIDs are rejected with `ValueError`; replaying the same record twice is not an
+  implicit feature.
+- Order is exactly tuple/progression order, not creation time.
+
+#### 2. Project provider-relevant history
+
+The compiler walks the selected records once:
+
+- `System` records are not emitted from the selected progression; the canonical
+  `branch.msgs.system` is handled in the system fold below.
+- `ActionRequest` records are not emitted independently. Their function and arguments are already
+  present on the correlated `ActionResponse` content.
+- `ActionResponse` records are accumulated until the next historical `Instruction`.
+- `AssistantResponse` becomes an ephemeral copy of `AssistantResponseContent`.
+- `Instruction` becomes an ephemeral copy with `tool_schemas=()`, `response_format=None`, and no
+  structure instance. Pending action responses are appended to its prompt context.
+- A base `Message` or other record whose role is `unset` is ignored; routed traffic is not a
+  provider conversation turn.
+- Any future fixed-role conversational subtype not covered above raises `TypeError` so adding a
+  subtype cannot silently change prompt semantics.
+
+Action responses use the current provider-visible projection:
+
+```python
+{
+    "function": response.content.function,
+    "arguments": response.content.arguments,
+    "output": response.content.output,
+}
+```
+
+For each target instruction, projected dictionaries append in action-response order. A dictionary
+already equal to an existing prompt-context item is not appended again. Pending responses after
+the last historical instruction append to the current ephemeral instruction.
+
+#### 3. Validate conversation ordering and merge assistant runs
+
+- Consecutive `AssistantResponseContent` objects merge into one assistant message by joining their
+  text with exactly `"\n\n"`.
+- Adjacent retained instructions are rejected with `ValueError("Consecutive instructions require
+  an intervening assistant response")`. The compiler does not preserve the current accidental
+  silent drop.
+- If a system message exists and retained history is non-empty, the first retained content must be
+  an instruction. Otherwise compilation raises
+  `ValueError("First message in progression must be an Instruction or System")`, preserving the
+  active path's explicit error.
+- With no retained history, the current ephemeral instruction is the first content.
+- The current instruction is appended exactly once after retained history.
+
+#### 4. Fold system, context, and guidance
+
+The compiler keeps the shipped role sequence: it does not emit a provider `system` message. It
+builds one guidance prefix and applies it to the first instruction content:
+
+```text
+<system.rendered, when present>
+
+<context section from D3, when blocks are present>
+
+<that instruction's existing guidance, when present>
+```
+
+Each non-empty section is joined with exactly two newline characters. Non-string guidance renders
+through the existing minimal-YAML renderer before joining.
+
+When retained history exists, the fold applies to its first instruction, matching current system
+placement. Otherwise it applies to the current instruction. Context blocks can compile without a
+system message; whether the provider registry runs on a systemless branch remains a migration
+decision in ADR-0008.
+
+#### 5. Render immutable provider-neutral messages
+
+- Each instruction uses the existing structured instruction renderer and has role `user`.
+  Historical views render only durable sections; the current ephemeral view additionally renders
+  the TurnRequest's Tools, ResponseSchema, and ResponseFormat sections.
+- Each assistant response renders its normalized text and has role `assistant`.
+- A falsy rendered value is omitted, matching the active path.
+- Multimodal instruction content remains a list containing a text part and `image_url` parts.
+- The returned `messages` tuple preserves the final content order.
+- `CompiledMessage` contains only `role` and rendered `content`; message UUIDs and metadata do not
+  enter the provider request.
+
+The algorithm has no retry, timeout, token cap, or provider call. It is deterministic for the
+branch snapshot and `TurnRequest` supplied. Callers that require a stable snapshot must avoid
+concurrent history mutation while compiling; cross-task branch locking is outside this ADR.
+
+### D3 — Context blocks use a canonical source-attributed JSON section
+
+`ContextBlock` is data, not preformatted policy text. The compiler renders all blocks as one
+canonical JSON array:
+
+```python
+from lionagi.ln import json_dumps
+
+payload = [
+    {"provider_name": block.provider_name, "content": block.content}
+    for block in request.context_blocks
+]
+encoded = json_dumps(payload, sort_keys=True)
+section = "LIONAGI_CONTEXT_BLOCKS_JSON\n" + encoded + "\nEND_LIONAGI_CONTEXT_BLOCKS_JSON"
+```
+
+The exact provider-visible shape for two blocks is:
+
+```text
+LIONAGI_CONTEXT_BLOCKS_JSON
+[{"content":"first retrieved value","provider_name":"catalog"},{"content":"second retrieved value","provider_name":"memory"}]
+END_LIONAGI_CONTEXT_BLOCKS_JSON
+```
+
+Exact semantics:
+
+- block order is `TurnRequest.context_blocks` order, which ADR-0008 defines as retained
+  registration order;
+- empty `provider_name` or `content` is rejected with `ValueError`; the registry should omit empty
+  results before constructing blocks;
+- JSON escaping preserves quotes, newlines, and control characters inside the `content` field;
+- system text, the context section, and guidance are separate two-newline-delimited sections;
+- context content remains untrusted model input. Attribution and syntactic encoding prevent
+  accidental string adjacency; they do not authorize instructions found in retrieved data or
+  guarantee resistance to semantic prompt injection; and
+- the context section exists only in compiled content. Neither the JSON text nor the source blocks
+  are copied into the record-ready instruction.
+
+This target is the concrete source-attributed envelope required by ADR-0008 delta 1.
+
+### D4 — Provider translation occurs after neutral compilation
+
+The operation compiler returns `CompiledMessage`, not OpenAI-, Anthropic-, or CLI-specific request
+objects. The default service projection is mechanically:
+
+```python
+provider_messages = [
+    {"role": message.role.value, "content": message.content}
+    for message in compiled.messages
+]
+```
+
+Provider adapters may translate multimodal part names or other service-specific shapes at the
+`iModel` boundary. They may not re-read `Branch.messages`, refold actions, move system policy,
+re-run context providers, or mutate the compiled instruction. If a provider needs a native tools
+field or response-format field, that translation is driven from explicit operation parameters,
+not reconstructed from durable history.
+
+An adapter error occurs before model invocation and leaves history unchanged. Recording happens
+only after compilation succeeds and follows each operation's existing behavior: direct `chat()`
+does not automatically record, `communicate()` records its instruction/response, and `run()`
+records streamed messages.
+
+### D5 — Chat and run share compilation and diverge only for execution
+
+Both operation paths use the same sequence:
 
 ```mermaid
-flowchart LR
-    API[Branch call surface] --> TR[TurnRequest]
-    H[MessageManager raw history] --> C[Canonical compiler]
-    TR --> C
-    C --> CR[CompiledChatRequest]
-    CR --> IM[iModel boundary]
+sequenceDiagram
+    participant API as Branch call surface
+    participant P as Context providers
+    participant C as compile_chat_request
+    participant A as Provider adapter
+    participant M as iModel
+    API->>P: gather source-attributed blocks
+    P-->>API: tuple[ContextBlock, ...]
+    API->>C: Branch + TurnRequest
+    C-->>API: CompiledChatRequest
+    API->>A: CompiledMessage tuple
+    A-->>API: provider messages
+    API->>M: invoke or stream
 ```
+
+After compilation:
+
+- chat selects the model from its existing `ChatParam`/Branch operation state, adds the deprecated
+  `include_token_usage_to_model` value only when explicitly present, and invokes once;
+- run verifies a CLI model, adds resume state, `stream=True`, an optional stream deadline, and
+  optional persistence callbacks; and
+- neither path changes `compiled.messages` or compiles a second time.
+
+There is no separate `compile_run_request()`. Run-only settings such as `stream_persist`,
+`persist_dir`, and `snapshot_dir` remain execution parameters and never enter `TurnRequest`.
+
+### D6 — Migrate by adaptation, characterization, and removal of competing policy
+
+The target module ownership is:
+
+```text
+lionagi/operations/
+├── types.py                 TurnRequest, ContextBlock, CompiledMessage,
+│                            CompiledChatRequest
+└── chat/
+    ├── _compile.py          compile_chat_request and pure helpers
+    ├── _prepare.py          temporary compatibility adapter; then removed/delegated
+    └── chat.py              provider invocation only
+
+lionagi/protocols/messages/
+├── manager.py              ordered raw records and factories only
+└── prepare.py              compatibility delegation, then deprecation/removal
+```
+
+Migration order is part of the decision:
+
+1. Capture current successful provider-visible payloads for chat and run: empty history, systemful
+   and systemless history, action results, consecutive assistant responses, images, tools,
+   response formats, selected progressions, and context-provider blocks.
+2. Add the typed contracts and compiler without changing public Branch signatures.
+3. Adapt `ChatParam`/`RunParam` plus the newly built instruction into `TurnRequest`. Preserve the
+   legacy empty-progression behavior in that adapter.
+4. Route both chat and run through the compiler. Any intentional difference—canonical context
+   delimiters and explicit malformed-history errors in this ADR—gets a focused expectation rather
+   than an accidental snapshot update.
+5. Make `MessageManager.to_chat_msgs()` explicitly raw and keep it only for callers that want a
+   literal record projection.
+6. Delegate `prepare_messages_for_chat()` to the compiler where compatible, deprecate unsupported
+   option combinations, then remove independent prompt policy at the declared compatibility
+   boundary.
+7. Remove `_prepare_run_kwargs()` after all production callers use the compiler.
+
+Completion requires one payload test matrix shared by chat and run. A change that updates only one
+side fails the boundary contract.
 
 ## Consequences
 
-One deterministic compiler becomes the regression surface for prompt history, action results,
-structured output, tools, images, and injected context. Durable messages round-trip without
-carrying objects that exist only for one model call, and provider preparation no longer leaks into
-the record manager.
+### Positive
 
-The migration touches a high-risk compatibility boundary. It must pin current chat and run payloads
-with characterization tests before delegating or removing legacy helpers. A typed intermediate
-model adds a small allocation and translation cost, and provider-specific payload extensions must
-pass through explicit adapter fields rather than mutating message records.
+- Durable instructions no longer retain objects or schemas that exist only for one call.
+- One deterministic compiler becomes the regression surface for history, actions, structured
+  output instructions, tools, images, system policy, and injected context.
+- Chat and run cannot drift in prompt semantics while retaining independent execution mechanics.
+- Source attribution survives into provider-visible context without persisting retrieved text as a
+  conversation record.
+- Provider adapters consume a small frozen-field intermediate shape instead of depending on
+  `MessageManager` internals.
+
+### Negative
+
+- Compilation allocates record-ready and ephemeral content copies. This is deliberate isolation
+  overhead; no performance rationale or benchmark currently justifies in-place mutation.
+- The migration touches a compatibility-sensitive request boundary and must distinguish intended
+  changes from regressions in payload snapshots.
+- Canonical JSON context encoding adds prompt characters compared with direct concatenation.
+- `TurnRequest` introduces another internal type alongside `ChatParam` during migration. The overlap
+  must be temporary; leaving both as prompt authorities would recreate P2.
+
+### Maintenance and reversal cost
+
+- Adding a new conversational message kind requires an explicit compiler case and shared chat/run
+  tests. Silent fallback is forbidden.
+- Adding a transient call option requires a `TurnRequest` field or explicit provider-adapter input;
+  putting it back on durable `InstructionContent` violates D1.
+- Reversing to provider-specific compilers would duplicate the history algorithm and invalidate
+  the parity test matrix. Reversing the JSON context envelope would change provider-visible prompt
+  text and requires a documented compatibility decision.
+- The compiler is highly testable without a live model: branch records and a request are sufficient
+  to assert the complete output.
+
+## Alternatives considered
+
+### Keep current-call configuration in `InstructionContent` and strip it on replay
+
+This preserves existing factories and keeps all rendering inputs on one object. It lost because
+the object then has two lifetimes: record storage and request execution. Type/BaseModel response
+formats cannot round-trip, dictionary formats behave differently, and every replay path must
+remember to clear schemas. The current `to_dict()` and `with_updates()` exceptions are direct
+evidence of that burden.
+
+### Move all compilation into `MessageManager`
+
+The manager already owns messages and could expose one `prepare()` method. This would reduce the
+number of modules a caller touches. It lost because the manager would need current model kwargs,
+tool schemas, response formats, provider blocks, and system-fold policy—operation inputs unrelated
+to durable membership and order. It would reverse ADR-0006's manager boundary.
+
+### Let each provider adapter compile raw history
+
+Provider-local compilation could use native system, tool, and multimodal features directly. It
+lost because action folding, historical schema stripping, progression validation, and assistant
+normalization would be repeated for every provider. Equivalent turns could then change meaning
+when only the model provider changes.
+
+### Keep `_prepare_run_kwargs()` as the canonical boundary without typed intermediates
+
+This is the smallest code change because chat and run already call it. It lost because its input is
+a branch plus broad `ChatParam`, its output mixes messages into a mutable kwargs dictionary, and it
+uses a private branch slot for context. The signature does not separate durable data, transient
+data, compiled messages, or reserved provider keys.
+
+### Emit a native provider `system` message
+
+A dedicated system-role item would avoid folding policy into the first user message and maps to
+many chat APIs. It lost for this migration because it changes the provider-visible role sequence,
+and not every CLI or provider surface treats native system messages identically. This ADR keeps the
+current fold; a future role-sequence change needs its own characterization and decision.
+
+### Preserve context as direct string concatenation
+
+This is shortest and has the lowest token overhead. It lost because source names disappear and
+empty delimiters let system text, retrieved text, and guidance become one syntactic run. Canonical
+JSON costs characters but preserves source/content fields and escaping deterministically.
+
+### Mutate historical content in place to avoid copies
+
+In-place clearing of old schemas and folding of action outputs would allocate less. It lost because
+compilation failure or concurrent inspection could observe partially rewritten history, and later
+turns would inherit previous call policy. The compiler's primary invariant is non-mutation.
 
 ## Notes
 
-Alternatives considered were retaining configuration in `InstructionContent` and stripping it on
-replay, moving all compilation into `MessageManager`, and letting each provider build payloads from
-raw history. The first preserves serialization exceptions, the second couples durable storage to
-operation policy, and the third multiplies prompt semantics. One operation-owned compiler keeps the
-record and service boundaries explicit.
+Current implementation anchors used to define migration behavior:
+`lionagi/protocols/messages/instruction.py`, `lionagi/protocols/messages/manager.py`,
+`lionagi/protocols/messages/prepare.py`, `lionagi/operations/types.py`,
+`lionagi/operations/chat/_prepare.py`, `lionagi/operations/chat/chat.py`,
+`lionagi/operations/communicate/communicate.py`, and `lionagi/operations/run/run.py`.

--- a/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
+++ b/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
@@ -9,86 +9,464 @@
 ## Context
 
 LionAGI can gather knowledge immediately before a chat or run turn without adding that knowledge to
-durable conversation history. `ContextProvider` is a structural asynchronous interface whose
-`provide(branch, instruction)` method returns a text block or no result. Each `Branch` lazily owns
-an ordered `ContextProviderRegistry`; a branch that never registers providers does no provider work.
+durable conversation history. The seam exists because model-visible context has a shorter lifetime
+than recorded user and assistant turns.
 
-The registry invokes providers sequentially in registration order and contains provider exceptions.
-It tokenizes every non-empty successful result, applies each provider's optional maximum, and then
-selects blocks under a total token budget by descending priority. Kept blocks render in registration
-order. The budget limits rendered text, not provider invocation: all providers run before any
-total-budget result is dropped.
+**P1 — Optional retrieval must add no work to branches that do not use it.** Most branches have no
+registered providers. Creating provider infrastructure or running a gather pass on every turn would
+add overhead to the default path. `Branch.providers` therefore creates the registry lazily, and the
+operation path tests the private registry without forcing creation (`lionagi/session/branch.py`;
+`lionagi/operations/chat/_prepare.py`).
 
-Chat and run gather providers before compiling the model request. A branch without a system message
-does not invoke them because the current compiler has no injection target; the most recent report
-marks every registered provider as skipped. With a system message, blocks are held in a private
-per-turn slot, concatenated into the first instruction's system-guidance fold, and cleared in a
-`finally` block after compilation. The text is sent to the model but is not inserted into
-`Branch.messages`.
+**P2 — External context sources fail independently of the model turn.** A provider may consult
+memory, search, a local corpus, or an external service. Failure in one source should not suppress
+other sources or prevent an ordinary turn. The registry invokes each provider under exception
+containment and retains failures in a diagnostic report (`lionagi/protocols/context_providers.py`).
 
-`ProviderReport` is an in-memory last-turn diagnostic. It retains rendered blocks, provider names
-and token counts for selected results, and unclassified skipped and failed names. Empty results are
-not represented, skip reasons are not distinguished, and reports are not emitted to logs or run
-metadata. The current concatenation also supplies no guaranteed delimiter between system text, the
-joined provider blocks, and guidance.
+**P3 — Model-visible context needs a bounded rendered footprint.** Providers can return arbitrarily
+large text. The registry applies an optional per-provider maximum and a total rendered-token budget,
+protecting higher-priority results first. The current budget bounds selected output only: it does
+not avoid provider calls or bound remote retrieval cost.
 
-The registry is independent of `MemoryStore`. A provider may consult `branch.memory` or any external
-source, but the context contract neither requires nor adapts the memory interface. Memory backend
-and lifecycle semantics belong to the separate substrate boundary (see the substrates ADR on
-memory-store contracts). The registry also exposes a contained `gather_writeback()` hook. One
-production turn path invokes it: when providers are registered and an action-invoking turn produces
-non-empty action results, the operate pipeline calls `gather_writeback()` with those results
-(`lionagi/operations/operate/operate.py`). Turns without action results, and the chat and run
-paths, do not trigger writeback.
+**P4 — Selection priority and rendering order answer different questions.** Priority decides which
+blocks survive a budget conflict; registration order decides how retained blocks appear. Stable
+selection plus original-order rendering preserves deterministic composition without making a
+low-priority block jump ahead merely because it was evaluated later.
+
+**P5 — Injection must be ephemeral.** The active compiler needs the selected text for one call, but
+`Branch.messages` must not acquire retrieved context as a fake user or system turn. The
+implementation uses a private per-turn slot, consumes it during request preparation, and clears it
+in a `finally` block in both chat and run.
+
+**P6 — Attribution exists, but only as last-turn diagnostics.** `ProviderReport` captures retained
+raw blocks, provider names and token counts, skipped names, and failed names. It is overwritten on
+the next provider pass, carries no turn identifier, conflates skip reasons, and is not persisted or
+emitted to run metadata.
+
+**P7 — The current render target requires a system message.** Provider blocks are inserted into the
+system-guidance fold. A branch without `branch.msgs.system` skips every registered provider without
+invocation and reports all names as skipped. This avoids wasted retrieval but makes system presence
+an implicit eligibility rule.
+
+**P8 — Post-action writeback has one production entry point, not a general turn lifecycle.** The
+registry exposes optional provider `writeback` hooks. `operate()` invokes them after non-empty
+action responses are produced; direct chat, communicate-without-actions, and run do not. The hook
+is failure-contained but has no report or exactly-once guarantee
+(`lionagi/operations/operate/operate.py`).
+
+**P9 — Context providers and memory stores are separate seams.** `ContextProviderRegistry` imports
+no `MemoryStore` and imposes no source backend. A provider may use `branch.memory`, a search service,
+or another source, but provider selection and memory lifecycle are not the same contract.
+
+| Concern | Decision |
+|---------|----------|
+| Ownership and registration | D1: Store one lazily-created ordered registry on each Branch. |
+| Retrieval and failure behavior | D2: Invoke providers sequentially, contain provider exceptions, and ignore empty results. |
+| Caps and priority | D3: Apply per-provider and total rendered-token limits after retrieval, select by descending priority, and render retained blocks in registration order. |
+| Turn integration | D4: Gather before chat/run compilation, inject through a private per-turn slot only when a system render target exists, and always clear the slot after preparation. |
+| Attribution | D5: Retain one in-memory `ProviderReport` describing selected, skipped, and failed providers. |
+| Source independence | D6: Keep the provider protocol independent of `MemoryStore` and concrete adapters. |
+| Post-action writeback | D7: Invoke optional async writeback hooks from the operate action-result path and contain their failures. |
+
+This ADR deliberately does **not** decide:
+
+- how any concrete provider queries, ranks, caches, authenticates to, or writes to its source;
+- memory-store backend and lifecycle semantics, which belong to the substrates boundary;
+- canonical source-attributed prompt encoding; ADR-0007 specifies the aspirational compiler shape,
+  while this retrospective ADR records the current concatenation exactly;
+- a timeout, retry, concurrency, or cost policy for provider invocation; none exists in the shipped
+  registry;
+- durable report retention, redaction, or privacy policy; these remain explicit deltas; or
+- whether systemless branches should invoke providers. The current skip is descriptive, not an
+  aspirational resolution.
 
 ## Decision
 
-Pre-turn context is a Branch-owned, failure-contained operational input, not a conversational
-message. The load-bearing invariants are:
+### D1 — Each Branch lazily owns one ordered registry
 
-- providers structurally implement `async provide(Branch, Instruction) -> str | None` and run in
-  registration order;
-- provider exceptions do not fail the turn, and an empty result contributes no rendered block;
-- per-provider and total limits apply after retrieval, priority determines which successful blocks
-  fit, and retained blocks preserve registration order;
-- providers run only when a system message supplies the current render target; otherwise all
-  registered names are reported as skipped without invocation;
-- selected text exists only in the per-turn compiler input, never in durable message history, and
-  the slot is cleared even when compilation fails;
-- `last_context_report` retains only the latest in-memory report and is diagnostic rather than a
-  durable audit record;
-- context providers and memory stores remain independent structural interfaces; and
-- provider writeback fires on the operate path when action results exist, and otherwise only when
-  a caller explicitly invokes `gather_writeback()`; both follow the same exception-containment
-  policy as retrieval.
+The public protocol and registry signatures are:
 
-The implementation anchors are `lionagi/protocols/context_providers.py`,
-`lionagi/operations/chat/_prepare.py`, `lionagi/operations/chat/chat.py`,
-`lionagi/operations/run/run.py`, and `lionagi/session/branch.py`.
+```python
+# lionagi/protocols/context_providers.py
+@runtime_checkable
+class ContextProvider(Protocol):
+    async def provide(
+        self,
+        branch: Branch,
+        instruction: Instruction,
+    ) -> str | None: ...
+
+
+class ContextProviderRegistry:
+    def __init__(self, budget: int = 2000): ...
+
+    def register(
+        self,
+        provider: ContextProvider,
+        *,
+        priority: int = 0,
+        max_tokens: int | None = None,
+        name: str | None = None,
+    ) -> None: ...
+
+    async def gather(
+        self,
+        branch: Branch,
+        instruction: Instruction,
+    ) -> ProviderReport: ...
+
+    async def gather_writeback(
+        self,
+        branch: Branch,
+        action_responses: list,
+    ) -> None: ...
+```
+
+The registry stores private entries in append order:
+
+```python
+@dataclass
+class _Entry:
+    provider: ContextProvider
+    priority: int
+    max_tokens: int | None
+    name: str
+```
+
+Branch ownership is:
+
+```python
+# lionagi/session/branch.py
+class Branch(...):
+    _context_providers: ContextProviderRegistry | None = PrivateAttr(None)
+    _context_injection_slot: list[str] | None = PrivateAttr(None)
+    _last_context_report: Any = PrivateAttr(None)
+
+    @property
+    def providers(self) -> ContextProviderRegistry:
+        if self._context_providers is None:
+            self._context_providers = ContextProviderRegistry()
+        return self._context_providers
+
+    @property
+    def last_context_report(self):
+        return self._last_context_report
+```
+
+Exact ownership and registration semantics:
+
+- a newly constructed branch has no registry, no injection slot, and no report;
+- the first access to `branch.providers` constructs `ContextProviderRegistry(budget=2000)` and all
+  later accesses return the same object;
+- operation code checks `branch._context_providers` directly. It does not touch the property and
+  therefore does not create an empty registry on the zero-provider path;
+- `register()` appends one `_Entry`; there is no duplicate-provider or duplicate-name check, no
+  replacement by name, and no unregister method;
+- name resolution is `explicit name`, then truthy `provider.name`, then the provider class name;
+- `bool(registry)` and `len(registry)` reflect whether entries exist; `names` returns a new list in
+  registration order; and
+- `ContextProvider` is structural and runtime-checkable. Registration itself does not call
+  `isinstance()` or validate the method; a missing or non-async `provide` raises during the awaited
+  call and is recorded as a contained provider failure by `gather()`.
+
+Branch-local ownership permits different provider sets and budgets on different conversation
+branches. The registry itself holds provider objects strongly for the branch lifetime.
+
+### D2 — Retrieval is sequential and provider exceptions are contained
+
+`gather()` invokes `provide(branch, instruction)` for every registered entry in registration order.
+It does not use parallel tasks.
+
+Exact retrieval cases:
+
+- **Empty registry:** returns a new report with four empty lists and imports no tokenizer.
+- **Successful non-empty string:** tokenizes the string and enters it into budget selection.
+- **`None` or any other falsy result:** contributes no block and no fired, skipped, or failed
+  outcome. Empty results are therefore invisible in the report.
+- **Provider raises `Exception`:** logs a warning with traceback, appends the provider name to
+  `report.failed`, and continues to the next entry.
+- **Provider raises `BaseException` outside `Exception`:** is not contained and propagates.
+- **Protocol violation:** tokenization and later processing occur outside the `provide` try/except.
+  The protocol requires `str | None`; the registry does not promise containment for arbitrary
+  truthy non-string return values, though the current tokenizer returns zero on many encoding
+  errors.
+- **No timeout or retry:** a provider that waits indefinitely delays the turn indefinitely; a
+  transient failure is attempted once.
+
+All providers finish retrieval before the total budget selects any blocks. A result that is later
+dropped may already have paid its full I/O and computation cost.
+
+Sequential invocation was retained because order and failure isolation are deterministic and the
+initial seam did not define concurrency or shared-source rate pressure. There is no measured
+latency evidence in the code for preferring this shape; the absence of a timeout is a known cost,
+not an assertion that provider latency is harmless.
+
+### D3 — Limits bound selected rendered text, with priority-based admission
+
+The token measurement is:
+
+```python
+tokens = TokenCalculator.tokenize(text)
+```
+
+With no explicit encoding or tokenizer, `TokenCalculator` resolves the default through
+`get_encoding_name(None)`, which falls back to `o200k_base`. Tokenization exceptions are contained
+inside `TokenCalculator.tokenize()` and return a count of zero. The budget is therefore a local
+rendered-text estimate, not the exact token count for every eventual model.
+
+Admission has two stages.
+
+#### Per-provider maximum
+
+```python
+if entry.max_tokens and tokens > entry.max_tokens:
+    report.skipped.append(entry.name)
+    continue
+```
+
+Exact consequences of the truthiness check:
+
+- `max_tokens=None` means no per-provider cap;
+- a positive value skips the result only when `tokens` is strictly greater than the value; equality
+  fits;
+- `max_tokens=0` is falsy and therefore also means no cap in the shipped implementation; and
+- a negative value is truthy and causes any non-empty result with a non-negative count to exceed
+  it. The registry performs no constructor or registration validation.
+
+A per-provider overflow does not truncate. The whole block is skipped and its name enters the
+undifferentiated `skipped` list.
+
+#### Total registry budget
+
+Successful, per-provider-admitted results are stable-sorted by descending integer priority. The
+registry then greedily admits a result when `total + tokens <= budget` and skips it otherwise.
+
+Exact consequences:
+
+- higher numeric priority is considered first;
+- equal priorities retain registration order because Python sorting is stable;
+- an oversized high-priority block may be skipped while a later smaller block still fits;
+- a zero or negative budget skips any block with a positive token count; a zero-token block can fit
+  a zero budget;
+- there is no partial truncation and no reservation per provider;
+- priority affects admission only. After selection, `report.blocks` and `report.fired` are rebuilt
+  by walking successes in original registration order; and
+- `report.fired` adds `{ "provider_name": entry.name, "tokens": tokens }` for each retained block.
+
+The default total is **2000 tokens**. It was inherited from the initial context-injection design as
+an approximately 2k hard cap to limit context creep while leaving the rest of the model window to
+conversation and response. No benchmark, model-window derivation, or workload measurement is
+recorded for the exact value 2000. It is mutable as `registry.budget` and is not an application
+setting.
+
+Priority is not a relevance score and is not normalized. It is a caller-assigned admission order
+used only under budget pressure.
+
+### D4 — Gather before compilation, inject ephemerally, and clear after preparation
+
+The shared chat/run helper is:
+
+```python
+# lionagi/operations/chat/_prepare.py
+async def _apply_context_providers(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    param: ChatParam,
+) -> Instruction | None: ...
+```
+
+The active call sequence is:
 
 ```mermaid
 sequenceDiagram
     participant O as chat or run
+    participant B as Branch
     participant R as ContextProviderRegistry
-    participant C as Request compiler
-    O->>R: gather(branch, instruction)
-    R-->>O: ProviderReport and selected blocks
-    O->>C: compile with ephemeral blocks
-    C-->>O: provider request
-    O->>O: clear per-turn slot
+    participant C as _prepare_run_kwargs
+    O->>B: inspect private registry
+    alt no registered providers
+        B-->>O: no pre-built instruction
+    else no system message
+        O->>B: last report = all names skipped
+        B-->>O: no pre-built instruction
+    else system message present
+        O->>R: gather(branch, pre-built instruction)
+        R-->>O: ProviderReport
+        O->>B: save report and blocks in per-turn slot
+    end
+    O->>C: prepare request
+    C-->>O: instruction and model kwargs
+    O->>B: clear slot in finally
 ```
+
+Exact turn semantics:
+
+- **No registry or empty registry:** `_apply_context_providers()` returns `None` and does not modify
+  `_last_context_report` or `_context_injection_slot`. The ordinary preparation path builds the
+  instruction once.
+- **Systemless branch:** the helper does not build an instruction and does not call any provider.
+  It overwrites `_last_context_report` with `ProviderReport(skipped=registry.names)` and returns
+  `None`.
+- **Systemful branch:** the helper builds the current `Instruction` once, passes that exact object
+  to every provider, saves the returned report, and assigns `report.blocks` to the private slot.
+  `_prepare_run_kwargs()` reuses the pre-built instruction instead of constructing another.
+- **Rendering:** `_prepare_run_kwargs()` joins blocks with exactly one newline, then computes
+  `branch.msgs.system.rendered + injected + guidance`. It adds no guaranteed delimiter between the
+  system string and first block or between the last block and guidance. Non-string guidance first
+  renders through minimal YAML.
+- **History placement:** with retained history, that system/injection/guidance value becomes the
+  guidance of the first historical instruction; with no retained history, it becomes guidance on
+  the current instruction.
+- **Clear on preparation success or failure:** chat and run wrap `_prepare_run_kwargs()` in
+  `try/finally` and set `_context_injection_slot = None`. The slot is cleared before provider
+  invocation/streaming begins.
+- **Gather failure outside normal containment:** `_apply_context_providers()` is awaited before the
+  `try/finally` in both callers. An unexpected error escaping `gather()` prevents compilation; the
+  helper assigns the slot only after gather succeeds.
+- **Durability:** direct `chat()` does not auto-record any messages; `communicate()` records its
+  instruction and assistant response after invocation; `run()` records the instruction before
+  streaming. None receives the private block list in its durable content. The injected text exists
+  only in the ephemeral content copy rendered into model kwargs.
+
+The budget therefore limits injected text sent to the model, not the stored history and not the
+cost of calling providers.
+
+### D5 — `ProviderReport` is a mutable-list, last-turn diagnostic
+
+The shipped report contract is:
+
+```python
+# lionagi/protocols/context_providers.py
+@dataclass(frozen=True)
+class ProviderReport:
+    blocks: list[str] = field(default_factory=list)
+    fired: list[dict] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+```
+
+The dataclass is frozen only at the attribute level. Its four lists remain mutable; `gather()`
+appends to them while building the result, and callers can mutate them afterward.
+
+Exact attribution semantics:
+
+- `blocks[i]` and `fired[i]` describe the same retained provider result because both are appended
+  in retained registration order;
+- each fired entry has only `provider_name` and integer `tokens` keys;
+- `skipped` combines per-provider overflow and total-budget exclusion without a reason code or
+  token count;
+- `failed` contains names whose `provide()` raised `Exception`, without the exception value in the
+  report; the warning log carries traceback details;
+- empty/falsy provider results have no outcome row;
+- duplicate provider names make correlation ambiguous because entries have no stable entry ID;
+- a systemless turn lists every registered name in `skipped`, also without a distinct reason;
+- `branch.last_context_report` stores one reference, overwritten by the next provider-bearing or
+  systemless provider pass; turns with no registry leave the previous value unchanged; and
+- the report has no timestamp, turn/message ID, duration, budget total, redaction marker, or durable
+  sink.
+
+Raw selected blocks remain in memory through the report even after the private injection slot is
+cleared. Clearing the slot is therefore not a privacy or erasure guarantee.
+
+### D6 — Provider selection is independent of memory storage
+
+`ContextProvider` requires only `provide(branch, instruction) -> str | None`. The registry has no
+import from `lionagi/protocols/memory.py`, does not require `branch.memory`, and does not translate
+memory records into blocks.
+
+Exact boundary consequences:
+
+- a provider may read `branch.memory`, another local store, a search index, computed state, or an
+  external service;
+- a branch with no provider can still use its memory store directly;
+- a branch with providers need not instantiate `branch.memory`;
+- registry priority and budget apply to returned text regardless of its source; and
+- source-specific retries, caching, credentials, query construction, and result formatting belong
+  to the provider implementation, not the registry.
+
+This separation keeps the context seam composable with sources that are not memories and prevents
+the registry from becoming a second memory lifecycle API.
+
+### D7 — Optional writeback runs only after operate produces action responses
+
+The registry does not declare a second protocol, but it discovers an optional method dynamically:
+
+```python
+async def writeback(
+    branch: Branch,
+    action_responses: list,
+) -> None: ...
+```
+
+`gather_writeback()` walks entries in registration order. A provider without `writeback` is skipped.
+For each present hook it executes `await hook(branch, action_responses)`.
+
+Exact writeback semantics:
+
+- `operate()` first obtains action responses, returns immediately when the result is empty, removes
+  `None` entries, and returns again if the filtered list is empty;
+- when the filtered list is non-empty and `branch._context_providers` is truthy, `operate()` calls
+  `gather_writeback(branch, action_response_models)` once before attaching the responses to its
+  structured result;
+- direct chat and run do not call `gather_writeback()`. CLI tool-result messages yielded by run do
+  not activate this hook;
+- registry presence activates the scan, but each provider decides whether a writeback method exists
+  and whether that method performs work;
+- hooks execute sequentially in registration order;
+- an `Exception` from one hook is warned with traceback and contained; later hooks still run and the
+  turn result proceeds;
+- there is no returned report, status list, retry, timeout, transaction, turn ID, or idempotency key;
+  and
+- the code provides at-most-one registry invocation for one successful pass through this section
+  of one `operate()` call. It does not provide exactly-once durable effects if callers retry the
+  operation or a provider performs a partial write before raising.
+
+The source comment that writeback is “off by default” refers to provider policy: registration alone
+does not create a writeback method or force one to persist. The operate call site is automatic once
+non-empty action responses and a registry are present.
 
 ## Consequences
 
-Retrieval failures cannot block ordinary turns, context remains outside durable chat history, and
-priority-based selection bounds the text sent to the model. Callers can inspect immediate
-attribution without requiring a persistence backend, and providers are free to use memory, search,
-or external services.
+### Positive
 
-The current seam does not bound retrieval cost, cannot inject on a systemless branch, and cannot
-reconstruct attribution across turns. Raw blocks retained in the latest report may contain
-sensitive source material. Ambiguous skip outcomes and missing text boundaries make policy analysis
-and prompt inspection less reliable than the provider interface implies.
+- Branches that never access `providers` retain a zero-registry, zero-gather default path.
+- One provider failure cannot suppress successful results from later providers or fail an ordinary
+  turn.
+- Priority-based selection bounds retained rendered text while preserving deterministic display
+  order.
+- Retrieved blocks reach chat and run without becoming durable messages.
+- Immediate source names and token counts are inspectable without requiring a persistence backend.
+- Providers can use memory, search, composition, or external sources behind one structural
+  protocol.
+- Post-action writeback failures cannot replace an otherwise successful operate result.
+
+### Negative
+
+- Sequential invocation and no timeout let one slow provider delay every later provider and the
+  model turn.
+- All providers run before the total budget drops any result, so the budget does not constrain
+  retrieval cost.
+- The default 2000-token cap and tokenizer are not calibrated to the selected model.
+- Systemless branches silently change eligibility: all providers are reported skipped and none is
+  called.
+- Direct concatenation provides neither guaranteed section separators nor source names in the
+  model-visible text.
+- Last-turn reports lose history, conflate outcomes, and retain raw selected text in mutable lists.
+- Writeback has a narrower lifecycle than its “post-turn” label suggests and no idempotency or
+  outcome record.
+
+### Maintenance and reversal cost
+
+- Changing gather order or making it concurrent affects provider side-effect order and latency, so
+  it requires explicit tests for equal priority, failures, and shared-source providers.
+- Changing tokenization or the 2000 default changes which blocks fit and can alter model behavior
+  without any message-history change.
+- Persisting reports requires a redaction and retention decision because `blocks` contains raw
+  source text.
+- Moving injection into durable messages would require replay/migration rules to prevent stale
+  context from accumulating.
+- Unifying writeback across chat, run, and operate requires a turn-completion contract and
+  idempotency identity; adding another call site alone would risk duplicate writes.
 
 ## Current-vs-ideal delta
 
@@ -101,10 +479,70 @@ and prompt inspection less reliable than the provider interface implies.
 | 5 | Decide the systemless-branch policy; acceptance requires chat and run either to compile a documented context envelope without a system message or to expose the current skip behavior as a stable public contract. | S | (filled at issue-open time) |
 | 6 | Define the lifecycle of provider writeback; acceptance requires either one documented post-turn invocation point with exactly-once-per-turn tests or renaming the hook as an explicitly caller-driven utility. | M | (filled at issue-open time) |
 
+## Alternatives considered
+
+### Persist selected blocks as ordinary messages
+
+This would make replay and audit straightforward because model-visible context would live beside
+the turn. It lost because retrieved material is operational, refreshed per turn, and subject to
+budget/policy changes. Storing it as conversation history would replay stale source text, consume
+future context windows, and misrepresent it as a user, assistant, or system utterance.
+
+### Require every provider to retrieve through `MemoryStore`
+
+A single storage interface would simplify adapter testing and could centralize persistence. It lost
+because context can come from search, composition, computed branch state, or external services that
+are not memory records. Forcing those sources through memory would either narrow the seam or turn
+`MemoryStore` into a generic service locator.
+
+### Invoke providers concurrently
+
+Parallel gather would reduce wall-clock latency when providers are independent. It lost in the
+shipped seam because no concurrency, cancellation, timeout, or shared-rate-limit contract was
+defined, and provider side effects would no longer have registration-order execution. The current
+sequential shape is deterministic, but its latency cost remains a delta candidate rather than a
+claim of superiority.
+
+### Use budget priority to avoid invoking providers
+
+The registry could preselect providers before retrieval and save remote cost. It lost because the
+actual token size is known only after `provide()` returns, and the protocol exposes no cost or size
+estimate. Preflight selection would need a new provider contract; the current budget honestly caps
+rendered output only.
+
+### Fail the turn when any provider fails
+
+Fail-fast behavior would make missing context unmistakable and could be appropriate when context is
+mandatory policy. It lost for this general-purpose seam because providers are optional knowledge
+inputs, may use independent services, and should degrade separately. The report and warning expose
+failure without making model availability depend on every source.
+
+### Persist a full report automatically
+
+Durable per-turn outcomes would support longitudinal analysis and debugging. It lost from the
+shipped minimum because raw `blocks` may contain sensitive source text and no retention/redaction
+contract existed. The delta table preserves a report-reference design that must settle those
+questions first.
+
+### Synthesize a system envelope on systemless branches
+
+This would make providers work uniformly and avoid system presence as an eligibility condition. It
+was not taken because the current injection point is specifically the system-guidance fold; adding
+another provider-visible role or guidance shape changes prompt semantics. The choice remains
+explicitly open in delta 5 and ADR-0007 provides a target compiler capable of carrying blocks
+without relying on the private slot.
+
+### Invoke writeback after every chat and run turn
+
+A universal post-turn hook would match the method's broad label. It lost because the current hook
+accepts action responses, not an arbitrary turn result, and only `operate()` has the structured
+post-action list at that point. Generalization requires an event shape, invocation timing, and
+idempotency contract rather than adding calls with empty or incompatible payloads.
+
 ## Notes
 
-Alternatives considered were persisting injected blocks as ordinary messages and requiring all
-providers to retrieve through `MemoryStore`. Persisted blocks would contaminate durable user and
-assistant history with operational context; a memory-only source contract cannot represent search,
-composition, or other external providers. The Branch-owned structural registry preserves ephemeral
-injection while keeping source selection pluggable.
+Implementation anchors: `lionagi/protocols/context_providers.py`,
+`lionagi/operations/chat/_prepare.py`, `lionagi/operations/chat/chat.py`,
+`lionagi/operations/run/run.py`, `lionagi/operations/operate/operate.py`,
+`lionagi/operations/types.py`, `lionagi/session/branch.py`, and
+`lionagi/service/token_calculator.py`.

--- a/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
+++ b/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
@@ -8,89 +8,579 @@
 
 ## Context
 
-`Branch` is the public verb surface for a conversation. It exposes model transport,
-structured parsing, action execution, composed operation, interpretation, and reasoning-loop
-methods while keeping most implementations in `lionagi/operations/`. The façade imports those
-implementations inside each method, which lets operation modules depend on `Branch` only for type
-checking and avoids a runtime import cycle (`lionagi/session/branch.py`,
-`lionagi/operations/types.py`).
+`Branch` is the public verb surface for one conversation, but the implementations of those verbs
+live under `lionagi/operations/`. The split grew around five concrete problems.
 
-Named extensions are session-scoped. `Session` owns one `OperationManager`, shares it with every
-included branch, and registers asynchronous callables into it. `Branch.get_operation()` resolves a
-built-in branch method before consulting that registry, and `Operation` uses the same lookup when a
-graph node is invoked (`lionagi/session/session.py`, `lionagi/operations/manager.py`,
-`lionagi/operations/node.py`).
+**P1 — A caller needs one state-owning surface without making it the implementation layer.** Model
+transport, structured parsing, action execution, composed operation, interpretation, and reasoning
+loops all need the same branch managers. Publishing those functions only as unrelated
+module calls would make callers assemble and pass that state themselves; implementing them directly
+on `Branch` would make an already stateful façade own every algorithm.
 
-The model-facing verbs have distinct state contracts. `chat()` performs an API request and logs the
-event without adding the instruction or response to branch messages. `communicate()` records an API
-instruction and response and may then parse the response. `run()` is restricted to CLI endpoints;
-it streams and records typed instruction, assistant, action-request, and action-response messages
-while owning stream cleanup and lifecycle signals. `run_and_collect()` converts that stream back to
-a single result shape (`lionagi/operations/chat/chat.py`,
-`lionagi/operations/communicate/communicate.py`, `lionagi/operations/run/run.py`).
+**P2 — Operation implementations and `Branch` would form a runtime import cycle.** Implementations
+need a branch instance, while the façade needs to expose the implementations. The shipped direction
+is a type-only dependency from operation modules to `Branch` and a lazy, method-local import from
+the façade to the implementation (`lionagi/session/branch.py`; `lionagi/operations/types.py`).
 
-`Middle` is the structural substitution seam used by `operate()`. Its current docstring calls the
-seam one assistant turn, but its implementations do not share that cardinality: CLI collection may
-join several assistant messages, and the LNDL adapter may run several inner exchanges. The stable
-as-built contract is one logical adapter invocation that owns whatever recorded exchange or bounded
-exchange sequence it performs (`lionagi/operations/types.py`,
+**P3 — Named extensions must resolve the same way from direct calls and graph nodes.** A session can
+register a coroutine by name, and an `Operation` graph node stores only an operation name and
+parameters. If those paths had separate registries or precedence rules, a graph invocation could
+mean something different from `Session.run_operation()`.
+
+**P4 — API calls and CLI streams do not have the same state or cleanup contract.** `chat()` is an
+unrecorded one-shot request. `chat_and_record()` adds an explicit recording wrapper without adding
+an operation lifecycle. `communicate()` records an instruction and assistant response before
+optional parsing and does own a lifecycle. `run()` is a public async generator restricted to CLI
+endpoints; it records typed stream messages, handles provider session resumption, closes the
+provider stream on every exit, and owns its lifecycle signals. Treating all four as one transport
+primitive would hide meaningful differences on empty output, partial output, consumer abandonment,
+and provider failure.
+
+**P5 — The adapter seam cannot truthfully promise one provider message.** `Middle` was documented as
+advancing a branch by one assistant turn. Its implementations already have broader cardinality:
+`run_and_collect()` can join several assistant messages, and the LNDL adapter can perform several
+recorded exchanges. The stable as-built unit is one logical adapter invocation, not one provider
+message (`lionagi/operations/types.py`; `lionagi/operations/run/run.py`;
 `lionagi/operations/lndl_middle/lndl_middle.py`).
+
+| Concern | Decision |
+|---------|----------|
+| Public operation boundary | D1: `Branch` remains the façade and lazily delegates to operation modules. |
+| Named extension lookup | D2: one session-owned async registry serves direct and graph dispatch, after built-ins. |
+| Model-facing transport behavior | D3: `chat`, `chat_and_record`, `communicate`, `run`, and `run_and_collect` retain distinct persistence and failure semantics. |
+| Lifecycle and cleanup ownership | D4: the wrapper or stream that owns an exchange owns its lifecycle and cleanup signals. |
+| Adapter substitution | D5: `Middle` means one logical adapter invocation and may contain streaming or a bounded inner loop. |
+
+This ADR deliberately does **not** decide:
+
+- Composed response-schema construction, validation, or outer action execution; ADR-0022 owns that
+  coordinator contract.
+- Dependency scheduling, graph mutation, branch cloning, or flow result envelopes; ADR-0023 owns the
+  graph execution kernel.
+- LNDL syntax or its specific multi-round policy; ADR-0024 records the operations adapter only.
+- Provider endpoint implementation, request serialization, rate limiting, or credentials; those are
+  service-provider concerns below the operation façade.
+- Durable branch/session persistence; the operations layer emits and records state but does not
+  choose a persistence substrate.
 
 ## Decision
 
-The operation layer retains `Branch` as its public façade, the session-owned asynchronous registry
-as its named extension mechanism, and `Middle` as the typed adapter seam for a logical model
-exchange.
+### D1 — `Branch` is the public façade and operation modules are the implementation layer
+
+The shipped dependency shape is:
 
 ```text
-Session-owned registry ───────┐
-                              v
-Caller ──> Branch façade ──> built-in verb implementation
-                    │
-                    └── operate() ──> Middle adapter
-                                      ├── communicate (API, recorded)
-                                      ├── run_and_collect (CLI, streamed and recorded)
-                                      └── bounded adapter (for example LNDL)
+lionagi/
+├── session/
+│   ├── branch.py                 # public façade; lazy imports inside verb methods
+│   └── session.py                # branch collection and shared operation manager
+└── operations/
+    ├── types.py                  # parameter dataclasses and Middle protocol
+    ├── manager.py                # named-operation registry
+    ├── node.py                   # graph-executable Operation
+    ├── chat/chat.py              # unrecorded API request
+    ├── communicate/communicate.py# recorded API request + optional parse
+    ├── run/run.py                # recorded CLI stream + collection adapter
+    ├── operate/operate.py        # composed coordinator (ADR-0022)
+    ├── act/act.py
+    ├── parse/parse.py
+    ├── select/select.py             # module exists; no Branch.select façade is shipped
+    ├── interpret/interpret.py
+    └── ReAct/ReAct.py
 ```
 
-The load-bearing invariants are:
+The public methods construct the relevant parameter object and import their implementation inside
+the method. Representative shipped signatures are:
 
-- Built-in `Branch` methods take precedence over session-registered names. Registered operations
-  must be asynchronous and become visible to every branch included in the session.
-- Operation implementations receive a fully formed branch; they do not own branch or session
-  construction. Runtime imports from the façade remain lazy or type-only in the implementation
-  direction.
-- `chat()` is non-recording, while `communicate()`, `run()`, and any custom `Middle` own their message
-  persistence. `operate()` does not append a duplicate instruction or response around a `Middle`.
-- `run()` remains a public async-generator contract for CLI endpoints. API one-shot calls and CLI
-  stream lifecycle are not forced into one transport primitive.
-- A `Middle` accepts `branch`, `instruction`, `ChatParam`, optional `ParseParam`, `clear_messages`, and
-  `skip_validation`, and returns the logical operation result. The protocol does not guarantee one
-  provider message or prohibit a bounded internal loop.
+```python
+class Branch:
+    async def chat(
+        self,
+        instruction: Instruction | JsonValue = None,
+        guidance: JsonValue = None,
+        context: JsonValue = None,
+        sender: ID.Ref = None,
+        recipient: ID.Ref = None,
+        request_fields: list[str] | dict[str, JsonValue] = None,
+        response_format: type[BaseModel] | BaseModel = None,
+        progression: Progression | list[ID[RoledMessage].ID] = None,
+        imodel: iModel = None,
+        tool_schemas: list[dict] = None,
+        images: list = None,
+        image_detail: Literal["low", "high", "auto"] = None,
+        plain_content: str = None,
+        return_ins_res_message: bool = False,
+        include_token_usage_to_model: bool = False,
+        **kwargs,
+    ) -> tuple[Instruction, AssistantResponse]: ...
+
+    async def chat_and_record(
+        self,
+        instruction: Instruction | JsonValue = None,
+        **kwargs,
+    ) -> str: ...
+
+    async def communicate(
+        self,
+        instruction: Instruction | JsonValue = None,
+        *,
+        guidance: JsonValue = None,
+        context: JsonValue = None,
+        plain_content: str = None,
+        sender: SenderRecipient = None,
+        recipient: SenderRecipient = None,
+        progression: ID.IDSeq = None,
+        response_format: type[BaseModel] = None,
+        request_fields: dict | list[str] = None,
+        chat_model: iModel = None,
+        parse_model: iModel = None,
+        skip_validation: bool = False,
+        images: list = None,
+        image_detail: Literal["low", "high", "auto"] = None,
+        num_parse_retries: int = 3,
+        clear_messages: bool = False,
+        include_token_usage_to_model: bool = False,
+        **kwargs,
+    ) -> BaseModel | dict | str | None: ...
+
+    async def run(
+        self,
+        instruction: str = "",
+        *,
+        chat_model: iModel | None = None,
+        guidance=None,
+        context=None,
+        sender=None,
+        recipient=None,
+        images=None,
+        image_detail="auto",
+        stream_persist: bool = False,
+        persist_dir: str | None = None,
+        response_format=None,
+        **kwargs,
+    ) -> AsyncGenerator[RoledMessage, None]: ...
+```
+
+Exact semantics:
+
+- A façade method receives an already constructed `Branch`; operation implementations do not create
+  or attach a branch or session.
+- `chat_model` and `parse_model` default through the branch's `iModelManager`; callers may override
+  them on the methods that expose those parameters.
+- Implementation imports remain method-local. Importing `Branch` does not eagerly import the
+  transport, parsing, action, or reasoning-loop implementations.
+- The public annotation on `Branch.chat()` says it returns the instruction/response tuple, but its
+  default runtime path returns response text. The implementation-level `chat()` correctly declares
+  the union. `return_ins_res_message` is therefore the authoritative runtime discriminator; the
+  façade annotation is currently under-specified.
+- `BranchOperations` and the actual façade drift in both directions. The literal lists `select`,
+  although no `Branch.select()` method is shipped; it omits the public `run()` and
+  `chat_and_record()` methods. `select` resolves only if a session registers that name, while the
+  omitted public methods resolve through normal attribute lookup. The graph node consequently uses
+  `BranchOperations | str`; the literal is a typing aid, not a closed or complete runtime registry.
+- The public `ReAct()` wrapper (and its keyword-preparation helper) defaults `max_extensions` to 3;
+  `ReActStream()` called directly defaults it to 0 — no extension rounds unless the caller opts in
+  (the internal v1 entry point shares the 0 default). The core stream treats
+  `None`, zero, and negative values as no extension work; values above 100 emit a warning and clamp
+  to 100. The bounds prevent an extension loop from growing without limit, but the operations code
+  records no empirical rationale for exactly 3 or 100 (`lionagi/operations/ReAct/ReAct.py`).
+- An exception from the delegated implementation propagates unless that implementation documents a
+  more specific conversion. The façade does not turn arbitrary failures into values.
+
+**Why this way.** `Branch` already owns the managers required by every verb, so it is the coherent
+caller boundary. Method-local delegation preserves that discoverability without reversing the
+dependency direction. It also permits operation modules to use `Branch` only under `TYPE_CHECKING`,
+which removes the runtime cycle rather than hiding it in a package-level re-export.
+
+### D2 — Named operations use one session-owned asynchronous registry
+
+The registry and dispatch contracts are:
+
+```python
+class OperationManager(Manager):
+    registry: dict[str, Callable]
+
+    def register(
+        self,
+        operation: str,
+        func: Callable,
+        update: bool = False,
+    ): ...
+
+class Session:
+    _operation_manager: OperationManager
+
+    def register_operation(
+        self,
+        operation: str,
+        func: Callable,
+        *,
+        update: bool = False,
+    ): ...
+
+    def operation(self, name: str = None, *, update: bool = False): ...
+
+    async def run_operation(
+        self,
+        operation: str,
+        *,
+        branch: Branch | ID.Ref | None = None,
+        **kwargs: Any,
+    ) -> Any: ...
+
+class Branch:
+    def get_operation(self, operation: str) -> Callable | None:
+        if hasattr(self, operation):
+            return getattr(self, operation)
+        return self._operation_manager.registry.get(operation)
+```
+
+When `Session.include_branches()` accepts a branch, it sets the branch's owner, session user,
+observer, optional hook bus, memory store, and, load-bearing here, the exact same
+`Session._operation_manager` instance. It also registers the branch in the session exchange and
+selects the first included branch as the default when no default exists
+(`lionagi/session/session.py`).
+
+Exact semantics:
+
+- Registration rejects an existing name unless `update=True`.
+- Registration rejects a callable for which `is_coro_func()` is false. The registry does not wrap a
+  synchronous function in a coroutine.
+- `Session.operation()` is a decorator; absent an explicit `name`, it registers `func.__name__`.
+- Every branch included in the same session observes later registrations because all hold the same
+  manager object. A standalone branch starts with a private manager until session inclusion rewires
+  it.
+- Lookup checks `hasattr(branch, operation)` first. A registered name cannot shadow a built-in
+  attribute, even with `update=True`; `update` only replaces a registry entry.
+- `Session.run_operation()` uses the default branch when `branch` is absent, resolves a string or
+  UUID branch reference through `Session.branches`, and raises `ValueError("Unknown operation:
+  ...")` when lookup returns `None`.
+- `Operation._invoke()` uses the same `Branch.get_operation()` path. A missing operation becomes
+  `OperationError("Unsupported operation type: ...")` inside event invocation.
+- `Operation._invoke()` awaits ordinary operations. The special `ReActStream` name consumes its
+  async generator into a list because an `Operation` node settles to one response value.
+
+**Why this way.** Session ownership matches the intended lifetime: named extensions coordinate a
+set of branches, and graph nodes need them after branch cloning or allocation. Built-in precedence
+keeps the stable façade from being silently redefined by registration. Reusing the same lookup from
+direct and graph dispatch makes an operation name one contract rather than two.
+
+### D3 — API one-shot, explicit recording, recorded API, CLI stream, and collection remain distinct
+
+The implementation-level contracts are:
+
+```python
+async def chat(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    chat_param: ChatParam,
+    return_ins_res_message: bool = False,
+) -> tuple[Instruction, AssistantResponse] | str: ...
+
+async def communicate(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    chat_param: ChatParam,
+    parse_param: ParseParam | None = None,
+    clear_messages: bool = False,
+    skip_validation: bool = False,
+    request_fields: dict | None = None,
+) -> Any: ...
+
+async def run(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    param: RunParam,
+) -> AsyncGenerator[RoledMessage]: ...
+
+async def run_and_collect(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    chat_param: ChatParam,
+    parse_param: ParseParam | None = None,
+    clear_messages: bool = False,
+    skip_validation: bool = False,
+) -> Any: ...
+```
+
+| Path | Endpoint family | Records instruction/response | Result contract |
+|------|-----------------|------------------------------|-----------------|
+| `chat` | API one-shot | No | response text, or `(Instruction, AssistantResponse)` when requested |
+| `chat_and_record` | API one-shot through `chat` | Yes | response text |
+| `communicate` | API one-shot | Yes, before optional parse | parsed value, fuzzy field mapping, or response text |
+| `run` | CLI stream only | Yes, as messages arrive | async stream of instruction, assistant, action-request, action-response messages |
+| `run_and_collect` | CLI stream through `run` | Already recorded by `run` | joined assistant text, parsed value, or `None` when no assistant text arrives |
+
+Exact semantics for `chat` and `communicate`:
+
+- Both apply registered context providers, construct one instruction/request, invoke the selected
+  model, clear the temporary context-injection slot in a `finally`, and emit/log the API call.
+- `chat` does not append the instruction or response to branch messages. If the API event status is
+  `FAILED`, it raises `ExecutionError` before reading a null response.
+- `communicate(clear_messages=True)` clears branch messages before the request. After a successful
+  `chat(..., return_ins_res_message=True)`, it appends the instruction and assistant response in
+  that order.
+- `communicate(skip_validation=True)` returns the recorded assistant response text immediately.
+- With `ParseParam` and a response format, `communicate` propagates any instruction-carried
+  `Structure`, parses the text, preserves the original model response in metadata when a second
+  assistant parse response exists, and wraps a parsing `ValueError` with the requested type.
+- With `request_fields` and no structured parse, it fuzzy-validates the response mapping, fills
+  unmatched fields with `Undefined`, and removes those `Undefined` entries before returning.
+- `num_parse_retries` defaults to 3. Values above 5 emit a `UserWarning` and are clamped to 5. The
+  code recommends fewer than 3 but records no empirical rationale for either the inherited default
+  or cap (`lionagi/operations/communicate/communicate.py`).
+
+Exact semantics for `chat_and_record`:
+
+- It removes any caller-supplied `return_ins_res_message`, forces that flag to true, delegates once
+  to `Branch.chat()`, then appends the returned instruction and assistant response in that order via
+  the asynchronous message path.
+- It returns only `AssistantResponse.response`; callers cannot request the message tuple through
+  this wrapper.
+- A failure from `chat()` propagates before either message is appended. If the instruction append
+  succeeds and the response append fails, the wrapper does not roll the instruction back.
+- It does not call `_observed_run()`. Recording and lifecycle are independent decisions: message-add
+  hooks and signals see the two appends, but no `RunStart`, `RunEnd`, or `RunFailed` is introduced by
+  this wrapper itself (`lionagi/session/branch.py`).
+
+Exact semantics for `run` and `run_and_collect`:
+
+- `run` replaces `branch.chat_model` when `RunParam.imodel` is supplied. It rejects a non-CLI model
+  with a `ValueError` that directs the caller to CLI endpoint prefixes; it does not fall back to
+  `communicate`.
+- It records and yields the instruction before consuming provider chunks. When the model has a
+  `provider_session_id`, it passes that value as `resume`.
+- `system` chunks update the endpoint session id; `thinking` chunks accumulate metadata; `text`
+  chunks accumulate assistant content; `tool_use` and matching `tool_result` chunks become recorded
+  and yielded action messages; unmatched tool results are ignored; `result` metadata is attached to
+  the final assistant response.
+- Assistant text is flushed before a tool request, before a real error is raised, and at normal end.
+  Consequently one stream may yield several assistant responses.
+- An error chunk marked `benign_eos` ends normally. Any other error chunk flushes already received
+  text and raises a classified provider error; an empty error becomes the literal diagnostic
+  `"(empty error)"`.
+- A positive numeric `timeout` from model kwargs becomes one absolute stream deadline. `None`, zero,
+  a negative value, or a non-number disables enforcement. No operations-layer default timeout is
+  imposed; the value is inherited from caller/provider options.
+- On normal completion, failure, stop control, generator close, or consumer abandonment, `run`
+  explicitly closes the stream generator and restores the prior `streaming_process_func`. A
+  secondary close failure is logged and cannot replace an exception already propagating.
+- With `stream_persist=True`, `run` writes a branch snapshot, appends stream chunks to a JSONL buffer,
+  writes a final snapshot during cleanup, and removes the live buffer if it exists. `snapshot_dir`
+  falls back to `persist_dir`.
+- `run_and_collect(clear_messages=True)` clears first, promotes `ChatParam` to `RunParam`, consumes
+  `run`, joins non-empty assistant responses with two newlines, and returns `None` if none arrived.
+  It returns raw joined text when validation is skipped or no parse response format exists;
+  otherwise it parses once after collection.
+
+**Why this way.** The distinct functions make persistence, lifecycle, and cleanup observable in the
+call shape. `chat_and_record` is the smallest opt-in stateful wrapper around the unrecorded
+primitive; `communicate` adds parsing and a top-level lifecycle. A CLI stream must preserve partial
+output and deterministically close an underlying process when the consumer stops early.
+`run_and_collect` adapts that richer stream to the one-result `Middle` shape without weakening the
+stream contract itself.
+
+### D4 — The wrapper that owns the exchange owns lifecycle and cleanup
+
+`Branch._observed_run()` emits a branch-level `RunStart`, awaits a coroutine, drains pending message
+signals, then emits `RunEnd` with duration and result or `RunFailed` with the exception. Observer
+exceptions are logged and swallowed so they do not change the operation result
+(`lionagi/session/branch.py`).
+
+The ownership matrix is:
+
+| Public path | Lifecycle owner | Reason |
+|-------------|-----------------|--------|
+| `chat()` | none at branch wrapper | low-level, unrecorded API primitive |
+| `chat_and_record()` | none at branch wrapper | explicit message recording without an operation-lifecycle wrapper |
+| `communicate()` | `Branch._observed_run` | one recorded API exchange |
+| `operate()` | `Branch._observed_run` | one logical composed operation, regardless of adapter internals |
+| `run()` | `run` async generator | lifecycle must span iteration and generator close |
+| `ReAct()` | explicit `ReAct` wrapper | one outer lifecycle while nested CLI turns suppress their own signals |
+
+Exact semantics:
+
+- `operate()` and `communicate()` pass their coroutine to `_observed_run`; their implementations do
+  not emit an additional outer lifecycle.
+- `chat_and_record()` deliberately does not use `_observed_run`; it emits the normal message-add
+  effects of `a_add_message()` but no run lifecycle of its own.
+- `run()` cannot use a coroutine wrapper because work happens during async iteration. It emits at
+  most one terminal signal per emitted start. Consumer abandonment is a clean `RunEnd`; provider or
+  operation failure is `RunFailed`.
+- `run()` checks a task-scoped `ContextVar` before lifecycle emission. `ReAct()` sets that variable
+  while its nested turns run, so concurrent tasks using the same branch do not suppress one another.
+- Message-add signals are drained before terminal emission. Lifecycle observer failures are
+  non-authoritative and do not replace the transport result or primary exception.
+- Cleanup belongs to the stream even when lifecycle is suppressed: nested execution still closes
+  generators, restores callbacks, writes final snapshots, and removes temporary buffers.
+
+**Why this way.** Lifecycle scope follows the actual resource lifetime. Wrapping `run()` only around
+generator construction would end the lifecycle before iteration; letting every nested turn emit
+would turn one reasoning loop into multiple apparent top-level runs. The split is more complex than
+one universal wrapper but preserves truthful start/terminal pairs.
+
+### D5 — `Middle` is a logical exchange adapter, not a one-provider-message promise
+
+The shipped structural protocol is:
+
+```python
+class Middle(Protocol):
+    async def __call__(
+        self,
+        branch: Branch,
+        instruction: JsonValue | Instruction,
+        chat_param: ChatParam,
+        parse_param: ParseParam | None = None,
+        clear_messages: bool = False,
+        skip_validation: bool = False,
+    ) -> Any: ...
+```
+
+The argument dataclasses passed through the seam are frozen, slotted parameter objects:
+
+```python
+@dataclass(slots=True, frozen=True, init=False)
+class ChatParam(MorphParam):
+    guidance: JsonValue = None
+    context: JsonValue = None
+    sender: SenderRecipient = None
+    recipient: SenderRecipient = None
+    response_format: type[BaseModel] | dict = None
+    structure: type[Structure] | str | None = None
+    progression: ID.RefSeq = None
+    tool_schemas: list[dict] = None
+    images: list = None
+    image_detail: Literal["low", "high", "auto"] = None
+    plain_content: str = None
+    include_token_usage_to_model: bool = False
+    imodel: iModel = None
+    imodel_kw: dict = None
+
+@dataclass(slots=True, frozen=True, init=False)
+class RunParam(ChatParam):
+    stream_persist: bool = False
+    persist_dir: str | Path = LIONAGI_HOME / "logs" / "runs"
+    snapshot_dir: str | Path | None = None
+```
+
+Exact semantics:
+
+- `operate()` calls the selected `Middle` exactly once. The adapter may call a provider once, consume
+  a stream containing several assistant messages, or execute a bounded series of recorded inner
+  exchanges.
+- The adapter owns message clearing and persistence for the exchange it performs. `operate()` does
+  not append a duplicate instruction or response around it.
+- `communicate` and `run_and_collect` are the canonical API and CLI implementations. A caller may
+  inject any async callable satisfying the protocol.
+- `clear_messages` is a pre-exchange instruction to the adapter. `skip_validation` is forwarded into
+  the adapter; ADR-0022 records its additional outer-coordinator effect.
+- The protocol does not require a response model, guarantee one provider response, expose streaming
+  chunks, or convert exceptions to values. Those properties belong to the chosen adapter.
+- `RunParam.persist_dir` inherits the library run-log location. No rationale for that specific path
+  is recorded in the operations code; callers can override it.
+
+**Why this way.** The seam substitutes transport-plus-exchange behavior while keeping outer schema
+and action policy in `operate()`. Defining it by logical invocation matches every shipped adapter.
+Narrowing it to one provider message would make the CLI collector and LNDL adapter non-conforming;
+widening it to every operation verb would confuse persisted exchanges with pure parsing or action
+execution.
 
 ## Consequences
 
-Library callers get one discoverable branch surface, while graph nodes and custom session operations
-reuse the same dispatch path. Transport implementations retain the cleanup and persistence behavior
-their endpoint family requires, and custom adapters can replace transport-plus-turn behavior without
-replacing the branch.
-
-The façade is broader than a conventional thin interface, and lifecycle ownership is not uniform:
-`operate()` and `communicate()` use the branch wrapper, `run()` emits its own lifecycle, and `ReAct()`
-coordinates nested lifecycle suppression. The extension registry's location under `operations/`
-also obscures its session-owned lifetime.
+- Callers get one discoverable branch surface while operation implementations remain independently
+  testable modules.
+- Session extensions and graph nodes share lookup and precedence. A custom operation registered once
+  is visible to every branch included in that session.
+- Choosing `chat`, `chat_and_record`, or `communicate` is a state and lifecycle decision, not merely
+  a convenience alias: the first leaves conversation messages unchanged, the second records without
+  a run lifecycle, and the third records under one observed operation lifecycle.
+- CLI streams preserve partial messages, native tool messages, cancellation cleanup, and provider
+  resumption. Adapting them to a single result requires explicit collection.
+- Custom `Middle` implementations can replace a full logical exchange without reimplementing the
+  composed validation and action phase.
+- Contributors must understand that lifecycle ownership is intentionally split. Adding a wrapper at
+  the wrong layer can duplicate start/terminal signals or end a run before a generator is consumed.
+- Reversing D1 or D2 is high-cost because public callers and graph dispatch both depend on the
+  façade/lookup contract. Replacing a `Middle` is low-cost when it honors D5. Unifying D3 would be
+  high-risk because it changes persistence and cancellation behavior.
+- The façade and `flow.py` depend on the operation model, but the measured eight-component
+  operations architecture remains `κ = 12 / (8 × 7) = 0.214`, below the 0.3 target. The decision
+  boundaries remain testable through injected models, registered coroutine operations, and custom
+  `Middle` callables (`τ ≈ 0.9` for the area; static tests do not establish provider reliability).
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
 | 1 | Replace the `Middle` one-turn wording with a logical-exchange contract that states message-recording, streaming, bounded-loop, native-tool, and validation responsibilities; add conformance tests for `communicate`, `run_and_collect`, and LNDL. | M | (filled at issue-open time) |
-| 2 | Make the branch-operation vocabulary explicitly extensible or include every built-in verb, including `run`, and publish the intended registry and adapter exports from one canonical namespace. | S | (filled at issue-open time) |
+| 2 | Make the branch-operation vocabulary explicitly extensible or align it with the façade by adding or removing `select` and including `run` and `chat_and_record`; publish the intended registry and adapter exports from one canonical namespace. | S | (filled at issue-open time) |
 | 3 | Document the session ownership of the named-operation registry in its type and public API, preserving built-in precedence and asynchronous registration checks. | S | (filled at issue-open time) |
 | 4 | Represent lifecycle ownership for API turns, CLI streams, and nested operations in an explicit internal contract and add tests that prevent duplicate start or terminal signals. | M | (filled at issue-open time) |
+| 5 | Correct the public `Branch.chat()` return annotation so it expresses response text by default and the instruction/response tuple when `return_ins_res_message=True`; add typing coverage for both call forms. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Publish operation functions instead of a `Branch` façade
+
+This would make dependency direction obvious and keep `Branch` smaller. It lost because every call
+would still require the caller to select and pass the branch's managers, models, observer, hooks,
+and persistence state. It would also create a second public calling convention while graph nodes
+already dispatch by branch operation name.
+
+### Eagerly import all implementations from `branch.py`
+
+This would make navigation and static symbol discovery simpler. It lost because implementations
+type-reference `Branch` and some import branch-owned types; eager imports reintroduce the runtime
+cycle that the method-local imports avoid. It would also load provider- and operation-specific code
+when a caller only constructs a branch.
+
+### Give every branch an independent named-operation registry
+
+This would permit branch-local overrides and narrower visibility. It lost because session-created
+clones and graph-assigned branches would not reliably see the same custom operation. Coordinated
+flows would need registry-copy rules and could drift after registration. The shipped session-owned
+manager gives one lifetime and one lookup truth.
+
+### Allow registered operations to shadow built-in methods
+
+This would make the extension mechanism maximally flexible. It lost because a registration could
+silently redefine a stable public verb for all branches in a session. `update=True` intentionally
+means replace a registry entry, not replace `Branch.operate` or another façade method.
+
+### Collapse API and CLI calls into one transport primitive
+
+This would reduce the number of public verbs and adapters. It lost because an API invocation is a
+single awaited event while a CLI invocation is an async-generator resource whose cleanup must span
+iteration and consumer abandonment. A single primitive would either hide the stream or force every
+API call through streaming lifecycle machinery.
+
+### Make the façade record every model call automatically
+
+This would make history behavior superficially uniform. It lost because `chat()` is intentionally a
+non-recording primitive used when a caller needs a request without conversation mutation.
+`chat_and_record()` already supplies the explicit recording wrapper. Automatic recording would also
+duplicate messages for `communicate`, `run`, and custom `Middle` implementations that already own
+persistence.
+
+### Define `Middle` as exactly one provider turn
+
+This would be a narrower, easier-to-test protocol. It lost against shipped behavior:
+`run_and_collect` may combine multiple assistant messages and LNDL owns several inner exchanges.
+The logical-invocation definition preserves a useful substitution seam without falsifying adapter
+cardinality.
+
+### Make every branch verb a `Middle`
+
+This would provide one universal callable shape. It lost because `parse`, `act`, and `interpret` do
+not share the persisted model-exchange contract, and `run` must remain an async generator rather
+than an awaited one-result callable. Forcing them through `Middle` would erase meaningful types and
+lifecycle boundaries.
 
 ## Notes
 
-A single transport primitive was rejected because one-shot API calls and cancellation-sensitive CLI
-streams have different cleanup and message-order obligations. Making every verb a `Middle` was also
-rejected because parsing, action execution, and interpretation are not persisted model exchanges.
+Primary implementation anchors are `lionagi/session/branch.py`, `lionagi/session/session.py`,
+`lionagi/operations/types.py`, `lionagi/operations/manager.py`, `lionagi/operations/node.py`,
+`lionagi/operations/chat/chat.py`, `lionagi/operations/communicate/communicate.py`, and
+`lionagi/operations/run/run.py`. Focused behavioral anchors live under `tests/operations/test_chat.py`,
+`tests/operations/test_communicate.py`, `tests/operations/run/`, and
+`tests/session/test_run_lifecycle.py`.

--- a/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
+++ b/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
@@ -8,85 +8,428 @@
 
 ## Context
 
-`Branch.operate()` is the composed operation entry point. Its preparer turns public arguments into
-`ChatParam` or `RunParam`, optional `ParseParam`, and optional `ActionParam`. A CLI model or a request
-for stream persistence selects `RunParam`; action enablement carries an explicit concurrent or
-sequential strategy (`lionagi/session/branch.py`, `lionagi/operations/operate/operate.py`,
-`lionagi/operations/types.py`).
+`Branch.operate()` is the composed operation entry point: one call can select an API or CLI adapter,
+ask for generated structured fields, expose actions to a model, validate the returned value, execute
+accepted action requests, and attach action results. Four problems force the current coordinator
+shape.
 
-Structured responses and actions require a response shape that differs between request and result.
-When a base model, additional fields, reasoning, or actions are requested, `operate()` constructs an
-internal `Operative`: action requests are exposed to the model, while action responses are excluded
-from the request schema and included in the response schema (`lionagi/operations/operate/step.py`,
-`lionagi/operations/schema/structure.py`).
+**P1 — A broad public call must become a small typed internal request.** The façade accepts an
+`Instruct` or loose instruction/guidance/context values, model overrides, response types, field
+specifications, action controls, persistence controls, and an optional `Middle`. Passing that bag
+through every stage would make precedence and defaults implicit. `prepare_operate_kw()` resolves it
+into `ChatParam` or `RunParam`, optional `ParseParam`, optional `ActionParam`, and coordinator flags
+(`lionagi/session/branch.py`; `lionagi/operations/operate/operate.py`).
 
-After one `Middle` invocation, the coordinator applies the caller's validation policy. It only
-executes tools when an `ActionParam` exists and the returned model or mapping contains
-`action_requests`. Execution uses the normal `act()` path, including authorization, hooks, event
-logging, message recording, and the selected execution strategy, then enriches the original result
-with `action_responses` (`lionagi/operations/operate/operate.py`,
-`lionagi/operations/act/act.py`).
+**P2 — The model request schema and the returned result schema are not identical.** When reasoning,
+additional fields, or actions are enabled, the request may include `reason`, `action_required`, and
+`action_requests`. `action_responses` cannot be requested from the model because it is produced by
+the runtime after tool execution, but it must exist in the final response type. The internal
+`Operative` materializes those two related models (`lionagi/operations/operate/step.py`;
+`lionagi/operations/operate/operative.py`).
 
-The current public contract contains accumulated seams. `skip_validation=True` returns immediately
-after the adapter and therefore also skips action execution. A caller-supplied `operative` is
-accepted but deliberately replaced with `None` by the preparer. `Structure` exists in parameter
-types and parsing internals but is not selectable through the composed branch façade.
+**P3 — Validation policy and action policy must have a defined order.** A raw adapter result can be
+text, a mapping, or a Pydantic model. The caller can request return-value, return-`None`, or raise
+behavior on a model mismatch. Action requests are safe to inspect only after the adapter has
+returned and the outer validation policy has run. The shipped shortcut `skip_validation=True`
+returns even earlier and therefore also bypasses the action phase.
+
+**P4 — Tool execution must not fork by transport.** API-native and CLI-native model responses can
+both request tools, but authorization, hook emission, event logging, message recording, error
+conversion, and execution strategy belong to `act()`. If each adapter executed tools directly,
+those governance paths could diverge.
+
+The public contract has accumulated three known seams. A caller-supplied `operative` is accepted by
+`Branch.operate()` and `prepare_operate_kw()` but intentionally replaced with `None`. `Structure`
+exists in `ChatParam` and `ParseParam` and is used inside parsing, but no dedicated `structure`
+argument exists on `Branch.operate()` or `prepare_operate_kw()`. Finally, the name
+`skip_validation` describes only one of the two phases it disables.
+
+| Concern | Decision |
+|---------|----------|
+| Public argument normalization | D1: the preparer produces typed chat/run, parse, and action parameter objects with fixed precedence. |
+| Request/response shape | D2: one internal `Operative` generates a request model without action responses and a response model with them. |
+| Adapter and validation order | D3: one `Middle` invocation precedes outer model-policy handling; raw short-circuit returns before all post-processing. |
+| Action execution and enrichment | D4: explicit action enablement plus structured requests dispatch through `act()` and augment the original result. |
+
+This ADR deliberately does **not** decide:
+
+- The persistence and lifecycle behavior of the canonical `Middle` implementations; ADR-0021 owns
+  the API/CLI adapter contracts.
+- Multi-round LNDL behavior; ADR-0024 records that specialized adapter.
+- Action-manager registration, tool-schema generation internals, or the governance policy itself;
+  this ADR decides only that the common action path is used.
+- Dependency ordering between multiple `operate()` calls; ADR-0023 owns graph execution.
+- A new public `Structure` or caller-owned `Operative` contract. Their current non-selection and
+  replacement behavior are recorded as retrospective deltas, not silently promoted to a target.
 
 ## Decision
 
-`operate()` remains the single coordinator that composes adapter selection, response-shape
-construction, validation policy, authorized action execution, and result enrichment.
+### D1 — `prepare_operate_kw()` normalizes the public call into typed parameters
 
-```text
-Caller
-  │
-  v
-Branch.operate ──> prepare parameters ──> choose or accept Middle
-                                             │
-                                             v
-                                     one adapter invocation
-                                             │
-                                  ┌──────────┴──────────┐
-                                  v                     v
-                           validation policy     early raw return
-                                  │               (skip_validation)
-                                  v
-                        action_requests present?
-                                  │ yes
-                                  v
-                     authorize + hooks + act + record
-                                  │
-                                  v
-                         enrich original result
+The implementation contract is:
+
+```python
+def prepare_operate_kw(
+    branch: Branch,
+    *,
+    instruct: Instruct = None,
+    instruction: Instruction | JsonValue = None,
+    guidance: JsonValue = None,
+    context: JsonValue = None,
+    sender: SenderRecipient = None,
+    recipient: SenderRecipient = None,
+    progression: Progression = None,
+    chat_model: iModel = None,
+    invoke_actions: bool = True,
+    tool_schemas: list[dict] = None,
+    images: list = None,
+    image_detail: Literal["low", "high", "auto"] = None,
+    parse_model: iModel = None,
+    skip_validation: bool = False,
+    handle_validation: HandleValidation = "return_value",
+    tools: ToolRef = None,
+    operative: Operative = None,
+    response_format: type[BaseModel] = None,
+    actions: bool = False,
+    reason: bool = False,
+    call_params: AlcallParams = None,
+    action_strategy: Literal["sequential", "concurrent"] = "concurrent",
+    verbose_action: bool = False,
+    field_models: list[FieldModel | Spec] = None,
+    include_token_usage_to_model: bool = False,
+    clear_messages: bool = False,
+    stream_persist: bool = False,
+    persist_dir: str | None = None,
+    snapshot_dir: str | None = None,
+    middle: Middle | None = None,
+    **kwargs,
+) -> dict: ...
 ```
 
-The load-bearing invariants are:
+The instruction model normalized by the preparer has these Pydantic fields:
 
-- Unless the caller supplies a `Middle`, `RunParam` or a CLI model selects `run_and_collect`; all
-  other calls select `communicate`.
-- When an `ActionParam` exists, `operate()` obtains the selected branch tool schemas and publishes
-  them to the adapter. The generated request model excludes `action_responses`, and its response
-  model includes them.
-- The selected `Middle` is invoked exactly once by `operate()`. The adapter owns message persistence
-  and may internally stream or loop under ADR-0021.
-- `skip_validation=True` is a raw-result short circuit. It bypasses outer type enforcement and the
-  entire outer action phase.
-- Tool execution requires both explicit action enablement and structured `action_requests`; arbitrary
-  text does not trigger an action. All accepted requests go through `act()` rather than a transport-
-  specific tool path.
-- `handle_validation` governs a returned value that is not an instance of the caller's requested
-  model: return the value, return `None`, or raise. Successful action responses augment rather than
-  replace the original structured result.
+```python
+class Instruct(HashableModel):
+    instruction: str | None = None
+    guidance: JsonValue | None = None
+    context: JsonValue | None = None
+    reason: bool | None = None
+    actions: bool | None = None
+    action_strategy: Literal["sequential", "concurrent"] | None = None
+```
+
+The returned mapping has one fixed shape:
+
+```python
+{
+    "instruction": instruct.instruction,
+    "chat_param": ChatParam(...) | RunParam(...),
+    "parse_param": ParseParam(...) | None,
+    "action_param": ActionParam(...) | None,
+    "handle_validation": "raise" | "return_value" | "return_none",
+    "invoke_actions": bool,
+    "skip_validation": bool,
+    "clear_messages": bool,
+    "operative": None,
+    "middle": Middle | None,
+    "field_models": list[FieldModel | Spec] | None,
+    "reason": bool | None,
+}
+```
+
+Exact normalization semantics:
+
+- `chat_model` defaults to `branch.chat_model`; `parse_model` defaults to that selected chat model,
+  not independently to `branch.parse_model`.
+- A mapping passed as `instruct` is validated into `Instruct`. When no `instruct` is supplied, one is
+  built from the loose instruction, guidance, and context arguments.
+- Explicit `reason=True` sets `instruct.reason = True`. Explicit `actions=True` sets
+  `instruct.actions = True` and copies a truthy `action_strategy` into the instruction model.
+- `RunParam` is selected when the selected model is CLI-backed, `stream_persist` is true, or either
+  `persist_dir` or `snapshot_dir` is not `None`. Otherwise the preparer builds `ChatParam`.
+- `RunParam.stream_persist` is copied even when false. `persist_dir` and `snapshot_dir` override their
+  dataclass defaults only when explicitly non-`None`.
+- `response_format` is copied into the chat/run parameter. A `ParseParam` is created only when a
+  response format exists and validation is not skipped.
+- `ActionParam` is created only when `invoke_actions` is true **and** either the normalized
+  instruction or the loose `actions` flag enables actions. The implementation expression is
+  `action_strategy or instruct.action_strategy or "concurrent"`, and it always uses
+  `suppress_errors=True`.
+- At the public `Branch.operate()` boundary, `action_strategy` itself defaults to the truthy value
+  `"concurrent"` and is always forwarded. Consequently an `Instruct(actions=True,
+  action_strategy="sequential")` does **not** select sequential execution when the caller omits the
+  loose keyword: the façade default wins. The intended-looking instruction fallback is reachable
+  only through a direct internal preparer call that supplies a falsey strategy. The public API
+  cannot currently distinguish “keyword omitted” from “explicitly concurrent.”
+- Public `tool_schemas` are copied into the initial chat/run parameter, but D2 replaces the effective
+  schemas from the selected branch tools whenever an `ActionParam` exists.
+- `request_model`, `operative_model`, and `imodel` in `**kwargs` are rejected as removed names with
+  guidance to `response_format=` or `chat_model=`. Remaining `**kwargs` become model invocation
+  options.
+- A caller-supplied `operative` is discarded by setting the returned value to `None`. This is
+  deliberate in the current code so D2 has one construction site, but it makes the accepted public
+  argument ineffective.
+- `field_models` entries are converted later from `FieldModel` or `Spec`; any other entry raises
+  `TypeError`. Entries whose resulting `Spec.name` is empty do not enter the generated field map.
+
+The structured-parse default created by `make_parse_param()` uses:
+
+```python
+AlcallParams(
+    retry_initial_delay=1,
+    retry_backoff=1.85,
+    retry_attempts=3,
+    max_concurrent=1,
+    throttle_period=1,
+)
+```
+
+These inherited values serialize parsing attempts, allow three retries, and space retry work. The
+operations code records no measurement or other rationale for the exact `1`, `1.85`, `3`, and `1`
+values; they are centralized in `lionagi/operations/_defaults.py` so callers can replace the
+parameter object where exposed.
+
+**Why this way.** A preparer gives every downstream stage one small vocabulary and one precedence
+rule. Selecting `RunParam` during preparation makes adapter choice structural rather than a late
+collection of Boolean checks. The current ignored `operative` argument is retained only as shipped
+truth; it is not evidence that two schema owners are desirable.
+
+### D2 — One generated `Operative` separates model-request and runtime-response fields
+
+The coordinator signature and schema factories are:
+
+```python
+async def operate(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    chat_param: ChatParam,
+    action_param: ActionParam | None = None,
+    parse_param: ParseParam | None = None,
+    handle_validation: HandleValidation = "return_value",
+    invoke_actions: bool = True,
+    skip_validation: bool = False,
+    clear_messages: bool = False,
+    reason: bool = False,
+    field_models: list[FieldModel | Spec] | None = None,
+    operative: Operative | None = None,
+    middle: Middle | None = None,
+) -> BaseModel | dict | str | None: ...
+
+class Step:
+    @staticmethod
+    def request_operative(
+        *,
+        name: str | None = None,
+        operative_name: str | None = None,
+        adapter: Literal["pydantic"] = "pydantic",
+        reason: bool = False,
+        actions: bool = False,
+        fields: dict[str, Spec] | None = None,
+        field_models: list | None = None,
+        max_retries: int = 3,
+        auto_retry_parse: bool = True,
+        base_type: type[BaseModel] | None = None,
+        **kwargs,
+    ) -> Operative: ...
+
+    @staticmethod
+    def respond_operative(
+        operative: Operative,
+        additional_fields: dict[str, Spec] | None = None,
+    ) -> Operative: ...
+```
+
+When actions are requested, the generated semantic fields are:
+
+```python
+class ActionRequestModel(HashableModel):
+    function: str | None = None
+    arguments: dict[str, Any] | None = None
+
+class ActionResponseModel(HashableModel):
+    function: str = Field(default_factory=str)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    output: Any = None
+
+# Generated nullable/listable fields
+action_required: bool | None
+action_requests: list[ActionRequestModel] | None
+action_responses: list[ActionResponseModel] | None
+```
+
+Exact schema semantics:
+
+- The coordinator recognizes a caller model class when `chat_param.response_format` is a
+  `BaseModel` subclass, or uses the type of a `BaseModel` instance. A dictionary response format is
+  passed to adapters but does not become `model_class` for outer instance checking.
+- An internal `Operative` is constructed when at least one of these is present: a base model class,
+  action enablement, named field specs, or reasoning.
+- `reason=True` adds the nullable `Reason` field. `actions=True` at construction adds
+  `action_required`, `action_requests`, and `action_responses`. Named field specs are added by name.
+- `Step.request_operative()` sets `request_exclude={"action_responses"}` when actions are present.
+  `Step.respond_operative()` then materializes the response model from all specs. Therefore the
+  provider request cannot fabricate runtime action results, while the returned model can hold them.
+- Generated model names are based on the explicit name, the base type name, or `"Operative"`, with
+  `Request` and `Response` suffixes. The only shipped adapter is `"pydantic"`.
+- The generated response type replaces `_cctx.response_format` and `_pctx.response_format`, so both
+  provider rendering and parsing target the same superset model.
+- When an `ActionParam` exists, the coordinator calls `branch.acts.get_tool_schema()` for the
+  selected `tools` (or all tools when the selector is absent), unwraps `{"tools": [...]}` to the
+  list expected by an instruction, and replaces the effective chat/run tool schemas.
+- `Operative.max_retries` defaults to 3, but `operate()` itself never loops over the `Middle`; retry
+  behavior belongs to parsing or the selected adapter. The exact default is inherited and has no
+  recorded operations-level measurement rationale.
+
+**Why this way.** Request and response are related but not identical protocols. One `Operative`
+keeps their shared base and generated fields aligned, while `request_exclude` expresses the one
+runtime-only field. Building a completely separate result model would duplicate the base schema and
+risk drift; requesting `action_responses` from the model would erase the boundary between proposed
+calls and observed tool results.
+
+### D3 — The coordinator invokes one adapter, then applies one outer validation policy
+
+The execution order is normative as-built behavior:
+
+```text
+prepared params
+    │
+    ├─ publish selected tool schemas
+    ├─ build request/response Operative when needed
+    ├─ select or accept one Middle
+    v
+await middle(branch, instruction, chat_param, parse_param,
+             clear_messages, skip_validation=skip_validation)
+    │
+    ├─ skip_validation=True ───────────────> return raw result
+    ├─ requested model mismatch ───────────> handle_validation policy
+    ├─ invoke_actions=False ───────────────> return validated/current result
+    └─ otherwise ──────────────────────────> D4 action inspection
+```
+
+Exact adapter-selection and validation semantics:
+
+- A caller-supplied `middle` wins without additional wrapping.
+- Without one, `RunParam` or a CLI-backed `branch.chat_model` selects `run_and_collect`; otherwise
+  the coordinator selects `communicate`.
+- The selected `Middle` is awaited exactly once by `operate()`. An adapter may internally stream or
+  loop under ADR-0021, but the coordinator does not retry it.
+- `clear_messages` and `skip_validation` are passed to the adapter positionally/by keyword as shown
+  in the `Middle` protocol. Message persistence remains adapter-owned.
+- `skip_validation=True` returns immediately after the adapter. No outer model instance check,
+  `invoke_actions` check, action-request inspection, tool execution, provider writeback, or result
+  enrichment occurs.
+- When a caller model class exists and the returned value is not an instance of that class,
+  `handle_validation="return_value"` returns it unchanged, `"return_none"` returns `None`, and
+  `"raise"` raises a `ValueError` naming the expected model and including at most the first 200
+  characters of `repr(result)`.
+- The model mismatch branch returns immediately for `return_value` and `return_none`. It does not
+  continue into actions even if the returned mapping happens to contain `action_requests`.
+- With no caller model class, a generated action/reason/field model can still be returned and
+  inspected. The outer type policy is specifically relative to the caller's requested base model.
+- `invoke_actions=False` returns after validation and before request inspection. This flag is a
+  second action gate independent of whether an `ActionParam` was prepared.
+
+**Why this way.** The adapter owns transport and inner parsing; the coordinator owns the caller's
+outer contract. Applying the mismatch policy before tools prevents side effects from a value the
+caller has declared invalid. The raw shortcut is intentionally the earliest return in shipped code,
+although its broad scope is a naming/documentation debt captured below.
+
+### D4 — Structured action requests execute through `act()` and augment the result
+
+The action parameter and dispatcher contracts are:
+
+```python
+@dataclass(slots=True, frozen=True, init=False)
+class ActionParam(MorphParam):
+    action_call_params: AlcallParams = None
+    tools: ToolRef = None
+    strategy: Literal["concurrent", "sequential"] = "concurrent"
+    suppress_errors: bool = True
+    verbose_action: bool = False
+
+async def act(
+    branch: Branch,
+    action_request: list | ActionRequest | BaseModel | dict,
+    action_param: ActionParam,
+) -> list[ActionResponse]: ...
+```
+
+The accepted action request payload is structurally:
+
+```json
+{
+  "function": "registered_tool_name",
+  "arguments": {"named_argument": "value"}
+}
+```
+
+A list of those mappings, an `ActionRequest`, or a Pydantic model exposing both `function` and
+`arguments` is accepted. Any other shape raises `ValueError` before invocation.
+
+Exact action and enrichment semantics:
+
+- The coordinator reads `action_requests` from any returned `BaseModel` attribute or mapping key.
+  Plain text and other values produce no requests.
+- Execution requires an `ActionParam` and `requests is not None`. An absent field does nothing; an
+  empty list dispatches but yields no responses and therefore no enrichment.
+- All requests go through `act()`. `"concurrent"` uses the configured `AlcallParams` callable;
+  `"sequential"` awaits requests in input order; any other strategy raises `ConfigurationError`.
+- The default action `AlcallParams` sets `output_dropna=True` and otherwise inherits library
+  defaults. No operations-level rationale is recorded for additional concurrency or retry numbers
+  because none are fixed here.
+- Before invoking a tool, `_act()` asks `branch.authorize(ToolInvocation(...))`. Denial is returned
+  as an `ActionResponseModel` with an error payload and is recorded in branch messages; it is not
+  raised as a transport exception.
+- When hooks exist, `_act()` emits `TOOL_PRE`, then `TOOL_POST` on success or `TOOL_ERROR` on an
+  exception. Successful calls are emitted/logged and their action request/response messages are
+  recorded.
+- Tool-hook payloads truncate argument and successful-result summaries to 200 characters; verbose
+  debug logging truncates its argument preview to 50 characters. These are observability bounds and
+  do not truncate the actual invocation or result. The code records no rationale for the exact 200
+  and 50 values (`lionagi/operations/act/act.py`).
+- With `suppress_errors=True`, a tool exception is logged, recorded as an action response, and
+  returned as an `ActionResponseModel` so a later model round can adapt. With false, the original
+  exception is re-raised after the error hook and log path.
+- `None` responses are removed before enrichment. If none remain, the original result is returned.
+- When context providers are registered, every non-`None` action response model is offered to their
+  writeback hook before enrichment. This includes governance-denial and suppressed tool-error
+  values; the writeback path does not filter by success.
+- For an internally generated Pydantic result, the coordinator sets `operative.response_model`,
+  updates `action_responses`, and returns the updated model. For a mapping, it mutates
+  `result["action_responses"]`. The action phase never replaces the original result with the list of
+  tool responses.
+
+**Why this way.** `act()` is the one path that carries authorization, hooks, durable event logging,
+message state, suppression policy, and strategy. Keeping it outside adapters ensures API, CLI, and
+custom `Middle` implementations cannot accidentally create different tool-governance contracts.
+Augmentation preserves the model's original reasoning and fields alongside observed tool results.
 
 ## Consequences
 
-API and CLI adapters share one structured-output and tool-execution stack. Authorization and hooks
-remain effective for model-requested actions regardless of transport, and callers can inject a
-specialized adapter without duplicating response or action policy.
-
-The coordinator carries several responsibilities and depends on a generated response model that is
-not part of the public contract. The raw-result shortcut has broader effects than its name suggests,
-and currently accepted arguments can imply capabilities that the façade does not honor.
+- API and CLI adapters share one generated schema, validation policy, authorization path, and
+  result-enrichment policy.
+- A model sees only the action-request side of the protocol; runtime action responses remain
+  distinguishable and are attached after execution.
+- Explicit action enablement is required. Merely returning text that resembles a call, or returning
+  `action_requests` when no `ActionParam` exists, causes no tool side effect.
+- An instruction-embedded sequential strategy is currently shadowed by the façade's truthy
+  `"concurrent"` default unless the loose keyword is also supplied. Callers must set
+  `action_strategy="sequential"` explicitly at the branch boundary.
+- Validation policy can prevent side effects: a caller-model mismatch returns or raises before
+  action execution. Conversely, `skip_validation` is a raw-output mode that disables the entire
+  outer action phase.
+- The coordinator carries parameter normalization, schema materialization, adapter selection,
+  validation, action orchestration, and enrichment in one module. This centralizes policy but raises
+  the cost of changing its order; every return path must be checked for side effects.
+- Contributors adding an adapter need only satisfy `Middle`; they must not duplicate outer action
+  execution. Contributors changing generated fields must update both request exclusion and response
+  enrichment semantics.
+- Reversing D2 is medium-to-high cost because generated provider schemas and returned Pydantic types
+  are coupled. Changing D3 or D4 ordering is behaviorally high-risk because it changes whether a
+  tool executes. Replacing the default adapter selection in D1 is lower cost if ADR-0021 persistence
+  semantics remain intact.
+- The existing operation-boundary tests provide high testability (`τ ≈ 0.9` for the area), but they
+  do not establish provider-side structured-output reliability or the safety of arbitrary tools.
 
 ## Current-vs-ideal delta
 
@@ -95,9 +438,79 @@ and currently accepted arguments can imply capabilities that the façade does no
 | 1 | Deprecate and remove the ignored public `operative` argument, or define and implement a precedence rule that honors it while preserving generated request and response fields. | S | (filled at issue-open time) |
 | 2 | Expose `Structure` through the chosen public branch APIs and parameter builders, or mark it internal and remove it from public parameter types; add one end-to-end public-path test. | S | (filled at issue-open time) |
 | 3 | Split the raw-result shortcut into explicit validation and post-processing controls, or rename and document `skip_validation` so callers know that it also disables outer action execution. | S | (filled at issue-open time) |
+| 4 | Make action-strategy precedence distinguish an omitted façade keyword from explicit `"concurrent"`, then add a public-path test proving that `Instruct.action_strategy` either governs execution or is deliberately removed. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Separate API and CLI operation coordinators
+
+This would allow transport-specific parameter lists and simpler local control flow. It lost because
+the generated request/response model, mismatch policy, authorization, hooks, and result enrichment
+are transport-independent. Two coordinators would duplicate the highest-risk ordering rules and
+could make the same structured request execute tools differently by endpoint family.
+
+### Let each `Middle` execute its own action requests
+
+This would keep the full model/tool conversation inside the adapter and could support provider-
+native tool loops. It lost for the outer `operate()` phase because adapters would need to reproduce
+authorization, hooks, logging, message recording, suppression, and enrichment. The LNDL adapter may
+execute actions inside its bounded language loop, but it still routes those calls through `act()`;
+that specialized behavior does not replace the common outer rule.
+
+### Ask the model to return `action_responses`
+
+This would permit one response schema and avoid post-execution model updates. It lost because a
+model cannot authoritatively report a result that only the runtime observes. Including the field in
+the request would invite fabricated tool outcomes and blur proposed calls with executed effects.
+
+### Maintain unrelated request and result models
+
+This would give complete freedom to shape each side. It lost because the base caller model,
+reasoning field, and action-request fields must match on both sides. Independent construction would
+duplicate those specs and create drift. `Operative` instead makes the response a materialized
+superset of the request.
+
+### Honor a caller-supplied `Operative` with implicit precedence
+
+This could enable advanced schema customization immediately. It lost in the shipped preparer
+because no precedence rule answers how caller fields combine with `response_format`, `reason`,
+actions, and `field_models`, or who owns `request_exclude`. The code chooses one construction site
+by discarding the argument; the delta requires an explicit contract before changing that behavior.
+
+### Let `Instruct.action_strategy` win when the loose keyword is omitted
+
+This would make a self-contained `Instruct` govern both action enablement and scheduling. It would
+also preserve the apparent fallback order in `prepare_operate_kw()`. It did not ship at the public
+boundary because `Branch.operate(action_strategy="concurrent")` always forwards a truthy default, so
+the preparer cannot observe omission. Correcting it requires an omission sentinel or a single
+authoritative strategy field; silently changing precedence would alter execution ordering for
+existing calls.
+
+### Treat `skip_validation` as “skip only the final instance check”
+
+This interpretation would preserve parsing or tools while relaxing the caller-model assertion. It
+lost against the current early return: the flag is passed into the adapter and then checked
+immediately after it. Changing it would cause tool side effects for calls that are raw-only today,
+so it requires a named behavioral decision rather than documentation sleight of hand.
+
+### Execute actions before outer model mismatch handling
+
+This could salvage valid action requests from an otherwise imperfect structured response. It lost
+because a tool side effect would occur before the caller's declared validation policy was honored.
+The current order is fail-before-effect for caller-model mismatches.
+
+### Return tool responses instead of enriching the original result
+
+This would simplify the return type after actions. It lost because it discards the model's original
+fields and reasoning and changes the response shape depending on whether any tool ran. Enrichment
+keeps one logical result and makes action outcomes an explicit field.
 
 ## Notes
 
-Separate API and CLI operation coordinators were rejected because they would duplicate structured
-validation and action policy. Moving outer action execution into every `Middle` was rejected because
-it would let adapters diverge from the common authorization, hook, logging, and enrichment path.
+Primary implementation anchors are `lionagi/session/branch.py`,
+`lionagi/operations/operate/operate.py`, `lionagi/operations/operate/step.py`,
+`lionagi/operations/operate/operative.py`, `lionagi/operations/fields.py`,
+`lionagi/operations/_defaults.py`, `lionagi/operations/schema/structure.py`, and
+`lionagi/operations/act/act.py`. Focused behavioral anchors live in
+`tests/operations/test_operate.py`, `tests/operations/operate/`, and
+`tests/operations/test_act.py`.

--- a/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
+++ b/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
@@ -8,97 +8,713 @@
 
 ## Context
 
-Graph execution uses `Operation` as the executable node. An operation stores a branch-method or
-registered-operation name plus parameters, receives its branch immediately before invocation, and
-dispatches through `Branch.get_operation()`. `OperationGraphBuilder` constructs dependency,
-expansion, aggregation, and conditional graph shapes but does not execute them
-(`lionagi/operations/node.py`, `lionagi/operations/builder.py`).
+LionAGI represents a multi-step operation as a directed graph of executable `Operation` nodes.
+Construction and execution are intentionally separate, but the execution kernel must turn a generic
+graph into branch-aware asynchronous work. Six concrete problems shaped the current implementation.
 
-`Session.flow()` delegates a `Graph[Operation]` to `DependencyAwareExecutor`. The executor rejects
-cycles, validates edge conditions, preallocates branches, creates a completion event per operation,
-and starts operation coroutines under a capacity limiter. Explicitly assigned branches are reused;
-dependent or context-inheriting operations without one receive session-owned clones. Every terminal,
-failed, skipped, cancelled, or exceptional path releases its completion event
-(`lionagi/session/session.py`, `lionagi/operations/flow.py`).
+**P1 — A graph node needs a serializable request and late-bound conversation state.** A builder can
+know an operation name and parameters before it knows which branch should invoke them. `Operation`
+therefore stores the request and optional branch id, while its private branch reference is assigned
+immediately before invocation (`lionagi/operations/node.py`).
 
-The executor injects predecessor results and shared flow context into operation parameters. A primary
-dependency may also supply inherited conversation messages. Successful response dictionaries with a
-`context` key are deep-merged into one shared context state. Parallel writes to the same key have no
-declared ordering or reducer and therefore resolve by completion timing (`lionagi/operations/flow.py`).
+**P2 — Dependency failure or skipping must never strand downstream waiters.** Independent nodes
+should run concurrently, but every predecessor path must settle before dependents decide whether to
+run. The executor creates one `ConcurrencyEvent` per operation and releases it from terminal,
+skipped, completed, failed, cancelled, and defensive exception paths
+(`lionagi/operations/flow.py`).
 
-`ReactiveExecutor` extends the same kernel. It observes spawn and escalation requests, schedules
-initial and injected nodes in one task group, synchronizes graph mutation, rejects cycles and
-duplicates, and enforces a spawn cap. `flow_stream()` yields a typed event per settled node through a
-memory channel, with an asyncio task driving the reactive executor. Checkpoint writing and graph
-reconstruction remain caller-owned and are not kernel capabilities (see the scheduling-control-plane
-ADR on flow checkpoint and resume semantics).
+**P3 — Conversation isolation must be explicit rather than an accident of scheduling.** An
+explicitly assigned branch is reused. A dependent or context-inheriting operation without one gets
+a session-owned clone allocated before execution. Some nodes also request conversation-message
+inheritance from one primary predecessor.
+
+**P4 — Data context has two sources with different semantics.** Every predecessor result is exposed
+under an operation-id-derived key, while a shared flow context is copied into each operation and can
+be updated by successful response mappings. Parallel writes to the same shared key have no declared
+reducer, so completion order currently decides the winner. One reserved shared key,
+`operator_messages`, is control input rather than model context: pending entries are rendered into
+the instruction and removed from the per-operation context before dispatch.
+
+**P5 — A running graph may grow, but growth must reuse the static kernel.** Reactive work can arrive
+through a returned `SpawnRequest`, a bus emission, explicit injection, or an escalation. Accepted
+nodes still need dependency waits, capacity limiting, branch allocation, context preparation, pause
+behavior, and ordinary `Branch.get_operation()` dispatch.
+
+**P6 — Restoring node results is not the same as restoring a running workflow.** The kernel can
+short-circuit operations already in a terminal state and expose restored responses. It does not own
+a checkpoint format, serialized spawned topology, branch-history reconstruction, or durable event
+replay. Those omissions are decisive for reactive continuation, not incidental implementation
+details.
+
+| Concern | Decision |
+|---------|----------|
+| Graph request model | D1: `Operation` is the executable node and `OperationGraphBuilder` constructs graph shapes without executing them. |
+| Static dependency execution | D2: an acyclic executor uses per-node completion events and bounded operation admission. |
+| Branch allocation | D3: explicit branches are reused; dependent/context-inheriting nodes receive session-owned clones, with optional primary-message inheritance. |
+| Conditions, context, and results | D4: edge conditions gate paths, predecessor results are namespaced by id, response context deep-merges into shared state, and operator messages render once into instructions. |
+| Pause and restored terminals | D5: a soft boundary gate pauses new operations; pre-set terminal nodes short-circuit without kernel-owned persistence. |
+| Reactive mutation and streaming | D6: reactive execution extends the same kernel with synchronized, capped, cycle-checked injection and typed completion events. |
+
+This ADR deliberately does **not** decide:
+
+- Checkpoint storage, retention, schema migration, or resume degradation policy; those are owned by
+  the scheduling-control-plane ADR on flow checkpoint and resume semantics.
+- How a CLI planner maps roles, workspaces, or persisted definitions into initial graph nodes; the
+  kernel receives an already constructed `Graph[Operation]`.
+- The semantics of individual branch verbs; ADR-0021 and ADR-0022 own operation dispatch and
+  composed execution.
+- Distributed graph scheduling, cross-process queues, or remote workers. The executor is an
+  in-process async kernel.
+- Deterministic conflict resolution for shared context. The current completion-timing behavior is
+  recorded as shipped truth and retained as a delta, not specified as an ideal reducer.
 
 ## Decision
 
-`flow.py` is the execution kernel for operation graphs, not for every branch verb. Static dependency
-execution is the base contract; reactive graph growth is a constrained extension of that contract.
+### D1 — `Operation` is the executable node; the builder only constructs graph state
 
-```text
-OperationGraphBuilder ──> Graph[Operation]
-                               │
-                               v
-                  DependencyAwareExecutor
-                    │ dependency events
-                    │ branch allocation
-                    │ capacity + pause gate
-                    │ context materialization
-                    v
-                     Branch operation dispatch
-                               ^
-                               │ inherits execution semantics
-                       ReactiveExecutor
-                    spawn bus + guarded mutation
+The node contract is:
+
+```python
+BranchOperations = Literal[
+    "chat",
+    "operate",
+    "communicate",
+    "parse",
+    "ReAct",
+    "select",
+    "interpret",
+    "act",
+    "ReActStream",
+]
+
+class Operation(Node, Event):
+    operation: BranchOperations | str
+    parameters: dict[str, Any] | BaseModel = Field(
+        default_factory=dict,
+        exclude=True,
+    )
+    _branch: Any = PrivateAttr(default=None)
+
+    @property
+    def branch_id(self) -> UUID | None: ...
+
+    @property
+    def graph_id(self) -> str | None: ...
+
+    @property
+    def request(self) -> dict: ...
+
+    @property
+    def response(self): ...
+
+    async def _invoke(self): ...
+
+def create_operation(
+    operation: BranchOperations | str,
+    parameters: dict[str, Any] | BaseModel = None,
+    **kwargs,
+): ...
 ```
 
-The load-bearing invariants are:
+`parameters` are excluded from the ordinary Pydantic field dump, but `request` returns a mapping:
+it uses `model_dump()` or legacy `dict()` for a model and returns `{}` for any other non-mapping
+value. `response` projects `execution.response` after event invocation.
 
-- Execution requires an acyclic graph and valid edge-condition types. An `Operation` invokes only a
-  built-in or session-registered branch operation.
-- An explicit `branch_id` reuses that branch. Otherwise, dependent or context-inheriting nodes are
-  preallocated isolated clones; accepted reactive children receive clones when injected.
-- Dependencies are represented by per-node completion events. Every execution path sets its event,
-  so downstream waiters cannot hang solely because an upstream operation failed or was skipped.
-- The capacity limiter encloses preparation and invocation. A pause gate stops new operations at the
-  operation boundary without interrupting operations already past that boundary.
-- Predecessor results and the shared flow context state are passed as operation context. Conversation
-  inheritance is explicit metadata and follows one primary dependency.
-- Reactive injection is synchronized, capped, and cycle-checked. Dependent spawns receive an edge
-  from their emitter; independent spawns do not. Bus delivery and returned-request scanning are
-  de-duplicated by request identity.
-- Pre-marked terminal nodes may be short-circuited with restored responses, but persistence, topology
-  serialization, and branch-history reconstruction are outside the kernel.
-- The current `completed_operations` result contains every settled result except skipped nodes,
-  including failed operations. `FlowEvent.status` is the accurate completed/failed/skipped signal.
+The builder's public construction surface is:
+
+```python
+class ExpansionStrategy(Enum):
+    CONCURRENT = "concurrent"
+    SEQUENTIAL = "sequential"
+    SEQUENTIAL_CONCURRENT_CHUNK = "sequential_concurrent_chunk"
+    CONCURRENT_SEQUENTIAL_CHUNK = "concurrent_sequential_chunk"
+
+class OperationGraphBuilder:
+    def __init__(self, name: str = "DynamicGraph"): ...
+
+    def add_operation(
+        self,
+        operation: str,
+        node_id: str | None = None,
+        depends_on: list[str] | None = None,
+        inherit_context: bool = False,
+        branch=None,
+        **parameters,
+    ) -> str: ...
+
+    def expand_from_result(
+        self,
+        items: list[Any],
+        source_node_id: str,
+        operation: str,
+        strategy: ExpansionStrategy = ExpansionStrategy.CONCURRENT,
+        inherit_context: bool = False,
+        chain_context: bool = False,
+        **shared_params,
+    ) -> list[str]: ...
+
+    def add_aggregation(
+        self,
+        operation: str,
+        node_id: str | None = None,
+        source_node_ids: list[str] | None = None,
+        inherit_context: bool = False,
+        inherit_from_source: int = 0,
+        branch=None,
+        **parameters,
+    ) -> str: ...
+
+    def add_conditional_branch(
+        self,
+        condition_check_op: str,
+        true_op: str,
+        false_op: str | None = None,
+        **check_params,
+    ) -> dict[str, str]: ...
+```
+
+Exact node and builder semantics:
+
+- `Operation._invoke()` requires `_branch` to be set, resolves the name through
+  `Branch.get_operation()`, stores the actual branch id, and awaits the callable. A missing branch
+  raises `ExecutionError`; a missing operation raises `OperationError`.
+- `ReActStream` is the only special operation name: its async generator is fully consumed into a
+  list so the event has one terminal response.
+- `node_id` on builder methods is a human reference stored as
+  `metadata["reference_id"]`; it does not replace the generated element UUID.
+- `add_operation()` adds `depends_on` edges only for dependency ids already known to that builder.
+  With no explicit dependency, it links every current head to the new node using a `"sequential"`
+  label. A supplied branch is normalized through `ID.get_id()`.
+- `inherit_context=True` with dependencies records one `primary_dependency`, always the first
+  `depends_on` entry. This metadata controls conversation-message inheritance under D3.
+- `expand_from_result()` raises `OperationError` when the source is unknown. Model items are dumped
+  into parameters; other items become `item_index` and stringified `item`. Every child records the
+  source and strategy and receives an expansion edge from the source.
+- The expansion strategy is stored in parameters/metadata and edge labels. In this builder method,
+  it does not itself install inter-child dependency edges; `chain_context` changes the primary
+  message-inheritance source only for sequential strategy children after the first.
+- `add_aggregation()` uses explicit sources or current heads, raises when neither exists, stores
+  source ids and count in parameters, and adds an edge from every source. `inherit_from_source` is
+  clamped to the final source index.
+- `add_conditional_branch()` creates a check node and labeled `if_true`/`if_false` outgoing edges.
+  Labels alone are descriptive; executable gating requires an `EdgeCondition` consumed by D4.
+- Builder methods mutate a generic `Graph`; `get_graph()` returns it. No builder method calls
+  `flow()`, assigns runtime branches beyond metadata, or invokes an operation.
+
+**Why this way.** Late branch binding lets one graph definition execute inside a session without
+serializing a live branch into each node. Keeping construction separate makes graph topology
+inspectable and testable before effects occur. The open `| str` operation name is required for
+session-registered verbs and for built-ins not enumerated by the current literal.
+
+### D2 — Static execution is acyclic, dependency-aware, and capacity-bounded
+
+The base executor contract is:
+
+```python
+UNLIMITED_CONCURRENCY = int(os.environ.get("LIONAGI_MAX_CONCURRENCY", "10000"))
+
+class DependencyAwareExecutor:
+    def __init__(
+        self,
+        session: Session,
+        graph: Graph,
+        context: dict[str, Any] | None = None,
+        max_concurrent: int = 5,
+        verbose: bool = False,
+        default_branch: Branch = None,
+        alcall_params: AlcallParams | None = None,
+        executor_ref: dict[str, Any] | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
+    ): ...
+
+    async def execute(self) -> dict[str, Any]: ...
+```
+
+The session façade defaults to `max_concurrent=5`; the module-level `flow()` accepts `None`, which
+the executor interprets as `UNLIMITED_CONCURRENCY`. The name means “use a high configured bound,” not
+literal infinity: its inherited environment default is 10,000. `parallel=False` at the `flow()`
+boundary forces `max_concurrent=1`. The code records no benchmark or dependency-capacity rationale
+for 5 or 10,000; callers are expected to select the bound their operations can absorb.
+
+Exact scheduling semantics:
+
+- `execute()` rejects a cyclic graph with `OperationError` before branch allocation or invocation.
+- Every edge carrying a condition must hold an `EdgeCondition` with an `apply` method. Invalid types
+  or missing application behavior fail validation before work starts.
+- Construction creates one `ConcurrencyEvent` for every `Operation`. A node already marked
+  `COMPLETED` has its event set and its response copied into results immediately.
+- Branches are preallocated under D3 before tasks are submitted.
+- All operation coroutines are submitted through the selected `AlcallParams`; a shared
+  `CapacityLimiter` encloses preparation and invocation. Capacity therefore bounds model/tool work
+  and the immediately preceding context/branch materialization.
+- An operation first evaluates incoming paths, then waits for all declared predecessors and
+  aggregation sources, then crosses the pause gate, then acquires capacity.
+- A failed `Event.invoke()` is represented by the operation's `FAILED` status and becomes
+  `{"error": str(operation.execution.error)}` in `results`. An unexpected executor-level exception
+  is defensively converted to the same mapping when no result exists.
+- Cancellation, keyboard interrupt, and system exit set the completion event and re-raise. Every
+  ordinary path also sets the event in `finally`, including skip, failure, and defensive exception.
+  Downstream waiters therefore do not hang solely because an upstream node did not complete
+  successfully.
+- Progress callbacks receive `queued`, `started`, `completed`, or `failed`. A condition-skipped node
+  currently reports `failed` to that callback even though its event/flow status is `SKIPPED`; the
+  typed `FlowEvent` in D6 distinguishes this ordinary skip from an invoked operation failure. It is
+  not fully authoritative for defensive executor exceptions, as D4 and D6 record.
+
+**Why this way.** Per-node events express dependency settlement independently of task submission
+order. A sequential traversal would leave independent work idle; unbounded submission without a
+limiter would transfer overload to providers and tools. The limiter surrounds the full operation
+boundary so capacity represents active operations, not only the final await.
+
+### D3 — Branch reuse, cloning, and primary-message inheritance are explicit
+
+Before execution, `_preallocate_all_branches()` scans `Operation` nodes:
+
+```text
+explicit branch_id resolves in Session.branches
+    └─ reuse that exact Branch
+
+no branch_id + (has predecessors or inherit_context)
+    └─ clone Session.default_branch
+       ├─ Session.include_branches(clone)
+       ├─ call on_branch_created(clone), when supplied
+       └─ optionally mark pending primary-message inheritance
+
+no branch_id + root/no inheritance
+    └─ resolve to executor default branch or Session.default_branch at invocation
+```
+
+Exact branch semantics:
+
+- Explicit `branch_id` takes precedence. If lookup fails, the executor logs the miss and leaves the
+  node for normal fallback rather than failing preallocation.
+- Clones are made from `session.default_branch` with `sender=session.id`, stored in
+  `operation_branches`, and included through the full session inclusion path. That path establishes
+  ownership, observer, shared registry, hooks, memory, and exchange registration.
+- The optional synchronous `on_branch_created` callback runs for each preallocated clone after
+  session inclusion. It is a wiring seam; its return value does not affect execution.
+- `inherit_context` here means conversation-message inheritance, not D4's data mapping. The clone is
+  marked with `pending_context_inheritance` and the configured `primary_dependency`.
+- When the operation is prepared after dependencies settle, the executor finds the primary
+  predecessor's branch, clears the clone's message pile, and copies cloned predecessor messages.
+  It then clears the pending flag. Only one primary dependency supplies conversation history.
+- A node that was preallocated but has no usable primary result keeps its ordinary cloned history.
+- Reactive children do not use this preallocation path. D6 clones from an explicit child branch,
+  the emitter branch for dependent spawns, or the session default.
+
+**Why this way.** Reusing an explicit branch allows intentional state accumulation. Cloning dependent
+work prevents parallel operations from racing on one conversation while still letting a caller
+choose one primary history to inherit. Preallocation avoids acquiring the session branch lock in
+the operation hot path.
+
+### D4 — Incoming paths gate execution; context is materialized and deep-merged
+
+For each operation, the condition input is:
+
+```python
+{
+    "result": predecessor_result_as_mapping_or_scalar,
+    "context": executor.context.content,
+}
+```
+
+The per-operation input context is assembled as:
+
+```python
+{
+    "<predecessor-uuid>_result": predecessor_result,
+    # ...one entry per settled, non-skipped predecessor with a result
+    # then shared flow-context keys
+}
+```
+
+The reserved live-steer entry shape and rendered instruction block are:
+
+```python
+{
+    "operator_messages": [
+        {
+            "ts": float | str,
+            "text": str,
+            "rendered_into_op": str | None,  # runtime breadcrumb
+        }
+    ]
+}
+```
+
+```text
+[OPERATOR STEER]
+A human operator sent these live corrections while this flow is running.
+Attend to them before continuing. Most recent last.
+- <UTC timestamp>: <text>
+[/OPERATOR STEER]
+
+<original instruction>
+```
+
+The static result envelope is:
+
+```python
+{
+    "completed_operations": list[UUID],
+    "operation_results": dict[UUID, Any],
+    "final_context": dict[str, Any],
+    "skipped_operations": list[UUID],
+}
+```
+
+Exact condition, context, and result semantics:
+
+- A node with no incoming edges has a valid path. With incoming edges, an edge whose predecessor was
+  skipped is ignored; the node runs when **at least one** remaining edge condition returns true.
+  An edge with no condition returns true. If no incoming path passes, the node is marked `SKIPPED`.
+- Condition checks wait on the predecessor's completion event before reading its result. A failed
+  predecessor contributes its error mapping and may still satisfy an unconditional edge; failure
+  does not automatically skip all dependents.
+- `_wait_for_dependencies()` then waits for every graph predecessor. Aggregations also wait for each
+  UUID string named in `aggregation_sources` when it matches a completion-event id.
+- Predecessor results are converted recursively to mappings except for string, integer, float, and
+  Boolean scalars. Skipped predecessors contribute no result key.
+- If an operation's existing `context` is a mapping, predecessor entries update it. If it is another
+  value, that value is preserved under `original_context` before predecessor entries are added.
+- Shared flow context is applied after predecessor context. It updates a mapping in place or is
+  combined with `original_context` for a non-mapping. A colliding shared key therefore overrides a
+  predecessor-derived key at preparation time.
+- `_render_operator_messages()` always removes `operator_messages` from the operation's context;
+  the raw queue is never passed to the model as JSON. Dictionary entries without a truthy
+  `rendered_into_op` are formatted in list order, prepended to the instruction, and mutated with the
+  current operation id as their breadcrumb. Non-dictionary entries and already-rendered entries do
+  not render. Numeric timestamps become UTC `YYYY-MM-DDTHH:MM:SSZ`; unparseable timestamps fall back
+  to `str(ts)`.
+- A second last-chance check runs immediately before `Operation.invoke()`. If new unrendered entries
+  reached the canonical shared queue after context preparation, it reattaches the queue long enough
+  to render and pop it. Breadcrumb mutation is shared across the shallow context copies, so the same
+  entry is consumed once across later operations (`lionagi/operations/flow.py`).
+- When a successful operation response is a mapping containing `context`, `deep_update()` merges
+  that value into the single shared `Note`. Nested non-conflicting keys survive.
+- The response-side `context` value is not type-validated before `deep_update()`. A non-mapping
+  raises after the operation response has already been stored. The defensive catch leaves that
+  stored response and the operation's completed event status intact, does not apply the invalid
+  context, and can omit the ordinary completed progress callback.
+- Parallel operations can finish in either order. When their returned context mappings collide,
+  there is no namespace or reducer; whichever deep merge executes later wins for that key.
+- An exception raised while checking a condition is caught as an executor-level error mapping and
+  releases the completion event, but the node's `EventStatus` is not explicitly set to `FAILED`.
+  Static results therefore include the error entry as settled, and D6's status projection can label
+  this defensive path `completed`. Invoked operation failures do set `FAILED` and project correctly.
+- `completed_operations` is computed as every id in `results` that is not skipped. Because failed
+  operations also receive error entries in `results`, the name includes failures. It means
+  “settled with a result entry and not skipped,” not `EventStatus.COMPLETED`.
+- `operation_results` is the authoritative per-id value/error mapping. `skipped_operations` is
+  disjoint from `completed_operations`; `_validate_execution_results()` raises if the lists overlap.
+
+**Why this way.** Namespacing predecessor results by UUID prevents ordinary fan-in collisions and
+lets an aggregation inspect every source. A shared context supports flow-wide accumulation without
+requiring each node to know all predecessors. The current ungoverned collision rule is simple but
+nondeterministic; D4 records it honestly rather than claiming deterministic reduction. Rendering
+operator corrections into the instruction gives them a dedicated, consume-once channel instead of
+mixing control directives into ordinary model context.
+
+### D5 — Pause is soft at operation boundaries; restored terminal nodes short-circuit
+
+The control methods are synchronous and idempotent:
+
+```python
+class DependencyAwareExecutor:
+    def pause(self) -> None: ...
+    def resume(self) -> None: ...
+```
+
+Exact control and restoration semantics:
+
+- `pause()` installs a new unset `ConcurrencyEvent` only when no pause exists. Repeated calls while
+  paused keep the same gate.
+- `resume()` sets the current gate and clears the reference. Calling it while not paused is a no-op.
+  A later `pause()` creates a fresh event.
+- Operations wait at the gate after condition/dependency waits and before acquiring the capacity
+  limiter. Operations already past that boundary continue; pause does not cancel or interrupt them.
+- A waiting operation emits a best-effort `NodePaused` signal. Signal construction/emission errors
+  cannot break the pause path.
+- An operation whose status is in `Event._TERMINAL_STATUSES` returns without invocation. When it has
+  a response and no result entry, that response is restored into `results`; its completion event is
+  set.
+- Constructor-time special handling preloads only `COMPLETED` responses, but execution-time
+  short-circuiting applies to all terminal statuses.
+- The kernel does not load terminal state from disk, validate a checkpoint version, reconstruct a
+  branch, or rebuild topology. A caller must restore the graph nodes and responses before calling
+  the executor.
+
+**Why this way.** A boundary pause has a clear safety property: admitted operations settle, new ones
+wait. Interrupting active model/tool calls would require per-verb cancellation and compensation
+semantics the graph kernel does not own. Terminal short-circuiting enables caller-managed replay
+without coupling a reusable scheduler to one durability format.
+
+### D6 — Reactive execution synchronizes and caps graph growth, then streams typed settlements
+
+The default spawn payload is:
+
+```python
+class SpawnRequest(BaseModel):
+    instruction: str
+    assignee: str | None = None
+    operation: Literal["operate", "chat", "communicate", "ReAct"] = "operate"
+    independent: bool = False
+    reason: str | None = None
+```
+
+The reactive and streaming contracts are:
+
+```python
+@dataclass(slots=True)
+class FlowEvent:
+    operation_id: str
+    name: str
+    status: str               # "completed" | "failed" | "skipped"
+    result: Any
+    spawned: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "completed"
+
+class ReactiveExecutor(DependencyAwareExecutor):
+    def __init__(
+        self,
+        *args: Any,
+        spawn_type: type | None = None,
+        node_builder: Any = None,
+        max_spawn: int = 50,
+        spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
+        **kwargs: Any,
+    ): ...
+
+    async def execute(self) -> dict[str, Any]: ...
+    async def execute_stream(self): ...
+
+    def inject(
+        self,
+        operation: Operation,
+        *,
+        after: Operation | str | None = None,
+        independent: bool = False,
+    ) -> bool: ...
+```
+
+Reactive execution returns the D4 envelope plus:
+
+```python
+{
+    "spawned_operations": int,
+    "escalated_operations": list[UUID],
+    "dropped_spawns": [
+        {
+            "reason": "builder_error" | "null_child" | "cycle"
+                      | "max_spawn_exceeded" | "duplicate",
+            "assignee": str | None,
+            "emitter_id": UUID | None,
+            # optional: "op_id", "error"
+        }
+    ],
+}
+```
+
+Exact reactive semantics:
+
+- The executor reuses D2's acyclicity, edge validation, preallocation, capacity limiter, operation
+  method, pause gate, context logic, and result storage. Initial and accepted nodes run in one task
+  group.
+- While running, it subscribes through the session's public observer to the configured spawn type
+  and `EscalationRequest`. It unsubscribes in `finally`.
+- Spawn requests are discovered both from bus delivery and by recursively scanning settled results
+  through lists, tuples, Pydantic model fields, and mapping values to depth 4. The bound prevents an
+  unbounded walk through arbitrary returned structures; the code records no rationale for exactly
+  four nested levels.
+- The same request object is de-duplicated by Python object identity. Its second sighting is recorded
+  as a `duplicate` dropped spawn; semantically identical but distinct objects are not de-duplicated.
+- The default node builder creates the requested operation (or `operate`) with only the request
+  instruction. A custom builder exception becomes `builder_error`; a `None` child becomes
+  `null_child`. Neither aborts the rest of the graph.
+- A recorded `builder_error` keeps at most 500 characters of the exception string. The best-effort
+  `NodeSpawned` signal keeps at most 512 characters of the child instruction. These caps bound
+  observability payloads only; they do not alter the exception used for logging or the instruction
+  stored on the operation. No rationale for the exact 500/512 split is recorded.
+- Acceptance is guarded by a threading lock. The default cap is 50 accepted injected nodes; initial
+  nodes do not count. At the cap, the child is dropped with `max_spawn_exceeded`. The code records no
+  workload measurement for exactly 50; it is an inherited runaway guard and is caller-configurable.
+- A new child is added to the graph and receives a completion event. A dependent spawn adds an edge
+  from emitter to child; an independent spawn does not. If that mutation creates a cycle, the edge
+  and newly added node/event are removed before returning false.
+- An injected `Operation` whose UUID is already present is not rejected as an operation duplicate.
+  It can receive another spawn edge, increments the spawn count, is marked spawned, and is scheduled
+  again. Because it is not `newly_added`, it receives neither a new completion event nor branch
+  assignment nor `parent_id` metadata. Request-identity de-duplication therefore does not make
+  explicit operation reinjection idempotent.
+- Accepted children increment the spawn count, are marked as spawned, and are scheduled through the
+  same `_run_tracked()` path. Newly added dependent children store `parent_id` metadata.
+- A newly added reactive child branch is always a clone. The base is the child's explicit branch
+  when valid, otherwise the emitter's branch for a dependent spawn, otherwise the session default.
+  The clone is session-included before `spawn_branch_setup(child, clone)` runs.
+- `on_branch_created` from D3 is not called for reactive clones. The separate
+  `spawn_branch_setup` seam is invoked, which leaves general persistence-hook parity unresolved.
+- `inject()` outside a running executor returns false. Accepted explicit injections follow the same
+  cap, edge, cycle, branch, and scheduling rules.
+- An escalation with route `"higher_tier"` and an emitter creates an independent child of the same
+  operation, copies parameters, and replaces the instruction with an escalation notice. Other
+  routes record/emit the escalation without scheduling a child.
+
+Exact streaming semantics:
+
+- `_run_tracked()` emits one `FlowEvent` after each node settles. Status is `skipped` for the skip
+  set, `failed` for `EventStatus.FAILED`, and `completed` otherwise. It discriminates ordinary
+  invoked failures, but an executor-level exception that stored an error without setting the event
+  status still projects as `completed`.
+- `execute_stream()` uses `anyio.create_memory_object_stream(math.inf)`: the completion-event
+  channel is unbounded and provides no backpressure. No recorded rationale establishes that unbound;
+  it follows the assumption that completion events are small and short-lived.
+- An asyncio task created with `asyncio.ensure_future()` owns the task group while the async
+  generator drains the channel. This avoids spanning an AnyIO task-group context across `yield` and
+  makes the current streaming surface asyncio-specific.
+- Normal channel close is followed by awaiting the driver so driver exceptions propagate. If the
+  consumer breaks early, the generator cancels and awaits the driver so remaining work does not
+  keep running invisibly.
+
+**Why this way.** A second scheduler would duplicate the most failure-sensitive parts of static
+execution. Synchronized mutation plus an immediate acyclicity check preserves the graph invariant
+while a hard cap prevents unbounded self-expansion. The typed event makes completion-order streaming
+explicit and improves on the legacy aggregate result name, while retaining the defensive-error gap
+documented above.
 
 ## Consequences
 
-Static and reactive callers share dependency ordering, concurrency limits, pause behavior, branch
-isolation, context propagation, and operation dispatch. A fixed graph can resume from caller-restored
-terminal nodes without coupling the reusable kernel to a checkpoint format.
-
-The shared context state can be nondeterministic when parallel nodes write colliding keys. The result
-name can mislead consumers into reporting failures as successes. Reactive execution adds observer,
-mutation, streaming-driver, and branch-allocation paths to an already broad module, and its streaming
-surface is asyncio-specific.
+- Fixed and reactive graphs share dependency ordering, capacity, pause, branch, context, and dispatch
+  semantics.
+- Every upstream path releases its event, so a failed or skipped predecessor cannot deadlock a
+  dependent solely by failing to signal settlement.
+- Explicit branch reuse supports intentional shared history; default cloning isolates dependent
+  work but increases session branch count and copying cost.
+- Incoming edge conditions are OR paths, while dependency waiting is all-predecessor settlement.
+  Contributors must not confuse “one valid path” with “wait for one predecessor.”
+- The shared flow context is convenient but not deterministic under colliding parallel writes.
+  Consumers needing reproducibility must avoid collisions today.
+- Live operator messages are rendered once as an instruction prefix and withheld from raw model
+  context. The shared queue is mutated with consumption breadcrumbs, so callers treating their
+  input context as immutable will observe otherwise.
+- `completed_operations` is a compatibility hazard because failures appear in it. Consumers needing
+  truth must inspect operation status and results together. `FlowEvent.status` improves ordinary
+  failure reporting but still labels defensive executor errors completed when no event failure was
+  set.
+- Reactive mutation is bounded and cycle-safe, but object-identity de-duplication does not provide
+  durable or semantic idempotency across reconstruction, and reinjecting an existing operation UUID
+  can schedule that node again without a fresh branch or completion event.
+- Streaming offers immediate settlement events but is currently tied to asyncio and an unbounded
+  in-memory channel.
+- Pre-marked nodes enable caller-owned static resume, but reactive continuation remains unsafe
+  without persisted spawned topology, edges, branches, messages, requests, and shared context.
+- Reversing D1 or D2 is high-cost because graph definitions and all flow callers depend on them.
+  Changing D4 collision policy is medium-cost and requires migration guidance for consumers.
+  Replacing D6 internals is feasible if the result/event contracts and static-kernel reuse remain.
+- Focused static, reactive, stream, parallelism, pause, and node tests support `τ ≈ 0.9`; they do not
+  establish crash consistency or portability to every async backend.
 
 ## Current-vs-ideal delta
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Replace `completed_operations` with explicit completed, failed, and skipped collections, retaining a deprecated compatibility alias whose settled-not-skipped meaning is documented. | M | (filled at issue-open time) |
+| 1 | Replace `completed_operations` with explicit completed, failed, and skipped collections, retaining a deprecated compatibility alias whose settled-not-skipped meaning is documented; classify defensive executor exceptions consistently in both the aggregate and `FlowEvent`. | M | (filled at issue-open time) |
 | 2 | Define deterministic shared-context semantics by namespacing node outputs by default and requiring an explicit reducer for colliding shared keys; add parallel collision tests. | M | (filled at issue-open time) |
 | 3 | Pass `on_branch_created` into reactive execution and invoke it for every injected clone; add identical persistence-hook coverage for preallocated and spawned branches. | S | (filled at issue-open time) |
 | 4 | Extract reactive graph mutation and streaming-driver concerns behind internal collaborators while retaining one public executor contract; document the required async backend. | M | (filled at issue-open time) |
 | 5 | Specify durable reactive continuation with persisted spawned topology, parent edges, operation requests, branch reconstruction, context, and conversation-history policy; keep the current fail-closed refusal until all fields can be restored. | L | (filled at issue-open time) |
+| 6 | Validate that an operation response's `context` is a mapping before deep merge; on mismatch, produce one explicit failed status/result and add a regression test for progress and streaming status. | S | (filled at issue-open time) |
+| 7 | Define existing-operation UUID injection as reject, no-op, or intentional rerun; enforce that choice before graph mutation and test branch, completion-event, and spawn-count behavior. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Execute the graph as a sequential traversal
+
+This would make result order, context writes, and error propagation easy to reason about. It lost
+because independent nodes would never overlap, discarding the principal value of a DAG. It also
+would not remove the need for condition semantics or branch isolation.
+
+### Schedule dependents by recursively awaiting predecessor tasks
+
+This would avoid an explicit event table. It lost because terminal/restored/skipped nodes and
+reactively injected nodes do not all originate from one stable task tree. Per-node completion events
+provide a uniform settlement primitive and can be pre-set for restored work.
+
+### Use one shared branch for every node
+
+This would avoid cloning and make all prior messages visible. It lost because independent nodes
+would mutate one conversation concurrently, producing nondeterministic history and provider-session
+state. The explicit `branch_id` path remains available when shared accumulation is intentional.
+
+### Clone a branch for every node, including independent roots with no metadata
+
+This would maximize isolation and make allocation uniform. It lost because root nodes commonly use
+the caller's intended default conversation; cloning every root changes history semantics and creates
+unnecessary branches. The current rule clones only when dependency/history isolation requires it.
+
+### Replace shared context with immutable per-edge payloads only
+
+This would eliminate completion-order collisions and make dataflow fully explicit. It lost in the
+shipped architecture because callers rely on a flow-wide workspace and operations can contribute
+context without knowing every downstream edge. Deterministic namespacing/reducers remain the
+smaller corrective path.
+
+### Pass `operator_messages` through as ordinary context
+
+This would avoid special-key handling and mutation of the caller's queue. It lost because live
+corrections are control directives, not background data: leaving the raw list in context makes
+consumption ambiguous and asks each operation to notice the convention. The shipped renderer turns
+pending entries into a visible instruction prefix, removes the raw key, and records one consumption
+breadcrumb.
+
+### Treat any predecessor failure as automatic downstream skip
+
+This would make failure propagation simple. It lost because some operations can consume error
+results, unconditional alternate paths may remain valid, and edge conditions are the explicit place
+to decide viability. Failed predecessors therefore settle and expose an error mapping.
+
+### Build a separate reactive scheduler
+
+This would isolate mutation and streaming complexity from the static executor. It lost because the
+new scheduler would need to duplicate dependency events, branch allocation, capacity, pause,
+conditions, context, and operation dispatch. Subclassing preserves one execution kernel while the
+delta acknowledges that internal collaborators would improve maintainability.
+
+### Permit unlimited reactive spawning
+
+This would avoid dropping legitimate recursive work. It lost because a self-returning
+`SpawnRequest` can grow without bound. The configurable cap provides an explicit failure record
+instead of exhausting memory or provider capacity.
+
+### Treat an existing operation UUID as an idempotent injected no-op
+
+This would make explicit reinjection safe for callers retrying delivery. It did not ship: the
+acceptance path tests only whether a node must be added, then still counts and schedules an existing
+node. The current behavior is recorded rather than called idempotent; delta 7 requires an explicit
+choice before consumers rely on conflict handling.
+
+### Persist checkpoints inside `flow.py`
+
+This would make resume appear self-contained. It lost because storage format, topology versioning,
+branch serialization, partial-write policy, and degradation behavior are cross-layer concerns. The
+kernel supports restored terminal nodes but does not pretend that is a complete durable replay.
+
+### Use a task group directly across async-generator yields
+
+This would avoid the asyncio driver task in streaming mode. It lost because AnyIO task-group context
+ownership cannot safely span generator yields. The current detached driver is explicit, though it
+creates the asyncio-specific portability delta.
 
 ## Notes
 
-A sequential traversal was rejected because it would discard independent-node concurrency. A second
-reactive scheduler was rejected because it would duplicate dependency, branch, pause, and context
-semantics. Checkpoint persistence inside the kernel was rejected because durability formats and
-degradation policy belong to callers rather than graph scheduling.
+Primary implementation anchors are `lionagi/operations/node.py`,
+`lionagi/operations/builder.py`, `lionagi/operations/flow.py`,
+`lionagi/protocols/graph/edge.py`, `lionagi/casts/emission.py`, and
+`lionagi/session/session.py`. Focused behavioral anchors live in
+`tests/operations/test_operation_node.py`, `tests/operations/test_builder_extended.py`,
+`tests/operations/test_flow.py`, `tests/operations/test_flow_parallelism.py`,
+`tests/operations/test_flow_pause.py`, `tests/operations/test_flow_stream.py`, and
+`tests/operations/test_reactive_flow.py`, plus operator-message coverage in
+`tests/operations/test_flow_operator_steer.py`.

--- a/docs/adr/ADR-0024-lndl-operate-integration-adapter.md
+++ b/docs/adr/ADR-0024-lndl-operate-integration-adapter.md
@@ -8,77 +8,427 @@
 
 ## Context
 
-LNDL is integrated into operations as an opt-in `Middle`, exported from
-`lionagi.operations.lndl_middle`. It does not add a runtime or replace `operate()`; callers select it
-with `middle=lndl_middle`, and `build_lndl_middle()` creates the same adapter with a custom round
-budget. The default budget is three (`lionagi/operations/lndl_middle/__init__.py`,
-`lionagi/operations/lndl_middle/lndl_middle.py`).
+LNDL is a fenced, tag-based language for assembling structured output from declared values and tool
+calls. The operations integration is deliberately smaller than the language package: it is an
+opt-in `Middle` passed to `Branch.operate()`. Five problems determine the shipped adapter.
 
-Each round reuses the normal API or CLI turn implementation. The first round injects the LNDL system
-prompt, a rendered target-model field specification, and caller guidance. Per-round native tool
-schemas and response-format rendering are removed because LNDL's assembler, rather than the provider
-transport, constructs and validates the target result.
+**P1 — LNDL needs the existing branch transport and operation policy, not a second runtime.** API
+models already use `communicate()`, CLI models use `run_and_collect()`, and tool requests already use
+`act()`. A separate LNDL runtime would duplicate model selection, message persistence,
+authorization, hooks, logging, and action-response messages.
 
-The adapter normalizes, lexes, parses, and assembles fenced LNDL blocks. Missing blocks or a missing
-`OUT{}` produce `Continue`; language errors produce `Retry`; and an assembled output produces a
-`Success` candidate. Retry notices are sent on the next round. Exhaustion raises `LNDLError`, while
-non-LNDL exceptions propagate rather than becoming a returned `Failed` value.
+**P2 — Provider-native tools and structured-output rendering conflict with the LNDL protocol.** LNDL
+expects free text containing fenced `<lvar>`, `<lact>`, and `OUT{}` constructs. The provider must be
+told the exact target fields, but it must not be asked to satisfy a native response schema or emit
+native tool calls during each inner round. The adapter therefore renders a target summary into
+guidance and strips both native surfaces (`lionagi/operations/lndl_middle/lndl_middle.py`).
 
-The as-built action rule differs by round shape. With `OUT{}`, only action calls reachable from the
-assembled output execute. Without `OUT{}`, every declared action call executes before the next round,
-and its result is available by alias to later rounds. All calls are translated to ordinary branch
-action requests and use the concurrent, error-suppressed `act()` path, so authorization, hooks,
-logging, and message recording still apply. This eager continuation behavior conflicts with the
-prior record's statement that only `OUT{}`-referenced actions execute.
+**P3 — Tool-dependent structured output may require more than one exchange.** A first response can
+declare actions without a final `OUT{}`; their results become branch messages and alias values for a
+later round. Syntax, assembly, or target validation can also fail in a repairable way. The adapter
+owns a bounded loop and carries the latest repair diagnostic forward.
+
+**P4 — The implementation has two action-commit rules.** In a response with `OUT{}`, only action
+calls reachable from the assembled output execute. In a response without `OUT{}`, every declared
+action call executes before continuing. The latter enables information-gathering rounds but can
+produce a side effect before any final output commits. It also conflicts with the superseded
+record's output-gated statement; this retrospective ADR records the code as truth.
+
+**P5 — Language vocabulary and adapter failure behavior are not aligned.** The LNDL package defines
+`Success`, `Continue`, `Retry`, `Exhausted`, and `Failed`. The adapter directly constructs only the
+first three, raises `LNDLError` on budget exhaustion, and lets non-LNDL exceptions propagate. The
+language assembler accepts a scratchpad, and the prompt promises cross-round `note.X`, but the
+operations adapter does not pass or accumulate that state.
+
+| Concern | Decision |
+|---------|----------|
+| Integration and budget | D1: LNDL is an opt-in `Middle` with a configurable bounded round loop, default 3. |
+| Inner request shaping | D2: round one carries the LNDL prompt and target field summary; all rounds disable native tools and response formatting. |
+| Round classification | D3: fenced text is normalized, parsed, and assembled into `Continue`, `Retry`, or a `Success` candidate with exact repair behavior. |
+| Action timing and bridge | D4: continuation rounds execute all declared actions; success rounds execute only output-reachable actions, always through `act()`. |
+| Completion and failure | D5: resolved output is optionally target-validated; exhaustion raises and unexpected exceptions propagate. |
+
+This ADR deliberately does **not** decide:
+
+- A replacement LNDL grammar, lexer, parser, or general assembler API. The adapter consumes those
+  language-package contracts but does not own them.
+- A new default for ordinary `operate()` calls. LNDL remains opt-in and does not change ADR-0022's
+  default API/CLI adapter selection.
+- Expansion of the tool registry or dotted tool aliases. The adapter executes whichever tool names
+  the branch advertises.
+- Quantitative model-quality or cost gates. No measurement policy is asserted as implemented by
+  this retrospective operations record.
+- Cross-round `note.X` persistence as a shipped feature. The prompt/package seam exists, but the
+  adapter does not thread scratchpad state; the delta below requires an explicit resolution.
 
 ## Decision
 
-The implemented LNDL behavior is a bounded-loop turn adapter under the contracts of ADR-0021 and
-ADR-0022. This record carries forward the as-built integration seam and replaces broader prior claims
-that are not enforced by the operations implementation.
+### D1 — LNDL is an opt-in, configurable `Middle`
+
+The public module and callable contracts are:
 
 ```text
-operate(middle=lndl_middle)
-          │
-          v
-  prompt + target specification
-          │
-          v
- communicate or run_and_collect
-          │
-          v
- normalize ─> lex ─> parse ─> assemble
-          │
-          ├── Retry/Continue ──> next round
-          └── Success ──> act pending calls ─> validate ─> return
+lionagi/
+├── operations/lndl_middle/
+│   ├── __init__.py          # public exports
+│   └── lndl_middle.py       # adapter, round classifier, action bridge
+└── lndl/
+    ├── extract.py           # fenced-block extraction
+    ├── normalize.py         # conservative syntax repair
+    ├── lexer.py
+    ├── parser.py
+    ├── assembler.py         # target assembly and ActionCall placeholders
+    ├── round_outcome.py     # outcome algebra
+    ├── prompt.py
+    └── errors.py
 ```
 
-The load-bearing invariants are:
+```python
+DEFAULT_ROUND_BUDGET = 3
 
-- LNDL is opt-in per `operate()` call. Non-LNDL callers and the default adapter-selection policy are
-  unchanged.
-- One LNDL adapter invocation may own several recorded inner exchanges, bounded by the configured
-  round budget. API models use `communicate`; CLI models and `RunParam` use `run_and_collect`.
-- Round-one guidance contains the LNDL prompt and, when available, the exact target-model field
-  names. Native provider tools and native response-format rendering are disabled for inner rounds.
-- Language failures are repairable retries. A valid assembled result is action-resolved and then
-  validated against the target model unless validation is skipped; budget exhaustion raises.
-- A continuation round with no `OUT{}` eagerly executes every valid declared action. A success round
-  executes only actions reachable through its assembled output. Cross-round action results are kept
-  by alias for the duration of the adapter invocation.
-- LNDL actions go through `act()` and therefore do not bypass branch authorization or hooks. Tool
-  failures are returned as action results so a later round can repair or adapt.
+def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET): ...
+
+lndl_middle = build_lndl_middle()
+
+# The returned callable satisfies Middle:
+async def _lndl_middle(
+    branch: Branch,
+    instruction: JsonValue | Instruction,
+    chat_param: ChatParam,
+    parse_param: ParseParam | None = None,
+    clear_messages: bool = False,
+    skip_validation: bool = False,
+) -> Any: ...
+```
+
+Callers select the ready-made or configured adapter explicitly:
+
+```python
+from lionagi.operations.lndl_middle import build_lndl_middle, lndl_middle
+
+result = await branch.operate(
+    instruction="Produce the requested structured result",
+    response_format=TargetModel,
+    middle=lndl_middle,
+)
+
+one_round = build_lndl_middle(round_budget=1)
+```
+
+Exact integration and budget semantics:
+
+- `lionagi.operations.lndl_middle` exports exactly `DEFAULT_ROUND_BUDGET`,
+  `build_lndl_middle`, and `lndl_middle`.
+- Ordinary `operate()` behavior is unchanged unless the caller supplies this `Middle`.
+- One adapter invocation may own several recorded inner exchanges. It clears branch messages once at
+  entry when `clear_messages=True`; individual inner calls are not asked to clear again.
+- Rounds are `range(1, round_budget + 1)`. A budget of 1 permits one provider exchange. Zero or a
+  negative value performs no exchange and reaches exhaustion immediately; the builder does not
+  validate positivity.
+- A non-integer budget is also not validated by the builder; iteration raises `TypeError` before the
+  first provider exchange.
+- The default 3 is a hard bound on provider exchanges per adapter invocation, not a retry count per
+  parse step or tool. The code records no experiment or other rationale for exactly 3; it is an
+  inherited compromise between repair opportunity and bounded cost.
+- `parse_param` is accepted for `Middle` conformance but is not read. The adapter validates through
+  the target copied from `chat_param.response_format`.
+
+**Why this way.** A `Middle` is the existing substitution seam for one logical exchange under
+ADR-0021. The closure returned by `build_lndl_middle()` captures one budget without adding global
+configuration or changing the `Middle` signature. Opt-in selection contains the behavioral and
+cost difference to calls that ask for it.
+
+### D2 — The adapter renders LNDL guidance and strips native provider contracts
+
+Before round one, the adapter derives:
+
+```python
+target = chat_param.response_format
+base_guidance = chat_param.guidance or ""
+guidance_parts = [get_lndl_system_prompt()]
+
+target_spec = _render_target_spec(target)
+if target_spec:
+    guidance_parts.append(target_spec)
+if base_guidance:
+    guidance_parts.append(base_guidance)
+
+lndl_guidance = "\n\n".join(guidance_parts)
+stripped_chat_param = chat_param.with_updates(
+    tool_schemas=[],
+    response_format=None,
+)
+```
+
+The target summary format is derived from Pydantic `model_fields`:
+
+```text
+Specs: answer(str), detail(str, optional)
+Specs: findings(list[Finding: name, score]), scores(dict[str, float])
+```
+
+Exact prompt and transport semantics:
+
+- `target` is the effective response type supplied by ADR-0022. When `operate()` generated an
+  action/reason response model, the adapter sees that generated type, not merely the caller's base
+  type.
+- A target without `model_fields` produces no additional `Specs:` line. Field order follows the
+  target model declaration order.
+- Optional single types are unwrapped and marked `", optional"`. Lists, mappings, and nested
+  Pydantic models render recursively; nested models are summarized by model name and field names.
+- Round-one guidance is the LNDL system prompt, target summary when available, then the caller's
+  original guidance. Later rounds use `stripped_chat_param`, which retains the caller's original
+  guidance but does not repeat the injected LNDL prompt/target summary.
+- Although `ChatParam.guidance` accepts `JsonValue`, construction joins guidance parts as strings.
+  A truthy non-string guidance value therefore raises `TypeError` before round one. No coercion or
+  serialization is applied by this adapter.
+- Every inner call receives `tool_schemas=[]` and `response_format=None`. LNDL tags remain free text;
+  the provider transport neither invokes native tools nor performs native structured-output
+  rendering.
+- Round one sends the caller instruction unchanged. Later rounds send `"Round N of M."`; when the
+  previous round supplied a repair error, the notice includes that error and asks for repair.
+- `RunParam` or a CLI-backed branch model selects `run_and_collect`; otherwise a `ChatParam` selects
+  `communicate`. Both are called with `skip_validation=True`, so the inner result is raw text while
+  retaining ADR-0021 message persistence.
+
+**Why this way.** Once native `response_format` is removed, the model still needs the exact field
+names to construct `OUT{}`. Rendering those fields in LNDL's own vocabulary preserves that contract.
+Disabling native tools prevents the provider from executing a call outside D4's parser/assembler
+reachability rule and common `act()` path.
+
+### D3 — Each raw response classifies into continue, repair, or a success candidate
+
+The round outcome algebra in the language package is:
+
+```python
+@dataclass(slots=True, frozen=True)
+class Success:
+    output: Any
+
+@dataclass(slots=True, frozen=True)
+class Continue:
+    notes_committed: tuple[str, ...] = ()
+
+@dataclass(slots=True, frozen=True)
+class Retry:
+    error: str
+    note_keys: tuple[str, ...] = ()
+
+@dataclass(slots=True, frozen=True)
+class Exhausted:
+    last_error: str | None = None
+
+@dataclass(slots=True, frozen=True)
+class Failed:
+    error: BaseException
+
+RoundOutcome = Success | Continue | Retry | Exhausted | Failed
+```
+
+The operations adapter's classifier has the narrower contract:
+
+```python
+def _classify_round(
+    text: str,
+    target: Any,
+    action_results: dict[str, Any],
+) -> tuple[RoundOutcome, list[ActionCall], dict[str, Any] | None]: ...
+```
+
+Its actual state transition is:
+
+```text
+no fenced lndl block
+    └─ Continue, no actions
+
+fenced block(s)
+    └─ normalize → lex → parse
+       ├─ LNDLError ───────────────────────────────> Retry(error)
+       ├─ no OUT{} ─> build every lact ActionCall
+       │              ├─ invalid call ─────────────> Retry(error)
+       │              └─ valid calls ──────────────> Continue(pending=all)
+       └─ OUT{} ─────> assemble target-shaped dict
+                      ├─ LNDLError ─────────────────> Retry(error)
+                      └─ Success(output=dict,
+                                 pending=reachable actions)
+```
+
+Exact parsing and assembly semantics:
+
+- Only fenced blocks whose language tag is case-insensitively `lndl` are extracted. Backtick and
+  tilde fences are accepted by the extractor. Multiple blocks are joined in source order before
+  normalization.
+- Empty-string output contains no fenced block and becomes `Continue`. CLI collection with no
+  assistant text returns `None`, however; the classifier passes that value to the regular-expression
+  extractor and raises `TypeError`. The adapter does not currently normalize no-text output across
+  endpoint families.
+- Unfenced tags are ignored by the adapter because extraction returns no blocks; the round becomes a
+  `Continue`, not a syntax error.
+- Normalization repairs supported curly-brace tags, XML-style `name=` attributes, an opening tag
+  missing `>` when a parenthesized call is recognizable, and `Note.` casing in tag declarations.
+  It does not promise arbitrary fuzzy grammar repair.
+- The lexer and parser produce a `Program` containing lvars, lacts, and an optional out block.
+- With no `OUT{}`, each declared lact is parsed into an `ActionCall`. A malformed function call is an
+  `InvalidConstructorError`, a subclass of `LNDLError`, and therefore becomes `Retry` rather than
+  escaping.
+- With `OUT{}`, `assemble()` resolves only listed aliases, accepts historical action results by
+  alias, constructs scalar/list/mapping/nested-model values, and checks that all required target
+  fields appear. Missing aliases or required fields become `Retry` diagnostics.
+- Recursive bracket groups inside `OUT{}` are capped at nesting depth 32 by the parser. Exceeding
+  the cap raises a language `ParseError` and therefore becomes a repairable `Retry` in the adapter.
+  The cap bounds recursive descent; the code records no rationale for exactly 32
+  (`lionagi/lndl/parser.py`).
+- A lact referenced from `OUT{}` becomes an `ActionCall` placeholder when no result exists yet.
+  `collect_actions()` recursively finds placeholders in mappings and lists.
+- `_classify_round()` catches `LNDLError` only. A non-language exception from normalization,
+  parsing, assembly, or surrounding code propagates under D5.
+- The assembler can accept `scratchpad=` and can collect `note.X` declarations. This adapter calls
+  `assemble(program, target, action_results=action_results)` without a scratchpad and does not call
+  `collect_notes()`. Consequently `note.X` values are not retained between adapter rounds despite
+  prompt/package vocabulary that describes them.
+
+**Why this way.** Language-shaped errors are actionable model feedback, so they consume another
+bounded round. Missing LNDL text is treated as continued reasoning because the model may need a
+second turn. Unexpected implementation/transport errors are not assumed repairable and therefore
+are not flattened into a `Retry` string.
+
+### D4 — Action execution is round-shape dependent and always goes through `act()`
+
+The placeholder and bridge contracts are:
+
+```python
+@dataclass(slots=True, frozen=True)
+class ActionCall:
+    name: str
+    function: str
+    arguments: dict[str, Any]
+    raw_call: str
+
+async def _bridge_action_calls(
+    branch: Branch,
+    calls: list[ActionCall],
+) -> dict[str, Any]: ...
+
+_ACTION_PARAM = ActionParam(
+    action_call_params=get_default_action_call(),
+    tools=None,
+    strategy="concurrent",
+    suppress_errors=True,
+    verbose_action=False,
+)
+```
+
+The bridge transforms every placeholder into the ordinary branch request payload:
+
+```json
+{
+  "function": "tool_name",
+  "arguments": {"literal_argument": "value"}
+}
+```
+
+Exact action semantics:
+
+- A `Continue` round with no `OUT{}` executes every valid lact declared in that round. No reachability
+  filter exists because there is no final output graph to traverse.
+- A `Success` candidate executes only `ActionCall` placeholders reachable from the assembled
+  `OUT{}` value. Unreferenced lacts in the same response do not execute.
+- Calls are converted with `branch.msgs.create_action_request()` and sent together to the normal
+  `act()` dispatcher with concurrent strategy and suppressed errors.
+- Authorization denial, hooks, event logging, action request/response messages, and exception-as-tool-
+  result behavior are inherited unchanged from ADR-0022 D4. The adapter does not call the action
+  manager directly.
+- Returned responses are zipped strictly to input calls and stored as `alias -> response.output`.
+  A cardinality mismatch raises rather than silently associating the wrong result.
+- `action_results` lives for one adapter invocation. A later `OUT{}` can reference an alias executed
+  in an earlier continuation round without redeclaring the lact.
+- Alias conflict behavior is last-write for continuation rounds: executing a no-`OUT{}` lact under
+  an alias already present in `action_results` overwrites the earlier value. In contrast, an
+  `OUT{}` round that redeclares an already-resolved lact alias reads the historical result during
+  assembly, creates no `ActionCall` placeholder for the new body, and therefore does not execute
+  the redeclared call. Aliases are identities for one adapter invocation, not versioned calls.
+- After success-round actions execute, `replace_actions()` recursively substitutes results by alias.
+  A placeholder with no corresponding result is retained and may fail target validation.
+- Tool failures are values because suppression is enabled. They can be read from branch history and
+  referenced/adapted by a later round instead of aborting the LNDL loop.
+- `skip_validation=True` does **not** disable this inner LNDL action bridge. It disables final target
+  validation under D5 and ADR-0022's outer action phase; any lact selected by D4 still executes.
+
+**Why this way.** Continuation rounds exist to obtain information required for a later output, so the
+current code eagerly runs their declarations. Output-bearing rounds have an explicit commit graph,
+so only reachable calls run. Both policies retain the common governance path. The asymmetry is
+intentional as-built behavior but remains an unresolved product/design choice because eager
+continuation calls may have side effects.
+
+### D5 — The first valid resolved output returns; exhaustion raises
+
+After D4 resolves a `Success` candidate, the adapter applies:
+
+```python
+if skip_validation or target is None or not hasattr(target, "model_validate"):
+    return assembled
+
+try:
+    return target.model_validate(assembled)
+except ValidationError as e:
+    last_error = str(e)
+    continue
+```
+
+Exact completion and failure semantics:
+
+- A success candidate with no target, a non-Pydantic target, or `skip_validation=True` returns the
+  assembled mapping after action replacement.
+- Otherwise `target.model_validate()` is authoritative. A Pydantic `ValidationError` becomes the
+  next round's repair notice; the current round does not return a partially valid model.
+- The adapter returns on the first successfully validated candidate. Unused budget is not consumed.
+- `Retry` stores its error as `last_error` and starts the next round. `Continue` runs any pending
+  actions and starts the next round without setting a new error, so an older repair diagnostic can
+  remain the exhaustion detail.
+- When the loop ends without return, the adapter raises `LNDLError`. The message names the configured
+  budget and includes `last_error`, or states that no `OUT{}` was produced when no repair error
+  exists.
+- The adapter never returns `Exhausted` or `Failed`, and never directly constructs those variants.
+  They remain broader language-package vocabulary rather than the external `Middle` result.
+- A transport exception, action-bridge exception not suppressed by `act()`, programmer error, or
+  any other non-`LNDLError` propagates unchanged. It is not converted to `Failed`.
+- The pre-round `TypeError` paths for non-string guidance, non-integer budgets, and CLI no-text
+  results are instances of that propagation rule; none consumes the remaining repair budget as a
+  typed `Retry`.
+- `Branch.operate()` then applies ADR-0022's outer validation to the adapter result unless the same
+  `skip_validation` flag caused the raw short-circuit.
+
+**Why this way.** A caller requesting a Pydantic result must not receive a bare error string or
+`None` after repair budget exhaustion. Raising makes the absence of a value explicit. Returning the
+first valid model bounds cost and preserves the `Middle` one-result contract, while unexpected
+failures retain their original exception type for diagnosis.
 
 ## Consequences
 
-LNDL can reuse the established transport, message, validation, and tool-governance paths, and callers
-can choose it without affecting ordinary operations. The target model is made explicit to the prompt
-even though native structured-output rendering is disabled.
-
-One logical operation may incur several provider exchanges and action rounds. The eager continuation
-rule can cause a tool side effect before any `OUT{}` commits it. The adapter uses only
-`Continue`/`Retry`/`Success` values directly, so the package's broader round-outcome vocabulary does
-not describe the externally observed exhaustion and unexpected-failure behavior precisely.
+- LNDL reuses established API/CLI transport, branch message persistence, authorization, hooks,
+  logging, and action response messages.
+- Non-LNDL `operate()` calls are unaffected; the extra prompt, parsing, actions, and round budget
+  occur only when the adapter is selected.
+- The target's exact field names remain visible after native response formatting is disabled.
+- One logical operation may incur up to the configured number of provider exchanges and multiple
+  tool batches. Cost and latency are therefore bounded but higher than a canonical one-turn adapter.
+- Language errors are repairable; transport and implementation failures remain distinguishable.
+- A continuation round can cause tool side effects before any `OUT{}` commits them. Tool authors and
+  callers cannot infer output-gated execution from the prompt's single-round examples.
+- Cross-round action results work by alias and chat history, but cross-round `note.X` values do not.
+  The prompt currently promises more state than the adapter supplies.
+- Alias reuse is asymmetric: a continuation round overwrites the stored result, while an output
+  round's redeclared alias resolves to the historical value without running the new call.
+- API empty text consumes a continuation round, while CLI no-text output raises `TypeError`; callers
+  do not yet receive endpoint-neutral empty-output semantics.
+- The public outcome vocabulary overstates what callers observe: exhaustion and unexpected failure
+  are exceptions, not `RoundOutcome` values.
+- Reversing D1 or D2 is low-to-medium cost because the adapter is opt-in. Changing D4 is behaviorally
+  high-risk because it changes tool side effects. Changing D5 from exceptions to outcome values is a
+  public return-contract migration.
+- Focused classifier, dispatch, prompt, action-hook, exhaustion, and end-to-end operate tests support
+  high testability, but do not establish model adherence or safe behavior for arbitrary side-effecting
+  tools.
 
 ## Current-vs-ideal delta
 
@@ -87,14 +437,100 @@ not describe the externally observed exhaustion and unexpected-failure behavior 
 | 1 | Choose one LNDL action-commit rule for no-`OUT{}` rounds, then align the system prompt, adapter, architecture record, and tests so eager continuation actions or output-gated actions are stated consistently. | M | (filled at issue-open time) |
 | 2 | Decide whether `note.X` is supported across adapter rounds; either thread and test bounded scratchpad state or remove the cross-round promise from the prompt and public language surface. | M | (filled at issue-open time) |
 | 3 | Align the adapter's public failure contract with the round-outcome vocabulary by defining whether exhaustion and unexpected failures are typed outcomes or raised exceptions, and add end-to-end tests for the chosen policy. | S | (filled at issue-open time) |
+| 4 | Normalize or explicitly reject non-string `JsonValue` guidance before prompt joining, and add an end-to-end test that fixes the selected wire rendering. | S | (filled at issue-open time) |
+| 5 | Define one endpoint-neutral no-assistant-output transition (`Continue`, `Retry`, or terminal failure), normalize API and CLI adapters to it, and test both families. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Build a dedicated LNDL runtime
+
+This would let the language own transport, state, tools, retries, and results end to end. It lost
+because those capabilities already exist on `Branch`; recreating them would produce a second model
+manager, message history, authorization path, hook path, and error policy. A `Middle` supplies the
+needed bounded-loop substitution without duplicating the runtime.
+
+### Make LNDL the default `operate()` adapter
+
+This would give every structured request the same language and repair loop. It lost because it adds
+prompt tokens, free-text parsing, possible tool rounds, and different failure/cost semantics to
+callers that currently use native structured output successfully. Opt-in selection contains that
+trade-off.
+
+### Keep native provider tools and response formatting enabled inside rounds
+
+This could exploit provider-native function calling and JSON schema enforcement. It lost because a
+native tool call bypasses LNDL's `OUT{}` reachability rule, while a native response format asks the
+provider to emit JSON rather than fenced LNDL. Running both protocols at once creates two competing
+sources of action and schema truth.
+
+### Run exactly one LNDL round
+
+This would make cost and side effects easy to bound and preserve a literal one-turn `Middle`. It lost
+because a model cannot incorporate newly executed tool results into an `OUT{}` in the same response.
+The configurable budget retains a one-round option for callers that need it.
+
+### Execute only `OUT{}`-reachable actions in every round
+
+This would make the commit rule uniform and avoid side effects from an uncommitted continuation.
+It lost in the current implementation because no-`OUT{}` rounds are the mechanism for gathering
+tool results before the final structured response. It remains viable, but adopting it requires a
+different explicit multi-round design, as recorded in delta 1.
+
+### Execute every declared action even when `OUT{}` exists
+
+This would make all rounds uniformly eager and simplify classification. It lost because output-
+bearing responses provide an explicit reachability/commit set; running scratch lacts would execute
+work the model deliberately omitted from its result.
+
+### Invoke the action manager directly
+
+This would remove `ActionRequest` construction and part of the outer operation dependency. It lost
+because it would bypass `Branch.authorize`, tool hooks, event logging, and action messages. Routing
+through `act()` is the governance invariant carried from ADR-0022.
+
+### Return `Exhausted` and `Failed` values from the `Middle`
+
+This would align the adapter with the full `RoundOutcome` algebra and make failure matching
+explicit. It lost in shipped behavior because `operate()` and structured callers expect the target
+result or an exception, not an outcome wrapper. The current raise policy prevents a bare terminal
+outcome from passing outer validation as if it were the requested value.
+
+### Version action identities by round instead of alias
+
+This would permit the same alias to denote a fresh call in a later round and retain both results.
+It lost to the simpler invocation-local `dict[alias, result]` bridge, which lets a later `OUT{}`
+reference an earlier tool result without another syntax. The cost is the current asymmetric
+collision rule: continuation execution overwrites, while output assembly prefers an existing value
+and suppresses the redeclared call.
+
+### Thread unbounded `note.X` scratchpad state automatically
+
+This would fulfill the prompt's current promise. It was not taken because the adapter has no bound,
+retention, collision, or serialization contract for that state, and currently carries only action
+results. The alternative is deferred pending the explicit implement-or-remove decision in delta 2.
+
+### Leave the round budget unbounded
+
+This would maximize the opportunity for model repair. It lost because malformed output or repeated
+continuations could consume provider calls indefinitely. A closure-captured finite budget makes the
+failure and cost boundary visible, even though the exact default of 3 lacks a recorded measurement
+rationale.
+
+### Require a positive integer budget at adapter construction
+
+This would fail configuration before prompt construction and give zero, negative, and non-integer
+budgets one clear error. It did not ship: the closure stores the value unchanged and lets `range()`
+or exhaustion define behavior. The permissive shape keeps the builder small but produces two
+different failure classes, so callers should pass a positive integer until the contract is tightened.
 
 ## Notes
 
-A dedicated LNDL runtime was rejected because it would duplicate branch transport, validation, and
-action governance. Direct invocation of the action manager was rejected because it would bypass the
-normal authorization and hook path. The alternative output-gated continuation rule remains viable,
-but adopting it is a behavioral change and requires the explicit resolution captured in the delta.
+The superseded record included broader language-package, scratchpad, and measurement claims. This
+ADR carries forward only the implemented `operate()` seam and its verified action/failure behavior.
 
-Language-package cleanup, action-registry expansion, and quantitative measurement policy are not
-asserted as implemented operation behavior by this retrospective record; each requires a separate
-current decision if it remains desired.
+Primary implementation anchors are `lionagi/operations/lndl_middle/__init__.py`,
+`lionagi/operations/lndl_middle/lndl_middle.py`, `lionagi/lndl/extract.py`,
+`lionagi/lndl/normalize.py`, `lionagi/lndl/lexer.py`, `lionagi/lndl/parser.py`,
+`lionagi/lndl/assembler.py`, `lionagi/lndl/types.py`, `lionagi/lndl/round_outcome.py`,
+`lionagi/lndl/prompt.py`, and `lionagi/operations/act/act.py`. Focused behavioral anchors live in
+`tests/operations/test_lndl_middle.py`.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -13,19 +13,75 @@
   — every v0 ADR referenced gets an explicit disposition in the corpus index:
   carried-forward-as / merged-into / retired-because.
 
+## Depth contract (applies to every section — read before writing)
+
+An ADR is the record a maintainer reads two years from now to understand what the
+design thinking was. It must be usable AS a development document: someone extending
+or debugging this area should be able to work from the ADR, checking the source only
+to confirm. That imposes four obligations:
+
+1. **Every consideration is recorded.** If a question was weighed while deciding —
+   even one settled quickly — it appears here with its answer and reason. The
+   reasoning may not live only in a chat log, a workspace file, or someone's head.
+2. **Decisions are enumerated and separable.** An ADR that decides four coupled
+   things names them D1-D4 in a table up front and gives each its own section.
+   A reader must be able to cite "ADR-NNNN D3" and mean something exact.
+3. **Contracts are shown, not paraphrased.** Where the decision fixes a signature,
+   a data shape, a settings field, a state machine, a wire payload, or an ordering
+   guarantee, the ADR shows the real thing (actual Python signatures, Pydantic
+   model fields, table columns, JSON payload shapes, module trees) — extracted
+   from source for Retrospective ADRs, specified exactly for Aspirational ones.
+4. **Rejected paths are kept with their reasons.** "Alternatives considered" is a
+   required section with real content: what the alternative was, what it would have
+   bought, and the specific reason it lost. Deferred designs are retained in full,
+   marked DEFERRED — a deferred design that is not written down is a lost design.
+
+Target size falls out of the content, not a quota — but a load-bearing area ADR
+that satisfies the four obligations rarely fits under ~250 lines, and the corpus's
+richest records run 400-700. If a draft is under ~150 lines, it is almost certainly
+paraphrasing contracts instead of showing them, or dropping considerations.
+
 ## Context
 
 What forces exist. For retrospective ADRs: what the code actually does TODAY and
-why it evolved that way (honest, not aspirational). 3-6 paragraphs max.
+why it evolved that way (honest, not aspirational). Name the problems this decision
+answers as P1, P2, … — each a concrete failure or need, with the code path or
+scenario where it bites. Close with the decision table:
+
+| Concern | Decision |
+|---------|----------|
+| <one row per named decision> | D1: <one-line statement> |
+| … | D2: … |
+
+And an explicit out-of-scope list: what this ADR deliberately does NOT decide,
+each item with the one-line reason (points at the owning ADR when one exists).
 
 ## Decision
 
-The decision, stated in the present tense, with the load-bearing invariants named
-explicitly. Code anchors (`path.py` — module level, not line numbers, which rot).
+One subsection per decision (### D1 — <name>), each carrying:
+
+- The decision in present tense.
+- **The contract**: real signatures / model fields / table shapes / payload
+  examples / module trees — whatever artifact the decision actually fixes.
+  Code anchors at module level (`path.py`; line numbers rot).
+- **Exact semantics**: the enumerated behavior cases (what happens on miss, on
+  restart, on conflict, on the empty input, on the error path). Bullet-per-case;
+  a case not listed is a case not decided.
+- **Why this way**: the considerations that led here, including the ones that
+  were settled fast. Where a comparison was made (two libraries, two orderings,
+  two storage layouts), show the comparison, not just the winner.
+- Budget/limit numbers where they exist (timeouts, retry counts, cache sizes,
+  pool caps) — with the reason the number is what it is.
+
+Decisions that are part of the design but not shipped are still sections, marked
+**DEFERRED**, with the target design written in full.
 
 ## Consequences
 
-What becomes easier, what becomes harder, what is deliberately given up.
+What becomes easier, what becomes harder, what is deliberately given up — each as
+a concrete claim someone could dispute, not a platitude. Includes the maintenance
+consequences: what a contributor must now know, what new failure modes exist,
+what the cost of reversing each Dn would be.
 
 ## Current-vs-ideal delta
 
@@ -37,7 +93,20 @@ verbatim into a GitHub issue (deliverable + acceptance).
 |---|-------|------|-------|
 | 1 | <what to change> | S/M/L | (filled at issue-open time) |
 
+## Alternatives considered
+
+Required, one subsection per alternative that was genuinely weighed:
+
+- **<Alternative>** — what it is, what it would have bought, and the specific
+  reason it lost (with evidence: a measured cost, a violated invariant, a
+  concrete failure scenario). Name external references where they shaped the
+  call (a library's approach adopted or rejected, a pattern from another
+  system).
+
+An empty or perfunctory section here means the decision was not actually
+examined — go back.
+
 ## Notes
 
-Optional: alternatives considered and why rejected. Keep short — the analyses
-backing this decision live outside the repo.
+Optional: anything that aids future tracing and fits nowhere above (migration
+history, compatibility windows, naming rationale).


### PR DESCRIPTION
Amendment to the merged ADR bundles 1 and 2: rewrites the eleven ADRs (0001-0004, 0006-0008, 0021-0024) from thin decision summaries into full development-document form per the revised template.

What changed per ADR:
- Named problems (P1..Pn) in Context, decision table, one section per decision.
- Real contracts extracted from source: Python signatures, Pydantic model fields with defaults, payload shapes, module trees.
- Exact semantics enumerated per behavior case (miss / restart / conflict / empty / error paths), read from the code paths.
- Budget/limit numbers stated with rationale, or honestly labeled inherited-without-recorded-rationale.
- Argued Alternatives considered, including deliberately-not-taken shapes.

TEMPLATE.md gains a Depth contract section codifying the four obligations (considerations recorded, decisions enumerated D1-Dn, contracts shown not paraphrased, rejected paths kept).

Verification: every quoted contract re-checked against source; empirical claims (serialization round-trip failures, capacity-exhaustion behavior, default asymmetries) reproduced live before inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)