### PR TITLE
docs(adr): bundle 4 — orchestration (0033-0038) + agent-roles (0041-0044) + hooks (0047)

### DIFF
--- a/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
+++ b/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
@@ -1,0 +1,618 @@
+# ADR-0033: Operation-Graph Orchestration Boundary
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0083, v0-0095
+
+## Context
+
+Lionagi has one operation-graph execution kernel, not separate executors for the
+library, engines, and CLI. The boundary exists because six concrete problems must
+have one answer:
+
+**P1 — Execution semantics can drift between callers.** A graph submitted by a
+library caller, a domain engine, Studio, or the CLI must use the same dependency
+waits, edge-condition evaluation, branch allocation, concurrency limit, and result
+collection. A second general executor in any caller would create a second answer.
+`lionagi/session/session.py` and `lionagi/operations/flow.py` are the governing
+anchors.
+
+**P2 — Initial topology and live mutation have different authorities.** A caller
+knows the intended initial plan, but only a running executor knows whether a live
+injection would exceed capacity, introduce a cycle, or require a branch clone. The
+initial graph therefore arrives complete; live mutation passes through one locked
+admission path.
+
+**P3 — Two graph builders currently disagree about an omitted dependency list.**
+The role-task builders add only declared dependency or aggregation edges.
+`OperationGraphBuilder.add_operation()` instead links a new operation after all
+current heads when `depends_on` is falsey. The CLI uses that incremental builder,
+so nominal fan-out and dependency-free DAG roots can be serialized accidentally.
+`lionagi/orchestration/patterns.py`, `lionagi/operations/builder.py`,
+`lionagi/cli/orchestrate/flow.py`, and `lionagi/cli/orchestrate/fanout.py` contain
+the divergence.
+
+**P4 — Model-emitted work is a request, not execution authority.** A
+`SpawnRequest` can name an operation and assignee, but it must not reach arbitrary
+registered operations or an unprovisioned branch. Role routing validates the
+request first; graph admission separately decides whether the child enters the
+live graph. `lionagi/casts/emission.py` and
+`lionagi/orchestration/patterns.py` define the request and routing contracts.
+
+**P5 — Lifecycle observation is canonical in vocabulary but optional in
+transport.** The executor reports queued, started, completed, and failed progress
+through a synchronous callback and emits spawn, pause, and escalation signals on
+the Session bus. `flow_progress_signals()` translates callback progress into the
+canonical node signals, but it lives under `lionagi/engines/` and is installed by
+Engine DAG runs and Studio, not uniformly by direct CLI flow calls.
+
+**P6 — Results must expose partial and rejected work without leaking executor
+internals.** Ordinary and reactive runs return stable dictionary envelopes.
+Reactive admission failures must remain inspectable because a dropped child is not
+equivalent to a completed child and does not necessarily fail the parent.
+
+| Concern | Decision |
+|---------|----------|
+| Shared execution boundary | D1: `Session.flow()` delegates every operation graph to the common dependency-aware or reactive executor. |
+| Initial graph topology | D2: callers own initial topology; the two builder semantics and their current divergence remain explicit. |
+| Planned and live work | D3: `TaskAssignment` and `SpawnRequest` are typed requests, with role routing before locked executor admission. |
+| Dependencies, branches, and concurrency | D4: the kernel owns waits, context propagation, branch allocation, edge conditions, and capacity. |
+| Lifecycle and result observation | D5: `op_id` is lifecycle identity; progress translation is opt-in today; result and rejection payloads are stable. |
+| Adapter responsibility | D6: CLI, Studio, and engines may decorate and persist runs but do not become graph executors. |
+
+Out of scope:
+
+- Role, model, mode, artifact, and policy selection. Those are builder or adapter
+  concerns; this ADR decides only how a selected operation graph executes.
+- Domain reaction topology. ADR-0034 owns engines that coordinate non-DAG work.
+- Persisted completion across process boundaries. ADR-0035 owns the completion
+  record and machine-facing wait contract.
+- Dynamic role-palette expansion and tier selection. ADR-0036 and ADR-0038 own
+  those target policies; this ADR supplies their final admission chokepoint.
+- Queue leases and resident process lifecycle. ADR-0037 owns host-level work
+  acquisition and recovery.
+
+```mermaid
+flowchart TD
+    A[CLI, Studio, engines, library callers] --> B[Initial graph builders]
+    B --> C[Graph of Operation]
+    A --> O[Optional lifecycle adapter]
+    O --> S[Session.flow]
+    C --> S
+    S --> K{reactive?}
+    K -->|no| D[DependencyAwareExecutor]
+    K -->|yes| R[ReactiveExecutor]
+    R --> M[Locked live admission]
+    D --> X[Result envelope]
+    M --> X
+    D --> P[Progress callback]
+    R --> P
+    P --> O
+```
+
+## Decision
+
+### D1 — One Session façade and execution kernel
+
+Every initial operation graph enters through `Session.flow()`. The Session resolves
+the default branch and delegates without redefining scheduling semantics.
+
+**The contract** (`lionagi/session/session.py`; `lionagi/operations/flow.py`):
+
+```python
+async def Session.flow(
+    self,
+    graph: Graph,
+    *,
+    context: dict[str, Any] | None = None,
+    parallel: bool = True,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    default_branch: Branch | ID.Ref | None = None,
+    alcall_params: Any = None,
+    on_progress: Any = None,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+    executor_ref: dict[str, Any] | None = None,
+    on_branch_created: Callable[[Any], None] | None = None,
+    spawn_branch_setup: Callable[[Any, Any], None] | None = None,
+) -> dict[str, Any]: ...
+
+async def flow_stream(
+    session: Session,
+    graph: Graph,
+    *,
+    branch: Branch = None,
+    context: dict[str, Any] | None = None,
+    max_concurrent: int | None = None,
+    verbose: bool = False,
+    alcall_params: AlcallParams | None = None,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+): ...  # yields FlowEvent
+```
+
+```python
+@dataclass(slots=True)
+class FlowEvent:
+    operation_id: str
+    name: str
+    status: str          # "completed" | "failed" | "skipped"
+    result: Any
+    spawned: bool = False
+
+    @property
+    def ok(self) -> bool: ...
+```
+
+**Exact semantics**:
+
+- `reactive=False` constructs `DependencyAwareExecutor`; `reactive=True`
+  constructs `ReactiveExecutor`. There is no caller-specific executor selected by
+  CLI, Studio, or engine identity.
+- `parallel=False` forces `max_concurrent=1`. Otherwise the Session default is
+  five concurrent operations.
+- A `max_concurrent=None` passed to the lower-level executor uses
+  `LIONAGI_MAX_CONCURRENCY`, defaulting to 10,000. This is a practical
+  “effectively unlimited” fallback, not an actual absence of a limiter.
+- The source records no design rationale for the values 5, 50, or 10,000. They
+  are inherited compatibility defaults; changing them is behaviorally visible.
+- Before work begins, both executors reject a cyclic graph with
+  `OperationError("Graph must be acyclic for flow execution")` and validate every
+  non-null edge condition.
+- `flow_stream()` is always reactive and emits one `FlowEvent` after each
+  operation settles. Closing the consumer early cancels and awaits its detached
+  driver.
+- `cleanup_flow_results()` may clear or filter operation results after execution;
+  it is not part of scheduling.
+
+**Why this way**: Session already owns branches, the observer, and registered
+operations. Keeping execution immediately below that façade gives every surface
+the same branch and signal context while leaving initial plan construction outside
+the kernel.
+
+### D2 — Caller-owned initial topology, with the shipped builder divergence recorded
+
+Initial graph design remains outside the kernel. The two shipped construction
+surfaces are not semantically interchangeable.
+
+**The contracts** (`lionagi/operations/builder.py`;
+`lionagi/orchestration/patterns.py`):
+
+```python
+def OperationGraphBuilder.add_operation(
+    self,
+    operation: str,
+    node_id: str | None = None,
+    depends_on: list[str] | None = None,
+    inherit_context: bool = False,
+    branch=None,
+    **parameters,
+) -> str: ...
+
+def build_fanout_graph(
+    session: Session,
+    assignments: list[TaskAssignment],
+    roles: dict[str, Branch],
+    *,
+    synthesis_role: str | None = None,
+) -> tuple[Graph, list[str]]: ...
+
+def build_dag_graph(
+    session: Session,
+    assignments: list[TaskAssignment],
+    roles: dict[str, Branch],
+) -> tuple[Graph, list[str | None]]: ...
+```
+
+| Construction case | Shipped edge semantics |
+|-------------------|------------------------|
+| `OperationGraphBuilder.add_operation(..., depends_on=[...])` | Add `depends_on` edges only for ids already present in `_operations`. Unknown ids are silently ignored. |
+| `OperationGraphBuilder.add_operation(..., depends_on=None or [])` with current heads | Add `sequential` edges from every current head, then make the new node the sole head. |
+| `build_fanout_graph()` worker | Add a worker node with no worker-to-worker edge. |
+| `build_fanout_graph(..., synthesis_role=...)` | Add one synthesis node and an `aggregate` edge from every worker. |
+| `build_dag_graph()` | Convert each one-based `TaskAssignment.depends_on` reference to an index and add only declared `depends_on` edges. |
+
+**Exact semantics**:
+
+- The role-task dependency normalizer strips each reference, parses it as an
+  integer, subtracts one, and drops non-integer, self, and out-of-range values
+  with a warning.
+- Forward ordinal references are accepted by `_resolve_dep_indices()` because
+  validity is checked against the final assignment count, not construction order.
+- Duplicate dependency references are not deduplicated by the normalizer.
+- An assignment whose role is absent produces no node. Fan-out skips it; DAG
+  preserves a `None` placeholder so ordinal references remain aligned.
+- If no assignment maps to a role, each role-task builder raises `ValueError`.
+- The incremental builder's falsey `depends_on` branch means `None` and `[]` are
+  indistinguishable. A caller cannot currently express an independent root after
+  a head exists through `add_operation()`.
+- The executor does not infer or repair intended initial topology. It executes
+  the edges it receives.
+
+**Why this way**: initial topology is policy, while dependency waiting is
+mechanism. The divergence is retained as retrospective truth, not endorsed as
+ideal; delta 1 makes independent construction explicit.
+
+### D3 — Typed planned work, typed live requests, and two-stage authority
+
+`TaskAssignment` is the planned-work contract. `SpawnRequest` is the live-growth
+contract. Neither object authorizes execution by itself.
+
+**The contracts** (`lionagi/casts/emission.py`;
+`lionagi/orchestration/patterns.py`):
+
+```python
+class TaskAssignment(BaseModel):
+    task: str
+    assignee: str
+    inputs: list[str] = Field(default_factory=list)
+    exit_criteria: str | None = None
+    depends_on: list[str] = Field(default_factory=list)
+    modes: list[str] = Field(default_factory=list)
+
+class SpawnRequest(BaseModel):
+    instruction: str
+    assignee: str | None = None
+    operation: Literal["operate", "chat", "communicate", "ReAct"] = "operate"
+    independent: bool = False
+    reason: str | None = None
+
+def role_node_builder(
+    roles: dict[str, Branch],
+    *,
+    decorate_instruction: Callable[[SpawnRequest, str], str] | None = None,
+): ...  # returns Callable[[SpawnRequest, Operation], Operation]
+```
+
+**Routing semantics**:
+
+- `plan()` drops an assignment whose assignee is not in the supplied role set.
+  If `max_tasks` is non-zero, it truncates the validated list to that count.
+- `role_node_builder()` checks the requested operation against
+  `SPAWN_ALLOWED_OPERATIONS` even though the Pydantic field is already a
+  `Literal`. A value outside the allowlist falls back to `operate` and is logged;
+  a model-emitted request cannot reach a custom registered operation.
+- A named assignee must already exist in the role map. An unknown assignee raises
+  `ValueError`, which reactive injection records as `builder_error`.
+- An omitted assignee leaves `branch_id` unset; branch assignment then follows D4.
+- Successful static routing allocates a monotonic `spawn-N` id after assignee
+  validation, stores it as both `spawn_id` and `reference_id`, and stamps the
+  assignee when present. A later cycle or cap rejection may leave a sequence gap.
+- `decorate_instruction`, when provided, receives the request and allocated
+  `spawn_id`; it changes instruction text but does not change admission authority.
+- The executor extracts requests recursively from direct values, lists, tuples,
+  Pydantic model fields, and dictionary values to depth four. The value four is
+  an inherited defensive recursion cap with no recorded rationale.
+- A request observed both on the signal bus and in the completed response is
+  identity-deduplicated. The second sighting is recorded as `duplicate`.
+
+**Admission semantics** (`ReactiveExecutor._accept_node()`):
+
+1. Hold `_graph_lock` for cap, insertion, edge, and cycle checks.
+2. Reject when `_spawn_count >= max_spawn`.
+3. Add the child if its id is not already present.
+4. Unless `independent=True`, add a `spawn` edge from the emitter when one exists.
+5. Recheck graph acyclicity; remove the new edge and newly added node on failure.
+6. Increment the accepted count and record the spawned id.
+7. Outside the lock, clone and register a branch for a new child, emit
+   `NodeSpawned`, and report queued progress.
+
+The routing stage decides whether a request can become a candidate operation. The
+admission stage decides whether that candidate can enter this running graph.
+
+### D4 — Kernel-owned waits, branch allocation, context, and capacity
+
+The kernel owns the runtime mechanics after a graph is submitted.
+
+**The executor construction contract** (`lionagi/operations/flow.py`):
+
+```python
+class DependencyAwareExecutor:
+    def __init__(
+        self,
+        session: Session,
+        graph: Graph,
+        context: dict[str, Any] | None = None,
+        max_concurrent: int = 5,
+        verbose: bool = False,
+        default_branch: Branch = None,
+        alcall_params: AlcallParams | None = None,
+        executor_ref: dict[str, Any] | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
+    ): ...
+
+class ReactiveExecutor(DependencyAwareExecutor):
+    def __init__(
+        self,
+        *args: Any,
+        spawn_type: type | None = None,
+        node_builder: Any = None,
+        max_spawn: int = 50,
+        spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
+        **kwargs: Any,
+    ): ...
+```
+
+**Exact semantics**:
+
+- A node with a valid `branch_id` uses that Session branch. A node without one is
+  preallocated a clone when it has predecessors or requests inheritance. Other
+  nodes fall back to the supplied default branch or `session.default_branch`.
+- Reactive children always receive a clone: first from their explicit branch
+  template; otherwise from the emitter's branch when dependent; otherwise from
+  the Session default branch. The clone is included in the Session before run.
+- `on_branch_created` is called for ordinary preallocation. Reactive cloning uses
+  the separate `spawn_branch_setup` callback; the general branch-created hook is
+  not called on that path today.
+- A dependent operation waits for every predecessor completion event. Edge
+  conditions are evaluated after their head completes; a node runs when at least
+  one incoming edge remains valid, and is skipped when all incoming paths fail or
+  originate at skipped nodes.
+- A skipped operation is placed in `skipped_operations`, marked `SKIPPED`, and
+  reported through progress as `failed`; no operation result is inserted for the
+  skip path.
+- Predecessor results are added to the operation context under
+  `<predecessor_uuid>_result`. Flow context is then merged into that dictionary.
+  A completed response containing a dictionary `context` deep-merges that value
+  back into the flow context.
+- A soft pause takes effect only at an operation boundary. Operations already
+  inside the capacity limiter finish; waiting operations emit `NodePaused` and
+  resume after the installed event is released.
+- Operation invocation failure is stored as `{"error": str(error)}`. Cancellation,
+  `KeyboardInterrupt`, and `SystemExit` set the completion event and propagate.
+  Other unexpected flow-level exceptions are converted to an error result.
+- Existing terminal operations are not invoked again. Their response is reused
+  when present and their completion event is set.
+
+**Why this way**: dependency state, accepted live nodes, and branch clones are
+shared mutable execution state. Keeping them under one executor prevents callers
+from observing or mutating half-applied admission decisions.
+
+### D5 — `op_id` lifecycle identity and stable result envelopes
+
+Canonical lifecycle identity is the operation UUID serialized as `op_id`.
+Authored `reference_id` and branch names are presentation names, not identity.
+
+**The signal contract** (`lionagi/session/signal.py`):
+
+```python
+SIGNAL_SCHEMA_VERSION: int = 1
+
+NodeLifecycleState = Literal[
+    "queued",
+    "running",
+    "awaiting_approval",
+    "paused",
+    "succeeded",
+    "failed",
+    "escalated",
+]
+
+class NodeQueued(Signal):
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+    parent_id: str | None = None
+    depends_on: list[str] = []
+
+class NodeStarted(NodeQueued): ...      # same payload fields in shipped source
+class NodeCompleted(NodeQueued): ...    # same payload fields in shipped source
+class NodeFailed(NodeQueued): ...       # same payload fields in shipped source
+
+class NodeSpawned(Signal):
+    op_id: str = ""
+    parent_id: str | None = None
+    independent: bool = False
+    assignee: str | None = None
+    instruction: str | None = None
+```
+
+The four progress classes are separate Pydantic classes in source rather than
+subclasses of `NodeQueued`; the compact block above documents their identical
+field shape, not Python inheritance.
+
+**Progress adapter** (`lionagi/engines/flow_signals.py`):
+
+```python
+@asynccontextmanager
+async def flow_progress_signals(
+    session: Any,
+    graph: Any,
+) -> AsyncIterator[Callable[[str, str, str, float], None]]: ...
+```
+
+- The callback recognizes only `queued`, `started`, `completed`, and `failed`.
+  Unknown progress strings are ignored.
+- It prefers authored `reference_id` for `name`, retains predecessor ids, and
+  updates its edge map when `NodeSpawned` arrives.
+- Callback-to-bus emission is asynchronous, but context-manager exit awaits every
+  scheduled emission with `return_exceptions=True`. Observer failure therefore
+  does not replace the flow result, and installed observers drain before return.
+- `lane_for()` starts at `queued`. Terminal states are sticky until a later
+  `queued` or `running` signal explicitly begins another attempt.
+- `NodeSpawned.instruction` is truncated to 512 characters. Dropped builder error
+  text is truncated to 500 characters. The source records no rationale for those
+  observability caps.
+
+**Result payloads** (`lionagi/operations/flow.py`):
+
+```python
+# Every flow
+{
+    "completed_operations": list[UUID],
+    "operation_results": dict[UUID, Any],
+    "final_context": dict[str, Any],
+    "skipped_operations": list[UUID],
+}
+
+# Additional keys when reactive=True
+{
+    "spawned_operations": int,
+    "escalated_operations": list[UUID],
+    "dropped_spawns": list[{
+        "reason": Literal[
+            "builder_error",
+            "null_child",
+            "cycle",
+            "max_spawn_exceeded",
+            "duplicate",
+        ],
+        "assignee": Any,
+        "emitter_id": UUID | None,
+        # optional error or op_id depending on reason
+    }],
+}
+```
+
+- Completed ids and skipped ids are validated to be disjoint.
+- Result order follows dictionary/set materialization in the executor; the API
+  does not promise graph order or completion order.
+- `inject()` outside an active reactive run returns `False` and logs a warning.
+  It has no result object in which to add a dropped entry.
+- A prebuilt `inject()` bypasses `role_node_builder()` but not `_accept_node()`;
+  it remains subject to cap, cycle, branch, and ledger rules.
+
+### D6 — Adapters decorate runs but do not own execution
+
+The CLI is an adapter and an initial-graph caller today. It legitimately owns
+model and pack resolution, branch names, artifact directories, checkpoint and
+state persistence, control polling, and terminal presentation. Studio and engines
+likewise install observation and persistence around `Session.flow()`.
+
+**Shipped boundary**:
+
+```text
+lionagi/session/session.py             public flow façade
+lionagi/operations/flow.py             scheduling and live admission
+lionagi/orchestration/patterns.py       library role/task planning and graph construction
+lionagi/engines/flow_signals.py         optional callback-to-signal adapter
+lionagi/cli/orchestrate/_orchestration.py model, branch, artifact, and persistence setup
+lionagi/cli/orchestrate/flow.py         CLI plan, topology, checkpoint, control, synthesis
+lionagi/cli/orchestrate/fanout.py       CLI fan-out construction and presentation
+```
+
+**Exact semantics**:
+
+- `EngineRun.run_dag()` installs `flow_progress_signals()` and delegates to the
+  Session. It does not plan or execute nodes itself.
+- CLI graph code may decorate instructions and metadata before submission and
+  correlate reactive children afterward, but accepted live graph mutation remains
+  inside `ReactiveExecutor`.
+- CLI use of `OperationGraphBuilder` means it currently participates in D2's
+  topology divergence. That is a recorded defect, not a second executor.
+- Direct CLI flow calls do not uniformly install the lifecycle translation
+  adapter, so absence of a canonical signal does not prove a node did not run.
+
+**Why this way**: forcing adapter-specific artifact, terminal, or persistence
+policy into the kernel would couple generic scheduling to one surface. Letting an
+adapter schedule independently would be worse: execution correctness would vary by
+entry point.
+
+## Consequences
+
+- Scheduling, dependency waits, capacity, branch assignment, and runtime graph
+  safety have one implementation and one failure model.
+- Typed requests, result envelopes, and signals expose most failures without
+  exposing task-group or lock internals.
+- Callers must understand that initial topology is authoritative. The kernel does
+  not infer “fan-out” from a list of nodes.
+- Correcting the incremental-builder divergence can expose races that accidental
+  serialization previously hid; migration therefore requires topology and
+  concurrency tests together.
+- Uniform lifecycle emission would increase observer traffic and make
+  drain-before-return ordering a compatibility obligation for every caller.
+- Reactive admission is best-effort and non-transactional with parent work. A
+  rejected child is recorded; it does not roll back the emitter.
+- Reversing D1 would be high cost because every caller and observation surface
+  would need a new execution contract. Reversing D2 or D5 is medium cost because
+  builders and observers are public integration points. Changing the numeric
+  defaults is low implementation cost but potentially high behavioral impact.
+- Contributors extending orchestration must decide whether they are adding plan
+  policy (builder/engine/adapter) or runtime mechanism (kernel) before choosing a
+  module.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Make sequential linking explicit in `OperationGraphBuilder`, migrate CLI fan-out and dependency-free DAG roots to independent-node construction, and add topology tests proving that no undeclared worker-to-worker edges exist. | M | (filled at issue-open time) |
+| 2 | Implement one `TaskAssignment.depends_on` normalizer for pattern and CLI builders, document whether forward ordinal references are accepted, and validate the normalized graph for cycles before execution. | S | (filled at issue-open time) |
+| 3 | Move callback-to-node-signal conversion from `engines` to a neutral flow/session module, expose a named observed-flow façade, and migrate EngineRun, Studio, CLI fan-out, CLI synthesis, and main CLI flow without changing signal ordering or result shape. | M | (filled at issue-open time) |
+| 4 | Parameterize the shared role-task builders with branch, instruction, identity, and artifact decorators, then remove CLI-owned duplicate edge wiring while preserving checkpoint and artifact identities. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Separate executors for engines or CLI
+
+This would let each surface optimize its own scheduling and lifecycle handling. It
+lost because the same `Graph[Operation]`, Session branches, edge conditions, and
+reactive requests would acquire surface-dependent behavior. The existing code
+already demonstrates that engines can wrap `Session.flow()` without becoming an
+executor.
+
+### Kernel-owned initial planning
+
+Moving task decomposition, role selection, and edge construction into the executor
+would guarantee one builder. It lost because those are domain and product policies:
+the research engine is a reaction tree, the CLI carries artifacts and checkpoints,
+and library callers may already own a graph. The executor needs a graph, not a
+reason why the graph was chosen.
+
+### Treat every omitted dependency as an independent root
+
+This would fix fan-out callers but break the shipped incremental-builder
+convenience where successive operations intentionally form a chain. It lost as an
+unqualified compatibility change. The delta instead requires an explicit API so
+both independent and sequential intent are representable.
+
+### Treat every omitted dependency as “after current heads”
+
+This is the current incremental-builder shape and makes simple chain construction
+compact. It lost as the universal rule because a fan-out loop becomes a chain and
+multiple independent DAG roots cannot be represented after the first node.
+
+### Let emitted `SpawnRequest` call any registered operation
+
+This would make reactive flows extensible without changing the request `Literal`.
+It lost because model output would become authority to reach custom operations.
+The allowlist and branch map are deliberate confinement boundaries.
+
+### Put lifecycle translation in role-pattern code
+
+Role builders see authored task and assignee data and could emit rich signals. It
+lost because direct graph callers and injected prebuilt operations need the same
+lifecycle, while role-pattern code does not observe all executor transitions.
+
+### Emit canonical lifecycle signals directly and only from the executor
+
+This would remove the opt-in adapter. It was not the shipped choice: the executor
+retains a generic progress callback, while signal persistence is installed by
+callers that need it. The current-vs-ideal delta records neutral observation as the
+desired consolidation path without rewriting retrospective truth.
+
+### Force CLI orchestration through the convenience `fanout()` helper
+
+That would reuse library graph construction immediately. It lost because the CLI
+also needs per-leg artifact directives, stable identities, checkpoints, resume,
+control polling, and synthesis metadata. Shared builders need decorator seams
+before the duplicate topology path can be removed safely.
+
+### Roll back an emitter when a live child is rejected
+
+This would make a spawn request appear atomic with its parent. It lost because the
+parent operation has already completed and may have external effects; the graph
+executor has no transaction spanning an LLM turn, tools, and arbitrary operations.
+The honest contract is retained parent work plus a reasoned rejection ledger.
+
+## Notes
+
+Unknown Role and Mode diagnostics list the available catalog names, and
+`examples/reactive_spawn.py` is constructed to produce an accepted spawn while
+directing protected workflows to the engine layer. These improve discoverability
+but do not change graph semantics.

--- a/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
+++ b/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
@@ -1,0 +1,565 @@
+# ADR-0034: Domain-Engine Coordination and Autonomy Safeguards
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0075, v0-0077; extends ADR-0033
+
+## Context
+
+Domain engines encode reusable reaction topology for work whose decomposition is
+stable enough to deserve code. Six problems shape that layer.
+
+**P1 — Reusable policy and mutable run state have different lifetimes.** Model
+routing, roles, thresholds, and caps may be reused. A Session, observed events,
+deduplication keys, pending coroutines, counters, and a deadline must not leak from
+one invocation into the next. `lionagi/engines/engine.py` separates `Engine` from
+`EngineRun` for that reason.
+
+**P2 — The shipped domains do not share one useful topology.** Research is a
+novelty-bounded tree, review is dimensional fan-out plus verification and verdict,
+hypothesis is an event-reference chain with pending experiments, coding is a
+subprocess-gated plan/implement/test/fix/verify chain, and planning is a planned
+operation DAG. Forcing all five through one topology would move domain semantics
+into generic graph plumbing.
+
+**P3 — Prompted autonomy limits are not safety controls.** Recursive or reactive
+work must stop at hard agent and wall-clock bounds, and concurrent activity must
+pass a semaphore. Semantic depth, deduplication, and a quality judge reduce work;
+they cannot replace the hard bounds.
+
+**P4 — Typed emissions can be absent or malformed.** Domain transitions depend on
+events such as findings, questions, tests, and verdicts. A prose-only or invalid
+response must be observable and may receive a bounded repair turn, but the engine
+must not fabricate the missing domain event.
+
+**P5 — Expansion quality and terminal reporting have different failure policy.** A
+judge is advisory: infrastructure failure fails open while budget exhaustion fails
+closed. Terminal synthesis or partial export is budget-exempt so evidence already
+collected is not lost merely because discretionary expansion stopped.
+
+**P6 — Bounded completion must remain distinguishable from a broken run.** String
+results retain `str` compatibility while carrying a live run handle, skipped
+emission diagnostics, and explicit degradation state. Internal deadline or
+agent-budget exhaustion can return partial evidence; external cancellation and
+non-budget failures still propagate.
+
+| Concern | Decision |
+|---------|----------|
+| Configuration and state lifetime | D1: `Engine` is reusable configuration and `EngineRun` owns all invocation state. |
+| Hard resource bounds | D2: agent creation and wall-clock deadlines dominate semantic gates; concurrency is separately bounded. |
+| Typed event coordination | D3: event queries unwrap payloads, repair is bounded, and judge failures follow explicit policies. |
+| Domain topology | D4: each concrete engine owns its reaction shape and typed events. |
+| Terminal and degraded result | D5: string results use `EngineResult`; budget/deadline paths use bounded partial export and explicit reasons. |
+| Operation-DAG interoperation | D6: engine DAG execution observes and delegates through ADR-0033 instead of scheduling again. |
+
+Out of scope:
+
+- Generic graph scheduling and reactive node admission. ADR-0033 owns them.
+- Role-palette composition and dynamic role recruitment. ADR-0036 owns that target.
+- Resident queue leases, task attempts, and process recovery. ADR-0037 owns the
+  host boundary.
+- Provider implementation and tool execution semantics. Engines select existing
+  Branch configuration; they do not redefine providers or tools.
+- A universal durable event-retention policy. The current store is in memory; the
+  missing compaction contract is recorded in the delta.
+
+```mermaid
+flowchart TD
+    E[Reusable Engine config] --> R[Fresh EngineRun]
+    R --> S[Session and observer]
+    R --> B[Budget and deadline]
+    R --> C[Concurrency semaphore]
+    R --> Q[Active and pending tasks]
+    S --> V[Typed domain events]
+    V --> T[Domain reaction topology]
+    B --> T
+    C --> T
+    T --> X[Terminal or partial export]
+    X --> O[EngineResult or structured domain result]
+```
+
+## Decision
+
+### D1 — Reusable `Engine`, isolated `EngineRun`
+
+`Engine` stores stateless configuration. `new_run()` creates all mutable
+invocation state, using a caller-provided Session only when explicitly supplied.
+
+**The contracts** (`lionagi/engines/engine.py`):
+
+```python
+class Engine:
+    run_context_cls: type[EngineRun] = EngineRun
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        models: dict[str, str] | None = None,
+        max_depth: int = 3,
+        max_concurrent: int = 5,
+        max_agents: int = 50,
+        deadline_s: float | None = None,
+        judge_model: str | None = None,
+        judge_role: str = "critic",
+        cancel_timeout_s: float = 30.0,
+    ) -> None: ...
+
+    def new_run(
+        self,
+        *,
+        session: Session | None = None,
+        on_event: EventCallback | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
+    ) -> EngineRun: ...
+
+class EngineRun:
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        session: Session | None = None,
+        on_event: EventCallback | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
+    ) -> None: ...
+```
+
+The fresh run owns:
+
+```text
+session: Session
+root: str
+agents_made: int
+_sem: Semaphore(engine.max_concurrent)
+_active: set[asyncio.Task]
+_pending: deque[coroutine]
+_seen: set[str]
+_t0: monotonic timestamp
+_deadline: monotonic timestamp | None
+_run_task: asyncio.Task | None
+_emission_failures: list[str]
+_agent_errors: list[str]
+```
+
+**Exact semantics**:
+
+- No Session supplied: the run constructs a new `Session()`.
+- Session supplied: the run uses that Session and its observer; it does not clone
+  or reset it.
+- `models` is copied on Engine construction. `model_for(stage)` returns the
+  stage-specific mapping when truthy, otherwise the base model.
+- `seen(key)` strips and lowercases the key. It returns `True` for a duplicate and
+  records a previously unseen key.
+- `events` is the Session observer flow's item pile. Long-lived runs retain that
+  in-memory history; no compaction occurs.
+- `on_event`, when set, receives plain dictionaries of the form
+  `{"type": kind, **data}`. Agent errors are additionally accumulated.
+- `ChainRun` adds per-event-type lists, deterministic prefix counters, an
+  `eid -> event` index, and pending-domain state in its concrete subclasses.
+
+**Why this way**: the Engine object is safe to configure once and reuse. Mutable
+state has a single owner and lifetime, which makes budget, quiescence, and cleanup
+reasoning local to one invocation.
+
+### D2 — Hard agent/deadline bounds and separate concurrency
+
+Agent count and deadline are hard run controls. Concurrency limits simultaneous
+work but does not grant more budget.
+
+**The creation contract** (`lionagi/engines/engine.py`):
+
+```python
+async def EngineRun.make_agent(
+    self,
+    role: str,
+    *,
+    name: str | None = None,
+    modes: list[str] | None = None,
+    model: str | None = None,
+    tools: tuple[str, ...] = (),
+    emits: tuple[type, ...] = (),
+    permissions: Any = None,
+    cwd: str | None = None,
+    secure: bool = True,
+    exempt: bool = False,
+    mcp_servers: list[str] | None = None,
+    extra_prompt: str | None = None,
+) -> Branch: ...
+
+class EngineBudgetError(RuntimeError): ...
+```
+
+**Exact semantics**:
+
+- `budget_left()` is false when `agents_made >= max_agents` or the monotonic
+  deadline has arrived. Depth, novelty, deduplication, and judge results are not
+  consulted by this hard predicate.
+- A non-exempt `make_agent()` call without budget emits one `budget_exhausted`
+  notification for the run and raises `EngineBudgetError`.
+- An exempt terminal agent bypasses the pre-check but still increments
+  `agents_made`. Exemption preserves reporting; it is not hidden from accounting.
+- `spawn(coro)` checks the same predicate before scheduling. On exhaustion it
+  closes the coroutine when possible, emits the one-time notification, and returns
+  `None`.
+- A spawn attempted without a running asyncio loop is queued in `_pending`;
+  `drain_pending()` later schedules every queued coroutine.
+- `wait_quiescence()` repeatedly gathers active tasks. `CancelledError` and
+  `EngineBudgetError` are treated as bounded expansion stopping; any other task
+  error is re-raised, singly or as an exception group.
+- The deadline watchdog sleeps until `_deadline`, records exhaustion, and cancels
+  the root `_run_task`. `Engine.run()` then cancels spawned tasks in cleanup.
+- `cancel_active()` requests cancellation, waits at most `cancel_timeout_s`, warns
+  about tasks still pending, issues a final cancel, and returns. A task that
+  suppresses cancellation can therefore outlive the wait window, but the run does
+  not wait indefinitely.
+- `run_team()` is sequential even though the run owns a semaphore. One agent
+  failure is converted to a notification and failure text so later team members
+  continue.
+
+**Shipped numeric defaults and their traceable rationale**:
+
+| Setting | Default | Recorded reason |
+|---------|---------|-----------------|
+| `Engine.max_depth` | `3` | Inherited compatibility default; no rationale is recorded in source. |
+| `Engine.max_concurrent` | `5` | Inherited compatibility default; no rationale is recorded in source. |
+| `Engine.max_agents` | `50` | Inherited compatibility default; no rationale is recorded in source. |
+| `Engine.deadline_s` | `None` | No wall-clock deadline unless the caller chooses one. |
+| `Engine.cancel_timeout_s` | `30.0` seconds | Bounds cleanup of cancellation-resistant tasks; the exact value has no recorded rationale. |
+| Partial-export timeout | `120.0` seconds | Kept short enough that a hung synthesis call cannot extend a cancelled run without bound; the exact value has no further recorded rationale. |
+
+**Why this way**: semantic controls improve work selection but are fallible model or
+domain policy. Agent creation and monotonic time are enforceable locally and remain
+authoritative when those policies fail.
+
+### D3 — Typed payload queries, bounded repair, and advisory judging
+
+Domain coordination observes typed emissions on the Session bus. `EngineRun`
+provides a payload-oriented query so callers do not depend on envelope shape.
+
+**The contracts** (`lionagi/engines/engine.py`):
+
+```python
+class EngineEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+class JudgeVerdict(EngineEvent):
+    subject: str = ""
+    allow: bool = True
+    reason: str = ""
+
+def EngineRun.by_type(self, event_type: type) -> list[Any]: ...
+
+async def EngineRun.operate_with_repair(
+    self,
+    branch: Branch,
+    instruction: str,
+    *,
+    arrived: Callable[[], bool],
+    emits: tuple[type, ...] = (),
+    retries: int = 1,
+) -> Any: ...
+
+async def Engine.judge(
+    self,
+    run: EngineRun,
+    eid: str,
+    subject: str,
+) -> bool: ...
+```
+
+**Exact semantics**:
+
+- `by_type(T)` walks observer items, unwraps `Signal.data`, and delegates matching
+  to the observer's type/callable filter. Matching values inside structured
+  capability bundles are returned as payloads, not their envelopes.
+- `operate_with_repair()` always performs the original operation once. While
+  `arrived()` remains false, it re-prompts at most `retries` times.
+- CLI-backed branches receive a complete fenced-JSON example built from required
+  Pydantic fields. Other branches receive expected top-level emission keys and a
+  schema-correction instruction.
+- Repair asks the model to emit; it never constructs a domain event on the model's
+  behalf.
+- If all attempts finish without `arrived()`, the method emits
+  `emission_missing`, records `<agent> x<attempt-count>`, and returns the last raw
+  response.
+- All concrete engine repair defaults are one retry. No comparative rationale for
+  one rather than zero or two is recorded in source; it is a bounded compatibility
+  default.
+- No `judge_model`: judging is a no-op and returns `True`.
+- A typed `JudgeVerdict` whose subject matches the requested id is authoritative.
+  In its absence, response text containing `reject` fails the gate; other text
+  passes.
+- Judge `EngineBudgetError` returns `False`: no budget means no expansion.
+- Other judge exceptions emit `judge_error` and return `True`: infrastructure
+  failure is fail-open while D2 remains authoritative.
+
+**Why this way**: payload-oriented queries keep engines independent of observer
+transport. Bounded repair addresses common serialization failure without turning a
+missing emission into invented evidence. The judge is an optimization, not a hard
+availability dependency.
+
+### D4 — Each engine owns its domain reaction topology
+
+The concrete engines intentionally do not share one execution shape.
+
+**Shipped topology and public configuration**:
+
+| Engine | Constructor additions | Reaction shape and edge behavior |
+|--------|-----------------------|----------------------------------|
+| `ResearchEngine` (`lionagi/engines/research.py`) | `novelty_threshold=0.7`, roles `("researcher", "analyst", "critic")`, `synthesis_role="synthesizer"`, `repair_retries=1` | Runs each node's team sequentially; high-novelty findings and explicit depth requests spawn deeper nodes until `max_depth`; normalized topic dedup prevents re-exploration. |
+| `ReviewEngine` (`lionagi/engines/review.py`) | four default dimensions, reviewer/verifier roles, `verify_severities=("critical", "major")`, `repair_retries=1` | Reviews dimensions concurrently; qualifying issues spawn adversarial verification; all verifiers quiesce before one exempt verdict turn. |
+| `HypothesisEngine` (`lionagi/engines/hypothesis.py`) | seven stage roles, executable methods `("analysis", "comparison", "proof")`, `max_questions=8`, `repair_retries=1` | Typed events carry reference ids through question, evidence, hypothesis, experiment, result, conclusion, and application reactions; non-executable experiments enter `run.pending`. |
+| `CodingEngine` (`lionagi/engines/coding.py`) | plan/implement/verify roles, `max_fix_rounds=3`, test and turn timeouts `600.0`, heartbeat `30.0`, optional stage timeout, guarded worker tool settings | Runs a plan/implement/test/fix/verify chain; subprocess results are ground truth; missing change metadata can be synthesized only when workspace delta proves work occurred. |
+| `PlanningEngine` (`lionagi/engines/planning.py`) | orchestrator, five-role default roster, synthesis role, `reactive=True` | Plans `TaskAssignment` objects, retries an empty plan once, builds an operation DAG, delegates through D6, then synthesizes results. |
+
+The exact domain event fields remain in their defining modules. The load-bearing
+base shapes include:
+
+```python
+class ChainEvent(BaseModel):
+    eid: str = ""  # engine-assigned
+
+class FindingEmitted(Finding):
+    novelty: float = Field(default=0.5, ge=0.0, le=1.0)
+    depth: int = 0
+
+class IssueFound(Finding):
+    dimension: str
+    location: str = ""
+    severity: str = "minor"
+
+class VerifyResult(EngineEvent):
+    issue: str
+    holds: bool = True
+    rationale: str = ""
+```
+
+**Exact cross-engine semantics**:
+
+- Research rejects an empty stripped topic. Hypothesis rejects an empty normalized
+  seed list. Planning rejects an empty stripped prompt and raises `PlanError` after
+  one empty-plan retry. Coding validates its spec before run state and requires a
+  non-empty test command.
+- Research and hypothesis override `_partial_export()` only when evidence exists;
+  they prefix a budget-exhausted status and synthesize the retained events.
+- Review's concurrent dimension failure cancels already-spawned verifier work and
+  propagates. Individual research team-agent errors are recorded and the team
+  continues.
+- Hypothesis stage guards catch and notify ordinary stage errors so unrelated
+  event chains can continue. Non-executable experiment methods are retained as
+  pending rather than treated as failure.
+- Coding's test timeout is 600 seconds, turn timeout is 600 seconds, maximum fix
+  rounds is three, and heartbeat interval is 30 seconds by default. The source
+  explains the behavioral role of each bound but records no rationale for the
+  exact values.
+- Research's 0.7 novelty threshold, hypothesis's eight-question cap, and coding's
+  three-fix cap likewise have no recorded numeric rationale. They are explicit
+  policy defaults and caller-overridable.
+- Only PlanningEngine submits a `Graph[Operation]` through `Session.flow()`. The
+  others coordinate Branch turns and typed domain events directly.
+
+**Why this way**: the common layer is lifecycle, budget, event observation, repair,
+and terminal behavior. Reaction edges encode domain meaning and stay with the
+engine that can name and test that meaning.
+
+### D5 — Explicit degradation and backward-compatible string results
+
+String-producing engines return an `EngineResult`, a `str` subclass with structured
+run metadata. Non-string domain results pass through unchanged.
+
+**The contracts** (`lionagi/engines/engine.py`):
+
+```python
+class EngineResult(str):
+    text: str
+    skipped: list[str]
+    degraded: bool
+    degrade_reason: str
+    run: EngineRun
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        events_by_type: Callable[[type], list[Any]],
+        skipped: list[str],
+        degraded: bool,
+        run: EngineRun,
+        degrade_reason: str = "",
+    ) -> EngineResult: ...
+
+    def events_by_type(self, event_type: type) -> list[Any]: ...
+
+async def Engine.run(
+    self,
+    *args: Any,
+    session: Session | None = None,
+    on_event: EventCallback | None = None,
+    on_branch_created: Callable[[Any], None] | None = None,
+    **kwargs: Any,
+) -> Any: ...
+```
+
+**Exact semantics**:
+
+- `str(result) == result.text`. `skipped` is a copy of missing-emission
+  diagnostics. `events_by_type()` remains backed by the live run's query method.
+- A clean string result has `degraded=False` and `degrade_reason=""`.
+- If discretionary spawned work hit the budget but the root completed,
+  `degrade_reason="budget"` is still set; truncation is not hidden by the success
+  path.
+- A root-level `EngineBudgetError`, or an exception group containing only budget
+  errors, cancels active work, runs `_partial_export()`, and marks `budget`.
+- An internal deadline cancellation follows the same export path and marks
+  `deadline`.
+- Partial export is shielded and bounded to 120 seconds. Timeout or export failure
+  is logged and yields no partial result; external cancellation during partial
+  export cancels the export task and propagates.
+- An exception group with any non-budget leaf propagates. Budget handling does not
+  launder ordinary failures into a degraded result.
+- Caller cancellation propagates after run-owned cleanup. On Python 3.10, a caller
+  cancellation simultaneous with the deadline may be classified as the internal
+  deadline because the stronger `Task.cancelling()` signal is unavailable; the
+  source records this compatibility edge case.
+- `_wrap_result()` wraps only plain strings. Existing `EngineResult` and non-string
+  values pass through. `CodingEngine` therefore returns its structured
+  `CodeResultRecorded` rather than an `EngineResult`.
+- The `run` property retains the whole Session and its branches. Consumers should
+  not keep it longer than needed.
+
+**Why this way**: callers that historically consumed a string keep working, while
+new callers can distinguish full success, bounded partial completion, and missing
+emissions without parsing report prose.
+
+### D6 — Engine DAG execution delegates to the graph boundary
+
+An engine may use a graph when its domain topology is naturally an operation DAG.
+It does not gain a second scheduler.
+
+**The contract** (`lionagi/engines/engine.py`):
+
+```python
+async def EngineRun.run_dag(
+    self,
+    graph: Any,
+    *,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    executor_ref: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+    spawn_branch_setup: Any = None,
+) -> dict[str, Any]: ...
+```
+
+**Exact semantics**:
+
+- The method enters `flow_progress_signals(self.session, graph)`, passes the
+  resulting callback to `Session.flow()`, awaits the result, then exits the context
+  so observer emissions drain before return.
+- It applies no planning, role, budget, or domain policy itself. PlanningEngine
+  chooses the graph before calling it.
+- `max_spawn=50` and `max_concurrent=5` mirror the ADR-0033 defaults. No separate
+  engine rationale is recorded.
+- The method's generic placement on every `EngineRun` is current package debt. The
+  neutral observed-flow façade in ADR-0033's delta is the intended generic owner.
+
+## Consequences
+
+- Known workflows reuse tested domain policy without replanning every invocation.
+- Resource bounds, typed-emission repair, judge behavior, cleanup, and terminal
+  degradation are consistent across local, API, CLI-backed, and process-gated
+  workers.
+- New engines add real maintenance surface: event models, reaction edges, routing
+  stages, partial-export semantics, and conformance tests.
+- Advisory judging and repair add bounded model cost. Exempt terminal turns can
+  take the recorded agent count beyond `max_agents` by design.
+- The live `EngineResult.run` handle and retained observer history can consume
+  substantial memory in long runs. Callers must release results they no longer
+  need; a compaction contract is not yet shipped.
+- Contributors must choose explicitly between a domain reaction loop and an
+  operation DAG. That distinction is intentional and affects where failures,
+  retries, and typed events belong.
+- Reversing D1 or D5 is high cost because it changes reuse and caller-visible
+  result semantics. Changing a concrete topology is scoped to that engine but can
+  invalidate its event-reference and partial-export contracts.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Define and implement an event-retention or compaction policy for long-running `EngineRun` instances, with a test proving that required audit and terminal-summary events survive compaction. | M | (filled at issue-open time) |
+| 2 | Change `EngineRun.run_dag()` into a compatibility delegator over the neutral observed-flow façade and document the façade, rather than the engine method, as the generic graph-observation surface. | S | (filled at issue-open time) |
+| 3 | Add one conformance suite that exercises agent budget, deadline cancellation, emission repair, judge failure, and terminal degradation across every concrete engine shape. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### One DAG-only engine model
+
+This would give every workflow one visualizable scheduling representation and
+reuse ADR-0033 universally. It lost because research and hypothesis react to typed
+events whose future branches do not exist at plan time, while coding contains
+subprocess gates and workspace truth that are clearer as a guarded chain. Encoding
+all of that as generic graph metadata would hide domain policy in node callbacks.
+
+### One bespoke runtime per domain
+
+This would let each engine choose its own task lifecycle and optimize aggressively.
+It lost because agent budget, deadline cancellation, event observation, repair,
+and cleanup are cross-domain invariants. Copying them would create inconsistent
+failure and degradation behavior.
+
+### Store mutable state on the reusable Engine
+
+This would reduce the number of objects and make counters easy to inspect. It lost
+because concurrent or sequential reuse would share Sessions, counters, pending
+tasks, and dedup keys. A prior run could suppress or exhaust later work.
+
+### Prompt-only autonomy limits
+
+This would avoid counters, watchdogs, and cancellation machinery. It lost because a
+model can ignore or misunderstand a prompt, and recursive reactions can be emitted
+indirectly. Enforceable agent creation and monotonic deadline checks are required.
+
+### Make the quality judge authoritative and fail-closed on every error
+
+This would prevent expansion whenever quality cannot be proven. It lost because a
+judge provider or parse failure would become a global availability dependency.
+Budget exhaustion still fails closed; other judge errors fail open under the hard
+bounds.
+
+### Fabricate a minimal event after repair exhaustion
+
+This would keep pipelines moving and simplify downstream code. It lost because a
+syntactically valid placeholder is not evidence. Missing emission stays observable,
+and downstream domain logic decides whether absence is legitimate or terminal.
+
+### Raise on all budget exhaustion
+
+This would make limits unmistakable. It lost because a bounded run may already
+hold useful evidence, and losing terminal synthesis makes the budget less useful.
+`EngineBudgetError` remains the internal control signal; the public string result
+marks degradation explicitly.
+
+### Return a new result model instead of a `str` subclass
+
+This would be cleaner for new code. It lost on backward compatibility: existing
+callers expect text. `EngineResult` preserves string behavior while adding a typed
+inspection surface.
+
+### Unbounded repair until a typed event arrives
+
+This would maximize the chance of satisfying a stage contract. It lost because a
+malformed or incapable worker could spend the entire run. One retry is the shipped
+default; final absence is recorded rather than hidden.
+
+### Put graph scheduling inside PlanningEngine
+
+This would make the planning engine self-contained. It lost because graph
+execution, branch allocation, lifecycle, and live admission already have one owner
+in ADR-0033. `run_dag()` is an observation-and-delegation convenience only.

--- a/docs/adr/ADR-0035-persisted-run-completion-contract.md
+++ b/docs/adr/ADR-0035-persisted-run-completion-contract.md
@@ -1,0 +1,473 @@
+# ADR-0035: Persisted Run-Completion Contract
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0094
+
+## Context
+
+An orchestration process ending is not sufficient evidence that its work
+completed. Persisted state is the boundary because five problems cannot be solved
+reliably from process exit or human output.
+
+**P1 — Process exit and work completion are different facts.** A command may exit
+normally after producing no evidence, after cancellation, or after recording a
+failed run. Conversely, the process that started work may not be the process that
+later observes completion.
+
+**P2 — Completion spans heterogeneous records.** Lionagi records Sessions,
+invocations, plays, and scheduled runs with kind-specific status vocabularies. A
+consumer may wait for a mixed set and must not hard-code one terminal set for all
+of them.
+
+**P3 — Human monitoring output is not a machine contract.** Dashboards and monitor
+lines may change presentation. Automation needs one frozen line grammar and one
+importable structured API, with diagnostics kept off stdout.
+
+**P4 — Artifact locations differ internally by kind.** A Session id maps directly
+to a run directory. An invocation, play, or scheduled run must resolve through its
+backing primary Session. Consumers should receive that stable manifest container,
+not learn every record relationship.
+
+**P5 — A completion record is useful only if status writes are trustworthy.** A
+terminal record must not silently return to running or oscillate to another
+terminal state. Concurrent writers must not win by racing a Python read-modify-
+write gap. `lionagi/state/db.py` therefore owns both the vocabularies and the
+guarded write path.
+
+`lionagi/cli/wait.py` is the machine-facing read boundary. It resolves mixed run
+kinds, polls until each reaches its schema-owned terminal status, produces a
+structured outcome, and renders a tab-delimited line. The state layer owns the
+write integrity that makes those outcomes meaningful.
+
+| Concern | Decision |
+|---------|----------|
+| Completion authority | D1: persisted, kind-specific state is authoritative; process state is not. |
+| Resolution and waiting | D2: `wait_for_terminal()` resolves mixed ids, refetches by canonical kind/id, and returns outcomes in input order. |
+| Outcome and stdout contract | D3: one structured outcome shape and one frozen tab-delimited rendering expose status, reason, run directory, and exit code. |
+| CLI diagnostics and aggregate exit | D4: stdout carries contract lines only; stderr and process exit report lookup, interruption, and aggregate success. |
+| Status integrity | D5: one transactional update path validates vocabularies, protects terminal values, and performs storage-level compare-and-set. |
+
+Out of scope:
+
+- Certification of artifact contents. Completion reports where evidence lives; it
+  does not assert that a manifest or artifact satisfies a caller's acceptance test.
+- The human dashboard and monitor presentation. They may consume the same state but
+  do not define this machine grammar.
+- Push delivery. The shipped implementation polls; a subscription-backed transport
+  is retained as a delta and must preserve identical outcomes and bytes.
+- Persistence schema design beyond status integrity and backing-session resolution.
+  The persistence-state area owns table lifecycle and storage architecture.
+- Host queue acknowledgement. ADR-0037 defines the target TaskSource contract;
+  `li wait` observes persisted run records, not queue leases.
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant W as wait_for_terminal
+    participant D as StateDB
+    C->>W: ids, interval, callbacks
+    W->>D: resolve each raw id by kind
+    loop while canonical ids are non-terminal
+        W->>D: refetch by kind and id
+        D-->>W: status, reason, artifact link, exit code
+    end
+    W-->>C: outcome dictionaries in input order
+    C->>C: optional format_wait_line
+```
+
+## Decision
+
+### D1 — Persisted kind-specific state is completion authority
+
+Terminal predicates live beside record schemas, and the wait path imports them.
+It does not infer completion from an exit code or maintain a duplicate vocabulary.
+
+**The contract** (`lionagi/state/db.py`):
+
+```python
+SESSION_TERMINAL_STATUSES = frozenset({
+    "completed",
+    "completed_empty",
+    "failed",
+    "timed_out",
+    "aborted",
+    "cancelled",
+})
+
+INVOCATION_TERMINAL_STATUSES = SESSION_TERMINAL_STATUSES
+SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({
+    "completed", "failed", "skipped", "cancelled"
+})
+PLAY_TERMINAL_STATUSES = frozenset({
+    "merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"
+})
+
+TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
+    "session": SESSION_TERMINAL_STATUSES,
+    "invocation": INVOCATION_TERMINAL_STATUSES,
+    "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES,
+    "show": frozenset({"completed", "aborted"}),
+    "play": PLAY_TERMINAL_STATUSES,
+    "team": frozenset({"archived"}),
+}
+```
+
+The wait surface supports four of those kinds:
+
+| Kind | Terminal statuses | Success statuses for aggregate CLI exit |
+|------|-------------------|------------------------------------------|
+| `session` | `completed`, `completed_empty`, `failed`, `timed_out`, `aborted`, `cancelled` | `completed` |
+| `invocation` | same as Session | `completed` |
+| `play` | `merged`, `escalated`, `gate_failed`, `blocked`, `aborted_after_finish` | `merged` |
+| `schedule_run` | `completed`, `failed`, `skipped`, `cancelled` | `completed` |
+
+**Exact semantics**:
+
+- A completed-empty Session or invocation is terminal but not successful for the
+  aggregate CLI exit. Completion and acceptance remain separate.
+- A terminal status with a non-zero recorded `exit_code` is still classified by
+  the kind/status success table; the exit code is reported as evidence rather than
+  used as the terminal predicate.
+- `show` and `team` terminal sets are schema-owned but are not accepted by
+  `_resolve_wait_target()` today.
+- A kind absent from the terminal mapping has no terminal statuses in the wait
+  loop and would not complete through that path. Supported resolvers always return
+  one of the four documented kinds.
+- Status reason vocabulary is separately validated by
+  `lionagi/state/reasons.py`. A missing or unrecognized persisted code is reported
+  as the literal `unknown`, never replaced with an invented valid reason.
+
+**Why this way**: record owners know which states are terminal and what those
+states mean. Centralizing the sets with the schema makes every observer and writer
+share one vocabulary.
+
+### D2 — Mixed-kind resolution and poll-until-terminal
+
+`wait_for_terminal()` is the importable core. It contains no argument parsing,
+signal-handler installation, or printing.
+
+**The contract** (`lionagi/cli/wait.py`):
+
+```python
+async def wait_for_terminal(
+    ids: list[str],
+    *,
+    interval: float = 1.0,
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+    should_stop: Callable[[], bool] | None = None,
+) -> list[dict[str, Any]]: ...
+```
+
+Resolution order is:
+
+```text
+raw id or accepted short prefix
+  ├─ session / invocation / play through _resolve_any_target
+  │    └─ branch-id fallback may resolve to its Session
+  └─ schedule_run through _resolve_schedule_run
+```
+
+After resolution, refetch is closed by kind:
+
+```python
+if kind == "session":      db.get_session(entity_id)
+if kind == "invocation":   db.get_invocation(entity_id)
+if kind == "play":         db.get_play(entity_id)
+if kind == "schedule_run": db.get_schedule_run(entity_id)
+```
+
+**Exact semantics**:
+
+- Empty `ids` returns an empty list without polling.
+- An id unresolved at the initial lookup produces an immediate outcome with
+  `status="not_found"`, `kind=None`, `reason="unknown"`, no artifact or exit
+  code, and `success=False`.
+- A resolved terminal row produces an outcome immediately. A non-terminal row is
+  keyed in `pending` by canonical id and refetched on each tick.
+- If a row existed at resolution and disappears during polling, waiting does not
+  hang. It produces `status="unknown"`, preserves the resolved kind, and marks the
+  outcome unsuccessful.
+- `on_result` is called once when each pending canonical run resolves. Immediate
+  terminal and not-found inputs invoke it during initial resolution.
+- `should_stop`, when supplied, is checked before and after each tick. A stop
+  returns only outcomes already known; still-pending ids are omitted.
+- Return order follows the input-resolution order. Raw aliases are replaced by
+  canonical ids for resolved rows; unresolved ids retain the raw value.
+- Duplicate canonical ids share one pending entry but remain duplicated in the
+  final ordered projection. The callback follows resolution events rather than
+  promising one call per duplicate list position.
+- Polling sleeps only while pending work remains. The default interval is one
+  second. Source records it as a responsiveness/load compromise only by usage;
+  no explicit rationale for the exact value is recorded.
+- A negative interval is not validated at this layer and will reach
+  `asyncio.sleep()`, which returns immediately for non-positive delay. CLI parsing
+  likewise accepts any float.
+
+**Why this way**: the structured core can be called by Python consumers or wrapped
+by CLI presentation. Kind-specific refetch remains explicit and auditable instead
+of relying on a polymorphic row with ambiguous status semantics.
+
+### D3 — Structured outcome and frozen line grammar
+
+Every resolved or terminally classified item uses the same dictionary shape.
+
+**Outcome payload** (`lionagi/cli/wait.py`):
+
+```python
+{
+    "run_id": str,
+    "kind": Literal["session", "invocation", "play", "schedule_run"] | None,
+    "status": str,
+    "reason": str,
+    "artifact_dir": str | None,
+    "exit_code": int | None,
+    "success": bool,
+}
+```
+
+**Renderer**:
+
+```python
+def format_wait_line(outcome: dict[str, Any]) -> str: ...
+```
+
+```text
+<run_id>\tstatus=<status>\treason=<reason>\tartifact_dir=<dir-or-dash>\texit_code=<int-or-dash>
+```
+
+**Artifact-directory resolution**:
+
+| Kind | Resolution |
+|------|------------|
+| Session | `RUNS_ROOT / row["id"]` |
+| Invocation | Resolve primary Session, then `RUNS_ROOT / session["id"]` |
+| Play | Resolve primary Session, then `RUNS_ROOT / session["id"]` |
+| Scheduled run | Follow `invocation_id`, resolve that invocation's primary Session, then its run directory |
+
+**Exact semantics**:
+
+- The path is returned even when the directory does not yet exist. It identifies
+  the manifest container by persisted relationship, not by filesystem probing.
+- Missing backing Session or scheduled-run invocation produces
+  `artifact_dir=None`, rendered as `-`.
+- Missing `exit_code` is rendered as `-`; integers, including zero and negative
+  values, are rendered with `str()`.
+- Missing or invalid reason is rendered as `unknown`, not `-`.
+- Fields are tab-delimited and ordered exactly as shown. There is no quoting or
+  escaping layer. Persisted status and reason vocabularies are constrained; an
+  artifact path containing a tab would make the line ambiguous, and no explicit
+  sanitizer exists today.
+- The structured `success` field is deliberately absent from the line. Consumers
+  receive status and evidence; the CLI uses `success` only for aggregate process
+  exit.
+
+**Why this way**: one line is easy to consume from shell without requiring JSON,
+while the Python dictionary preserves kind and success classification. Returning
+the run directory gives every consumer the same stable place to inspect `run.json`
+and artifacts.
+
+### D4 — Stdout isolation and aggregate CLI exit
+
+`run_wait()` is a thin CLI shim around D2 and D3.
+
+**The contract** (`lionagi/cli/wait.py`; `lionagi/cli/status.py`):
+
+```python
+def run_wait(argv: list[str]) -> int: ...
+
+EXIT_UNKNOWN = 2
+EXIT_RUNNING = 3
+```
+
+CLI arguments:
+
+```text
+li wait <id> [<id> ...] [--interval SECS]
+```
+
+Ids may be comma- or space-separated and may mix supported kinds.
+
+**Exact semantics**:
+
+- The CLI prints `format_wait_line(outcome)` only for outcomes other than initial
+  `not_found`. Not-found diagnostics use the CLI logging helper and go to stderr.
+- A row that disappears during polling produces an `unknown` contract line and an
+  aggregate unknown exit.
+- A missing state database is diagnosed on stderr and returns `EXIT_UNKNOWN`
+  without entering the async wait.
+- SIGINT or SIGTERM is installed by `run_async`. Interruption, or any result list
+  shorter than the watched-id list, returns `EXIT_RUNNING`; still-running work is
+  neither declared successful nor failed.
+- Any `not_found` or `unknown` outcome returns `EXIT_UNKNOWN`.
+- Otherwise, all `success=True` returns zero; any terminal unsuccessful outcome
+  returns one.
+- Human diagnostics do not share stdout with the machine line. The line may be
+  printed incrementally as each run becomes terminal rather than waiting for the
+  entire set.
+
+**Why this way**: stdout remains composable input for another process, while
+process exit gives a coarse aggregate for shell control flow. Stderr remains free
+to explain lookup and state problems without corrupting contract lines.
+
+### D5 — Transactional status vocabulary, terminal protection, and CAS
+
+Every ordinary status transition passes through `StateDB.update_status()`.
+
+**The contract** (`lionagi/state/db.py`):
+
+```python
+async def StateDB.update_status(
+    self,
+    entity_type: str,
+    entity_id: str,
+    *,
+    new_status: str,
+    reason_code: str,
+    reason_summary: str = "",
+    evidence_refs: list[dict[str, Any]] | None = None,
+    source: str = "executor",
+    actor: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+    expected_updated_at: float | None = None,
+    extra_fields: dict[str, Any] | None = None,
+    override: bool = False,
+    override_actor: str | None = None,
+    override_justification: str | None = None,
+) -> bool: ...
+```
+
+Allowed status sources are the closed set:
+
+```python
+frozenset({"executor", "agent", "admin", "system"})
+```
+
+**Exact semantics**:
+
+- Unknown source, reason code, entity type, new status, or same-row extra field is
+  rejected before the write.
+- `expected_statuses` is an optional membership guard. Include `None` to match SQL
+  NULL. A mismatch returns `False` without writing or auditing a rejection.
+- The row is selected inside the transaction; non-SQLite dialects add
+  `FOR UPDATE`.
+- If the previous status is terminal and the new status differs, an ordinary
+  write inserts `status_transition_rejected` into `admin_events`, commits that
+  audit record, then raises `TransitionRejectedError` after the transaction.
+- Rewriting the same terminal status is allowed. It may refresh reason metadata
+  and is not considered leaving terminal.
+- `override=True` requires both actor and justification. A valid repair inserts a
+  distinct `status_transition_override` admin event, then applies the write.
+- The SQL `UPDATE` repeats a NULL-safe previous-status predicate. A concurrent
+  status change therefore yields zero affected rows even if Python read the old
+  value first.
+- `expected_updated_at`, when provided, adds an optimistic version predicate. If
+  that guard loses, the method returns `False`; a concurrent writer owns the row.
+- Without the version guard, a zero-row CAS result is treated as an unexpected
+  storage race and raises `RuntimeError`.
+- Status, reason fields, allowed extra fields, `updated_at`, and the corresponding
+  `status_transitions` row are written in one transaction.
+- Only Session may currently write an extra status field, `ended_at`.
+
+**Why this way**: `li wait` can be stable only if terminal state cannot be silently
+rewritten. Storage-level guards close the race that a Python pre-check alone would
+leave, while explicit, attributed override preserves an operational repair path.
+
+## Consequences
+
+- Shell and Python consumers share one completion definition across four run
+  kinds.
+- Completed-empty, missing-artifact, cancelled, skipped, and failed outcomes
+  remain distinguishable even when their launching processes exited normally.
+- The frozen stdout grammar is a compatibility obligation. Adding or reordering a
+  field requires a new contract version or separate output mode.
+- Polling holds a process and issues repeated reads until terminal state. The
+  one-second default can load the database when many waiters watch many ids.
+- Strict terminal protection exposes legacy writers that attempted to overwrite
+  completed records; this is intentional evidence of a state-integrity defect.
+- Artifact presence and quality remain separate from completion. A consumer must
+  inspect the run manifest when its acceptance policy requires contents.
+- Reversing D1 or D5 is high cost because every consumer's trust in completion
+  would weaken. Replacing polling behind D2 is low contract cost only if D3 bytes,
+  ordering, and edge outcomes remain identical.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|-------|------|-------|
+| 1 | Add a subscription-backed wait implementation over the durable dispatch boundary and prove byte-for-byte equivalence with poll-backed output for every supported run kind. | M | (filled at issue-open time) |
+| 2 | Apply the same stdout-only machine-output discipline to orchestration commands that are consumed programmatically, with tests that route every advisory and provider diagnostic to stderr. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Treat process exit as completion
+
+This would be simple for shell callers and require no database. It lost because a
+normal exit can accompany completed-empty, cancelled, or recorded failure, and the
+observer may be a different process from the launcher.
+
+### Extend the human monitor line in place
+
+This would reuse an existing presentation and avoid another command. It lost
+because monitor output serves people, may include progress and styling, and does
+not provide a frozen one-line-per-terminal-run grammar.
+
+### Require consumers to query StateDB directly
+
+This would expose all record fields and avoid a polling wrapper. It lost because
+each consumer would duplicate kind resolution, terminal sets, backing-session
+relationships, unknown-reason handling, and output formatting. Schema evolution
+would become a consumer break rather than an adapter change.
+
+### Use one universal terminal and success vocabulary
+
+This would simplify the loop to `status in {completed, failed}`. It lost because a
+play succeeds at `merged`, a scheduled run can terminate at `skipped`, and a
+Session can terminate at `completed_empty`. Flattening those states would discard
+meaning or misclassify success.
+
+### Emit JSON Lines on stdout
+
+JSON would escape paths safely and include kind and success. It lost as the shipped
+compatibility format because the accepted contract is a compact tab-delimited
+line. A future alternate mode may add JSON but cannot silently replace D3.
+
+### Infer a valid reason from terminal status
+
+This would eliminate `reason=unknown` and give every line a neat reason. It lost
+because inference invents evidence. Persisted missing or invalid data must remain
+visible as unknown.
+
+### Verify artifact existence before reporting terminal
+
+This would keep consumers from receiving a missing directory. It lost because the
+completion record and artifact evidence are separate. A run can be terminal with
+missing artifacts, and that distinction must remain observable rather than hang
+the wait.
+
+### Allow terminal rewrites when the new value is also terminal
+
+This would make repairs convenient, for example failed to completed. It lost
+because downstream automation may already have acted on the first terminal value.
+Any such repair requires actor, justification, and a distinct audit event.
+
+### Protect terminal writes only in Python
+
+This would avoid a more complex SQL predicate. It lost because concurrent writers
+can change the row after the Python read. The repeated previous-status and optional
+`updated_at` predicates make the storage engine arbitrate the race.
+
+### Poll faster or slower by default
+
+A shorter interval improves latency and increases database load; a longer interval
+does the reverse. The shipped value is one second and no measurement or recorded
+rationale selects it. It remains caller-configurable rather than being presented
+as an optimized constant.
+
+## Notes
+
+This ADR defines the orchestration-facing completion read and the integrity floor
+it depends on. It does not take ownership of the broader persistence-state schema.

--- a/docs/adr/ADR-0036-casts-role-palettes-as-playstyle.md
+++ b/docs/adr/ADR-0036-casts-role-palettes-as-playstyle.md
@@ -1,0 +1,546 @@
+# ADR-0036: Casts Role Palettes as Playstyle
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0033
+
+## Context
+
+Casts supplies a closed built-in catalog of behavioral roles and modes, ordinary
+typed emission contracts, and pack overlays for model, effort, modes, and policy.
+It does not yet make role composition part of a play. Five problems require a
+target contract.
+
+**P1 — A play's collaboration style is implicit.** Current CLI planning exposes
+the full built-in role catalog plus user profiles to the orchestrator.
+`PlanningEngine` instead defaults to a fixed five-role tuple unless a caller
+supplies another roster. Playbooks describe prompts and runtime options but do not
+declare the intended role composition as play data. `lionagi/casts/pattern.py`,
+`lionagi/casts/catalog.py`, `lionagi/casts/pack.py`,
+`lionagi/engines/planning.py`, and `lionagi/cli/orchestrate/__init__.py` are the
+current anchors.
+
+**P2 — Static routing cannot deliberately recruit a role.**
+`role_node_builder()` resolves a `SpawnRequest` only against branches already in
+its role map. An unknown assignee fails closed. This preserves authority but gives
+an orchestrator no typed way to recruit a catalog role that was deliberately left
+outside the initial composition.
+
+**P3 — Behavioral role and delegation authority are conflated.** A casts role may
+emit ordinary typed findings or verdicts and always retain escalation, yet should
+not necessarily grow a live operation graph. Role name alone must not imply spawn
+authority.
+
+**P4 — Prompt guidance can contradict the capability grant.** Bare and fallback
+workers receive a leaf-only system prompt from
+`lionagi/cli/orchestrate/_common.py`. A later `grant_spawn()` appends the generic
+schema block produced by `render_capabilities_prompt()` but does not revoke the
+leaf sentence or explain the assignee and budget policy. Runtime enforcement wins,
+but valid behavior is needlessly hard for the worker to infer.
+
+**P5 — Dynamic recruitment creates authority and concurrency races.** Role
+expansion must be limited separately from operation count, must authorize the
+requester from trusted graph metadata, and must ensure two concurrent requests for
+the same new role provision once and consume one unit.
+
+Current source contracts that the target builds on are:
+
+```python
+@dataclass(init=False, frozen=True, slots=True)
+class Role(Pattern):
+    name: str
+    description: str
+    body: str = ""
+    emits: tuple = ()
+    artifact_defaults: dict | None = None
+
+@dataclass(frozen=True, slots=True)
+class RoleConfig:
+    model: str | None = None
+    effort: str | None = None
+    default_modes: tuple[str, ...] = ()
+    modes_allow: tuple[str, ...] = ()
+    active: bool = True
+```
+
+`Role.load()` and `Mode.load()` fail with the available canonical names;
+`list_roles()` and `list_modes()` enumerate the closed built-in modules. Pack
+`active` is an overlay for ordinary roster membership, not a per-play authority
+grant.
+
+| Concern | Decision |
+|---------|----------|
+| Play composition | D1: every new play declares a non-empty typed role palette and expansion policy. |
+| Initial planning and provisioning | D2: palette roles are assignable immediately; catalog roles outside it are expansion-only and pass one resolver. |
+| Live role expansion | D3: an awaitable router authorizes, reserves, provisions, and atomically publishes new role routes. |
+| Authority and budgets | D4: trusted requester identity, distinct-role budget, and operation spawn budget are separate and observable. |
+| Prompt and enforcement agreement | D5: one authoritative delegation clause is composed and replaced on grant/revocation. |
+| Checkpoint and compatibility | D6: palette state is persisted; legacy palette-free plays have a bounded compatibility path whose removal release is deferred. |
+
+Out of scope:
+
+- Operation admission after a candidate is built. ADR-0033 still owns cycle,
+  `max_spawn`, branch clone, edge, and dropped-admission behavior.
+- The contents of the built-in casts role and mode catalogs. This ADR selects from
+  them; it does not add role definitions.
+- Model-tier escalation. ADR-0038 owns stronger-route selection for an existing
+  responsibility.
+- Queue attempts and resident host recovery. ADR-0037 owns those bounds.
+- Automatic recruitment from user profiles. Profiles are not a closed catalog and
+  must be named in the initial palette.
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator operation
+    participant R as PaletteRoleRouter
+    participant C as Casts catalog
+    participant P as Branch provisioner
+    participant K as Reactive admission
+    O->>R: SpawnRequest + trusted requester role
+    R->>C: validate outside-palette role
+    R->>R: authorize and reserve distinct-role unit
+    R->>P: provision branch outside palette lock
+    P-->>R: branch or failure
+    R->>R: atomically publish route or roll back
+    R->>K: candidate Operation
+    K-->>O: accepted node or dropped ledger entry
+```
+
+## Decision
+
+### D1 — A play declares a typed role palette
+
+A role palette is part of playstyle. It is neither a fixed roster attached to a
+playbook kind nor ambient access to the full catalog.
+
+**The target contract** (`lionagi/orchestration/palette.py`):
+
+```python
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, Field, model_validator
+
+RoleDisposition = Literal["emission_capable", "terminal"]
+
+
+class PaletteRole(BaseModel):
+    role: str
+    disposition: RoleDisposition = "terminal"
+    modes: tuple[str, ...] = ()
+
+
+class PaletteExpansionPolicy(BaseModel):
+    max_new_roles: int = Field(default=0, ge=0)
+    orchestrator_may_expand: bool = True
+    catalog: Literal["casts"] = "casts"
+
+
+class PlayRolePalette(BaseModel):
+    roles: tuple[PaletteRole, ...]
+    expansion: PaletteExpansionPolicy = Field(
+        default_factory=PaletteExpansionPolicy
+    )
+
+
+class PaletteRouteRejection(BaseModel):
+    assignee: str
+    reason: Literal[
+        "unknown_catalog_role",
+        "requester_not_authorized",
+        "palette_budget_exhausted",
+        "role_provision_failed",
+    ]
+    detail: str = ""
+```
+
+Validation occurs before planning or worker-branch construction:
+
+1. `roles` must contain at least one item.
+2. Each `role` name is non-empty after stripping and is unique by canonical name.
+3. Each role is either a built-in casts role or an explicitly configured user
+   profile named in this initial palette.
+4. Every requested mode must exist in `list_modes()` and pass that role's pack
+   `modes_allow` rule.
+5. Duplicate modes within one palette role are rejected rather than silently
+   deduplicated.
+6. `max_new_roles` is non-negative by field validation.
+7. Expansion source is exactly `casts`; no path, module, or arbitrary provider is
+   accepted.
+
+**Exact semantics**:
+
+- Empty palette or any invalid entry rejects configuration as one Pydantic
+  validation failure. No worker branch, graph node, artifact directory, or budget
+  reservation is created.
+- `terminal` describes delegation authority only. It does not change operation
+  lifecycle, ordinary casts emission contracts, or universal escalation.
+- `emission_capable` grants `SpawnRequest` emission and participation in graph
+  growth under D3/D4. It does not bypass target-role or operation admission policy.
+- `max_new_roles=0` is the default and makes every outside-palette request reject,
+  even though `orchestrator_may_expand=True`. Expansion requires an explicit
+  positive budget.
+- Pack `active=False` may exclude a role from an ambient roster but does not
+  override an explicit initial palette entry. The play declaration is the scoped
+  authority; pack policy and model resolution still must succeed.
+
+**Why this way**: composition and authority become inspectable data. The closed
+catalog bounds automatic recruitment, while explicit initial entries retain the
+ability to use a profile without turning all profiles into an expansion source.
+
+### D2 — Palette-aware planning and initial provisioning
+
+Planning sees two role sets with distinct meaning: immediately assignable palette
+roles and expansion-only casts roles.
+
+**The target planner input shape**:
+
+```python
+class PalettePlanningContext(BaseModel):
+    assignable_roles: tuple[str, ...]
+    expansion_only_roles: tuple[str, ...]
+    max_new_roles: int
+    orchestrator_may_expand: bool
+```
+
+**Target module boundary**:
+
+```text
+lionagi/orchestration/
+├── palette.py          models, state, router protocol, validation
+├── patterns.py         static role builder and palette-aware planner adapter
+└── prompts.py          rendered palette roster and delegation clauses
+
+lionagi/cli/orchestrate/
+└── _orchestration.py   branch/model/artifact provisioner injected into router
+```
+
+**Exact semantics**:
+
+- Every initial palette role is provisioned at most once before graph execution
+  and entered in the run's role map, even when no initial assignment uses it. This
+  makes its declared authority and routing availability deterministic.
+- Planning output naming an initial palette role proceeds through ordinary
+  `TaskAssignment` validation.
+- Planning output naming a built-in expansion-only role is sent to the same
+  palette resolver used for live requests before the existing unknown-assignee
+  filter. A successful resolution provisions and publishes the role, then graph
+  construction continues.
+- Planning output naming an unknown catalog role rejects with
+  `unknown_catalog_role`; it is not silently reinterpreted as a profile.
+- Planning expansion is authorized as an orchestrator request. There is no model-
+  supplied requester field in `TaskAssignment`; the planner call site supplies
+  the trusted role.
+- Empty or unusable planning output retains the owning planner's failure behavior;
+  palette resolution does not fabricate an assignment.
+- Ordinary workers can name only roles already present in the palette state. They
+  cannot use a planning or live request to expand the authority set.
+- A role admitted during planning consumes the same distinct-role budget as a role
+  admitted during live execution.
+
+**Why this way**: the planner can express deliberate recruitment without receiving
+ambient authority to every role. Using one resolver prevents planned and live
+expansion from acquiring different authorization or accounting rules.
+
+### D3 — Awaitable, race-safe live role routing
+
+The current synchronous `role_node_builder()` remains the static-map
+implementation. Palette expansion uses a separate awaitable router because branch
+provisioning may perform provider and filesystem work.
+
+**The target contracts** (`lionagi/orchestration/palette.py`):
+
+```python
+class PaletteRoleRouter(Protocol):
+    async def __call__(
+        self,
+        request: SpawnRequest,
+        emitter: Operation,
+        requester_role: str,
+    ) -> Operation | PaletteRouteRejection: ...
+
+
+class PaletteSnapshot(BaseModel):
+    initial_roles: tuple[str, ...]
+    expanded_roles: tuple[str, ...] = ()
+    reserved_roles: tuple[str, ...] = ()
+    max_new_roles: int
+    consumed_new_roles: int = 0
+
+
+class PaletteRuntimeState:
+    role_routes: dict[str, Branch]
+    lock: asyncio.Lock
+    in_flight: dict[str, asyncio.Future[Branch]]
+    snapshot: PaletteSnapshot
+```
+
+The runtime state is an implementation object; `PaletteSnapshot` is the persisted
+contract.
+
+**Routing algorithm**:
+
+1. Normalize and read `request.assignee`. An omitted assignee uses the existing
+   emitter-role route and performs no role expansion.
+2. Under the palette lock, return an existing role route immediately when present.
+3. Reject an outside role absent from the casts catalog.
+4. Reject unless `requester_role == "orchestrator"` and
+   `orchestrator_may_expand` is true.
+5. If another request is provisioning the same role, capture its future, release
+   the lock, and await that result without reserving another unit.
+6. Otherwise reject when `consumed + len(reserved_roles) >= max_new_roles`.
+7. Reserve the canonical role and publish one in-flight future; release the lock.
+8. Provision the branch outside the lock.
+9. Reacquire the lock. On success, publish the route, move the role from reserved
+   to expanded, increment consumed once, and resolve all same-role waiters.
+10. On exception or cancellation, remove the reservation and in-flight entry,
+    resolve waiters with the same failure, and return `role_provision_failed`.
+11. Build the child operation through the ordinary allowlisted role-operation
+    builder and return it to ADR-0033 admission.
+
+**Exact semantics**:
+
+- Reusing an initial or previously expanded role consumes no new-role unit.
+- Two concurrent requests for the same outside role share one provision attempt
+  and consume at most one unit.
+- Two concurrent requests for different roles may provision concurrently after
+  each reserves a unit. The lock is never held across provider or filesystem I/O.
+- Failed provisioning consumes no unit and publishes no role route or partially
+  configured branch.
+- A branch is added to the route map only after all model, tool, mode, policy, and
+  artifact setup succeeds.
+- Router exceptions are converted to `role_provision_failed` with bounded,
+  non-sensitive detail; they do not escape as untyped executor errors.
+- The reactive executor awaits routing before entering its existing synchronous
+  `_accept_node()` lock. Palette locking and graph locking are never nested.
+- A trusted code caller using prebuilt `ReactiveExecutor.inject()` bypasses the
+  palette router, as it does today, but remains subject to graph admission. This is
+  an operator API, not model authority.
+
+**Why this way**: provisioning cannot safely occur while holding the graph's
+synchronous lock, and a synchronous router cannot represent it honestly. Separate
+reservation and commit phases bound authority while keeping slow work outside the
+critical section.
+
+### D4 — Trusted requester identity and two independent budgets
+
+Palette expansion and operation spawning are different resources.
+
+**The target metadata and ledger contracts**:
+
+```python
+# Trusted graph-builder metadata, never copied from model output.
+operation.metadata["requester_role"] = <canonical role name>
+
+# Palette rejection appended to the existing reactive dropped_spawns list.
+{
+    "reason": Literal[
+        "unknown_catalog_role",
+        "requester_not_authorized",
+        "palette_budget_exhausted",
+        "role_provision_failed",
+    ],
+    "assignee": str,
+    "emitter_id": str | None,
+    "detail": str,
+}
+```
+
+**Exact semantics**:
+
+- The graph builder stamps `requester_role` from the branch/role route it created.
+  `SpawnRequest.assignee`, `reason`, instruction text, and any structured context
+  cannot establish requester identity.
+- Missing trusted requester metadata is unauthorized for outside-palette
+  expansion. It is not treated as orchestrator by default.
+- `max_new_roles` counts distinct roles added to the palette. ADR-0033
+  `max_spawn` counts accepted operations. A request can consume a palette unit and
+  later be rejected by graph cap or cycle admission; the role remains available
+  because provisioning itself succeeded.
+- Conversely, an existing-role request consumes no palette unit but still consumes
+  one ordinary spawn admission when accepted.
+- Palette rejections join `dropped_spawns` with their specific reason. Existing
+  reasons (`builder_error`, `null_child`, `cycle`, `max_spawn_exceeded`,
+  `duplicate`) remain unchanged for their stages.
+- The default `max_new_roles=0` is a least-authority default. No empirical reason
+  selects another universal number, so plays choose their own explicit cap.
+
+**Why this way**: a role route expands who can perform work; an operation expands
+how much work runs. Combining the counters would let many new roles hide behind one
+operation or let one role exhaust recruitment by doing ordinary work.
+
+### D5 — One authoritative delegation clause in the prompt
+
+Capability prompts must agree with runtime enforcement without becoming the
+enforcement mechanism.
+
+**The target prompt contract** (`lionagi/orchestration/prompts.py`):
+
+```python
+def render_delegation_clause(
+    *,
+    role: str,
+    disposition: RoleDisposition,
+    allowed_assignees: tuple[str, ...],
+    may_expand_palette: bool,
+    remaining_new_roles: int,
+    remaining_spawns: int,
+) -> str: ...
+```
+
+**Exact semantics**:
+
+- A terminal role receives one leaf clause stating it cannot create graph work.
+  It may still emit its ordinary role results and `EscalationRequest`.
+- An emission-capable role receives one block naming spawn permission, currently
+  allowed assignees, whether outside-palette expansion is available, both budget
+  values, and the fact that rejected requests appear in the run ledger.
+- The block replaces any existing leaf or delegation clause using stable markers;
+  it does not append contradictory prose.
+- Granting spawn installs both the runtime Operable and the rendered clause.
+  Revocation removes the SpawnRequest grant and restores the terminal leaf clause.
+- A changing remaining-budget value need not rewrite the system message after
+  every spawn. The prompt states the value at turn construction and that runtime
+  state is authoritative.
+- Ignored or manipulated prompt text cannot expand authority. Schema validation,
+  requester metadata, router policy, and both budgets remain enforcement.
+
+**Why this way**: valid behavior should be discoverable. A single replaceable
+clause removes the current leaf-versus-grant contradiction while retaining hard
+checks below the prompt.
+
+### D6 — Persisted palette state and migration compatibility
+
+Checkpoints record enough state to resume without resetting recruitment authority
+or charging the same role twice.
+
+**The persisted contract** is `PaletteSnapshot` from D3 plus the original
+`PlayRolePalette` specification and ADR-0033's ordinary spawn counters.
+
+**Exact semantics**:
+
+- A checkpoint writes the declared initial palette, accepted expanded roles,
+  current reservations, maximum and consumed distinct-role counts, and the
+  operation spawn count in the same checkpoint boundary.
+- A clean checkpoint contains no reservations. If a process stops with a reserved
+  role, resume treats the reservation as uncommitted: it removes it and permits a
+  fresh provision attempt without incrementing consumed count.
+- Resume validates the saved palette against the current catalogs and pack before
+  accepting new work. Missing roles or now-invalid modes fail resume explicitly;
+  they are not silently dropped.
+- Expanded roles are reconstructed into the route map once. Their saved membership
+  is authoritative for budget accounting; reconstruction does not charge again.
+- A changed play specification whose palette or maximum differs from the
+  checkpoint is a resume conflict and requires a new run or an explicit migration.
+- User profiles remain valid only when present in `initial_roles`; an expanded role
+  must resolve from the casts catalog.
+
+**DEFERRED — palette-free compatibility cutoff**: legacy playbooks without a
+palette temporarily resolve to the current full planning roster and emit a
+deprecation warning. The removal release is not verified or decided in the current
+corpus. Implementers must set and document that compatibility window before making
+palette declarations mandatory; until then, new and migrated built-ins must
+declare palettes while legacy fallback remains explicit.
+
+**Why this way**: a restart must not restore a larger authority set or a fresh
+budget. Persisting declarative and consumed state makes replay deterministic; a
+partially provisioned branch is treated as uncommitted work.
+
+## Consequences
+
+- Plays can express narrow terminal pipelines, exploratory emitter-heavy teams,
+  and mixed collaboration styles using the same objective.
+- Delegation authority and recruitment spend become visible in data instead of
+  being inferred from role names or prompt prose.
+- Dynamic recruitment adds branch-provisioning failure, reservation cleanup, and
+  two-dimensional budget accounting. These are observable and testable but
+  materially expand orchestration state.
+- A catalog role can remain unavailable because model, tools, modes, or policy
+  cannot be resolved. Such failure occurs before route publication.
+- Persisted runs gain a compatibility obligation for palette snapshots and resume
+  conflicts.
+- The design gives up ambient access to every role and prompt-only flexibility. A
+  role named in prose cannot execute unless typed state and routing policy allow
+  it.
+- Reversing D1 or D4 is high cost because play data and checkpoint accounting
+  depend on them. Changing prompt rendering is lower cost as long as runtime
+  authority and stable markers remain.
+
+## Alternatives considered
+
+### Fixed role sets per playbook kind
+
+This would be easy to validate and document. It lost because collaboration style
+is a property of a play instance: two plays using the same operational template may
+need a narrow review pair or a broad exploratory team. A fixed set would push
+variation back into prose or new playbook kinds.
+
+### Expose the full casts catalog to every run
+
+This matches current CLI discoverability and eliminates recruitment failures. It
+lost because role availability becomes ambient authority and cost. A play cannot
+state or enforce a narrow collaboration boundary.
+
+### Use pack `active` as the palette
+
+This would reuse an existing boolean. It lost because `active` is a reusable pack
+overlay, not per-play composition, and carries neither disposition, modes, nor a
+distinct-role expansion budget.
+
+### Infer spawn authority from role name
+
+This would avoid `RoleDisposition`; orchestrators and coordinators could spawn,
+other roles could not. It lost because behavioral identity and delegation policy
+change independently. A researcher may be allowed to decompose one play and be a
+terminal specialist in another.
+
+### Let any worker recruit any catalog role
+
+This would maximize adaptive collaboration. It lost because every emission-capable
+worker could expand the authority set and consume provider setup without an
+orchestrator decision. Ordinary workers are limited to already-published routes.
+
+### Provision every catalog role at startup
+
+This would make routing synchronous and eliminate provision races. It lost because
+unused roles would still incur model, tool, prompt, branch, and artifact setup, and
+the runtime would possess more configured capability than the play declared.
+
+### Hold one lock across reservation and branch provisioning
+
+This would make the algorithm easy to reason about. It lost because provider and
+filesystem work would serialize all palette requests and risk blocking unrelated
+role lookups. Reservation plus an in-flight future preserves correctness without
+holding the lock across I/O.
+
+### Reuse the synchronous `role_node_builder()` for expansion
+
+This would avoid a second interface. It lost because the existing builder assumes a
+complete static role map and cannot await branch provisioning. Making it sometimes
+async would also break ADR-0033's current synchronous node-builder contract.
+
+### Combine `max_new_roles` with `max_spawn`
+
+This would expose one intuitive budget. It lost because distinct authority growth
+and operation volume are not interchangeable. A reused role should not spend a new-
+role unit, and a newly provisioned role can exist even if its first operation loses
+graph admission.
+
+### Trust a model-emitted requester field
+
+This would make routing self-contained. It lost because the requester could claim
+to be the orchestrator. Identity comes from the operation/branch construction path,
+not the payload being authorized.
+
+### Keep the generic capability schema block as the only prompt guidance
+
+This would avoid prompt-specific rendering. It lost because schema alone does not
+resolve the current contradiction with the leaf instruction and does not explain
+assignee or budget policy.
+
+### Automatically expand user profiles
+
+This would make custom workers as flexible as built-ins. It lost because profiles
+are not a bounded, centrally enumerable authority source. They remain available by
+explicit initial declaration.

--- a/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
+++ b/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
@@ -1,0 +1,558 @@
+# ADR-0037: Resident Engine Host and Task Queue
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0098; extends ADR-0033, ADR-0034
+
+## Context
+
+Long-running orchestration needs a structured way to receive work, isolate
+concurrent tasks, report boundary state, and recover from process loss. The current
+engine layer can accept a caller-provided Session, and a Session may run more than
+one graph sequentially, but no `TaskSource`, `SummaryStore`, or resident host exists
+under `lionagi/` or `tests/`.
+
+Six concrete problems define the target.
+
+**P1 — Work acquisition is not a flow-control operation.** `Branch.control()`
+steers an existing operation's control flow, while ADR-0033 reactive spawn admits a
+new operation to an already-running graph. Neither claims a new queued task with a
+lease and attempt number.
+
+**P2 — Concurrent tasks cannot safely share a Session.** Branch ownership,
+observer traffic, message history, operation ids, run budgets, and lifecycle
+signals are Session-scoped. Sharing one Session would let one task observe or
+mutate another task's state.
+
+**P3 — A process crash needs a durable recovery owner.** In-memory task groups can
+cancel cleanly but cannot prove whether abandoned work should be retried. Atomic
+claim plus lease allows another host to recover after expiry without pretending
+execution is exactly once.
+
+**P4 — Flow completion, summary persistence, and queue acknowledgement form an
+ordered boundary.** A queue item must not be marked complete before its durable
+summary is written. A partial or failed summary must remain distinguishable from a
+complete one.
+
+**P5 — Poison work needs a global attempt ceiling.** A host-local retry counter
+resets on restart and permits an infinite cross-process loop. Attempt accounting
+and terminal/dead-letter disposition belong to the queue.
+
+**P6 — The seam is only justified if the repository exercises it.** Protocols with
+no in-tree source and summary implementation merely move integration names. The
+first version must ship a real implementation used by end-to-end tests.
+
+The resident host is valuable for lease, isolation, summary, and host lifecycle
+contracts, not primarily import-time savings. It stays above ADR-0033: it claims a
+Task and awaits a flow or engine; it does not execute graph nodes itself.
+
+| Concern | Decision |
+|---------|----------|
+| Queue and summary ports | D1: introduce typed `TaskSource` and `SummaryStore` protocols plus frozen payload models. |
+| Claim, lease, and acknowledgement | D2: claim has one winner; completion/failure are lease-guarded and idempotent; the queue owns attempts and terminal disposition. |
+| Host isolation and concurrency | D3: one bounded host task group creates a fresh Session and explicit working directory per claimed Task. |
+| Flow-to-summary ordering | D4: normal flow return writes a complete summary before queue completion; every non-complete path marks pending and fails the task. |
+| Crash, deadline, and restart | D5: leases provide at-least-once recovery; watchdogs bound live tasks; memory pressure stops claims and drains. |
+| Implementations and extensions | D6: ship an in-tree exercised implementation; external durable adapters depend only on the two ports. |
+
+Out of scope:
+
+- Operation scheduling within one task. ADR-0033 remains the execution kernel.
+- Engine reaction topology and agent budgets. ADR-0034 remains the domain-policy
+  owner.
+- Model-tier escalation inside a flow. ADR-0038 owns local escalation; this ADR
+  only maps final give-up to a Task failure.
+- A general state-store consolidation port. No verified method surface exists and
+  the persistence-state area owns that decision.
+- Exactly-once execution. A lease can expire after side effects but before
+  acknowledgement; operations and adapters must tolerate at-least-once recovery.
+- A first-version lease-renewal protocol. Deadline compatibility replaces renewal
+  in D2.
+
+```mermaid
+flowchart TD
+    Q[TaskSource] -->|claim Task + lease| H[Resident host]
+    H --> S1[Fresh Session A]
+    H --> S2[Fresh Session B]
+    S1 --> E1[Engine or observed flow]
+    S2 --> E2[Engine or observed flow]
+    E1 --> M[Host-authored facts]
+    E2 --> M
+    M --> SS[SummaryStore]
+    SS -->|write succeeds| C[TaskSource.complete]
+    E1 -->|failure/deadline/give-up| F[mark_pending + TaskSource.fail]
+    E2 -->|failure/deadline/give-up| F
+```
+
+## Decision
+
+### D1 — Two narrow typed ports and their payloads
+
+The resident host depends on task acquisition/acknowledgement and summary storage,
+not on a particular queue or database.
+
+**The target contract** (`lionagi/orchestration/host.py`):
+
+```python
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class HostModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class Task(HostModel):
+    id: str
+    objective: str
+    cwd: Path
+    lease_id: str
+    lease_expires_at: datetime
+    attempt: int = Field(ge=1)
+    deadline: datetime
+
+
+class TaskResult(HostModel):
+    run_id: str
+    status: Literal["completed"]
+    summary_ref: str
+
+
+class TaskFailure(HostModel):
+    code: Literal[
+        "invalid_task",
+        "flow_failed",
+        "cancelled",
+        "deadline",
+        "summary_failed",
+        "escalation_give_up",
+    ]
+    detail: str
+    retryable: bool
+
+
+class TaskAck(HostModel):
+    applied: bool
+    rejection: Literal[
+        "missing_holder",
+        "stale_lease",
+        "attempt_ceiling",
+    ] | None = None
+
+
+class SessionSummary(HostModel):
+    facts: dict[str, Any]
+    narrative: str | None
+    manifest_ref: str
+
+
+class TaskSource(Protocol):
+    async def claim(self) -> Task | None: ...
+
+    async def complete(
+        self,
+        task_id: str,
+        lease_id: str,
+        result: TaskResult,
+    ) -> TaskAck: ...
+
+    async def fail(
+        self,
+        task_id: str,
+        lease_id: str,
+        failure: TaskFailure,
+    ) -> TaskAck: ...
+
+
+class SummaryStore(Protocol):
+    async def write(
+        self,
+        session_key: str,
+        summary: SessionSummary,
+    ) -> None: ...
+
+    async def mark_pending(
+        self,
+        session_key: str,
+        reason: str,
+    ) -> None: ...
+```
+
+**Validation semantics**:
+
+- All payloads reject unknown fields and are frozen after construction.
+- Task id, objective, and lease id must be non-empty after stripping.
+- `lease_expires_at` and `deadline` must be timezone-aware UTC datetimes. A naive
+  datetime is invalid rather than being interpreted in local time.
+- `deadline <= lease_expires_at` is required. The first protocol has no renewal,
+  so a lease shorter than the task's permitted lifetime is an invalid claim.
+- `attempt` starts at one and increases only when the queue reissues a Task.
+- `TaskResult.status` has one value. Non-complete outcomes use `TaskFailure`, not a
+  polymorphic result status.
+- `SessionSummary.facts` is host-authored machine data. `narrative` is optional
+  session-authored prose. `manifest_ref` identifies the durable run manifest.
+
+**Why this way**: the two ports match two independent durability responsibilities.
+The queue decides ownership and retry; the summary store decides durable evidence.
+Neither needs a Session or executor dependency.
+
+### D2 — Atomic claim, lease-guarded idempotent acknowledgement
+
+`claim()` is an atomic dequeue-and-lease operation with exactly one winner per
+attempt.
+
+**Normative TaskSource state machine**:
+
+```text
+queued(attempt=N)
+  --claim one winner--> leased(task_id, lease_id, attempt=N, expires_at)
+  --complete same lease--> completed
+  --fail retryable below ceiling--> queued(attempt=N+1)
+  --fail non-retryable--> terminal_failed
+  --fail retryable at ceiling--> dead_letter
+  --lease expires--> reclaimable queued(attempt=N+1) or dead_letter at ceiling
+```
+
+**Exact semantics**:
+
+- Claim returns `None` when no task is available. A polling source owns its own
+  wait/backoff; a blocking source may await delivery. The host must not infer that
+  `None` means shutdown.
+- A source never returns a Task whose lease is already expired. The host still
+  validates the timestamp defensively.
+- `complete()` and `fail()` compare both task id and lease id. Task id alone never
+  proves ownership.
+- First valid acknowledgement records the transition atomically and returns
+  `TaskAck(applied=True, rejection=None)`.
+- An exact replay with the same lease and equivalent payload returns the same
+  successful acknowledgement without repeating side effects.
+- A different payload after a terminal acknowledgement, or an acknowledgement from
+  an old/mismatched/expired lease, returns
+  `TaskAck(applied=False, rejection="stale_lease")`.
+- An unknown task or one with no retained holder/ack record returns
+  `TaskAck(applied=False, rejection="missing_holder")`.
+- A retryable failure at the configured global attempt ceiling is recorded as
+  dead-letter. The failure acknowledgement is applied, but the requested retry is
+  refused and reported as
+  `TaskAck(applied=True, rejection="attempt_ceiling")`.
+- Tasks at or above the ceiling are never returned by `claim()`.
+- The attempt ceiling is queue configuration shared by all hosts. This ADR does
+  not choose a universal numeric default because no workload evidence supports
+  one; an implementation must require or document its configured value.
+- Completion and failure do not extend or renew a lease. There is no renewal method
+  in protocol version one.
+
+**Why this way**: queue ownership must survive host restarts and concurrent
+claimers. A lease-id compare-and-set makes stale work visible, while idempotent
+acknowledgement allows safe retry after a lost response.
+
+### D3 — Bounded host task group and per-task Session isolation
+
+One host process may run several tasks, but every claimed Task receives independent
+run state.
+
+**The target host contract** (`lionagi/orchestration/host.py`):
+
+```python
+class ResidentEngineHost:
+    def __init__(
+        self,
+        *,
+        source: TaskSource,
+        summaries: SummaryStore,
+        max_concurrent_tasks: int,
+        session_factory: Callable[[], Session],
+        run_task: Callable[[Task, Session], Awaitable[dict[str, Any]]],
+        summarize: Callable[
+            [Task, Session, dict[str, Any]],
+            Awaitable[str | None],
+        ] | None = None,
+        should_stop_claiming: Callable[[], bool] | None = None,
+    ) -> None: ...
+
+    async def serve(self) -> None: ...
+
+    async def drain(self) -> None: ...
+```
+
+`max_concurrent_tasks` is required and must be at least one. There is no universal
+default because task cost varies materially by engine and provider.
+
+**Exact semantics**:
+
+- The serve loop never holds more than `max_concurrent_tasks` leases for active
+  host jobs. It does not prefetch unbounded queued work.
+- For each valid claim it calls `session_factory()` exactly once. No Session,
+  Branch, observer, engine-run counter, or operation graph is shared between
+  concurrent Tasks.
+- Immutable Engine configuration and process-level clients or connection pools may
+  be shared. Mutable `EngineRun` is created inside the Task's Session.
+- `cwd` must exist and be a directory before execution. Failure produces
+  `invalid_task`; the host does not create a missing task workspace implicitly.
+- Concurrent tasks do not call process-global `os.chdir()`. The Task cwd is passed
+  into Branch/tool/provider/workspace configuration explicitly.
+- A Task whose deadline is already reached fails with `deadline` before creating a
+  flow. A Task whose lease cannot cover its deadline fails with `invalid_task`.
+- Session creation or runner setup failure is `invalid_task` when caused by Task
+  data and `flow_failed` otherwise.
+- `run_task` must await the selected Engine or ADR-0033 observed-flow façade. The
+  host does not inspect or schedule individual graph nodes.
+- `should_stop_claiming()` true stops new claims but does not cancel active Tasks.
+  `drain()` awaits all active jobs and returns only after their cooperative ack
+  paths settle.
+- `serve()` cancellation stops claiming, cooperatively cancels active host jobs,
+  and lets D4 report `cancelled` when the process remains alive long enough. A hard
+  process loss is handled only by lease expiry.
+
+**Why this way**: Session is the isolation boundary already used by Branch,
+observer, and engine state. A process may safely amortize immutable setup without
+making concurrent tasks share conversational or scheduling state.
+
+### D4 — Summary-before-complete ordering
+
+Normal flow return is not queue completion until a complete summary is durably
+written.
+
+**Host-authored fact payload**:
+
+```json
+{
+  "task_id": "task-...",
+  "attempt": 1,
+  "run_id": "run-...",
+  "started_at": "UTC timestamp",
+  "ended_at": "UTC timestamp",
+  "elapsed_ms": 0.0,
+  "operation_statuses": {},
+  "artifact_refs": [],
+  "usage": {},
+  "degraded": false,
+  "degrade_reason": ""
+}
+```
+
+Fields unavailable for a runner are represented by empty objects/lists or null
+values defined by that adapter; the host never invents usage or artifact evidence.
+
+**Success sequence**:
+
+1. Await the Engine or observed flow to return normally.
+2. Read machine facts from recorded run state and manifest data.
+3. Optionally request one best-effort narrative turn.
+4. Construct `SessionSummary(facts=..., narrative=..., manifest_ref=...)`.
+5. `await SummaryStore.write(session_key, summary)`.
+6. `await TaskSource.complete(task.id, task.lease_id, TaskResult(...))`.
+7. Treat `TaskAck.applied=False` as an ownership loss, not as successful host
+   completion.
+
+**Failure sequence**:
+
+1. Classify the failure as `invalid_task`, `flow_failed`, `cancelled`, `deadline`,
+   `summary_failed`, or `escalation_give_up`.
+2. Best-effort `SummaryStore.mark_pending(session_key, reason)`.
+3. `await TaskSource.fail(task.id, task.lease_id, TaskFailure(...))`.
+4. Retain/log both a `mark_pending` error and an acknowledgement error; neither is
+   rewritten as completion.
+
+**Exact semantics**:
+
+- `SummaryStore.write()` is idempotent by `session_key`. Replaying the same summary
+  succeeds without duplicating it; a different summary for a completed key is a
+  conflict and raises.
+- `mark_pending()` is also idempotent and may update diagnostic reason while the
+  key remains non-complete. It never converts an existing complete summary back to
+  pending.
+- The default `session_key` is the durable `run_id`, not task id, because queue
+  retries create distinct run attempts.
+- Narrative failure is best-effort: facts and manifest can still be written with
+  `narrative=None`, and the Task may complete.
+- Failure to build facts, resolve the manifest, or write the complete summary is
+  `summary_failed`, retryable unless the adapter classifies the storage error as
+  permanent.
+- Flow failure, cooperative cancellation, watchdog expiry, or escalation give-up
+  never writes a partial summary as complete. Existing partial files remain
+  referenced only through pending state.
+- A queue completion acknowledgement lost after summary write is safe to retry:
+  both summary write and completion are idempotent by their keys.
+
+**Why this way**: the summary is the durable evidence promised by a completed
+TaskResult. Completing first creates a crash window in which the queue says done
+but no evidence can be found.
+
+### D5 — Deadline, crash recovery, and graceful memory-pressure restart
+
+Leases make task execution recoverable, not exactly once or free of interruption.
+
+**Exact semantics**:
+
+- Each host job installs a watchdog for `Task.deadline`. Expiry cancels the local
+  Engine/flow, drains run-owned tasks through their existing cleanup, marks summary
+  pending, and calls `fail(code="deadline", retryable=True)` while the lease is
+  valid.
+- Because `deadline <= lease_expires_at`, normal watchdog and failure reporting
+  have a lease-valid window. An adapter should include operational slack when
+  issuing the lease; the protocol does not prescribe a numeric slack value without
+  latency evidence.
+- If the process dies before acknowledgement, the queue reclaims only after lease
+  expiry and increments attempt. Any external side effect from the abandoned run
+  may already exist.
+- A stale host that later resumes cannot complete the new attempt because its old
+  lease id fails D2.
+- A host crash interrupts every active Task in that process. Other host processes
+  and future claims are independent.
+- Memory-pressure detection invokes `should_stop_claiming`, drains current jobs,
+  and exits for supervisor restart. It does not cancel unrelated Tasks merely to
+  reach a lower resident set faster.
+- The first protocol has no heartbeat or lease renewal. A Task whose legitimate
+  maximum deadline does not fit one lease must be rejected or split; silently
+  running past the lease is forbidden.
+
+**Crash matrix**:
+
+| Crash point | Durable state | Recovery |
+|-------------|---------------|----------|
+| Before claim commit | Task remains queued | Any host may claim. |
+| After lease, before Session creation | Lease held, no run | Reclaim after expiry. |
+| During flow | Lease held, partial effects possible | Reclaim after expiry; operations must tolerate retry. |
+| After summary write, before complete ack | Complete summary, Task still leased | Idempotent write and ack retry; otherwise reclaim can discover prior summary. |
+| After complete ack | Task completed | Exact ack replay is harmless; no further claim. |
+| During pending/fail path | Pending or absent summary, lease may remain | Idempotent mark/fail retry or lease reclaim. |
+
+**Why this way**: cross-process recovery needs durable ownership, while the
+operation layer cannot promise rollback of arbitrary tools and provider calls.
+Lease expiry plus idempotent boundaries is the honest at-least-once contract.
+
+### D6 — Exercised in-tree adapters and extension boundary
+
+The protocol pair ships only with a real in-tree implementation used by end-to-end
+tests.
+
+**Target module tree**:
+
+```text
+lionagi/orchestration/
+├── host.py                 contracts and ResidentEngineHost
+└── queue/
+    ├── __init__.py
+    └── local.py            in-tree TaskSource and SummaryStore implementation
+
+tests/orchestration/
+├── test_resident_host.py
+└── test_local_task_queue.py
+```
+
+**Required conformance cases**:
+
+- concurrent claimers yield one lease winner;
+- fresh Session per concurrent Task;
+- identical complete/fail retries are idempotent;
+- stale lease rejection after reclaim;
+- invalid cwd and lease-shorter-than-deadline rejection;
+- summary write happens before complete;
+- summary failure produces pending plus fail, never complete;
+- deadline cancellation and crash-style lease reclaim;
+- attempt ceiling dead-letters poison work;
+- stop-claiming drains without cancelling active Tasks.
+
+External durable adapters import the models and implement only `TaskSource` and
+`SummaryStore`. Product-specific queue clients do not enter core orchestration.
+
+A future steering adapter may retain a live executor reference for a claimed Task,
+but that does not change acquisition or acknowledgement and is not part of protocol
+version one.
+
+**Why this way**: an exercised local implementation proves the protocols support a
+complete host loop and gives adapter authors a behavioral reference. Keeping
+external clients behind the ports prevents host logic from depending on one queue.
+
+## Consequences
+
+- Queue ownership, task isolation, completion, and summary ordering become
+  explicit and testable.
+- A process can reuse expensive immutable clients while a Task crash remains
+  recoverable through its lease.
+- Host and queue provide at-least-once, not exactly-once, execution. Tool and
+  operation idempotency become more important for retried Tasks.
+- Long leases delay crash recovery; short leases increase stale-completion and
+  duplicate-execution risk. Version one requires the queue to size a lease for the
+  declared deadline rather than renew it.
+- Summary storage becomes part of the completion critical path. Its outage leaves
+  Tasks failed or retryable rather than falsely complete.
+- Reversing D1/D2 is high cost because external adapters depend on the models and
+  lease semantics. Changing host concurrency is configuration-only because it is
+  required rather than frozen to a universal default.
+
+## Alternatives considered
+
+### Share one Session across concurrent Tasks
+
+This would reuse branches and observer setup. It lost because histories, signals,
+budgets, and operation ids would interleave, and cancellation or cleanup for one
+Task could affect another. Process clients may be shared; Session state may not.
+
+### Start one subprocess per Task and use process exit as queue completion
+
+This gives strong memory isolation and simple cancellation. It lost as the queue
+contract because exit does not prove summary persistence or a semantic result and
+does not provide lease-guarded acknowledgement. A runner may still use a subprocess
+internally under the same host protocol.
+
+### Observe `RunEnd` instead of awaiting the owned flow
+
+This would make the host event-driven. It lost because the host already owns the
+awaitable, and an observed signal can race persistence/drain or be absent on a
+failure path. Awaiting defines lifetime; signals provide observation.
+
+### Add lease renewal in protocol version one
+
+Renewal would support unbounded tasks and shorter recovery windows. It lost for the
+first contract because it adds heartbeat races, holder fencing, and another method
+without a current implementation. Requiring lease expiry no earlier than deadline
+keeps version one closed and testable.
+
+### Use task id as the summary idempotency key
+
+This would put every attempt under one record. It lost because retries are distinct
+runs with distinct evidence. `run_id` keeps attempts inspectable while the queue
+links them through task id and attempt.
+
+### Mark queue complete before writing the summary
+
+This reduces acknowledgement latency and allows asynchronous summarization. It
+lost because a crash creates a completed Task with no promised evidence. Summary
+write is deliberately on the completion path.
+
+### Make session-authored narrative mandatory
+
+This would guarantee a readable report. It lost because one extra model turn can
+fail after otherwise complete, durable machine facts. Narrative is best-effort;
+facts and manifest are authoritative.
+
+### Let the host own retry count
+
+This would simplify queue adapters. It lost because host restart or another host's
+claim resets local state. Only the durable queue can enforce a global attempt
+ceiling.
+
+### Requeue poison work indefinitely
+
+This maximizes eventual-success chance. It lost because permanent invalid input or
+deterministic flow failure would consume capacity forever. A configured ceiling
+and dead-letter outcome make operator action explicit.
+
+### Put a specific durable queue client in the core package
+
+This would ship production connectivity immediately. It lost because queue client
+configuration and lifecycle would couple core orchestration to one external
+system. The target ships an in-tree reference implementation and narrow ports.
+
+### Define protocols without an in-tree implementation
+
+This would let external adapters proceed sooner. It lost because no end-to-end
+path would prove claim, summary, and ack semantics compose. Interfaces are accepted
+only with exercised behavior.

--- a/docs/adr/ADR-0038-escalation-tier-routing.md
+++ b/docs/adr/ADR-0038-escalation-tier-routing.md
@@ -1,0 +1,827 @@
+# ADR-0038: Escalation Tier Routing
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: orchestration
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0099; extends ADR-0033, ADR-0037
+
+## Context
+
+`EscalationRequest` is the universal typed escape hatch available to casts roles
+that emit structured results. The reactive executor already observes it, records
+the emitter id, and emits `NodeEscalated`. That substrate exists, but it does not
+yet perform tier routing. Six problems define the target.
+
+**P1 — `higher_tier` does not select a higher tier.**
+`ReactiveExecutor._schedule_escalation()` currently creates a child with the
+emitter's same operation name, copies its dictionary parameters, prefixes the
+instruction with `[escalation]`, and admits the child independently. It neither
+consults `node_builder` nor deliberately selects a stronger branch or model.
+Because the child has no explicit branch and is independent, branch allocation
+clones the Session default branch rather than the emitter's branch; that route may
+or may not use the emitter's model, but it is not a tier decision.
+`lionagi/operations/flow.py` is the governing anchor.
+
+**P2 — Route policy is hidden in an evidence map.** The shipped request has
+`reason`, `context`, `blocking`, and `from_role` fields. The executor reads
+`context["route"]`, accepting an untyped value and defaulting a missing key to
+`higher_tier`. `context` is otherwise described as evidence for a recipient, not
+as control policy. `lionagi/casts/emission.py` contains the current model.
+
+**P3 — Spawn and escalation have different authority.** A `SpawnRequest` asks to
+create a new responsibility and may select an assignee and operation. An
+escalation retries the emitter's existing responsibility through a configured
+stronger route. Reusing `role_node_builder()` would let spawn assignee policy and
+its monotonic `spawn-N` identity decide model-tier progression while leaving the
+escalation rung implicit. `lionagi/orchestration/patterns.py` defines the current
+spawn boundary.
+
+**P4 — Local retries need a hard bound independent of graph growth.** The
+ordinary `max_spawn` cap limits all accepted live nodes, but it does not state how
+many of them one escalation lineage may consume. A child that emits another
+`EscalationRequest` can currently repeat until the shared graph cap happens to
+stop it. Local tier progression needs its own lineage bound while still consuming
+the shared admission budget.
+
+**P5 — Routing failure and explicit give-up are not fully inspectable.** The
+current result exposes `escalated_operations` as a set-derived id list but does
+not record source tier, target tier, rung, accepted/rejected outcome, or the reason
+no route was available. `NodeEscalated.route` is a plain string, and emission is
+best-effort. A maintainer cannot reconstruct the routing decision from the final
+result alone. `lionagi/session/signal.py` and `lionagi/operations/flow.py` define
+the current observation surfaces.
+
+**P6 — A flow does not necessarily own a queue lease.** A resident host may need
+to translate terminal give-up into a failed Task attempt, while a library flow
+has no `TaskSource` to call. Direct queue access from the executor would make
+standalone flows depend on host infrastructure and duplicate the queue's global
+attempt accounting.
+
+The current contracts from which the target migrates are:
+
+```python
+# lionagi/casts/emission.py
+class EscalationRequest(BaseModel):
+    reason: str
+    context: dict = Field(default_factory=dict)
+    blocking: bool = True
+    from_role: str | None = None
+
+# lionagi/casts/pack.py — no ordered ladder exists today
+@dataclass(frozen=True, slots=True)
+class RoleConfig:
+    model: str | None = None
+    effort: str | None = None
+    default_modes: tuple[str, ...] = ()
+    modes_allow: tuple[str, ...] = ()
+    active: bool = True
+
+# lionagi/session/signal.py
+class NodeEscalated(Signal):
+    op_id: str = ""
+    name: str = ""
+    reason: str = ""
+    route: str = ""
+    escalation_request: Any = None
+
+# lionagi/operations/flow.py — reactive result additions
+{
+    "spawned_operations": int,
+    "escalated_operations": list[UUID],
+    "dropped_spawns": list[dict[str, Any]],
+}
+```
+
+| Concern | Decision |
+|---------|----------|
+| Request route | D1: `route` becomes a first-class closed field with an explicit legacy-context normalizer. |
+| Tier authority | D2: orchestration consumes prevalidated, preprovisioned tier branch templates through a separate synchronous builder. |
+| Local routing and bounds | D3: each lineage advances at most two configured rungs and every child re-enters the common admission chokepoint. |
+| Observation and results | D4: an append-only typed attempt ledger and additive signal fields expose requested route, resolved route, tiers, rung, and outcome. |
+| Host handoff | D5: the executor returns terminal give-up; only a resident-host adapter may translate it to queue failure. |
+| Migration and integration | D6: Session, streaming, Engine, CLI, and legacy producers receive one additive compatibility path with explicit removal work. |
+
+Out of scope:
+
+- Defining which concrete model is objectively stronger. The selected role-pack
+  order is the authority; orchestration validates structure and progression, not
+  benchmark quality.
+- General role composition or recruitment. ADR-0036 owns who may join a play;
+  escalation retains the emitter's responsibility and role.
+- Operation-graph scheduling, cycle checks, branch cloning, and the shared spawn
+  cap. ADR-0033 owns the admission mechanism this ADR calls.
+- Queue leases and attempt disposition. ADR-0037 owns at-least-once recovery and
+  the global attempt ceiling.
+- Human approval routing and tool-permission escalation. Those are distinct
+  authorization paths; this ADR concerns typed operation-result escalation.
+
+```mermaid
+flowchart LR
+    E[Emitting Operation] --> Q[EscalationRequest]
+    Q --> N[Route normalizer]
+    N --> X[ReactiveExecutor]
+    X --> B[EscalationNodeBuilder]
+    B --> T[Preprovisioned tier templates]
+    B --> C[Candidate Operation]
+    C --> A[ADR-0033 admission]
+    X --> L[EscalationAttempt ledger]
+    X --> S[NodeEscalated]
+    L --> H[Optional resident-host adapter]
+    H --> TS[TaskSource.fail]
+```
+
+## Decision
+
+### D1 — First-class route with fail-closed legacy normalization
+
+`EscalationRequest` gains a typed route. `context` remains recipient evidence and
+new producers do not encode routing control inside it.
+
+**The target contract** (`lionagi/casts/emission.py`;
+`lionagi/orchestration/escalation.py`):
+
+```python
+EscalationRoute = Literal["higher_tier", "give_up"]
+
+
+class EscalationRequest(_EmissionModel):
+    reason: str
+    context: dict = Field(default_factory=dict)
+    blocking: bool = True
+    from_role: str | None = None
+    route: EscalationRoute = "higher_tier"
+
+
+class NormalizedEscalationRoute(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    route: EscalationRoute
+    source: Literal["field", "legacy_context", "default", "invalid_legacy"]
+
+
+def normalize_escalation_route(
+    request: EscalationRequest,
+) -> NormalizedEscalationRoute: ...
+```
+
+**Exact semantics**:
+
+- An explicitly supplied `request.route` is authoritative. A conflicting
+  `context["route"]` is retained as evidence but ignored for routing.
+- Pydantic's `model_fields_set` distinguishes an omitted route from an explicitly
+  supplied default. This is required because both otherwise read as
+  `"higher_tier"` after model construction.
+- When the field was omitted and the legacy context value is exactly
+  `"higher_tier"` or `"give_up"`, that value is honored with
+  `source="legacy_context"`.
+- When both field and legacy key were omitted, the route is `higher_tier` with
+  `source="default"`, preserving current producer behavior.
+- When the field was omitted but the legacy key is present with any other value,
+  normalization returns `give_up` with `source="invalid_legacy"`. An invalid
+  untyped value must not trigger a retry accidentally.
+- A first-class route outside the two-value `Literal` fails model validation
+  before reaching the executor because `_EmissionModel` also forbids unknown
+  fields.
+- `blocking` and `from_role` remain payload evidence. Neither grants routing
+  authority, selects a branch, nor changes the rung. Trusted role and tier come
+  from the emitter's operation metadata and registered tier templates.
+- Requests are still observed through both Session-bus delivery and settled-result
+  extraction. Recursive extraction retains the shipped depth-four defensive cap;
+  the source records no rationale for exactly four.
+- The same request object observed twice is processed once by identity. The
+  duplicate produces no second child, signal, or attempt row. Semantically equal
+  but separately constructed requests remain separate requests.
+- A request delivered while no reactive run is active is ignored, as today. A
+  request delivered during a run without a current emitter is recorded as an
+  orphan give-up under D4; it is never allowed to select an arbitrary operation.
+
+**Why this way**: route is control data and needs a closed schema. The compatibility
+normalizer preserves existing valid producers without allowing arbitrary legacy
+strings to become execution authority.
+
+### D2 — Separate builder over preprovisioned tier templates
+
+Escalation uses a dedicated synchronous builder. It does not reuse the spawn
+builder, inspect providers, load packs, or provision branches while the graph is
+mutating.
+
+**The target contracts** (`lionagi/orchestration/escalation.py`):
+
+```python
+from collections.abc import Mapping
+from typing import Protocol
+from uuid import UUID
+
+
+class TierBranchTemplate(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role: str
+    tier: str
+    branch_id: UUID
+    model: str
+    effort: str | None = None
+
+
+class EscalationRouteContext(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    emitter: Operation
+    request: EscalationRequest
+    role: str | None
+    current_tier: str | None
+    rung: int = Field(ge=0, le=2)
+
+
+class EscalationNodeBuilder(Protocol):
+    def __call__(
+        self,
+        context: EscalationRouteContext,
+        /,
+    ) -> Operation | None: ...
+
+
+def escalation_node_builder(
+    routes: Mapping[str, tuple[TierBranchTemplate, ...]],
+) -> EscalationNodeBuilder: ...
+```
+
+`routes` is the runtime projection consumed by orchestration. The agent-role
+configuration owner decides how a selected pack declares the ordered tiers. The
+orchestration setup adapter resolves that declaration into concrete branch
+templates before the flow starts.
+
+**Template validation semantics**:
+
+- Role and tier names must be non-empty after stripping. Role keys and each
+  role's tier names are unique after canonical normalization.
+- Each role has an ordered weak-to-strong tuple. “Higher” means the next item in
+  this configured tuple; orchestration never infers strength from provider name,
+  price, token limit, or model spelling.
+- Every `branch_id` must already exist in the Session and must identify a branch
+  provisioned with the declared model and effort fingerprint.
+- Adjacent templates must not have the same `(model, effort)` pair. A configured
+  tier name change without an execution-route change is rejected as a false bump.
+- The base operation's tier must occur in its role's tuple. Missing role or tier
+  metadata means the route is unavailable; model-emitted `from_role` is not used
+  as a fallback.
+- All templates reachable within `max_escalation_rungs` are provisioned before
+  execution. Provider, filesystem, mode, tool, policy, or branch setup failure
+  rejects orchestration setup before an operation runs.
+- A template branch is a clone source, not a shared mutable worker. ADR-0033's
+  admission path clones it for each accepted child and includes the clone in the
+  Session.
+
+**Builder semantics**:
+
+- The builder selects exactly the template after `current_tier`. It never skips a
+  configured rung to find an available provider.
+- It creates a new `Operation` with the same `operation` value as the emitter.
+  Every non-`instruction` entry from `emitter.request` is shallow-copied. The
+  instruction retains the shipped compatibility form:
+
+  ```text
+  [escalation] <request.reason>
+  Original: <original instruction or empty string>
+  ```
+
+- The child points at the selected template through `branch_id` and receives
+  trusted metadata:
+
+  ```python
+  {
+      "assignee": <emitter role>,
+      "model_tier": <target tier>,
+      "escalation_rung": <source rung + 1>,
+      "escalated_from": <emitter operation id as str>,
+      "escalation_id": "escalation-<full child operation UUID>",
+      "reference_id": "escalation-<full child operation UUID>",
+  }
+  ```
+
+- The full child UUID makes escalation identity collision-free without a second
+  mutable counter. `spawn_id` is never copied or minted: `spawn-N` remains owned
+  by `role_node_builder()`, while adapters use `escalation_id` for artifact and
+  persistence correlation.
+- `None` means no stronger configured route. It is a normal give-up outcome, not
+  an executor exception.
+- A builder exception is caught by the executor, logged, and converted to
+  `builder_error`. It neither fails unrelated graph nodes nor falls back to the
+  current branch.
+- The executor verifies that a returned child is an `Operation`, retains the
+  emitter's operation name, has a registered template branch, advances exactly
+  one rung, and names the selected tier before admission. A malformed child is a
+  `builder_invalid` give-up.
+
+**Why this way**: branch and provider setup can perform I/O and belongs before the
+run. The synchronous builder then performs a deterministic lookup and node
+construction without nesting provisioning work inside the graph lock.
+
+### D3 — Two local rungs, followed by common admission
+
+The root operation has escalation rung zero. Each accepted tier child increments
+that trusted metadata by one. A lineage may accept at most two escalation
+children.
+
+**The target executor and façade parameters**
+(`lionagi/operations/flow.py`; `lionagi/session/session.py`):
+
+```python
+class EscalationPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    max_escalation_rungs: int = Field(default=2, ge=0, le=2)
+
+
+class ReactiveExecutor(DependencyAwareExecutor):
+    def __init__(
+        self,
+        *args: Any,
+        spawn_type: type | None = None,
+        node_builder: Any = None,
+        escalation_builder: EscalationNodeBuilder | None = None,
+        max_spawn: int = 50,
+        max_escalation_rungs: int = 2,
+        spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
+        **kwargs: Any,
+    ): ...
+
+
+async def Session.flow(
+    self,
+    graph: Graph,
+    *,
+    context: dict[str, Any] | None = None,
+    parallel: bool = True,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    default_branch: Branch | ID.Ref | None = None,
+    alcall_params: Any = None,
+    on_progress: Any = None,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    escalation_builder: EscalationNodeBuilder | None = None,
+    max_spawn: int = 50,
+    max_escalation_rungs: int = 2,
+    executor_ref: dict[str, Any] | None = None,
+    on_branch_created: Callable[[Any], None] | None = None,
+    spawn_branch_setup: Callable[[Any, Any], None] | None = None,
+) -> dict[str, Any]: ...
+
+
+async def Session.flow_stream(
+    self,
+    graph: Graph,
+    *,
+    context: dict[str, Any] | None = None,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    default_branch: Branch | ID.Ref | None = None,
+    alcall_params: Any = None,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    escalation_builder: EscalationNodeBuilder | None = None,
+    max_spawn: int = 50,
+    max_escalation_rungs: int = 2,
+): ...  # yields FlowEvent
+
+
+async def EngineRun.run_dag(
+    self,
+    graph: Any,
+    *,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    escalation_builder: EscalationNodeBuilder | None = None,
+    max_spawn: int = 50,
+    max_escalation_rungs: int = 2,
+    max_concurrent: int = 5,
+    verbose: bool = False,
+    executor_ref: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+    spawn_branch_setup: Any = None,
+) -> dict[str, Any]: ...
+```
+
+The lower-level `flow()` and `flow_stream()` functions mirror their Session
+facades and forward the same two new arguments. No surface silently drops the
+escalation builder or chooses a different rung default.
+
+**Routing sequence**:
+
+```mermaid
+sequenceDiagram
+    participant O as Emitter operation
+    participant X as ReactiveExecutor
+    participant B as EscalationNodeBuilder
+    participant A as Locked admission
+    participant S as Session observer
+    O->>X: EscalationRequest
+    X->>X: normalize route; derive trusted role/tier/rung
+    alt explicit give_up or missing emitter
+        X->>X: append give-up attempt
+    else rung is already 2
+        X->>X: append rung_exhausted give-up
+    else no builder or no next template
+        X->>X: append route_unavailable give-up
+    else candidate requested
+        X->>B: EscalationRouteContext
+        B-->>X: child Operation or None
+        X->>A: _accept_node(child, independent=True)
+        A-->>X: accepted or rejected
+        X->>X: append attempt; schedule only if accepted
+    end
+    X-->>S: NodeEscalated with resolved outcome
+```
+
+**Exact semantics**:
+
+- `max_escalation_rungs` accepts only `0`, `1`, or `2`. Other values raise
+  `ValueError` before observer registration or graph execution.
+- The default two permits base → tier 1 → tier 2, then stops. It is the smallest
+  retained design that permits two demonstrably different stronger attempts while
+  placing a fixed ceiling on local cost. No measurement establishes two as an
+  optimal universal value; callers may lower it but may not raise it in this
+  contract.
+- A missing `escalation_rung` is zero. A non-integer, negative, or greater-than-two
+  metadata value is invalid trusted state and resolves to give-up with
+  `invalid_rung`; it is not clamped.
+- `route="give_up"` never calls the builder. `route="higher_tier"` calls it only
+  when there is an emitter, the rung is below the configured maximum, and a
+  builder is installed.
+- A missing builder, missing role/tier metadata, absent next template, builder
+  `None`, builder exception, or invalid child all resolve to give-up. The executor
+  never performs the current unqualified default-branch replay.
+- A valid child enters `_accept_node(..., independent=True)`, preserving shipped
+  escalation independence and `escalated_from` provenance. It is subject to the
+  same lock, graph insertion, completion event, acyclicity check, branch clone,
+  `spawn_branch_setup`, progress callback, and task group as every injected node.
+- An accepted escalation child increments the ordinary `spawned_operations`
+  count and consumes one `max_spawn` unit. Initial nodes still do not consume that
+  cap. The exact inherited default of 50 has no recorded workload rationale and
+  is not changed here.
+- The rung limit bounds depth, not breadth. Distinct request objects emitted by
+  one operation are distinct routing attempts and may each propose the same next
+  tier; their accepted children all consume the shared `max_spawn` budget. This
+  ADR does not introduce semantic request coalescing beyond shipped identity
+  de-duplication.
+- Admission rejection does not try a different tier. The candidate is not run,
+  and the attempt resolves to give-up with `admission_rejected`; the detailed
+  cycle or cap cause remains in the existing `dropped_spawns` ledger.
+- Accepted child execution failure follows ordinary operation failure semantics.
+  It is not automatically converted into another escalation; only a typed request
+  emitted by that child can request the next rung.
+- Cancellation while an accepted child is running follows ADR-0033 task-group
+  cleanup. No rung refund is performed because the operation was admitted and may
+  have produced effects.
+
+**Why this way**: lineage rungs bound repeated escalation; `max_spawn` bounds the
+whole live graph. Both checks are necessary because they protect different
+resources, and admission remains the sole graph-mutation authority.
+
+### D4 — Typed attempt ledger and additive signal details
+
+Every non-duplicate request processed during a running flow produces one attempt
+row, including requests that cannot identify an emitter.
+
+**The target contracts** (`lionagi/orchestration/escalation.py`;
+`lionagi/session/signal.py`):
+
+```python
+EscalationRoutingReason = Literal[
+    "explicit_give_up",
+    "invalid_legacy_route",
+    "orphan_request",
+    "invalid_rung",
+    "rung_exhausted",
+    "route_unavailable",
+    "builder_error",
+    "builder_invalid",
+    "admission_rejected",
+    "accepted",
+]
+
+
+class EscalationAttempt(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    emitter_id: str
+    child_id: str | None = None
+    source_tier: str | None = None
+    target_tier: str | None = None
+    rung: int | None = Field(default=None, ge=0, le=2)
+    requested_route: str | None = None
+    route_source: Literal[
+        "field", "legacy_context", "default", "invalid_legacy"
+    ]
+    route: Literal["higher_tier", "give_up"]
+    outcome: Literal["accepted", "rejected", "give_up"]
+    reason: EscalationRoutingReason
+    request_reason: str = ""             # model-supplied reason
+
+
+class NodeEscalated(Signal):
+    op_id: str = ""
+    name: str = ""
+    reason: str = ""                 # request.reason, retained
+    route: Literal["higher_tier", "give_up"] = "give_up"
+    escalation_request: Any = None
+    source_tier: str | None = None
+    target_tier: str | None = None
+    rung: int | None = None
+    outcome: Literal["accepted", "rejected", "give_up"] | None = None
+    routing_reason: str | None = None
+```
+
+The additive reactive result shape is:
+
+```python
+{
+    # existing reactive fields retained
+    "spawned_operations": int,
+    "escalated_operations": list[UUID],
+    "dropped_spawns": list[dict[str, Any]],
+
+    # new authoritative routing history
+    "escalation_attempts": list[EscalationAttempt],
+}
+```
+
+`reason` uses stable machine codes:
+
+| Condition | Resolved route | Outcome | Attempt reason |
+|-----------|----------------|---------|----------------|
+| Explicit valid `give_up` | `give_up` | `give_up` | `explicit_give_up` |
+| Invalid legacy route | `give_up` | `give_up` | `invalid_legacy_route` |
+| No current emitter | `give_up` | `give_up` | `orphan_request` |
+| Invalid trusted rung | `give_up` | `give_up` | `invalid_rung` |
+| Rung equals configured maximum | `give_up` | `give_up` | `rung_exhausted` |
+| Builder absent, route missing, or builder returns `None` | `give_up` | `give_up` | `route_unavailable` |
+| Builder raises | `give_up` | `give_up` | `builder_error` |
+| Builder returns an invalid child | `give_up` | `give_up` | `builder_invalid` |
+| Candidate fails graph admission | `give_up` | `rejected` | `admission_rejected` |
+| Candidate enters the task group | `higher_tier` | `accepted` | `accepted` |
+
+**Exact observation semantics**:
+
+- The attempt is appended before the `NodeEscalated` emission is scheduled. The
+  returned result is therefore authoritative even when a signal observer fails.
+- The in-process list contains frozen `EscalationAttempt` instances. Persistence
+  adapters serialize each with `model_dump(mode="json")`; they do not store
+  `repr()` output or an untyped exception object.
+- Attempt order is processing order. It is not graph order, completion order, or
+  tier order across parallel lineages.
+- `requested_route` preserves the normalized valid input. An invalid legacy
+  string is retained verbatim; a non-string invalid value is represented as
+  `None`. `route_source` records the compatibility path, and `route` is always
+  the closed, resolved control outcome.
+- `source_tier` is the trusted emitter tier when available. `target_tier` and
+  `child_id` are present only when the builder produced a validated candidate;
+  an admission-rejected candidate retains both for diagnosis.
+- `rung` is the emitter's current rung. Root operations use zero; orphan or
+  invalid-rung requests use `None`. An accepted child is stamped with `rung + 1`.
+- `request_reason` preserves the model-supplied explanation while `reason`
+  remains a stable machine code suitable for filtering and host policy.
+- `NodeEscalated.route` reports the resolved route, not merely the requested one.
+  A requested higher tier that cannot be built or admitted emits `give_up`.
+- `NodeEscalated.reason` preserves the model-supplied reason.
+  `routing_reason` carries the machine code from the attempt.
+- New signal fields are nullable/additive, so `SIGNAL_SCHEMA_VERSION` remains one
+  under the shipped version policy. A future removal or rename requires a bump.
+- `escalation_request` remains a named field rather than `Signal.data`; otherwise
+  the Session observer would match the same request again as a fresh payload.
+- Signal emission remains observational and best-effort: observer failure does not
+  replace the route result or cancel an accepted child. Persistence adapters must
+  use the result ledger as their reconciliation source.
+- `escalated_operations` retains compatibility as a de-duplicated emitter-id list.
+  It contains every processed attempt with a real emitter, including terminal
+  give-up and admission rejection. Its set-derived order is unspecified.
+- `spawned_operations` continues to count accepted nodes from both spawn and
+  escalation. Consumers needing the split count accepted rows in
+  `escalation_attempts`.
+- `flow_stream()` still yields operation `FlowEvent` values rather than attempt
+  rows. Selected-tier observation arrives through `NodeEscalated`; the final
+  non-streaming result remains the complete ledger.
+
+**Why this way**: one append-only typed record makes every routing branch
+reconstructable without turning observer delivery into control flow. Additive
+signal fields improve live visibility while preserving the existing envelope.
+
+### D5 — Give-up is returned to the owner, not sent to a queue by the kernel
+
+The executor terminates its responsibility at the result boundary. It never
+imports `TaskSource`, looks up a Task id, or acknowledges a lease.
+
+**Exact semantics**:
+
+- A standalone flow returns normally with its operation results and one or more
+  `EscalationAttempt(outcome="give_up" | "rejected")` rows. Give-up does not
+  manufacture an exception because partial sibling results remain useful.
+- A result consumer determines terminal give-up by inspecting the attempt ledger,
+  not by parsing operation prose or relying on eventual signal delivery.
+- The CLI adapter treats a give-up without the required result/artifact evidence
+  as an unsuccessful persisted run, preserving its existing escalation backstop.
+- A resident host may map terminal give-up to ADR-0037's:
+
+  ```python
+  TaskFailure(
+      code="escalation_give_up",
+      detail=<bounded attempt summary>,
+      retryable=<host policy>,
+  )
+  ```
+
+  It first marks the Session summary pending, then calls
+  `TaskSource.fail(task.id, task.lease_id, failure)` under the host's ordinary
+  failure ordering.
+- The host chooses `retryable` from Task policy and evidence. The model's
+  `blocking` field does not decide queue disposition.
+- ADR-0037's TaskSource owns the global attempt count and dead-letter ceiling.
+  A reissued Task begins a new flow and a fresh local rung count; its queue
+  attempt still increments globally.
+- An acknowledgement from a stale lease remains rejected by TaskSource. The
+  executor has no fallback queue write and does not retry acknowledgement.
+- Runs not owned by a resident host have no queue handoff. Returning the typed
+  give-up is complete behavior, not a missing integration.
+
+**Why this way**: local routing depth and cross-run retry count have different
+lifetimes and owners. The result boundary lets a host compose them without making
+the graph kernel lease-aware.
+
+### D6 — Compatibility migration and adapter parity
+
+The target lands as an additive public surface, with one deliberate behavior
+change: an unavailable higher tier gives up instead of silently repeating the
+same operation on an unqualified default-branch route.
+
+**Target module tree**:
+
+```text
+lionagi/
+├── casts/emission.py                  EscalationRequest.route
+├── orchestration/
+│   ├── escalation.py                 models, normalizer, builder protocol/helper
+│   └── __init__.py                   public escalation exports
+├── operations/flow.py                rung checks, builder call, attempt ledger
+├── session/
+│   ├── session.py                    façade pass-through
+│   └── signal.py                     additive NodeEscalated fields
+├── engines/engine.py                 run_dag pass-through
+└── cli/orchestrate/flow.py           route setup, templates, persistence projection
+
+tests/
+├── orchestration/test_escalation_builder.py
+├── operations/test_escalation_routing.py
+└── cli/orchestrate/test_escalation_tiers.py
+```
+
+**Compatibility and rollout semantics**:
+
+- Existing `EscalationRequest(reason=..., context={"route": ...})` producers are
+  accepted by D1. New examples, prompts, and tests use the first-class field.
+- **DEFERRED — legacy-context cutoff**: the release that stops consulting
+  `context["route"]` is not decided in this corpus. Before removal, maintainers
+  must publish the compatibility window and add a diagnostic for legacy use.
+- `escalation_builder=None` is accepted for API compatibility. A higher-tier
+  request then resolves to `route_unavailable` give-up; it never invokes the
+  shipped same-operation/default-branch replay path.
+- `max_escalation_rungs=2` is forwarded identically by `Session.flow()`,
+  `flow()`, `flow_stream()`, and `EngineRun.run_dag()`. A missing pass-through is
+  a contract defect, not an adapter default.
+- PlanningEngine and direct library users may omit tier routing. They continue to
+  run ordinary DAG and spawn behavior, but escalation gives up when no builder is
+  configured.
+- CLI or other configured adapters validate role ladders and provision reachable
+  tier branches before submitting the graph. Initial operations are stamped with
+  trusted `assignee`, `model_tier`, and `escalation_rung=0` metadata.
+- Escalation children receive `escalation_id` before admission. CLI
+  artifact/workspace setup must not infer a role-attributed child id after it has
+  run; the builder-supplied id drives branch setup, result projection, and
+  artifacts.
+- Persisted checkpoints include the attempt ledger and accepted child's tier/rung
+  metadata. Resume does not rerun an already accepted attempt merely because its
+  signal was absent.
+- Tests cover explicit and legacy route precedence, invalid legacy fail-closed,
+  missing emitter, missing builder, every builder outcome, exact one-rung
+  progression, two-rung exhaustion, shared spawn cap, branch-template cloning,
+  duplicate request identity, signal fields, streaming pass-through, and host
+  mapping without a kernel queue import.
+
+**Why this way**: the API can migrate without breaking construction of existing
+requests, while the unsafe part of the current behavior—calling the same route a
+“higher tier”—ends immediately when the target ships.
+
+## Consequences
+
+- A configured escalation can run the same responsibility on a genuinely
+  different `(model, effort)` route without granting arbitrary operation or role
+  selection.
+- Missing or broken routing becomes a typed give-up instead of an unresolved
+  same-operation/default-branch retry. Some runs that previously spent another attempt will now stop earlier;
+  that is the intended behavior change.
+- The executor gains a second builder interface and one append-only ledger, but it
+  does not gain pack, provider, filesystem, or queue dependencies.
+- Preprovisioning reachable tiers increases setup cost and Session branch count
+  even when no escalation occurs. It makes the live builder deterministic and
+  keeps I/O outside mutation locks.
+- The two-rung ceiling bounds one lineage but does not replace the shared
+  `max_spawn` cap or a host queue's global attempt ceiling.
+- A selected pack can misorder weak and strong models. The configuration owner is
+  accountable for model quality; orchestration can prove only that the route
+  changed and advanced in declared order.
+- Result consumers gain exact routing history. Signal-only consumers still need
+  reconciliation because `NodeEscalated` remains observational and best-effort.
+- Reversing D1 or D4 is high cost once producers and persistence depend on the
+  typed route and ledger. Replacing the template source is moderate cost because
+  the executor depends only on the builder protocol and runtime projection.
+
+## Alternatives considered
+
+### Keep the same-operation instruction retry
+
+This preserves the current operation copy, default-branch allocation, and prompt
+prefix without new setup. It can help when the extra instruction or default
+branch changes behavior. It lost because it does not satisfy the meaning of
+`higher_tier`, proves no stronger capability, and can spend multiple spawn units
+on an unchanged failure condition. If a caller wants a retry, it should be named
+and budgeted as retry policy rather than reported as tier escalation.
+
+### Reuse `node_builder` and `role_node_builder()`
+
+This would avoid another callback and reuse branch routing already exercised by
+reactive spawn. It lost because that builder consumes `SpawnRequest`, selects an
+assignee and operation, allocates `spawn-N`, and has no source-tier or rung input.
+Adding escalation policy to it would couple new-work delegation and same-work
+capability progression while making their ledgers ambiguous.
+
+### Let the executor read Pack and build the higher-tier Branch
+
+This would make escalation self-contained and allow lazy provisioning only when
+needed. It lost because provider and filesystem setup can block or fail, Pack is a
+configuration concern above the kernel, and the executor would gain dependencies
+on model resolution, tools, modes, policy, and artifacts. Prevalidated branch
+templates keep that coupling outside the graph mechanism.
+
+### Infer tier order from provider or model names
+
+This would avoid a new ordered configuration: larger version numbers, “pro”, or a
+price table could imply strength. It lost because names and prices do not define
+capability across providers, change over time, and cannot express a role-specific
+preference. The selected configuration must state the order explicitly.
+
+### Provision a higher tier asynchronously inside the routing callback
+
+This would avoid paying setup cost for unused tiers. It lost for the first
+contract because the shipped live builder is synchronous, provider/filesystem I/O
+must not run under or adjacent to the mutation critical section, and cancellation
+would create partially published routes. A later ADR may introduce an awaitable
+reservation/provision protocol if measurements justify it.
+
+### Permit unbounded local rungs
+
+This maximizes the chance that some stronger model completes the work. It lost
+because a misconfigured ladder or repeatedly escalating model can consume the
+entire graph budget and provider spend. Two accepted transitions preserve a small
+base/stronger/strongest ladder while guaranteeing local termination.
+
+### Use only `max_spawn` as the escalation bound
+
+This exposes one counter and already prevents infinite graph growth. It lost
+because unrelated spawned work can change how many escalation retries a lineage
+receives, and one lineage can consume all remaining live-node capacity. The
+lineage rung and graph cap are independent limits.
+
+### Use one counter for local rungs and queue attempts
+
+This would expose a single end-to-end retry budget. It lost because a flow-local
+counter disappears with the process while a queue attempt must survive leases and
+host restarts. Combining them either makes the kernel queue-aware or makes global
+accounting non-durable.
+
+### Call `TaskSource.fail()` directly from the executor
+
+This would make give-up automatically retry in hosted deployments. It lost because
+many flows have no Task or lease, summary-before-fail ordering belongs to the
+resident host, and stale-lease handling cannot be implemented from an Operation.
+Typed return plus an adapter preserves both standalone and hosted semantics.
+
+### Signal only, without an attempt ledger
+
+This minimizes result size and reuses `NodeEscalated`. It lost because signal
+delivery is best-effort, current signal fields do not identify selected tiers or
+admission outcome, and persisted consumers need a deterministic reconciliation
+source after restart.
+
+## Notes
+
+The local maximum of two is a deliberate safety ceiling inherited from the
+superseded proposal, not an empirically optimized model-routing constant. The
+target keeps it caller-lowerable and records the absence of measurement rather
+than presenting the number as universal tuning guidance.

--- a/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
+++ b/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
@@ -1,0 +1,559 @@
+# ADR-0041: Agent specification and Branch construction boundary
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: agent-roles
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0078, v0-0100
+
+## Context
+
+LionAGI needs a reusable description of an agent without forcing description-time code to open
+files, resolve credentials, construct an API provider, discover remote tools, or allocate a live
+conversation. It also needs one place where that description becomes a fully wired `Branch`.
+The shipped implementation divides those responsibilities between `AgentSpec` and
+`create_agent()`.
+
+This ADR answers six concrete problems.
+
+**P1 — Identity and runtime state have different lifetimes.** A casts `Role` and ordered
+`Mode` set can be inspected, validated, serialized in part, and reused without a provider.
+A `Branch` owns live message, action, model, logging, capability, observer, memory, and context
+state. Treating the declarative input as the live agent would make composition perform I/O and make
+reuse dependent on construction order.
+
+**P2 — Role-backed construction has cross-cutting wiring.** Provider selection, effort translation,
+trusted settings, the Lion system preamble, built-in tools, MCP discovery, and emission grants must
+agree. If every caller performs those steps independently, prompt order and granted capability
+sets drift.
+
+**P3 — prompt and emission overrides need three-state semantics.** The prompt has four ordered
+sources. Emission selection distinguishes “use the Role declaration,” “replace it,” and “grant
+nothing.” Collapsing `None` and an empty tuple would remove a useful denial state.
+
+**P4 — raw prompt workers are legitimate but are not casts agents.** CLI orchestration supports
+bare workers and external prompt profiles. They have no `Role` to compose and therefore cannot
+implicitly acquire a Role emission contract. Their direct `Branch` construction is an explicit
+escape hatch, not a second Role-backed factory.
+
+**P5 — two unrelated facilities currently use “context” language.** The
+`AgentSpec.context_management` flag controls the coding toolkit's `context` tool and a one-line
+prompt hint. Pre-turn `ContextProvider` registration and execution live on `Branch` and chat/run
+operation preparation. Setting the agent flag does not configure, disable, or populate the provider
+registry.
+
+**P6 — the current boundary leaks mutation and has incomplete export and interception coverage.**
+Settings hooks and permission hooks are appended to the passed `AgentSpec` during construction.
+Reusing one instance can therefore duplicate handlers. The YAML writer omits several serializable
+fields. MCP tools are discovered after built-in tool interception and do not receive the resolved
+permission preprocessor.
+
+The as-built dependency direction is:
+
+```text
+casts Pattern/Role/Mode
+          │
+          ▼
+   casts Profile
+          │
+          ▼
+      AgentSpec                 Branch.providers
+   (declared intent)        (pre-turn live registry)
+          │                         ▲
+          ▼                         │
+     create_agent ───────────────► Branch
+  settings/provider/tools/         live conversation
+  prompt/MCP/capability grants
+```
+
+| Concern | Decision |
+|---|---|
+| Declarative agent contract | D1: `AgentSpec` owns Role-backed identity and requested runtime intent, not live state. |
+| Materialization boundary | D2: `create_agent()` is the canonical Role-backed path for I/O, Branch allocation, tools, and grants. |
+| Prompt and emission composition | D3: Prompt sources are ordered and emission selection keeps its three distinct states. |
+| Raw-prompt construction | D4: Direct `Branch` construction is a visible non-casts escape hatch with no implicit Role grants. |
+| Pre-turn context | D5: `ContextProviderRegistry` remains Branch/operations state; `context_management` is only a coding-tool switch. |
+| Persistence and reuse | D6: The current YAML and construction mutation are recorded as shipped limitations, not treated as intended completeness. |
+
+This ADR does not decide:
+
+- How per-role model, effort, modes, and external-profile precedence should be resolved. That target
+  belongs to ADR-0043.
+- How prompt directives are renamed or executable permission interception becomes complete. That
+  target belongs to ADR-0044.
+- The internal ranking, budgeting, or writeback behavior of context providers. This ADR records
+  only their ownership boundary because the full mechanism belongs with messages and operations.
+- Provider endpoint selection and rate limiting beyond the inputs that the factory consumes.
+- Session-level hook ownership. ADR-0047 records those scopes.
+- Branch lifecycle after construction, including chat, operate, persistence, and orchestration
+  scheduling.
+
+## Decision
+
+### D1 — `AgentSpec` is a declarative Role-backed runtime request
+
+`AgentSpec` contains a casts `Profile` plus requested runtime choices. It is not a provider, tool
+registry, capability registry, or conversation.
+
+**The contract** (`lionagi/agent/spec.py`):
+
+```python
+@dataclass
+class AgentSpec(HooksMixin):
+    profile: Profile
+    model: str | None = None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()
+    permissions: PermissionPolicy | None = None
+    grant_emissions: bool = True
+    emits: tuple | None = None
+    pack: str | Pack | None = "default"
+    lion_system: bool = True
+    extra_prompt: str | None = None
+    hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
+    cwd: str | None = None
+    yolo: bool = False
+    mcp_servers: list[str] | None = None
+    mcp_config_path: str | None = None
+    context_management: bool = True
+
+    @classmethod
+    def compose(
+        cls,
+        role: Any,
+        *,
+        modes: list[Any] | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        tools: tuple[str, ...] | list[str] = (),
+        permissions: Any = None,
+        pack: str | Pack | None = "default",
+        grant_emissions: bool = True,
+        emits: tuple | None = None,
+        system_prompt: str | None = None,
+        cwd: str | None = None,
+        yolo: bool = False,
+    ) -> AgentSpec: ...
+```
+
+`compose()` creates `Profile.compose(role, modes=...)`, resolves the permission representation,
+copies `tools` to a tuple, stores `system_prompt` as `extra_prompt`, and returns. It does not
+load settings, inspect MCP files, instantiate `iModel`, or allocate `Branch`.
+
+Permission inputs accepted at this boundary are:
+
+| Input | Stored result |
+|---|---|
+| `None` | `None` |
+| existing `PermissionPolicy` | same object |
+| `dict` | `PermissionPolicy.from_dict(dict)` |
+| `"safe"`, `"read_only"`, `"allow_all"`, `"deny_all"` | corresponding preset |
+| unknown string | `ValueError` listing valid presets |
+| any other type | `TypeError` |
+
+Hook declaration is mutable builder syntax on the spec:
+
+```python
+spec.pre(tool_name, handler)       # key "pre:<tool_name>"
+spec.post(tool_name, handler)      # key "post:<tool_name>"
+spec.on_error(tool_name, handler)  # key "error:<tool_name>"
+```
+
+Each method appends in declaration order and returns the same spec for chaining.
+
+**Exact semantics.**
+
+- Empty `tools` means no agent-factory tools are registered. It does not mean “all tools.”
+- `pack=None` disables the directives block. `pack="default"` loads the packaged pack and raises
+  if that resource cannot be loaded. A non-default string is not a file path here; it resolves to
+  no pack and therefore renders no directives. A caller must pass a `Pack` object for a custom
+  pack.
+- `system_prompt=""` is normalized to `None` by `compose()`.
+- `mcp_servers` and `mcp_config_path` are model fields but are not accepted by `compose()`; callers
+  set them on the returned spec or construct the dataclass directly.
+- `AgentSpec.coding()` fixes Role `implementer`, effort default `"high"`, and tool request
+  `("coding",)`. With `secure=True` it appends destructive-command and workspace path guards.
+- The spec is mutable. “Declarative” describes its responsibility, not frozen value semantics.
+
+**Why this way.** A value-like request separates inspectable identity from external effects while
+remaining Python-native: Role and Mode objects, model classes, permission objects, and callables do
+not need a second configuration language. A fully frozen spec was not shipped because hook builder
+methods and coding preset adjustment currently mutate fields.
+
+### D2 — `create_agent()` is the Role-backed materialization boundary
+
+Role-backed callers use the asynchronous factory. It is the only shipped construction path that
+both composes the casts prompt and grants the resulting Role emission contract.
+
+**The contract** (`lionagi/agent/factory.py`):
+
+```python
+async def create_agent(
+    config: AgentSpec,
+    *,
+    load_settings: bool = True,
+    project_dir: str | None = None,
+    trust_project_settings: bool = False,
+    trusted_hook_modules: set[str] | frozenset[str] | None = None,
+    chat_model: Any = None,
+    log_config: Any = None,
+) -> Branch: ...
+```
+
+The materialization sequence is normative as-built behavior:
+
+```text
+1. optionally load settings and append trusted hooks to the passed spec
+2. accept chat_model, or parse spec.model and construct iModel
+3. allocate Branch
+4. compose and install the system message
+5. append PermissionPolicy as "security_pre:*" on the passed spec
+6. register requested built-in/coding tools and attach their hooks
+7. discover and register MCP tools
+8. grant the resolved emission Operable, when non-empty
+9. return Branch
+```
+
+Provider construction translates `provider/model` strings through `parse_model_spec()`. Explicit
+`chat_model` wins. Otherwise, if `spec.model` is absent, the factory supplies no model keyword and
+`Branch` applies its own default. Provider-specific effort and yolo keyword maps are used only when
+the provider supports them. CLI providers receive the placeholder API key their subprocess
+transport expects; API providers must resolve real credentials.
+
+Settings trust is two-dimensional:
+
+- Global `~/.lionagi/settings.yaml` may load when `load_settings=True`.
+- Project settings are included only when `trust_project_settings=True`.
+- Python hook imports are restricted to `trusted_hook_modules`; the default set contains only
+  `lionagi.agent.hooks`.
+- An untrusted configured module raises `PermissionError`. An absent or unresolvable trusted
+  function is skipped by the settings resolver.
+
+Settings hook input has this shipped shape (`lionagi/agent/settings.py`):
+
+```yaml
+hooks:
+  pre|post|on_error:
+    <tool-name>:
+      - "trusted.module:function"
+      - python: "trusted.module:function"
+      - command: ["executable", "arg", "{argument_key}"]
+```
+
+A single mapping/string may be supplied instead of the per-tool list and is normalized to a
+one-item list. Python import paths without `:` and trusted modules/functions that cannot be
+imported resolve to no handler. A command must be an argv list of strings; shell strings raise
+`ValueError`.
+
+Pre-command hooks send the argument mapping as JSON on stdin. Non-zero exit, subprocess creation
+failure, and the 10-second deadline raise `PermissionError`, preventing the Tool. Post-command
+hooks send the result mapping and log/swallow subprocess or timeout failure. Both timeout paths
+terminate the process group, then wait up to 2 seconds for exit. Ten and two seconds are inherited
+implementation values; no recorded rationale establishes those exact thresholds. An `on_error`
+command currently builds the post-shaped callable and is appended to `error:<tool>`, but the
+shipped Tool execution path never invokes error handlers (ADR-0044 records the target repair).
+
+MCP discovery follows this search contract:
+
+| Input | Behavior |
+|---|---|
+| existing `spec.mcp_config_path` | load only that path |
+| non-existing explicit path | load nothing; do not fall back |
+| no explicit path, project trust true | search ancestor `.lionagi/.mcp.json` and `.mcp.json` |
+| no project match | try `~/.lionagi/.mcp.json` |
+| no file | return without discovery |
+| `mcp_servers is None` | discover all configured servers |
+| explicit list | load only the named servers |
+
+The current `ActionManager.load_mcp_config()` supplies
+`MCPSecurityConfig(allow_commands=True, allow_urls=True)` when no transport policy is passed.
+The factory does not expose an `mcp_security` argument. This is current behavior, not the
+aspirational trust contract in ADR-0044.
+
+**Error and repetition semantics.**
+
+- A settings parse, explicit untrusted hook, provider-construction, Branch-construction, prompt,
+  built-in tool registration, or emission-grant error propagates; the factory does not return a
+  partial Branch.
+- Per-server MCP discovery failures other than transport denial are logged by `ActionManager` and
+  represented as an empty tool list for that server. Transport-policy denial propagates.
+- There is no rollback of external work already performed before a later construction failure.
+- Constructing twice from the same spec re-applies settings hooks and inserts another permission
+  hook. The factory aliases `spec = config`; it does not copy.
+- Built-in tool duplicate handling is delegated to `ActionManager.register_tool(update=False)` and
+  raises for duplicate function names.
+- MCP registration occurs after built-in interception. Newly discovered `Tool` objects keep their
+  own default pre/postprocessor fields and do not receive the spec hook chain.
+
+**Why this way.** The factory is the imperative shell around the declarative spec. It centralizes
+cross-cutting order without moving provider or filesystem effects into casts. Keeping Branch
+allocation here also gives emission grants one auditable construction point.
+
+### D3 — prompt order and emission selection are deterministic
+
+**The prompt contract** (`lionagi/agent/spec.py` and `lionagi/agent/factory.py`):
+
+```text
+optional LION_SYSTEM_MESSAGE
+Role.body
+Mode[0].behaviors
+Mode[1].behaviors
+...
+selected Pack RolePolicy block
+extra_prompt
+optional coding-context one-liner
+```
+
+Within `AgentSpec.build_system_message()`, non-empty parts are joined by exactly two newline
+characters. The Role policy block renders sections in this order when their tuples are non-empty:
+`## Authority`, `## Operational Boundaries`, `## Escalation Conditions`. The factory then
+prepends `LION_SYSTEM_MESSAGE.strip() + "\n\n"` when `lion_system=True`. The coding-context
+one-liner is appended before that preamble step when `"coding" in spec.tools` and
+`context_management=True`.
+
+An empty composed message installs no system message. An empty casts body can still produce a
+message through directives, extra prompt, or the coding one-liner.
+
+**The emission contract**:
+
+```python
+def emission_operable(self) -> Operable | None:
+    if not self.grant_emissions:
+        return None
+    if self.emits is not None:
+        return build_emission_operable(
+            tuple(self.emits),
+            name=f"{self.profile.role.name}_emissions",
+        )
+    return self.profile.emission_operable()
+```
+
+| State | Meaning |
+|---|---|
+| `grant_emissions=False` | grant nothing, regardless of `emits` |
+| `grant_emissions=True, emits=None` | use the Role's declaration |
+| `grant_emissions=True, emits=(...)` | replace the Role declaration |
+| `grant_emissions=True, emits=()` | explicit empty override; grant nothing |
+
+A non-empty emission tuple is converted to an `Operable` and gains
+`EscalationRequest` unless already present. The factory calls
+`branch.grant_capabilities(op)` only for a truthy non-`None` result.
+
+**Why this way.** Ordered prompt composition makes mode ordering meaningful and reproducible.
+Three-state emission selection lets orchestration suppress, inherit, or narrow a Role contract
+without editing the Role itself.
+
+### D4 — direct `Branch` construction is a raw-prompt escape hatch
+
+CLI orchestration has two construction families (`lionagi/cli/orchestrate/_orchestration.py`):
+
+```text
+built-in casts Role
+    AgentSpec.compose(role, modes, extra prompt)
+    → create_agent(...)
+    → Branch with casts prompt and factory wiring
+
+bare worker or external AgentProfile replacement
+    Branch(chat_model=..., system=verbatim_system, ...)
+    → no Profile composition
+    → no Role emission grant
+```
+
+A task-level `system_prompt_override` also selects the verbatim path. External profile prompt text
+wins over casts composition in the current CLI. Bare workers receive the fixed bare-worker prompt.
+Both branches can later be included in a `Session` and receive session-owned routing, but that does
+not retroactively make them Role-backed agents.
+
+**Exact semantics.**
+
+- Direct construction is not prohibited; it is the supported path for identities with no casts
+  Role.
+- A raw path receives no pack directives, Role body, Mode behaviors, factory settings hooks, agent
+  permission hooks, built-in agent tools, MCP discovery, or Role emission grants unless its caller
+  wires those separately.
+- `grant_spawn` is granted after either construction path by orchestration and is independent of
+  Role emissions.
+- The distinction is behavioral, not merely a different constructor spelling.
+
+**Why this way.** Forcing verbatim prompts through a fabricated Role would claim typed emissions
+and directives the prompt did not declare. Conversely, allowing Role-backed callers to bypass the
+factory would duplicate and eventually drift the materialization stack.
+
+### D5 — pre-turn context providers belong to `Branch` and operations
+
+The coding context-tool switch and pre-turn provider registry are separate contracts.
+
+**The provider ownership contract** (`lionagi/session/branch.py` and
+`lionagi/protocols/context_providers.py`):
+
+```python
+class ContextProvider(Protocol):
+    async def provide(
+        self,
+        branch: Branch,
+        instruction: Instruction,
+    ) -> str | None: ...
+
+class ContextProviderRegistry:
+    def __init__(self, budget: int = 2000): ...
+    def register(
+        self,
+        provider: ContextProvider,
+        *,
+        priority: int = 0,
+        max_tokens: int | None = None,
+        name: str | None = None,
+    ) -> None: ...
+
+class Branch:
+    @property
+    def providers(self) -> ContextProviderRegistry: ...
+```
+
+`Branch.providers` lazily creates the registry. Chat and run preparation invoke it only when
+entries exist and a system message provides a render target. Provider blocks are inserted into the
+first-message system-guidance fold for that turn, never into the durable message record, and the
+per-turn slot is cleared after request preparation. Provider failure is recorded and skipped.
+
+The default 2,000-token provider budget is inherited from the implementation; no recorded rationale
+explains that exact number. It bounds ephemeral injection, not the coding context tool.
+
+By contrast, `AgentSpec.context_management=False` has exactly two factory effects:
+
+1. remove `"context"` from `DEFAULT_CODING_TOOLS` before binding `CodingToolkit`;
+2. omit the context-curation prompt one-liner.
+
+It does not touch `Branch._context_providers`, `Branch.providers`, or operation preparation.
+
+**Why this way.** Providers depend on the current Branch, instruction, progression, and per-turn
+render slot. They are live operation state. The coding context tool is simply one requested tool
+plus user guidance and belongs to agent construction.
+
+### D6 — current YAML is a partial export and construction is not idempotent
+
+The shipped YAML surface is:
+
+```yaml
+role: <canonical role name>
+modes: [<canonical mode names>]
+model: <string-or-null>
+effort: <string-or-null>
+tools: [<tool requests>]
+pack: <string-or-null>
+system_prompt: <literal-extra-prompt-or-null>
+yolo: <bool>
+lion_system: <bool>
+context_management: <bool>
+cwd: <optional string; omitted when falsy>
+```
+
+`from_yaml()` additionally accepts `permissions`, but `to_yaml()` never writes it. The writer also
+omits `grant_emissions`, `emits`, `hook_handlers`, `mcp_servers`, and
+`mcp_config_path`. A `Pack` object serializes as `pack: null`. Hook callables are intentionally
+code-only; the remaining omissions make the method a partial export rather than a full spec
+round trip.
+
+The current code does preserve `lion_system=False` and `context_management=False` on read because
+it restores those keys explicitly after `compose()` applies its defaults.
+
+Construction mutates two parts of the input:
+
+- `apply_hooks_from_settings()` appends resolved handlers through `HooksMixin`;
+- `_apply_permissions()` inserts `policy.to_pre_hook()` into `security_pre:*`.
+
+No marker deduplicates either operation.
+
+**Why this way.** The first version optimized for a convenient, human-readable subset and builder
+ergonomics. This ADR does not reclassify those choices as a stable persistence or idempotency
+contract; the delta below makes the intended repair explicit.
+
+## Consequences
+
+- Callers can inspect and compose Role identity without allocating a provider or Branch.
+- Role-backed construction has one place for prompt, tool, MCP, and emission ordering.
+- Raw prompts remain possible without silently inheriting a typed Role contract.
+- Maintainers debugging an unexpected prompt must check Profile, pack, extra prompt,
+  `lion_system`, and the coding-context condition in that order.
+- Maintainers debugging tool authorization must distinguish tools registered before and after MCP
+  discovery; current coverage is intentionally recorded as incomplete.
+- Reversing D1/D2 would be expensive because casts, CLI orchestration, Branch, provider creation,
+  and capability grants would all need a new shared lifecycle owner.
+- Reversing D4 is moderate cost but requires a typed external Role loader so raw identities can
+  truthfully declare emissions.
+- Reversing D5 would couple construction to per-turn Branch state and would blur two existing
+  context facilities.
+- Construction can leave partial external setup before failure and can accumulate handlers on a
+  reused spec. Callers needing repeatable construction should create a fresh spec until the delta
+  is closed.
+- The factory's current transport trust default for an explicitly selected MCP file is broader than
+  its project-file discovery default; ADR-0044 owns the target correction.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Make settings and permission application non-mutating and idempotent; accept when constructing twice from one `AgentSpec` installs each handler exactly once and leaves the spec unchanged. | M | (filled at issue-open time) |
+| 2 | Apply the resolved permission/interceptor chain after all tools, including MCP-discovered tools, are registered; accept when `deny_all` blocks an MCP tool call in a regression test. | M | (filled at issue-open time) |
+| 3 | Define the `AgentSpec` YAML contract as either a complete serializable round trip or an explicitly named partial export; accept when permissions, emission settings, and MCP fields are preserved or documented as excluded. | M | (filled at issue-open time) |
+| 4 | Separate the coding context-tool flag from Branch context-provider terminology; accept when public names and documentation cannot imply that `context_management` enables or disables `ContextProviderRegistry`. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Put provider construction and filesystem discovery inside `AgentSpec.compose()`
+
+This would make one call appear self-contained and could return a ready-to-use object. It lost
+because composition would become asynchronous and environment-dependent, Role/Profile tests would
+need provider credentials and filesystem fixtures, and merely inspecting intent could allocate live
+resources. The shipped pure-description/effectful-factory split keeps those failure domains apart.
+
+### Require every caller to construct `Branch` directly
+
+This would remove one factory abstraction and let specialized callers tune every detail. It lost
+because each Role-backed caller would have to reproduce prompt ordering, provider effort mapping,
+settings trust, tool attachment, MCP discovery, and emission grants. The existing CLI already shows
+why direct construction is appropriate only when no Role contract exists.
+
+### Make `AgentSpec` the live agent façade
+
+The spec could hold a Branch internally and forward chat and tool methods. That would provide one
+user-facing object, but it would combine reusable configuration with one mutable conversation
+identity. Copy, serialization, restart, and multi-Branch use would become ambiguous, so the shipped
+types keep the lifecycle boundary explicit.
+
+### Treat external prompts as synthetic Roles
+
+This would route every worker through the factory and reduce constructor variety. It lost because a
+prompt file does not provide typed emissions, artifact defaults, canonical Role identity, or a
+validated Mode contract. Fabricating those fields would grant ambient capabilities. ADR-0043
+instead requires explicit overlay or replacement disposition.
+
+### Make `context_management` control both coding tools and providers
+
+One switch would be superficially convenient. It lost because providers are registered on a live
+Branch and may be useful to chat-only agents with no coding toolkit. Conversely, the coding context
+tool may be disabled without disabling externally registered pre-turn knowledge.
+
+### Collapse `emits=None` and `emits=()`
+
+A two-state API would be simpler. It lost because orchestration needs both inheritance from the Role
+and an explicit “grant nothing” override. `grant_emissions=False` remains the stronger global
+short-circuit.
+
+### Make YAML a pickle-equivalent full snapshot
+
+A complete snapshot could preserve callables and runtime objects. It lost because hook callables,
+provider clients, and `Pack` objects are code/runtime state and unsafe or non-portable to deserialize
+as data. A complete data contract can include serializable intent while keeping code-only handlers
+explicitly excluded.
+
+## Notes
+
+In pari materia resolves the boundary: `AgentSpec` fields are interpreted alongside their actual
+factory and operation consumers, not as a claim that every similarly named runtime facility is
+agent configuration.
+
+Source anchors: `lionagi/agent/spec.py`, `lionagi/agent/factory.py`,
+`lionagi/agent/settings.py`, `lionagi/protocols/action/manager.py`,
+`lionagi/session/branch.py`, `lionagi/protocols/context_providers.py`,
+`lionagi/operations/chat/_prepare.py`, and
+`lionagi/cli/orchestrate/_orchestration.py`.

--- a/docs/adr/ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md
+++ b/docs/adr/ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md
@@ -1,0 +1,561 @@
+# ADR-0042: Casts pattern catalog and typed role authoring
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: agent-roles
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0071, v0-0078
+
+## Context
+
+Casts is LionAGI's built-in vocabulary for named agent behavior. It needs to keep behavioral
+identity small, deterministic, and typed while still allowing deployments to tune how a known Role
+runs. The shipped design uses Python declarations for behavior and a YAML-backed `Pack` for
+configuration and prompt overlays.
+
+This ADR answers five concrete problems.
+
+**P1 — Role identity must carry real Python types.** A Role does not only contain prose. Its
+`emits` tuple contains Pydantic model classes that become capability contracts. A data-only role
+file would need a second name-to-type resolver and a second failure surface.
+
+**P2 — cognitive overlays are ordered and can be incompatible.** A `Profile` needs exactly one
+Role, zero or more Modes, deterministic prompt order, and conflict validation that catches a
+declaration from either member of a pair.
+
+**P3 — discovery needs one canonical source.** Listing, loading, the API catalog, and the packaged
+default must agree on the supported built-in Role and Mode names. Module stems exist for Python
+imports; canonical names exist for public lookup. They are related but not interchangeable.
+
+**P4 — runtime tuning must not redefine behavioral types.** Packs need to select model, effort,
+default/allowed Modes, active roster membership, and Role-specific prompt directives. They do not
+need to introduce arbitrary Python model classes or replace Role bodies.
+
+**P5 — catalog output is descriptive, not executable state.** Consumers need a plain-data view for
+documentation and APIs without gaining a way to mutate the canonical declarations or execute agent
+behavior.
+
+The source layout is itself part of the authoring contract:
+
+```text
+lionagi/casts/
+├── pattern.py              PatternKind, Pattern, Role, Mode, load/list helpers
+├── profile.py              one Role + ordered Modes
+├── emission.py             Pydantic emission models and Operable builder
+├── pack.py                 RolePolicy, RoleConfig, Pack
+├── catalog.py              derived plain-data catalog
+├── packs/
+│   └── default.yaml        packaged overlay for every built-in Role
+└── roles/
+    ├── <role_module>.py     exactly one canonical ROLE object
+    └── modes/
+        └── <mode_module>.py exactly one canonical MODE object
+```
+
+On 2026-07-09 the discoverable set is 40 Roles and 14 Modes. The packaged default pack contains a
+`RoleConfig` and `RolePolicy` entry for all 40 Role names. These counts describe the current
+filesystem-derived catalog; they are not a separately versioned manifest.
+
+| Concern | Decision |
+|---|---|
+| Pattern value model | D1: `Pattern`, `Role`, and `Mode` are frozen, slotted Python declarations with typed behavior fields. |
+| Identity composition | D2: `Profile` contains one Role and an ordered, conflict-validated Mode tuple. |
+| Built-in discovery | D3: one canonical `ROLE` or `MODE` object per inline module defines the closed built-in catalog. |
+| Pack boundary | D4: `Pack` overlays known names with runtime config and prompt directives; it does not define behavior types. |
+| Emission and catalog projection | D5: Role model classes build typed Operables; `build_catalog()` returns a derived plain-data projection. |
+
+This ADR does not decide:
+
+- Per-call or per-task precedence among pack config, external profiles, and runtime overrides.
+  ADR-0043 owns that target.
+- Whether prompt-only `RolePolicy` should retain its name. ADR-0044 owns the rename and
+  enforcement distinction.
+- Agent materialization, provider selection, tool registration, or capability grant timing.
+  ADR-0041 owns construction.
+- User-defined Role plugins. The current catalog is closed; an extension registry requires a
+  separate decision and typed loading contract.
+- The internal fields of every emission model. This ADR fixes how Role declarations refer to those
+  model classes and how they become an Operable.
+
+## Decision
+
+### D1 — Pattern declarations are frozen, slotted Python values
+
+**The contract** (`lionagi/casts/pattern.py`):
+
+```python
+class PatternKind(Enum):
+    OTHER = "other"
+    ROLE = "role"
+    MODE = "mode"
+
+@dataclass(init=False, frozen=True, slots=True)
+class Pattern(Params, Composable):
+    name: str
+    description: str
+
+    @property
+    def kind(self) -> PatternKind:
+        return PatternKind.OTHER
+
+@dataclass(init=False, frozen=True, slots=True)
+class Mode(Pattern):
+    behaviors: str = ""
+    conflicts_with: frozenset = field(default_factory=frozenset)
+
+    @property
+    def kind(self) -> PatternKind:
+        return PatternKind.MODE
+
+@dataclass(init=False, frozen=True, slots=True)
+class Role(Pattern):
+    body: str = ""
+    emits: tuple = ()
+    artifact_defaults: dict | None = None
+
+    @property
+    def kind(self) -> PatternKind:
+        return PatternKind.ROLE
+```
+
+`Pattern` uses `Params` with `none_as_sentinel=True` and `empty_as_sentinel=True`. The public
+semantic split is:
+
+| Type | Owns | Does not own |
+|---|---|---|
+| `Pattern` | canonical name and description | runtime or prompt behavior |
+| `Role` | prompt body, emission model classes, optional artifact defaults | model/provider choice and permission enforcement |
+| `Mode` | cognitive behavior text and names of conflicting Modes | Role identity, tools, or emissions |
+
+A Role module is an ordinary Python module:
+
+```python
+from lionagi.casts.emission import DesignSpec, ExecutionPlan
+from lionagi.casts.pattern import Role
+
+ROLE = Role(
+    name="architect",
+    description="...",
+    emits=(DesignSpec, ExecutionPlan),
+    body="...",
+)
+```
+
+A Mode module has the parallel shape:
+
+```python
+from lionagi.casts.pattern import Mode
+
+MODE = Mode(
+    name="adversarial",
+    description="...",
+    conflicts_with=frozenset(),
+    behaviors="...",
+)
+```
+
+**Exact semantics.**
+
+- Frozen dataclass assignment is rejected after construction. `slots=True` prevents arbitrary
+  instance attributes.
+- `Role.body=""` and `Mode.behaviors=""` contribute no prompt text.
+- `conflicts_with` stores canonical Mode names. The Mode object does not resolve or validate those
+  names by itself.
+- `Role.emits` holds Python model classes, not strings. Import or class-reference failures happen
+  when the declaration module is imported.
+- `Role.artifact_defaults=None` means the Role makes no default artifact claim.
+- `Role.to_dict()` projects emission classes to their `__name__` strings so the result remains
+  JSON-friendly; this projection is not a loader contract.
+- Equality and hashing follow the frozen value object's inherited/dataclass behavior; runtime agent
+  identity is still represented by `Profile`, not object identity of a mutable service.
+
+**Why this way.** Inline Python keeps body, description, artifact defaults, and real emission types
+next to each other. Type import failures are visible to ordinary imports and tests. Frozen values
+prevent an agent run from rewriting canonical behavior in place.
+
+### D2 — `Profile` composes one Role with an ordered Mode tuple
+
+**The contract** (`lionagi/casts/profile.py`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class Profile:
+    name: str
+    role: Role
+    modes: tuple[Mode, ...] = ()
+
+    def __post_init__(self) -> None: ...
+
+    def emission_operable(self) -> Operable | None: ...
+
+    def build_system_message(self) -> str: ...
+
+    @classmethod
+    def compose(
+        cls,
+        role: str | Role,
+        *,
+        modes: list[str | Mode] | None = None,
+        name: str | None = None,
+    ) -> Profile: ...
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> Profile: ...
+
+    def to_yaml(self, path: str | Path) -> None: ...
+```
+
+Conflict validation walks Modes in input order. For each new Mode it compares all earlier distinct
+entries and rejects the pair when either direction declares the other:
+
+```python
+if (
+    new.name in earlier.conflicts_with
+    or earlier.name in new.conflicts_with
+):
+    raise ValueError(
+        f"Mode conflict: {new.name!r} vs {earlier.name!r}"
+    )
+```
+
+Prompt composition is exactly:
+
+```python
+parts = [role.body] if role.body else []
+parts += [mode.behaviors for mode in modes if mode.behaviors]
+system_message = "\n\n".join(parts)
+```
+
+**Exact semantics.**
+
+- `role` may be a canonical string or an existing `Role` object.
+- `modes=None` and `modes=[]` both produce `()`.
+- Each string Mode is resolved by `Mode.load()`; objects pass through.
+- `name=None` defaults to the Role's canonical name. A custom Profile name does not rename the
+  Role.
+- Mode order is preserved and is prompt order.
+- Conflict declarations are effectively symmetric at validation time even if only one Mode lists
+  the other.
+- Duplicate Mode names are not explicitly rejected. The `seen` dictionary replaces the earlier
+  same-name entry after comparison; a duplicate only fails if the declarations themselves make it
+  conflict.
+- Empty Role body and empty Mode behaviors can yield an empty system message.
+- `emission_operable()` delegates only to the Role; Modes cannot add or remove emission types.
+- YAML is symmetric for exactly `{name, role, modes}` using canonical public names. Missing
+  `role` raises `KeyError`; unknown Role or Mode names raise `ValueError`; file and YAML errors
+  propagate.
+
+**Why this way.** One Role keeps identity singular; ordered Modes preserve intentional cognitive
+composition. Checking both conflict directions makes correctness independent of which module
+declared the incompatibility. Delegating emissions to the Role prevents a reasoning overlay from
+quietly expanding runtime authority.
+
+### D3 — inline modules are the canonical closed built-in catalog
+
+The loading contract is:
+
+```python
+class Role:
+    @classmethod
+    def load(cls, name: str, /) -> Role: ...
+
+class Mode:
+    @classmethod
+    def load(cls, name: str, /) -> Mode: ...
+
+def list_roles() -> list[str]: ...
+def list_modes() -> list[str]: ...
+```
+
+A public name maps to an import stem by replacing dashes with underscores. For example,
+`postmortem-lead` maps to `postmortem_lead.py` and `visual-spatial` maps to
+`visual_spatial.py`. This transform is one-way import plumbing; the underscore stem is not a public
+alias.
+
+Discovery scans only direct `*.py` files. It excludes names beginning with underscore and the
+literal `TEMPLATE` stem, imports every remaining module, reads `ROLE.name` or `MODE.name`, sorts
+the canonical names, and returns a new list.
+
+Current Role names:
+
+```text
+analyst, arbitrator, architect, assessor, auditor, commentator, contrarian,
+coordinator, critic, curator, deployer, entrepreneur, evaluator, explorer,
+facilitator, implementer, innovator, investigator, mentor, migrator, modeler,
+negotiator, operator, orchestrator, persona, planner, postmortem-lead,
+prototyper, refactorer, researcher, responder, reviewer, scribe, strategist,
+suggester, synthesizer, tester, translator, troubleshooter, writer
+```
+
+Current Mode names:
+
+```text
+adversarial, associative, constraint-solving, empathetic, evidential, fast,
+framing, metacognitive, premortem, probabilistic, slow, socratic, systematic,
+visual-spatial
+```
+
+**Exact semantics.**
+
+- `Role.load("postmortem-lead")` imports `roles.postmortem_lead` and accepts the object only when
+  `ROLE.name == "postmortem-lead"`.
+- `Role.load("postmortem_lead")` looks for that stem but rejects the object as non-canonical because
+  its declared name differs. Module stems are not aliases.
+- A missing target module becomes `ValueError("Unknown role/mode ... Available: ...")`.
+- A `ModuleNotFoundError` raised by a dependency inside an existing declaration module propagates;
+  it is not misreported as an unknown pattern.
+- Missing `ROLE`/`MODE` attributes, malformed objects, duplicate canonical names, and import-time
+  errors are not normalized into a second registry error model. They surface through import/list
+  calls and tests.
+- `list_roles()` and `list_modes()` derive live results each call; no static manifest or cache is
+  authoritative.
+- The built-in set is closed by package contents. Packs do not participate in `load()` or
+  `list_*()`.
+
+**Why this way.** Find-by-module gives each behavior a searchable, reviewable file and makes Python
+the only declaration interpreter. Canonical-name equality prevents accidental alias creation from
+filename normalization.
+
+### D4 — Packs overlay known Role names without extending behavior
+
+**The contract** (`lionagi/casts/pack.py`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class RolePolicy:
+    authority: tuple[str, ...] = ()
+    boundaries: tuple[str, ...] = ()
+    escalations: tuple[str, ...] = ()
+
+@dataclass(frozen=True, slots=True)
+class RoleConfig:
+    model: str | None = None
+    effort: str | None = None
+    default_modes: tuple[str, ...] = ()
+    modes_allow: tuple[str, ...] = ()
+    active: bool = True
+
+@dataclass(frozen=True, slots=True)
+class Pack:
+    name: str
+    policies: dict[str, RolePolicy] = field(default_factory=dict)
+    configs: dict[str, RoleConfig] = field(default_factory=dict)
+
+    def policy(self, role: str, /) -> RolePolicy | None:
+        return self.policies.get(role)
+
+    def config(self, role: str, /) -> RoleConfig | None:
+        return self.configs.get(role)
+
+    @classmethod
+    def from_file(cls, path: str | Path, /) -> Pack: ...
+```
+
+The YAML input shape is:
+
+```yaml
+name: default
+roles:
+  analyst:
+    authority: [...]
+    boundaries: [...]
+    escalations: [...]
+    model: <string-or-null>
+    effort: <string-or-null>
+    default_modes: [...]
+    modes_allow: [...]
+    active: true
+```
+
+Missing sequences become empty tuples. Missing `active` becomes `True`. Missing `name` becomes the
+file stem. Each role entry produces both a `RolePolicy` and a `RoleConfig`, even when all fields
+use defaults.
+
+**Exact semantics.**
+
+- `policy()` and `config()` are dictionary lookups and return `None` on a miss.
+- Pack parsing does not validate that a role key exists in the built-in catalog.
+- Pack parsing does not resolve Mode names. Consumers such as CLI mode resolution perform that
+  check.
+- Pack parsing does not carry Role `body`, `description`, `emits`, or
+  `artifact_defaults`; therefore a pack-only name cannot become a loadable Role.
+- `frozen=True` prevents rebinding Pack fields, but the contained dictionaries are ordinary mutable
+  dictionaries. Consumers treat Packs as read-only configuration values; deep immutability is not
+  enforced by the type.
+- YAML read and parse errors propagate from `Path.read_text()` and `yaml.safe_load()`.
+- The packaged default currently covers all 40 built-in Roles with both config and policy entries.
+
+**Why this way.** A pack is a deployment/configuration overlay, not a second behavioral type
+system. This boundary allows runtime tuning without inventing string-to-model-class resolution or
+letting configuration files grant new emission types.
+
+### D5 — Role emissions are typed, and catalog output is a derived projection
+
+A Role turns its emission declaration into an Operable through
+`lionagi/casts/emission.py`:
+
+```python
+def build_emission_operable(
+    emits: tuple[type[BaseModel], ...],
+    /,
+    *,
+    name: str = "emissions",
+) -> Operable | None:
+    models = tuple(emits)
+    if not models:
+        return None
+    if EscalationRequest not in models:
+        models = (*models, EscalationRequest)
+    specs = tuple(
+        Spec(model, name=field_name_for(model))
+        for model in models
+    )
+    return Operable(specs, name=name)
+```
+
+`field_name_for()` converts PascalCase to snake_case and handles acronym runs. The emission base
+sets Pydantic `extra="forbid"`, so model output with undeclared fields fails validation.
+
+**Exact emission semantics.**
+
+- Empty or sentinel Role emissions return `None`.
+- A non-empty Role contract always includes `EscalationRequest`.
+- Already declaring `EscalationRequest` does not duplicate it.
+- Model order is retained when building specs; each field key derives from the model class name.
+- Duplicate model classes are not explicitly deduplicated by the builder.
+- `Profile.emission_operable()` and, by default, `AgentSpec.emission_operable()` delegate to this
+  Role contract.
+
+The read-only catalog projection is (`lionagi/casts/catalog.py`):
+
+```python
+def build_catalog() -> dict:
+    pack = _load_default_pack()
+    roles = [_role_entry(Role.load(n), pack) for n in list_roles()]
+    modes = [_mode_entry(Mode.load(n)) for n in list_modes()]
+    return {"roles": roles, "modes": modes}
+```
+
+Its payload shapes are:
+
+```python
+{
+    "roles": [{
+        "name": str,
+        "description": str,
+        "emits": [{"model": str, "key": str}],
+        "body": str,
+        "config": {
+            "active": bool,
+            "model": str | None,
+            "effort": str | None,
+            "default_modes": list[str],
+            "modes_allow": list[str],
+            "authority": list[str],
+            "boundaries": list[str],
+            "escalations": list[str],
+        } | None,
+    }],
+    "modes": [{
+        "name": str,
+        "description": str,
+        "behaviors": str,
+        "conflicts_with": list[str],  # sorted
+    }],
+}
+```
+
+The packaged pack loader used by catalog generation catches any exception and returns `None` by
+default. In that failure mode Roles and Modes still list, every Role's `config` is `None`, and no
+agent behavior executes. Each call returns fresh lists and dictionaries; mutating the returned
+payload does not mutate Role, Mode, Profile, or Pack state.
+
+**Why this way.** Direct model classes keep the executable type contract in Python. The catalog is
+a projection suitable for APIs and documentation, not a parallel registry or mutation surface.
+
+## Consequences
+
+- Role authors work in one Python module with normal imports and type checking.
+- Profile prompt output is deterministic from Role body and ordered Mode behaviors.
+- A Mode cannot quietly expand a Role's emission authority.
+- The public catalog is easy to serialize and safe to mutate locally because it is rebuilt.
+- A broken declaration module can make list/load fail at import time. That is deliberate visibility,
+  but it means catalog completeness depends on import tests rather than an independent manifest.
+- Counts can change when package files change. Maintainers must update documentation that quotes
+  them and keep default-pack coverage tests aligned.
+- Packs can contain unknown role or mode strings until a consumer validates them. ADR-0043 makes
+  that validation fail before Branch construction.
+- Reversing Python-native authoring would require a stable schema for model-class references,
+  artifact defaults, body text, and extension loading.
+- Reversing the closed catalog would require namespacing, collision rules, trust policy, typed
+  emissions, unloading/reload behavior, and pack interaction; adding a search path alone is not
+  sufficient.
+- Contributors must preserve canonical public names when renaming module stems and must treat dash
+  replacement as import plumbing only.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Generate and validate a deterministic built-in catalog index from the Python declarations; accept when role files, mode files, canonical names, and default-pack coverage are checked together without changing the authoring format. | S | (filled at issue-open time) |
+| 2 | Correct public documentation that says users extend the catalog through packs; accept when packs are described only as overlays unless a typed external Role loader is implemented. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Author Roles and Modes as YAML or JSON
+
+Data files would make non-Python editing and schema validation straightforward and could support
+external search paths. They lost because Role emissions are Python model classes and artifact
+defaults are typed structures. A data format would need a trusted import resolver, versioned schema,
+collision rules, and error translation without a current user-defined-Role requirement.
+
+### Put every declaration in one Python registry module
+
+One file would make count and uniqueness checks obvious and avoid filesystem discovery. It lost
+because 40 Role bodies and 14 Mode behaviors would create a high-conflict monolith, reduce
+searchability, and make changes to unrelated behaviors share one review surface. Inline modules
+keep declarations isolated while list functions derive the set.
+
+### Let packs define new Role bodies and emissions
+
+This would give users an extension mechanism with no new package. It lost because pack YAML
+currently has no safe representation for Python model classes and no namespace/collision contract.
+Accepting a pack-only name as a Role would either make emissions untyped or create an ambient code
+loader disguised as configuration.
+
+### Maintain a hand-written static manifest as source of truth
+
+A manifest would provide deterministic ordering, counts, and early duplicate detection. It lost as
+the canonical authoring source because every addition would require two edits and drift could make
+the manifest disagree with modules. The current delta proposes a generated and validated index,
+not a second hand-maintained truth.
+
+### Use arbitrary entry points or an extension registry now
+
+An extension registry would support third-party Roles and Modes and avoid modifying the package. It
+lost because the present requirement is a closed built-in set. Trust, canonical names, collision
+handling, dependency failure, emission imports, and pack overlay precedence must be decided before
+external code becomes discoverable.
+
+### Make Modes able to add emission models
+
+A Mode such as “adversarial” could then request specialized output automatically. It lost because a
+Mode describes how reasoning is shaped, while a Role declares what the agent may emit. Combining
+them would make changing prompt style also change runtime capability grants.
+
+### Return live Role and Mode objects from `build_catalog()`
+
+This would avoid projection code and preserve every method. It lost because API and documentation
+consumers need serializable, non-executable data. Live objects would expose model classes and blur
+inspection with behavior.
+
+## Notes
+
+Expressio unius applies to the closed catalog: the Role and Mode modules are the supported set, and
+pack-only names are not implicit patterns. A typed extension registry can be decided separately if
+that requirement appears.
+
+Source anchors: `lionagi/casts/pattern.py`, `lionagi/casts/profile.py`,
+`lionagi/casts/emission.py`, `lionagi/casts/pack.py`, `lionagi/casts/catalog.py`,
+`lionagi/casts/roles/`, `lionagi/casts/roles/modes/`, and
+`lionagi/casts/packs/default.yaml`.

--- a/docs/adr/ADR-0043-per-role-configuration-resolution.md
+++ b/docs/adr/ADR-0043-per-role-configuration-resolution.md
@@ -1,0 +1,643 @@
+# ADR-0043: Per-role configuration resolution
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: agent-roles
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0074
+
+## Context
+
+LionAGI currently resolves agent configuration in several places. `Pack` parses per-Role model,
+effort, default Mode, allowed Mode, active, and prompt-directive values. CLI orchestration selects
+some of those fields. `AgentSpec` independently composes the prompt and loads a pack. External
+Markdown `AgentProfile` files provide still another prompt and provider overlay.
+
+This ADR defines the target state. It does not claim the resolver described below is shipped.
+
+Five current failure scenarios require one resolution contract.
+
+**P1 — selected-pack drift.** CLI worker construction reads model, effort, and Modes from the
+selected custom `Pack`, but its later `AgentSpec.compose()` call omits `pack=env.pack`. The spec
+therefore defaults to the packaged `"default"` pack when rendering directives. One worker can
+receive runtime tuning from one pack and prompt guidance from another
+(`lionagi/cli/orchestrate/_orchestration.py`; `lionagi/agent/spec.py`).
+
+**P2 — precedence is distributed and partly implicit.** Task model overrides, orchestration
+defaults, external profiles, pack configuration, and provider defaults are selected in different
+branches of `build_worker_branch()`. A maintainer cannot inspect one value to explain why the
+effective model, effort, Modes, prompt, and roster membership were chosen.
+
+**P3 — same-name external profiles silently change identity.** `available_roles()` unions built-in
+Role names and external agent-profile names. `resolve_worker_spec(role)` attempts the external
+profile before the casts-role construction path. A same-named file can therefore replace the casts
+prompt with a verbatim prompt merely by existing on disk.
+
+**P4 — invalid configuration degrades silently.** `resolve_modes()` logs and drops unknown or
+disallowed Mode names. An explicit empty list is also treated like “not specified,” so pack defaults
+return. The worker still starts with behavior different from the request.
+
+**P5 — roster membership is not enforced.** `RoleConfig.active` is parsed and exposed in
+`build_catalog()`, but `available_roles()` lists every built-in Role and planner assignment does not
+filter or reject inactive Roles.
+
+A naming collision increases the ambiguity: casts `Profile` is one Role plus ordered Modes; CLI
+`AgentProfile` is a Markdown prompt/provider overlay. The target gives the external type and its
+disposition explicit names.
+
+The target boundary is a pure core inside the existing effectful construction shell:
+
+```text
+filesystem/provider discovery
+        │ supplies typed inputs
+        ▼
+resolve_agent_spec(...)       pure, deterministic, no mutation
+        │
+        ▼
+ResolvedAgentSpec             immutable effective values + provenance
+        │
+        ▼
+Role-backed factory or explicit raw-prompt materializer
+        │
+        ▼
+Branch
+```
+
+| Concern | Decision |
+|---|---|
+| Resolution boundary | D1: one pure function returns one immutable `ResolvedAgentSpec` and performs no discovery or construction. |
+| Precedence | D2: model, effort, Modes, tools, permissions, and prompt sources have explicit per-field precedence. |
+| External prompts | D3: an external profile declares `overlay` or `replacement`; filename collision never chooses a disposition. |
+| Roster | D4: selected-pack `active` controls built-in roster membership and assignment validation. |
+| Validation | D5: unknown, disallowed, conflicting, or structurally invalid inputs fail before provider or Branch creation. |
+| Pack continuity and explainability | D6: the selected `Pack` and per-field provenance pass unchanged into construction. |
+
+This ADR does not decide:
+
+- How pack prompt fields are renamed. ADR-0044 calls the target type
+  `RolePromptDirectives`; the resolver treats current `RolePolicy` as its compatibility input.
+- How tool permission checks execute. ADR-0044 owns interception.
+- How external Markdown files are discovered, which directories are trusted, or how frontmatter is
+  parsed. Discovery produces typed resolver input.
+- Provider endpoint creation, credential lookup, or model-specific effort translation. Those occur
+  after resolution.
+- The exact release count for accepting a legacy profile with no disposition. Compatibility policy
+  owns the duration; this ADR fixes the warning and semantic fallback while that window exists.
+- User-defined casts Roles. A replacement profile is a raw identity, not an extension to the
+  built-in Role catalog.
+
+## Decision
+
+### D1 — resolve configuration through one pure typed function
+
+The target public contract is:
+
+```python
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Literal
+
+class PromptDisposition(str, Enum):
+    OVERLAY = "overlay"
+    REPLACEMENT = "replacement"
+
+@dataclass(frozen=True, slots=True)
+class TaskAgentOverrides:
+    model: str | None = None
+    effort: str | None = None
+    modes: tuple[str, ...] | None = None
+    extra_prompt: str | None = None
+    tools: tuple[str, ...] | None = None
+    permissions: PermissionPolicy | None = None
+    yolo: bool | None = None
+    bypass: bool | None = None
+    fast_mode: bool | None = None
+    lion_system: bool | None = None
+
+@dataclass(frozen=True, slots=True)
+class ExternalAgentProfileInput:
+    name: str
+    body: str
+    disposition: PromptDisposition | None
+    base_role: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    yolo: bool = False
+    bypass: bool = False
+    fast_mode: bool = False
+    lion_system: bool | None = None
+    artifact_defaults: Mapping[str, Any] | None = None
+    timeout: int | None = None
+    resume_on_timeout: bool = False
+    enabled: bool = True
+
+@dataclass(frozen=True, slots=True)
+class RuntimeAgentDefaults:
+    model: str | None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()
+    permissions: PermissionPolicy | None = None
+    yolo: bool = False
+    bypass: bool = False
+    fast_mode: bool = False
+    lion_system: bool = True
+
+@dataclass(frozen=True, slots=True)
+class RawProfileIdentity:
+    name: str
+
+@dataclass(frozen=True, slots=True)
+class ExternalProfileRef:
+    """Explicit selector for a raw replacement identity.
+
+    String Role names always select the built-in casts catalog; callers use
+    this type (or an `external:<name>` surface token parsed into it) when they
+    intend an external replacement, including on a name collision.
+    """
+
+    name: str
+
+@dataclass(frozen=True, slots=True)
+class ResolutionDiagnostic:
+    code: Literal["legacy_profile_replacement"]
+    message: str
+
+@dataclass(frozen=True, slots=True)
+class ResolvedAgentSpec:
+    identity: Profile | RawProfileIdentity
+    selected_pack: Pack
+    active: bool
+
+    model: str
+    effort: str | None
+    tools: tuple[str, ...]
+    permissions: PermissionPolicy | None
+    yolo: bool
+    bypass: bool
+    fast_mode: bool
+    lion_system: bool
+
+    prompt_disposition: Literal["casts", "overlay", "replacement"]
+    prompt_body: str
+    prompt_overlays: tuple[str, ...]
+    grant_role_emissions: bool
+    artifact_defaults: Mapping[str, Any] | None
+    timeout: int | None
+    resume_on_timeout: bool
+
+    sources: Mapping[str, str]
+    diagnostics: tuple[ResolutionDiagnostic, ...]
+
+def resolve_agent_spec(
+    role: str | Role | ExternalProfileRef,
+    *,
+    requested_modes: Sequence[str | Mode] | None,
+    selected_pack: Pack,
+    task_overrides: TaskAgentOverrides,
+    external_profile: ExternalAgentProfileInput | None,
+    runtime_defaults: RuntimeAgentDefaults,
+) -> ResolvedAgentSpec: ...
+```
+
+The concrete implementation belongs in the agent-configuration boundary, not CLI orchestration.
+The resolver may depend on casts and the agent permission type. It must not depend on filesystem
+search, environment variables, provider endpoints, `iModel`, `Branch`, `Session`, or CLI parser
+objects.
+
+`ResolvedAgentSpec` is an effective snapshot:
+
+- all sequences are tuples;
+- `sources` and `artifact_defaults` are exposed as read-only mappings or defensive copies;
+- permission rule mappings are defensively copied before exposure;
+- no method mutates input `Role`, `Mode`, `Pack`, external profile, task overrides, or defaults;
+- equal inputs yield equal resolved values and equal diagnostics.
+
+The selected `Pack` is retained by identity for construction and explanation, but is treated as
+read-only. A materializer must not re-run precedence or silently replace it with `"default"`.
+
+**Exact semantics.**
+
+- `selected_pack`, `task_overrides`, and `runtime_defaults` are required typed inputs. Callers
+  construct defaults explicitly; ambient process settings are not read.
+- `role` as a string is resolved only against the built-in casts catalog. An external replacement
+  is selected with `ExternalProfileRef`; command/API surfaces may parse the explicit
+  `external:<name>` token into that type before calling the resolver.
+- A Role object passes through after its canonical name is checked against selected-pack config.
+- `ExternalProfileRef(name)` requires an explicitly supplied external profile with the same name.
+  The resolver never searches for it.
+- The resolver returns no `Branch`, opens no path, imports no user module, and allocates no provider.
+- `model` must resolve to a non-empty string or resolution raises `AgentResolutionError` with code
+  `model_unresolved`.
+- `effort=None` is valid after all precedence levels; it means the later model/provider default.
+- Diagnostics are non-fatal compatibility facts only. Invalid configuration is represented by a
+  typed exception, never a diagnostic plus altered behavior.
+
+**Why this way.** A pure snapshot makes configuration explainable and table-testable. The
+effectful shell can discover inputs and materialize outputs without owning policy.
+
+### D2 — field precedence is explicit and preserves empty overrides
+
+The target precedence table is normative:
+
+| Concern | Highest to lowest precedence |
+|---|---|
+| Model | task or CLI override → external profile → selected pack → runtime default |
+| Effort | task or CLI override → external profile → selected pack → runtime/model default |
+| Modes | explicit task value, including empty → selected-pack defaults → none |
+| Tools | explicit task value, including empty → runtime default |
+| Permissions | explicit task policy → runtime default |
+| Boolean provider flags (`yolo`, `bypass`, `fast_mode`) | explicit task value → external profile true → runtime default |
+| Lion system preamble | explicit task value → explicit external profile value → runtime default |
+| Prompt | explicit raw replacement, or Role → ordered Modes → selected-pack directives → external overlay → explicit task overlay |
+| Roster | active built-in Roles from selected pack, plus explicitly enabled raw replacement profiles |
+| Artifact defaults | external profile override → Role declaration → none |
+| Timeout/resume | external profile → no deadline/no resume |
+
+For model and effort, “external profile” participates only when a profile was explicitly selected
+or supplied by the discovery layer. The resolver never searches by name and never lets a file win
+because its name matches a Role.
+
+Mode resolution distinguishes absence from emptiness:
+
+```text
+requested_modes is None  → use selected-pack default_modes
+requested_modes == ()    → use no Modes; do not restore defaults
+requested_modes non-empty → validate exactly that ordered sequence
+```
+
+`modes_allow=()` retains its current meaning of unrestricted. A non-empty allowlist constrains only
+explicit task Modes and pack defaults alike in the target; an invalid pack default is a pack
+configuration error rather than trusted input.
+
+Prompt construction uses exactly two newlines between non-empty blocks. For a casts or overlay
+identity:
+
+```text
+Role.body
+Mode[0].behaviors
+...
+selected-pack directive block
+external overlay body, when present
+task extra_prompt, when present
+```
+
+The global `LION_SYSTEM_MESSAGE` preamble is not part of `prompt_body`. `lion_system` tells the
+materializer whether to prepend it. This keeps resolution deterministic without importing a
+process-specific prompt resource.
+
+`prompt_overlays` retains only the non-empty external and task overlay blocks, in that order. It is
+empty for casts without overlays and for replacement identities. `prompt_body` remains the complete
+rendered result used for explanation and raw replacement; the retained overlay tuple lets the
+Role-backed adapter reconstruct the same prompt through `AgentSpec` without duplicating Role,
+Mode, or selected-pack text.
+
+Boolean flags use explicit optional task fields so `False` can override an external/profile
+`True`. An implementation must not use truthiness such as `task_value or profile_value` for these
+fields.
+
+The `sources` mapping records at least:
+
+```python
+{
+    "identity": "casts:architect" | "external:<name>",
+    "model": "task" | "external_profile" | "pack" | "runtime_default",
+    "effort": "task" | "external_profile" | "pack" | "runtime_default" | "provider_default",
+    "modes": "task" | "pack" | "none",
+    "tools": "task" | "runtime_default",
+    "permissions": "task" | "runtime_default" | "none",
+    "prompt": "casts" | "external_overlay" | "external_replacement",
+    "active": "pack" | "external_profile",
+}
+```
+
+**Miss, empty, and conflict semantics.**
+
+- An unknown Role raises `role_unknown` unless an explicitly supplied, enabled replacement profile
+  is selected by `ExternalProfileRef`.
+- Missing pack config for a built-in Role raises `role_missing_from_pack`. Falling back to another
+  pack is forbidden.
+- An empty prompt block is skipped without adding separators.
+- Duplicate Mode names raise `mode_duplicate`; the target is stricter than current `Profile`
+  construction so effective configuration has one unambiguous occurrence.
+- A Mode pair conflict raises `mode_conflict` and names both Modes.
+- A task extra prompt of `""` is an explicit empty overlay and has no rendered effect; it does not
+  select replacement semantics.
+- Empty tools means register no configured tools.
+- `permissions=None` after precedence means no agent `PermissionPolicy`; the separate governance
+  gate may still apply.
+
+**Why this way.** Per-field precedence reflects the current strongest-source intent while making
+absence and explicit denial distinguishable. Provenance turns “why did this worker run this way?”
+into data rather than source archaeology.
+
+### D3 — external prompt profiles declare overlay or replacement
+
+The external profile input has two legal dispositions.
+
+#### Overlay
+
+`disposition="overlay"` requires `base_role`. The resolver:
+
+1. loads that built-in Role;
+2. verifies the requested/selected Role agrees with `base_role`;
+3. resolves and validates Modes;
+4. renders Role, Modes, selected-pack directives, external body, then task overlay;
+5. retains `Profile` identity and Role emission eligibility.
+
+An overlay may override model, effort, runtime flags, artifact defaults, timeout, and resume
+settings. It does not redefine the Role's `emits` tuple or Mode catalog.
+
+#### Replacement
+
+`disposition="replacement"` requires `base_role is None`. The resolver:
+
+1. creates `RawProfileIdentity(name)`;
+2. rejects non-empty requested Modes with `modes_on_replacement`;
+3. uses the external body, followed only by an explicit task prompt overlay;
+4. sets `grant_role_emissions=False`;
+5. does not render pack Role directives or claim casts Role identity.
+
+A replacement remains a supported raw-prompt escape hatch. It is not added to `Role.load()`,
+`list_roles()`, or the casts catalog.
+
+**Collision semantics.**
+
+- A same-named external profile never shadows a built-in Role.
+- Supplying a replacement is an explicit caller choice and must use `ExternalProfileRef`; name
+  equality alone is insufficient. A same-named built-in Role remains selected by its bare string.
+- An `ExternalProfileRef` with no supplied profile raises `external_profile_missing`; a supplied
+  profile with a different name raises `external_profile_name_mismatch`.
+- An `ExternalProfileRef` paired with `disposition="overlay"` raises
+  `external_ref_requires_replacement`. A replacement profile supplied alongside a bare built-in
+  Role raises `replacement_requires_external_ref`; it is never silently ignored or applied.
+- An overlay whose `base_role` is missing raises `overlay_role_missing`.
+- An overlay supplied for a different requested Role raises `overlay_role_mismatch`.
+- A replacement with a `base_role` raises `replacement_has_base_role`.
+- A disabled external profile raises `external_profile_inactive` when explicitly selected and is
+  omitted from roster output.
+
+**Legacy compatibility.**
+
+During the bounded compatibility window, a profile with `disposition=None` is interpreted as
+`replacement` and returns:
+
+```python
+ResolutionDiagnostic(
+    code="legacy_profile_replacement",
+    message=(
+        "External profile '<name>' has no disposition; treating it as "
+        "'replacement' during the compatibility window."
+    ),
+)
+```
+
+The warning is emitted by the effectful caller once per loaded profile, not by the pure resolver
+through logging. When the compatibility window closes, the same input raises
+`profile_disposition_required`. The number of releases is deliberately not fixed here.
+
+**Why this way.** Overlay and replacement are both valid, but they have different identity and
+capability consequences. Making the disposition data prevents filesystem presence from changing
+Role semantics.
+
+### D4 — selected-pack active state controls the planner roster
+
+For each built-in Role, selected-pack `RoleConfig.active` is authoritative.
+
+Target roster construction is:
+
+```python
+def resolved_role_roster(
+    *,
+    selected_pack: Pack,
+    external_profiles: Sequence[ExternalAgentProfileInput],
+) -> tuple[str, ...]:
+    """Active built-in Role names plus explicit external:<name> replacement tokens."""
+```
+
+**Exact semantics.**
+
+- A built-in Role is listed only when its selected-pack config exists and `active is True`.
+- An inactive Role remains loadable for catalog inspection but cannot be assigned through the
+  resolved orchestration surface.
+- Explicit assignment to an inactive built-in Role raises `role_inactive` before provider creation.
+- Overlay profiles do not add a second roster identity; they decorate their base Role when
+  explicitly selected.
+- Enabled replacement profiles add `external:<name>` tokens. External identities are always
+  namespaced this way, not only on collision; a parser converts that token to `ExternalProfileRef`.
+- Bare names remain reserved for built-in Roles, so a replacement name colliding with a built-in
+  Role is still independently addressable without ambiguity.
+- Duplicate external replacement names after discovery are a discovery/configuration error; the
+  resolver does not choose search-order winners.
+- Planner guidance and assignment validation consume the same tuple. Separate roster formatting may
+  not recalculate membership.
+
+**Why this way.** `active` otherwise has no runtime meaning. One roster value prevents the planner
+from advertising identities that execution later rejects or, worse, quietly changes.
+
+### D5 — invalid configuration fails before materialization
+
+The target exception contract is:
+
+```python
+class AgentResolutionError(ValueError):
+    code: Literal[
+        "model_unresolved",
+        "role_unknown",
+        "role_missing_from_pack",
+        "role_inactive",
+        "mode_unknown",
+        "mode_disallowed",
+        "mode_duplicate",
+        "mode_conflict",
+        "pack_default_invalid",
+        "overlay_role_missing",
+        "overlay_role_mismatch",
+        "replacement_has_base_role",
+        "modes_on_replacement",
+        "external_profile_missing",
+        "external_profile_name_mismatch",
+        "external_ref_requires_replacement",
+        "replacement_requires_external_ref",
+        "external_profile_inactive",
+        "profile_disposition_required",
+        "resume_without_timeout",
+    ]
+    subject: str | None
+    details: Mapping[str, Any]
+```
+
+All errors are raised before `iModel`, `Branch`, tool, MCP, or capability allocation.
+
+Validation order is deterministic:
+
+```text
+1. classify explicit casts vs external identity
+2. validate profile disposition and base-role relationship
+3. require selected-pack entry and active state for casts identity
+4. resolve model and effort sources
+5. choose requested or default Modes
+6. validate Mode existence, uniqueness, allowlist, and pair conflicts
+7. resolve tools, permissions, flags, artifacts, and deadline values
+8. compose prompt and source map
+9. return ResolvedAgentSpec
+```
+
+The first failure in that order is returned. Bulk diagnostic accumulation is not used for fatal
+errors because later checks may depend on an identity or pack entry that did not resolve.
+
+Specific behavior:
+
+- Unknown explicit Modes raise `mode_unknown`, not warnings.
+- Disallowed explicit Modes raise `mode_disallowed` and retain the rejected name and allowlist in
+  `details`.
+- Unknown or disallowed pack defaults raise `pack_default_invalid`, identifying the pack and Role.
+- External timeout accepts only a positive non-boolean integer; invalid values are discovery/schema
+  errors before resolver invocation.
+- `resume_on_timeout=True` with `timeout=None` raises `resume_without_timeout`; auto-resume cannot
+  have meaning without a deadline.
+- A prompt replacement never receives a Role emission contract even if its name equals a Role.
+
+**Why this way.** Silent dropping changes requested behavior while returning a seemingly valid
+agent. Early typed failure is cheaper than debugging a worker that started under unintended Modes
+or directives.
+
+### D6 — construction consumes the selected pack and resolved values unchanged
+
+The Role-backed materializer converts the snapshot without re-resolving it:
+
+```python
+def agent_spec_from_resolved(resolved: ResolvedAgentSpec) -> AgentSpec:
+    """Pure adapter for casts/overlay identities; rejects replacement identity."""
+
+async def create_resolved_agent(
+    resolved: ResolvedAgentSpec,
+    *,
+    chat_model=None,
+    log_config=None,
+    load_settings: bool = True,
+    project_dir: str | None = None,
+    trust_project_settings: bool = False,
+) -> Branch:
+    """Materialize casts/overlay through create_agent; replacement through
+    the explicit raw-prompt path."""
+```
+
+For casts and overlay identities, the adapter must preserve:
+
+- the resolved `Profile` and ordered Modes;
+- the exact `selected_pack` object;
+- resolved model, effort, tools, permission policy, `yolo`, `lion_system`, and the exact
+  `prompt_overlays` sequence;
+- `grant_emissions=resolved.grant_role_emissions`.
+
+The adapter sets `pack=resolved.selected_pack` and joins `prompt_overlays` with exactly two
+newlines into `AgentSpec.extra_prompt`. Because the resolved `Profile` already contains the Role
+and ordered Modes, `AgentSpec.build_system_message()` then reconstructs `prompt_body` exactly once:
+Profile body, selected-pack directives, then the retained overlays. An adapter test must assert that
+the reconstructed text equals `resolved.prompt_body` before the global Lion preamble is applied.
+
+For replacement identity it installs `prompt_body` verbatim according to `lion_system` and does
+not synthesize a Role, pack directives, or Role grants.
+
+`bypass`, `fast_mode`, `artifact_defaults`, `timeout`, and `resume_on_timeout` remain on
+`ResolvedAgentSpec`; they are provider/orchestration inputs, not current `AgentSpec` fields. The
+materializer consumes them when it builds the provider and run envelope. If a caller supplies an
+already-built `chat_model`, that caller owns provider-only flag application; resolution is not run
+again.
+
+Construction may add runtime-only state such as settings hooks, an existing `chat_model`, log
+configuration, MCP discovery, and Branch name. It may not repeat precedence, consult a different
+pack, restore default Modes after an explicit empty tuple, or search again for a same-named
+external profile.
+
+**Why this way.** Resolution is useful only if materialization cannot reinterpret it. Passing the
+pack and provenance through makes configuration drift observable and prevents the custom-pack bug
+that motivated this ADR.
+
+## Consequences
+
+- Library and CLI callers can explain effective configuration from one immutable value.
+- Custom-pack runtime tuning and prompt directives cannot diverge.
+- Same-named files stop silently changing casts identity.
+- Planner roster and assignment validation share one active-set contract.
+- Explicit empty Modes and tools become meaningful denial/disable states.
+- Previously tolerated invalid Modes and pack defaults become startup errors. This is an intentional
+  behavior change and requires error handling at CLI/API boundaries.
+- External profile frontmatter gains a required disposition after a compatibility window.
+- The resolver adds public types, error codes, and provenance that must remain stable or be migrated.
+- Provider discovery still occurs separately; callers must construct typed inputs before resolution.
+- Reversing the pure resolver is moderate-to-high cost once library and CLI surfaces depend on the
+  error and source maps.
+- Reversing explicit profile disposition would reintroduce hidden identity changes and potential
+  capability over-grant.
+- A frozen top-level result does not make referenced model classes or Pack internals magically
+  immutable; adapters must keep defensive-copy and no-mutation rules.
+
+## Alternatives considered
+
+### Keep today's profile-first lookup
+
+This preserves compatibility and requires no new disposition field. It lost because adding a file
+can replace a built-in Role's body, directives, Modes, and emission eligibility without an explicit
+request. The behavior is not explainable from the task assignment alone.
+
+### Remove external raw profiles
+
+A casts-only system would have one identity model and one factory path. It lost because verbatim
+prompts are a valid escape hatch for specialized workers and existing profiles carry useful model
+and timeout defaults. The decision makes replacement explicit instead of removing it.
+
+### Treat every external profile as an overlay
+
+This would keep all workers Role-backed and preserve factory wiring. It lost because some profiles
+are intentionally complete prompts with no truthful base Role or emission declaration. Forcing a
+base Role would add prompt text and capabilities the author did not request.
+
+### Treat every external profile as a replacement
+
+This matches legacy behavior and is simple. It lost because users also need to tune or extend a
+known Role while retaining its typed identity, Modes, directives, and emissions. Overlay expresses
+that intent without shadowing.
+
+### Resolve configuration inside `create_agent()`
+
+The factory already owns construction and could read pack, task, profile, and runtime settings.
+It lost because resolution would inherit filesystem/provider effects and become hard to test or
+reuse. It would also leave CLI and library callers unable to inspect the effective values before
+allocation.
+
+### Add a second settings hierarchy outside Pack
+
+A separate agent defaults file could own model/effort precedence and leave Pack prompt-only. It lost
+because `RoleConfig` already owns those per-Role fields. A second hierarchy would require
+cross-file precedence and could drift from the directives selected for the same Role.
+
+### Keep warning-and-drop Mode validation
+
+This maximizes run completion when planner output is imperfect. It lost because the worker then runs
+with different reasoning behavior from the request, and pack typos can persist unnoticed. A typed
+configuration error lets the planner or caller correct the assignment before side effects.
+
+### Make `active=False` advisory planner text only
+
+This would avoid hard failures for direct assignments. It lost because an advisory flag still
+allows stale or malicious assignments and gives catalog state no enforceable meaning. The same
+resolved roster must drive both guidance and validation.
+
+### Store only effective values, not provenance
+
+A smaller result type would be sufficient for construction. It lost because the core motivation is
+distributed precedence. Without sources, maintainers still cannot explain why a value won or detect
+that selected-pack policy drifted.
+
+## Notes
+
+Contra proferentem resolves ambiguous external profiles toward the minimal explicit contract:
+composition and replacement are both supported, but the caller chooses. During migration only, a
+missing disposition retains legacy replacement behavior with a typed warning.
+
+Source evidence for the current gaps: `lionagi/casts/pack.py`,
+`lionagi/casts/catalog.py`, `lionagi/agent/spec.py`,
+`lionagi/cli/_providers.py`, and
+`lionagi/cli/orchestrate/_orchestration.py`.

--- a/docs/adr/ADR-0044-agent-prompt-directives-and-executable-permissions.md
+++ b/docs/adr/ADR-0044-agent-prompt-directives-and-executable-permissions.md
@@ -1,0 +1,682 @@
+# ADR-0044: Agent prompt directives and executable permissions
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: agent-roles
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0074
+
+## Context
+
+LionAGI currently uses the word “policy” for two mechanisms with different force.
+
+Casts `RolePolicy` contains free-form authority, boundary, and escalation strings. `AgentSpec`
+renders them into the system prompt and the catalog exposes them as metadata. Nothing in that type
+routes an escalation or prevents an operation.
+
+Agent `PermissionPolicy` is executable. It evaluates a tool name, action, and arguments and returns
+allow, deny, or escalate. The agent factory turns that policy into a Tool preprocessor. The
+Session governance gate is another executable check before tool resolution.
+
+The naming collision and current construction order create five concrete failures.
+
+**P1 — prompt text can be mistaken for enforcement.** “Authority” and “runtime operational
+envelope” imply a grant, but the strings are only model guidance. A model can ignore them, and no
+runtime component parses them into a decision.
+
+**P2 — permission coverage depends on registration source.** Built-in tools receive preprocessors
+when they are registered. MCP tools are discovered afterward and receive none. A `deny_all` policy
+can block a built-in reader while allowing a discovered MCP tool.
+
+**P3 — argument transformation can invalidate an earlier decision.** The current factory correctly
+runs security hooks again after user pre-hooks when any user hook exists. That ordering is
+load-bearing and must survive a universal interceptor design.
+
+**P4 — transport trust and invocation authorization are separate.** Trusting a command or URL
+enough to discover MCP schemas does not grant the resulting tool permission to execute every
+operation. Conversely, a tool allow rule does not authorize loading an untrusted transport.
+
+**P5 — ordinary Tool and CodingToolkit paths are only partly uniform.** Both use the same pre/post
+chain helpers, but error handlers are registered into spec/toolkit maps and are not installed on
+`Tool` or invoked by `FunctionCalling`. Existing non-dict post results also bypass post handlers.
+
+The target trust and invocation path is:
+
+```text
+MCP config discovery ──► MCPSecurityConfig ──► register Tool
+                                                   │
+all built-ins and MCP tools registered             │
+                    └──────────────────────────────┘
+                                   │
+                                   ▼
+                      attach one interceptor plan
+                                   │
+tool request ─► Session gate ─► security ─► transform ─► security ─► invoke
+                                                           │
+                                         success ─► post   │   error ─► error handlers
+```
+
+| Concern | Decision |
+|---|---|
+| Prompt guidance type | D1: casts exposes non-enforcing `RolePromptDirectives`; `RolePolicy` is a deprecated alias only. |
+| Executable permission model | D2: `PermissionPolicy` is the typed per-tool allow/deny/escalate decision source with fail-closed validation. |
+| Universal interception | D3: construction attaches one idempotent interceptor plan after every built-in and MCP Tool is registered. |
+| Invocation state machine | D4: security runs before and after transformations; denial cannot be recovered by post/error hooks. |
+| MCP trust | D5: `MCPSecurityConfig` is an explicit, fail-closed construction input independent of tool permission. |
+| Governance boundary | D6: the Session pre-invocation gate remains an earlier executable control and prompt directives never join either enforcement path. |
+
+This ADR does not decide:
+
+- A policy language for centralized authorization or relationship-based access.
+- How escalation requests are routed to a human or another agent. Prompt guidance may request an
+  escalation emission; executable `on_escalate` is a caller-supplied callback.
+- Per-role configuration precedence. ADR-0043 resolves which directives and PermissionPolicy reach
+  construction.
+- Session HookBus or service API hook ownership. ADR-0047 records those mechanisms.
+- Operating-system sandboxing. Tool permission is one application boundary and does not replace
+  process, filesystem, or network isolation.
+- MCP protocol authentication. This ADR fixes local transport admission and post-discovery Tool
+  authorization.
+
+## Decision
+
+### D1 — casts prompt guidance is `RolePromptDirectives`, not executable policy
+
+The target casts contract is:
+
+```python
+@dataclass(frozen=True, slots=True)
+class RolePromptDirectives:
+    """Non-enforcing text rendered into a Role's system prompt."""
+
+    # Legacy field names remain data-compatible. "authority" is guidance
+    # about the model's decision scope, not an executable grant.
+    authority: tuple[str, ...] = ()
+    boundaries: tuple[str, ...] = ()
+    escalations: tuple[str, ...] = ()
+
+# Deprecated import compatibility; no second model or behavior.
+RolePolicy = RolePromptDirectives
+```
+
+`Pack` changes its canonical field and accessor names:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Pack:
+    name: str
+    directives: dict[str, RolePromptDirectives]
+    configs: dict[str, RoleConfig]
+
+    def prompt_directives(
+        self,
+        role: str,
+        /,
+    ) -> RolePromptDirectives | None: ...
+```
+
+During migration, `Pack.policies` and `Pack.policy(role)` are deprecated read aliases to the same
+objects. The YAML keys `authority`, `boundaries`, and `escalations` remain accepted so existing
+packs do not change meaning. New documentation and catalog descriptions call them decision-scope
+guidance, operating constraints, and escalation guidance.
+
+Prompt rendering remains:
+
+```text
+## Authority
+- <authority guidance>
+
+## Operational Boundaries
+- <boundary guidance>
+
+## Escalation Conditions
+When any condition occurs, STOP and emit an escalation_request with the reason:
+- <escalation guidance>
+```
+
+Those headings are model-facing compatibility text. Public API descriptions must state that the
+block is non-enforcing. Catalog output nests it under `directives` or labels the existing fields as
+prompt directives; it must not call them granted permissions.
+
+**Exact semantics.**
+
+- Empty tuples render no section.
+- If all tuples are empty, the directives block is empty.
+- A missing Role entry renders no directives.
+- The strings are not parsed into `PermissionPolicy` rules.
+- `escalations` do not install an `on_escalate` callback or a routing target.
+- `RolePolicy` and `RolePromptDirectives` refer to one data model during migration. They may not
+  diverge or be selected independently.
+- Import or runtime deprecation signaling must not make pack loading fail. Removal timing belongs to
+  compatibility policy.
+
+**Why this way.** Renaming the type corrects the security claim while preserving the stable YAML
+shape and prompt content. Inventing enforcement semantics for free-form prose would be unsafe and
+would couple casts to tools.
+
+### D2 — `PermissionPolicy` is the executable per-tool decision contract
+
+The target retains the shipped decision shape and makes validation stricter
+(`lionagi/agent/permissions.py`):
+
+```python
+PermissionBehavior = Literal["allow", "deny", "escalate"]
+PermissionMode = Literal["allow_all", "deny_all", "rules"]
+
+@dataclass(frozen=True, slots=True)
+class PermissionDecision:
+    behavior: PermissionBehavior
+    tool_name: str
+    action: str
+    reason: str
+    matched_rule: str | None = None
+
+@dataclass(slots=True)
+class PermissionPolicy:
+    mode: PermissionMode = "allow_all"
+    allow: dict[str, list[str]] = field(default_factory=dict)
+    deny: dict[str, list[str]] = field(default_factory=dict)
+    escalate: dict[str, list[str]] = field(default_factory=dict)
+    on_escalate: EscalationHandler | None = None
+
+    def check(
+        self,
+        tool_name: str,
+        action: str,
+        args: Mapping[str, Any],
+    ) -> PermissionDecision: ...
+
+    def to_pre_hook(self) -> PreToolHook: ...
+```
+
+Rules use case-insensitive glob matching through `fnmatch`. Tool-key aliases are normalized:
+
+| Input key | Canonical key |
+|---|---|
+| `bash_tool` | `bash` |
+| `reader_tool` | `reader` |
+| `editor_tool` | `editor` |
+| `search_tool` | `search` |
+| `context_tool` | `context` |
+| any other name | lowercase name |
+
+The evaluated match string is:
+
+| Tool | Match input |
+|---|---|
+| `bash` | `args["command"]` or empty string |
+| `editor` | `args["file_path"]` or empty string |
+| `reader` | `args["path"]` or empty string |
+| `search` | `pattern + " " + (path or "")` |
+| other/MCP | `action` followed by argument values in mapping order |
+
+Rules for the canonical tool and wildcard `"*"` are concatenated. Evaluation order is normative:
+
+```text
+mode=allow_all → allow immediately
+mode=deny_all  → deny immediately
+rules mode:
+    reject shell-control operators for bash
+    first matching deny rule     → deny
+    first matching allow rule    → allow
+    first matching escalate rule → escalate
+    no match                     → deny
+```
+
+The bash shell-control check rejects `;`, `&&`, `||`, `|`, backticks, `$(...)`,
+redirection, and newline before glob rules. Even `allow={"bash": ["*"]}` does not override it.
+
+Preset contracts remain:
+
+```python
+PermissionPolicy.allow_all()
+PermissionPolicy.deny_all()
+PermissionPolicy.read_only()
+PermissionPolicy.safe()
+```
+
+`read_only` allows reader, search, and context; denies editor and bash. `safe` allows reader,
+editor, search, and context; denies destructive bash patterns and escalates other bash commands.
+Because deny is checked before escalate, a destructive pattern does not reach escalation.
+
+**Escalation semantics.**
+
+- If `on_escalate is None`, escalation raises `PermissionError` before invocation.
+- Callback result `True` allows unchanged arguments.
+- Callback result `dict` replaces arguments and is then subject to the final security check in D4.
+- Any other result denies with `PermissionError`.
+- Callback exception denies and propagates as a pre-invocation failure.
+- A prompt `escalations` string never supplies this callback.
+
+**Validation changes in the target.**
+
+- Unknown `mode` raises configuration error instead of falling through to rules/default-deny.
+- Rule keys and patterns must be strings; rule collections are defensively copied.
+- `on_escalate` must be callable or `None`.
+- Decision behavior is a closed Literal/enum rather than an unchecked string.
+- Invalid configuration fails during ADR-0043 resolution or construction, before any Tool runs.
+
+**Why this way.** The existing deny/allow/escalate order and default deny are conservative and
+tested. Tightening construction validation prevents misspelled modes from masquerading as a valid
+policy.
+
+### D3 — attach one interceptor plan after all Tools are registered
+
+The target adapter contract is:
+
+```python
+PreToolHook = Callable[
+    [str, str, dict[str, Any]],
+    Awaitable[dict[str, Any] | None],
+]
+PostToolHook = Callable[
+    [str, str, dict[str, Any], Any],
+    Awaitable[Any | None],
+]
+ErrorToolHook = Callable[
+    [str, str, dict[str, Any], BaseException],
+    Awaitable[ErrorDisposition | None],
+]
+
+@dataclass(frozen=True, slots=True)
+class Reraise:
+    pass
+
+@dataclass(frozen=True, slots=True)
+class ReplaceResult:
+    value: Any
+
+ErrorDisposition = Reraise | ReplaceResult
+
+@dataclass(frozen=True, slots=True)
+class ToolInterceptorPlan:
+    tool_name: str
+    security_pre: tuple[PreToolHook, ...] = ()
+    transforms: tuple[PreToolHook, ...] = ()
+    post: tuple[PostToolHook, ...] = ()
+    on_error: tuple[ErrorToolHook, ...] = ()
+
+async def apply_tool_interceptors(
+    branch: Branch,
+    *,
+    policy: PermissionPolicy | None,
+    hook_handlers: Mapping[str, Sequence[Callable]],
+) -> None:
+    """Bind one plan to every Tool currently in branch.acts.registry."""
+```
+
+Construction order changes to:
+
+```text
+create Branch
+register ordinary/coding tools
+load and register MCP tools under MCPSecurityConfig
+snapshot branch.acts.registry
+build one per-tool ToolInterceptorPlan
+bind each plan exactly once
+grant capabilities
+return Branch
+```
+
+Plan construction recognizes wildcard, canonical, and current `<name>_tool` compatibility keys.
+The registered Tool's actual function name is recorded for audit, while built-in aliases are
+canonicalized for PermissionPolicy lookup.
+
+Existing Tool pre/postprocessors are not discarded:
+
+- an existing preprocessor becomes the first user transformation between security passes;
+- spec/CodingToolkit pre-hooks follow in declaration order;
+- an existing postprocessor runs before additional declared post handlers;
+- error handlers run in declaration order only for invocation or postprocessing failure.
+
+The binding operation is idempotent. Reapplying the same policy and handler identities leaves one
+plan. Attempting to replace an existing plan with a different plan after the Branch has been
+returned raises a construction error; runtime policy swaps require an explicit future contract.
+
+**Exact coverage semantics.**
+
+- Every entry in `branch.acts.registry` at binding time is covered, regardless of whether it came
+  from ordinary registration, `CodingToolkit`, or MCP discovery.
+- A tool registered after binding is rejected by the Role-backed construction surface or must pass
+  through the same binding API before becoming visible.
+- Empty registry is valid and binds nothing.
+- Missing policy means there are no agent security hooks, but user transforms/post/error handlers
+  can still bind.
+- `deny_all` blocks discovered MCP tools because policy lookup falls back to their canonical
+  registered name and global mode.
+- CodingToolkit and ordinary Tool no longer maintain separate execution code. They produce handler
+  declarations consumed by the same plan.
+- Construction does not mutate the input `AgentSpec.hook_handlers`; it snapshots handlers into
+  tuples.
+
+**Why this way.** Binding after discovery closes the coverage gap and makes the registry snapshot
+the auditable authorization surface. One plan preserves hook ordering without forcing MCP
+registration code to know agent policy.
+
+### D4 — invocation follows a fail-closed interceptor state machine
+
+The target execution algorithm is:
+
+```python
+async def invoke_with_interceptor(
+    tool: Tool,
+    plan: ToolInterceptorPlan,
+    arguments: dict[str, Any],
+) -> Any:
+    original = dict(arguments)
+    current = dict(original)
+    security_changed = False
+
+    def replacement_or_current(value: Any, prior: dict[str, Any]) -> dict[str, Any]:
+        if value is None:
+            return prior
+        if not isinstance(value, dict):
+            raise TypeError("interceptor must return dict or None")
+        return dict(value)
+
+    # S1: security on caller-supplied arguments
+    for check in plan.security_pre:
+        prior = current
+        replacement = await check(
+            plan.tool_name, action(current), dict(current)
+        )
+        current = replacement_or_current(replacement, current)
+        security_changed = security_changed or current != prior
+
+    # T: user/existing transformations
+    for transform in plan.transforms:
+        replacement = await transform(
+            plan.tool_name, action(current), dict(current)
+        )
+        current = replacement_or_current(replacement, current)
+
+    # S2: security on final arguments after any replacement. A security
+    # callback may affirm the mapping by returning None or an equal dict; a
+    # second transformation is unstable and fails closed.
+    if plan.transforms or security_changed:
+        for check in plan.security_pre:
+            replacement = await check(
+                plan.tool_name, action(current), dict(current)
+            )
+            checked = replacement_or_current(replacement, current)
+            if checked != current:
+                raise PermissionError(
+                    "security hook changed arguments during final validation"
+                )
+
+    # Transformation output must still satisfy the Tool request model and
+    # callable schema. Validation is outside the recoverable invocation region.
+    current = validate_tool_arguments(tool, current)
+
+    try:
+        result = await invoke_tool_callable(tool, current)
+        for handler in plan.post:
+            replacement = await handler(
+                plan.tool_name, action(current), current, result
+            )
+            if replacement is not None:
+                result = replacement
+        return result
+    except get_cancelled_exc_class():
+        raise
+    except Exception as exc:
+        return await handle_invocation_error(plan, current, exc)
+```
+
+The pseudocode shows ordering; cancellation classes continue to follow the runtime's cancellation
+policy and are not casually converted to results.
+
+**Security semantics.**
+
+- A security check exception, explicit deny, unresolved escalation, invalid return type, or
+  cancellation prevents invocation.
+- Security and transformation failures occur outside the recoverable invocation-error region.
+  User error handlers cannot turn a PermissionError into a successful result.
+- When neither a security check nor a transform replaces arguments, security runs once.
+- After any security replacement or when at least one transform exists, the complete security
+  chain runs again on the final mapping. A transformer cannot rewrite allowed arguments into
+  denied arguments.
+- A security callback that returns replacement arguments is itself followed by remaining checks and
+  by the final security pass. The final pass may affirm the mapping with `None` or an equal
+  dictionary; attempting another replacement is unstable and fails closed.
+- Argument mappings are copied at entry; a handler must return a replacement mapping rather than
+  relying on mutation.
+- Tool request-model/schema validation still occurs before or as part of `FunctionCalling`
+  construction; interceptor transformation output is validated again against the callable contract
+  before invocation.
+
+**Success and error semantics.**
+
+- Post handlers may replace a successful result. `None` means no replacement.
+- If a post handler raises, the error path receives that exception and the underlying tool is not
+  invoked again.
+- Error handlers are not called for governance or permission denial.
+- Each invocation/post error handler receives the same tool name, final arguments, and original
+  exception.
+- `None` or `Reraise()` keeps the original exception. `ReplaceResult(value)` converts only an
+  invocation/post failure into a result.
+- If multiple error handlers return replacement results, the first replacement wins and remaining
+  handlers are observational only; a later handler cannot restore invocation.
+- If an error handler raises, the original invocation exception remains primary and the handler
+  exception is attached/logged as secondary.
+- Post/error handlers cannot cause a denied callable to run because they execute only after both
+  security passes and only around the callable/post region.
+
+This target supersedes the shipped partial behavior where `_chain_post_hooks()` skips every
+non-dict result and `error:*` registrations are stored but never invoked.
+
+**Why this way.** Authorization must judge the arguments that actually reach the callable. Keeping
+denial outside error recovery makes “fail closed” mechanically true instead of a documentation
+promise.
+
+### D5 — MCP transport admission is explicit and fail-closed
+
+The existing transport type already has the required shape
+(`lionagi/service/connections/mcp_wrapper.py`):
+
+```python
+@dataclass(frozen=True)
+class MCPSecurityConfig:
+    allow_commands: bool = False
+    command_allowlist: frozenset[str] | None = None
+    allow_urls: bool = False
+    url_allowlist: frozenset[str] | None = None
+    env_denylist_patterns: frozenset[str] = <sensitive defaults>
+    filter_sensitive_env: bool = True
+    max_connections_per_server: int = 5
+```
+
+The target construction signatures expose it:
+
+```python
+async def create_agent(
+    config: AgentSpec,
+    *,
+    ...
+    trust_project_settings: bool = False,
+    mcp_security: MCPSecurityConfig | None = None,
+) -> Branch: ...
+
+async def _load_mcp(
+    branch: Branch,
+    spec: AgentSpec,
+    *,
+    trust_project_settings: bool,
+    mcp_security: MCPSecurityConfig,
+) -> None: ...
+```
+
+`None` resolves to `MCPSecurityConfig()`, whose command and URL transports are denied. An explicit
+configuration file path chooses a file; it does not imply `allow_commands=True` or
+`allow_urls=True`.
+
+**Exact transport semantics.**
+
+- Project-file discovery still requires `trust_project_settings=True`.
+- Command transport additionally requires `allow_commands=True` and, when present, an exact bare
+  command allowlist match.
+- A command containing a path separator is rejected under allowlist mode; callers allow the bare
+  executable name instead.
+- URL transport additionally requires `allow_urls=True`, an `https` or `wss` scheme, and, when
+  present, an exact hostname allowlist match.
+- Sensitive environment variables are removed by default using case-insensitive deny-pattern
+  matching.
+- The target enforces `max_connections_per_server=5` as the per-server pool cap. The field and
+  default already exist, but the shipped pool does not read them, so there is no cap today. Five is
+  an inherited value with no recorded sizing rationale; implementation must either enforce it or
+  remove the misleading field rather than present it as measured.
+- Transport denial aborts that discovery path before tool registration.
+- Successfully discovered Tools are still subject to D3/D4 PermissionPolicy interception.
+- Permission allow does not relax transport denial, and transport allow does not create a
+  PermissionPolicy allow rule.
+
+**Why this way.** Discovery can execute commands or connect to a service before a Tool invocation
+exists. It therefore needs its own admission decision. Passing the existing fail-closed type avoids
+inventing a second trust vocabulary.
+
+### D6 — Session governance is an earlier executable control
+
+The Session gate contract remains separate (`ToolInvocation` in `lionagi/session/control.py`,
+`SessionObserver.authorize` in `lionagi/session/observer.py`, and `lionagi/operations/act/act.py`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class ToolInvocation:
+    function: str
+    arguments: dict = field(default_factory=dict)
+    branch_id: str | None = None
+
+async def SessionObserver.authorize(action: Any) -> bool: ...
+```
+
+Before Tool lookup/invocation, action execution passes a `ToolInvocation` to
+`branch.authorize()`.
+
+**Exact semantics.**
+
+- With no Session/observer gate, authorization returns `True`.
+- A falsy gate result denies.
+- A gate exception also denies.
+- Denial stores a `GateDenied` signal and returns a tool-shaped error response so an agent loop can
+  adapt; the callable is not invoked.
+- A governance allow does not skip PermissionPolicy. Both gates must allow.
+- Prompt directives do not participate in either check.
+- HookBus `TOOL_PRE` observers occur after the governance gate and do not replace it.
+- Transport trust occurs earlier during discovery and is not consulted again as an action gate.
+
+The effective control order is therefore:
+
+```text
+transport admission at construction
+    AND Session governance at action time
+    AND agent PermissionPolicy at Tool time
+```
+
+**Why this way.** These controls answer different questions: may this transport be loaded, may this
+session attempt this action, and may this resolved agent invoke this Tool with these arguments.
+Collapsing them would either grant ambient authority or couple unrelated lifetimes.
+
+## Consequences
+
+- Readers can distinguish model guidance from executable controls by type and package ownership.
+- Existing pack YAML remains readable while public naming stops claiming enforcement.
+- Built-in, CodingToolkit, and MCP Tools share one security/transform/post/error contract.
+- Argument transformers cannot evade policy by changing an already-approved call.
+- MCP discovery becomes fail-closed unless the caller explicitly admits its transport.
+- Callers that currently rely on automatic command/URL trust or unwrapped MCP tools must configure
+  transport and invocation permissions.
+- The second security pass adds policy-evaluation cost only when transforms exist. This is accepted
+  because argument mutation is exactly the case that invalidates the first result.
+- Error recovery becomes explicit and typed; denial is deliberately not recoverable through user
+  error hooks.
+- Postprocessors that relied on receiving only dictionaries must adapt to the general result type.
+- Construction must either reject or bind tools added after the registry snapshot.
+- Reversing D1 is low implementation cost but high semantic risk because it restores a false
+  security claim.
+- Reversing D3/D4 is high cost once all tool families rely on one state machine.
+- Reversing fail-closed MCP defaults is localized but expands the construction trust boundary.
+- Prompt escalation still has no routing guarantee. Maintainers must not describe it as one until a
+  typed router exists.
+
+## Alternatives considered
+
+### Keep `RolePolicy` and improve documentation only
+
+This is source-compatible and avoids catalog migration. It lost because the type name and “runtime
+operational envelope” description continue to imply enforcement at every import and API surface.
+Documentation would be fighting the public vocabulary.
+
+### Convert free-form directives directly into PermissionPolicy rules
+
+This would make the prompt block executable and unify the two models. It lost because prose such as
+“cannot override a security ruling” has no unambiguous tool/action/resource mapping. Parsing it
+would create false confidence and unpredictable denial.
+
+### Move prompt directives into the executable governance package
+
+One package could own all concepts named policy. It lost because casts needs prompt composition
+without depending on Session or tools. Non-enforcing behavioral text belongs with the Role; only
+its name and claims need correction.
+
+### Attach permission hooks while each tool is registered
+
+This is the current simple model and avoids a registry-wide pass. It lost because registration has
+multiple sources and MCP discovery happens later. Every new source would need to remember an
+agent-specific concern, making missing coverage the default failure mode.
+
+### Apply the interceptor only to MCP Tools
+
+This would close the visible gap with minimal changes. It lost because CodingToolkit, standalone
+built-ins, and MCP would still retain separate ordering and error semantics. The requirement is one
+auditable invocation contract.
+
+### Run security only before user transformations
+
+This is cheaper and was a common preprocessor shape. It lost on a concrete failure: an allowed
+`echo` command can be rewritten by a user hook into denied `rm` arguments. The existing
+double-check test demonstrates the need.
+
+### Run security only after transformations
+
+This avoids the double check while judging final arguments. It lost because untrusted transformers
+would receive arguments the initial policy might forbid and escalation callbacks could be bypassed.
+The first pass is admission to preprocessing; the second is admission to invocation.
+
+### Let error handlers recover permission denials
+
+Uniform error recovery would simplify one handler API. It lost because a user hook could return a
+success value after deny and make the enforcement result externally indistinguishable from an
+allowed call. Denial must terminate before the recoverable region.
+
+### Treat MCP transport trust as tool permission
+
+One policy could contain server and tool rules. It lost because transport actions occur during
+construction before Tool names and invocation arguments exist. It also conflates permission to load
+a server with permission to invoke every discovered capability.
+
+### Default MCP transport admission to allow for compatibility
+
+This preserves current explicit-config behavior. It lost because selecting a file is not informed
+consent to execute arbitrary commands or connect to arbitrary URLs. Migration requires explicit
+settings, which is the intended trust signal.
+
+### Rely only on Session governance
+
+A single gate before action would reduce layers. It lost because standalone Branches may have no
+Session gate, Role-specific least authority differs from session-wide governance, and transport
+admission is earlier still. Defense layers have distinct owners rather than duplicated semantics.
+
+## Notes
+
+In pari materia resolves “policy” against executable behavior: a type that only renders strings
+into a prompt is a directive. Only `PermissionPolicy` and the pre-invocation governance gate may
+claim to allow, deny, or escalate a Tool operation.
+
+Source evidence for the current state: `lionagi/casts/pack.py`,
+`lionagi/casts/catalog.py`, `lionagi/agent/spec.py`,
+`lionagi/agent/permissions.py`, `lionagi/agent/factory.py`,
+`lionagi/tools/coding.py`, `lionagi/protocols/action/tool.py`,
+`lionagi/protocols/action/function_calling.py`,
+`lionagi/protocols/action/manager.py`,
+`lionagi/service/connections/mcp_wrapper.py`, `lionagi/session/control.py`,
+`lionagi/session/observer.py`, and `lionagi/operations/act/act.py`.

--- a/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
+++ b/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
@@ -1,0 +1,865 @@
+# ADR-0047: Hook mechanism scopes and canonical ownership
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: hooks
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0023, v0-0072, v0-0076
+
+## Context
+
+LionAGI has three live mechanisms called hooks. They intercept different operations, have different
+lifetimes, and deliberately provide different failure semantics. Treating them as alternative
+implementations of one handler interface would remove behavior required by at least one caller.
+
+This ADR answers six concrete problems.
+
+**P1 — “hook” names three different timing contracts.** A Session hook may be an ordered observer
+or a guard before the action manager. A service hook surrounds one `Event` before and after an API
+call and also handles streaming chunks. An agent Tool hook can replace invocation arguments and
+results. A common name does not make their handler arguments or control effects substitutable.
+
+**P2 — Session hooks need both ordered execution and reactive recording.** Persistence and guards
+need registration order, sequential awaits, and `StopHook` short-circuiting. Session-wide reactive
+subscribers use typed filters and concurrent async fan-out. The shipped `HookBus` therefore owns
+the ordered chain and records `HookSignal` envelopes through `SessionObserver`; neither discipline
+can replace the other.
+
+**P3 — service hooks must work without a Session.** `iModel` can be constructed and invoked on its
+own. Its `HookRegistry` is attached to that model, and `APICalling(HookedEvent)` applies pre-create,
+pre-invocation, post-invocation, timeout, exit, and stream rules around the provider event. Moving
+that control path into Session state would silently remove hooks from standalone model use.
+
+**P4 — Tool interception needs invocation data, not telemetry summaries.** A Tool preprocessor
+receives the argument mapping and may replace it before the callable runs. The Session
+`HookPoint.TOOL_PRE` payload contains `tool_name`, `call_id`, and a 200-character summary. It can
+block by raising but cannot transform the Tool's argument mapping. An observation adapter cannot
+manufacture the stronger mutation contract.
+
+**P5 — the public Session vocabulary is wider than the wired implementation.** `HookPoint` has
+eleven values. Seven have production emit sites: session start/end, branch creation, tool
+pre/post/error, and message addition. `API_PRE_CALL`, `API_POST_CALL`, `API_STREAM_CHUNK`, and
+`ARTIFACT_CREATED` have no production `HookBus` emit site. A declared enum member is not evidence
+that its integration exists.
+
+**P6 — lazy ownership and compatibility surfaces expose real maintenance traps.** Creating
+`Session.hooks` after branches were included does not backfill the bus onto those branches.
+`build_session_bus()` accepts declarative overrides, but the shipped `Session.hooks` property calls
+it with defaults only. Service stream-handler typing and `iModel.create_event()` return annotation
+also differ from their runtime calls. These facts must be visible instead of hidden behind a claim
+of a completed universal hook system.
+
+The shipped ownership and invocation relationships are:
+
+```text
+Session
+├── HookBus ── ordered handlers ──► HookSignal ──best effort──► SessionObserver
+│      └── TOOL_PRE may block                              └── Flow / reactive subscribers
+├── Branch message callback ──► MESSAGE_ADD handler chain + MessageAdded signal
+└── Branch action
+       └── governance gate ──► HookBus TOOL_PRE ──► ActionManager
+                                                    └── Tool preprocessor
+                                                        ──► callable
+                                                        ──► Tool postprocessor
+                                                    ──► HookBus TOOL_POST/ERROR
+
+iModel (standalone or Branch-owned)
+└── HookRegistry
+      ├── pre-event-create
+      ├── HookedEvent pre-invocation ──► APICalling core ──► post-invocation
+      └── per-chunk stream handlers
+```
+
+| Concern | Decision |
+|---|---|
+| Scope ownership | D1: Session, service-event, and Tool-invocation hooks remain three canonical mechanisms with explicit boundaries. |
+| Ordered Session dispatch | D2: `HookBus` owns the closed point vocabulary, sequential chains, `StopHook`, and blocking `TOOL_PRE`. |
+| Session recording and lifetime | D3: `SessionObserver` is the recording/reactive transport; Session owns bus attachment and persistence routing. |
+| Service event lifecycle | D4: `HookRegistry` and `HookedEvent` remain per-`iModel` control with their shipped status, timeout, exit, and stream semantics. |
+| Tool interception | D5: `Tool.preprocessor` and `Tool.postprocessor` remain the mutable per-invocation interception surface. |
+| Cross-scope integration | D6: adapters may add observations, but must preserve the source scope, ordering, payload, and failure behavior. |
+
+This ADR does not decide:
+
+- Executable Tool permission policy or the target universal interceptor plan. ADR-0044 owns those
+  changes; this ADR records the currently shipped mechanism that target must replace.
+- Session governance policy. `SessionObserver.authorize()` is mentioned only to locate hooks in the
+  invocation order.
+- Capability grants and structured emissions. They share `SessionObserver` transport but are not
+  hook execution.
+- The persistence schema for session signals or messages. This ADR records the hook-side payload and
+  routing contracts only.
+- A new API-call telemetry bridge. The current absence is recorded; implementing the bridge is a
+  separate change with its own typed payload.
+- Artifact production ownership. No canonical artifact emit site exists in the hook system today.
+- User code discovery or import trust for hook modules. The loader resolves already registered
+  names; it is not a general plugin loader.
+
+## Decision
+
+### D1 — canonical ownership is per scope, not one universal module
+
+There is no single canonical handler ABI for all hooks. Canonical ownership is:
+
+| Canonical mechanism | Lifetime and scope | Handler sees | Control it can exert |
+|---|---|---|---|
+| `lionagi/hooks/HookBus` | one Session bus shared by attached Branches | point-specific keyword payload | sequential observation; `TOOL_PRE` may block by raising |
+| `lionagi/service/hooks/HookRegistry` + `HookedEvent` | one `iModel` and its API events | event type or event instance; hook params; stream chunk tuple | replace event at pre-create; abort before core; observe/fail after core; process chunks |
+| `AgentSpec`/`CodingToolkit` Tool hooks | one registered Tool invocation | validated invocation arguments or returned result | replace arguments, block callable, replace dictionary results |
+
+The module boundary is:
+
+```text
+lionagi/
+├── hooks/
+│   ├── bus.py             HookPoint, HookBus, HookSignal, StopHook, @hook
+│   ├── loader.py          named handler registry and per-point default replacement
+│   ├── builtins.py        Session persistence and logging handlers
+│   └── persist.py         CLI message-persistence routing through a Session bus
+├── session/
+│   ├── observer.py        SessionObserver recording, filters, routes, governance gate
+│   ├── signal.py          Signal and MessageAdded envelopes
+│   ├── session.py         lazy Session ownership of observer and bus
+│   └── branch.py          observer/bus attachment and message callbacks
+├── service/hooks/
+│   ├── _types.py          HookEventTypes, HookDict, StreamHandlers
+│   ├── hook_registry.py   one handler per service phase and per stream key
+│   ├── hook_event.py      timeout/status/exit wrapper
+│   └── hooked_event.py    pre/core/post template method
+├── agent/
+│   ├── spec.py            HooksMixin declarations
+│   └── factory.py         per-Tool hook-chain attachment
+└── protocols/action/
+    ├── tool.py             Tool preprocessor/postprocessor fields
+    └── function_calling.py invocation order
+```
+
+`SessionObserver` is the canonical recording and reactive fan-out transport for session signals;
+it is not the execution API for service or Tool pre-invocation hooks. `HookBus` remains the
+canonical ordered Session hook dispatcher; being bound to an observer does not delegate its
+handler chain to reactive subscribers.
+
+**Exact semantics.**
+
+- A standalone `Branch` has neither Session observer nor Session bus. `Branch.emit()` returns an
+  empty list and `Branch.authorize()` allows.
+- A standalone `iModel` still owns a fresh `HookRegistry` by default and may be given a configured
+  registry. No Session is required.
+- A Tool preprocessor is stored on the Tool object and runs inside `FunctionCalling`; it is not
+  registered on `HookBus` or `SessionObserver`.
+- The same callable can be adapted into more than one scope only when its signature and failure
+  behavior are explicitly adapted. Registering the same function object does not unify lifetimes.
+
+**Why this way.** The narrowest shared abstraction is observation, not control. All three
+mechanisms can report that something occurred, but only the mechanism surrounding the operation
+has the data and timing needed to change or stop it. Keeping canonical ownership per scope avoids
+claiming that a post-facto signal can enforce a precondition.
+
+### D2 — `HookBus` owns ordered Session hook dispatch
+
+**The contract** (`lionagi/hooks/bus.py`):
+
+```python
+class HookPoint(str, Enum):
+    SESSION_START = "session.start"
+    SESSION_END = "session.end"
+    BRANCH_CREATE = "branch.create"
+    API_PRE_CALL = "api.pre_call"
+    API_POST_CALL = "api.post_call"
+    API_STREAM_CHUNK = "api.stream_chunk"
+    TOOL_PRE = "tool.pre"
+    TOOL_POST = "tool.post"
+    TOOL_ERROR = "tool.error"
+    MESSAGE_ADD = "message.add"
+    ARTIFACT_CREATED = "artifact.created"
+
+HookHandler = Callable[..., Awaitable[Any] | Any]
+
+class StopHook(Exception): ...
+
+class HookSignal(Signal):
+    point: HookPoint | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+class HookBus:
+    def __init__(self, observer: SessionObserver | None = None) -> None: ...
+    def bind(self, observer: SessionObserver | None) -> HookBus: ...
+    def on(self, point: HookPoint | str, handler: HookHandler) -> None: ...
+    def off(self, point: HookPoint | str, handler: HookHandler) -> None: ...
+    def handlers_for(self, point: HookPoint | str) -> list[HookHandler]: ...
+    async def blocking_emit(
+        self, point: HookPoint | str, /, **kwargs: Any
+    ) -> None: ...
+    async def emit(
+        self, point: HookPoint | str, /, **kwargs: Any
+    ) -> None: ...
+
+def hook(point: HookPoint | str) -> Callable[[HookHandler], HookHandler]: ...
+```
+
+**Registration and miss semantics.**
+
+- Enum members and exact value strings are accepted. An unknown string raises `ValueError` before
+  registration, removal, lookup, or emission.
+- `on()` appends. Duplicate registrations are allowed and run more than once.
+- `off()` removes the first equal registered handler. A missing handler or point is a no-op.
+- `handlers_for()` returns a copy; mutating it does not mutate the bus.
+- Emission snapshots the current handler list. Registration changes made by a running handler
+  affect later emissions, not the current chain.
+- No handlers is a valid emission. A bound bus can still record the point.
+- `@hook(point)` sets `__lionagi_hook_point__` on the callable. It does not register or discover the
+  function by itself.
+
+**Dispatch and error semantics.**
+
+- Non-`TOOL_PRE` `emit()` awaits handlers sequentially in registration order. Sync return values
+  are accepted through `maybe_await`.
+- `StopHook` stops the remaining handlers for that point and is swallowed. It does not stop the
+  observed operation.
+- Any other handler exception at a non-blocking point is logged, swallowed, and the next handler
+  runs.
+- `emit(TOOL_PRE, ...)` delegates to `blocking_emit()`. A non-`StopHook` exception propagates,
+  later handlers do not run, and the Tool invocation is prevented by the caller in
+  `operations/act/act.py`.
+- A `StopHook` at `TOOL_PRE` only stops sibling handlers; the Tool invocation continues.
+- After a successful or `StopHook`-short-circuited chain, the bus records a `HookSignal` through its
+  bound observer. A raised blocking exception exits before recording, so denied `TOOL_PRE`
+  attempts currently have no `HookSignal` audit record.
+- Observer recording is best effort. Observer exceptions are logged and swallowed after the
+  ordered handler chain has completed.
+- `MESSAGE_ADD` deliberately skips `HookSignal` recording because the Branch separately emits a
+  typed `MessageAdded` signal. Its `HookBus` handlers still run.
+
+The eleven-point vocabulary is closed by the enum and pinned by tests. It is not a promise that all
+points emit. The shipped production matrix is:
+
+| Point | Production source | Payload supplied at that source | State |
+|---|---|---|---|
+| `SESSION_START` | CLI persistence setup | `session_id`, `model`, `provider`, `effort`, `agent_name`, `agent_hash`, `invocation_id` | wired |
+| `SESSION_END` | CLI persistence teardown | `session_id`, `status`, `error`, plus available usage fields | wired |
+| `BRANCH_CREATE` | CLI persistence setup | `branch_id`, `model`, `provider`, `agent_name` | wired |
+| `TOOL_PRE` | `_act()` before `ActionManager.invoke()` | `tool_name`, `call_id`, `args_summary` | wired, blocking |
+| `TOOL_POST` | `_act()` after successful invoke | `call_id`, `tool_name`, `result_summary`, `duration` | wired |
+| `TOOL_ERROR` | `_act()` when invoke raises | `call_id`, `tool_name`, `error`, `duration=None` | wired |
+| `MESSAGE_ADD` | routed Branch message callback | `branch_id`, `message` | conditionally wired by persistence routing |
+| `API_PRE_CALL` | none | none | dormant |
+| `API_POST_CALL` | none | none | dormant |
+| `API_STREAM_CHUNK` | none | none | dormant |
+| `ARTIFACT_CREATED` | none | none | dormant |
+
+`call_id` is a fresh UUID4 string shared by a Tool's pre and post/error emissions. Argument and
+result summaries are truncated to 200 characters. The truncation bounds incidental telemetry size;
+no recorded rationale explains why exactly 200 was selected.
+
+**Why this way.** Sequential execution makes persistence and guard ordering inspectable. A special
+blocking path is necessary because ordinary hooks are intentionally failure-isolated. Recording
+after dispatch preserves the handler discipline while exposing successful hook activity to the
+typed Session transport.
+
+### D3 — Session owns bus attachment; `SessionObserver` owns recording and fan-out
+
+**The Session and observer contract** (`lionagi/session/session.py`,
+`lionagi/session/observer.py`, and `lionagi/session/signal.py`):
+
+```python
+class Signal(Element):
+    data: Any = None
+    emitter_role: str | None = None
+    schema_version: int = 1
+
+class Session:
+    @property
+    def hooks(self) -> HookBus: ...
+
+    @property
+    def observer(self) -> SessionObserver: ...
+
+class SessionObserver:
+    def observe(
+        self,
+        *keys: type | Filter | Predicate | Any,
+        handler: Handler | None = None,
+        role: str | None = None,
+    ) -> Any: ...
+
+    def unobserve(self, handler: Handler) -> int: ...
+    def route(self, condition: Predicate, *, into: str) -> SessionObserver: ...
+    def gate(self, check: Gate) -> SessionObserver: ...
+    async def authorize(self, action: Any) -> bool: ...
+    async def emit(self, event: Any) -> list[Any]: ...
+    def stream(self, name: str) -> list[Any]: ...
+    def by_type(self, event_type: type) -> list[Any]: ...
+    def bind_db_persistence(self, session_id: str, db: Any = None) -> None: ...
+    def unbind_db_persistence(self) -> None: ...
+```
+
+`Session.observer` is lazy and stores one `SessionObserver(session=self)`. `Session.hooks` is also
+lazy and stores one `build_session_bus(observer=self.observer)`. Repeated property access returns
+the same objects for that Session.
+
+`SessionObserver.emit()` follows this as-built order:
+
+```text
+coerce a non-Observable value to Signal(data=value)
+→ evaluate the observer gate against the payload
+→ store the event in the Session Flow even when denied
+→ if allowed, append matching named routes
+→ invoke matching synchronous subscribers
+→ gather matching async subscribers
+→ return synchronous results followed by async results
+```
+
+This reactive dispatch is not registration-ordered for async completion and has no `StopHook`
+contract. A `HookBus` bound to it still runs its own chain first. If the observer gate denies a
+`HookSignal`, the signal remains stored but reactive subscribers and routes do not receive it.
+
+Observer database persistence serializes Signal fields into a JSON-safe payload. Payloads over
+16,384 bytes are replaced by a bounded object containing `truncated`, `original_bytes`, and a
+clipped `data` string. The 16 KiB value bounds the database payload column; it is not a hard cap on
+the whole stream frame because row metadata adds overhead.
+
+**The loader contract** (`lionagi/hooks/loader.py`):
+
+```python
+DEFAULT_HOOKS: dict[HookPoint, list[HookHandler]] = {
+    HookPoint.SESSION_START: [persist_session_start],
+    HookPoint.SESSION_END: [persist_session_end],
+    HookPoint.MESSAGE_ADD: [persist_message],
+    HookPoint.BRANCH_CREATE: [persist_branch_provenance],
+}
+
+def register_handler(
+    name: str,
+    handler: Callable[..., Awaitable[Any]],
+) -> None: ...
+
+def resolve_handler(name: str) -> HookHandler: ...
+
+def load_hooks_for_agent(
+    agent_hooks: dict[str, list[str]] | None,
+) -> dict[HookPoint, list[HookHandler]]: ...
+
+def build_session_bus(
+    agent_hooks: dict[str, list[str]] | None = None,
+    *,
+    observer: Any = None,
+) -> HookBus: ...
+```
+
+**Loader and attachment semantics.**
+
+- `register_handler()` is a process-global name registry and last writer wins.
+- `resolve_handler()` raises `KeyError` for a miss and includes the registered names.
+- `load_hooks_for_agent(None)` and an empty mapping return no overrides. Unknown points raise
+  `ValueError`; a per-point value that is not a list raises `ValueError`; unknown handler names
+  raise `KeyError`.
+- An override for a default point replaces the whole default list. An explicit empty list disables
+  that default. Overrides for non-default points are appended to the fresh bus.
+- Each `build_session_bus()` call returns a new bus. The global handler-name registry is shared;
+  registered handler chains are not.
+- The shipped `Session.hooks` property does not pass `agent_hooks`. Declarative overrides work when
+  a caller invokes `build_session_bus()` explicitly, but no production AgentSpec/profile path feeds
+  them into Session construction.
+- `include_branches()` assigns `branch._observer` immediately. It assigns `branch._hooks` only if
+  the bus already exists. Creating the bus later does not backfill branches already included.
+- Branches included after bus creation receive the existing bus. Removing a Branch clears its
+  Session observer and bus references.
+
+Message persistence has an explicit routing adapter (`lionagi/hooks/persist.py`):
+
+```python
+def route_message_persistence(
+    session: Any,
+    branch: Any,
+    on_message: Callable[[Any], Awaitable[None]],
+) -> HookHandler: ...
+
+def unroute_message_persistence(
+    holder: Any,
+    handler: HookHandler,
+) -> None: ...
+```
+
+Routing creates/accesses the Session bus, removes the default `persist_message` handler from the
+shared bus, assigns the bus to that Branch, registers `branch._persist_via_bus` once on the Branch's
+message callbacks, and adds a Branch-id-filtered async handler. Teardown removes both registrations.
+The adapter is why the CLI persistence path supplies its own callback rather than using two
+competing persistence writes.
+
+The default `persist_message` signature requires `session_id` and accepts Branch/session
+progression ids, but the Branch's routed `MESSAGE_ADD` emission supplies only `branch_id` and
+`message`. Standard CLI routing removes that default before live messages flow. Directly attaching
+the default bus without the routing adapter does not create the missing persistence identifiers;
+its handler error is isolated by non-blocking `HookBus.emit()`.
+
+**Why this way.** Session signals need one queryable Flow, while persistence and guards need a
+different dispatch discipline over that transport. Lazy objects avoid Session hook allocation when
+unused. The current access-order and loader gaps are organic limitations, not intended guarantees.
+
+### D4 — service hooks remain a per-`iModel` event lifecycle
+
+The service mechanism owns one handler per lifecycle phase and one handler per streaming chunk key.
+
+**The type and registry contract** (`lionagi/service/hooks/_types.py` and
+`lionagi/service/hooks/hook_registry.py`):
+
+```python
+class HookEventTypes(str, Enum):
+    PreEventCreate = "pre_event_create"
+    PreInvocation = "pre_invocation"
+    PostInvocation = "post_invocation"
+
+class HookDict(TypedDict):
+    pre_event_create: Callable | None
+    pre_invocation: Callable | None
+    post_invocation: Callable | None
+
+StreamHandlers = dict[str, Callable[[SC], Awaitable[None]]]
+
+class AssociatedEventInfo(TypedDict, total=False):
+    lion_class: str
+    event_id: str
+    event_created_at: float
+
+class HookRegistry:
+    def __init__(
+        self,
+        hooks: HookDict = None,
+        stream_handlers: StreamHandlers = None,
+    ): ...
+
+    def pre_event_create_hook(self, fn: F) -> F: ...
+    def pre_invoke(self, fn: F) -> F: ...
+    def post_invoke(self, fn: F) -> F: ...
+
+    async def call(
+        self,
+        event_like: Event | type[Event],
+        /,
+        *,
+        hook_type: HookEventTypes = None,
+        chunk_type=None,
+        chunk=None,
+        should_exit: bool = False,
+        **kw,
+    ): ...
+```
+
+String hook keys `pre_event_create`, `pre_event_create_hook`, `pre_invoke`, `pre_invocation`,
+`post_invoke`, and `post_invocation` normalize to enum keys. Other keys fail validation. Sync
+handlers are wrapped for asynchronous execution. Decorators overwrite an existing phase handler
+and emit a warning; the registry is not a multi-handler chain.
+
+At runtime, a stream handler is called as:
+
+```python
+await handler(None, chunk_type, chunk, **hook_params)
+```
+
+The shipped `StreamHandlers` alias documents a one-chunk callable even though dispatch passes three
+positional arguments plus keywords. Tests and runtime use the three-argument form; the annotation is
+not a faithful callable contract today.
+
+**The event wrapper contract** (`lionagi/service/hooks/hook_event.py`):
+
+```python
+class HookEvent(Event):
+    registry: HookRegistry = Field(..., exclude=True)
+    hook_type: HookEventTypes
+    exit: bool = Field(False, exclude=True)
+    timeout: int | float = Field(30, exclude=True)
+    params: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    event_like: Event | type[Event] = Field(..., exclude=True)
+    associated_event_info: AssociatedEventInfo | None = None
+
+    async def invoke(self): ...
+```
+
+`exit=None` normalizes to `False`. Each service phase injects the resolved `exit` value into the
+handler's keyword arguments. The registry returns `(result, should_exit, EventStatus)` plus
+associated-event metadata.
+
+| Path | Result | `should_exit` | Status |
+|---|---|---|---|
+| any phase succeeds | handler return | `False` | `COMPLETED` |
+| pre-create or pre-invoke raises cancellation | `(Undefined, error)` | `True` | `CANCELLED` |
+| pre-create or pre-invoke raises another exception | exception object | configured `exit` | `CANCELLED` |
+| post-invoke raises cancellation | `(Undefined, error)` | `True` | `CANCELLED` |
+| post-invoke raises another exception | exception object | configured `exit` | `ABORTED` |
+| stream handler succeeds | handler return | `False` | `None` |
+| stream handler raises cancellation | `(Undefined, error)` | `True` | `CANCELLED` |
+| stream handler raises another exception | exception object | configured `exit` | `ABORTED` |
+
+`HookEvent.invoke()` starts at `PROCESSING`, applies an AnyIO timeout, copies metadata, and records
+duration. Cancellation propagates. Other registry/wiring failures become `FAILED`, clear the
+response, record the error, and set `_should_exit` from the configured `exit` policy. A handler must
+raise to signal phase failure; merely returning an exception object records it as the response-side
+error while retaining the registry's success status.
+
+**The `iModel` and template-method contract** (`lionagi/service/imodel.py` and
+`lionagi/service/hooks/hooked_event.py`):
+
+```python
+class iModel:
+    def __init__(
+        self,
+        ...,
+        streaming_process_func: Callable = None,
+        provider_metadata: dict | None = None,
+        hook_registry: HookRegistry | dict | None = None,
+        exit_hook: bool = False,
+        ...,
+    ) -> None: ...
+
+    async def create_event(
+        self,
+        create_event_type: type[Event] = APICalling,
+        create_event_exit_hook: bool = None,
+        create_event_hook_timeout: float = 10.0,
+        create_event_hook_params: dict = None,
+        pre_invoke_event_exit_hook: bool = None,
+        pre_invoke_event_hook_timeout: float = 30.0,
+        pre_invoke_event_hook_params: dict = None,
+        post_invoke_event_exit_hook: bool = None,
+        post_invoke_event_hook_timeout: float = 30.0,
+        post_invoke_event_hook_params: dict = None,
+        **kwargs,
+    ) -> tuple[HookEvent | None, APICalling]: ...
+
+class HookedEvent(Event):
+    async def _core_invoke(self): ...
+    async def _core_stream(self): ...
+    async def _invoke(self): ...
+    async def _stream(self): ...
+    def create_pre_invoke_hook(
+        self,
+        hook_registry,
+        exit_hook: bool = None,
+        hook_timeout: float = 30.0,
+        hook_params: dict = None,
+    ): ...
+    def create_post_invoke_hook(
+        self,
+        hook_registry,
+        exit_hook: bool = None,
+        hook_timeout: float = 30.0,
+        hook_params: dict = None,
+    ): ...
+```
+
+Despite its annotation, `iModel.create_event()` returns the created `APICalling` object, not a
+`(HookEvent, APICalling)` tuple. The pre-create HookEvent remains available only as internal local
+state and through logging.
+
+**Creation and invocation semantics.**
+
+- With no registered handler, no HookEvent is attached and the core path is unchanged.
+- A pre-create hook receives the event class. Its response value is currently unused beyond the
+  exit/cancellation decision: construction of the event runs unconditionally after the hook, and
+  no code path substitutes the hook's return value for the constructed event
+  (`lionagi/service/imodel.py`, `create_event()`).
+- A pre-create failure with `exit=False` does not prevent default construction. A cancellation or
+  failure with `_should_exit=True` raises before construction.
+- Pre-invocation and post-invocation HookEvents attach only when their phase is present in the
+  registry.
+- A failed or cancelled pre-invocation HookEvent prevents `_core_invoke()` and `_core_stream()`.
+  This status check blocks even when the non-cancellation `exit` setting was false.
+- Non-stream `_core_invoke()` errors are held until the post hook runs. If both core and post fail,
+  the original core error wins. A regular post-handler exception becomes `ABORTED`: with
+  `exit=False` it is logged and the successful core result survives; with `exit=True` its cause
+  propagates when the core succeeded. Cancellation and wrapper-level `FAILED`/`CANCELLED` states
+  propagate only when there is no earlier core error.
+- Streaming runs its pre hook, yields core chunks, and runs its post hook only after normal stream
+  completion. A core-stream error bypasses the post section. A non-cancellation `Exception` raised
+  by the post-stream wrapper is logged because chunks have already been delivered; cancellation
+  keeps the runtime's cancellation behavior. HookEvent status is not used to retract data.
+- Per-chunk registry handlers take precedence over `streaming_process_func`. A non-exception return
+  replaces the processed chunk; `None` causes the caller to yield the original chunk. A handler
+  error with `exit=False` is ignored for delivery and the original chunk continues; with
+  `should_exit=True` the cause is raised.
+
+Pre-create hooks default to 10 seconds; pre/post HookEvents default to 30 seconds. `HookEvent`
+itself also defaults to 30 seconds. These are inherited implementation values; no recorded
+rationale explains the exact thresholds. The global hook logger buffers 100 entries before its
+logger-specific persistence behavior; 100 is likewise inherited without a recorded sizing study.
+
+**Why this way.** The template method surrounds the actual provider event and retains standalone
+`iModel` behavior. Phase-specific status lets callers distinguish cancellation from aborted
+postprocessing. Streaming necessarily gives post-delivery failures weaker control because already
+yielded chunks cannot be rolled back.
+
+### D5 — Tool hooks are per-Tool mutable interceptors
+
+The shipped agent declaration surface is (`lionagi/agent/spec.py`):
+
+```python
+class HooksMixin:
+    hook_handlers: dict[str, list[Callable]]
+
+    def pre(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+    def post(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+    def on_error(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+```
+
+Those methods append handlers under `pre:<name>`, `post:<name>`, and `error:<name>` and return the
+same mutable spec. `CodingToolkit` has parallel `security_pre()`, `pre()`, `post()`, and
+`on_error()` builders.
+
+The execution carrier is (`lionagi/protocols/action/tool.py` and
+`lionagi/protocols/action/function_calling.py`):
+
+```python
+class Tool(Element):
+    func_callable: Callable[..., Any]
+    request_options: type | None = None
+    preprocessor: Callable[[Any], Any] | None = None
+    preprocessor_kwargs: dict[str, Any] = Field(default_factory=dict)
+    postprocessor: Callable[[Any], Any] | None = None
+    postprocessor_kwargs: dict[str, Any] = Field(default_factory=dict)
+    strict_func_call: bool = False
+
+class FunctionCalling(Event):
+    func_tool: Tool
+    arguments: dict[str, Any] | BaseModel
+
+    async def _invoke(self) -> Any: ...
+```
+
+FunctionCalling validates request-model and required-field shape during model construction, then
+invokes in this order:
+
+```text
+Tool.preprocessor(arguments)
+→ Tool.func_callable(**arguments)
+→ Tool.postprocessor(response)
+```
+
+A preprocessor return becomes the new argument mapping. A postprocessor return becomes the response.
+The shipped factory builds a narrower convention over those fields:
+
+```python
+async def pre_hook(
+    tool_name: str,
+    action: str,
+    args: dict,
+) -> dict | None: ...
+
+async def post_hook(
+    tool_name: str,
+    action: str,
+    args: dict,
+    result: Any,
+) -> Any | None: ...
+```
+
+**Exact factory semantics.**
+
+- Handler lookup order on the standalone reader/editor/bash/search path is wildcard, canonical
+  tool name, then `<canonical_name>_tool` compatibility alias. `CodingToolkit`'s own hook lookup
+  (`lionagi/tools/coding.py`) — the path exercised by the default `AgentSpec.coding()`
+  construction — consults only `"*"` and the exact tool name, with no alias fallback.
+- Security pre-hooks run first. When at least one user pre-hook exists, the complete security list
+  runs again after all user pre-hooks.
+- Each factory pre-hook receives the canonical tool name, `args.get("action", "")`, and the
+  current argument mapping. A dictionary return replaces that mapping; other returns are ignored.
+  A raised exception prevents the callable.
+- The current `FunctionCalling` path does not re-run request-model validation after a preprocessor
+  replaces arguments.
+- The factory post chain runs only when the Tool result is a dictionary. It calls each handler with
+  the canonical tool name, empty action, empty argument mapping, and current result. Each dictionary
+  return replaces the result; non-dictionary returns are ignored. A non-dictionary Tool result
+  bypasses all declared post handlers.
+- `error:<name>` handlers are copied into CodingToolkit maps, but `Tool` has no error-processor
+  field and `FunctionCalling` never invokes them. Registration is not execution.
+- Ordinary built-ins receive their chained preprocessors/postprocessors before registration.
+  MCP-discovered Tools are registered later and currently receive none of these agent hooks.
+- Tool-level preprocessing is inside `ActionManager.invoke()`. Session `TOOL_PRE` fires earlier with
+  a summary payload; Session `TOOL_POST` or `TOOL_ERROR` fires after the manager returns or raises.
+- The built-in `auto_format_python` post-hook runs `ruff format` as an argv subprocess with shell
+  disabled and a 10-second timeout. Ten seconds is inherited; no recorded rationale establishes the
+  exact formatter deadline.
+
+The effective shipped action order is:
+
+```text
+validate action-request envelope
+→ SessionObserver.authorize(ToolInvocation)
+   └── deny: record GateDenied and return a Tool-shaped denial; no HookBus point fires
+→ HookBus TOOL_PRE(summary)
+   └── raised guard: propagate; no TOOL_ERROR and no HookSignal record
+→ ActionManager.invoke()
+   └── FunctionCalling Tool.preprocessor(arguments)
+       └── callable
+       └── Tool.postprocessor(result)
+→ HookBus TOOL_POST(summary) on success
+  or HookBus TOOL_ERROR(exception) on manager/invocation error
+```
+
+**Why this way.** Tool preprocessors sit at the only layer that owns the callable's argument mapping
+and result. The Session bus provides lifecycle visibility and an earlier coarse guard, but its
+summary payload is intentionally unsuitable for silent mutation. ADR-0044 specifies the target
+interceptor repair; this retrospective ADR does not pretend that target is already shipped.
+
+### D6 — cross-scope adapters are observational and semantics-preserving
+
+The shipped adapter is `HookBus` to `SessionObserver`: after the ordered chain succeeds, it emits a
+typed `HookSignal`. This establishes the rule for future bridges.
+
+An adapter is valid only when it preserves all of these properties:
+
+1. **Scope.** A per-`iModel` hook continues to function without a Session. Session binding adds
+   telemetry; it does not become the sole execution path.
+2. **Timing.** A pre-invocation guard still runs before the core operation. Emitting an observation
+   after completion cannot satisfy that contract.
+3. **Ordering.** An ordered chain is not translated into unordered reactive subscribers when
+   handler order or `StopHook` matters.
+4. **Payload.** Summary telemetry is not promoted into mutable invocation arguments. An adapter may
+   redact or summarize a stronger payload, but may not claim the reverse transformation.
+5. **Failure behavior.** Best-effort observation failure does not change the source operation.
+   Blocking source failure remains blocking and must be audited separately if an observation is
+   still required.
+6. **No duplicate canonical event.** `MESSAGE_ADD` uses `MessageAdded` on the observer and suppresses
+   a redundant `HookSignal`.
+
+The three dormant API HookPoints may acquire meaning only through a typed optional
+service-to-session adapter that states when it emits, what it redacts, and whether it observes a
+stream chunk before or after the service handler. `ARTIFACT_CREATED` remains dormant until the
+artifact owner supplies a payload and emit site. Merely calling `bus.emit()` in tests is not a
+production integration.
+
+**Why this way.** Adapters can unify telemetry without erasing control boundaries. That is the
+maximum safe consolidation supported by the shipped code. A stronger universal hook API would
+need a new operation wrapper, payload algebra, and compatibility plan rather than aliases between
+unlike callables.
+
+## Consequences
+
+- Session hooks remain ordered and observable, service hooks retain standalone and streaming
+  behavior, and Tool guards retain argument transformation.
+- Maintainers must identify the operation and owner before registering a “hook.” Import path alone
+  is not cosmetic: it determines lifetime, handler signature, and failure semantics.
+- `HookPoint` catalog consumers must distinguish enum availability from production wiring. Four
+  values currently describe reserved vocabulary only.
+- A `TOOL_PRE` denial is effective but not recorded as a HookSignal because recording follows the
+  successful chain. Audit consumers cannot infer denied attempts from HookSignal history.
+- Session bus attachment currently depends on access order. A Branch can have an observer and no
+  HookBus even while its Session later has a bus.
+- Declarative Session hook override utilities exist, but the default Session construction path does
+  not consume agent/profile declarations.
+- Service hook authors must know the actual three-positional-argument stream call and the actual
+  `APICalling` return from `create_event()` until the annotations are repaired.
+- Service post-invocation failure can replace a successful non-stream result only when exit or
+  cancellation semantics require propagation; an `ABORTED` post hook with `exit=False` leaves the
+  core result intact. No post hook can retract delivered stream chunks, and a core error remains
+  primary when both core and post fail.
+- Tool hook authors must know that error handlers are stored but unwired, post handlers are
+  dictionary-only, and MCP tools are outside current factory coverage.
+- Reversing D1 would be high cost: it requires changing standalone `iModel`, Session dispatch,
+  FunctionCalling mutation, settings loaders, tests, and all handler signatures together.
+- Reversing D2 or D3 independently would either lose ordered guards/persistence or duplicate the
+  Session event record.
+- Reversing D4 requires a compatibility wrapper around every provider event and stream path.
+- Reversing D5 requires the universal interceptor design in ADR-0044, including revalidation and
+  complete Tool-registration coverage.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Make Session hook attachment independent of lazy access order; accept when branches included before or after `Session.hooks` creation receive the same bus and emit the same tool signals. | S | (filled at issue-open time) |
+| 2 | Give the three dormant API `HookPoint` values production semantics through a typed, optional service-to-session observation adapter; accept when a session-bound iModel records API observations without changing service pre-invocation control or standalone iModel behavior. | M | (filled at issue-open time) |
+| 3 | Deprecate the unwired `ARTIFACT_CREATED` point until the artifact owner supplies a typed production emit site; accept when no public HookPoint is advertised without a payload contract and an integration test. | S | (filled at issue-open time) |
+| 4 | Record blocked `TOOL_PRE` attempts without swallowing the blocking exception; accept when denied calls produce an audit signal and the underlying tool is never invoked. | S | (filled at issue-open time) |
+| 5 | Align service hook annotations with runtime behavior; accept when `StreamHandlers` describes the actual stream callback arguments and `iModel.create_event()` has one truthful return type covered by static and runtime tests. | S | (filled at issue-open time) |
+| 6 | Either wire declarative Session hook overrides into a production construction boundary or document `build_session_bus(agent_hooks=...)` as an explicit low-level utility; accept when one public construction path and its tests demonstrate the chosen ownership. | M | (filled at issue-open time) |
+| 7 | Make the default `MESSAGE_ADD` handler compatible with the Branch emission payload or remove it from the default bus; accept when direct Session/Branch use cannot invoke `persist_message` without its required session and progression context. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Replace all three mechanisms with `HookBus`
+
+One named-point API would reduce vocabulary and allow one declarative loader. It lost because a
+Session bus does not exist for standalone `iModel` use, its handler payloads do not carry mutable
+Tool arguments, and its flat sequential chain does not model pre-create replacement or streamed
+post-delivery behavior. Keeping adapters at the observation boundary buys shared telemetry without
+weakening control.
+
+### Use only `SessionObserver` for execution and observation
+
+One typed Flow would give uniform filters, routing, persistence, and replay. It lost as an execution
+API because async subscriber completion is not ordered, there is no `StopHook` chain, and the
+observer's ordinary `emit()` occurs when an event is reported rather than necessarily before the
+operation. It also has Session scope, so it cannot be the sole service hook owner.
+
+### Translate every `HookBus.on()` registration directly to `SessionObserver.observe()`
+
+This would retain named points while deleting the bus's handler dictionary. It lost because
+reactive async subscribers are gathered rather than awaited as one ordered chain. Persistence
+handlers could race, `StopHook` would have no defined sibling set, and `TOOL_PRE` could no longer
+guarantee that every earlier guard completed before invocation.
+
+### Complete the original universal migration with compatibility wrappers
+
+Wrappers could preserve old imports while routing service and Tool handlers through one new core.
+That would buy a gradual deprecation path. It lost as the current decision because no common core
+contract exists: service handlers accept event objects and status/exit rules, Tool handlers replace
+arguments/results, and Session handlers accept loose keyword payloads. Wrappers would hide rather
+than resolve those semantic differences. A future universal operation-interceptor design must be
+specified first.
+
+### Replace Tool preprocessors with Session `TOOL_PRE`
+
+Moving guards to one Session point would make them visible to Session configuration and HookSignal
+telemetry. It lost because the current payload contains only a redacted string summary and cannot
+replace arguments. Expanding it to raw arguments would also put sensitive invocation data in the
+observer record by default and would still not cover standalone Branches without a Session bus.
+
+### Replace service post hooks with observations of completed API events
+
+Deriving post events from `EventStatus` would remove a bespoke phase name and works for pure
+telemetry. It lost as a complete replacement because the service hook can currently fail an
+otherwise successful non-stream invocation, runs without a Session, and has distinct stream
+semantics. It remains a valid optional adapter for observation-only consumers.
+
+### Use a universal around-middleware chain
+
+An `async handler(context, next)` contract could express pre, post, mutation, and short-circuiting
+for every operation. It would buy one powerful abstraction. It lost because Session lifecycle
+signals are not all invocations with a meaningful `next`, streaming needs yield-aware middleware,
+and converting the provider and Tool hot paths would be a high-blast-radius behavioral rewrite for
+no current cross-scope handler requirement.
+
+### Use one process-global bus
+
+A singleton would let service events publish without Session plumbing and make handler registration
+easy. It lost because handlers and observations would leak across concurrent Sessions and models,
+teardown ownership would be ambiguous, and tests would inherit process-order state. The one
+process-global structure that remains is only the loader's name-to-callable registry; actual buses
+are per Session.
+
+### Treat all eleven HookPoints as already supported
+
+Keeping the broader catalog in documentation would reserve convenient names and avoid deprecation.
+It lost because callers would register handlers that never run and mistake a test-only `emit()` for
+production integration. Dormant points are recorded honestly and require a typed emit site before
+they become operational claims.
+
+## Notes
+
+In pari materia resolves the word “canonical” against scope, timing, payload, and failure
+requirements. It does not require one shared handler ABI. The observer is canonical for Session
+recording; HookBus is canonical for ordered Session hook execution; HookRegistry/HookedEvent is
+canonical for service event control; Tool preprocessors are canonical for mutable Tool invocation.
+
+Source anchors: `lionagi/hooks/bus.py`, `lionagi/hooks/loader.py`,
+`lionagi/hooks/builtins.py`, `lionagi/hooks/persist.py`,
+`lionagi/session/signal.py`, `lionagi/session/observer.py`,
+`lionagi/session/session.py`, `lionagi/session/branch.py`,
+`lionagi/operations/_observe.py`, `lionagi/operations/act/act.py`,
+`lionagi/cli/_runs.py`, `lionagi/service/hooks/_types.py`,
+`lionagi/service/hooks/_utils.py`, `lionagi/service/hooks/hook_event.py`,
+`lionagi/service/hooks/hook_registry.py`, `lionagi/service/hooks/hooked_event.py`,
+`lionagi/service/imodel.py`, `lionagi/service/connections/api_calling.py`,
+`lionagi/agent/spec.py`, `lionagi/agent/factory.py`,
+`lionagi/tools/coding.py`, `lionagi/protocols/action/tool.py`, and
+`lionagi/protocols/action/function_calling.py`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,4 +97,36 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   boundary
 - 0031-0032 — unused (intentional gaps)
 
+### orchestration (0033-0040)
+
+- [ADR-0033](ADR-0033-operation-graph-orchestration-boundary.md) — Operation-graph
+  orchestration boundary
+- [ADR-0034](ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md) — Domain-engine
+  coordination and autonomy safeguards
+- [ADR-0035](ADR-0035-persisted-run-completion-contract.md) — Persisted run-completion
+  contract
+- [ADR-0036](ADR-0036-casts-role-palettes-as-playstyle.md) — Casts role palettes as playstyle
+- [ADR-0037](ADR-0037-resident-engine-host-and-task-queue.md) — Resident engine host and task
+  queue
+- [ADR-0038](ADR-0038-escalation-tier-routing.md) — Escalation tier routing
+- 0039-0040 — unused (intentional gaps)
+
+### agent-roles (0041-0046)
+
+- [ADR-0041](ADR-0041-agent-specification-and-branch-construction.md) — Agent specification
+  and Branch construction boundary
+- [ADR-0042](ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md) — Casts pattern
+  catalog and typed role authoring
+- [ADR-0043](ADR-0043-per-role-configuration-resolution.md) — Per-role configuration
+  resolution
+- [ADR-0044](ADR-0044-agent-prompt-directives-and-executable-permissions.md) — Agent prompt
+  directives and executable permissions
+- 0045-0046 — unused (intentional gaps)
+
+### hooks (0047-0049)
+
+- [ADR-0047](ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md) — Hook mechanism
+  scopes and canonical ownership
+- 0048-0049 — unused (intentional gaps)
+
 Remaining areas land here as their records are accepted.


### PR DESCRIPTION
Fourth ADR corpus bundle: eleven records across three areas.

- **orchestration (0033-0038)**: operation-graph orchestration boundary, domain-engine coordination and autonomy safeguards, persisted run-completion contract, casts role palettes as playstyle, resident engine host and task queue, escalation tier routing.
- **agent-roles (0041-0044)**: agent specification and Branch construction, casts pattern catalog and typed role authoring, per-role configuration resolution, agent prompt directives and executable permissions.
- **hooks (0047)**: hook mechanism scopes and canonical ownership.

README index extended with the three area sections (0039-0040, 0045-0046, 0048-0049 are intentional gaps). All records follow docs/adr/TEMPLATE.md, one kind each (retrospective or aspirational), every quoted contract checked against current source.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)