### PR TITLE
docs(adr): bundle 6 — scheduling-control-plane (0068-0073) + studio (0076-0083) + governance (0086-0087) + substrates (0090-0093)

### DIFF
--- a/docs/adr/ADR-0068-three-public-orchestration-lanes.md
+++ b/docs/adr/ADR-0068-three-public-orchestration-lanes.md
@@ -1,0 +1,377 @@
+# ADR-0068: Three public orchestration lanes
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0069, ADR-0073
+
+## Context
+
+LionAGI has one dependency-aware operation-graph kernel but more than one way to define work.
+The public surface must communicate whether a graph is authored or planned and whether its
+topology may grow after execution starts. Hiding those distinctions behind one universal runner
+would make planner calls, recovery guarantees, and control support implicit.
+
+The current implementation exposes two reactive entry shapes. `li play` rewrites to
+`li o flow -p <name>` in `lionagi/cli/main.py`, and `li o flow` plans and executes through
+`lionagi/cli/orchestrate/flow.py`. Studio also executes authored WorkflowDefs without a planner
+through `lionagi/studio/services/workflow_run.py`, but the equivalent headless
+`li flow run <name-or-file>` command does not exist. ADR-0073 records that current fixed runner
+and its migration gaps.
+
+This ADR answers five problems:
+
+- **P1 — Definition provenance is ambiguous.** A maintainer cannot reason about reproducibility
+  unless the run says whether its graph came from a playbook, a planner response, or an authored
+  fixed definition.
+- **P2 — Planning authority is ambiguous.** A command that may call a planner and a command that
+  must never call one cannot share an undifferentiated contract without surprising callers.
+- **P3 — Topology mutability is ambiguous.** Reactive flows may admit `SpawnRequest` nodes under a
+  cap; fixed workflows must reject any attempt to grow the authored topology.
+- **P4 — Capability inheritance is unsafe.** Pause/checkpoint support in the reactive executor
+  does not establish equivalent controls or recovery in the fixed runner.
+- **P5 — Adjacent control-plane mechanisms look like runners.** Schedule triggers, durable task
+  admission, workers, and dispatch delivery move or admit work; none defines a fourth way to
+  author an operation graph.
+
+| Concern | Decision |
+|---|---|
+| Public lane taxonomy | D1: Expose exactly reactive play, planned reactive flow, and fixed workflow lanes. |
+| Shared execution boundary | D2: Give each lane an adapter and converge only at `Session.flow()`. |
+| Lane capability truth | D3: Publish planning, growth, control, and recovery per lane; never infer parity. |
+| Stable invocation provenance | D4: Persist a lane-tagged, source-pinned invocation envelope. |
+| Scheduling and delivery boundary | D5: Treat triggers, admission, workers, and dispatch as consumers or siblings of lanes, not lanes. |
+
+Out of scope:
+
+- The operation-graph execution algorithm is owned by the operations ADRs; this ADR fixes public
+  lane boundaries around that kernel.
+- Reactive control and checkpoint mechanics are owned by ADR-0069; this ADR only constrains which
+  lanes may advertise them.
+- Fixed WorkflowDef compilation and current storage are owned by ADR-0073.
+- Queue transition and lease semantics are owned by ADR-0071 and the target convergence in
+  ADR-0072.
+- Trigger evaluation and outbound dispatch delivery are owned by ADR-0070.
+- Provider selection, model fallback, usage accounting, and authorization do not determine lane
+  identity and are not introduced here.
+
+## Decision
+
+### D1 — Exactly three public lanes
+
+LionAGI exposes exactly three public orchestration lanes. A lane is a contract for how a graph is
+defined, whether planning occurs, and whether graph growth is permitted. It is not a separate
+executor implementation.
+
+| Lane | Canonical public entry | Definition source | Planner call | Runtime growth | Lane-specific control |
+|---|---|---|---|---|---|
+| Reactive play | `li play <name> [args...]` | Resolved playbook plus invocation arguments | Allowed and normally required through the shared reactive planner | Allowed only when reactive policy and caps permit | ADR-0069 reactive controls |
+| Planned reactive flow | `li o flow [MODEL] PROMPT` or `li o flow -f <spec>` | Prompt or flow specification | Required for a new run; forbidden when replaying a checkpointed plan | Allowed only when reactive policy and caps permit | ADR-0069 reactive controls |
+| Fixed workflow | `li flow run <name-or-file>` | Authored, validated WorkflowDef | Forbidden | Forbidden | Fixed-run lifecycle only |
+
+The target CLI grammar is:
+
+```text
+li play <name> [playbook-args...] [flow-options...]
+li o flow [MODEL] PROMPT [--reactive MODE] [--max-ops N] [flow-options...]
+li o flow --resume <RUN_OR_SESSION_ID> [--allow-degraded-context]
+li flow run <name-or-file> [--input KEY=VALUE ...] [--base-dir DIR]
+```
+
+Exact lane semantics:
+
+- **Unknown playbook/name/file:** resolution fails before planning or execution; no empty run is
+  presented as success.
+- **Empty planned result:** the planned lane retries planning once and then fails loudly, matching
+  the existing `FlowPlanError` behavior in `lionagi/cli/orchestrate/flow.py`.
+- **Reactive disabled:** `--reactive off` selects the planned reactive lane with fixed topology for
+  that invocation; it does not convert the run into the fixed-workflow lane because the graph was
+  still planner-defined.
+- **Checkpoint replay:** `li o flow --resume` remains in the planned reactive lane but reuses the
+  recorded plan and configuration without a planner call.
+- **Fixed definition with unsupported node:** compilation fails before `Session.flow()`; the fixed
+  adapter does not fall back to planning.
+- **Attempted fixed graph growth:** no spawn type or reactive node builder is installed, so a fixed
+  run cannot accept `SpawnRequest` topology changes.
+
+Why this way: the three questions—where the graph came from, whether a planner may change the
+definition, and whether the graph may grow at runtime—produce three materially different public
+contracts already visible in source. Playbooks do not form a fourth lane because
+`_handle_play_shortcut()` deliberately rewrites them into the planned-flow path. A non-reactive
+planned flow does not become a fixed workflow because provenance and reproducibility still depend
+on a planner-produced graph.
+
+Code anchors for current seams: `lionagi/cli/main.py` (`_handle_play_shortcut`),
+`lionagi/cli/orchestrate/flow.py` (`_run_flow`, `_run_flow_inner`, `_resume_flow`),
+`lionagi/studio/services/workflow_run.py` (`run_workflow_def`).
+
+### D2 — Lane adapters converge at `Session.flow()`
+
+Each lane owns an adapter. The adapter resolves the definition, validates lane-specific inputs,
+builds an OperationGraph, stamps provenance, selects recovery/control capabilities, and presents
+the result. The adapter then calls the shared graph kernel.
+
+```text
+li play ──► PlayAdapter ───────┐
+                               ├─► reactive planner ─► OperationGraph ─┐
+li o flow ─► PlannedFlowAdapter┘                                      │
+                                                                      ├─► Session.flow(...)
+li flow run ─► FixedWorkflowAdapter ─────► OperationGraph ─────────────┘
+```
+
+Target adapter interface:
+
+```python
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+LaneKind = Literal["reactive_play", "planned_reactive_flow", "fixed_workflow"]
+
+@dataclass(frozen=True)
+class LaneInvocation:
+    lane: LaneKind
+    source_ref: str
+    source_kind: Literal["playbook", "prompt", "flow_spec", "checkpoint", "workflow_def"]
+    source_content_hash: str | None
+    inputs: dict[str, Any] = field(default_factory=dict)
+    base_dir: Path | None = None
+    reactive_mode: str = "off"
+    max_ops: int = 0
+
+@dataclass(frozen=True)
+class PreparedLaneRun:
+    graph: "Graph"
+    context: dict[str, Any]
+    invocation: LaneInvocation
+    recovery: dict[str, Any]
+
+class LaneAdapter(Protocol):
+    lane: LaneKind
+
+    async def prepare(self, invocation: LaneInvocation) -> PreparedLaneRun: ...
+    async def execute(self, prepared: PreparedLaneRun) -> dict[str, Any]: ...
+```
+
+`execute()` must delegate graph ordering to `Session.flow()` rather than implement its own graph
+scheduler. The fixed adapter passes `reactive=False` by omission and never supplies `spawn_type`,
+`node_builder`, or `max_spawn`. Reactive adapters use the existing planner and may enable reactive
+execution subject to D3.
+
+Exact adapter failure semantics:
+
+- Validation or resolution errors occur in `prepare()` and create no false completed result.
+- A kernel exception propagates through the lane's existing terminalization path; adapters may
+  translate it for CLI/API presentation but may not report success.
+- Empty input is lane-specific: an authored definition may validly use `{}` context; a planned
+  lane still requires a usable prompt/spec; a play still requires a resolvable playbook name.
+- Adapter retries are not implicit. Planning retains its explicit one retry for an empty plan;
+  fixed compilation and graph execution do not retry unless another ADR adds a safe policy.
+- Shared execution results retain the kernel shape:
+
+```python
+{
+    "completed_operations": list,
+    "operation_results": dict,
+    "final_context": dict,
+    "skipped_operations": list,
+    # reactive runs additionally expose:
+    "spawned_operations": int,
+    "escalated_operations": list,
+    "dropped_spawns": list[dict],
+}
+```
+
+Why this way: the current code already converges reactive execution through
+`PlanningEngine.new_run(...).run_dag(...)` and fixed execution through `Session.flow()`. The shared
+kernel owns dependency ordering, edge conditions, branch allocation, and operation results.
+Keeping source resolution and presentation in adapters prevents planner concerns from entering the
+kernel and prevents the fixed compiler from becoming a second executor.
+
+### D3 — Capabilities are declared per lane
+
+Public help, API schemas, and persisted run metadata must publish a capability matrix rather than
+imply that a capability on one `Session.flow()` caller is universal.
+
+| Capability | Reactive play | Planned reactive flow | Fixed workflow |
+|---|---:|---:|---:|
+| Planner may run | yes | yes for new run; no for checkpoint replay | no |
+| Runtime `SpawnRequest` growth | policy-controlled | policy-controlled | no |
+| `pause` / `resume` | ADR-0069 | ADR-0069 | not until separately implemented |
+| Context-mode operator message | ADR-0069 | ADR-0069 | not until separately implemented |
+| Reactive checkpoint replay | ADR-0069 | ADR-0069 | no |
+| Fixed source/hash replay | no | no | required target provenance |
+| Queue lease/restart survival | only when admitted through ADR-0072 | only when admitted through ADR-0072 | only when admitted through ADR-0072 |
+
+Target metadata projection:
+
+```python
+lane_capabilities: dict[str, bool] = {
+    "planner": ...,
+    "reactive_growth": ...,
+    "live_pause": ...,
+    "live_message": ...,
+    "checkpoint_resume": ...,
+    "leased_admission": ...,
+}
+```
+
+Exact semantics:
+
+- A missing or false capability means the public binding must reject the request; it must not
+  enqueue a control that no consumer will apply.
+- Capability flags describe the concrete invocation, not only the lane. For example,
+  `reactive_growth=False` on `li o flow --reactive off` is truthful even though the lane can support
+  growth on another run.
+- Queue admission is orthogonal: a direct CLI run and a queued run may use the same lane adapter
+  but have different restart ownership.
+- Adding fixed-run cancellation does not automatically add message injection or checkpoint replay;
+  each capability needs its own consumer and terminal semantics.
+
+Why this way: ADR-0069's poller exists only for live `flow`/`play` sessions, while the current
+WorkflowDef runner installs no such poller. Advertising by lane and invocation prevents the shared
+kernel from being mistaken for a shared lifecycle/control implementation.
+
+### D4 — Every run persists lane and source provenance
+
+Every adapter must persist enough information to answer “what exact definition produced this
+graph?” without inferring from command text.
+
+Target provenance payload:
+
+```json
+{
+  "lane": "fixed_workflow",
+  "source": {
+    "kind": "workflow_def",
+    "ref": "daily-review",
+    "version": 4,
+    "content_hash": "sha256:..."
+  },
+  "planner": {"used": false},
+  "reactive": {"enabled": false, "max_ops": 0},
+  "admission": {"task_id": null, "lease_attempt": null}
+}
+```
+
+The fixed lane's version/hash fields are required after ADR-0073's registry migration. Until that
+migration, the adapter must report the current unversioned `workflow_def_id` and omit—not invent—a
+hash. Planned checkpoint replay records both the new session id and the original checkpoint
+session id, matching the current `resumed_from` metadata seam.
+
+Exact semantics:
+
+- Name resolution pins an immutable version/hash before execution starts.
+- File mode hashes the validated file bytes that were compiled.
+- A source that changes after pinning does not mutate the in-flight run.
+- A missing pinned version is a resolution error; the adapter must not silently use “latest.”
+- The persisted lane is the selected adapter, not inferred later from `invocation_kind` alone.
+
+Why this way: current reactive checkpoints already persist prompt, plan, configuration, session id,
+and run id, while current WorkflowDef runs persist `workflow_def_id` and name in session metadata.
+The target makes that provenance uniform enough for operators without pretending all definition
+stores are identical.
+
+### D5 — Control-plane mechanisms submit to or observe lanes
+
+Schedule triggers, durable task submission, worker leases, and outbound dispatch retain separate
+contracts:
+
+```text
+trigger ──► task admission ──► lane adapter ──► Session.flow
+manual ───► task admission ──► lane adapter ──► Session.flow
+
+run transition ──► dispatch outbox ──► configured external transport
+```
+
+Target routing key:
+
+```python
+action_kind: Literal["agent", "flow", "fanout", "play", "flow_yaml", "workflow"]
+```
+
+`play` routes to the reactive-play adapter, `flow`/`flow_yaml` route to the planned reactive
+adapter, and `workflow` routes to the fixed adapter. Other action kinds remain non-lane task
+adapters and do not increase the public orchestration-lane count.
+
+Exact semantics:
+
+- A trigger evaluates cadence and admission policy, then submits; it does not execute a graph.
+- A worker chooses an adapter after winning a lease; producers do not import every adapter.
+- Dispatch begins from a committed producer fact and never owns task status.
+- A failed outbound notification cannot change the already-committed task terminal state.
+- A task that is queued but has no eligible adapter/worker remains queued with a diagnosable reason;
+  it is not silently reclassified as another lane.
+
+Why this way: a lane answers how graph work is defined. Admission and delivery answer when work may
+start and how an outcome leaves the process. Keeping those axes separate preserves low coupling
+and allows ADR-0072 to unify lifecycle ownership without inventing more graph executors.
+
+## Consequences
+
+- Public command names disclose the planning boundary: `li o flow` may plan; `li flow run` may not.
+- `Session.flow()` can evolve once for dependency execution while lane-specific provenance,
+  control, and recovery remain explicit adapters.
+- Schedulers and workers select a typed `action_kind` rather than infer behavior from arbitrary
+  arguments.
+- Documentation must maintain the capability matrix; adding one capability now requires changing
+  the owning adapter and its advertised metadata.
+- The fixed command, version/hash provenance, and adapter registry are required before the target
+  surface is complete.
+- Reversing D1 is expensive because command names and persisted provenance become public; reversing
+  D2 is also expensive because it would duplicate the graph kernel. D3-D5 are additive and can be
+  extended without changing the lane count when their boundaries remain intact.
+
+Coupling remains bounded by the adapter registry: producers depend on one admission contract;
+workers depend on one registry; each adapter depends on the graph kernel. Producers do not import
+all lane implementations.
+
+## Alternatives considered
+
+### One universal `li run`
+
+One command could accept a prompt, playbook, YAML, or WorkflowDef and guess the mode. It would buy a
+smaller apparent CLI, but it makes planner authority and topology mutability data-dependent. The
+same command could be reproducible in one invocation and planner-mutated in the next. It lost
+because P1-P3 require the mode to be knowable before execution.
+
+### Four lanes with playbooks separate from reactive flows
+
+A playbook has its own resolution and argument schema, so treating it as a lane would make that
+provenance visible. It lost because the current and intended implementation deliberately rewrites
+`li play` to `li o flow -p`; planning, reactive growth, controls, and execution are the same. The
+adapter distinction is sufficient without claiming a fourth execution contract.
+
+### Two lanes: dynamic and fixed
+
+Collapsing plays and planned flows into “dynamic” would buy an even smaller taxonomy. It lost
+because playbook identity and argument validation are stable public provenance worth naming, while
+the public `li play` command already exists. The three-lane names preserve that entry contract
+without adding a kernel.
+
+### Separate executor per lane
+
+Independent executors could optimize lifecycle behavior locally. They lost because dependency
+ordering, edge conditions, branch allocation, and result assembly are already shared by
+`Session.flow()`. Duplicating them would create semantic drift and force every graph fix into
+multiple runners.
+
+### Treat scheduling or dispatch as additional lanes
+
+This would make every execution transport visible as a lane and might simplify a UI menu. It lost
+because schedules do not define graphs and dispatch does not admit execution. Conflating them would
+make lane count grow whenever a new trigger or notification transport is added.
+
+### Advertise the union of all capabilities
+
+A universal capability matrix would be easy for clients to discover. It lost because the current
+fixed runner has no reactive poller or checkpoint consumer. Union advertising would accept control
+requests that cannot be applied, violating P4.
+
+## Notes
+
+The existing `li play` rewrite, planned-flow checkpoint format, reactive executor signature, and
+WorkflowDef runner are descriptive source anchors only. The `LaneInvocation`, `PreparedLaneRun`,
+adapter registry, `li flow run`, and uniform provenance envelope are target contracts specified by
+this aspirational ADR.

--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -1,0 +1,507 @@
+# ADR-0069: Reactive flow steering and recovery
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0085, v0-0088
+
+## Context
+
+`li play` is command sugar for `li o flow -p <name>`, so playbook runs and planned reactive
+flows use the same planning engine, dependency-aware executor, live control poller, and checkpoint
+writer. The executor may accept `SpawnRequest` values when reactive expansion is enabled, subject
+to a role filter and operation budget.
+
+Live control and cross-process recovery are separate mechanisms. Live control writes
+`session_controls` rows from one process and requires a poller plus in-memory executor in the
+original process. Recovery writes `checkpoint.json` into the run directory and reconstructs a new
+executor in a later process. Neither mechanism is a durable job queue or a universal runner handle.
+
+This ADR answers five concrete problems:
+
+- **P1 — A separate CLI process needs to steer a live executor.** It cannot hold an in-memory
+  Python reference, so requests need a durable transport and a single consumer.
+- **P2 — Pause cannot safely interrupt an arbitrary provider call.** The implemented safe boundary
+  is immediately before an operation acquires execution capacity and invokes its provider.
+- **P3 — Operator messages can be duplicated or missed.** Message application and DB stamping have
+  different crash semantics from idempotent pause/resume, and rendering must happen before an
+  operation's last provider-call boundary.
+- **P4 — Process death loses the in-memory DAG.** Planned topology, results, context, and
+  configuration need an independently readable checkpoint.
+- **P5 — Reactive topology and branch conversation are not reconstructible from the current
+  checkpoint.** Resume must refuse or explicitly degrade rather than call a partial replay exact.
+
+| Concern | Decision |
+|---|---|
+| Control addressing and transport | D1: Queue ordered `pause`, `resume`, and `message` rows only for live flow/play sessions. |
+| Cooperative pause semantics | D2: Gate new operation starts at the executor boundary; never preempt an in-flight provider call. |
+| Context-mode steering | D3: Apply messages at most once to shared flow context and render them once into a pending operation instruction. |
+| Checkpoint persistence | D4: Atomically replace a versioned full-state JSON checkpoint after operation outcomes. |
+| Resume and reactive-growth bounds | D5: Replay the recorded plan without planning; refuse spawned topology and gate degraded inherited context. |
+
+Out of scope:
+
+- Terminal cancellation is not shipped; `stop` is reserved in the table but has no CLI producer or
+  executor consumer.
+- Operation-node message injection is not shipped; only context-mode `msg` exists.
+- Mid-provider interruption, provider fallback, usage quotas, and model changes are not control
+  verbs.
+- Fixed WorkflowDef and scheduled-run controls are not implied; those paths do not run this poller.
+- Checkpoints are not queue leases, worker heartbeats, or exactly-once job persistence.
+- Full filesystem crash durability is not claimed: replacement is atomic to readers, but the
+  current writer does not issue an explicit file or directory `fsync`.
+
+## Decision
+
+### D1 — Ordered session-control rows are the live transport
+
+The public writers are:
+
+```python
+# lionagi/cli/orchestrate/_control.py
+def run_ctl_pause(args: argparse.Namespace) -> int: ...
+def run_ctl_resume(args: argparse.Namespace) -> int: ...
+def run_ctl_msg(args: argparse.Namespace) -> int: ...
+
+async def _enqueue_control_inner(
+    *, entity_id: str, verb: str, payload: dict[str, Any] | None
+) -> tuple[str, int]: ...
+```
+
+Their persisted contract is:
+
+```sql
+-- lionagi/state/schema.sql
+CREATE TABLE session_controls (
+  id          TEXT PRIMARY KEY,
+  session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  verb        TEXT NOT NULL CHECK(verb IN ('pause', 'resume', 'message', 'stop')),
+  payload     JSON,
+  created_at  REAL NOT NULL,
+  applied_at  REAL,
+  result      TEXT
+);
+
+CREATE INDEX idx_session_controls_pending
+  ON session_controls(session_id, applied_at) WHERE applied_at IS NULL;
+```
+
+Publicly accepted verbs are `pause`, `resume`, and `message`. `stop` is schema-reserved and is
+rejected by the current poller as unsupported if inserted by another caller. Pause and resume use
+`payload=NULL`; message uses `{"text": <string>}`. `StateDB.insert_session_control()` creates a
+UUID4-hex id, a current epoch timestamp, and leaves `applied_at` and `result` null.
+
+Exact addressing and queue semantics:
+
+- The CLI accepts a session, invocation, or play id, or a short prefix.
+- Prefix search is ordered by `sessions`, then `invocations`, then `plays`. Two matches in the
+  first matching table are rejected as ambiguous; a full-length id skips the prefix ambiguity
+  check.
+- A missing state database, unknown id, non-`running` session, or invocation kind outside
+  `{"flow", "play"}` fails without inserting a row.
+- The insert is bounded by `_DB_BUSY_TIMEOUT_S = 10.0`; timeout reports a busy database. The value
+  mirrors the status surface and prevents an unbounded CLI hang; no empirical rationale for ten
+  seconds is recorded in source.
+- Success means only “queued.” The message says application is expected within roughly two
+  seconds, but the writer does not wait for application.
+- The poller wakes every `_CONTROL_POLL_INTERVAL = 2.0` seconds. This is the control latency floor
+  when the event loop is healthy; the source records no measured rationale for the exact value.
+- Pending rows are read oldest-first by `(created_at, id)`. The id tie-break makes rapid enqueues
+  deterministic.
+- A transient list failure is retried on the next tick and does not fail the run.
+- If a successful effect cannot be terminally stamped, the poller stops that tick so a later
+  control cannot overtake the unstamped row.
+
+Terminal `result` values are `applied`, `applying`, or `rejected:<reason>`. The poller records a
+compact control log in session `node_metadata`, but `session_controls` remains the authoritative
+request/application row.
+
+Why this way: a database row lets a separate CLI process address a live flow without a process-wide
+handle registry. Restricting insertion to running flow/play sessions prevents controls from sitting
+pending forever against runners with no consumer.
+
+Code anchors: `lionagi/cli/orchestrate/_control.py`; `lionagi/cli/orchestrate/flow.py`
+(`_control_poll_loop`, `_apply_session_control`); `lionagi/state/db.py` (session-control methods);
+`lionagi/state/schema.sql`.
+
+### D2 — Pause and resume are idempotent operation-boundary effects
+
+The executor contract is:
+
+```python
+# lionagi/operations/flow.py
+class DependencyAwareExecutor:
+    def pause(self) -> None: ...
+    def resume(self) -> None: ...
+
+    async def _execute_operation(
+        self, operation: Operation, limiter: CapacityLimiter
+    ): ...
+```
+
+`pause()` installs an unset `ConcurrencyEvent` only when no pause event exists. `resume()` sets the
+current event and clears the reference; calling resume while unpaused is a no-op. Before a ready
+operation enters the concurrency limiter, `_execute_operation()` loops while a pause event exists,
+emits `NodePaused`, and waits for that particular event.
+
+Exact semantics:
+
+- **Pause twice:** both controls apply; the second call retains the same gate. There is no nested
+  pause count.
+- **Resume twice:** the first releases and clears the gate; the second is a no-op.
+- **Resume followed by pause:** a fresh event is installed, so operations reaching the boundary
+  after the later pause wait on the new gate.
+- **Operation already past the boundary:** it continues through `operation.invoke()`; pause never
+  cancels or interrupts its provider/tool activity.
+- **Operation waiting on dependencies:** it encounters the gate only after edge checks and
+  dependency completion.
+- **Skipped or already-terminal operation:** it completes its executor bookkeeping without waiting
+  on the pause gate.
+- **Run exits while paused:** the poller dies with the executor; queued future controls have no
+  consumer. The current code has no terminal cancel-on-pause behavior.
+- **Poller crash after effect but before stamp:** pause/resume are safe to reapply. `_finalize_applied`
+  retries the terminal stamp twice, then leaves the row pending for a later tick.
+
+The latency bound is cooperative, not real-time: control-poll delay plus time until an operation
+reaches the boundary. A long provider call can finish after pause acknowledgement because it was
+already in flight.
+
+Why this way: an operation boundary has clear state and does not require provider-specific
+cancellation guarantees. The tradeoff is latency; immediate preemption would need compensating
+semantics for tools, partial provider streams, and branch persistence that the current executor
+does not define.
+
+### D3 — Operator messages use at-most-once context steering
+
+The persisted input is:
+
+```json
+{"verb": "message", "payload": {"text": "operator correction"}}
+```
+
+The applied workspace entry is:
+
+```python
+{"ts": time.time(), "text": payload.get("text", "")}
+```
+
+Unrendered entries become one instruction prefix:
+
+```text
+[OPERATOR STEER]
+A human operator sent these live corrections while this flow is running.
+Attend to them before continuing. Most recent last.
+- <UTC timestamp>: <text>
+[/OPERATOR STEER]
+
+<original instruction>
+```
+
+The apply sequence differs deliberately from pause/resume:
+
+1. If the row already has `result='applying'`, leave it untouched.
+2. Stamp `result='applying'` while `applied_at` remains null.
+3. Confirm that at least one Operation in the current graph still has `PENDING` status.
+4. Append the entry to `executor.context.content["operator_messages"]`.
+5. Finalize the row as `applied`.
+
+Exact semantics:
+
+- **No pending operation:** finalize as `rejected:no-pending-ops`; completed/in-flight operations
+  are not rewritten.
+- **Unknown verb:** finalize as `rejected:unsupported-verb:<verb>`.
+- **Apply exception:** finalize as `rejected:error:<message>` truncated to 500 characters. A failure
+  to finalize returns the unstamped sentinel and stops later controls for the tick.
+- **Crash before `applying`:** the next poll may try normally.
+- **Crash after `applying`:** the row remains visibly mid-apply and is never reapplied
+  automatically. This chooses at-most-once delivery over possible duplication; it can lose a
+  message whose effect had not landed.
+- **Rendering:** `_prepare_operation()` copies shared context and renders pending entries at
+  dependency-render time. `_render_pending_operator_steers()` checks the canonical shared queue
+  again immediately before `operation.invoke()` to close the window where a message arrives after
+  preparation.
+- **Consume once:** rendered entries receive `rendered_into_op=<operation-id>` and are skipped by
+  later operations. The `operator_messages` key is removed from the per-operation context so raw
+  control JSON is not separately sent to the model.
+- **Several pending messages:** they are rendered together in stored order, with the most recent
+  last.
+- **Empty text:** the current payload accessor produces an empty list item; the CLI requires a text
+  argument but the poller itself does not reject an empty string.
+
+Why this way: context steering changes the next usable instruction without mutating graph topology.
+Stamp-before-apply is the honest crash choice for a non-idempotent append. Operation-node injection
+was not taken because it would require graph placement, dependencies, branch selection, and
+checkpoint replay semantics that do not exist.
+
+Code anchor: `lionagi/operations/flow.py` (`_render_operator_messages`,
+`_render_pending_operator_steers`); `lionagi/cli/orchestrate/flow.py`
+(`_apply_session_control`).
+
+### D4 — Checkpoints are full JSON snapshots replaced atomically
+
+The writer is a run-local dataclass:
+
+```python
+# lionagi/cli/orchestrate/_checkpoint.py
+CHECKPOINT_VERSION = 1
+
+@dataclass
+class CheckpointWriter:
+    path: Path
+    session_id: str
+    prompt: str
+    plan: list[dict]
+    config: dict[str, Any]
+    flow_context: dict[str, Any] = field(default_factory=dict)
+    ops: dict[str, dict[str, Any]] = field(default_factory=dict)
+    spawned: list[dict] = field(default_factory=list)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+    _seq: int = field(default=0, repr=False, compare=False)
+
+    def to_dict(self) -> dict[str, Any]: ...
+    async def record(
+        self,
+        agent_id: str,
+        *,
+        status: str,
+        response: Any,
+        flow_context: dict[str, Any] | None = None,
+    ) -> None: ...
+    async def record_spawned(
+        self,
+        node_id: str,
+        *,
+        status: str,
+        response: Any,
+        flow_context: dict[str, Any] | None = None,
+    ) -> None: ...
+```
+
+Wire shape:
+
+```json
+{
+  "version": 1,
+  "session_id": "...",
+  "prompt": "...",
+  "plan": [{"agent_id": "...", "dep_indices": [], "assignee": "..."}],
+  "flow_context": {},
+  "ops": {
+    "planned-agent-id": {
+      "agent_id": "planned-agent-id",
+      "status": "completed|failed",
+      "response": "..."
+    }
+  },
+  "spawned": [
+    {"node_id": "operation-uuid", "status": "completed|failed", "response": "..."}
+  ],
+  "config": {"model_spec": "...", "reactive_spec": "...", "max_ops": 0}
+}
+```
+
+Exact persistence semantics:
+
+- A writer is created only when checkpoint configuration is provided. Fresh and resumed CLI flows
+  construct one; unit seams that omit configuration do not.
+- `flush()` writes an initial snapshot before execution.
+- Planned nodes key `ops` by stable agent id. Spawned nodes use their operation UUID in a separate
+  list so a cloned branch name cannot overwrite a planned entry.
+- Re-recording a spawned node replaces the matching list entry; otherwise it appends.
+- Completion observers schedule writes, and `_execute_dag()` awaits all scheduled checkpoint tasks
+  before returning.
+- The `asyncio.Lock` serializes full snapshots. Each write uses a unique
+  `checkpoint.<sequence>.tmp`, serializes with `json.dumps(..., default=str)`, then calls
+  `os.replace(tmp, checkpoint.json)`. A reader therefore sees the old or new complete JSON file,
+  not a partially overwritten target.
+- The latest operation completion replaces the shared `flow_context` snapshot. It is an
+  accumulation, not per-operation history.
+- Serialization failures leave the previous target in place; the current caller suppresses some
+  checkpoint task exceptions at drain time, so checkpoint freshness is not guaranteed when a
+  write fails.
+- `load_checkpoint()` performs `json.loads(path.read_text())`. The current resume path does not
+  reject an unsupported `version` field explicitly; version 1 is descriptive, not a complete
+  migration gate.
+
+`CHECKPOINT_VERSION = 1` marks the initial shipped shape. No rationale beyond initial format
+versioning is recorded.
+
+Why this way: full snapshots are simple to inspect and avoid a partial event-log replay protocol.
+Atomic replacement protects readers from torn target files. The cost is write amplification after
+every completion and the lack of fsync-level durability or schema migration enforcement.
+
+### D5 — Resume replays the original plan and refuses unfaithful topology
+
+Resolution and replay contracts are:
+
+```python
+async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]]: ...
+
+def _apply_checkpoint_precompletion(
+    env: OrchestrationEnv,
+    plan_result: _PlanResult,
+    dag_state: _DagState,
+    checkpoint_ops: dict[str, dict],
+    *,
+    allow_degraded_context: bool,
+    checkpoint_spawned: list[dict] | None = None,
+) -> None: ...
+
+async def _resume_flow(
+    target: str,
+    *,
+    allow_degraded_context: bool = False,
+    dry_run: bool = False,
+    show_graph: bool = False,
+    notify: str | None = None,
+) -> tuple[str, str]: ...
+```
+
+Exact resolution semantics:
+
+- An exact run directory is preferred. Otherwise `_find_run_dir_by_id()` chooses the most recently
+  modified directory matching the supplied prefix; it does not report multiple prefix matches.
+- If no run directory checkpoint is found, the target is resolved through session/invocation/play
+  storage, then through the session's `node_metadata.run_id`.
+- Missing target, missing backing session, missing run id, or missing `checkpoint.json` raises
+  `FlowResumeError`.
+- `dry_run`, `show_graph`, and an explicit notify override come from the new invocation. Model,
+  prompt, playbook, operation cap, reactive policy, and other execution settings come from the
+  checkpoint.
+
+Exact replay semantics:
+
+- The persisted `plan` is reconstructed directly; the planner is not called.
+- An empty plan is rejected.
+- Previously completed nodes are pre-marked `COMPLETED` with their response. Previously failed
+  nodes are pre-marked `FAILED`; resume does not guess that retrying their possibly side-effecting
+  operation is safe.
+- Pending nodes run normally and receive restored shared result context.
+- If any pending node requested `inherit_context`, resume refuses because predecessor conversation
+  messages are not restored. `--allow-degraded-context` permits those named nodes to run with an
+  empty branch while retaining result context.
+- Any non-empty `spawned` checkpoint list refuses resume. The current writer records spawned
+  outcomes, but the plan does not contain their position or branch inheritance, so replay would
+  silently drop work.
+- A resumed run writes its own checkpoint and records `resumed_from=<original-session-id>`.
+
+Reactive growth itself is bounded by the live executor:
+
+```python
+async def flow(
+    session: Session,
+    graph: Graph,
+    *,
+    reactive: bool = False,
+    spawn_type: type | None = None,
+    node_builder: Any = None,
+    max_spawn: int = 50,
+    executor_ref: dict[str, Any] | None = None,
+    ...,
+) -> dict[str, Any]: ...
+```
+
+The CLI parses `--reactive off` as disabled, `all`/truthy spellings as all roles, and any other
+comma-separated value as an allowed role set. When `--max-ops N` is positive, initial planned
+nodes and spawns share the cap: `max_spawn=max(0, N-len(plan))`. Without a cap the CLI uses a
+conservative default of 20 spawned nodes to bound cost; the generic executor default remains 50.
+The CLI source explains the 20-node value only as a conservative guard against costly uncapped
+fan-out; no measured tuning record exists. Plans above 200 assignments are truncated to 200 as a
+runaway-planner defense; the numeric threshold likewise has no recorded empirical rationale.
+
+Spawn attempts reject and record `builder_error`, `null_child`, `cycle`,
+`max_spawn_exceeded`, or `duplicate`. Accepted nodes receive a branch clone, an optional dependency
+edge from the emitter, and a `NodeSpawned` signal. These live semantics do not make their topology
+recoverable by the version-1 checkpoint.
+
+Why this way: replaying a stable planner output avoids paying for or drifting through a second
+plan. Refusal is preferable to silently dropping spawned work or conversational inheritance. The
+explicit degraded flag makes the one supported fidelity loss visible to the caller.
+
+## Consequences
+
+- A separate CLI process can steer a live flow through the database without an in-process handle
+  registry.
+- Pause is safe at operation boundaries but can lag behind long in-flight calls.
+- Context steering is at-most-once; a crash in the `applying` window may lose a message and leaves a
+  visible row requiring diagnosis.
+- Full checkpoint snapshots are inspectable and atomically visible, but are not a transactional log
+  and do not guarantee fsync-level persistence.
+- Resume is planner-free and preserves completed/failed outcomes, but refuses checkpoints containing
+  reactive spawn outcomes and requires an explicit flag to lose inherited conversation state.
+- Contributors extending control must understand verb-specific apply/stamp ordering; treating a
+  message like idempotent pause/resume would introduce duplicate steering.
+- Reversing D1-D3 requires a new control transport and compatibility for pending rows. D4's JSON
+  format can be versioned, while D5's refusal rules may be relaxed only when the missing state is
+  actually persisted and replayed.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Add a terminal reactive-flow cancel control; acceptance: after acknowledgement, no new operation starts and the run persists a cancelled terminal state. | M | (filled at issue-open time) |
+| 2 | Replay reactively spawned nodes from checkpoints or reject affected checkpoints before execution; acceptance: resume never returns a partially replayed spawned DAG as successful recovery. | M | (filled at issue-open time) |
+| 3 | Persist predecessor conversation state needed by `inherit_context`; acceptance: eligible resumed operations receive the same inherited conversation without requiring degraded mode. | L | (filled at issue-open time) |
+| 4 | Enforce checkpoint-version compatibility and report unsupported versions before graph construction; acceptance: a checkpoint with an unknown version fails with a typed migration/compatibility error. | S | (filled at issue-open time) |
+| 5 | Add operator recovery for controls stranded in `applying`; acceptance: status distinguishes definitely-applied, definitely-not-applied, and indeterminate messages without automatic duplicate injection. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Process-local runner handle registry
+
+A registry could map run ids to executor objects and make pause/resume direct method calls. It
+would buy lower latency and simpler stamping, but a separate `li` process could not reach it
+without another IPC service, and a restart would erase every handle. It lost because the shipped
+control surface is explicitly cross-process.
+
+### Mid-provider cancellation
+
+Cancelling the coroutine immediately would buy faster stop/pause response. It lost because provider
+calls and tool actions may have external side effects and no uniform compensation contract. The
+operation boundary is the implemented point where “has not started” is unambiguous.
+
+### Operation-node message injection
+
+A message could become a first-class graph node with its own branch and dependencies. That would
+buy topology-level observability and targeted placement. It lost because the current design has no
+contract for where to attach the node, how to replay it, or how it should inherit context. Context
+mode meets the steering need without pretending those questions are solved.
+
+### Apply message then stamp
+
+This ordering would avoid messages stranded in `applying`. It lost because a crash after append but
+before stamp would cause the next poll to append the same instruction again. The chosen
+stamp-then-apply order accepts a visible at-most-once loss window instead of silent duplication.
+
+### Incremental checkpoint event log
+
+Appending one event per completion would reduce full-file write amplification and could support
+more exact replay. It lost for the current implementation because it needs log framing,
+compaction, corruption recovery, schema migration, and a deterministic fold. A full JSON snapshot
+is much smaller operational machinery for current flow sizes.
+
+### Replan on resume
+
+Calling the planner again could reconstruct a complete graph without storing as much topology. It
+lost because planner output is not deterministic: dependencies, roles, and node count could change,
+invalidating completed results and provenance.
+
+### Silently skip unsupported spawned nodes or inherited conversation
+
+This would maximize the number of checkpoints that appear resumable. It lost because the resulting
+run is not faithful. The code now refuses spawned checkpoints and requires an explicit degraded
+flag for inherited conversation.
+
+### Use the durable task queue as the live-control channel
+
+Controls could be tiny queue jobs, buying one generic transport. It lost because task admission
+and executor-local steering have different ownership and terminal semantics. A worker claiming a
+pause job would still need the live executor reference this design already exposes directly to the
+poller.
+
+## Notes
+
+The schema reserves `stop`, but reservation is not implementation. Current public vocabulary is
+only `pause | resume | message`. Checkpoint recovery is a reactive-flow feature and must not be
+described as durable task persistence.

--- a/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
+++ b/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
@@ -1,0 +1,608 @@
+# ADR-0070: Studio scheduling and dispatch delivery
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0027, v0-0058
+
+## Context
+
+Studio starts one in-process `SchedulerEngine` with the FastAPI lifespan. The engine owns trigger
+evaluation, fire-time admission, immediate child-process launch, run finalization, bounded inline
+follow-ups, outbound dispatch scans, and one host task-worker tick. These concerns share a timer,
+but they do not share one state machine.
+
+Schedules persist `cron`, `interval`, or `github_poll` triggers. Cron and interval schedules may
+also carry a metric threshold; in that form the cadence evaluates a condition and fires only on a
+breach. A manual fire is an operation over an existing schedule, not a fourth trigger type.
+
+Scheduled actions are launched immediately and awaited by the scheduler task. They enter
+`schedule_runs` as `running`, never as `queued`, and do not acquire worker leases. The generalized
+table also holds ad-hoc queued rows, but ADR-0071 records that separate path.
+
+`dispatch_outbox` is another sibling hosted by the same tick. It provides producer-driven durable
+outbound delivery with deduplication, guarded claims, bounded retry/backoff, optional
+acknowledgement, expiry, and dead letters. It does not execute LionAGI work.
+
+This ADR answers five problems:
+
+- **P1 — Trigger evaluation needs a host lifecycle.** Studio needs one loop with defined startup,
+  missed-fire, maintenance, and shutdown behavior.
+- **P2 — A due fire needs explicit admission.** Overlap, cumulative budget, run count, threshold
+  cooldown, and global concurrency must be decided before launch.
+- **P3 — Subprocess construction crosses a trust boundary.** Stored schedule fields become argv,
+  cwd, environment, and process-group state and must be validated without a shell.
+- **P4 — Follow-up recursion can become unbounded or unobservable.** Success/failure continuations
+  need a depth cap and parent linkage even though they are not first-class dependency rows.
+- **P5 — Outbound notifications need durability independent of task execution.** A notification
+  transport failure must be retryable without reopening or changing the producer's run status.
+
+| Concern | Decision |
+|---|---|
+| Engine lifecycle and tick order | D1: Run one 30-second in-process scheduler loop under Studio lifespan. |
+| Trigger and fire admission | D2: Persist three trigger types and apply missed-fire, overlap, threshold, budget, run-count, and global-slot gates before launch. |
+| Invocation and subprocess execution | D3: Record invocation/run facts, construct argv from a closed vocabulary, launch a new process group, and terminalize from exit outcome. |
+| Follow-up behavior | D4: Execute inline `on_success`/`on_fail` actions recursively with parent linkage and depth 10. |
+| Dispatch delivery | D5: Keep a separate at-least-once outbox with guarded delivery attempts and bounded acknowledgement. |
+
+Out of scope:
+
+- Scheduled fires are not currently routed through the leased queue; ADR-0072 owns that target.
+- The scheduler is not a distributed leader-elected service. One Studio process is assumed.
+- Schedule budgets are not a general usage ledger and do not select fallback models.
+- Follow-ups are not independently addressable dependency entities and have no separate
+  cancel/retry command.
+- Dispatch is not task admission, a trigger, or a live executor-control channel.
+- An external notification protocol is not fixed; `dispatch.notify_template` is configuration.
+
+## Decision
+
+### D1 — Studio owns one in-process 30-second loop
+
+Studio lifespan starts and stops the module singleton:
+
+```python
+# lionagi/studio/scheduler/engine.py
+class SchedulerEngine:
+    def __init__(self, svc: SchedulerStateService | None = None) -> None: ...
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def fire_now(self, schedule_id: str) -> str | None: ...
+
+scheduler = SchedulerEngine()
+
+_TICK_INTERVAL = 30
+_MAX_CHAIN_DEPTH = 10
+_DEFERRED_RECORD_EVERY = 10
+```
+
+`lionagi/studio/app.py` calls `scheduler.start()` before serving requests and
+`scheduler.stop()` during lifespan teardown. `start()` recomputes enabled cron schedule fire times
+under the current configured timezone, then creates the tick task. The loop checks missed fires
+once, then repeats `_tick()` followed by a 30-second sleep.
+
+Per-tick order is:
+
+```text
+1. periodic lifecycle reapers, when their interval elapsed
+2. periodic state-database checkpoint, when its interval elapsed
+3. due dispatch_outbox delivery scan
+4. host task-worker heartbeat/reap/claim pass
+5. enabled schedule evaluation
+```
+
+Relevant settings and defaults are:
+
+```python
+# lionagi/studio/config.py
+MAX_SCHEDULED_CONCURRENT = int(
+    os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED_CONCURRENT", "4")
+)
+INVOCATION_DEADLINE_SECONDS = int(
+    os.environ.get("LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS", "7200")
+)
+REAPER_INTERVAL_SECONDS = int(
+    os.environ.get("LIONAGI_STUDIO_REAPER_INTERVAL_SECONDS", "300")
+)
+SCHEDULER_TZ = os.environ.get("LIONAGI_SCHEDULER_TZ") or _system_local_tz_name()
+CHECKPOINT_INTERVAL_SECONDS = int(
+    os.environ.get("LIONAGI_STUDIO_CHECKPOINT_INTERVAL_SECONDS", "3600")
+)
+```
+
+Exact lifecycle semantics:
+
+- Startup cron recomputation skips already-due rows so missed-fire policy sees them first.
+- An invalid configured IANA timezone logs a warning and falls back to UTC rather than stopping the
+  scheduler.
+- One tick concern failing logs independently; dispatch or worker failure does not prevent schedule
+  evaluation in that tick.
+- A top-level `_tick()` exception is logged and the loop sleeps before retrying.
+- Fires are background tasks tracked in `_fire_tasks`; shutdown cancels the tick, cancels every
+  tracked fire, awaits them with `return_exceptions=True`, and clears the set.
+- Child processes are terminated by their cancellation path (D3), so scheduler shutdown does not
+  intentionally orphan their process groups.
+- Schedules do not fire while Studio is down. Startup applies only the stored `missed_fire_policy`.
+
+The 30-second tick is also the minimum normal latency for dispatch and the host task queue because
+neither has another sleep loop. Source comments treat it as an accepted local latency/load tradeoff
+but record no measurement for the exact value. The 300-second reaper, 3600-second DB checkpoint,
+two-hour invocation deadline, and default concurrency of four are configurable inherited defaults;
+their exact numeric tuning is not justified by measurements in this source area.
+
+Why this way: one local loop makes Studio deployment simple and gives all hosted maintenance work a
+bounded lifecycle. The tradeoff is availability and coupling inside `SchedulerEngine`: a Studio
+outage suspends triggers and the large engine class coordinates several policies.
+
+Code anchors: `lionagi/studio/app.py` (`lifespan`); `lionagi/studio/scheduler/engine.py`
+(`SchedulerEngine.start`, `_tick_loop`, `_tick`, `stop`); `lionagi/studio/config.py`.
+
+### D2 — Three trigger types pass explicit fire gates
+
+The persisted schedule contract is:
+
+```sql
+-- lionagi/state/schema.sql (selected columns)
+CREATE TABLE schedules (
+  id                  TEXT PRIMARY KEY,
+  name                TEXT NOT NULL UNIQUE,
+  enabled             INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+  trigger_type        TEXT NOT NULL
+                      CHECK(trigger_type IN ('cron', 'interval', 'github_poll')),
+  cron_expr           TEXT,
+  interval_sec        INTEGER,
+  github_repo         TEXT,
+  github_filter       JSON,
+  github_cursor       TEXT,
+  poll_interval_sec   INTEGER,
+  action_kind         TEXT NOT NULL
+                      CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml')),
+  action_model        TEXT,
+  action_prompt       TEXT,
+  action_agent        TEXT,
+  action_playbook     TEXT,
+  action_flow_yaml    TEXT,
+  action_project      TEXT,
+  action_extra_args   JSON DEFAULT '[]',
+  on_success          JSON,
+  on_fail             JSON,
+  last_fired_at       REAL,
+  next_fire_at        REAL,
+  missed_fire_policy  TEXT NOT NULL DEFAULT 'skip'
+                      CHECK(missed_fire_policy IN ('skip', 'run_once')),
+  overlap_policy      TEXT NOT NULL DEFAULT 'skip'
+                      CHECK(overlap_policy IN ('skip', 'allow')),
+  max_runs            INTEGER,
+  budget_usd          REAL,
+  budget_tokens       INTEGER,
+  project             TEXT,
+  threshold_config    JSON,
+  last_alert_at       REAL,
+  last_healthy_poll_at REAL,
+  poller_consecutive_401 INTEGER NOT NULL DEFAULT 0,
+  created_at          REAL NOT NULL,
+  updated_at          REAL NOT NULL
+);
+```
+
+The HTTP create model mirrors these columns:
+
+```python
+# lionagi/studio/services/schedules.py
+class CreateScheduleRequest(BaseModel):
+    name: str
+    description: str | None = None
+    trigger_type: str
+    cron_expr: str | None = None
+    interval_sec: int | None = None
+    github_repo: str | None = None
+    github_filter: dict | None = None
+    poll_interval_sec: int | None = None
+    action_kind: str
+    action_model: str | None = None
+    action_prompt: str | None = None
+    action_agent: str | None = None
+    action_playbook: str | None = None
+    action_flow_yaml: str | None = None
+    action_project: str | None = None
+    action_extra_args: list[str] | None = None
+    on_success: dict | None = None
+    on_fail: dict | None = None
+    missed_fire_policy: str = "skip"
+    overlap_policy: str = "skip"
+    max_runs: int | None = None
+    budget_usd: float | None = None
+    budget_tokens: int | None = None
+    project: str | None = None
+    threshold_config: dict | None = None
+```
+
+Creation requires the trigger and action kind. Cron requires a valid `cron_expr`; interval requires
+a positive integer `interval_sec`; GitHub polling requires `github_repo`; `flow_yaml` requires
+non-empty inline YAML. `max_runs`, `budget_usd`, and `budget_tokens` must be positive when supplied.
+Cron expressions are interpreted in `SCHEDULER_TZ`, while `next_fire_at` remains a UTC epoch.
+
+The management CLI currently exposes creation choices `agent`, `playbook`, and `flow_yaml`, while
+the table admits `agent`, `flow`, `fanout`, `play`, and `flow_yaml`. Creation stores the literal CLI
+value; it does not map `playbook` to `play`. The only alias mapping exists later in
+`subprocess.build_argv()`. Consequently `playbook` can fail the table constraint before fire time.
+This mismatch is current behavior, not an intended alias contract.
+
+Top-level fire admission order for cron/interval is:
+
+```text
+threshold evaluation/cooldown, when configured
+  → overlap gate
+  → cumulative token/cost gate
+  → max_runs reservation
+  → daemon-wide concurrency-slot reservation
+  → tracked fire task
+```
+
+Exact gate semantics:
+
+- **Missed fire `skip`:** startup writes a skipped run with evidence and advances
+  `next_fire_at`.
+- **Missed fire `run_once`:** startup reserves a future `next_fire_at` before creating one recovery
+  task. If reservation fails, it does not also queue recovery; the immediately following normal
+  tick may own the due fire.
+- **Overlap `skip`:** if the schedule id is already in the engine's in-memory `_running` map, write
+  a skipped run and advance cadence. `allow` bypasses this check.
+- **Threshold within bounds:** advance cadence without creating a run.
+- **Threshold breach in cooldown:** advance cadence without a run. Cooldown equals
+  `window_minutes * 60`; an in-memory reservation prevents two ticks from racing before
+  `last_alert_at` persists.
+- **Budget exhausted:** cumulative prior session cost or tokens disables the schedule before a new
+  fire. It does not interrupt a run already in flight and can overshoot by one run.
+- **`max_runs` exhausted:** top-level terminal run count plus in-process claims refuses the fire and
+  disables the schedule. Inline chain children do not consume the count.
+- **Global capacity exhausted:** automatic fires remain due and retry next tick. A skipped/deferred
+  record is written on the first deferral and every tenth deferral thereafter to avoid row spam.
+- **Manual fire:** applies budget, max-run, and global-slot checks; capacity is rejected to the
+  caller rather than deferred. It returns a generated 12-hex run id once the task is scheduled.
+- **GitHub polling:** uses its stored cursor and polling interval (default fallback 300 seconds) and
+  reserves capacity before advancing cursor for an event that will fire.
+
+The max-run and global-slot handles release idempotently from `_fire()`'s `finally`, including
+cancellation or failure before a run row is written. This closes in-process reservation leaks; it
+does not provide multi-process coordination.
+
+Why this way: the gates make refusal/defer reasons explicit and prevent a due fire from being
+silently dropped. The cost is policy concentration in one engine and single-process correctness
+for reservations.
+
+Code anchors: `lionagi/studio/services/schedules.py`; `lionagi/studio/scheduler/engine.py`
+(`_check_missed_fires`, `_maybe_fire`, `_reserve_max_runs_budget`, `_reserve_global_slot`,
+`_check_budget`); `lionagi/state/schema.sql`.
+
+### D3 — A scheduled fire is an immediate isolated child process
+
+The run and invocation rows are created by `SchedulerEngine._fire_inner()`. A valid fire first
+creates an invocation in `running`, builds argv, creates a `schedule_runs` row in `running`, stamps
+a transition reason, advances schedule cadence, then awaits the child process.
+
+The current schedule-run columns are:
+
+```sql
+CREATE TABLE schedule_runs (
+  id                    TEXT PRIMARY KEY,
+  schedule_id           TEXT REFERENCES schedules(id) ON DELETE CASCADE,
+  invocation_id         TEXT REFERENCES invocations(id),
+  trigger_context       JSON NOT NULL,
+  action_kind           TEXT NOT NULL,
+  action_args           JSON NOT NULL,
+  status                TEXT NOT NULL DEFAULT 'running'
+                        CHECK(status IN ('queued', 'waiting_dependency', 'running',
+                                         'retry_wait', 'completed', 'failed',
+                                         'timed_out', 'skipped', 'cancelled')),
+  exit_code             INTEGER,
+  chain_parent_id       TEXT REFERENCES schedule_runs(id),
+  chain_depth           INTEGER NOT NULL DEFAULT 0,
+  fired_at              REAL NOT NULL,
+  ended_at              REAL,
+  error_detail          TEXT,
+  created_at            REAL NOT NULL,
+  updated_at            REAL,
+  status_reason_code    TEXT,
+  status_reason_summary TEXT,
+  status_evidence_refs  JSON,
+  queued_at             REAL,
+  leased_by             TEXT,
+  lease_expires_at      REAL,
+  concurrency_key       TEXT,
+  lease_attempts        INTEGER NOT NULL DEFAULT 0,
+  required_capabilities JSON,
+  execution_target      TEXT,
+  library_ref           TEXT,
+  library_content_hash  TEXT
+);
+```
+
+Scheduled rows have non-null `schedule_id`, begin `running`, and leave queue/lease fields empty.
+They are owned by `_fire_inner()`, not ADR-0071's worker.
+
+The subprocess boundary is:
+
+```python
+# lionagi/studio/scheduler/subprocess.py
+def resolve_li_executable() -> tuple[list[str] | None, str | None]: ...
+
+def build_argv(
+    schedule: dict,
+    trigger_context: dict,
+    *,
+    executable_prefix: list[str] | None = None,
+) -> tuple[list[str], str | None]: ...
+
+async def spawn_and_wait(
+    argv: list[str],
+    invocation_id: str,
+    *,
+    tmp_path: str | None = None,
+    cwd: str | None = None,
+) -> tuple[int, str]: ...
+```
+
+Launcher vocabulary is the schedule table's five kinds plus `engine` for the shared launcher;
+`playbook` maps to `play` only inside `build_argv()`. `build_argv()` validates model/identifier
+tokens, forbids flag-like extra arguments, renders prompt templates, inserts `--` before free-form
+positionals, and uses `create_subprocess_exec` rather than a shell. `flow_yaml` is written to a
+temporary file and removed after execution.
+
+Cwd resolves in order:
+
+1. registered `action_project` path when it exists;
+2. valid `LIONAGI_SCHEDULER_CWD`;
+3. `None`, inheriting daemon cwd with a warning.
+
+The `li` executable resolves independently of the eventual child cwd. Failure to resolve an
+absolute executable path is a launch error rather than silently using a cwd-dependent prefix.
+
+`spawn_and_wait()` passes `LIONAGI_INVOCATION_ID`, redirects stdout to null, captures stderr, and
+uses `start_new_session=True`. On cancellation it terminates the full process group with a
+five-second grace, then re-raises. The five-second grace is a concrete shutdown budget inherited
+from this launcher; source records no measured rationale for the exact duration. Only the last
+2048 stderr bytes are retained; this bounds row payload size, with no recorded tuning evidence for
+2048.
+
+Exact outcome semantics:
+
+- **Invalid action before run-row creation:** the invocation already exists. The scheduler writes a
+  failed schedule-run row with empty `action_args`, terminalizes both records, advances cadence,
+  and checks max runs.
+- **Exit 0:** schedule run becomes `completed`; invocation terminal status is resolved from its
+  linked session evidence.
+- **Non-zero exit:** run becomes `failed`, stores `exit_code` and stderr tail, and records either a
+  missing-cwd or generic non-zero reason.
+- **Concurrent terminal writer wins:** guarded terminalization checks expected status `running`;
+  the scheduler treats a lost race as a checked no-op and continues follow-on bookkeeping.
+- **Scheduler cancellation:** child process group is terminated; run and invocation attempt to
+  become `cancelled`, then cancellation propagates.
+- **Internal exception after run creation:** both records attempt terminal `failed`; error detail is
+  bounded to the scheduler's chosen summary fields.
+- **Daemon crash:** there is no queue lease to reclaim the scheduled row. Startup lifecycle
+  reconciliation may classify stale records, but does not recreate the missed subprocess from that
+  row.
+
+Why this way: subprocess isolation keeps a scheduled action out of Studio's Python runtime and lets
+the existing CLI remain the action adapter. It gives up durable lease recovery and makes stable cwd
+and executable resolution load-bearing.
+
+### D4 — Follow-ups are bounded inline recursion
+
+Schedules may store `on_success` and `on_fail` JSON objects. After a child exits, the scheduler
+chooses at most one continuation:
+
+```text
+exit_code == 0 and on_success present → on_success
+exit_code != 0 and on_fail present    → on_fail
+otherwise                             → no continuation
+```
+
+The selected object overlays the parent schedule. Its `kind` or `action_kind` replaces
+`action_kind`; `model`, `prompt`, `agent`, and `playbook` map to their corresponding action fields.
+The child receives a trigger context containing the original context plus `chain_from`,
+`parent_exit_code`, and `parent_status`.
+
+Exact semantics:
+
+- The child row sets `chain_parent_id=<parent-run-id>` and increments `chain_depth`.
+- Recursion continues only while the current depth is less than `_MAX_CHAIN_DEPTH = 10`; at depth
+  10 no next child is launched.
+- Chain children do not reserve global slots or max-run claims and do not count against
+  `max_runs`; they execute within the already-admitted top-level fire task.
+- A follow-up is awaited inline, so the parent fire task and any top-level global slot remain held
+  until the chain completes.
+- Follow-ups have separate schedule-run and invocation rows but no independently persisted edge
+  object, policy, retry counter, or cancel address beyond their ids.
+- A follow-up failure can select its own inherited/overlaid `on_fail` and continue until the cap.
+
+Ten is a safety cap preventing unbounded recursive JSON. No recorded workload or measurement
+explains why ten rather than another bounded value.
+
+Why this way: inline recursion makes simple success/failure notification chains possible without a
+new dependency subsystem. The cost is weak addressability and policy inheritance through dict
+overlay.
+
+### D5 — Dispatch is a separate guarded outbox
+
+The payload model and enqueue signature are:
+
+```python
+# lionagi/session/signal.py
+class DispatchSignal(Signal):
+    dispatch_id: str = ""
+    kind: str = ""
+    deliver_to: str = ""
+    attempt: int = 0
+    ack_token: str | None = None
+    body: dict = {}
+
+# lionagi/dispatch/outbox.py
+async def enqueue_dispatch(
+    db: Any,
+    *,
+    kind: str,
+    deliver_to: str,
+    body: dict | None = None,
+    dedup_key: str | None = None,
+    ack_required: bool = False,
+    max_attempts: int = 8,
+    expires_at: float | None = None,
+    session_id: str | None = None,
+    schedule_run_id: str | None = None,
+) -> str: ...
+```
+
+Persistence contract:
+
+```sql
+CREATE TABLE dispatch_outbox (
+  id              TEXT PRIMARY KEY,
+  kind            TEXT NOT NULL,
+  deliver_to      TEXT NOT NULL,
+  payload         JSON NOT NULL,
+  dedup_key       TEXT,
+  status          TEXT NOT NULL DEFAULT 'pending'
+                  CHECK(status IN ('pending', 'delivering', 'delivered',
+                                   'acked', 'dead_letter', 'expired')),
+  attempt         INTEGER NOT NULL DEFAULT 0,
+  max_attempts    INTEGER NOT NULL DEFAULT 8,
+  next_attempt_at REAL NOT NULL,
+  ack_required    INTEGER NOT NULL DEFAULT 0,
+  ack_token       TEXT,
+  session_id      TEXT REFERENCES sessions(id),
+  schedule_run_id TEXT REFERENCES schedule_runs(id),
+  last_error      TEXT,
+  created_at      REAL NOT NULL,
+  expires_at      REAL,
+  updated_at      REAL
+);
+
+CREATE UNIQUE INDEX idx_dispatch_outbox_dedup
+  ON dispatch_outbox(dedup_key) WHERE dedup_key IS NOT NULL;
+```
+
+Exact enqueue and delivery semantics:
+
+- A duplicate non-null `dedup_key` returns the existing row id inside the insert transaction.
+- Enqueue writes `pending`, attempt zero, `next_attempt_at=now`, an optional generated ack token,
+  and one initial `status_transitions` fact.
+- Due scans include `pending` and lease-expired `delivering` rows. Expired rows transition to
+  `expired` before transport.
+- A delivery claim is a guarded transition to `delivering` that increments `attempt` and advances
+  `next_attempt_at` by `NOTIFY_TIMEOUT_SECONDS + 5` (15 seconds). The attempt guard ensures only one
+  overlapping scan wins.
+- The configured `dispatch.notify_template` is an argv list. `{payload}` and `{deliver_to}` are
+  substituted only as whole argv elements; no shell executes. If `{payload}` is absent, JSON is sent
+  on stdin.
+- Transport timeout is 10 seconds. The extra five-second claim lease is a small recovery margin;
+  the exact values have no recorded empirical tuning rationale.
+- Backoff is `min(30 * 2**attempt, 1800)` seconds with no jitter; 1800 bounds delay at 30 minutes.
+  The source records the formula as an inherited ruling but attaches no measurement or rationale
+  for the exact values.
+- Non-ack delivery stops at `delivered` after first transport success.
+- Ack-required success returns to `pending` and resends after backoff until `ack`, expiry, or
+  `max_attempts`; exhausting successful but unacked sends becomes `dead_letter` with an ack-timeout
+  reason.
+- Transport failure stores an error (bounded to 2000 characters), retries with backoff, or becomes
+  `dead_letter` at the attempt cap.
+- `ack_dispatch` requires `ack_required=1` and exact token match, then transitions to `acked`.
+- `retry_dispatch` is only for `dead_letter` or `expired`; it atomically resets attempt,
+  `next_attempt_at`, and error while returning to `pending`.
+- `purge_dispatch` deletes one row in a guarded DB transaction. CLI commands inspect, acknowledge,
+  retry, or purge; they do not enqueue arbitrary LionAGI work.
+
+Eight attempts is the default boundedness budget for both failed delivery and missing ack. Source
+does not record a workload-derived reason for exactly eight.
+
+Why this way: the outbox preserves an outbound fact independently of transport liveness and keeps
+notification failure out of task control flow. A generic task queue would invert ownership: the
+consumer would appear to own work already committed by the producer.
+
+## Consequences
+
+- Local deployment is simple: starting Studio starts triggers, dispatch delivery, and one host
+  worker.
+- Schedules do not execute while Studio is unavailable; `run_once`/`skip` only govern cadence
+  recovery, not interrupted process replay.
+- Immediate scheduler-owned launch gives scheduled work different restart semantics from ad-hoc
+  leased tasks even though both use `schedule_runs`.
+- Subprocess isolation and process-group teardown reduce runtime sharing but make executable and cwd
+  resolution critical. The daemon-cwd fallback remains environment-dependent.
+- Budget and concurrency refusal are visible, but reservations are single-process.
+- Inline follow-ups are bounded and linked, but cannot be independently managed as durable edges.
+- Dispatch survives producer return and retries independently; it adds its own statuses, attempt
+  counters, ack secrets, and operator recovery paths.
+- Reversing D1-D4 toward queued admission is a medium migration because historical rows and
+  invocation linkage must remain readable. Reversing D5 would require migrating pending/dead-letter
+  delivery state and is therefore costly.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Require a stable execution root for every new schedule and migrate existing schedules off inherited daemon cwd; acceptance: schedule behavior is unchanged when Studio starts from a different directory. | S | (filled at issue-open time) |
+| 2 | Align `li schedule create` with the persisted action vocabulary; acceptance: every supported stored action is creatable by its canonical public name or explicitly rejected as internal. | S | (filled at issue-open time) |
+| 3 | Split trigger/admission, subprocess execution, and follow-up policy behind characterization tests; acceptance: each concern can be tested without starting the complete scheduler loop. | M | (filled at issue-open time) |
+| 4 | Route scheduled fires through the queued admission contract in ADR-0072; acceptance: a due trigger writes `queued` and execution starts only after a worker wins a lease. | M | (filled at issue-open time) |
+| 5 | Expose explicit queue/dispatch latency and oldest-due metrics; acceptance: operators can distinguish a healthy 30-second wait from stalled trigger, task, or delivery work. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### External scheduler daemon
+
+A separate process could isolate trigger failures, continue without the Studio web server, and
+support independent deployment. It lost for the current local deployment model because it adds
+service discovery, leader election/duplicate-fire protection, configuration, and lifecycle
+coordination that the code does not need at present.
+
+### In-process execution instead of child `li`
+
+Calling lane functions directly would avoid process startup and simplify result capture. It lost
+because scheduled actions would share Studio's imports, event loop, working directory, provider
+state, and failure domain. The existing CLI already supplies the action adapters and invocation
+linkage.
+
+### Queue every scheduled fire today
+
+This would immediately unify restart and lease semantics with ADR-0071. It is the target in
+ADR-0072, but it was not the organically shipped path. Presenting it as current would hide that
+`_fire_inner()` creates `running` and directly awaits the child.
+
+### One state machine for schedules, tasks, and dispatch
+
+A universal transition service could reduce helper count. It lost because schedule cadence,
+execution ownership, and outbound delivery have different states and failure recovery. Shared
+transaction mechanics are useful; a shared lifecycle vocabulary is not.
+
+### Durable dependency records for every follow-up
+
+First-class edges would buy independent inspection, retry, and cancellation. It lost for the
+current implementation because simple bounded success/failure continuations were satisfied by
+inline JSON. If independent management becomes required, the current overlay shape should be
+migrated rather than described as already durable.
+
+### Dispatch as task transport
+
+Treating an outbound signal as a queued task would reuse worker leases. It lost because dispatch is
+producer-driven delivery after state commits. A notification consumer does not own or execute the
+source task and must not change its lifecycle.
+
+### Unbounded acknowledgement retries
+
+Retry-until-ack could maximize eventual receipt. It lost because a dead or non-acking consumer
+would resend forever. `max_attempts` and optional expiry make failure terminal and inspectable.
+
+### Shell command string for notify transport
+
+A shell string would be easy to configure and could express pipes/redirection. It lost because
+payload and routing values are external data. Whole-argv substitution through
+`create_subprocess_exec` keeps metacharacters inert.
+
+## Notes
+
+The broader launcher accepts `engine`, but the `schedules.action_kind` constraint does not. This ADR
+lists the persisted schedule vocabulary, not every internal launcher branch. `playbook` is a
+fire-time alias only and remains a creation-path mismatch until Delta 2 is implemented.

--- a/docs/adr/ADR-0071-durable-ad-hoc-task-queue.md
+++ b/docs/adr/ADR-0071-durable-ad-hoc-task-queue.md
@@ -1,0 +1,552 @@
+# ADR-0071: Durable ad-hoc task queue
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0061, v0-0062, v0-0101
+
+## Context
+
+`schedule_runs` was generalized so `schedule_id` may be null. The in-process
+`submit_task()` binding validates a `TaskApplication` and inserts a null-schedule row in `queued`
+state with action arguments, execution target, required capabilities, optional library provenance,
+queue timestamp, and an optional host-scoped concurrency key.
+
+Submission idempotency is deliberately inactive: a non-null key is rejected rather than accepted
+without deduplication. There is no `li task submit` command or `/api/tasks` binding. The queue is
+therefore a real library capability, not yet a complete public task-admission surface.
+
+The Studio scheduler tick hosts one worker. It heartbeats into `workers`, reaps expired leases,
+pages through eligible ad-hoc rows, matches target/capability labels, and claims through a guarded
+`queued -> running` transition. Execution reuses the scheduler subprocess argv builder. Terminal
+writes retain lease identity so a stale worker cannot overwrite a row reclaimed by another worker.
+
+The transition helper is a restricted compare-and-swap implementation for dispatch and
+schedule-run rows. It appends `status_transitions` atomically with a successful status update, but
+does not implement every state declared by the schema and does not deduplicate its modeled
+`idempotency_key`. Scheduled fires still bypass this path and enter `running` under
+`SchedulerEngine`.
+
+This ADR answers five problems:
+
+- **P1 — Ad-hoc work must survive until a worker sees it.** Direct function calls alone lose work
+  when the daemon is unavailable.
+- **P2 — Submission needs one typed validation boundary.** Action kind, payload, target,
+  capabilities, and provenance must be normalized once before persistence.
+- **P3 — Competing workers need one ownership transition.** A read followed by an unguarded update
+  would let two workers execute the same row.
+- **P4 — Worker death needs bounded recovery.** A lease must eventually return work to the queue or
+  fail it instead of leaving `running` forever.
+- **P5 — Placement metadata must not become authorization.** Capabilities and concurrency keys
+  decide eligibility/order only; machine locks and permission checks retain separate authority.
+
+| Concern | Decision |
+|---|---|
+| Submission contract | D1: Validate one frozen `TaskApplication`; reject unsupported idempotency keys. |
+| Persistent queue entity | D2: Store ad-hoc work as `schedule_runs` rows with `schedule_id IS NULL` and initial `queued`. |
+| State ownership | D3: Use one guarded transition function for the restricted shipped schedule-run graph and append transition facts atomically. |
+| Worker lease and recovery | D4: Heartbeat, reap expired leases, claim with a five-minute lease, and stop after three expired attempts. |
+| Capability and concurrency routing | D5: Match eligibility/serialization labels, prefer affinity labels, and use advisory host-scoped concurrency keys. |
+
+Out of scope:
+
+- CLI and HTTP submission bindings are not shipped.
+- Submit-level idempotency is not shipped.
+- Scheduled fires are not queue rows and are not claimed by this worker.
+- Fixed `workflow` actions are persisted but explicitly excluded from claims because no workflow
+  worker adapter is wired.
+- Remote worker transport and remote execution-target implementations are not shipped.
+- Capability tokens are not permissions. Authorization remains outside this queue.
+- Dependency waiting, retry backoff states, timed-out/skipped transitions, and running cancellation
+  are present in the table vocabulary but not in the restricted task transition graph.
+
+## Decision
+
+### D1 — `TaskApplication` is the single in-process submit shape
+
+The shipped contract is:
+
+```python
+# lionagi/studio/services/task_applications.py
+@dataclass(frozen=True)
+class TaskApplication:
+    action_kind: str
+    args: dict[str, Any]
+    execution_target: str
+    required_capabilities: list[str] = field(default_factory=list)
+    library_ref: str | None = None
+    library_content_hash: str | None = None
+    idempotency_key: str | None = None
+
+async def submit_task(db: StateDB, app: TaskApplication) -> str: ...
+
+async def cancel_task(
+    db: StateDB,
+    run_id: str,
+    *,
+    actor: Actor,
+) -> bool: ...
+```
+
+Accepted action kinds are the subprocess launcher's set
+`agent | flow | fanout | play | flow_yaml | engine`, plus `workflow`. `playbook` is accepted as an
+input alias and normalized to `play` before storage. Execution targets are the closed set:
+
+```python
+{"host", "local_worktree", "daytona", "remote_agent", "process"}
+```
+
+Exact validation semantics:
+
+- A non-null `idempotency_key` always raises `ValueError`. Empty string is also non-null and is
+  rejected. This prevents a retrying caller from believing deduplication occurred.
+- Unknown action kind raises and lists the canonical set plus accepted aliases.
+- Unknown execution target raises and lists the closed set.
+- `args` must be a dict. An empty dict is valid.
+- `required_capabilities` must be a list of non-empty strings. An empty list is valid and is the
+  default. Duplicate strings are not rejected or normalized at submission.
+- `library_ref` and `library_content_hash` are stored verbatim as optional provenance; submission
+  does not resolve the ref or verify the hash.
+- `TaskApplication` is frozen, so the submitted object is not mutated during alias normalization.
+- Validation failure occurs before a transaction and inserts no row.
+
+Why this way: one dataclass gives future CLI and HTTP bindings the same library boundary. Explicitly
+rejecting the dormant idempotency field is safer than accepting a contract the database does not
+enforce.
+
+Code anchor: `lionagi/studio/services/task_applications.py` (`TaskApplication`, `_validate`,
+`submit_task`).
+
+### D2 — Ad-hoc tasks reuse `schedule_runs`
+
+Submission generates a full string UUID, derives a concurrency key from serialization-class
+capabilities, and inserts one row:
+
+```sql
+INSERT INTO schedule_runs (
+  id, schedule_id, invocation_id, trigger_context,
+  action_kind, action_args, status, chain_depth,
+  fired_at, created_at, queued_at, concurrency_key,
+  required_capabilities, execution_target,
+  library_ref, library_content_hash
+)
+VALUES (
+  :id, NULL, NULL, {},
+  :action_kind, :action_args, 'queued', 0,
+  :now, :now, :now, :concurrency_key,
+  :required_capabilities, :execution_target,
+  :library_ref, :library_content_hash
+);
+```
+
+The table contract shared with scheduled runs is:
+
+```sql
+-- lionagi/state/schema.sql (queue-relevant columns)
+CREATE TABLE schedule_runs (
+  id                    TEXT PRIMARY KEY,
+  schedule_id           TEXT REFERENCES schedules(id) ON DELETE CASCADE,
+  invocation_id         TEXT REFERENCES invocations(id),
+  trigger_context       JSON NOT NULL,
+  action_kind           TEXT NOT NULL,
+  action_args           JSON NOT NULL,
+  status                TEXT NOT NULL DEFAULT 'running'
+                        CHECK(status IN ('queued', 'waiting_dependency', 'running',
+                                         'retry_wait', 'completed', 'failed',
+                                         'timed_out', 'skipped', 'cancelled')),
+  exit_code             INTEGER,
+  chain_parent_id       TEXT REFERENCES schedule_runs(id),
+  chain_depth           INTEGER NOT NULL DEFAULT 0,
+  fired_at              REAL NOT NULL,
+  ended_at              REAL,
+  error_detail          TEXT,
+  created_at            REAL NOT NULL,
+  updated_at            REAL,
+  status_reason_code    TEXT,
+  status_reason_summary TEXT,
+  status_evidence_refs  JSON,
+  queued_at             REAL,
+  leased_by             TEXT,
+  lease_expires_at      REAL,
+  concurrency_key       TEXT,
+  lease_attempts        INTEGER NOT NULL DEFAULT 0,
+  required_capabilities JSON,
+  execution_target      TEXT,
+  library_ref           TEXT,
+  library_content_hash  TEXT
+);
+
+CREATE INDEX idx_schedule_runs_queue
+  ON schedule_runs(status, queued_at)
+  WHERE status IN ('queued', 'retry_wait');
+
+CREATE INDEX idx_schedule_runs_concurrency
+  ON schedule_runs(concurrency_key, status)
+  WHERE status IN ('queued', 'running', 'retry_wait');
+```
+
+Exact initial-state semantics:
+
+- `schedule_id`, `invocation_id`, lease owner, and lease expiry are null.
+- `trigger_context` is `{}`; `chain_depth` is zero.
+- `fired_at`, `created_at`, and `queued_at` all receive the submission timestamp. The use of
+  `fired_at` is inherited from the shared run table even though no trigger fired.
+- The initial insert does not append a `status_transitions` row. Transition history begins with the
+  first post-submit status move.
+- Queued persistence survives daemon restart because it is a database row; no in-memory claim is
+  needed for discovery.
+- Reusing the table does not unify ownership: scheduled rows have non-null `schedule_id` and enter
+  `running`, while ad-hoc rows have null `schedule_id` and enter `queued`.
+
+Why this way: the row already has run identity, lifecycle columns, invocation linkage, and history
+surfaces. A second task table would duplicate those fields and require joins or migration before
+one operator view could show both.
+
+### D3 — Restricted schedule-run transitions use guarded CAS
+
+The request/result models are:
+
+```python
+# lionagi/state/transitions.py
+class Actor(BaseModel):
+    type: Literal["scheduler", "operator", "system", "webhook", "agent"]
+    id: str
+
+class StateReason(BaseModel):
+    code: str
+    summary: str = ""
+    evidence_refs: list[dict] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+class TransitionRequest(BaseModel):
+    entity_type: str
+    entity_id: str
+    from_state: str | None
+    to_state: str
+    reason: StateReason
+    actor: Actor
+    idempotency_key: str
+
+class TransitionResult(BaseModel):
+    applied: bool
+    conflict: bool = False
+    previous_state: str | None = None
+    current_state: str
+    transition_id: str
+    event_id: str | None = None
+
+async def transition(
+    db: Any,
+    request: TransitionRequest,
+    *,
+    guard: dict[str, Any] | None = None,
+    patch: dict[str, Any] | None = None,
+) -> TransitionResult: ...
+```
+
+The shipped schedule-run graph is:
+
+```text
+queued ──► running ──► completed
+  │           ├──────► failed
+  │           └──────► queued      (lease-expiry reaper only by convention)
+  └──────► cancelled
+
+completed, failed, cancelled ──► no outgoing edges
+```
+
+Although the table admits `waiting_dependency`, `retry_wait`, `timed_out`, and `skipped`, the
+transition vocabulary has no task-path edges for them. An undeclared edge raises `ValueError`.
+
+Exact compare-and-swap semantics:
+
+- Unsupported entity type, invalid reason code, or guard/patch column outside the per-entity
+  allowlist raises before mutation.
+- Missing row raises `LookupError`.
+- A `from_state` mismatch returns `applied=False, conflict=True` before vocabulary validation. A
+  second cancel therefore becomes a conflict result, not a terminal-edge exception.
+- Extra guard mismatch likewise returns a conflict.
+- The update uses `WHERE id=:id AND status=:from_state` plus guard predicates. If another writer
+  wins between read and update, rowcount zero returns a conflict.
+- Status, `updated_at`, allowed patch fields, and one `status_transitions` insert commit in the same
+  `db._tx()` transaction.
+- Schedule-run guard/patch fields are limited to `leased_by`, `lease_expires_at`, and
+  `lease_attempts`.
+- A successful result has `event_id=None`; this fallback does not emit a separate event-plane fact.
+- `TransitionRequest.idempotency_key` is required by the model but is not stored or checked by the
+  current implementation. Repeating a request is safe only when state/guard mismatch makes it a
+  conflict; arbitrary idempotency-key deduplication is not shipped.
+
+Transition facts use:
+
+```sql
+CREATE TABLE status_transitions (
+  id              TEXT PRIMARY KEY,
+  entity_type     TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  previous_status TEXT,
+  status          TEXT NOT NULL,
+  reason_code     TEXT NOT NULL,
+  reason_summary  TEXT,
+  evidence_refs   JSON,
+  source          TEXT NOT NULL,
+  actor           TEXT,
+  created_at      REAL NOT NULL,
+  metadata        JSON
+);
+```
+
+Why this way: CAS plus lease guards makes ownership loss an explicit non-write. An unrestricted
+generic state engine was not required for the shipped slice; the cost is visible incompleteness and
+a modeled idempotency field without deduplication.
+
+### D4 — One host worker claims, executes, and reaps leased rows
+
+Worker contracts and defaults are:
+
+```python
+# lionagi/studio/scheduler/worker.py
+TASK_WORKER_ENABLED = True
+DEFAULT_LEASE_TTL_SECONDS = 300.0
+DEFAULT_HEARTBEAT_TTL_SECONDS = 90.0
+MAX_LEASE_ATTEMPTS = 3
+
+ExecuteFn = Callable[[dict[str, Any]], Awaitable[tuple[int, str]]]
+
+async def register_heartbeat(
+    db: StateDB,
+    *,
+    worker_id: str,
+    advertised_capabilities: list[str] | None = None,
+    execution_targets: list[str] | None = None,
+    now: float | None = None,
+) -> None: ...
+
+async def reap_expired_leases(
+    db: StateDB, *, now: float | None = None
+) -> dict[str, int]: ...
+
+async def claim_and_execute(
+    db: StateDB,
+    *,
+    worker_id: str,
+    execute: ExecuteFn | None = None,
+    now: float | None = None,
+    lease_ttl: float = 300.0,
+    limit: int = 20,
+    advertised_capabilities: list[str] | None = None,
+    execution_targets: list[str] | None = None,
+    heartbeat_ttl: float = 90.0,
+) -> int: ...
+
+async def worker_tick(...) -> dict[str, int]: ...
+```
+
+The workers table is:
+
+```sql
+CREATE TABLE workers (
+  worker_id               TEXT PRIMARY KEY,
+  advertised_capabilities JSON NOT NULL DEFAULT '[]',
+  execution_targets       JSON NOT NULL DEFAULT '[]',
+  last_heartbeat_at       REAL NOT NULL,
+  leased_run_id           TEXT REFERENCES schedule_runs(id)
+);
+```
+
+The Studio engine creates one id shaped `host:<8 hex>` and calls `worker_tick()` once per scheduler
+tick. A tick heartbeats first, reaps expired leases second, and claims/executes third. The default
+execution target is `host`.
+
+Claim SQL considers only:
+
+```sql
+WHERE status = 'queued'
+  AND schedule_id IS NULL
+  AND action_kind != 'workflow'
+ORDER BY queued_at ASC, id ASC
+```
+
+Exact lease semantics:
+
+- A known worker whose heartbeat age exceeds 90 seconds claims nothing. A worker with no heartbeat
+  row is treated as not stale for compatibility with direct callers. The normal Studio tick writes
+  its own heartbeat immediately before checking.
+- Candidates are paged 50 rows at a time using a `(queued_at, id)` keyset cursor. A pass scans at
+  most 5000 queued rows and attempts at most 20 eligible claims.
+- The 50-row page is a database/dialect-friendly batching choice; 5000 bounds one tick's scan so a
+  deep ineligible prefix does not monopolize it; 20 bounds executions per pass. No measured tuning
+  rationale for the exact values is recorded.
+- Claim is one `queued -> running` transition that atomically writes `leased_by`,
+  `lease_expires_at=now+300`, and increments `lease_attempts`.
+- Lost claim or concurrent cancel is skipped; the worker does not retry that row in the same pass.
+- `default_execute()` converts `action_args` into a schedule-like dict, resolves the absolute `li`
+  prefix, builds argv through the same launcher, and awaits the child. Build/resolve errors become
+  `(1, error)` rather than escaping.
+- Exit zero attempts `running -> completed`; non-zero or executor exception attempts
+  `running -> failed`. Both terminal writes guard the exact lease owner and stored expiry value.
+- Lease expiry by time alone does not invalidate a terminal write. The stale worker loses only
+  after a reaper/claimant changes the guarded fields or status.
+- The current worker does not renew leases during long execution.
+- Reaper selects `running` rows with non-null expiry strictly less than `now`. Under three attempts,
+  it guards the observed expiry, clears lease fields, and returns to `queued`. At three or more, it
+  transitions to terminal `failed`.
+- A reaper/terminal race is resolved by CAS. A stale terminal writer cannot overwrite a reclaimed
+  lease.
+- Terminal execution currently changes status and writes a transition fact but does not patch
+  `ended_at`, `exit_code`, or `error_detail` on the schedule-run row.
+
+Five minutes gives ordinary subprocess tasks time to complete before recovery, 90 seconds gives
+three 30-second Studio ticks before heartbeat staleness, and three expiries bounds recovery. Only
+the “conservative bounded recovery” intent is recorded; no workload measurement justifies the exact
+five-minute or three-attempt values.
+
+Why this way: a lease turns worker ownership into database state and makes restart recovery
+possible without a broker. Reusing the subprocess launcher avoids a second action vocabulary. The
+cost is queue latency tied to Studio, sequential execution inside a claim pass, and no lease
+renewal.
+
+### D5 — Capabilities route and order; they do not authorize
+
+Capability classification is centralized:
+
+```python
+# lionagi/studio/scheduler/capabilities.py
+DEFAULT_CAPABILITY_CLASS = "eligibility"
+
+CAPABILITY_CLASSES: dict[str, str] = {
+    "gpu-exclusive": "serialization",
+    "warmed-cache": "affinity",
+}
+
+def worker_can_serve(
+    required_capabilities: Iterable[str] | None,
+    advertised_capabilities: Iterable[str] | None,
+) -> bool: ...
+
+def affinity_score(...) -> int: ...
+
+def host_scoped_concurrency_key(
+    host: str,
+    required_capabilities: Iterable[str] | None,
+) -> str | None: ...
+```
+
+Exact routing semantics:
+
+- Unknown tokens default to `eligibility`.
+- Eligibility and serialization tokens must be a subset of worker advertisements.
+- `execution_target` must be in the worker target set. A null/empty stored target is claimable by
+  any worker, though `TaskApplication` validation always requires a known non-empty target.
+- Affinity tokens never filter. Candidate order is descending count of matching affinity tokens,
+  with the original oldest-first SQL order retained for ties by stable sort.
+- Serialization tokens are sorted and folded into
+  `<hostname>:<token+token...>`. No serialization tokens yields null concurrency key.
+- Before claiming, the worker reads concurrency keys of all `running` rows. A matching key blocks a
+  candidate.
+- Once one key is claimed in a pass, it remains in the pass-local blocked set even if execution
+  finishes before later candidates are examined. The next tick may admit the next row.
+- This is advisory serialization. A machine-local resource such as a GPU still requires an
+  authoritative worker-side lock; the queue key cannot prevent another local process outside this
+  queue from using it.
+- Tokens do not grant tool or data permission. A worker that can route a task must still execute
+  under the relevant authorization policy.
+
+Why this way: a small declarative map keeps placement rules testable and prevents token-name
+branches from spreading through submit and worker code. Separating eligibility, affinity, and
+serialization avoids turning a warm cache preference into a hard scheduling failure.
+
+## Consequences
+
+- Ad-hoc queued work survives daemon restart before claim.
+- Guarded leases prevent competing claimants and block stale terminal writes after ownership
+  changes.
+- Reusing `schedule_runs` gives one run-shaped storage entity but does not yet give scheduled fires
+  the queue's semantics.
+- Public clients cannot submit through CLI/HTTP, and retries cannot deduplicate submission.
+- Workflow actions may be stored but remain permanently ineligible for the shipped worker.
+- Queue service time is coupled to the 30-second Studio tick and sequential child execution.
+- The transition helper is load-bearing but incomplete: contributors must check the closed graph,
+  guard/patch allowlist, and absent idempotency-key storage before adding a state.
+- Capability labels improve routing without becoming a permission system; machine-local locking
+  remains an execution responsibility.
+- Reversing D2 would require migrating historical ad-hoc rows to a new task table. D3-D5 are easier
+  to replace behind their typed functions, but pending leases and transition history require a
+  compatibility plan.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Add `li task submit` and HTTP task submission as thin bindings over `submit_task()`; acceptance: both bindings apply identical validation and persist the same provenance fields. | M | (filled at issue-open time) |
+| 2 | Implement atomic submit idempotency; acceptance: repeating one non-empty idempotency key returns the original task id and never inserts a second row. | M | (filled at issue-open time) |
+| 3 | Admit fixed `workflow` tasks to an eligible worker adapter; acceptance: a queued fixed workflow is leased, executed, and terminalized without bypassing the lease guard. | M | (filled at issue-open time) |
+| 4 | Complete the schedule-run transition owner and event record; acceptance: every declared lifecycle edge uses one guarded API and produces one durable transition fact. | M | (filled at issue-open time) |
+| 5 | Add lease renewal or explicitly constrain admitted task duration below the lease; acceptance: a healthy long-running worker cannot lose ownership solely because execution exceeds the initial TTL. | M | (filled at issue-open time) |
+| 6 | Persist worker execution outcome columns atomically with terminal transition; acceptance: `ended_at`, `exit_code`, error detail, status, and the transition fact cannot disagree after a crash. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A parallel `tasks` table
+
+A dedicated table could avoid inherited schedule columns such as `fired_at` and make the domain
+name clearer. It lost because `schedule_runs` already carries identity, lifecycle, invocation,
+reason, lease, and provenance columns. A second table would duplicate the claim protocol and split
+operator history.
+
+### Accept but ignore `idempotency_key`
+
+This would preserve forward API compatibility and let callers start sending keys. It lost because
+a retry would create a duplicate while appearing safe. Explicit rejection truthfully exposes the
+missing guarantee.
+
+### External broker
+
+A broker could provide mature leasing, visibility timeouts, and multi-worker scale. It lost for the
+current single-operator deployment because the database already supplies durable rows and guarded
+transactions. Adding a service would increase operations cost before the existing path reaches its
+limits.
+
+### Unguarded `SELECT` then `UPDATE`
+
+This would simplify SQL. It lost because two workers could read the same queued row and both launch
+it. The compare-and-swap result is the ownership decision.
+
+### Unbounded lease requeue
+
+Always returning expired work to `queued` would maximize retries. It lost because permanently
+failing or non-idempotent tasks could churn forever. Three attempts makes terminal failure
+inspectable, while the exact cap remains tunable future policy.
+
+### Heartbeat as lease ownership
+
+Keeping a worker heartbeat fresh could be treated as proof that all of its tasks remain owned. It
+lost because one live worker can still hang a single task. Per-row lease expiry is the recovery
+fact; heartbeat affects only eligibility for new claims.
+
+### Capabilities as permissions
+
+Using the same token to route and authorize would reduce concepts. It lost because advertisements
+are worker placement claims, not trusted grants, and an advisory concurrency key cannot secure a
+machine resource.
+
+### Hard affinity filtering
+
+Requiring `warmed-cache` advertisements would improve locality when present. It lost because an
+otherwise capable worker would leave work queued indefinitely merely because a performance hint was
+absent. Stable preferential ordering retains the optimization without turning it into availability
+policy.
+
+### In-memory semaphore instead of persisted concurrency key
+
+A semaphore would be simpler for one worker process. It lost because queue admission must remain
+visible across restarts and future workers. The database key is still only advisory, but it prevents
+known queue claim overlap without pretending to replace the OS resource lock.
+
+## Notes
+
+The current transition module's top docstring still describes an earlier dispatch-only fallback,
+but `_ENTITY_TABLES`, the vocabulary, and production callers include `schedule_run`. The executable
+contract is the code shape recorded above, including its deliberately restricted graph and inactive
+idempotency-key field.

--- a/docs/adr/ADR-0072-unified-task-admission-and-lifecycle.md
+++ b/docs/adr/ADR-0072-unified-task-admission-and-lifecycle.md
@@ -1,0 +1,515 @@
+# ADR-0072: Unified task admission and lifecycle
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0071
+
+## Context
+
+LionAGI currently has two execution owners in one table. Scheduled fires enter `schedule_runs` as
+`running` and are awaited by `SchedulerEngine`; ad-hoc task applications enter as `queued` and are
+leased by the host worker. The split means restart recovery, cancellation, transition history, and
+worker placement apply to one row class but not the other.
+
+Manual task submission is currently only an in-process function, and its idempotency field is
+rejected. The schema already contains the generalized run identity, queue timestamps, lease owner
+and expiry, capability labels, execution target, and provenance fields needed for convergence. A
+new broker or parallel task entity is unnecessary at current scale.
+
+This target must retain the distinction between graph-execution lanes and task admission. A task
+selects a lane adapter after claim; it does not become a fourth orchestration lane. Outbound
+`dispatch_outbox` delivery also remains separate because it transports already-committed producer
+facts rather than owning work.
+
+This ADR answers six problems:
+
+- **P1 — Producers can create duplicate work.** Schedule ticks, CLI retries, and HTTP retries need
+  one atomic idempotency rule.
+- **P2 — Two owners write the same lifecycle differently.** Direct scheduled launch and leased
+  execution cannot provide one recovery or audit contract.
+- **P3 — Direct status writes bypass reason and lease guards.** One API must own state, evidence,
+  lease fields, and transition facts in one transaction.
+- **P4 — Workers need a stable adapter boundary.** Producers must not know how every action kind is
+  executed, and a worker must not claim work it cannot route.
+- **P5 — Cancellation and expiry race with terminal completion.** Ownership and terminalization
+  need compare-and-swap rules that make exactly one outcome authoritative.
+- **P6 — Delivery state can contaminate execution state.** Notification retry/ack must not reopen a
+  completed, failed, or cancelled task.
+
+| Concern | Decision |
+|---|---|
+| Admission shape | D1: All schedule fires and public submissions use one typed `TaskApplication`. |
+| Atomic deduplication | D2: Persist a non-empty idempotency key plus canonical payload hash; same key/same payload returns the original task. |
+| Lifecycle owner | D3: Enforce one closed state graph and atomically write status, reason, lease patch, and transition fact. |
+| Worker and adapter dispatch | D4: Claim through leases, then route by a registry-backed action adapter. |
+| Recovery, timeout, and cancellation | D5: Resolve ownership races through guarded transitions and separate queued from cooperative running cancellation. |
+| Outbound delivery boundary | D6: Keep `dispatch_outbox` as a terminal-fact consumer, never a task state owner. |
+
+Out of scope:
+
+- This ADR does not change the three public orchestration lanes in ADR-0068.
+- It does not specify distributed broker adoption, leader election, or cross-database transactions.
+- It does not make capability labels authorization grants.
+- It does not define task dependencies; `waiting_dependency` remains a reserved lifecycle state
+  until a separate dependency contract names the dependency records and readiness rule.
+- It does not define model fallback or usage-ledger policy.
+- It does not merge live reactive controls with task cancellation; lane adapters translate a
+  cancellation request only when they implement one.
+- It does not replace dispatch delivery or its acknowledgement/dead-letter lifecycle.
+
+## Decision
+
+### D1 — One typed application admits all executable work
+
+The target public contract is Python-native:
+
+```python
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ActionKind = Literal[
+    "agent",
+    "flow",
+    "fanout",
+    "play",
+    "flow_yaml",
+    "workflow",
+]
+
+ExecutionTarget = Literal[
+    "host",
+    "local_worktree",
+    "daytona",
+    "remote_agent",
+    "process",
+]
+
+@dataclass(frozen=True)
+class TaskApplication:
+    action_kind: ActionKind
+    args: dict[str, Any]
+    execution_target: ExecutionTarget
+    idempotency_key: str
+    required_capabilities: list[str] = field(default_factory=list)
+    library_ref: str | None = None
+    library_content_hash: str | None = None
+
+async def submit_task(db: StateDB, app: TaskApplication) -> str: ...
+```
+
+Bindings are thin and share this function:
+
+```text
+li task submit ... ────────────┐
+POST /api/tasks ───────────────┼─► TaskApplication ─► submit_task()
+schedule trigger admission ───┤
+in-process library caller ─────┘
+```
+
+Every accepted application creates a `schedule_runs` row with `status='queued'`. Schedule
+evaluation supplies `schedule_id`, invocation linkage is created by the executing adapter rather
+than the trigger, and no producer writes `running` directly.
+
+Exact admission semantics:
+
+- `action_kind`, `execution_target`, and capability validation follow ADR-0071's closed sets.
+- The public canonical name is `play`; `playbook` may be accepted at compatibility bindings only if
+  normalized before constructing `TaskApplication`.
+- `args` must be a JSON-serializable mapping. Empty is valid when the selected adapter accepts it.
+- `required_capabilities` is normalized to a stable de-duplicated list for hashing and storage;
+  empty means no capability constraint.
+- `idempotency_key` must be a non-empty string after trimming and is always required at the library
+  boundary. CLI bindings generate and print one only when the caller omits it; HTTP clients may
+  supply one explicitly.
+- `library_ref` and `library_content_hash` are provenance. For `workflow`, both become required once
+  ADR-0073's versioned registry lands; other adapters may leave them null.
+- Validation or serialization failure writes nothing.
+- A schedule's admission key is deterministic from schedule id and nominal fire time:
+  `schedule:<schedule-id>:<nominal-fire-epoch>`. Re-evaluating the same cadence point therefore does
+  not duplicate a row.
+- Immediate/manual fire is still an operation over a schedule, but it submits through this contract
+  with a unique caller-visible key and returns a task id, not evidence that execution started.
+
+Why this way: producers agree on what work is before workers decide how to run it. Requiring the key
+at the core makes idempotency impossible to omit accidentally in a new binding.
+
+Current migration seams: `lionagi/studio/services/task_applications.py`,
+`lionagi/studio/scheduler/engine.py`, `lionagi/state/schema.sql`.
+
+### D2 — Idempotency is one atomic insert-or-return decision
+
+The target extends the generalized row with admission identity:
+
+```sql
+ALTER TABLE schedule_runs ADD COLUMN idempotency_key TEXT;
+ALTER TABLE schedule_runs ADD COLUMN application_hash TEXT;
+ALTER TABLE schedule_runs ADD COLUMN admission_source TEXT;
+
+CREATE UNIQUE INDEX idx_schedule_runs_idempotency
+  ON schedule_runs(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+```
+
+New admitted rows always set all three columns. Historical direct scheduled rows may retain nulls
+during migration; no new public admission may.
+
+The hash input is canonical JSON over exactly:
+
+```json
+{
+  "action_kind": "workflow",
+  "args": {},
+  "execution_target": "host",
+  "required_capabilities": [],
+  "library_ref": "daily-review@4",
+  "library_content_hash": "sha256:..."
+}
+```
+
+Keys are sorted, arrays use normalized order where order is not semantic (capabilities), and the
+hash is `sha256:<lowercase hex>`. The idempotency key itself is not part of the hash.
+
+Target transaction semantics:
+
+1. Validate and canonicalize the application.
+2. Attempt one queued-row insert with the unique key and hash.
+3. On unique conflict, select the existing row by key inside the same transaction.
+4. If hashes match, return the existing id without changing status, queue time, lease, attempts, or
+   provenance.
+5. If hashes differ, raise `TaskIdempotencyConflict(key, existing_task_id)`; never mutate the old
+   task and never insert the new payload.
+
+Exact error/restart semantics:
+
+- A process crash before commit leaves no row; retry inserts normally.
+- A crash after commit but before reply returns the same id on retry.
+- Two concurrent same-key/same-payload submissions converge on one id.
+- Two concurrent same-key/different-payload submissions produce one winner and one explicit
+  conflict.
+- Reusing a key after the original task is terminal still returns that original task. Keys are not
+  a “currently pending only” lock.
+- Cancellation or failure does not free a key for another payload.
+- An empty key is rejected before SQL; null is reserved only for historical rows during migration.
+
+Why this way: “effectively once” admission is achievable with one unique constraint and payload
+comparison even though execution itself may be retried. Returning an existing row without checking
+the payload would hide caller bugs; deleting terminal keys would make delayed retries duplicate
+work.
+
+### D3 — One transition owner enforces the full admitted-task lifecycle
+
+The target lifecycle is the table's closed nine-state vocabulary:
+
+```text
+queued ───────────────► running ─────────► completed
+  │                       ├──────────────► failed
+  │                       ├──────────────► timed_out
+  │                       ├──────────────► retry_wait ──► queued
+  │                       └──────────────► cancelled
+  ├───────────────────► waiting_dependency ──► queued
+  │                           ├───────────────► skipped
+  │                           └───────────────► cancelled
+  ├───────────────────► skipped
+  └───────────────────► cancelled
+
+completed | failed | timed_out | skipped | cancelled ──► no outgoing edges
+```
+
+`waiting_dependency` has no public producer until a dependency ADR supplies durable dependency
+records. The transition owner nevertheless reserves only the edges above, so a future dependency
+implementation cannot invent a different lifecycle accidentally.
+
+Target request/result contracts retain the shipped models and make idempotency real:
+
+```python
+class TransitionRequest(BaseModel):
+    entity_type: Literal["schedule_run"]
+    entity_id: str
+    from_state: str
+    to_state: str
+    reason: StateReason
+    actor: Actor
+    idempotency_key: str
+
+class TransitionResult(BaseModel):
+    applied: bool
+    conflict: bool = False
+    previous_state: str | None = None
+    current_state: str
+    transition_id: str
+    event_id: str
+
+async def transition_task(
+    db: StateDB,
+    request: TransitionRequest,
+    *,
+    guard: dict[str, Any] | None = None,
+    patch: dict[str, Any] | None = None,
+) -> TransitionResult: ...
+```
+
+Each successful call commits in one transaction:
+
+- compare-and-swap guard over id, current status, and any declared lease fields;
+- new status and `updated_at`;
+- reason/evidence projection on `schedule_runs`;
+- allowed lifecycle patch (`queued_at`, lease fields, attempts, terminal timestamps, exit detail,
+  retry time, cancellation-request fields);
+- exactly one `status_transitions` fact;
+- exactly one task lifecycle event, whose id is returned as `event_id`.
+
+The transition idempotency key gains a unique index scoped to entity id. Repeating the same key and
+same canonical transition request returns the original result; reusing it with different content
+raises a conflict.
+
+Exact transition semantics:
+
+- Missing task raises typed `TaskNotFound`; it does not synthesize a failed transition.
+- Wrong `from_state`, lease-owner mismatch, or a race lost between read and write returns
+  `applied=False, conflict=True` with the observed current state.
+- An undeclared edge raises before mutation.
+- A terminal state never re-enters queued through this API. Operator retry is a new submission with
+  a new idempotency key or a separately approved future contract, not a hidden terminal rewrite.
+- Direct updates to `schedule_runs.status` for admitted work are forbidden. Database maintenance
+  may repair corrupt rows only through an explicitly audited admin path.
+- Transition facts are the stable source for later projections; UI/operator work views consume them
+  but never own status.
+
+Why this way: status, evidence, lease ownership, and audit history represent one decision. Splitting
+them across writes creates crash windows where the row and history disagree. A closed graph also
+makes impossible transitions reviewable rather than convention-only.
+
+### D4 — Workers claim first and select a registered adapter second
+
+Workers retain ADR-0071's heartbeat, capability, target, concurrency, and lease rules. The execution
+boundary becomes a registry rather than a hard-coded subprocess-only function:
+
+```python
+class TaskAdapter(Protocol):
+    action_kind: str
+
+    def validate_args(self, args: dict[str, Any]) -> None: ...
+
+    async def execute(
+        self,
+        task: dict[str, Any],
+        *,
+        cancellation: "CancellationToken",
+    ) -> "TaskExecutionResult": ...
+
+@dataclass(frozen=True)
+class TaskExecutionResult:
+    status: Literal["completed", "failed", "timed_out", "cancelled"]
+    exit_code: int | None = None
+    error_detail: str | None = None
+    invocation_id: str | None = None
+    evidence_refs: list[dict] = field(default_factory=list)
+
+class TaskAdapterRegistry:
+    def register(self, adapter: TaskAdapter) -> None: ...
+    def get(self, action_kind: str) -> TaskAdapter | None: ...
+```
+
+Canonical routing is:
+
+| `action_kind` | Adapter |
+|---|---|
+| `play` | reactive-play adapter |
+| `flow`, `flow_yaml` | planned reactive-flow adapter |
+| `workflow` | fixed-workflow adapter from ADR-0073 |
+| `agent`, `fanout` | their existing execution adapters |
+
+Exact worker semantics:
+
+- Submission validates that an adapter name is registered for the deployment before committing a
+  new public task. Historical rows with a now-missing adapter remain queued and surface a placement
+  reason; workers do not claim them.
+- A worker filters by execution target and required capabilities before claim, then performs one
+  guarded `queued -> running` transition with lease fields and attempt increment.
+- Adapter lookup occurs again after claim. If the adapter disappeared between admission and claim,
+  execution records a typed failure or returns through retry policy; it never dispatches as another
+  kind.
+- The worker passes the claimed task id, immutable application payload, current attempt, and
+  cancellation token. Adapters do not update task status directly.
+- The worker converts `TaskExecutionResult` into one guarded terminal transition while it still
+  owns the lease. Exit details, invocation linkage, terminal timestamp, evidence, and status commit
+  together through D3.
+- If the terminal guard loses, the adapter result is retained only as diagnostic evidence; it does
+  not overwrite the new owner.
+- Producers depend only on `submit_task`; workers depend only on the registry; adapters depend on
+  their lane/kernel. This prevents imports from every producer to every executor.
+
+Why this way: claiming before adapter execution preserves one ownership contract. Registry lookup
+keeps action selection extensible without making producers topology-aware.
+
+### D5 — Recovery, timeouts, and cancellation are guarded lifecycle operations
+
+Lease expiry re-enters policy through D3:
+
+```text
+running + expired lease + attempts remaining
+  → retry_wait (clear owner/expiry, set retry_at, record lease-expiry reason)
+retry_wait + retry_at due
+  → queued (set queued_at, record retry-ready reason)
+running + expired lease + attempts exhausted
+  → failed
+```
+
+No transition is triggered merely by wall-clock passage; a reaper wins it through CAS. A worker may
+still complete after nominal expiry if no reaper has changed the guarded row, matching the current
+ownership rule.
+
+Target cancellation signatures are:
+
+```python
+async def request_task_cancel(
+    db: StateDB,
+    task_id: str,
+    *,
+    actor: Actor,
+    idempotency_key: str,
+) -> "CancelResult": ...
+
+class CancelResult(BaseModel):
+    task_id: str
+    state: Literal["cancelled", "cancellation_requested", "already_terminal"]
+    current_status: str
+```
+
+Exact cancellation semantics:
+
+- **Queued:** transition directly to `cancelled`; no worker may subsequently claim it.
+- **Waiting dependency or retry wait:** transition directly to `cancelled` and clear any readiness
+  timer/claimable marker.
+- **Running:** atomically set `cancel_requested_at/by` and append a cancellation-request event while
+  leaving status `running`. The worker forwards the request to the adapter's cooperative token.
+- **Adapter acknowledges cancellation:** current lease owner transitions `running -> cancelled`.
+- **Adapter ignores cancellation:** task remains running until it completes, times out, or loses its
+  lease; the system does not falsely report cancellation.
+- **Completion races cancellation request:** the first guarded terminal transition wins. A request
+  arriving after terminal returns `already_terminal` and does not rewrite history.
+- **Repeated request with the same key:** returns the original cancel result. A later request with a
+  new key sees current state and remains idempotent at the lifecycle level.
+- **Timeout:** a deadline reaper may transition current `running -> timed_out` only while its lease
+  and deadline guard still match. Adapter cleanup cannot later overwrite it.
+- **Restart:** queued/retry-wait state is durable; running work recovers only through lease expiry;
+  cancellation-request columns and event remain visible to the next owner/policy.
+
+Why this way: queued cancellation can be immediate because no external work owns the row. Running
+cancellation is necessarily cooperative for heterogeneous adapters. Persisting “requested” rather
+than immediately claiming “cancelled” keeps the state truthful.
+
+### D6 — Dispatch consumes committed facts and never owns task state
+
+`dispatch_outbox` remains the ADR-0070 contract. A producer may enqueue a terminal notification in
+the same transaction or in an idempotent post-transition hook keyed by the transition/event id:
+
+```text
+task terminal transition committed
+  └─► enqueue_dispatch(
+        kind="task_terminal",
+        dedup_key="task-terminal:<transition-id>",
+        schedule_run_id=<task-id>,
+        body={status, reason, evidence_refs}
+      )
+```
+
+Exact boundary semantics:
+
+- Dispatch enqueue failure is observable and retryable, but cannot roll back an already committed
+  task terminal transition unless both participate in one local database transaction.
+- Delivery, acknowledgement, expiry, dead letter, operator retry, and purge change only
+  `dispatch_outbox`.
+- A dead-letter notification does not turn a completed task into failed.
+- Dispatch payloads may refer to task transition ids, but dispatch consumers cannot mutate task
+  state without invoking a separate authorized task command.
+- Live reactive pause/message controls remain `session_controls`; they are not sent through the
+  dispatch outbox.
+
+Why this way: execution state answers what happened to work. Dispatch state answers whether an
+external side effect communicated that fact. Conflating them makes transport availability part of
+task correctness.
+
+## Consequences
+
+- Every admitted task gains the same queued, lease, restart, deduplication, reason, cancellation,
+  and terminal-write semantics.
+- Trigger evaluation becomes separable from execution. `SchedulerEngine` submits and advances
+  cadence; workers own launch.
+- Scheduled work gains queue latency and requires the trigger to make overlap/missed-fire decisions
+  before admission.
+- Idempotency keys become permanent identities for an application payload; callers must not reuse
+  them for different work.
+- The transition owner becomes load-bearing and requires concurrency, crash-window, and
+  idempotency tests for every edge.
+- Adapter registration becomes a deployment contract. Removing an adapter can strand queued
+  historical work unless migration or explicit failure policy is provided.
+- Running cancellation is truthful but not instantaneous; adapters that cannot cooperate rely on
+  timeout/lease recovery.
+- Dispatch remains independently retryable and cannot contaminate terminal task status.
+- Reversing D1-D3 after public bindings ship is costly because task ids, idempotency keys, and
+  transition facts are durable contracts. D4 adapters can evolve behind the registry; D5 policies
+  can tune budgets without changing state names.
+
+## Alternatives considered
+
+### Keep immediate scheduled launch
+
+This preserves lower latency and avoids changing the mature schedule fire path. It lost because it
+retains two owners and two restart/cancellation contracts in the same table, which is exactly P2.
+
+### External message broker
+
+A broker would buy mature consumer groups, visibility timeouts, and scale. It lost for current
+single-operator scale because the database already provides durable admission and guarded leases.
+The adapter and transition contracts leave room to replace storage later if measured demand
+justifies it.
+
+### Separate task table
+
+A clean task domain table would avoid inherited schedule-run names. It lost because the generalized
+row already contains run, queue, lease, provenance, and reason fields. Migration would duplicate
+history before delivering a different operational capability.
+
+### Optional idempotency keys
+
+Making the key optional would ease local callers. It lost because every retrying binding would need
+its own rule for when omission is safe. Required core keys make schedule and network retries
+uniform; convenience bindings may generate a key visibly.
+
+### Return existing id without comparing payload
+
+This is the simplest insert-or-get behavior. It lost because accidental key reuse with different
+work would silently execute the first payload while the caller believed the second was admitted.
+
+### Direct terminal status writes by adapters
+
+Adapters could update the row with their domain-specific results and reduce central API surface. It
+lost because lease ownership, reason projection, terminal columns, and transition history could
+split across transactions or bypass guards.
+
+### Immediate `running -> cancelled` on request
+
+This would give the user a fast terminal response. It lost because a provider/tool subprocess may
+continue producing side effects. “Cancellation requested” is distinct from “execution stopped.”
+
+### Requeue terminal failures in place
+
+Moving `failed -> queued` would preserve one task id and key. It lost because terminal history would
+become mutable and automatic retry safety depends on adapter side effects. Lease-loss recovery is
+explicitly non-terminal; retrying a terminal application should be a separately authorized
+submission/policy.
+
+### Use dispatch as both task queue and notification outbox
+
+One generic durable queue would reduce tables. It lost because inbound execution ownership and
+outbound producer delivery have different states, consumers, and failure consequences. A missing
+ack must not hold a task open.
+
+## Notes
+
+This is a target-state ADR. Current code anchors identify the migration seam, not proof that
+idempotent admission, full lifecycle ownership, queued schedules, workflow adapter dispatch, or
+cooperative running cancellation already exist.

--- a/docs/adr/ADR-0073-fixed-workflow-definition-execution.md
+++ b/docs/adr/ADR-0073-fixed-workflow-definition-execution.md
@@ -1,0 +1,567 @@
+# ADR-0073: Fixed workflow-definition execution
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: scheduling-control-plane
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0102, v0-0103
+
+## Context
+
+Studio persists authored graphs in `workflow_defs`. Names are unique, definitions are mutable in
+place, and rows have no namespace, version, or content hash. `POST /api/workflow-defs/{def_id}/run`
+loads one row, compiles it, creates a fresh `Session`, registers the engine operation, persists the
+run, and calls `Session.flow()` directly. There is no planner and reactive expansion is not enabled.
+
+The storage validator admits `input`, `chat`, `parse`, `fanout`, and `engine` node kinds. The
+compiler executes only `input`, `chat`, and `engine`; `parse` and `fanout` fail with a structured
+compile error. Removed `gate` nodes are rejected earlier by definition create/load validation and
+are redundantly listed in the compiler's dropped set.
+
+Chat models must be provider-prefixed when specified. Coding-engine cwd is resolved under an
+operator-supplied run-level `base_dir`, with raw traversal rejection, symlink resolution,
+containment, and existence checks. A definition cannot choose its own containment root.
+
+The runner persists a session, branches, messages, authored graph metadata, and per-node lifecycle
+signals. The session id is the public run id used by Studio history. There is no
+`li flow run`, registry-backed name/version resolution, content-hash provenance, artifact manifest,
+or fixed-lane control consumer. The separate `definitions` table versions only agent and playbook
+files, so the earlier accepted workflow-registry design is not current code.
+
+This ADR answers six problems:
+
+- **P1 — Authored graph shape must fail early.** Duplicate ids, invalid references, removed kinds,
+  unsafe conditions, and cycles must not reach the executor as ambiguous runtime failures.
+- **P2 — Definition nodes need a deterministic OperationGraph mapping.** Input markers, chat turns,
+  and engine definitions have different compilation rules.
+- **P3 — Authored edge expressions are code-like input.** They need a closed grammar without
+  `eval`, calls, imports, or hidden names.
+- **P4 — Model and filesystem configuration cross safety boundaries.** Model strings need provider
+  identity and engine cwd cannot escape an operator-owned root.
+- **P5 — Studio runs need normal persistence.** A fixed run must appear in Session history with
+  branches, messages, graph metadata, and terminal state.
+- **P6 — Current storage cannot supply reproducible headless identity.** Mutable unversioned rows
+  and a Studio-only route cannot pin a definition for CI/headless replay.
+
+| Concern | Decision |
+|---|---|
+| Definition storage and validation | D1: Persist version-1 canvas specs in unversioned `workflow_defs` and validate graph shape on create/update/load. |
+| Node compilation | D2: Treat `input` as context-only, compile `chat` to `chat_and_record`, compile `engine` through an EngineDef, and reject unsupported kinds. |
+| Edge semantics | D3: Compile authored edges manually, evaluate conditions with a bounded AST grammar, and reject cycles or misleading input-node gates. |
+| Model, engine, and cwd safety | D4: Require provider-prefixed chat models, validate effective engine options/budgets, and contain coding cwd under run `base_dir`. |
+| Run and persistence lifecycle | D5: Use a fresh Session plus request-scoped StateDB connection; session id is run id and ordinary runtime failures return `status='failed'`. |
+| Public identity boundary | D6: Describe the Studio id-only, unversioned contract honestly; headless version/hash/artifact/control behavior remains delta work. |
+
+Out of scope:
+
+- Planner calls and reactive `SpawnRequest` growth are forbidden by the fixed lane.
+- Reactive controls and checkpoint resume from ADR-0069 do not apply.
+- `parse`, `fanout`, and removed `gate` nodes are not emulated or silently dropped as executable
+  behavior.
+- Fixed workflow queue admission is not current; ADR-0072 owns the target worker adapter.
+- A versioned workflow registry, namespace, content hash, CLI runner, artifact layout, and durable
+  cancel are not shipped.
+- General Python expression evaluation and graph cycles are deliberately unsupported.
+
+## Decision
+
+### D1 — WorkflowDefs are mutable version-1 canvas rows
+
+The table is:
+
+```sql
+-- lionagi/state/schema.sql
+CREATE TABLE workflow_defs (
+  id          TEXT PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT,
+  spec_json   JSON,
+  created_at  REAL NOT NULL,
+  updated_at  REAL NOT NULL
+);
+
+CREATE INDEX idx_workflow_defs_name ON workflow_defs(name);
+CREATE INDEX idx_workflow_defs_updated ON workflow_defs(updated_at);
+```
+
+The HTTP models are:
+
+```python
+# lionagi/studio/services/workflow_defs.py
+class CreateWorkflowDefRequest(BaseModel):
+    name: str
+    description: str | None = None
+    spec_json: dict[str, Any] | None = None
+
+class UpdateWorkflowDefRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    spec_json: dict[str, Any] | None = None
+
+class RunWorkflowDefRequest(BaseModel):
+    inputs: dict[str, Any] | None = None
+    base_dir: str | None = None
+```
+
+A valid spec has this native JSON shape:
+
+```json
+{
+  "version": 1,
+  "nodes": [
+    {"id": "input", "kind": "input", "pos": {"x": 0, "y": 0}},
+    {
+      "id": "draft",
+      "kind": "chat",
+      "pos": {"x": 200, "y": 0},
+      "config": {"prompt": "Draft the answer", "model": "openai/gpt-4.1-mini"}
+    },
+    {
+      "id": "check",
+      "kind": "engine",
+      "pos": {"x": 400, "y": 0},
+      "config": {"engine_def_id": "review-engine", "max_agents": 3}
+    }
+  ],
+  "edges": [
+    {"id": "e1", "from": "input", "to": "draft"},
+    {"id": "e2", "from": "draft", "to": "check", "condition": "result != None"}
+  ],
+  "inputs": ["topic"],
+  "outputs": ["check"]
+}
+```
+
+Exact storage validation semantics:
+
+- `spec_json=None` is accepted at create/update. Such a row cannot run; the runner later raises
+  `WorkflowCompileError("workflow definition has no spec_json to run")`.
+- Non-null spec must be an object with `version == 1`.
+- A top-level `base_dir` is rejected. The containment root is a run request field.
+- `nodes` and `edges` must be arrays, capped at 200 and 400 respectively. The caps bound canvas and
+  compiler work; no recorded measurement explains the exact numbers.
+- Every node is an object with unique non-empty string id, admitted kind, and numeric non-boolean
+  `pos.x`/`pos.y`.
+- Admitted storage kinds are `input | chat | parse | fanout | engine`. `gate` is not admitted.
+- Chat config must be a mapping with non-empty string prompt. Optional model must be a string
+  containing `/`.
+- Every edge is an object with unique non-empty id; `from` and `to` must reference stored node ids.
+  Optional condition must be a non-empty string.
+- `inputs` and `outputs` must be arrays of strings. The current compiler does not use these lists to
+  map runtime values or select returned outputs; run inputs become shared flow context.
+- Definition name is trimmed and limited to 1–120 characters. Duplicate name raises
+  `NameConflictError`; the create route returns HTTP 409.
+- Create ids are 12 hex characters. Update mutates the same row; delete physically deletes it.
+- A saved legacy `gate` node found during GET returns HTTP 422 with the offending ids rather than
+  returning an unusable definition.
+- Empty update fields return success without changing the row.
+
+Why this way: a compact JSON canvas lets Studio persist and redraw authored topology without a
+second file format. In-place mutation is simple, but it cannot identify the exact historical
+definition used by a run.
+
+Code anchors: `lionagi/studio/services/workflow_defs.py` (`_validate_spec`, request models, routes);
+`lionagi/state/db.py` (workflow-def methods); `lionagi/state/schema.sql`.
+
+### D2 — Three executable kinds compile to the shared graph kernel
+
+Compiler contract:
+
+```python
+# lionagi/studio/services/workflow_compile.py
+EXECUTABLE_NODE_KINDS = frozenset({"input", "chat", "engine"})
+DROPPED_NODE_KINDS = frozenset({"parse", "fanout", "gate"})
+
+async def compile_workflow_def(
+    spec: dict[str, Any],
+    *,
+    resolve_engine_def: Callable[[str], Awaitable[dict[str, Any] | None]],
+    base_dir: str | None = None,
+) -> tuple[Graph, dict[str, str]]: ...
+
+class WorkflowCompileError(Exception):
+    message: str
+    node_id: str | None
+    edge_id: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"error": self.message, "node_id": self.node_id, "edge_id": self.edge_id}
+```
+
+Compilation returns the OperationGraph and a map from authored node id to internal Operation id.
+
+Exact node semantics:
+
+- `parse`, `fanout`, or `gate` anywhere in the compiler input raises a node-addressed
+  `WorkflowCompileError` before any node executes. Unknown kinds do the same.
+- `input` creates no Operation. The run's `inputs` dict is passed uniformly as
+  `Session.flow(context=inputs or {})`.
+- `chat` requires `config.prompt`. It compiles to `chat_and_record`, not plain `chat`, because the
+  latter does not append the turn through branch message persistence. The assistant response text
+  becomes the operation result for downstream context/conditions.
+- An explicit chat model creates `iModel(model=<provider/name>)` at compile time and is passed as the
+  Branch `imodel` override.
+- `engine` requires string `config.engine_def_id`. The runner resolves by id first, then by name.
+  A miss raises a node-addressed compile error.
+- Engine options are the stored EngineDef options overlaid by node `config.options`. Node
+  `max_depth`/`max_agents` override stored values only when non-null.
+- Effective options, kind-specific requirements, and integer budgets are revalidated at compile
+  time so a WorkflowDef cannot bypass EngineDef write validation. Budgets are integers in `[1,100]`.
+- Builder auto-chaining is disabled after every added node; authored edges alone establish
+  dependencies.
+- An empty graph is allowed if all nodes are `input` or there are no nodes. `Session.flow()` then
+  returns an empty operation result rather than calling a planner.
+
+The fixed topology invariant is structural: `run_workflow_def()` calls `session.flow(graph, ...)`
+without `reactive=True`, `spawn_type`, or a reactive node builder. Authored topology is not expanded
+at runtime.
+
+Why this way: compilation adapts authored concepts to the existing dependency-aware kernel. Using
+`chat_and_record` and the registered engine operation preserves normal messages and branches
+without building a standalone workflow executor.
+
+### D3 — Edges use a bounded safe-expression grammar
+
+Conditions compile to:
+
+```python
+class StudioExprCondition(EdgeCondition):
+    expr: str = Field(...)
+
+    async def apply(self, context: Any = None, *args: Any, **kwargs: Any) -> bool: ...
+```
+
+They evaluate only against:
+
+```python
+{
+    "result": <upstream operation result>,
+    "context": <shared flow context>,
+}
+```
+
+Allowed syntax is:
+
+- comparisons `== != < <= > >= in not in`;
+- boolean `and`, `or`, unary `not`;
+- string, integer, float, boolean, and `None` literals;
+- list and tuple literals composed from allowed values;
+- names, non-private attribute access, and subscription/key access.
+
+Calls, lambdas, comprehensions, formatted strings, assignment expressions, imports, private names,
+and private attributes are rejected. The implementation walks the parsed AST and never calls
+`eval`, `exec`, `compile`, or `__import__`.
+
+Budgets are `_MAX_EXPR_LEN = 1000` characters and `_MAX_AST_DEPTH = 20`. They bound parser/evaluator
+work and recursion; source contains no empirical rationale for the exact values.
+
+Exact edge semantics:
+
+- Bad syntax, disallowed AST node, excessive length, or excessive nesting becomes
+  `WorkflowCompileError` carrying the authored edge id.
+- A missing top-level name at evaluation raises `UnsafeExpressionError`; missing dict attribute,
+  object attribute, key, or index resolves to `None`.
+- Boolean evaluation short-circuits. Chained comparisons update the left operand conventionally.
+- An edge whose target is `input` or another non-operation node is rejected because no internal
+  target exists.
+- An unconditional edge from `input` to an executable node is omitted: input data already enters
+  through shared flow context.
+- A conditional edge from `input` is rejected. Dropping it would make the target run
+  unconditionally and silently ignore the authored gate.
+- Labels become a zero- or one-element edge-label list.
+- After edge creation, any graph cycle raises a graph-level compile error. Iteration must live
+  inside an operation, not an authored graph cycle.
+- At execution, a node with several incoming conditional edges runs when at least one incoming path
+  remains valid; it is skipped only when all incoming paths fail. This is the underlying
+  `DependencyAwareExecutor._check_edge_conditions()` contract.
+
+Why this way: the grammar gives designers simple conditional routing without a Python code-execution
+surface. Rejecting misleading input-node conditions is more honest than compiling a different
+graph from the one authored.
+
+Code anchors: `lionagi/studio/services/workflow_compile.py` (`_parse_expr`, `_validate_node`,
+`_eval_node`, `StudioExprCondition`, `compile_workflow_def`); `lionagi/operations/flow.py`
+(`_check_edge_conditions`).
+
+### D4 — Chat identity and coding cwd are validated before execution
+
+Chat model rule:
+
+```text
+config.model omitted        → use the branch's default iModel
+config.model="provider/name" → construct an explicit iModel override
+config.model without "/"    → validation/compile error
+```
+
+Engine definitions are a separate store with kinds
+`research | review | coding | hypothesis | planning`. Effective options admit only `test_cmd` and
+`export_dir`; option values are strings that do not begin with `-` and match a conservative token
+grammar. Coding requires a non-blank `test_cmd`. `max_depth` and `max_agents`, when supplied, are
+integers from 1 through 100.
+
+Engine runtime closure:
+
+```python
+def make_engine_operation(
+    session: Any,
+    *,
+    on_branch_created: Callable[[Any], None] | None = None,
+) -> Callable[..., Awaitable[Any]]: ...
+
+async def _engine_op(
+    context: dict[str, Any] | None = None,
+    engine_kind: str = "",
+    engine_model: str | None = None,
+    engine_max_depth: int | None = None,
+    engine_max_agents: int | None = None,
+    engine_options: dict[str, Any] | None = None,
+    engine_workspace: str | None = None,
+    **_ignored: Any,
+) -> Any: ...
+```
+
+The closure resolves the existing CLI engine-class registry, constructs the engine, derives a text
+input from predecessor result context first and shared inputs second, and calls `engine.run()` in
+the same Session. Result models are dumped to JSON; strings become `{"result": <text>}`; total
+sub-agent failure becomes `{"error": ...}`.
+
+Coding cwd contract:
+
+```python
+def _resolve_node_cwd(
+    node_id: str,
+    raw_cwd: Any,
+    base_dir: str | None,
+) -> str: ...
+```
+
+Exact cwd semantics, in order:
+
+1. `config.cwd` must be a non-empty string.
+2. Raw `..` traversal is rejected before resolution, even if a later resolution would return
+   inside the root.
+3. A node cwd requires run-level `base_dir`; absence is a compile error.
+4. Relative cwd joins the resolved base; absolute cwd is permitted only if it resolves inside the
+   base.
+5. Both base and candidate resolve symlinks before `relative_to(base)` containment.
+6. The resolved path must exist and be a directory.
+7. Only an EngineDef whose kind is `coding` may set cwd; other kinds fail compilation.
+8. The definition itself cannot contain top-level `base_dir`, so contributed content cannot choose
+   its own safety root.
+
+A coding workspace is passed as `engine.run(..., workspace=<resolved>)`. Research/review/planning
+engines do not receive a cwd keyword. A node with no cwd is unaffected by whether `base_dir` was
+supplied.
+
+Why this way: provider prefixes prevent an ambiguous model string from being interpreted by a
+default provider. Run-owned containment prevents a saved definition from escaping the operator's
+chosen filesystem boundary, including through symlinks.
+
+### D5 — A fixed run is a persisted Session executed in the request
+
+The run contract is:
+
+```python
+# lionagi/studio/services/workflow_run.py
+async def run_workflow_def(
+    def_id: str,
+    inputs: dict[str, Any] | None = None,
+    *,
+    base_dir: str | None = None,
+    _session: Any | None = None,
+) -> dict[str, Any]: ...
+
+# return shape (the annotation is plain dict[str, Any]; "completed"/"failed" is the
+# observed value set, not a Literal-typed contract)
+{"run_id": str(session.id), "status": "completed|failed"}
+```
+
+The route is declared `status_code=202`, but it awaits `run_workflow_def()` to completion before
+returning the body. It is not a background admission response and does not return a queued handle.
+
+Exact sequence:
+
+1. Load WorkflowDef by id. Missing row raises `WorkflowNotFoundError` and the route returns 404.
+2. Reject missing/empty spec with structured compile error.
+3. Resolve EngineDefs and compile before creating a Session persistence row. Compile failure returns
+   HTTP 422 with `{error,node_id,edge_id}` and creates no run session.
+4. Build an `early_graph` projection from executable authored nodes/edges for Studio rendering.
+5. Create a fresh `Session` (or use the private injected test seam).
+6. Open a request-scoped `StateDB`, create progression/session rows with
+   `invocation_kind='flow'`, `status='running'`, WorkflowDef id/name, and early graph metadata.
+7. Bind observer persistence and per-branch message hooks.
+8. Register the `engine` operation closure, including branch-persistence callbacks for engine
+   sub-agents.
+9. Execute `Session.flow(graph, context=inputs or {}, on_progress=..., on_branch_created=...)`.
+10. Terminalize and close only this request-scoped DB connection.
+
+The request-scoped connection is deliberate. CLI orchestration helpers use a process-wide shared
+DB registry suitable for one-shot processes; closing that registry from one Studio request could
+tear down concurrent runs.
+
+Exact outcome semantics:
+
+- Per-node queued/started/completed/failed signals persist through `flow_progress_signals`.
+- Flow-created branch clones and engine-created sub-agent branches receive persistence hooks after
+  creation; setup-time branches are hooked initially.
+- If `operation_results` contains any dict with an `error` key, overall status becomes `failed`.
+- An ordinary runtime exception is caught, status becomes `failed`, teardown records the exception,
+  and the function returns `{run_id,status}` rather than re-raising a bare server error.
+- `asyncio.CancelledError` sets status `cancelled`, tears down persistence, then re-raises; the
+  annotated return type does not list cancelled because no normal body is returned on that path.
+- Session id is the run id read by `/api/sessions/{id}` and Studio history; no parallel workflow-run
+  identity is created.
+- The result payload does not include operation outputs or an artifact path. Those remain in normal
+  session/branch persistence and operation result handling.
+- No control poller, checkpoint writer, queue lease, planner, or reactive node builder is started.
+
+Why this way: the fixed lane gets standard graph execution, branches, messages, and Studio history
+without another runtime. Awaiting inline keeps implementation simple but makes HTTP 202 semantically
+closer to a completed execution response than deferred admission.
+
+### D6 — Current identity is id-only and unversioned
+
+The current source of truth is `workflow_defs`. It supports lookup by id and by name internally,
+but the run route accepts only `def_id`. Session metadata records:
+
+```json
+{
+  "workflow_def_id": "12hexid",
+  "workflow_def_name": "daily-review",
+  "early_graph": {"nodes": [], "edges": []}
+}
+```
+
+It does not record definition version, content hash, namespace, original `spec_json`, or artifact
+manifest. A later edit to the same row changes what future runs compile; old run metadata cannot by
+itself reconstruct the exact prior definition.
+
+The other versioned store is not a current workflow registry:
+
+```sql
+CREATE TABLE definitions (
+  id         TEXT PRIMARY KEY,
+  kind       TEXT NOT NULL CHECK(kind IN ('agent', 'playbook')),
+  name       TEXT NOT NULL,
+  path       TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  version    INTEGER NOT NULL,
+  created_at REAL NOT NULL,
+  message    TEXT
+);
+
+CREATE UNIQUE INDEX idx_def_unique_version
+  ON definitions(kind, name, version);
+```
+
+Exact public-boundary semantics:
+
+- There is no `li flow run <name-or-file>` parser or binding.
+- There is no stable name/version resolution for fixed runs.
+- There is no content-hash comparison at run time.
+- There is no standard per-run artifact directory/manifest owned by this runner.
+- There is no fixed-run cancellation endpoint or `session_controls` consumer.
+- None of these missing features may be inferred from the existence of the shared Session kernel.
+
+Why this way: this section records the honest current boundary. Choosing whether to version
+`workflow_defs` in place or migrate into a widened registry is a future architectural decision; the
+current implementation provides evidence for neither choice as already settled.
+
+## Consequences
+
+- Fixed authored graphs reuse dependency execution, edge conditions, branch isolation, lifecycle
+  signals, and Studio history without a second kernel.
+- Unsupported nodes, unsafe expressions, cycles, ambiguous chat models, invalid engine budgets, and
+  unsafe coding cwd fail before provider execution.
+- `chat_and_record` and dynamic branch hooks preserve transcripts for authored and engine-created
+  branches.
+- The route is coupled to Studio and awaits the whole run despite HTTP 202.
+- Mutable unversioned definitions prevent exact historical replay and stable headless identity.
+- Input/output declarations are validated canvas metadata but not a runtime mapping/output-selection
+  contract.
+- Runtime failure normally becomes a returned failed status, while compile failure is an HTTP 422
+  before a run id exists.
+- Reversing D2-D5 into a standalone executor would be costly and would duplicate kernel semantics.
+  Replacing D1/D6 with versioned identity requires schema and historical-run migration but can
+  retain the compiler/runner behind a resolution adapter.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Implement `li flow run <name-or-file>` over the existing compiler-runner; acceptance: fixed workflows run without a Studio daemon and never call the planner. | M | (filled at issue-open time) |
+| 2 | Choose and migrate to one versioned workflow registry with namespace and content hash; acceptance: name-mode runs pin the exact version and hash while existing WorkflowDefs remain loadable or fail with an explicit migration error. | L | (filled at issue-open time) |
+| 3 | Materialize a stable fixed-run artifact manifest and per-node result files; acceptance: completed and ordinary failed runs expose the same documented layout and record its path on the session. | M | (filled at issue-open time) |
+| 4 | Define fixed-run cancellation and terminalization; acceptance: queued or running fixed work reaches one durable cancelled state without inheriting unsupported reactive controls. | M | (filled at issue-open time) |
+| 5 | Make the run HTTP contract honest about admission versus completion; acceptance: either return immediately with a durable queued/running handle or use a completion response status and document its blocking behavior. | S | (filled at issue-open time) |
+| 6 | Define runtime semantics for declared `inputs` and `outputs`; acceptance: input validation/mapping and selected output payloads are deterministic or the fields are removed from the executable spec. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A new standalone graph executor
+
+A fixed-specific executor could directly understand WorkflowDef nodes and avoid compilation. It
+would buy a closer domain model, but would duplicate dependency waits, conditional edges, branch
+allocation, result assembly, and persistence integration already in `Session.flow()`. It lost
+because a compiler adapter is a narrower seam.
+
+### Send WorkflowDefs through the planner
+
+A planner could translate unsupported nodes and repair incomplete graphs. It lost because fixed
+topology and reproducibility are the lane's defining guarantees. Planner output could change the
+authored graph and turn compile errors into nondeterministic behavior.
+
+### Silently ignore unsupported nodes
+
+Dropping `parse`, `fanout`, or legacy `gate` would allow more old definitions to run. It lost
+because downstream edges and outputs would no longer mean what the canvas shows. Structured
+node-addressed failure is safer.
+
+### Python `eval` for edge conditions
+
+`eval` would buy richer expressions with very little code. It lost because authored definitions
+are external input and calls/imports/dunder access create code execution. The bounded AST grammar
+covers comparisons and boolean routing without that surface.
+
+### Conditions as dedicated gate nodes
+
+Gate nodes could make routing visible on the canvas. They lost in the current model because
+conditions already belong to edges and a gate node introduces unclear data/result semantics. Saved
+legacy gates are rejected with migration guidance.
+
+### Let a definition carry `base_dir`
+
+This would make definitions self-contained and portable between callers. It lost because the
+definition would choose its own containment root, defeating the security boundary. The operator
+who invokes the run owns the root.
+
+### Allow cwd on all engine kinds
+
+A uniform config field would simplify the schema. It lost because only the coding engine's current
+`run()` signature accepts `workspace`; forwarding it to other engines would fail at runtime. The
+compiler rejects unsupported combinations early.
+
+### Reuse the process-wide CLI DB registry
+
+This would reduce persistence code. It lost because Studio is long-lived and concurrent; one
+request's teardown could close connections used by another run. Request-scoped StateDB ownership
+matches request lifetime.
+
+### Keep Studio as the only entry permanently
+
+One entry avoids CLI/schema migration. It lost as the target because headless and CI consumers need
+daemon-free fixed execution and stable source provenance. The current route remains the honest
+retrospective implementation until Delta 1 lands.
+
+### Promote `workflow_defs` versus widen `definitions`
+
+Both remain viable. Versioning `workflow_defs` in place preserves designer identity and JSON shape;
+widening `definitions` reuses version, name, path/content history, and registry tooling. Neither is
+selected because current source implements neither and migration consequences have not been
+decided. Delta 2 is intentionally a decision gate, not a fabricated conclusion.
+
+## Notes
+
+`gate` rejection is not normally a compiler error: create/load validation excludes it before the
+compiler. `parse` and `fanout` are the stored kinds that reach the compiler and receive structured
+dropped-kind errors. Coding cwd is engine-kind-specific, not a universal per-node field.

--- a/docs/adr/ADR-0076-studio-daemon-route-registry-and-local-control-plane.md
+++ b/docs/adr/ADR-0076-studio-daemon-route-registry-and-local-control-plane.md
@@ -1,0 +1,404 @@
+# ADR-0076: Studio daemon route registry and local control plane
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0001, v0-0002, v0-0006, v0-0008, v0-0018
+
+## Context
+
+Studio is a FastAPI daemon in `lionagi/studio/`, not a passive database viewer. The
+running application exposes reads, launches, cancellation, definition and schedule
+mutation, approvals, show import, and maintenance. It also owns scheduler startup,
+stale-state reconciliation, optional transcript mirroring, launch cleanup, and a
+deferred WAL checkpoint. The earlier CLI-primary, browser-mostly-read-only boundary
+therefore no longer describes the service.
+
+This ADR answers five concrete problems in the shipped daemon.
+
+**P1 — Endpoint decoration does not by itself make an endpoint public.** Service
+modules call `studio_route()`, but registration happens as a Python import side effect.
+Without one explicit composition root, a valid decorated handler can remain unreachable,
+duplicate registration can depend on import order, and clients cannot tell which route
+set is authoritative (`lionagi/studio/registry.py`; `lionagi/studio/app.py`).
+
+**P2 — One process has three delivery shapes.** Studio must run as an API-only daemon,
+serve a built Vite distribution, or sit behind the Vite development server. A catch-all
+SPA route would intercept FastAPI's trailing-slash redirects, while returning the SPA for
+unknown `/api/*` paths would turn API errors into HTML (`lionagi/studio/app.py`;
+`lionagi/studio/cli.py`).
+
+**P3 — Readiness depends on some lifecycle work but not all maintenance.** Stateful
+routes must not observe phantom sessions left from a prior process, yet a WAL checkpoint
+or optional transcript mirror must not indefinitely block liveness. Shutdown must settle
+owned tasks and launched subprocesses before the scheduler stops (`lionagi/studio/app.py`).
+
+**P4 — Loopback-first is not the same as an absent trust boundary.** A browser can reach
+a loopback daemon through DNS rebinding or cross-origin requests. When a bearer token is
+configured, schema and API paths expose protected information; the static SPA must still
+load without attaching a token to document navigation. State-changing requests with a
+body must not accept form-compatible content types that avoid a CORS preflight
+(`lionagi/studio/app.py`; `lionagi/studio/config.py`).
+
+**P5 — “SSE” names a framing mechanism, not one event protocol.** Session output,
+persisted session signals, show-directory changes, and Leo turns all emit unnamed
+`data:` frames, but their cursors, terminal tests, and error paths differ. Treating them
+as one replayable event log would promise semantics the code does not implement
+(`lionagi/studio/services/_sse.py`; `sessions.py`; `shows.py`; `leo.py`).
+
+| Concern | Decision |
+|---|---|
+| Public HTTP composition | D1: Make the declarative registry plus fixed module manifest the sole API composition root. |
+| API and SPA delivery | D2: Mount registered routes below `/api`, keep `/health` direct, and make SPA hosting optional. |
+| Process lifecycle | D3: Reconcile before readiness, defer non-critical maintenance, and stop owned resources in order. |
+| Local network boundary | D4: Apply host validation, explicit CORS, JSON-body enforcement, and optional bearer auth centrally. |
+| Live transport | D5: Keep endpoint-specific fetch-compatible SSE contracts and do not imply a central event bus. |
+
+Out of scope:
+
+- Scheduler firing, lease, retry, and worker semantics are owned by the
+  scheduling-control-plane area; this ADR records only daemon lifecycle wiring.
+- StateDB schema and file/database consistency are owned by ADR-0077.
+- The web client's information architecture is owned by ADR-0079 and ADR-0080.
+- A durable operator-command protocol is the aspirational decision in ADR-0083.
+- Network-wide identity, authorization roles, and remote exposure are not introduced
+  here; the shipped boundary is a local daemon with one optional bearer secret.
+
+## Decision
+
+### D1 — Declarative route registry and explicit composition root
+
+`lionagi/studio/registry.py` is the public HTTP composition root. Its shipped Python
+contract is:
+
+```python
+Handler = TypeVar("Handler", bound=Callable[..., Any])
+HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+
+@dataclass(frozen=True, slots=True)
+class StudioRoute:
+    order: int
+    area: str
+    path: str
+    method: HttpMethod
+    handler: Callable[..., Any]
+    response_model: Any | None
+    dependencies: tuple[Any, ...]
+    status_code: int | None
+    tags: tuple[str, ...]
+    name: str | None
+    summary: str | None
+    description: str | None
+    response_class: type[Response] | None
+    responses: Mapping[int | str, Mapping[str, Any]] | None
+    include_in_schema: bool
+
+def studio_route(
+    path: str,
+    *,
+    method: HttpMethod,
+    area: str,
+    response_model: Any | None = None,
+    dependencies: Sequence[Any] = (),
+    status_code: int | None = None,
+    tags: Sequence[str] | None = None,
+    name: str | None = None,
+    summary: str | None = None,
+    description: str | None = None,
+    response_class: type[Response] | None = None,
+    responses: Mapping[int | str, Mapping[str, Any]] | None = None,
+    include_in_schema: bool = True,
+) -> Callable[[Handler], Handler]: ...
+
+def load_studio_route_modules() -> None: ...
+def iter_studio_routes(*, area: str | None = None) -> tuple[StudioRoute, ...]: ...
+```
+
+The fixed manifest contains 22 service modules:
+
+```text
+casts, runs, engine_runs, definitions, agents, playbooks, shows, skills,
+plugins, teams, invocations, launches, projects, engine_defs, workflow_defs,
+sessions, run_tags, leo, approvals, admin, schedules, stats
+```
+
+All names are relative to `lionagi.studio.services`. `app._mount_studio_routes()`
+imports that manifest, iterates registration order, and calls
+`application.add_api_route(f"/api{route.path}", ...)`. Importing the current app
+produces 96 decorated `/api` routes. That number demonstrates the surface size; it
+is not a compatibility constant.
+
+Exact semantics:
+
+- Registration appends in decorator execution order; `iter_studio_routes()` sorts by
+  the captured integer `order` and returns an immutable tuple.
+- When `tags is None`, the route receives `(area,)`; an explicit empty sequence means
+  no tag.
+- The deduplication key is `(path, method, fn.__module__, fn.__qualname__)`. Repeating
+  that same registration raises `ValueError`; two different handlers can still claim
+  the same method/path and must be caught by route-contract verification.
+- Import caching makes repeated manifest imports harmless for already-loaded modules.
+  `_reset_registry()` exists for tests, not runtime hot reload.
+- A decorated handler in an unlisted module is not mounted. This is deliberate: public
+  reachability requires both declaration and inclusion at the composition root.
+- The manifest order controls registration order. Literal routes that might otherwise
+  be captured by parameter routes must be registered first within their service.
+
+Why this way: one registry makes metadata enumerable without introducing a parallel
+`APIRouter` hierarchy per small service. The fixed manifest also makes public inclusion
+an explicit reviewable act. The tradeoff is manual composition, so a missing manifest
+entry is a realistic failure mode rather than an impossible state.
+
+### D2 — `/api` boundary, direct health, and optional SPA mount
+
+The application factory is the stable construction seam:
+
+```python
+def create_app() -> FastAPI: ...
+
+app = create_app()
+```
+
+`create_app()` installs the lifespan, exception translation, central middleware,
+registered API routes, direct `GET /health`, optional assets, and final middleware
+order. `LionError` becomes `{"detail": exc.message}` with the error's status code.
+Health returns exactly:
+
+```json
+{"status": "ok"}
+```
+
+SPA discovery and fallback use:
+
+```python
+def _resolve_frontend_dist() -> Path | None: ...
+def _mount_spa(application: FastAPI, dist: Path) -> None: ...
+```
+
+Exact semantics:
+
+- If `LIONAGI_STUDIO_FRONTEND_DIST` is unset, the daemon is API-only.
+- If it is set but `<dist>/index.html` does not exist, the daemon remains API-only.
+- If `<dist>/assets` exists, it is mounted at `/assets` with `StaticFiles`.
+- An unmatched `/api` or `/api/*` request remains JSON 404; it never receives the SPA.
+- An unmatched non-API `GET` or `HEAD` receives `index.html` with `no-store`,
+  `no-cache`, and `must-revalidate`; any other method remains JSON 404.
+- The fallback is a 404 exception handler, not `/{full_path:path}`. This preserves
+  FastAPI's trailing-slash redirect behavior for routes such as `/api/runs/`.
+- `python -m lionagi.studio` starts Uvicorn with `HOST` and `STUDIO_PORT`.
+
+The shipped defaults in `lionagi/studio/config.py` are port `8765` and host
+`127.0.0.1`. The port is inherited from the existing Studio surface; no separate
+rationale is recorded beyond compatibility. Loopback is the safety-oriented default.
+
+### D3 — Ordered daemon lifecycle
+
+The lifespan contract is:
+
+```text
+startup:
+  scheduler.start()
+  run_startup_reconciliation()       # readiness gate
+  optional Claude mirror task
+  create _startup_warmup task         # WAL checkpoint, not a readiness gate
+  yield ready
+
+shutdown:
+  settle/cancel warmup task
+  stop mirror task
+  shutdown_launches()
+  scheduler.stop()
+```
+
+Exact semantics:
+
+- Scheduler startup happens before reconciliation so the daemon owns one initialized
+  scheduler throughout its ready lifetime.
+- Reconciliation is awaited before `yield`; stateful API reads do not race the repair
+  of stale session and invocation rows.
+- The WAL checkpoint runs in a named background task. Any failure is logged and does
+  not make startup fail.
+- Optional transcript mirroring is controlled by
+  `LIONAGI_STUDIO_MIRROR_CLAUDE` (default enabled), starts with a default `24h`
+  catch-up window, and polls every `5` seconds. These values are inherited operating
+  defaults; the source records bounded catch-up and live tailing as the reasons, but
+  no measurement selecting exactly 24 hours or 5 seconds.
+- Mirror shutdown signals its stop event and waits up to 10 seconds, then cancels the
+  task. Ten seconds is a backstop inherited from the implementation; no recorded
+  measurement justifies the exact value.
+- An unexpectedly failed mirror is logged by a done callback and does not stop Studio.
+- Warmup is cancelled and awaited on shutdown so no task is left pending.
+- Owned launches stop before the scheduler. Resources the daemon did not launch are
+  not claimed by this lifecycle.
+
+The split is intentional: reconciliation changes the truth read by API handlers and
+therefore gates readiness; checkpointing is maintenance and does not.
+
+### D4 — Central local security and request boundary
+
+The middleware execution order for an incoming request is fixed by Starlette's LIFO
+wrapping:
+
+```text
+Host validation
+  → CORS
+    → JSON content-type / CSRF guard
+      → optional bearer-token gate
+        → route handler
+```
+
+The relevant configuration fields and defaults are:
+
+```python
+STUDIO_PORT = int(env.get("LIONAGI_STUDIO_PORT", "8765"))
+HOST = env.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
+CORS_ORIGINS = configured comma-separated origins or [
+    "http://localhost:5173",
+    "http://localhost:3000",
+    "http://localhost:3765",
+    "https://lion-studio.khive.ai",
+]
+```
+
+Exact semantics:
+
+- Host validation runs first, including for preflight. It accepts `localhost`,
+  `127.0.0.1`, `::1`, and a configured non-wildcard bind host. Malformed authorities,
+  unlisted hosts, suffix tricks, and unbracketed IPv6 fail with HTTP 400.
+- CORS allowed methods are derived after all routes and optional mounts exist. `OPTIONS`
+  is always added. This avoids silently omitting FastAPI-generated `HEAD` methods.
+- With no `LIONAGI_STUDIO_AUTH_TOKEN`, requests are not bearer-gated. Startup emits a
+  warning, with a stronger warning for unauthenticated `0.0.0.0`.
+- With a token, every `/api` and `/api/*` path plus `/openapi.json`, `/docs`, `/redoc`,
+  and `/docs/oauth2-redirect` requires the exact `Authorization: Bearer <token>` value.
+  Failure returns `{"detail":"Unauthorized"}` and HTTP 401.
+- `/health` remains public. Non-API `GET` and `HEAD` requests other than schema/docs
+  remain public so the SPA document and hashed assets can load.
+- `OPTIONS` passes the inner guards because valid-host preflight is answered by CORS.
+- A non-GET/HEAD/OPTIONS `/api` request with a non-empty body must declare media type
+  `application/json`; otherwise it returns HTTP 415. Bodyless mutation requests do not
+  acquire a synthetic content-type requirement.
+- The rule is central. Individual services cannot opt out by omitting a dependency.
+
+This is defense in depth for the shipped local daemon; it is not a claim that one static
+bearer secret supplies user-level authorization.
+
+### D5 — Endpoint-specific SSE over authenticated fetch
+
+The shared transport helper is deliberately small:
+
+```python
+SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+def sse_response(generator: AsyncGenerator[str]) -> StreamingResponse:
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers=SSE_HEADERS,
+    )
+```
+
+All current producers emit unnamed frames of the form `data: <JSON>\n\n`, but their
+contracts are distinct:
+
+| Endpoint | Cursor/source | Poll/heartbeat | Terminal and miss semantics |
+|---|---|---|---|
+| `/api/sessions/{id}/stream` | local `after_ts`, messages after timestamp | poll 0.5s; heartbeat after 5s idle | preflight 404; `done` only after terminal status is stable more than 60s |
+| `/api/sessions/{id}/signals` | persisted per-session `seq`, starting at 0 | rows limited to 500 per poll; poll 0.5s; heartbeat after 5s | preflight 404; same 60s stable terminal test |
+| `/api/shows/{topic}/stream` | in-memory `(mtime,size)` map over sorted files | scan every 0.5s; no heartbeat | route preflight 404; generator emits `done` on invalid/missing directory or terminal DB status after 60s without file change |
+| `/api/leo/sessions/{id}/messages` | one in-memory turn, no replay cursor | no heartbeat/reconnect state | missing/expired session 404; concurrent turn 409; model error emits `error` then `done`; success emits effects, `text`, then `done` |
+
+The 0.5-second polls, 5-second heartbeats, and 60-second stability windows are shipped
+compatibility values. Their qualitative reasons are fast local feedback, keeping idle
+connections visibly alive, and avoiding closure on a transient terminal write. The source
+contains no measurement selecting the exact numbers. The signal batch cap of 500 bounds
+each database read while allowing replay to advance over repeated polls; no recorded
+measurement selects exactly 500.
+
+Fetch-based consumers are required when bearer auth is enabled because native
+`EventSource` cannot attach the authorization header. There is no `id:` field,
+`Last-Event-ID` handling, universal cursor, common error envelope, or central replay log.
+
+## Consequences
+
+- The daemon has one enumerable composition root and one central request boundary.
+  Adding a public service requires a decorated handler and a manifest decision.
+- API-only, daemon-hosted SPA, and Vite-development modes share the same FastAPI API.
+- Stateful readers see reconciled lifecycle data at readiness, while optional mirror and
+  checkpoint failures degrade observability or maintenance rather than availability.
+- A contributor changing a route path, trailing slash, response model, or stream frame
+  changes a compatibility surface consumed by both web and VS Code clients.
+- Reversing D1 requires rebuilding enumeration, ordering, and deduplication around another
+  router composition mechanism. Reversing D4 requires a replacement central trust boundary;
+  service-local checks are not equivalent.
+- Manual manifest maintenance can omit a service. The present dedup key also cannot reject
+  two different handlers for the same method/path.
+- Tokenless mode is intentionally possible and becomes unsafe if the bind boundary expands.
+- Endpoint-specific SSE keeps each service simple but makes reconnect and terminal behavior
+  client knowledge. A shared envelope is current debt, not a shipped guarantee.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Generate and verify the mounted Studio route manifest and OpenAPI snapshot in CI; fail when an intended public service is absent or an existing method/path changes without an explicit compatibility update. | S | (filled at issue-open time) |
+| 2 | Define a shared SSE frame envelope, error frame, terminal frame, and reconnect-cursor rule for session, signal, show, and Leo streams while preserving endpoint-specific payloads. | M | (filled at issue-open time) |
+| 3 | Decide whether filesystem show import is a browser-admin mutation or a CLI maintenance operation, then enforce one policy with matching authorization and confirmation behavior. | S | (filled at issue-open time) |
+| 4 | Document and test API-only, daemon-hosted SPA, Vite development, and container/reverse-proxy modes against the same host, CORS, token, and API-base rules. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### One `APIRouter` per service
+
+This would use familiar FastAPI composition and make each module mountable independently.
+It lost because the shipped services are already small, metadata-rich decorated handlers;
+adding routers would create a second inclusion and prefix mechanism without eliminating the
+need for an application-level manifest. It would also make current registry enumeration a
+migration requirement rather than a simplification.
+
+### Filesystem or package auto-discovery
+
+Scanning every `services/*.py` module would prevent a forgotten manifest entry and ease
+extension. It lost because import becomes publication: a helper or unfinished service could
+be exposed merely by existing. Explicit publication is safer for a control plane, provided
+CI addresses omission risk.
+
+### Read-only Studio with mutations left to the CLI
+
+This would narrow the browser trust boundary and preserve the early CLI-primary shape. It
+lost because launches, cancellation, definition and schedule mutation, approvals, show
+import, and maintenance are already shipped API responsibilities. Calling the daemon
+read-only would hide rather than remove those contracts.
+
+### Catch-all SPA route
+
+`/{full_path:path}` is the conventional SPA fallback and is simpler than an exception
+handler. It lost because it captures `/api` paths before FastAPI can perform trailing-slash
+redirects. The 404 handler preserves route resolution and keeps API misses JSON.
+
+### Require bearer auth for every path
+
+This would give one simple rule. It lost because browser document navigation and asset
+loads do not carry the runtime bearer header; protecting the shell would make authenticated
+mode unloadable. The chosen split keeps data under guarded `/api` while public static bytes
+contain no application state.
+
+### General Studio event bus and replay log
+
+A central taxonomy could unify reconnect, observability, and cross-entity subscriptions.
+It would also require a durable event model, cursor policy, retention, and compatibility
+rules that no current cross-entity use case demonstrates. It lost to bounded per-endpoint
+streams; the smaller shared-envelope delta remains justified by the two current clients.
+
+### WebSocket as the default live transport
+
+A duplex socket would support server and client events on one connection. Current session,
+signal, and show consumers are server-to-client only, and authenticated fetch already
+supports them. WebSocket therefore adds heartbeat, ticketing, and replay work without
+removing the need for ordinary HTTP commands. ADR-0083 may revisit transport only for a
+demonstrated operator-command need.

--- a/docs/adr/ADR-0077-studio-state-and-filesystem-boundary.md
+++ b/docs/adr/ADR-0077-studio-state-and-filesystem-boundary.md
@@ -1,0 +1,457 @@
+# ADR-0077: Studio state and filesystem boundary
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0011, v0-0012, v0-0016, v0-0019, v0-0020, v0-0021, v0-0022, v0-0055
+
+## Context
+
+Studio does not own an independent datastore. Its daemon, the CLI, and runtime all read
+and write the StateDB at `DEFAULT_DB_PATH = ~/.lionagi/state.db`. Studio services use two
+access idioms against that physical store: typed `StateDB` methods and hand-written SQL
+through a Studio-local `aiosqlite` connection helper. Authored definitions and show
+material also remain operationally significant files.
+
+This ADR answers six problems created by that hybrid boundary.
+
+**P1 — Duplicating runtime truth would split lifecycle state.** Schedule, workflow,
+launch, invocation, artifact, session, and status records already originate in StateDB.
+A separate Studio database would force synchronization before a UI could answer whether a
+run is current or terminal (`lionagi/state/schema.sql`; `lionagi/studio/services/*.py`).
+
+**P2 — “Definition” names two different persistence contracts.** Agent and playbook
+definitions are current files with append-only snapshots in `definitions`; workflow
+definitions are database rows whose `spec_json` is current. A generic definition API that
+erases this difference would falsely imply one save, rollback, and conflict model
+(`definitions.py`; `workflow_defs.py`).
+
+**P3 — A file plus a database row cannot be committed by one SQLite transaction.** The
+agent/playbook save path allocates a database version before writing the file. A disk error
+after commit advances history without updating the canonical current file, while direct
+editor writes update the file without creating a version (`definitions.py`; `state/db.py`).
+
+**P4 — Schema ownership is not consistently mediated.** Many services use `StateDB`, but
+sessions, runs, shows, statistics, definition history, and projects also issue SQL directly.
+`projects.py` even repeats the `projects` table and index DDL already present in
+`lionagi/state/schema.sql`, then runs it lazily from requests. A schema change can therefore
+break code outside typed StateDB methods.
+
+**P5 — Shows and artifacts cross the state/file boundary differently.** Shows merge rows
+with `_show.md`, `_intent.md`, play directories, and file-change events. Artifacts store
+queryable JSON plus an optional `file_path`. A path in state is metadata, not authorization
+to return arbitrary host bytes (`shows.py`; `invocations.py`; `state/schema.sql`).
+
+**P6 — The scheduler has a narrow persistence seam, not a Studio-wide repository.**
+`SchedulerStateService` makes scheduler engine I/O replaceable in tests, but it does not
+abstract raw SQL in unrelated Studio services and does not transfer scheduler execution
+semantics into this area (`scheduler_state.py`).
+
+| Concern | Decision |
+|---|---|
+| Operational truth | D1: Reuse StateDB as the sole queryable operational store. |
+| File-backed definitions | D2: Keep agent/playbook files canonical and use `definitions` as append-only history. |
+| Workflow definitions | D3: Keep database-backed workflow definitions as a distinct current-state contract. |
+| Access and schema ownership | D4: Record the shipped mix of StateDB calls and raw SQL, including duplicated project DDL. |
+| Shows and artifacts | D5: Treat files as authored/blob content and StateDB as structural and queryable metadata. |
+| Scheduler persistence | D6: Keep `SchedulerStateService` as the scheduler-specific injectable seam. |
+
+Out of scope:
+
+- A replacement application-service architecture is specified by ADR-0078, not described
+  as shipped here.
+- Scheduler firing, budget, lease, and retry policy remain scheduling-control-plane
+  decisions.
+- UI artifact rendering and the unified execution workspace target are in ADR-0081.
+- General file synchronization, distributed locking, and multi-process editing are not
+  provided by the present implementation.
+- This ADR does not ratify every raw SQL query as ideal; it records the current boundary.
+
+## Decision
+
+### D1 — StateDB is the shared operational store
+
+StateDB's default physical boundary is:
+
+```python
+DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
+
+class StateDB:
+    async def __aenter__(self) -> StateDB: ...
+    async def __aexit__(self, ...): ...
+```
+
+Studio's local raw-SQL helper opens the same path:
+
+```python
+@asynccontextmanager
+async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
+    # per connection:
+    # PRAGMA journal_mode = WAL
+    # PRAGMA busy_timeout = 5000
+    # PRAGMA foreign_keys = ON
+    # row_factory = aiosqlite.Row
+    ...
+```
+
+`get_active_connection_count() -> int` reports connections opened through this helper,
+not every StateDB/SQLAlchemy connection. The 5,000 ms SQLite busy timeout is intended to
+absorb modest concurrent-reader/single-writer contention. The exact value is inherited;
+the source records no measurement selecting five seconds.
+
+The shared schema contains the operational nouns Studio projects: messages,
+progressions, sessions, branches, definitions, shows, plays, invocations, schedules,
+schedule runs/task applications, artifacts, status transitions, session signals, engine
+runs/definitions, workflow definitions, projects, and related indexes
+(`lionagi/state/schema.sql`).
+
+Exact semantics:
+
+- If `DEFAULT_DB_PATH` does not exist, list operations commonly return empty collections
+  and get operations return `None`; they do not create a shadow database merely to read.
+- StateDB writes use its transaction helpers; raw Studio queries use their explicit
+  connection and commit behavior. Sharing a path does not make multiple service calls one
+  transaction.
+- WAL and foreign-key pragmas are applied to Studio-local raw connections. StateDB applies
+  its own schema/connection setup.
+- The CLI, runtime, daemon, web client projections, and VS Code projections converge on
+  the same rows. Studio does not copy lifecycle truth into a UI database.
+
+Why this way: the runtime is the producer of session and invocation truth. Reusing its
+store gives local tools one record without a replication protocol. The cost is that Studio
+queries are coupled to StateDB schema unless mediated through typed methods.
+
+### D2 — Agent and playbook files are current; `definitions` is history
+
+The editable set and file roots are closed:
+
+```python
+AGENTS_DIR = LIONAGI_HOME / "agents"
+PLAYBOOKS_DIR = LIONAGI_HOME / "playbooks"
+KIND_DIRS = {"agent": AGENTS_DIR, "playbook": PLAYBOOKS_DIR}
+_EXTENSIONS = (".md", ".playbook.yaml", ".yaml")
+```
+
+The history table is:
+
+```sql
+CREATE TABLE definitions (
+  id         TEXT PRIMARY KEY,
+  kind       TEXT NOT NULL CHECK(kind IN ('agent', 'playbook')),
+  name       TEXT NOT NULL,
+  path       TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  version    INTEGER NOT NULL,
+  created_at REAL NOT NULL,
+  message    TEXT
+);
+CREATE UNIQUE INDEX idx_def_unique_version
+  ON definitions(kind, name, version);
+```
+
+The service contract is:
+
+```python
+async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]: ...
+async def get_definition(kind: str, name: str) -> dict[str, Any] | None: ...
+async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | None: ...
+async def save_definition(
+    kind: str,
+    name: str,
+    content: str,
+    message: str | None = None,
+) -> dict[str, Any]: ...
+async def rollback_definition(
+    kind: str, name: str, target_version: int
+) -> dict[str, Any] | None: ...
+async def snapshot_current(kind: str | None = None) -> int: ...
+
+class SaveBody(BaseModel):
+    content: str
+    message: str | None = None
+```
+
+Exact save semantics:
+
+1. Validate `kind` and `name` before filesystem operations. Unknown kinds fail with
+   `ValueError`; the HTTP adapter maps that to 422.
+2. Resolve or create a per-process `(kind, name)` `asyncio.Lock`; different definitions
+   may save concurrently, while the same definition is serialized within one daemon.
+3. Locate a direct file, a `<name>/<name><ext>` file, or a literal candidate one directory
+   deep. Symlinked definitions may intentionally resolve outside the root.
+4. Call `StateDB.save_definition()` first. It selects `MAX(version)+1`, inserts a UUID row,
+   and retries an integrity collision up to five times under a StateDB lock.
+5. Only after the DB commit, create parent directories and write the file in a worker
+   thread.
+6. Return `{kind, name, version, saved_at, message}`.
+
+Five retries bound collisions from concurrent writers; the implementation records no
+measurement selecting exactly five. Exhaustion raises `RuntimeError` and does not return a
+version.
+
+Failure and conflict semantics:
+
+- A database failure prevents the file write.
+- A file failure after the database commit propagates, but the history row remains. There
+  is no compensation row or automatic reconciliation.
+- The in-process lock does not coordinate another daemon or a direct editor.
+- Listing scans disk first, then enriches matching entries with max DB version. A history
+  row without a current file is absent from the current-definition list.
+- Current content is read from disk; version content is read from StateDB.
+- Rollback reads an old row and calls the normal save path, creating version `N+1`; it
+  never rewinds or overwrites history. Missing target version returns `None`/HTTP 404.
+- Snapshot creates a version only when the current disk content differs from latest
+  history. Empty or missing roots produce zero snapshots.
+
+This is append-only history around a file source of truth, not an atomic cross-medium
+transaction.
+
+### D3 — Workflow definitions are database-current and separately typed
+
+Workflow definitions do not use D2's file/history path. Their current table is:
+
+```sql
+CREATE TABLE workflow_defs (
+  id          TEXT PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT,
+  spec_json   JSON,
+  created_at  REAL NOT NULL,
+  updated_at  REAL NOT NULL
+);
+```
+
+The HTTP request models are:
+
+```python
+class CreateWorkflowDefRequest(BaseModel):
+    name: str
+    description: str | None = None
+    spec_json: dict[str, Any] | None = None
+
+class UpdateWorkflowDefRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    spec_json: dict[str, Any] | None = None
+
+class RunWorkflowDefRequest(BaseModel):
+    inputs: dict[str, Any] | None = None
+    base_dir: str | None = None
+```
+
+`spec_json.version` must equal `1`; `base_dir` is forbidden inside the authored spec and
+is supplied only at run time. Nodes and edges are arrays capped at 200 and 400
+respectively. Valid node kinds are `input`, `chat`, `parse`, `fanout`, and `engine`.
+Node ids and edge ids are non-empty and unique; every node has numeric `pos.x`/`pos.y`;
+edge endpoints must exist; optional conditions are non-empty strings. Chat nodes require
+`config.prompt: str`; an optional model must be a provider-prefixed string. Inputs and
+outputs are arrays of strings.
+
+The node/edge caps bound Designer payload and validation work. No recorded measurement
+selects exactly 200 or 400; they are inherited shipped limits.
+
+Exact semantics:
+
+- Create strips the name, requires 1–120 characters, validates the graph, allocates a
+  12-hex-character id, and maps uniqueness failure to HTTP 409.
+- Invalid graph or name maps to HTTP 422. A removed `gate` node is rejected on writes and
+  also causes an actionable 422 when loading a legacy row.
+- Update first checks existence. An empty patch succeeds without changing `updated_at`;
+  non-empty patches validate only supplied fields and map a name conflict to 409.
+- Delete returns 404 when no row was removed.
+- List defaults to 100 rows, accepts 1–200, orders by `updated_at DESC`, and returns an
+  empty list when the DB file does not exist.
+- Run compilation returns HTTP 202 with `{run_id, status}`; `run_id` is the Session id.
+  Missing definitions map to 404 and compile errors to structured 422 detail.
+- There is no append-only workflow version history in this contract.
+
+The word “definition” therefore does not imply identical persistence. Consumers must
+select file-definition or workflow-definition operations explicitly.
+
+### D4 — Mixed typed and raw access is shipped, but not a complete adapter
+
+The current module-level boundary is:
+
+```text
+StateDB methods:
+  workflow_defs, schedules, schedule_runs, invocations, artifacts,
+  status transitions, definition-version inserts, scheduler state
+
+Studio-local SQL:
+  sessions and message hydration, run aggregates, definition history reads,
+  shows and plays, statistics, signals, projects, selected maintenance reads
+```
+
+`projects.py` declares this request-time DDL:
+
+```sql
+CREATE TABLE IF NOT EXISTS projects (
+  name TEXT PRIMARY KEY,
+  source TEXT NOT NULL,
+  path TEXT,
+  github TEXT,
+  description TEXT,
+  created_at REAL NOT NULL,
+  updated_at REAL NOT NULL,
+  last_seen_at REAL
+);
+CREATE INDEX IF NOT EXISTS idx_projects_source ON projects(source);
+CREATE INDEX IF NOT EXISTS idx_projects_updated ON projects(updated_at DESC);
+```
+
+The same table and indexes also appear in `lionagi/state/schema.sql`. This is duplicated
+ownership, not a second database. Each project request calls `_ensure_table()` before its
+query or mutation.
+
+Project exact semantics include:
+
+- List returns `{projects: [], unassigned_count: 0}` when the DB file is absent.
+- Project list/detail left-join sessions and derive counts. `editable` is true only for
+  sources `studio` and `global_override`.
+- Create trims a required name and inserts source `studio`; HTTP maps invalid name to 400
+  and other insertion failures, including conflict, to 409.
+- Update accepts only `description`, `github`, and `path`; no accepted fields or missing row
+  yields false and the route returns 404 “not found or no changes.”
+- Assignment updates named sessions or all unassigned rows, marks `project_source='manual'`,
+  and upserts the project. With neither selector it returns zero.
+- Delete removes only source `studio`; a missing or non-Studio row maps to HTTP 403.
+
+These details show why a generic statement that “Studio uses StateDB” is insufficient:
+schema and behavior also live in HTTP-service SQL today.
+
+### D5 — Shows and artifacts preserve a structural/content split
+
+Shows combine StateDB rows with filesystem content beneath `SHOWS_ROOT`. The key storage
+shapes are:
+
+```text
+shows: id, topic, goal, repo, base_branch, integration_branch, status,
+       show_dir, status_source, created_at, updated_at, status_reason_*
+plays: id, show_id, name, playbook, effort, status, attempt, session_id,
+       timing/exit/worktree/branch/merge fields, gate fields, depends_on,
+       sort_order, timestamps, status_reason_*
+```
+
+Exact show semantics:
+
+- List prefers the DB projection. A query failure or an empty DB result falls back to a
+  directory scan.
+- Detail may combine a DB show and play rows with `_show.md`, `_intent.md`, and verdict
+  files. If neither directory nor row exists, it returns `None`/404.
+- Filesystem paths are projected with `public_path()` rather than treated as content.
+- Import is a POST mutation. A missing shows root returns zero counts; existing folders are
+  imported into StateDB using runtime state methods and status transitions.
+- The file watcher contract is recorded in ADR-0076 D5.
+
+Artifacts are DB-first metadata:
+
+```sql
+artifacts(
+  id, invocation_id, session_id, created_at, updated_at,
+  kind, name, content JSON, file_path
+)
+```
+
+Four partial unique indexes cover invocation-only, session-only, both, and unattached
+natural keys because SQLite treats NULLs as distinct. `StateDB.insert_artifact()` updates
+the stable existing id for a matching natural key or creates a 12-hex id. It rejects empty
+`kind` or `name`. Studio serializes JSON content into an object and returns `file_path` as
+metadata; `GET /api/artifacts/{id}` does not read and return the referenced file.
+
+This preserves queryable outcomes while avoiding large blob insertion. It does not yet
+provide an authenticated, containment-checked content download contract.
+
+### D6 — `SchedulerStateService` is the narrow scheduler seam
+
+The protocol in `lionagi/studio/services/scheduler_state.py` contains:
+
+```python
+class SchedulerStateService(Protocol):
+    async def get_schedule(self, schedule_id: str) -> dict[str, Any] | None: ...
+    async def list_schedules(self, *, enabled: bool | None = None) -> list[dict[str, Any]]: ...
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
+    async def count_schedule_runs(self, schedule_id: str, *, chain_depth: int = 0) -> int: ...
+    async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]: ...
+    async def metric_value(self, metric: str, window_start: float) -> float: ...
+    async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
+    async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
+    async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
+    async def update_invocation(self, inv_id: str, **fields: Any) -> None: ...
+    async def update_status(..., expected_statuses: set[str | None] | frozenset[str | None] | None = None) -> bool: ...
+    async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
+```
+
+The real implementation opens a fresh StateDB context per protocol method. Scheduler helper
+functions accept the protocol so tests can substitute a fake. This seam covers persistence
+needed by scheduler execution; it does not own HTTP adaptation or unrelated Studio reads.
+
+## Consequences
+
+- CLI, runtime, daemon, web, and editor projections share one operational record.
+- Direct file editing, symlinks, and ordinary filesystem tools remain viable for agent and
+  playbook authoring. Rollback is auditable because it appends rather than rewrites.
+- Contributors must know which “definition” contract they are changing. File definitions
+  have history but a cross-medium failure window; workflows have DB-current state but no
+  built-in versions.
+- Raw SQL gives efficient projections but makes schema changes visible beyond StateDB's
+  typed method surface. Reversing D4 requires migrating each query and removing duplicated
+  DDL, not swapping one repository object.
+- Show availability depends on both DB and filesystem. Artifact metadata can survive without
+  readable blob content, and current APIs must not claim otherwise.
+- The scheduler can be tested against a fake state service without implying that all Studio
+  persistence is abstracted.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Remove the projects table/index DDL from the HTTP service, make StateDB schema and migrations the sole owner, and move project/session query methods behind typed StateDB operations while preserving the six project endpoints. | M | (filled at issue-open time) |
+| 2 | Add a definition-save reconciliation contract with content hashes, persisted file-write state, recovery for DB-first/file-second failures, and explicit multi-process edit behavior. | M | (filled at issue-open time) |
+| 3 | Replace repeated raw `aiosqlite` access with typed StateDB query methods or bounded read repositories, and add dialect-compatible tests for every retained raw query. | L | (filled at issue-open time) |
+| 4 | Complete the scheduler persistence seam by routing remaining scheduler-engine state access through `SchedulerStateService` or documenting each intentional exception in the scheduling-control-plane ADR. | S | (filled at issue-open time) |
+| 5 | Make artifact file references relative, authenticated, containment-checked, and hash-verifiable before the web client offers inline preview or download. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### A Studio-owned database
+
+This would isolate UI schema changes and allow aggressive read-model denormalization. It
+lost because lifecycle, schedules, invocations, and artifacts originate in runtime state;
+Studio would need a replication and conflict protocol before it could display authoritative
+status. One local source is simpler and already shipped.
+
+### Move all authored content into StateDB
+
+Database-current agents and playbooks would make save and history atomic and simplify remote
+editing. It lost because direct editors, symlinked definition trees, filesystem discovery,
+and version-control workflows are established behavior. D2 makes the non-atomic cost
+explicit instead of erasing those workflows.
+
+### Keep all current content on disk, including workflow graphs
+
+This would unify the meaning of definition and make workflows editor-friendly. It lost
+because the shipped Designer contract already treats `workflow_defs.spec_json` as current
+DB state with name uniqueness and typed graph validation. Moving it is a migration decision,
+not a harmless repository consolidation.
+
+### Treat DB-first/file-second save as transactional
+
+The per-process lock makes concurrent same-process saves appear serialized and could tempt
+documentation to call the operation atomic. It lost because a disk failure after the DB
+commit and a direct external edit are observable counterexamples. Honest failure semantics
+are more useful than a false transaction label.
+
+### Generic repository over every table
+
+A uniform CRUD interface could hide SQLAlchemy versus aiosqlite and make tests easy. It lost
+because StateDB has behavior-rich methods—status transitions, artifact natural-key upserts,
+definition version allocation—that generic CRUD would obscure. ADR-0078 instead calls for
+narrow command/query ports around changed operations.
+
+### Inline all artifact bytes in SQLite
+
+This would make artifact reads transactional and avoid missing files. It lost because logs,
+diffs, and generated outputs can be large, while structured outcome cards benefit from JSON
+queries. The current split stores queryable content and references blobs, with a required
+future safe-resolution boundary.

--- a/docs/adr/ADR-0078-studio-application-service-boundary.md
+++ b/docs/adr/ADR-0078-studio-application-service-boundary.md
@@ -1,0 +1,604 @@
+# ADR-0078: Studio application-service boundary
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0076 and ADR-0077
+
+## Context
+
+Studio's current service modules are effective HTTP endpoints but weak application
+boundaries. They combine FastAPI adaptation, Pydantic bodies, validation, raw SQL,
+filesystem access, subprocess/scheduler calls, and product decisions. The web client, VS
+Code extension, and `li schedule` client then reproduce parts of the same contract in
+TypeScript or `urllib` code.
+
+This aspirational ADR answers six implementation problems without claiming its target is
+already shipped.
+
+**P1 — Application behavior cannot be reused without HTTP.** Listing runs, saving a file
+definition, mutating a schedule, and resolving an artifact are currently functions near
+route handlers, but their error mapping and persistence choices remain transport-aware.
+The CLI either duplicates validation or calls the daemon even when an in-process service
+would suffice (`lionagi/studio/services/*.py`; `lionagi/studio/cli.py`).
+
+**P2 — Validation has more than one owner.** Schedule payload rules are parsed in the
+daemon and again in `li schedule`; the CLI validates recursive chain actions against
+scheduler-private limits. Workflow compilation imports execution metadata rather than a
+published application contract (`schedules.py`; `cli.py`; `workflow_compile.py`).
+
+**P3 — Persistence differences are hidden behind shared nouns.** Some services call
+StateDB, some execute SQL, project routes issue DDL, file definitions are DB-first/file-
+second, and workflow definitions are DB-current. A generic repository would erase rather
+than solve those differences (ADR-0077).
+
+**P4 — Scheduler integration can leak engine mechanics upward.** Studio must create,
+enable, disable, and inspect schedules, but application code should not own firing loops,
+leases, overlap, or worker recovery. The existing `SchedulerStateService` is the proper
+narrow persistence seam (`scheduler_state.py`).
+
+**P5 — Two clients independently encode a public daemon contract.** The web and VS Code
+clients each know trailing slashes, response fields, bearer headers, and SSE parsing. A
+route change can break one client while the Python service and the other client continue
+to run (`apps/studio/frontend/src/lib/api.ts`; `apps/vscode/src/api/*`).
+
+**P6 — A flag-day repository rewrite would amplify risk.** The daemon currently has 96
+registered API routes. Moving every query at once would mix architectural migration with
+behavior changes and make compatibility regressions difficult to attribute.
+
+| Concern | Decision |
+|---|---|
+| Package boundary | D1: Introduce `lionagi.studio.application` between transports and state. |
+| Command/query contract | D2: Publish typed, transport-independent request/result models and one explicit error taxonomy. |
+| Persistence ports | D3: Use capability-shaped StateDB and filesystem ports; keep file and workflow definitions separate. |
+| Scheduler boundary | D4: Submit and inspect schedules through application services backed by `SchedulerStateService`. |
+| Client compatibility | D5: Make OpenAPI plus behavior fixtures the versioned contract for web, CLI, and VS Code adapters. |
+| Migration quality | D6: Migrate operation-by-operation, keep coupling below 0.3, and require fake-port and cross-client tests. |
+
+Out of scope:
+
+- Replacing StateDB or changing its schema solely to satisfy this layering decision.
+- Redefining scheduler firing, budget, lease, retry, or worker semantics.
+- Building the unified execution UI in ADR-0081 or the operator protocol in ADR-0083.
+- Introducing a general event bus, ORM repository framework, dependency-injection
+  container, or network service separate from the Studio daemon.
+- Converging file-backed agent/playbook definitions with database-backed workflow
+  definitions; that requires a later migration decision.
+
+## Decision
+
+### D1 — `lionagi.studio.application` is the reusable boundary
+
+The target module tree is:
+
+```text
+lionagi/studio/
+├── application/
+│   ├── __init__.py          # public re-exports only
+│   ├── errors.py            # closed application error taxonomy
+│   ├── models.py            # shared ids, pages, command/query/result models
+│   ├── runs.py              # run queries
+│   ├── definitions.py       # file-definition commands/queries
+│   ├── workflows.py         # DB workflow-definition commands/queries
+│   ├── schedules.py         # schedule commands/queries
+│   ├── artifacts.py         # metadata + safe content resolution
+│   ├── projects.py          # project commands/queries
+│   └── ports.py             # capability protocols
+├── services/                # FastAPI adapters; no DDL or domain policy
+├── scheduler/               # firing/lease/worker mechanics
+├── registry.py
+└── app.py
+```
+
+The composition root constructs application services once and makes them available to
+route dependencies and in-process CLI adapters. Application modules may import StateDB data
+types and the narrow ports below. They do not import FastAPI, Starlette, VS Code/web types,
+or CLI parser namespaces.
+
+Dependency direction is:
+
+```mermaid
+flowchart LR
+  Web[Web HTTP/SSE adapter] --> App[Studio application]
+  CLI[CLI local/remote adapter] --> App
+  VS[VS Code HTTP/SSE adapter] --> Contract[Published daemon contract]
+  Contract --> Web
+  App --> State[State ports]
+  App --> Files[File/artifact ports]
+  App --> Scheduler[SchedulerStateService]
+```
+
+Exact semantics:
+
+- A route parses HTTP input, calls exactly one application operation, and maps its result or
+  application error. It does not execute DDL, open `aiosqlite`, or choose a file path.
+- An in-process CLI calls the same operation directly. A remote CLI serializes the same
+  request model through the versioned HTTP adapter.
+- Application services are async because StateDB, filesystem thread offload, and scheduler
+  calls are async from the caller's perspective.
+- Import cycles from application modules back into `services` are forbidden. Compatibility
+  adapters may call old service functions only during a bounded migration and must be named
+  `legacy_*` so the dependency can be removed mechanically.
+
+Why this way: the boundary corresponds to operator use cases, not tables. It permits reuse
+and fake-port tests while keeping the running FastAPI daemon as one deployment unit.
+
+### D2 — Typed commands, queries, results, and failures
+
+The target base models are Python-native Pydantic models:
+
+```python
+from typing import Generic, Literal, TypeVar
+from pydantic import BaseModel, ConfigDict, Field
+
+T = TypeVar("T")
+JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+class Page(ContractModel, Generic[T]):
+    items: tuple[T, ...]
+    offset: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    has_next: bool
+
+class RunQuery(ContractModel):
+    status: tuple[str, ...] = ()
+    playbook: str | None = None
+    project: str | None = None
+    project_is_null: bool = False
+    tags: tuple[str, ...] = ()
+    offset: int = Field(default=0, ge=0)
+    limit: int = Field(default=20, ge=1, le=5000)
+
+class RunSummary(ContractModel):
+    run_id: str
+    status: str
+    effective_health: str | None
+    playbook_name: str | None
+    agent_name: str | None
+    invocation_kind: str | None
+    invocation_id: str | None
+    project: str | None
+    started_at: float | None
+    ended_at: float | None
+    updated_at: float | None
+    branch_count: int = 0
+    message_count: int = 0
+    status_reason_code: str | None = None
+    status_reason_summary: str | None = None
+
+class SaveDefinition(ContractModel):
+    kind: Literal["agent", "playbook"]
+    name: str = Field(min_length=1)
+    content: str
+    message: str | None = None
+    expected_version: int | None = Field(default=None, ge=0)
+
+class SaveResult(ContractModel):
+    kind: Literal["agent", "playbook"]
+    name: str
+    version: int = Field(ge=1)
+    saved_at: float
+    reconciliation_id: str | None = None
+
+class ArtifactQuery(ContractModel):
+    artifact_id: str
+    include_preview: bool = False
+    preview_limit_bytes: int = Field(default=262_144, ge=1, le=1_048_576)
+
+class ArtifactResult(ContractModel):
+    id: str
+    kind: str
+    name: str
+    content: dict[str, object]
+    display_path: str | None
+    sha256: str | None
+    media_type: str | None
+    preview: bytes | None
+    preview_truncated: bool = False
+```
+
+`262_144` bytes is the target default bounded preview (256 KiB), with a 1 MiB hard cap.
+It is a conservative UI responsiveness and memory bound, not a measured optimum; changing
+either value is a contract change with tests.
+
+Schedule commands are a discriminated union rather than one bag of optional fields:
+
+```python
+class CronTrigger(ContractModel):
+    kind: Literal["cron"] = "cron"
+    expression: str
+
+class IntervalTrigger(ContractModel):
+    kind: Literal["interval"] = "interval"
+    seconds: int = Field(ge=1)
+
+class GithubPollTrigger(ContractModel):
+    kind: Literal["github_poll"] = "github_poll"
+    repository: str
+    poll_interval_seconds: int = Field(ge=1)
+    filters: dict[str, JsonValue] = Field(default_factory=dict)
+
+class ScheduleAction(ContractModel):
+    kind: Literal["agent", "flow", "fanout", "play", "flow_yaml"]
+    model: str | None = None
+    prompt: str | None = None
+    agent: str | None = None
+    playbook: str | None = None
+    flow_yaml: str | None = None
+    project: str | None = None
+    extra_args: tuple[str, ...] = ()
+    on_success: dict[str, JsonValue] | None = None
+    on_fail: dict[str, JsonValue] | None = None
+
+class SchedulePatch(ContractModel):
+    # Every field is optional, but model_fields_set distinguishes omitted from
+    # explicit null so nullable fields can be cleared without clearing others.
+    name: str | None = None
+    description: str | None = None
+    trigger: CronTrigger | IntervalTrigger | GithubPollTrigger | None = None
+    action: ScheduleAction | None = None
+    missed_fire_policy: Literal["skip", "run_once"] | None = None
+    overlap_policy: Literal["skip", "allow"] | None = None
+    max_runs: int | None = Field(default=None, ge=1)
+    budget_usd: float | None = Field(default=None, gt=0)
+    budget_tokens: int | None = Field(default=None, ge=1)
+    project: str | None = None
+
+class CreateSchedule(ContractModel):
+    kind: Literal["create"] = "create"
+    name: str
+    trigger: CronTrigger | IntervalTrigger | GithubPollTrigger
+    action: ScheduleAction
+    enabled: bool = True
+    max_runs: int | None = Field(default=None, ge=1)
+    budget_usd: float | None = Field(default=None, gt=0)
+    budget_tokens: int | None = Field(default=None, ge=1)
+
+class PatchSchedule(ContractModel):
+    kind: Literal["patch"] = "patch"
+    schedule_id: str
+    expected_updated_at: float
+    changes: SchedulePatch
+
+class SetScheduleEnabled(ContractModel):
+    kind: Literal["set_enabled"] = "set_enabled"
+    schedule_id: str
+    enabled: bool
+    expected_updated_at: float | None = None
+
+ScheduleCommand = CreateSchedule | PatchSchedule | SetScheduleEnabled
+
+class ScheduleResult(ContractModel):
+    schedule_id: str
+    name: str
+    enabled: bool
+    updated_at: float
+    next_fire_at: float | None
+```
+
+The minimum service protocol remains compact:
+
+```python
+class StudioApplication(Protocol):
+    async def list_runs(self, query: RunQuery) -> Page[RunSummary]: ...
+    async def save_file_definition(self, command: SaveDefinition) -> SaveResult: ...
+    async def mutate_schedule(self, command: ScheduleCommand) -> ScheduleResult: ...
+    async def resolve_artifact(self, query: ArtifactQuery) -> ArtifactResult: ...
+```
+
+The target error taxonomy is closed at the adapter boundary:
+
+```python
+class FieldFailure(ContractModel):
+    path: tuple[str | int, ...]
+    code: str
+    message: str
+
+class StudioApplicationError(Exception):
+    code: str
+
+class ValidationFailure(StudioApplicationError):       # code="validation"
+    field_errors: tuple[FieldFailure, ...]
+class NotFound(StudioApplicationError):                 # code="not_found"
+    resource: str; identifier: str
+class Conflict(StudioApplicationError):                 # code="conflict"
+    resource: str; expected: str | None; actual: str | None
+class StateUnavailable(StudioApplicationError):         # code="state_unavailable"
+    retryable: bool
+class ReconciliationRequired(StudioApplicationError):   # code="reconciliation_required"
+    reconciliation_id: str
+class PermissionDenied(StudioApplicationError):         # code="permission_denied"
+    reason: str
+```
+
+Exact error semantics:
+
+- Invalid input never reaches a port and maps to HTTP 422.
+- Missing resources map to 404.
+- Name conflicts, stale expected versions, and stale `updated_at` values map to 409.
+- State unavailability maps to 503 and carries whether retry is safe.
+- A definition DB commit followed by file-write failure creates a persisted reconciliation
+  record and returns `ReconciliationRequired`, not a success-shaped result.
+- Authentication remains the daemon middleware's responsibility; application-level
+  `PermissionDenied` represents operation authorization or containment denial, not a
+  missing bearer header.
+- Adapters serialize stable `code` plus structured fields. Human text is diagnostic and is
+  not the discriminant.
+
+### D3 — Capability-shaped state and file ports
+
+The target ports expose behavior required by operations, not generic CRUD:
+
+```python
+class RunReadPort(Protocol):
+    async def list_runs(self, query: RunQuery) -> Page[RunSummary]: ...
+    async def get_run(self, run_id: str, *, message_limit: int, cursor: str | None) -> RunDetail | None: ...
+
+class FileDefinitionPort(Protocol):
+    async def read_current(self, kind: str, name: str) -> FileDefinition | None: ...
+    async def current_hash(self, kind: str, name: str) -> str | None: ...
+    async def write_current(self, kind: str, name: str, content: str) -> FileWriteResult: ...
+
+class DefinitionHistoryPort(Protocol):
+    async def latest_version(self, kind: str, name: str) -> int: ...
+    async def append_version(self, draft: DefinitionVersionDraft) -> DefinitionVersion: ...
+    async def record_reconciliation(self, failure: DefinitionWriteFailure) -> str: ...
+
+class WorkflowDefinitionPort(Protocol):
+    async def create(self, command: CreateWorkflow) -> WorkflowDefinition: ...
+    async def update(self, command: PatchWorkflow) -> WorkflowDefinition: ...
+    async def delete(self, workflow_id: str) -> bool: ...
+
+class ArtifactMetadataPort(Protocol):
+    async def get(self, artifact_id: str) -> ArtifactMetadata | None: ...
+
+class ArtifactFilePort(Protocol):
+    async def preview(
+        self, relative_path: str, *, max_bytes: int, expected_sha256: str | None
+    ) -> VerifiedPreview: ...
+```
+
+`RunDetail` is the application-owned superset of `RunSummary` with branch/message/graph,
+cursor, artifact, and reason projections; `EvidenceRequest` contains the selected pane,
+opaque cursor, and bounded page size. They are defined in `application/models.py` and are
+serialized by the existing run-detail adapter without exposing StateDB rows directly.
+
+The value types used by those ports are exact transfer shapes:
+
+```python
+class FileDefinition(ContractModel):
+    kind: Literal["agent", "playbook"]
+    name: str
+    relative_path: str
+    content: str
+    sha256: str
+    version: int
+
+class FileWriteResult(ContractModel):
+    relative_path: str
+    sha256: str
+    bytes_written: int = Field(ge=0)
+
+class DefinitionVersionDraft(ContractModel):
+    kind: Literal["agent", "playbook"]
+    name: str
+    relative_path: str
+    content: str
+    content_sha256: str
+    message: str | None = None
+
+class DefinitionVersion(DefinitionVersionDraft):
+    id: str
+    version: int = Field(ge=1)
+    created_at: float
+
+class DefinitionWriteFailure(ContractModel):
+    version_id: str
+    kind: Literal["agent", "playbook"]
+    name: str
+    expected_sha256: str
+    error_code: str
+
+class CreateWorkflow(ContractModel):
+    name: str = Field(min_length=1, max_length=120)
+    description: str | None = None
+    spec: dict[str, JsonValue] | None = None
+
+class PatchWorkflow(ContractModel):
+    workflow_id: str
+    expected_updated_at: float
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = None
+    spec: dict[str, JsonValue] | None = None
+
+class WorkflowDefinition(ContractModel):
+    id: str
+    name: str
+    description: str | None
+    spec: dict[str, JsonValue] | None
+    created_at: float
+    updated_at: float
+
+class ArtifactMetadata(ContractModel):
+    id: str
+    kind: str
+    name: str
+    content: dict[str, JsonValue]
+    relative_path: str | None
+    sha256: str | None
+    media_type: str | None
+    size_bytes: int | None
+
+class VerifiedPreview(ContractModel):
+    data: bytes
+    sha256: str
+    truncated: bool
+    media_type: str
+```
+
+Exact semantics:
+
+- StateDB owns all schema and migration DDL. No HTTP adapter or application operation
+  executes `CREATE TABLE`, `ALTER TABLE`, or index DDL.
+- File-backed definitions and workflow definitions have different ports. No
+  `DefinitionRepository[Any]` erases source-of-truth or history differences.
+- `SaveDefinition.expected_version` is checked before appending. A mismatch is a conflict;
+  `None` explicitly requests last-write-wins compatibility behavior.
+- Definition save remains DB-history first until a separately accepted migration changes
+  the storage protocol. The new persisted reconciliation record makes the partial failure
+  observable and recoverable.
+- Artifact metadata is fetched before file access. The file port accepts a relative path,
+  resolves it under an approved root, rejects escape/symlink containment violations, reads
+  at most the requested cap, and verifies a supplied SHA-256 before returning bytes.
+- Empty result sets return typed empty pages. Missing individual resources return `None` to
+  the application service, which converts them to `NotFound`.
+
+### D4 — Scheduler application operations stop at `SchedulerStateService`
+
+The application layer may validate and submit schedule definitions, enable/disable them,
+trigger an explicitly supported manual fire, and query schedule/firing state. Its adapter
+depends on the existing `SchedulerStateService` protocol recorded in ADR-0077 D6.
+
+Exact boundary:
+
+- Application validation owns public schedule shapes and optimistic conflict checks.
+- `SchedulerStateService` owns persistence calls required by scheduler behavior.
+- `lionagi.studio.scheduler` owns cadence calculation, polling, budget evaluation,
+  overlap, chain depth, leases, worker execution, and recovery.
+- Application code does not import private scheduler constants. Limits required for public
+  validation are published from a small scheduler contract module and used by both daemon
+  and CLI adapters.
+- `li schedule` either invokes the application in-process or uses the remote contract. It
+  does not keep an independent recursive validator.
+- A state-unavailable result is explicit. No adapter interprets an empty schedule list as
+  proof that persistence is healthy.
+
+### D5 — One versioned daemon contract for all clients
+
+OpenAPI describes request/response schemas and status codes; checked-in behavior fixtures
+describe semantics OpenAPI cannot express, especially SSE and redirects. The contract
+artifact set is:
+
+```text
+studio-contract/
+├── openapi.json
+├── routes.json                 # method, canonical path, trailing-slash policy, auth class
+├── examples/
+│   ├── runs-page.json
+│   ├── run-detail.json
+│   ├── invocation-detail.json
+│   └── application-errors.json
+└── sse/
+    ├── session.ndjson
+    ├── signals.ndjson
+    ├── show.ndjson
+    └── leo.ndjson
+```
+
+The exact version rule is additive within major version 1:
+
+- Adding an optional response field or a new endpoint is compatible.
+- Removing/renaming a field, changing type/nullability, changing method or canonical path,
+  altering auth class, or changing an SSE terminal/reconnect rule requires a versioned
+  compatibility change and an explicit migration.
+- The web and VS Code client parsers run against the same fixtures in CI.
+- Trailing-slash redirects are tested from the client-visible origin because an absolute
+  redirect can become cross-origin.
+- Bearer mode and tokenless mode are both exercised for JSON and SSE.
+- Generated clients are permitted but not required; passing the behavior suite is the
+  normative enforcement mechanism.
+
+### D6 — Incremental migration, coupling, and testability gates
+
+Migration is strangler-style:
+
+1. Add application models, ports, and adapter tests for one changed operation.
+2. Implement the application operation by calling current StateDB/file capabilities.
+3. Make the existing HTTP route a thin adapter without changing its wire contract.
+4. Point the in-process or remote CLI path at the same request model.
+5. Run daemon, web, and VS Code contract fixtures.
+6. Remove the superseded service helper or mark a bounded compatibility adapter.
+
+No operation migrates merely to satisfy a directory quota. Changed behavior and the
+application extraction should be separate commits or separately testable steps even when
+delivered together.
+
+For the target six-component subgraph—web adapter, CLI adapter, VS adapter/contract,
+application services, state ports, and file/scheduler ports—with six intended direct
+dependencies, `κ = 6/(6×5) = 0.20`. This is below the required 0.3. (The six components
+collapse the D1 diagram's finer-grained nodes — the state ports count as one component and the
+file/scheduler ports as another — so the diagram's edge count and this κ edge count differ by
+construction.) Adding direct transport
+→StateDB or transport→filesystem edges increases coupling and fails the design review unless
+explicitly justified.
+
+Testability target is `τ ≥ 0.85`, evidenced by:
+
+- application tests using fake state, file, scheduler, and clock ports;
+- error-path tests for empty, miss, stale version, DB failure, file-after-commit failure,
+  containment denial, and hash mismatch;
+- adapter tests pinning HTTP status and payloads; and
+- cross-client fixture tests for JSON, trailing slashes, auth, SSE EOF, terminal frames,
+  and reconnection.
+
+## Consequences
+
+- Route handlers become small and application behavior becomes reusable without HTTP.
+- Schema ownership moves to StateDB while optimized query ports remain possible; the design
+  does not require an anemic generic repository.
+- File-definition and workflow-definition differences become visible in types. A caller
+  cannot accidentally assume rollback or version history exists for both.
+- The definition partial-failure window remains until storage changes, but it becomes a
+  typed, durable reconciliation state instead of an ambiguous exception.
+- Client compatibility is checked once against shared artifacts. The cost is maintaining
+  fixtures whenever a deliberate contract change occurs.
+- The migration adds interfaces and temporary adapters. Reversing D1 later is moderately
+  costly because transports will depend on these models, but ports keep persistence
+  replaceable.
+- Contributors must decide whether logic is HTTP adaptation, application policy, or
+  scheduler/state capability. That additional classification is deliberate maintenance
+  work.
+
+## Alternatives considered
+
+### Keep HTTP as the only application boundary
+
+This preserves the current deployment and makes remote and local behavior identical. It
+lost because local CLI commands must serialize through HTTP or duplicate validation, and
+application tests require constructing transport state. HTTP remains an adapter, not the
+only callable form.
+
+### Generic repository per table
+
+Uniform `get/list/create/update/delete` protocols would be quick to scaffold and easy to
+mock. They lost because important semantics live above CRUD: append-only version allocation,
+status-transition transactions, artifact natural-key upserts, safe path resolution, and
+schedule conflict policy. Capability ports make those decisions explicit.
+
+### One repository for every definition kind
+
+This would simplify UI and API vocabulary. It lost because files are current for agents and
+playbooks while StateDB rows are current for workflows. A common interface would either
+omit version/file semantics or pretend they apply universally.
+
+### Generated clients as the sole compatibility mechanism
+
+Generation would reduce duplicated TypeScript shapes. It lost as the sole mechanism because
+OpenAPI does not capture SSE parsing, reconnect, terminal frames, host/auth behavior, or
+redirect-origin failures. Generation remains allowed alongside behavior fixtures.
+
+### Introduce a central event bus with the application layer
+
+Commands and queries could publish events for clients and scheduler integration. It lost
+because the boundary can be delivered without a new durability, ordering, and retention
+system. Endpoint SSE normalization is a separate delta in ADR-0076.
+
+### Flag-day migration of all 96 routes
+
+This would reach a uniform architecture sooner and avoid temporary adapters. It lost because
+the blast radius spans every daemon client and mixes contract changes with structural moves.
+Operation-by-operation extraction keeps each step reversible and contract-testable.

--- a/docs/adr/ADR-0079-studio-web-client-architecture-and-deployment.md
+++ b/docs/adr/ADR-0079-studio-web-client-architecture-and-deployment.md
@@ -1,0 +1,373 @@
+# ADR-0079: Studio web client architecture and deployment
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0001, v0-0002, v0-0005, v0-0010, v0-0013, v0-0018, v0-0034, v0-0035
+
+## Context
+
+The checked-in Studio web client lives under `apps/studio/frontend/`. It is a
+client-rendered Vite application that talks to the Python Studio daemon. Earlier records
+described a Next.js application, centralized server-state/cache libraries, and a
+shadcn/Radix component system. Those packages and runtime assumptions are not present in
+the shipped source.
+
+This ADR answers six current-code problems.
+
+**P1 — Contributors need the real build and runtime contract.** Assuming SSR, a Node
+production server, or frontend API routes leads to deployment and debugging instructions
+that cannot work against the Vite bundle (`package.json`; `vite.config.mts`; `main.tsx`).
+
+**P2 — The same bundle runs with several API origins.** It may be served by the daemon,
+the Vite server, a static hosted origin that talks to loopback, or a reverse proxy. A wrong
+default can return the SPA's HTML for `/api/*` with status 200 or create an absolute
+cross-origin trailing-slash redirect (`api.ts`; `vite.config.mts`; `studio/cli.py`).
+
+**P3 — Browser auth must cover streams as well as ordinary fetches.** Desktop/runtime
+injection can provide a bearer token, but native `EventSource` cannot attach it. JSON and
+SSE need one token source and compatible error behavior (`src/lib/api.ts`).
+
+**P4 — Component and state ownership must match installed code.** Generic primitives are
+source-owned under `components/ui`; route and feature components own fetching and local
+reducers. Naming uninstalled libraries as architectural commitments would direct new code
+toward dependencies the application does not have (`package.json`; `components/**`).
+
+**P5 — The route tree is in migration.** The shell exposes a cockpit subset, while entity
+route files and shared redirect adapters preserve old links. If retired routes regain
+feature logic, Studio will have two information architectures and two state owners
+(`routes/**`; `lib/retiredRoutes.ts`).
+
+**P6 — Public vocabulary differs from some implementation symbols.** APIs and product
+labels use “playbook,” while graph editor types retain `Worker*` names. Internal type names
+must not silently redefine user vocabulary (`api.ts`; `types.ts`; Library components).
+
+| Concern | Decision |
+|---|---|
+| Stack and runtime | D1: Keep a React 19/TypeScript/Vite SPA with TanStack Router and no production Node requirement. |
+| API origin and delivery | D2: Resolve API base explicitly across same-origin, development, hosted-static, and runtime-injected modes. |
+| HTTP and SSE client | D3: Use one fetch-based bearer-aware client and fetch-based SSE parsing. |
+| Components and state | D4: Keep source-owned UI primitives and feature-local data ownership until a measured cache decision. |
+| Navigation compatibility | D5: Let TanStack Router own URL state and keep retired routes as redirect adapters only. |
+| Product vocabulary | D6: Keep “playbook” public while treating legacy `Worker*` names as internal migration residue. |
+
+Out of scope:
+
+- The canonical six-space cockpit taxonomy is decided by ADR-0080.
+- The shared execution workspace target is ADR-0081.
+- The VS Code client is recorded separately in ADR-0082.
+- This ADR does not select a future server-state cache, headless component library, SSR
+  framework, or design-system migration.
+- Daemon host, CORS, token, and SPA fallback enforcement are recorded in ADR-0076.
+
+## Decision
+
+### D1 — Client-rendered Vite SPA and checked-in dependency set
+
+The build contract in `apps/studio/frontend/package.json` is (abridged — devDependencies and
+tooling metadata omitted):
+
+```json
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "start": "vite preview",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "e2e": "npm run build && playwright test"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.170.15",
+    "dagre": "^0.8.5",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "react-markdown": "^10.1.0",
+    "reactflow": "^11.11.4",
+    "remark-gfm": "^4.0.1",
+    "smol-toml": "^1.7.0",
+    "use-intl": "^4.13.0",
+    "yaml": "^2.9.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
+  }
+}
+```
+
+The contract is the dependency roles, not a promise to freeze every patch version. React
+mounts one `RouterProvider` into `#root`; TanStack Router's generated route tree is created
+by the Vite plugin. There is no SSR entry point, server component graph, Node request
+handler, or frontend API route.
+
+The source ownership tree is:
+
+```text
+src/
+├── main.tsx                 # locale setup, preload failure guard, router mount
+├── routeTree.gen.ts         # generated TanStack route tree
+├── routes/                  # URL adapters and top-level page composition
+├── lib/
+│   ├── api.ts               # daemon JSON/SSE client
+│   ├── types.ts             # client response/view types
+│   ├── retiredRoutes.ts     # compatibility redirects
+│   └── operationGraph.ts    # signal-to-operation projection
+└── components/
+    ├── ui/                  # generic source-owned primitives
+    ├── shell/               # rail/topbar/footer/palette/layout
+    └── <feature>/           # mission, fleet, history, library, schedules, ...
+```
+
+Exact semantics:
+
+- `npm run build` type-checks before Vite emits `dist/`; a type failure produces no
+  successful build.
+- The router is entirely client-side. Deep-link serving therefore depends on ADR-0076's
+  SPA fallback or an equivalent static-host rewrite.
+- `vite:preloadError` triggers at most one guarded reload; a repeated broken chunk is
+  allowed to surface rather than forming a reload loop (`preloadReload.ts`).
+- Locale direction and language are applied before first React paint; the root component
+  validates locale choices against the `LOCALES` registry.
+- The production artifact is static HTML/JS/CSS. A Node runtime is required to build or run
+  Vite preview, not to serve the built application in daemon-hosted production.
+
+### D2 — Ordered API-base resolution and supported delivery shapes
+
+The browser-facing runtime injection contract is:
+
+```typescript
+declare global {
+  interface Window {
+    __STUDIO_API_BASE__?: string;
+    __STUDIO_AUTH_TOKEN__?: string;
+  }
+}
+
+export function resolveApiBase(): string {
+  // 1. non-empty window.__STUDIO_API_BASE__
+  // 2. non-empty import.meta.env.VITE_STUDIO_API_BASE
+  // 3. ports 3000/5173 -> same protocol/hostname, port 8765
+  // 4. any other browser origin -> "" (same origin)
+  // 5. no window (tests/SSR compatibility) -> http://localhost:8765
+}
+```
+
+`API_BASE` is computed once at module evaluation. Empty configured strings are treated as
+unset. The supported delivery matrix is:
+
+| Shape | Frontend origin | API base rule | Process shape |
+|---|---|---|---|
+| API-only daemon | no bundled UI | client supplied externally | one Python process |
+| Daemon-hosted `dist/` | daemon origin | `""` same-origin | one Python process after build |
+| Vite development | port 3000 or 5173 | browser fallback to daemon port 8765; Vite also proxies `/api` | Vite + Python |
+| Static hosted UI | hosted origin | build injects `window.__STUDIO_API_BASE__`, default `http://127.0.0.1:8765` on hosted builds | static host + local Python |
+| Reverse proxy/container | proxy origin | `""` same-origin | topology chosen by deployer |
+
+Vite preview proxies `/api` to the configured daemon so production-build tests exercise a
+single browser origin. `STUDIO_API_URL` overrides the proxy target; otherwise it uses
+`127.0.0.1` and the e2e/default port. The hosted build injector runs only when its hosted
+build marker is present, so ordinary `vite build` remains same-origin.
+
+Exact error semantics in `fetchJson()`:
+
+- Network/CORS/DNS failure reports a connectivity failure and rethrows.
+- Non-2xx parses a string `detail` when possible and throws it; otherwise it reports the
+  HTTP status.
+- HTTP 204 returns `undefined` without JSON parsing.
+- A non-JSON empty body returns `undefined`.
+- A non-JSON HTML document produces an explicit “API base likely unconfigured” error,
+  covering static hosts that rewrite unknown `/api/*` requests to `index.html` with 200.
+- Other non-JSON text is parsed as JSON and may throw normally.
+
+List paths whose daemon route is slash-terminated include the slash in the client. This
+avoids an absolute redirect whose target can be cross-origin when UI and daemon differ.
+
+### D3 — One bearer-aware fetch layer for JSON and SSE
+
+Token resolution is runtime-only:
+
+```typescript
+export function resolveAuthToken(): string | undefined {
+  return window.__STUDIO_AUTH_TOKEN__ || undefined;
+}
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T>;
+
+function sseSubscribe(
+  path: string,
+  onData: (data: string) => void,
+): () => void;
+```
+
+`fetchJson()` attaches `Authorization: Bearer <token>` when the token exists and otherwise
+preserves caller headers. Mutation helpers explicitly set `Content-Type: application/json`
+and stringify their bodies, matching ADR-0076's body guard.
+
+The SSE helper uses `fetch` plus `ReadableStream`, not native `EventSource`. Exact semantics:
+
+- It sends `Accept: text/event-stream` and the same optional bearer header as JSON calls.
+- It parses unnamed frames separated by `\n\n`, joins multiple `data:` lines, and passes
+  the payload string to the endpoint-specific consumer.
+- The returned closer sets a closed flag and aborts the request.
+- EOF or network error reconnects after 2,000 ms unless closed.
+- The endpoint consumer is responsible for JSON parsing and closing on its `done` frame.
+- Parser errors thrown by the consumer are not converted into a durable cursor or replay.
+- There is no `Last-Event-ID`; reconnect starts according to the endpoint's server contract.
+
+The two-second reconnect delay is a shipped inherited value. Its qualitative purpose is to
+avoid a tight retry loop while keeping local recovery responsive; no recorded measurement
+selects exactly two seconds.
+
+### D4 — Source-owned primitives and feature-local data state
+
+The generic component boundary is `src/components/ui`. It contains buttons, badges,
+fields, modal/split-pane/stacked-list primitives, status and timestamp renderers, toast,
+Markdown, skeleton, and related components. `components/shell` owns application chrome.
+Feature directories compose those primitives and own domain-specific loading, selection,
+reducers, and error states.
+
+The dependency manifest does not include shadcn, Radix, TanStack Query, or Zustand. This
+absence is load-bearing: those libraries are not available by architectural implication.
+
+Exact ownership semantics:
+
+- Generic role/name/state/keyboard behavior belongs in `components/ui`; feature-specific
+  API calls and domain labels do not.
+- Routes own validated search-parameter contracts and page-level composition.
+- Operational features currently call functions from `lib/api.ts` and use React state,
+  effects, reducers, or `Promise.allSettled`; there is no central server-state cache.
+- A feature may keep a specialized reducer, as Mission Control and Fleet do. It must not
+  claim cross-feature cache invalidation unless it implements it.
+- Shared interactive primitives require explicit accessibility behavior because no
+  installed headless component library supplies it.
+
+This decision records the current system. It does not reject a future cache or headless
+library; it requires an evidence-based ADR against this baseline.
+
+### D5 — TanStack Router owns navigation state; retired routes do not
+
+Routes are file-based and generate `routeTree.gen.ts`. Search validators reduce arbitrary
+input into typed route state. For example, Fleet preserves primitive legacy filters while
+normalizing the selected session `s`.
+
+The redirect target contract is:
+
+```typescript
+export type RetiredRedirectTo =
+  | "/fleet"
+  | "/library"
+  | "/schedules"
+  | "/system";
+
+export interface RetiredRedirectTarget<TTo extends RetiredRedirectTo> {
+  to: TTo;
+  search: Record<string, string | number | boolean | Array<string | number | boolean>>;
+}
+```
+
+Exact semantics:
+
+- Retired search preservation keeps non-empty strings, numbers, booleans, and non-empty
+  arrays of those primitives; it drops objects, functions, empty strings, and nullish data.
+- Explicit redirect overrides win over preserved search.
+- Retired invocation detail fetches the invocation, accepts `?s=` only when it names one of
+  its child sessions, otherwise selects the first child, and targets Fleet. Zero-child
+  invocations preserve their invocation id.
+- A failed invocation fetch rejects to the route error component; it is not silently
+  converted into a generic fallback.
+- Re-clicking an active rail space dispatches `studio:toggle-pane` instead of navigating.
+- The current rail exposes Mission Control, Library, Schedules, and System; Fleet is a
+  separate route shown as a Mission Control tab and command. ADR-0080 records the accepted
+  six-space baseline and treats this as implementation drift.
+- Retired route files may parse and redirect. They must not become a second implementation
+  owner after target parity exists.
+
+### D6 — Public “playbook” terminology survives legacy graph names
+
+Daemon paths, Library labels, creation/editing helpers, and filters use “playbook.” The
+client still contains `WorkerGraph`, `WorkerStepNode`, `WorkerLinkEdge`, `WorkerFormData`,
+and helpers such as `getWorkerGraph()`.
+
+Exact semantics:
+
+- Public labels and new API fields use `playbook`.
+- Existing `Worker*` symbols describe an internal graph/editor shape; they are not a public
+  noun or permission to add “worker” filters and routes.
+- Playbook payload detection treats non-empty `steps` or `links` as graph format; otherwise
+  it treats the definition as declarative.
+- Plugin and skill discovery remain Library capabilities backed by daemon GET endpoints.
+- Renaming legacy types is a mechanical cleanup only if serialized field names and public
+  paths remain unchanged.
+
+## Consequences
+
+- The production client is a static bundle and can be served by Python or a static/reverse-
+  proxy topology without a Node application server.
+- API-base resolution supports local development and hosted-local operation, but a wrong
+  injection is a deployment failure visible to every request.
+- JSON and streams share token injection. Endpoint-specific SSE reconnect semantics remain
+  a client responsibility until ADR-0076's envelope delta is implemented.
+- The small runtime dependency set keeps source code inspectable, while source-owned
+  components require accessibility and keyboard tests the team cannot outsource to a
+  headless library.
+- Without a central server-state cache, coordinated invalidation is local to each feature.
+  Reversing D4 requires measuring that pain and migrating feature consumers deliberately.
+- Redirects preserve old links while the cockpit consolidates. Their maintenance cost is
+  acceptable only while they stay adapters rather than duplicate pages.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Publish a current component ownership catalog for `components/ui`, shell components, and feature components, with role/name/state/keyboard accessibility tests for every shared interactive primitive. | M | (filled at issue-open time) |
+| 2 | Add shared daemon-contract tests for the web and VS Code clients covering response shapes, auth, trailing-slash redirects, and SSE parsing/reconnection. | M | (filled at issue-open time) |
+| 3 | Reduce retired route files to redirect-only adapters after Fleet, History, Library, Schedules, and System have parity; remove duplicated entity-page behavior. | L | (filled at issue-open time) |
+| 4 | Define cache invalidation and freshness behavior for operational screens before adding a server-state library; acceptance must show one status change propagating consistently to every visible consumer. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Next.js with SSR and frontend API routes
+
+SSR could improve first render and colocate a server-side API facade. It lost because the
+product reads a local daemon, the current bundle is fully client-rendered, and production
+can be served as static files by the Python process. Reintroducing Next.js would add a
+runtime and deployment boundary without a demonstrated server-rendering requirement.
+
+### Browser talks only to a same-origin proxy
+
+This would remove CORS and mixed-origin redirect concerns. It lost as a universal rule
+because the hosted-static product intentionally talks from a hosted origin to the
+operator's loopback daemon, and API-only clients have no frontend proxy. Same-origin remains
+the ordinary bundled/reverse-proxy default.
+
+### Native `EventSource`
+
+It supplies automatic SSE reconnect and a mature parser. It lost because the browser API
+cannot attach the runtime bearer header. Fetch streams preserve auth parity with ordinary
+requests, at the cost of maintaining reconnect and framing code.
+
+### TanStack Query plus Zustand immediately
+
+A query cache could centralize freshness, deduplicate reads, and simplify mutation
+invalidation; a client store could coordinate shell state. They lost as current decisions
+because neither is installed and no cache/freshness contract has been measured. Adding them
+before defining invalidation would relocate ambiguity into library calls.
+
+### shadcn/Radix component ownership
+
+Headless primitives could improve accessibility baselines and reduce custom interaction
+code. They lost as a retrospective claim because the dependency and directory model are
+absent. Re-adoption requires comparing migration cost and accessibility evidence against
+the source-owned baseline.
+
+### Preserve every entity page indefinitely
+
+Independent pages maximize directness and reduce consolidation work. They lost because
+route-per-storage-noun navigation is the problem ADR-0080 resolves. Permanent URLs survive
+as redirects; permanent duplicate implementation owners do not.

--- a/docs/adr/ADR-0080-studio-six-space-cockpit-information-architecture.md
+++ b/docs/adr/ADR-0080-studio-six-space-cockpit-information-architecture.md
@@ -1,0 +1,345 @@
+# ADR-0080: Studio six-space cockpit information architecture
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0015, v0-0031, v0-0032, v0-0093
+
+## Context
+
+Studio accumulated one route per backend entity. A later design compressed those routes
+into three broad surfaces, but delivery acceptance restored a six-space cockpit organized
+around operator intent. The amendment to v0-0093 is the last accepted IA decision and
+explicitly supersedes its original three-route contract. This ADR carries that accepted
+baseline forward while documenting that the checked-in shell has not restored every part.
+
+The decision answers six concrete problems.
+
+**P1 — Storage nouns are not an operator mental model.** Runs, invocations, shows,
+schedules, playbooks, skills, plugins, engines, projects, and maintenance each acquired
+routes even when they answered the same operator question. Navigation made the operator
+reassemble “what needs attention,” “what ran,” and “what can run” from tables.
+
+**P2 — Live attention and durable history are different work modes.** Compressing both
+into one Operations surface made current intervention and retrospective inspection compete
+for layout and filters. Acceptance therefore split Mission Control from History while
+keeping one status and execution model underneath.
+
+**P3 — Canvas authoring needs a first-class room.** Treating workflow design as a small
+Library detail understates its spatial and editing needs. Designer is a peer space, not a
+modal or catalog subtype.
+
+**P4 — Schedule definition and firing health are operated together.** Folding schedules
+into Library separates configuration from whether it will fire, while folding them into
+History treats a control object as a past event. Acceptance kept one dedicated Schedules
+space.
+
+**P5 — Deep links outlive route implementations.** Existing URLs for runs, invocations,
+shows, kanban, playbooks, and admin remain inbound contracts. Removing pages must not turn
+bookmarks into ambiguous 404s or preserve an entire second IA.
+
+**P6 — The checked-in rail and the accepted baseline disagree.** `IconRail.tsx` currently
+shows Mission Control, Library, Schedules, and System; shortcuts map 1–3 and 5; Fleet is a
+separate `/fleet` route/tab; no `/designer` or `/history` route file exists. Treating this
+intermediate state as a third accepted taxonomy would reintroduce the ambiguity this ADR
+eliminates.
+
+| Concern | Decision |
+|---|---|
+| Top-level taxonomy | D1: Use exactly six peer cockpit spaces with shortcuts 1 through 6. |
+| Execution ownership | D2: Separate live Mission Control/Fleet from canonical History while sharing execution semantics. |
+| Definition ownership | D3: Give Designer, Library, and Schedules distinct responsibilities. |
+| Project scope and detail | D4: Apply one project lens and keep selection/filter state URL-addressable. |
+| Compatibility | D5: Redirect retired entity URLs into one owning cockpit space and remove duplicate implementations after parity. |
+| Source drift | D6: Treat the current four-destination rail as incomplete restoration, not a competing decision. |
+
+Out of scope:
+
+- The exact unified execution/adaptation model is specified by ADR-0081.
+- The daemon route, auth, and SSE boundary is ADR-0076.
+- Component library and frontend deployment choices are ADR-0079.
+- Leo is not declared shipped by this ADR. Its persistent command protocol is ADR-0083.
+- Backend database nouns may remain for storage and joins; this ADR governs public
+  navigation and product labels.
+
+## Decision
+
+### D1 — Exactly six peer cockpit spaces
+
+The accepted public registry is:
+
+```typescript
+type CockpitSpaceId =
+  | "mission"
+  | "designer"
+  | "library"
+  | "history"
+  | "schedules"
+  | "system";
+
+interface CockpitSpace {
+  id: CockpitSpaceId;
+  route: "/" | "/designer" | "/library" | "/history" | "/schedules" | "/system";
+  shortcut: 1 | 2 | 3 | 4 | 5 | 6;
+  scope: "project" | "machine";
+}
+```
+
+Its values are normative:
+
+| Space | Route | Shortcut | Scope | Responsibility |
+|---|---|---:|---|---|
+| Mission Control | `/` | ⌘/Ctrl-1 | project | Current attention, live board, and Fleet sub-view |
+| Designer | `/designer` | ⌘/Ctrl-2 | project | Workflow and execution-plan canvas authoring |
+| Library | `/library` | ⌘/Ctrl-3 | project/global catalog | Definitions and capability catalog |
+| History | `/history` | ⌘/Ctrl-4 | project | Unified execution timeline and detail |
+| Schedules | `/schedules` | ⌘/Ctrl-5 | project | Schedule definitions and firing health |
+| System | `/system` | ⌘/Ctrl-6 | machine | Health, maintenance, and project inventory |
+
+Exact semantics:
+
+- The rail contains six peer navigation targets. Fleet is not a seventh peer.
+- The shortcut requires Meta or Control plus the digit; it navigates to the registry route
+  and prevents the browser default.
+- The visible label, command-palette destination, shortcut, route, and operator-command
+  vocabulary derive from one typed registry. Copying string sets is implementation drift.
+- System remains visually allowed in a lower rail cluster, but its location does not change
+  peer status or shortcut 6.
+- Unknown space ids are rejected. They do not fall back to Mission Control.
+- Missing route implementations are defects against this accepted registry, not permission
+  to omit registry entries.
+
+Why this way: six spaces preserve the accepted separation between attention, design,
+catalog, record, automation, and machine maintenance. The taxonomy describes operator
+intent rather than StateDB tables.
+
+### D2 — Mission Control/Fleet and History have distinct roles
+
+Mission Control answers “what needs attention now.” History answers “what happened and
+why.” Both consume the execution workspace contract in ADR-0081.
+
+The route roles are:
+
+```text
+/                  Mission Control default attention view
+/fleet             Mission Control sub-view for live operational projection
+/history            canonical execution record and master-detail owner
+```
+
+Exact semantics:
+
+- Fleet is selectable as a Mission Control tab/sub-view at `/fleet`; its separate path is
+  addressability, not peer-space status.
+- Mission Control may show recent or failed executions as attention cards, but full
+  historical filtering and detail ownership live in History.
+- History unifies sessions/runs, schedule firings, script/show executions, and their
+  internal invocation joins. These backend nouns do not regain peer rail pages.
+- “Invocation” is not a user-facing kind, tab, filter, or rail label. It remains an internal
+  correlation record.
+- One status oracle supplies Mission Control, Fleet, and History. A dead process cannot
+  appear healthy merely because its database row says `running`; spent one-shot schedules
+  cannot appear active.
+- Detail presentation is master-detail and does not unload the owning list. The selection is
+  reconstructible from the URL.
+- Empty live work produces an inviting zero state, not a fallback navigation into History.
+
+This separation reverses the earlier three-route design's rejection of a home/attention
+surface. The later acceptance is controlling under the last-in-time canon.
+
+### D3 — Designer, Library, and Schedules are separate workspaces
+
+The three definition/control spaces have non-overlapping primary responsibilities:
+
+```text
+Designer   author and validate visual workflow/execution-plan graphs
+Library    browse and inspect agents, workflows, playbooks, skills, plugins, engines
+Schedules  configure cadence/action and inspect next/last firing health
+```
+
+Exact semantics:
+
+- Designer owns canvas authoring. Library may link to a workflow definition or summary but
+  does not host a second full canvas implementation.
+- Library owns the capability catalog. Current Library kinds may include agent, workflow,
+  playbook, skill, plugin, and engine; adding a kind does not add a peer rail space.
+- Schedules owns both definition mutation and health because operators use them together.
+  Schedule firing execution detail links into History rather than duplicating History.
+- Public terminology remains “playbook” where the checked-in product uses it (ADR-0079);
+  this ADR does not revive invocation as a product noun.
+- System owns maintenance and project inventory. Destructive operations remain separated
+  from ordinary workspaces and require their own confirmation contract.
+
+### D4 — One project lens and URL-addressable detail
+
+The global lens applies to Mission Control, Designer, Library, History, and Schedules where
+the underlying object can be project-scoped. System is machine-scoped.
+
+The minimum URL-state contract is:
+
+```typescript
+interface CockpitLocationState {
+  project?: string;
+  selected?: string;
+  status?: string | string[];
+  q?: string;
+  view?: string;
+  cursor?: string;
+}
+```
+
+Each space may publish additional typed search fields, but `project` and detail selection
+must mean one thing across scoped spaces.
+
+Exact semantics:
+
+- Changing project re-runs the current space query. If selected detail belongs outside the
+  new project, selection is explicitly cleared with a replace-navigation; it is never left
+  showing cross-project data under the new lens.
+- A deep link restores space, project, filters, and selected entity without dependence on
+  prior in-memory React state.
+- Empty or invalid search values are normalized by the route validator.
+- System ignores project scope rather than showing a filtered machine-health view.
+- Project-global Library objects remain visible with an explicit global label; they are not
+  silently assigned to the selected project.
+- Changing a presentation pane does not discard filters or selection unless its route
+  contract says that selection is incompatible.
+
+### D5 — Redirect-only compatibility with one implementation owner
+
+Accepted compatibility destinations are:
+
+```text
+/runs[/<id>]          → /history with run selection
+/invocations[/<id>]   → /history without exposing the invocation noun
+/shows[/<topic>]      → /history with script/show selection
+/kanban               → /fleet
+/playbooks[...]       → /library with playbook/workflow selection
+/skills|/plugins|/engines → /library with the matching kind
+/admin[...]           → /system
+```
+
+The exact query key can evolve through an explicit route migration, but the owning space
+and the absence of duplicate feature logic are invariant.
+
+Exact semantics:
+
+- A retired URL validates and sanitizes its incoming search before redirecting.
+- Detail redirects preserve stable ids and project/filter context when representable.
+- Redirect errors show an actionable route error; they do not silently land on an unrelated
+  home view.
+- Redirect shims remain permanent compatibility code after old page components are deleted.
+- Old components are removed only after target-space parity covers the old task and a deep-
+  link test passes.
+- Adding new behavior to a retired route is prohibited; behavior belongs to its cockpit
+  owner.
+
+### D6 — Current shell differences are a delta, not a new taxonomy
+
+The checked-in source contract at the date of this ADR is:
+
+```typescript
+// apps/studio/frontend/src/components/shell/IconRail.tsx
+const SPACES = [
+  { id: "home", href: "/", key: 1 },
+  { id: "library", href: "/library", key: 2 },
+  { id: "schedules", href: "/schedules", key: 3 },
+];
+const SYSTEM_SPACE = { id: "system", href: "/system", key: 5 };
+
+// key handler accepts only 1..5, maps 5 to System, otherwise SPACES[n - 1]
+```
+
+The command registry adds Fleet as a separate navigation command. `routes/index.tsx`
+renders Mission Control with Overview and Fleet tabs; `routes/fleet.tsx` implements the
+Fleet path. There are no `routes/designer*` or `routes/history*` files.
+
+The exact drift is therefore:
+
+| Accepted contract | Checked-in source | Interpretation |
+|---|---|---|
+| six entries, shortcuts 1–6 | four visible entries; keys 1,2,3,5 | incomplete restoration |
+| Designer `/designer` | absent | missing accepted space |
+| History `/history` | absent | missing canonical record owner |
+| Library key 3 | key 2 | shortcut drift |
+| Schedules key 5 | key 3 | shortcut drift |
+| System key 6 | key 5 | shortcut drift |
+| Fleet Mission sub-view | `/fleet` tab plus separate command | partially aligned, not a seventh accepted space |
+
+This ADR intentionally records both the accepted decision and present code. It does not
+blur the gap into an aspirational redesign: the accepted IA is retrospective corpus truth,
+and the table is the current-vs-ideal delta requiring implementation restoration.
+
+## Consequences
+
+- The rail communicates one stable model: attend, design, browse, inspect history, operate
+  schedules, and maintain the machine.
+- Mission Control and History can evolve independently while sharing status, identity,
+  project, and detail adapters.
+- Designer receives enough space for canvas work; Schedules keeps configuration and firing
+  health together.
+- Route consolidation has a parity cost. A redirect cannot land until the target owns the
+  old task, and old implementation files cannot become permanent shadows.
+- Current source does not meet D1. Contributors must consult the drift table rather than
+  assuming the four-entry rail is canonical.
+- Reversing D1 would affect rail, shortcuts, commands, redirects, project lens, Leo
+  vocabulary, and tests; its reversal cost is high and requires a new IA ADR.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Restore Designer and History as first-class rail entries and implement the complete ⌘/Ctrl-1 through ⌘/Ctrl-6 shortcut contract with keyboard and screen-reader tests. | M | (filled at issue-open time) |
+| 2 | Make Fleet a Mission Control sub-view and History the sole execution-history owner; retain old entity URLs as redirect-only adapters after feature-parity tests pass. | L | (filled at issue-open time) |
+| 3 | Derive the rail, command palette, redirect destinations, and Leo navigation vocabulary from one typed space registry so no consumer can target a nonexistent cockpit space. | M | (filled at issue-open time) |
+| 4 | Add the global project lens to every scoped space and prove that changing project preserves or intentionally clears URL-addressable selection and filters. | M | (filled at issue-open time) |
+| 5 | Adopt one run-status oracle and windowed or virtualized history rendering across Mission Control, Fleet, and History; dead processes and spent one-shot schedules must not appear healthy or active. | L | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Route per backend entity
+
+This makes every API noun directly discoverable and lets each team build a small page. It
+lost because operators must correlate multiple pages to understand one execution and the
+rail becomes a database glossary. Backend nouns remain addressable inside owning spaces.
+
+### Original three-surface design
+
+Operations, Library, and System produced a very small rail and one unified operations
+canvas. It bought simplicity and strong consolidation. It lost at later acceptance because
+live attention and historical record needed distinct rooms, canvas authoring needed a peer
+Designer, and schedules were operated too frequently to bury in Library. The last-in-time
+canon makes the six-space amendment controlling.
+
+### Four-destination checked-in rail as the new standard
+
+Mission Control, Library, Schedules, and System are coherent and already implemented;
+Fleet provides live depth. Adopting them would minimize work. It lost because it silently
+abandons the accepted Designer and History responsibilities and assigns shortcuts that
+conflict with the accepted registry. Code drift is evidence of incomplete work, not a
+decision record.
+
+### Fleet as a seventh peer space
+
+A peer Fleet entry would make active orchestration immediately reachable and match its
+standalone URL. It lost because Fleet is one projection of Mission Control's “what needs
+attention now” job. A seventh peer would split the same question and weaken the six-space
+mental model.
+
+### Designer as a Library kind
+
+This would keep all definitions in one place and reduce the rail. It lost because a canvas,
+text synchronization, validation, and plan preview need an authoring workspace materially
+different from catalog browsing.
+
+### Invocation as a History tab
+
+This would map directly to the current database and preserve existing deep links. It lost
+because invocation is correlation plumbing: users investigate executions, not the internal
+aggregation row. Redirect resolution can use invocation ids without presenting the noun.
+
+### Slide-over as the sole detail presentation
+
+The earlier design kept one canvas visible behind a right slide-over and made every state
+shareable. The cockpit accepted master-detail panes instead. URL-addressability survives;
+the specific slide-over constraint does not.

--- a/docs/adr/ADR-0081-studio-execution-and-artifact-workspace-target.md
+++ b/docs/adr/ADR-0081-studio-execution-and-artifact-workspace-target.md
@@ -1,0 +1,507 @@
+# ADR-0081: Studio execution and artifact workspace target
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0012, v0-0015, v0-0020, v0-0021, v0-0022, v0-0031, v0-0055, v0-0066; extends ADR-0077 and ADR-0080
+
+## Context
+
+Studio already exposes sessions, runs, invocations, shows, plays, branches, messages,
+session signals, tool calls, and artifacts. The web client contains partial run,
+invocation, operation-graph, show-DAG, and outcome renderers. These are useful records and
+components, but they do not form one execution workspace or one evidence contract.
+
+This aspirational ADR answers seven concrete problems.
+
+**P1 — One execution appears under several backend identities.** A schedule firing may
+join a schedule run to an invocation and one or more sessions; a show has plays and optional
+sessions; a run API is a session projection. Exposing each record as a peer product noun
+forces the operator to perform the joins manually (`runs.py`; `invocations.py`; `shows.py`).
+
+**P2 — Live and historical screens can disagree about status.** Mission Control, Fleet,
+History, schedule views, and editor views can independently interpret `running`, process
+liveness, terminal reasons, and timestamps. One dead process can therefore appear healthy
+in one surface and stale in another (`runs.py`; `state/health.py`; frontend run-status code).
+
+**P3 — Branch messages are not automatically operation-scoped.** A branch may execute
+more than one operation, while current run detail hydrates a tail window per branch.
+Presenting the full branch transcript under one operation invents provenance unless
+persisted message/event boundaries support the claim (`sessions.py`; `runs.py`).
+
+**P4 — Tool audit messages are stored separately but read as a pair.** ActionRequest and
+ActionResponse are different persisted messages. Current adaptation pairs them when the
+request's `action_response_id` resolves, yet orphan requests and responses are diagnostic
+evidence and must not disappear (`runs.py`; StateDB message schema).
+
+**P5 — Artifacts mix queryable outcomes and optional host paths.** `artifacts.content` is
+JSON while `file_path` may name a larger blob. Returning arbitrary absolute paths or reading
+them directly from a renderer would bypass auth, containment, size, media-type, and hash
+checks (`state/schema.sql`; `invocations.py`).
+
+**P6 — Large histories need explicit window and partial-data semantics.** Session detail
+defaults to the newest 200 messages, caps a page at 1,000, and returns a versioned cursor.
+Signal streams replay from sequence zero in batches of 500. A unified workspace cannot
+silently treat either window as the whole execution (`sessions.py`; `signals.py`).
+
+**P7 — Detail renderers must not become control-plane backdoors.** Cancel, re-run, or other
+mutations may be useful, but a renderer that writes StateDB or opens files directly would
+bypass ADR-0078's command and authorization boundaries.
+
+| Concern | Decision |
+|---|---|
+| Canonical identity | D1: Normalize public executions into a closed `ExecutionRef` and `ExecutionRecord`, keeping invocation internal. |
+| Source adaptation and status | D2: Use typed adapters over current run/session/show/schedule APIs and one status oracle. |
+| Selection and layout | D3: Share one URL-addressable workspace state between History and Fleet. |
+| Evidence scope | D4: Project graph, timeline, messages, and signals with explicit operation/branch/partial scopes. |
+| Tool-call presentation | D5: Pair correlated request/response messages while retaining orphans. |
+| Artifact access | D6: Resolve content through authenticated identifier-based metadata and bounded verified preview contracts. |
+| Scale and commands | D7: Window large data, cancel stale reads, and route every mutation through typed application commands. |
+
+Out of scope:
+
+- Creating a new universal `executions` database table before the adapter contract proves
+  that one is required.
+- Replacing StateDB, the session signal log, or existing domain-specific daemon endpoints.
+- Claiming historical operation/message provenance the runtime did not persist.
+- Selecting a graph-first layout for every run; graph is one evidence projection.
+- Defining command authorization or confirmation generally; ADR-0078 and ADR-0083 own
+  those protocols.
+
+## Decision
+
+### D1 — Closed public identity and canonical execution record
+
+The public identity remains the skeleton's discriminated union:
+
+```typescript
+export type ExecutionRef =
+  | { kind: "session"; id: string }
+  | { kind: "run"; id: string }
+  | { kind: "show"; id: string }
+  | { kind: "schedule-run"; id: string };
+
+export interface ExecutionSelection {
+  ref: ExecutionRef;
+  operationId?: string;
+  artifactId?: string;
+}
+```
+
+`invocation` is deliberately absent. Its id may be retained as an internal join reference,
+but no public `ExecutionRef` variant, tab, filter, or label exposes it.
+
+The normalized record is:
+
+```typescript
+export type ExecutionStatus =
+  | "queued"
+  | "waiting"
+  | "running"
+  | "completed"
+  | "completed_empty"
+  | "failed"
+  | "timed_out"
+  | "cancelled"
+  | "aborted"
+  | "stale"
+  | "unknown";
+
+export interface ExecutionRecord {
+  ref: ExecutionRef;
+  title: string;
+  source: "agent" | "playbook" | "flow" | "show" | "schedule" | "engine" | "unknown";
+  status: ExecutionStatus;
+  rawStatus: string | null;
+  effectiveHealth: string | null;
+  project: string | null;
+  startedAt: number | null;
+  endedAt: number | null;
+  updatedAt: number | null;
+  reason: {
+    code: string | null;
+    summary: string | null;
+    evidenceRefs: Array<Record<string, unknown>>;
+  } | null;
+  lineage: {
+    parent?: ExecutionRef;
+    children: ExecutionRef[];
+    internalInvocationId?: string;
+    sessionIds: string[];
+    scheduleId?: string;
+    showTopic?: string;
+  };
+  capabilities: {
+    liveMessages: boolean;
+    liveSignals: boolean;
+    artifacts: boolean;
+    canCancel: boolean;
+    canRetry: boolean;
+  };
+}
+```
+
+Exact semantics:
+
+- `ref.kind` identifies which adapter can refresh the record. It is not inferred from the
+  display label.
+- `run` and `session` may currently resolve to the same StateDB session id. They remain
+  separate variants during compatibility migration so old URLs can retain their meaning.
+- `internalInvocationId` is never formatted as a product kind; it is used to fetch child
+  sessions, artifacts, and schedule failure detail.
+- Missing optional lineage does not fabricate parents. It produces empty arrays/undefined
+  fields and a visible partial-lineage state in the view.
+- Unknown raw statuses map to `unknown`, preserve `rawStatus`, and remain visible.
+- The adapter chooses stable ids from persisted records only. Array indexes, titles, and
+  timestamps are not identities.
+
+Why this way: one UI record removes storage nouns from navigation without forcing an early
+database migration. The closed union also makes unsupported kinds a compile-time and
+runtime error instead of an arbitrary string.
+
+### D2 — Typed source adapters and one status oracle
+
+Adapters consume current daemon contracts rather than query StateDB from the browser:
+
+```typescript
+export interface ExecutionAdapter<TRef extends ExecutionRef = ExecutionRef> {
+  readonly kind: TRef["kind"];
+  get(ref: TRef, signal: AbortSignal): Promise<ExecutionRecord | null>;
+  evidence(ref: TRef, request: EvidenceRequest, signal: AbortSignal): Promise<EvidencePage>;
+}
+
+export interface ExecutionAdapterRegistry {
+  session: ExecutionAdapter<{ kind: "session"; id: string }>;
+  run: ExecutionAdapter<{ kind: "run"; id: string }>;
+  show: ExecutionAdapter<{ kind: "show"; id: string }>;
+  "schedule-run": ExecutionAdapter<{ kind: "schedule-run"; id: string }>;
+}
+```
+
+The current source shapes that adapters must tolerate are explicitly different:
+
+- `/api/runs/` returns a page of session-derived rows including `run_id`, lifecycle,
+  effective health, provenance, counts, project, reasons, artifact contracts, and tags.
+- `/api/runs/{id}` is a superset with branches, tail-windowed messages, graph, steps,
+  cursor metadata, and evidence refs.
+- `/api/invocations/{id}` joins child session summaries, structured artifacts, and the
+  schedule-run exit/error fields.
+- `/api/shows/{topic}` joins the show row, plays, optional session links, and authored
+  filesystem content.
+- Schedule-run rows carry schedule id, invocation id, trigger context, action, status,
+  chain parent/depth, timestamps, exit/error, and queue/lease fields.
+
+The status oracle is a pure function:
+
+```typescript
+export interface StatusInput {
+  rawStatus: string | null;
+  effectiveHealth: string | null;
+  processAlive: boolean | null;
+  endedAt: number | null;
+  scheduleEnabled?: boolean;
+  scheduleRemainingRuns?: number | null;
+}
+
+export interface StatusVerdict {
+  status: ExecutionStatus;
+  tone: "neutral" | "active" | "success" | "warning" | "error";
+  terminal: boolean;
+  reason: string | null;
+}
+
+export function deriveExecutionStatus(input: StatusInput): StatusVerdict;
+```
+
+Exact semantics:
+
+- A running row with confirmed dead process/liveness becomes `stale`; raw `running` is kept
+  for diagnostics.
+- Confirmed terminal failure/timed-out/cancelled/aborted states remain terminal even when
+  liveness is unknown.
+- `completed_empty` is distinct from successful `completed` because it carries missing-
+  evidence meaning.
+- A spent bounded schedule cannot project as active merely because `enabled` was not yet
+  refreshed; remaining-run state participates when available.
+- `processAlive=null` is unknown, not false. The oracle must not invent stale status from an
+  unavailable probe.
+- All Mission Control, Fleet, History, detail header, filters, and status counts consume the
+  same verdict object.
+- Source fetch failure produces an error/partial state; it never becomes an empty successful
+  record set.
+
+### D3 — One URL-addressable workspace shared by History and Fleet
+
+The workspace state contract is:
+
+```typescript
+export type EvidencePane =
+  | "overview"
+  | "graph"
+  | "timeline"
+  | "messages"
+  | "tools"
+  | "artifacts"
+  | "raw";
+
+export interface ExecutionWorkspaceState {
+  project?: string;
+  statuses: ExecutionStatus[];
+  sources: ExecutionRecord["source"][];
+  query?: string;
+  liveOnly: boolean;
+  selection?: ExecutionSelection;
+  pane: EvidencePane;
+  messageCursor?: string;
+  signalAfterSeq?: number;
+}
+```
+
+Route adapters serialize this state into typed TanStack Router search parameters. History
+owns the full record; Fleet applies `liveOnly=true` and an appropriate status subset but
+does not define a second selection or detail model.
+
+Exact semantics:
+
+- Selecting an execution changes the URL and opens the master-detail pane without unloading
+  the list.
+- Selecting an operation or artifact extends the same selection. It never navigates to an
+  independent page whose filters cannot be reconstructed.
+- Invalid kind/id/pane values are rejected or normalized by the route validator.
+- Back/forward restores selection, pane, project, and filters.
+- A project change refreshes list and detail. An out-of-scope selection is cleared
+  explicitly, as required by ADR-0080.
+- Fleet and History may choose different default panes, but a shared deep link resolves to
+  the same execution and evidence.
+- Legacy run, show, and invocation URLs translate into this state. Invocation resolution
+  selects its primary/first child session when one exists and surfaces a partial state when
+  it has no child.
+
+### D4 — Evidence projections carry explicit scope and completeness
+
+The evidence page is discriminated:
+
+```typescript
+export type EvidenceScope =
+  | { kind: "execution" }
+  | { kind: "branch"; branchId: string }
+  | { kind: "operation"; operationId: string; basis: "persisted" | "timestamp-fallback" };
+
+export interface EvidencePage {
+  scope: EvidenceScope;
+  completeness: "complete" | "windowed" | "partial" | "unavailable";
+  items: EvidenceItem[];
+  nextCursor?: string;
+  warnings: string[];
+}
+
+export type EvidenceItem =
+  | { kind: "message"; message: MessageEvidence }
+  | { kind: "tool-call"; call: ToolCallEvidence }
+  | { kind: "signal"; signal: SignalEvidence }
+  | { kind: "status"; transition: StatusEvidence }
+  | { kind: "artifact"; artifact: ArtifactSummary };
+```
+
+Exact semantics:
+
+- Graph is a projection of persisted session metadata and session signals. It is not a
+  separate source of truth.
+- Signal operation status follows the ordered lifecycle mapping already used by
+  `operationGraph.ts`: queued, running, awaiting approval, succeeded, failed, escalated.
+  Unknown signal kinds remain available in raw/timeline evidence but do not change the
+  operation lane.
+- Multiple `depends_on` edges are preserved. Layout uses all known predecessors and guards
+  cycles rather than claiming the underlying execution graph is cyclic.
+- Operation-scoped messages require persisted operation/message association or explicit
+  start/end event boundaries.
+- When only timestamps are available, the pane labels the basis
+  `timestamp-fallback`, states the window, and warns that concurrent operations can overlap.
+- When neither association nor a safe interval exists, messages remain branch-scoped. The
+  UI does not relabel them as operation-scoped.
+- A session message response advertises `windowed` when a next cursor or a server limit
+  proves the view is incomplete. It shows full counts from `message_stats`, not the page
+  length.
+- An empty complete page renders “no evidence recorded.” An unavailable source renders an
+  error/partial diagnostic. These states are not interchangeable.
+
+The current message defaults—200 newest messages and maximum 1,000 per request—remain
+server compatibility values. The workspace consumes them; it does not claim those numbers
+are a complete transcript.
+
+### D5 — Correlated tool messages render as one unit without losing audit rows
+
+The target presentation model is:
+
+```typescript
+export interface ToolCallEvidence {
+  requestId: string;
+  responseId: string | null;
+  operationId: string | null;
+  function: string;
+  arguments: Record<string, unknown>;
+  output: unknown;
+  status: "pending" | "ok" | "error" | "orphan-request" | "orphan-response";
+  exitCode: number | null;
+  requestedAt: number | null;
+  respondedAt: number | null;
+  rawMessageIds: string[];
+}
+```
+
+Exact semantics:
+
+- An ActionRequest with an `action_response_id` matching an ActionResponse becomes one
+  rendered call and retains both persisted ids in `rawMessageIds`.
+- A request with no response remains visible as `pending` while execution is live and
+  `orphan-request` after the evidence source is terminal/complete.
+- An ActionResponse not referenced by a visible request remains `orphan-response`; it is not
+  dropped merely because the normal pairing direction is absent.
+- Tool status uses structured response/error/exit fields when available. Text keyword
+  inference is a labeled compatibility fallback, not authoritative failure classification.
+- Repeated function names do not correlate calls. Only persisted ids do.
+- Arguments and output are escaped/bounded in the default view; raw evidence remains
+  inspectable under an explicit raw pane.
+
+This keeps a readable unit while preserving the audit fact that request and response are
+separate messages.
+
+### D6 — Authenticated identifier-based artifact resolution
+
+The browser never receives an arbitrary readable host path as a content URL. It first uses
+artifact metadata, then an authenticated identifier endpoint implemented through ADR-0078:
+
+```python
+class ArtifactContentQuery(ContractModel):
+    artifact_id: str
+    mode: Literal["metadata", "preview", "download"] = "metadata"
+    max_bytes: int = Field(default=262_144, ge=1, le=1_048_576)
+
+class ArtifactContentResult(ContractModel):
+    artifact_id: str
+    kind: str
+    name: str
+    display_path: str | None
+    media_type: str | None
+    sha256: str | None
+    size_bytes: int | None
+    content_json: dict[str, object]
+    preview_base64: str | None
+    preview_truncated: bool
+    verified: bool
+```
+
+Exact semantics:
+
+- Metadata lookup happens in StateDB by `artifact_id`. Missing metadata is 404.
+- Structured `content` is returned independently of file availability.
+- File-backed content is addressable only through the artifact id. The service resolves a
+  stored relative path beneath an approved root and rejects absolute paths, traversal,
+  containment escape, and unsafe symlink resolution.
+- Preview reads no more than `max_bytes`, reports truncation, and permits only a reviewed
+  safe media-type set. Unknown/binary types remain download-only or unavailable.
+- When an expected SHA-256 exists, mismatch fails with conflict/integrity error; unverified
+  bytes are not displayed as trusted output.
+- Authentication and application authorization apply to metadata, preview, and download.
+  A static SPA path is never used for artifact bytes.
+- Missing file with present metadata yields a visible unavailable-content result; it does
+  not erase the artifact record.
+- Absolute host paths are never serialized to clients. `display_path` is relative and
+  informational.
+
+The 256 KiB default and 1 MiB preview cap match ADR-0078's target. They protect browser and
+daemon memory, but are admitted conservative defaults rather than measured optima.
+
+### D7 — Windowing, cancellation, partial state, and command separation
+
+Large execution views obey these budgets:
+
+```text
+message page: server default 200, hard maximum 1000
+signal replay read: server batch 500
+artifact preview: default 256 KiB, hard maximum 1 MiB
+list/history rendering: windowed or virtualized; no unbounded all-history DOM
+```
+
+Exact semantics:
+
+- Every selection/filter change aborts obsolete fetches and streams with `AbortController`.
+  Results from an old selection cannot overwrite the active detail.
+- “Load older” follows the opaque server cursor. The client never manufactures cursor
+  anchors or changes message limit mid-cursor.
+- Stream EOF before an explicit terminal frame becomes a recoverable transport error, not a
+  silently frozen “live” state.
+- Partial failures are per projection: artifact failure need not hide messages, and signal
+  failure need not erase persisted run metadata. The header shows degraded/partial status.
+- Macro graphs and long timelines render incrementally or virtually; empty sources avoid
+  allocating graph layouts.
+- A renderer receives data and raises typed intents only. It does not import StateDB, read a
+  host path, or call mutation endpoints directly.
+- Cancel/retry/other controls call ADR-0078 application commands. They show the target,
+  current status, risk, and explicit confirmation when required, then refresh the record.
+- A stale target or optimistic conflict is shown as conflict and forces refresh; the UI does
+  not repeat the mutation against old state automatically.
+
+## Consequences
+
+- Operators get one causal workspace from execution identity through graph, messages, tool
+  calls, status reasons, and work products.
+- History and Fleet can share adapters without forcing heterogeneous records into a new
+  universal table.
+- Provenance claims become honest: operation-scoped evidence names its persisted or fallback
+  basis, and branch-scoped history stays branch-scoped when boundaries are absent.
+- Artifact content becomes auditable and bounded. Some existing absolute-path records will
+  be metadata-only until migrated to approved relative references and hashes.
+- Adapters and completeness states add code, but they localize heterogeneity that is
+  currently spread through routes and components.
+- Reversing D1 after URLs and saved links depend on `ExecutionRef` is costly; adding an
+  adapter kind requires an explicit union and compatibility update.
+- The workspace cannot manufacture old boundaries. Some historical executions will remain
+  partial forever, which is preferable to false precision.
+
+## Alternatives considered
+
+### Preserve separate detail pages for every backend noun
+
+This would minimize adapters and keep each service response close to its table. It lost
+because status, selection, lineage, and artifact behavior would remain duplicated, and one
+schedule execution would still require cross-page correlation.
+
+### Create an `executions` table first
+
+A universal row could normalize identity and make History queries straightforward. It lost
+because the UI contract and joins are not stable enough to justify a migration, and a table
+does not by itself solve evidence scope, tool pairing, or artifact safety. Adapters let the
+model prove itself first.
+
+### Make every view graph-first
+
+Graphs are excellent for multi-operation DAGs and causal fan-out. They lost as the primary
+layout because single-agent transcripts, artifact-heavy investigations, and linear schedule
+runs are better served by master-detail and timeline evidence. Graph remains a projection.
+
+### Treat timestamps as authoritative operation boundaries
+
+This would let historical branch messages appear under graph nodes without runtime changes.
+It lost because concurrent operations overlap and clock/order gaps make the attribution
+ambiguous. A labeled fallback is permitted; silent authoritative attribution is not.
+
+### Collapse ActionRequest and ActionResponse in storage
+
+One persisted tool-call record would simplify rendering. It lost because the messages are
+separate audit events with independent timestamps and orphan diagnostics. Presentation pairs
+them while preserving both ids.
+
+### Return artifact file paths and let the browser fetch them
+
+This is simple and matches existing `file_path` metadata. It lost because paths expose host
+layout and bypass daemon authentication, containment, size, media-type, and hash checks.
+Identifier-based resolution keeps the daemon in the trust path.
+
+### Add a central event bus for the workspace
+
+A unified bus could feed graph, timeline, status, and artifacts live. It lost because
+persisted StateDB rows and endpoint streams already provide bounded sources; a bus would add
+ordering, retention, and replay decisions without fixing historical data. The workspace
+normalizes at the adapter layer instead.

--- a/docs/adr/ADR-0082-vscode-studio-observability-client.md
+++ b/docs/adr/ADR-0082-vscode-studio-observability-client.md
@@ -1,0 +1,405 @@
+# ADR-0082: VS Code Studio observability client
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0084; extends ADR-0076
+
+## Context
+
+The VS Code extension under `apps/vscode/` is a native TypeScript client of the public
+Studio daemon. It does not embed the Studio SPA and does not read StateDB. It provides an
+Explorer, status bar, run detail, operation-tree views, and optional lifecycle management
+for a local API-only daemon.
+
+This ADR answers six concrete problems in the shipped extension.
+
+**P1 — Editor observability must not create a second data model.** Direct SQLite reads
+would duplicate joins, lifecycle classification, auth, and live-stream behavior already
+owned by the daemon (`apps/vscode/src/api/*`; `lionagi/studio/services/runs.py`).
+
+**P2 — “Read-only” must distinguish application state from process supervision.** The
+extension starts or stops a Python child, but its `StudioClient` only issues GET requests.
+Calling the extension a control client because it manages a process would erase a useful
+negative capability boundary (`extension.ts`; `api/client.ts`; `backend/lifecycle.ts`).
+
+**P3 — The extension may attach or own, and ownership changes stop semantics.** A
+configured URL must be attach-only; an already healthy default daemon must not be killed;
+only a child spawned by the extension may be terminated (`backend/lifecycle.ts`).
+
+**P4 — Python availability is not guaranteed in the editor environment.** The extension
+may need an explicit interpreter, a workspace `.venv`, a source-checkout `uv sync`, or a
+system `python3` fallback. Failed provisioning and import preflight need actionable states.
+
+**P5 — Authenticated live output cannot use native EventSource.** Session output and
+persisted signals require bearer-aware fetch streams, terminal-frame handling, and visible
+transport EOF failure (`api/sse.ts`; `api/signals.ts`).
+
+**P6 — The extension and web client independently encode the daemon contract.** Run,
+project-group, invocation, auth, trailing-slash, and stream-shape changes can break the
+extension even if the daemon and web app continue to work.
+
+| Concern | Decision |
+|---|---|
+| Data boundary | D1: Use only Studio HTTP/SSE for application data; never read StateDB or embed the SPA. |
+| Capability boundary | D2: Keep `StudioClient` GET-only; classify backend start/stop as owned-process lifecycle. |
+| Daemon lifecycle | D3: Attach when configured/healthy, otherwise provision and supervise an API-only local child. |
+| Live observation | D4: Parse authenticated session and signal SSE with explicit terminal and EOF behavior. |
+| Native UX | D5: Prefer Explorer, status bar, commands, and purpose-built detail webviews over a general SPA webview. |
+| Compatibility | D6: Treat daemon OpenAPI and shared fixtures as the client seam. |
+
+Out of scope:
+
+- Launching runs, editing definitions, changing schedules, approvals, maintenance, or any
+  other Studio application mutation.
+- Shipping Docker, Node, a frontend build, or the web SPA as an extension dependency.
+- Defining the daemon's HTTP/SSE contract; ADR-0076 and ADR-0078 own it.
+- Converging the VS Code visual design with the browser cockpit.
+
+## Decision
+
+### D1 — Native client over Studio HTTP/SSE only
+
+The extension module tree is:
+
+```text
+apps/vscode/src/
+├── extension.ts              # composition and commands
+├── config.ts                 # `den.*` settings
+├── statusBar.ts
+├── api/
+│   ├── client.ts             # GET JSON client
+│   ├── types.ts              # daemon projections
+│   ├── sse.ts                # session message stream
+│   └── signals.ts            # persisted signal stream
+├── backend/lifecycle.ts      # attach/provision/spawn/supervise
+└── runs/
+    ├── runsExplorer.ts
+    ├── runItem.ts
+    ├── runDetailPanel.ts
+    ├── runTreeModel.ts
+    └── runTreePanel.ts
+```
+
+The injected dependency boundary is:
+
+```typescript
+export interface StudioDeps {
+  client: StudioClient;
+  backend: BackendManager;
+}
+```
+
+Exact semantics:
+
+- `StudioClient` obtains its base URL from `BackendManager` and its optional token from
+  extension configuration.
+- Every application record comes from `/api/*`; `/health` is used only for process
+  discovery/supervision.
+- No extension module imports a Python package, SQLite library, StateDB path, or browser
+  Studio bundle.
+- A purpose-built webview may render detail, but it receives messages from extension code;
+  it is not granted a separate daemon client or arbitrary host-file access.
+- When the backend is not running, the Explorer clears its cached grouping and returns no
+  rows rather than displaying stale data as current.
+
+Why this way: the daemon already owns lifecycle and read adaptation. Reusing it keeps the
+editor from becoming a second persistence consumer while preserving a native VS Code UX.
+
+### D2 — GET-only application client and negative capability
+
+The shipped JSON client contract is:
+
+```typescript
+export class StudioApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly detail: string,
+  );
+}
+
+export interface ListRunsOptions {
+  page?: number;
+  per_page?: number;
+  status?: string;
+  playbook?: string;
+  project?: string;
+  project_null?: boolean;
+}
+
+export class StudioClient {
+  constructor(
+    getBaseUrl: () => string,
+    getToken: () => string | undefined,
+  );
+
+  listRuns(opts?: ListRunsOptions): Promise<RunsPage>;
+  listProjectGroups(): Promise<ProjectGroupsPage>;
+  getRun(runId: string): Promise<Run>;
+  getInvocation(invocationId: string): Promise<InvocationDetail>;
+}
+```
+
+All four public methods call the private request helper with method `GET`. The paths are:
+
+```text
+/api/runs/                     # slash retained, optional query
+/api/runs/projects
+/api/runs/{runId}
+/api/invocations/{encodedId}
+```
+
+Exact semantics:
+
+- Every request sends `Content-Type: application/json` and adds the bearer header when
+  configured. GETs have no body.
+- Non-2xx responses attempt to parse `detail`; failure falls back to `statusText`, then
+  throws `StudioApiError(status, detail)`.
+- JSON response parsing errors propagate; they are not converted into empty pages.
+- Run ids are currently interpolated directly in `getRun`; invocation ids are encoded.
+  Contract tests must cover ids accepted by the daemon so this difference cannot become an
+  injection/path bug.
+- The client exposes no POST, PUT, PATCH, or DELETE application method.
+- `den.startBackend` and `den.stopBackend` call `BackendManager`; they do not hit `/api`
+  mutation routes.
+
+This negative capability is architectural. Adding launch, schedule, definition, approval,
+or maintenance methods requires a new decision, not an opportunistic helper.
+
+### D3 — Attach/provision/spawn lifecycle with ownership tracking
+
+The configuration contract is:
+
+```typescript
+den.url: string = ""
+den.pythonPath: string = ""
+den.port: number = 8765
+den.host: string = "127.0.0.1"
+den.autoStart: boolean = true
+den.authToken: string = ""
+
+export type BackendState = "stopped" | "starting" | "running" | "error";
+```
+
+Interpreter resolution order is:
+
+1. Explicit `den.pythonPath`, with import preflight.
+2. Existing workspace `.venv` Python, with preflight and optional `uv sync --extra studio
+   --no-dev` repair.
+3. Source checkout with `pyproject.toml` and `uv`, provisioned into `.venv` using the same
+   sync command.
+4. System `python3`, with import preflight.
+
+Every spawn executes `python -m lionagi.studio`. It propagates host, port, and a non-empty
+token through `LIONAGI_STUDIO_*` environment variables. It does not build or mount a
+frontend.
+
+Exact discovery and ownership semantics:
+
+- A non-empty `den.url` is attach-only. The manager probes it; unreachable configuration
+  becomes `error` and does not fall back to spawning another daemon.
+- With no configured URL, the default host/port is probed before spawning. A healthy daemon
+  is attached as unmanaged.
+- `stop()` detaches from unmanaged backends and explicitly reports they remain running.
+- `stop()` terminates only the child stored as owned. It first sends the platform default
+  termination and escalates to `SIGKILL` after 3 seconds if the child remains.
+- An epoch counter prevents a slow in-flight start from resurrecting state after a newer
+  start/stop.
+- A spawn that loses an address-in-use race re-probes the target; if another daemon is
+  healthy, it attaches instead of reporting failure.
+- Start waits up to 30 seconds for health. It probes every 400 ms and aborts when the spawn
+  fails or the start generation is superseded.
+- Supervisor reconciliation runs every 8 seconds. Two consecutive misses change a running
+  backend to `error`; a later healthy probe restores `running`.
+- Configured/existing/start-path probes use 2.5-second attempts with two retries; the recurring
+  reconciliation health probe uses 2.5 seconds with one retry; the general helper defaults to
+  1.5 seconds and zero retries. Import preflight is killed after 5 seconds. Provisioning is
+  killed after 180 seconds.
+
+The time values are shipped operating constants. Their reasons are bounded startup,
+avoiding port races, hysteresis against one slow health response, and bounding package
+installation/import checks. The source contains no measurements selecting the exact values.
+
+Failure semantics:
+
+- Missing imports produce an actionable install/configuration message before a doomed
+  spawn when preflight applies.
+- Provision failure and spawn failure transition to `error`; output is retained in the
+  extension output channel.
+- An owned child dying after readiness triggers reconciliation. If the port remains healthy,
+  the manager does not flap to error.
+- `dispose()` clears the supervisor, invokes ownership-aware stop, and disposes emitters and
+  output resources.
+
+### D4 — Authenticated session and signal streams
+
+The two shipped stream signatures are:
+
+```typescript
+export async function streamSession(
+  baseUrl: string,
+  sessionId: string,
+  token: string | undefined,
+  onEvent: (event: StudioEvent) => void,
+  signal: AbortSignal,
+): Promise<void>;
+
+export async function streamSignals(
+  baseUrl: string,
+  sessionId: string,
+  token: string | undefined,
+  onEvent: (event: SignalStreamEvent) => void,
+  signal: AbortSignal,
+): Promise<void>;
+```
+
+Their public event types are:
+
+```typescript
+type StudioEvent = { type: "heartbeat" } | { type: "done" } | MessageEvent;
+type SignalStreamEvent =
+  | { type: "heartbeat" }
+  | { type: "done" }
+  | {
+      id: string;
+      session_id: string;
+      seq: number;
+      kind: string;
+      op_id: string;
+      ts: number;
+      payload: Record<string, unknown>;
+    };
+```
+
+Exact semantics:
+
+- Both send `Accept: text/event-stream`, `Cache-Control: no-cache`, and optional bearer
+  authorization.
+- Session ids are URL-encoded.
+- Non-2xx or a missing response body throws before frame parsing.
+- Frames split on double newlines. Multiple `data:` lines are joined and parsed as JSON.
+- Malformed JSON frames are ignored; other valid event objects are delivered in arrival
+  order.
+- Heartbeats are visible to the caller type but ignored by current detail rendering.
+- Explicit `{type:"done"}` returns normally.
+- Transport EOF before `done` throws a visible stream-closed error. An AbortSignal-driven
+  close is handled by the caller and does not show a spurious error after retarget/dispose.
+- These functions do not reconnect or resume. The signals endpoint replays persisted rows
+  from seq zero on each new connection; the session message stream uses its server-local
+  timestamp cursor per connection.
+
+The missing reconnect/resume contract is a current delta, not an implied guarantee.
+
+### D5 — Native Explorer and bounded purpose-built webviews
+
+The Explorer groups runs under a pinned Active band and project buckets. The key budgets
+are:
+
+```typescript
+const POLL_INTERVAL_MS = 4_000;
+const PAGE_SIZE = 50;
+const ACTIVE_LIMIT = 100;
+```
+
+Exact semantics:
+
+- The root loads project counts and active runs concurrently with `Promise.allSettled`.
+  Active-band failure does not blank the archive; project-group failure does.
+- The active query requests status `running`, page 1, up to 100 rows, then sorts newest
+  first. It does not page active rows, so more than 100 current sessions are not shown in
+  the pinned band.
+- Project groups start with 50 rows and grow one page at a time. Unassigned runs use the
+  explicit `project_null` query.
+- Polling runs only while the view is visible, the backend is running, and active work is
+  known. Loading completion, not merely refresh request, starts polling to avoid the stale-
+  empty bootstrap race.
+- The four-second poll, page 50, and active cap 100 are inherited responsiveness/resource
+  bounds. No recorded measurement selects the exact values.
+- One run-detail webview is reused and retargeted; clicking multiple runs does not create
+  unbounded panels.
+- Retarget aborts the old stream before changing the selected run. The old stream's failure
+  cannot post an error into the new run.
+- Terminal runs fetch detail, merge it with list metadata, show structured failure reasons,
+  and flatten `steps[].messages[]`. Live runs consume session SSE.
+- Operation-tree views consume persisted signal SSE through extension code. Webviews do not
+  receive the auth token or fetch daemon data themselves.
+
+### D6 — Shared daemon contract is the compatibility seam
+
+The extension's `Run`, `RunsPage`, `ProjectGroupsPage`, `InvocationDetail`, session event,
+and signal event interfaces are projections of daemon payloads, not independent domain
+models. Compatibility therefore follows ADR-0078 D5:
+
+- OpenAPI and route snapshots pin method/path/shape/auth.
+- Recorded SSE fixtures pin heartbeat, data, terminal, malformed frame, EOF, and auth
+  behavior.
+- The VS Code serializers/parsers and web parsers run against the same fixtures.
+- Additive optional fields are tolerated. Removing or changing required fields, route
+  slashes, auth, or terminal behavior is versioned before an extension release consumes it.
+- A negative capability test inspects the public `StudioClient` surface and exercises its
+  request calls to prove only GET methods are emitted.
+
+## Consequences
+
+- The editor gets native local observability without a second datastore or SPA hosting
+  requirement.
+- Attach versus own is explicit, preventing the extension from killing a daemon it did not
+  spawn.
+- Provisioning makes source-checkout use more accessible but adds interpreter, package
+  manager, timeout, and health-race failure modes.
+- GET-only scope reduces application mutation risk. Reversing D2 would be a product and
+  authorization expansion, not a small API addition.
+- Fetch streams support bearer auth and visible EOF failure but currently require the caller
+  to reconnect manually.
+- Shared contract fixtures add release work but prevent one of two clients from silently
+  drifting.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Add a contract test suite that runs the VS Code serializers and SSE parsers against the daemon's current OpenAPI examples and recorded stream fixtures. | M | (filled at issue-open time) |
+| 2 | Add a negative capability test proving the extension client has no methods for launch, definition, schedule, approval, maintenance, or other mutation endpoints. | S | (filled at issue-open time) |
+| 3 | Define retry, backoff, resume, and terminal behavior for dropped session and signal streams; a transport EOF must produce a visible recoverable state rather than a frozen view. | M | (filled at issue-open time) |
+| 4 | Version or compatibility-gate daemon response and stream changes before publishing an extension release that depends on them. | S | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Direct SQLite/StateDB reads from the extension
+
+This would remove the daemon dependency and permit rich local queries. It lost because the
+extension would need schema migrations, query joins, lifecycle health logic, filesystem
+policy, and live observation. It would also bypass daemon auth and diverge from the web
+read model.
+
+### Embed the Studio SPA in a general webview
+
+This would maximize browser/editor parity and reuse feature components. It lost because the
+extension would inherit the frontend build and cockpit navigation while still requiring the
+daemon. Native Explorer and focused panels integrate better with editor workflows and keep
+the deployment API-only.
+
+### Make the extension a launch/control client
+
+Adding POST methods would let users launch or cancel work without leaving VS Code. It lost
+because the current product has a clear observer boundary and no editor-specific
+confirmation/authorization design. Process start/stop is sufficient for local availability.
+
+### Always spawn a private daemon
+
+This would simplify ownership and configuration. It lost because an existing daemon may
+already hold the port and serve the browser, and a configured remote/local URL reflects user
+intent. Attach-first avoids duplicate state processes and address races.
+
+### Require Docker for lifecycle management
+
+Docker could make dependencies reproducible and isolate the daemon. It lost because the
+extension should work in a Python source checkout or installed environment, including
+editor hosts where Docker is absent. The API-only process needs no frontend container.
+
+### Native EventSource for streams
+
+It offers automatic reconnect. It lost because the extension must attach the bearer header
+and requires explicit EOF/error behavior. Fetch streams keep authentication and cancellation
+under extension control.

--- a/docs/adr/ADR-0083-studio-operator-command-protocol.md
+++ b/docs/adr/ADR-0083-studio-operator-command-protocol.md
@@ -1,0 +1,684 @@
+# ADR-0083: Studio operator-command protocol
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: studio
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0067; extends ADR-0076, ADR-0078, and ADR-0080
+
+## Context
+
+Studio contains a Leo prototype but no persistent browser operator dock. The prototype
+proves that a LionAGI `Branch` can use read tools, emit declarative UI commands, and return
+mutation proposals without directly writing Studio state. It does not provide restart
+survival, replay cursors, confirmation acknowledgements, durable audit, or a frontend
+protocol.
+
+This aspirational ADR answers eight concrete problems.
+
+**P1 — In-memory conversations disappear and evict silently.** The prototype retains at
+most 50 `LeoSession` objects, expires them after two idle hours, lazily evicts on access,
+and loses every Branch/history on daemon restart (`lionagi/studio/services/leo.py`).
+
+**P2 — Current frames are endpoint-local dictionaries, not a versioned protocol.** A turn
+emits `ui_command`, `proposed_action`, `text`, `error`, and `done` frames but has no
+conversation/request/sequence envelope and no replay cursor (`leo.py`).
+
+**P3 — Destination strings already drift from the shell.** The prototype accepts
+`mission`, `fleet`, `designer`, `library`, `schedules`, and `system`, while the checked-in
+rail does not expose Designer and the accepted ADR-0080 registry includes History. Copying
+route vocabularies lets the model target nonexistent or retired spaces.
+
+**P4 — Proposed mutation is not the same as confirmed execution.** Existing mutation tools
+return endpoint strings and parameters for the browser to call. There is no target refresh,
+risk class, expiry, idempotency, application-command type, or durable proof that the
+operator confirmed the exact command.
+
+**P5 — Emitting a UI command does not mean the client applied it.** Navigation, selection,
+form prefill, and theme changes can be rejected by route validation, stale context, or a
+disconnected browser. The backend currently has no acknowledgement path.
+
+**P6 — Long-lived auth must not leak into URLs.** The default fetch-based SSE transport can
+attach the bearer header, but future browser transports must not solve auth by placing the
+daemon secret in a query string.
+
+**P7 — Failure and restart semantics must be machine-readable.** Auth, validation,
+conflict, stale context, denial, rate limit, model failure, service failure, cancellation,
+and replay gaps require stable codes. A string-only error cannot support safe client
+recovery.
+
+**P8 — Mutations require an audit record, including failure to record one.** Read-only
+explanation may degrade when optional observability is absent, but executing a state change
+without durable proposal/confirmation/result evidence breaks the safety boundary.
+
+### Existing prototype contract (source, not the target)
+
+The current HTTP surface is:
+
+```python
+class _MessageBody(BaseModel):
+    content: str
+
+POST /api/leo/sessions
+  -> {"id": "<uuid4>"}
+
+POST /api/leo/sessions/{session_id}/messages
+  body: {"content": "..."}
+  -> text/event-stream
+```
+
+One session has `id`, lazily-created `branch`, `created_at`, `last_used_at`, and an
+`asyncio.Lock`. Missing/expired ids return 404; a concurrent turn returns 409. The model
+error path emits `{"type":"error","detail":...}` followed by `done`. A successful turn
+emits any new-turn UI/proposal outputs, then `text`, then `done`. The lock is released when
+the response generator is consumed or aborted.
+
+Read tools call run, invocation, session, playbook, schedule, and doctor services. UI tools
+return:
+
+```json
+{"ui_command":{"kind":"navigate","space":"fleet","params":{"status":"failed"}}}
+{"ui_command":{"kind":"prefill_schedule","space":"schedules","params":{"name":"...","cron":"...","prompt":"...","desc":"..."}}}
+```
+
+Mutation tools only propose:
+
+```json
+{
+  "proposed_action": {
+    "kind": "launch_playbook | create_playbook | run_maintenance",
+    "params": {},
+    "description": "human text",
+    "endpoint": "POST /api/..."
+  }
+}
+```
+
+The 50-session and two-hour bounds prevent unbounded process memory; the source records no
+measurement selecting those exact numbers. They are prototype behavior, not retained target
+limits.
+
+| Concern | Decision |
+|---|---|
+| Persistence and concurrency | D1: Persist conversations, turns, frames, proposals, effects, and cursors in StateDB with one active turn per conversation. |
+| Frame protocol | D2: Use a version-1 envelope with conversation-wide monotonic sequence and typed payloads. |
+| Destinations and tools | D3: Generate destinations from ADR-0080 and expose tools as typed ADR-0078 application adapters. |
+| Proposal and confirmation | D4: Execute risky commands only through expiring, refreshed, idempotent, durably audited proposals. |
+| Client effects | D5: Require typed validation and acknowledgement before an emitted effect is considered applied. |
+| Transport and auth | D6: Use HTTP submit/cancel/ack plus authenticated fetch SSE; allow tickets only as short-lived one-use credentials. |
+| Replay, errors, and context | D7: Persist frames before delivery, replay by durable cursor, bound model context, and publish stable error codes. |
+| Degraded operation | D8: Fail closed when mutation audit is unavailable while allowing visibly degraded read-only explanation. |
+
+Out of scope:
+
+- Replacing ordinary cockpit navigation or control; the dock is optional assistance, not a
+  dependency for core operation.
+- Giving the model arbitrary URLs, shell strings, SQL, filesystem paths, or raw endpoint
+  invocation.
+- Selecting WebSocket without a demonstrated concurrent bidirectional requirement and a
+  later transport decision.
+- Defining the six-space IA or application commands; ADR-0080 and ADR-0078 own them.
+- Persisting a LionAGI runtime Session row as the conversation. Operator conversations are a
+  distinct product record with different retention and control semantics.
+
+## Decision
+
+### D1 — Durable StateDB records and one active turn per conversation
+
+The target tables are owned by StateDB schema/migrations:
+
+```sql
+CREATE TABLE studio_operator_conversations (
+  id                 TEXT PRIMARY KEY,
+  project            TEXT,
+  title              TEXT,
+  status             TEXT NOT NULL DEFAULT 'active'
+                     CHECK(status IN ('active', 'archived', 'deleted')),
+  next_sequence      INTEGER NOT NULL DEFAULT 1,
+  active_request_id  TEXT,
+  created_at         REAL NOT NULL,
+  updated_at         REAL NOT NULL,
+  archived_at        REAL,
+  deleted_at         REAL
+);
+
+CREATE TABLE studio_operator_turns (
+  request_id         TEXT PRIMARY KEY,
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  instruction        TEXT NOT NULL,
+  context_json       JSON NOT NULL,
+  context_hash       TEXT NOT NULL,
+  status             TEXT NOT NULL
+                     CHECK(status IN ('queued', 'running', 'awaiting_confirmation',
+                                      'completed', 'failed', 'cancelled')),
+  error_code         TEXT,
+  created_at         REAL NOT NULL,
+  started_at         REAL,
+  ended_at           REAL,
+  cancel_requested_at REAL
+);
+
+CREATE TABLE studio_operator_frames (
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  sequence           INTEGER NOT NULL,
+  request_id         TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  frame_type         TEXT NOT NULL,
+  payload_json       JSON NOT NULL,
+  created_at         REAL NOT NULL,
+  PRIMARY KEY(conversation_id, sequence)
+);
+
+CREATE INDEX idx_operator_frames_request
+  ON studio_operator_frames(request_id, sequence);
+
+CREATE TABLE studio_operator_proposals (
+  id                 TEXT PRIMARY KEY,
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  request_id         TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  command_type       TEXT NOT NULL,
+  command_json       JSON NOT NULL,
+  target_version     TEXT,
+  risk               TEXT NOT NULL CHECK(risk IN ('mutate', 'execute', 'admin')),
+  summary            TEXT NOT NULL,
+  idempotency_key    TEXT NOT NULL UNIQUE,
+  status             TEXT NOT NULL
+                     CHECK(status IN ('pending', 'confirmed', 'executing', 'succeeded',
+                                      'failed', 'expired', 'cancelled', 'conflict')),
+  expires_at         REAL NOT NULL,
+  confirmed_at       REAL,
+  completed_at       REAL,
+  result_json        JSON,
+  error_code         TEXT,
+  created_at         REAL NOT NULL
+);
+
+CREATE TABLE studio_operator_effects (
+  id                 TEXT PRIMARY KEY,
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  request_id         TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  effect_type        TEXT NOT NULL,
+  effect_json        JSON NOT NULL,
+  status             TEXT NOT NULL DEFAULT 'pending'
+                     CHECK(status IN ('pending', 'applied', 'rejected', 'expired')),
+  emitted_at         REAL NOT NULL,
+  acknowledged_at    REAL,
+  rejection_code     TEXT
+);
+```
+
+Exact persistence semantics:
+
+- Conversation ids, request ids, proposal ids, and effect ids are UUID strings.
+- `sequence` is monotonic across the whole conversation, not reset per request. A single
+  StateDB transaction increments `next_sequence` and inserts each frame, preventing
+  duplicates during concurrent delivery.
+- At most one turn is queued/running/awaiting confirmation per conversation.
+  `active_request_id` is set with a compare-and-set; a second submission returns conflict.
+- Different conversations may run concurrently subject to provider/application capacity.
+- Conversation rows are not automatically expired. They remain until explicit archive or
+  deletion, avoiding another silent two-hour loss contract.
+- Archive makes a conversation read-only and replayable. Delete is two-stage: mark deleted,
+  then an explicit maintenance policy may purge dependent rows after the documented
+  recovery window.
+- Daemon restart reloads rows and marks a previously `running` turn failed with
+  `service_restarted` unless its provider adapter has a durable resume handle. It appends
+  `error` and `done` frames; it does not pretend the turn completed.
+- StateDB absence or migration failure makes the operator protocol unavailable. It does not
+  fall back to ephemeral sessions under the same API.
+
+Why this way: a durable conversation needs different identity, retention, and replay from a
+runtime execution Session. Explicit deletion is more predictable than silent LRU/idle
+eviction.
+
+### D2 — Version-1 typed frame envelope
+
+The target Python contract is:
+
+```python
+OperatorFrameType = Literal[
+    "text", "tool_call", "tool_result", "ui_command", "proposal",
+    "confirmation", "error", "done"
+]
+
+class OperatorFrame(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    version: Literal[1] = 1
+    conversation_id: UUID
+    request_id: UUID
+    sequence: int = Field(ge=1)
+    type: OperatorFrameType
+    payload: TextPayload | ToolCallPayload | ToolResultPayload | UiCommandPayload | \
+             ProposalPayload | ConfirmationPayload | ErrorPayload | DonePayload
+    created_at: float
+```
+
+Wire JSON uses camelCase for the three id/sequence fields as in the original skeleton:
+
+```typescript
+export interface OperatorFrame<T extends OperatorPayload = OperatorPayload> {
+  version: 1;
+  conversationId: string;
+  requestId: string;
+  sequence: number;
+  type:
+    | "text" | "tool_call" | "tool_result" | "ui_command"
+    | "proposal" | "confirmation" | "error" | "done";
+  payload: T;
+  createdAt: number;
+}
+```
+
+The payload discriminants are exact:
+
+```typescript
+type TextPayload = { content: string; format: "plain" | "markdown" };
+type ToolCallPayload = {
+  callId: string; tool: string; arguments: Record<string, unknown>; mode: "read" | "draft";
+};
+type ToolResultPayload = {
+  callId: string; ok: boolean; result?: unknown; error?: ProtocolError;
+};
+type UiCommandPayload = { effect: UiEffect };
+type ProposalPayload = { proposal: CommandProposal };
+type ConfirmationPayload = {
+  proposalId: string; state: "required" | "confirmed" | "expired" | "executed";
+};
+type ErrorPayload = { error: ProtocolError };
+type DonePayload = {
+  outcome: "completed" | "failed" | "cancelled";
+  lastSequence: number;
+};
+```
+
+Exact frame semantics:
+
+- A frame is inserted durably before it is yielded to any stream.
+- Stream delivery is ordered by `sequence`; reconnect may redeliver a frame after the
+  client's cursor. Clients deduplicate by `(conversationId, sequence)`.
+- Every accepted request ends in exactly one durable `done` frame, including cancellation,
+  validation failure after acceptance, provider failure, and restart recovery.
+- Submission errors that prevent creation of a turn use an ordinary HTTP application error
+  and have no request/frame sequence.
+- `error` may be followed only by diagnostic frames and the terminal `done`; it does not
+  imply the stream transport itself failed.
+- Unknown version or frame type is a protocol error. Clients do not best-effort execute
+  unknown UI commands or proposals.
+- Text may stream in multiple frames. Concatenation order is sequence order; frame
+  boundaries are not semantic paragraphs.
+
+### D3 — Router-derived destinations and application-service tools
+
+The cockpit command schema is generated from ADR-0080's typed registry:
+
+```python
+class NavigateEffect(BaseModel):
+    kind: Literal["navigate"] = "navigate"
+    space: Literal["mission", "designer", "library", "history", "schedules", "system"]
+    params: dict[str, str | int | bool | list[str]] = Field(default_factory=dict)
+
+class SelectEffect(BaseModel):
+    kind: Literal["select"] = "select"
+    space: Literal["mission", "designer", "library", "history", "schedules"]
+    selection: dict[str, str]
+
+class PrefillEffect(BaseModel):
+    kind: Literal["prefill"] = "prefill"
+    form: Literal["schedule", "workflow", "playbook"]
+    values: dict[str, JsonValue]
+
+class ThemeEffect(BaseModel):
+    kind: Literal["theme"] = "theme"
+    theme: Literal["light", "dark"]
+
+UiEffect = NavigateEffect | SelectEffect | PrefillEffect | ThemeEffect
+```
+
+Fleet is represented as `space="mission"` with a validated sub-view/search parameter; it is
+not a seventh space. Every param is validated by the destination route schema before the
+effect is emitted and again by the client before application.
+
+Tools are registered by stable id with an execution class:
+
+```python
+class OperatorToolSpec(BaseModel):
+    id: str
+    title: str
+    input_model: type[BaseModel]
+    output_model: type[BaseModel]
+    execution_class: Literal["read", "navigate", "draft", "mutate", "execute", "admin"]
+    application_operation: str
+```
+
+Exact semantics:
+
+- Read, navigate, and draft tools may execute during the turn. Read tools call ADR-0078
+  application queries; navigate/draft tools emit acknowledged effects.
+- Mutate, execute, and admin tools never execute during model tool handling. They create D4
+  proposals.
+- No tool spec contains a raw URL, shell command, SQL statement, or file path for the model
+  to choose.
+- Tool input/output is Pydantic-validated with `extra="forbid"`.
+- Unknown tool ids and invalid inputs emit stable validation errors; the model does not get
+  a permissive arbitrary-call fallback.
+- Tool results include a bounded, redacted application projection. Secrets and full host
+  paths are not inserted into conversation frames.
+- The model provider and model remain configurable, but provider unavailability cannot
+  disable ordinary cockpit operation.
+
+### D4 — Expiring, refreshed, idempotent, audited proposals
+
+The proposal and confirmation contracts are:
+
+```python
+class CommandProposal(BaseModel):
+    id: UUID
+    command: StudioApplicationCommand
+    risk: Literal["mutate", "execute", "admin"]
+    summary: str
+    target: ResourceVersion | None
+    idempotency_key: UUID
+    expires_at: float
+
+class ConfirmProposalRequest(BaseModel):
+    expected_command_hash: str
+    expected_target_version: str | None = None
+
+class ProposalResult(BaseModel):
+    proposal_id: UUID
+    status: Literal["succeeded", "failed", "conflict", "expired"]
+    result: dict[str, JsonValue] | None = None
+    error: ProtocolError | None = None
+```
+
+Exact semantics:
+
+1. Model tool output is validated as an endpoint-independent ADR-0078 application command.
+2. The coordinator computes a canonical JSON hash, stores proposal/target/risk/summary,
+   allocates an idempotency key, and sets expiry to 10 minutes after creation.
+3. The client renders the exact command summary and risk, then confirms by proposal id plus
+   expected command hash and target version.
+4. Confirmation re-reads the proposal and target. Hash mismatch, changed target, expired
+   proposal, archived conversation, or non-pending status prevents execution.
+5. In one StateDB transaction, pending becomes confirmed/executing and a durable audit event
+   is appended before the application command is called.
+6. Repeated confirmation with the same idempotency key returns the stored terminal result or
+   current executing state; it never executes twice.
+7. The application result/failure and final proposal status are persisted, then emitted as
+   confirmation/tool-result frames.
+
+Ten minutes bounds staleness while allowing a human to inspect the proposal. It is a
+conservative initial safety value, not a measured optimum; changing it is a protocol/config
+decision and must remain visible in the proposal.
+
+Proposal cancellation and expiry are terminal. They do not mutate state. A new model turn
+must create a new proposal with a new hash and idempotency key.
+
+### D5 — Declarative effects require client acknowledgement
+
+The acknowledgement endpoint accepts:
+
+```python
+class AcknowledgeEffectRequest(BaseModel):
+    status: Literal["applied", "rejected"]
+    client_route: str | None = None
+    rejection_code: Literal[
+        "unsupported", "invalid_params", "stale_context", "not_visible", "client_error"
+    ] | None = None
+```
+
+Exact semantics:
+
+- Emitting `ui_command` inserts a `studio_operator_effects` row and frame with status
+  pending. The backend never calls it applied at emission time.
+- The client validates the effect against its registry and current context, attempts it, and
+  POSTs one acknowledgement.
+- `applied` requires the resulting route/selection/theme to match the validated command.
+- `rejected` requires a stable rejection code. Optional human detail is diagnostic only.
+- A repeated identical acknowledgement is idempotent. A contradictory second
+  acknowledgement returns conflict.
+- Disconnect leaves the effect pending. Replay shows it again, but the client checks local
+  effect id history before applying and then acknowledges, preventing duplicate navigation
+  or form overwrite.
+- Effects expire when their turn/proposal context is no longer valid. An expired effect is
+  not applied on reconnect.
+- A turn may finish while an informational navigation effect is pending, but the text must
+  say it was requested rather than completed. A workflow requiring effect completion emits
+  a confirmation frame only after acknowledgement.
+
+### D6 — HTTP commands and authenticated fetch SSE
+
+The version-1 HTTP surface is:
+
+```text
+POST   /api/operator/conversations
+GET    /api/operator/conversations/{id}
+DELETE /api/operator/conversations/{id}
+POST   /api/operator/conversations/{id}/turns
+POST   /api/operator/conversations/{id}/requests/{request_id}/cancel
+GET    /api/operator/conversations/{id}/stream?after_sequence=N
+POST   /api/operator/conversations/{id}/effects/{effect_id}/ack
+POST   /api/operator/conversations/{id}/proposals/{proposal_id}/confirm
+POST   /api/operator/stream-tickets
+```
+
+Turn submission body is:
+
+```python
+class OperatorTurnRequest(BaseModel):
+    instruction: str = Field(min_length=1, max_length=32_768)
+    context: OperatorContextSnapshot
+    expected_last_sequence: int = Field(ge=0)
+
+class OperatorContextSnapshot(BaseModel):
+    project: str | None = None
+    space: Literal["mission", "designer", "library", "history", "schedules", "system"]
+    route: str
+    selection: dict[str, str] | None = None
+    filters: dict[str, JsonValue] = Field(default_factory=dict)
+```
+
+The 32 KiB instruction cap bounds persistence and prompt abuse while remaining far above an
+ordinary operator instruction. It is a conservative initial bound, not a measured optimum.
+
+Exact transport semantics:
+
+- Create/submit/cancel/ack/confirm are ordinary authenticated JSON requests.
+- Submit returns HTTP 202 with `{conversationId, requestId, acceptedSequence}`.
+- Stream uses fetch SSE with the bearer header and unnamed `data:` JSON frames. The cursor
+  is `after_sequence`; frames returned have strictly greater sequence.
+- If `after_sequence` is beyond the current tail, the stream waits for new frames. If it is
+  older than retained data after an explicit purge, the server emits/returns `replay_gap`
+  with the earliest available cursor; it never silently starts later.
+- Cancellation is idempotent. Queued work becomes cancelled immediately; running provider
+  work receives best-effort cancellation and ultimately emits `done(cancelled)` or a
+  failure explaining why cancellation could not stop side effects already completed.
+- The default browser uses the bearer header. It does not need a ticket.
+- If a transport cannot attach headers, `POST /stream-tickets` returns a random one-use
+  credential valid for 60 seconds and scoped to one conversation/cursor. The stored server
+  value is hashed; redemption invalidates it; it is never the long-lived bearer token.
+- Sixty seconds is a short connection-establishment window chosen to limit URL/log exposure;
+  no measurement selects exactly 60 seconds.
+- WebSocket is not part of version 1. A later ADR must prove a concurrent bidirectional need
+  and specify auth, heartbeat, backpressure, acknowledgement, and replay.
+
+### D7 — Durable replay, bounded context, and stable errors
+
+Conversation replay and model context are separate:
+
+- The client may page every retained frame from StateDB.
+- The model receives the current instruction plus the newest complete turns that fit both a
+  64-frame and 128-KiB serialized-content cap. System/tool schemas are budgeted separately.
+- Frames are added newest-to-oldest by complete turn; the compiler never truncates half a
+  tool call/result pair. If one current instruction exceeds the instruction cap it is
+  rejected before turn creation.
+- The 64-frame/128-KiB limits bound provider input and latency while retaining substantial
+  local context. They are conservative initial budgets with no recorded production
+  calibration; the persisted full history remains available to the client.
+- Context compilation records the included sequence range and hash in the turn's
+  `context_json`, making a model answer traceable to its snapshot.
+
+Stable error codes are:
+
+```typescript
+export type OperatorErrorCode =
+  | "auth_required"
+  | "validation"
+  | "not_found"
+  | "denied"
+  | "conflict"
+  | "stale_context"
+  | "rate_limited"
+  | "model_failure"
+  | "service_failure"
+  | "service_restarted"
+  | "audit_unavailable"
+  | "replay_gap"
+  | "cancelled"
+  | "protocol_version";
+
+export interface ProtocolError {
+  code: OperatorErrorCode;
+  message: string;
+  retryable: boolean;
+  retryAfterMs?: number;
+  details?: Record<string, unknown>;
+}
+```
+
+Exact semantics:
+
+- HTTP auth failure occurs before a turn and uses the daemon error response.
+- Turn-level validation/model/service failures append typed error plus done frames.
+- Conflict and stale context are not automatically retried; the client refreshes first.
+- Rate limiting, when returned by the configured application/provider gate, includes
+  `retryAfterMs`; this ADR standardizes the error contract but does not invent a global
+  fixed request quota.
+- Provider retry is allowed only when the error says `retryable` and no mutate/execute/admin
+  proposal was confirmed as part of that attempt.
+- Client reconnect repeats reads by cursor and never repeats turn submission automatically.
+
+### D8 — Mutation audit fails closed; read-only explanation may degrade visibly
+
+The mutation audit reuses StateDB's append-only `admin_events` table with
+`action="studio.operator.command"`, `target_id=<proposal id>`, and this exact `details`
+payload:
+
+```json
+{
+  "conversation_id": "uuid",
+  "request_id": "uuid",
+  "proposal_id": "uuid",
+  "command_type": "stable application command id",
+  "command_hash": "sha256 hex",
+  "target": {"kind": "resource kind", "id": "resource id", "version": "opaque"},
+  "risk": "mutate | execute | admin",
+  "idempotency_key": "uuid",
+  "decision": "confirmed | denied | expired | executed | failed | indeterminate",
+  "result": {},
+  "error_code": null,
+  "confirmed_at": 0.0,
+  "completed_at": null
+}
+```
+
+Under the current single-token local boundary, `admin_events.actor` is the stable value
+`"studio_operator"`; the bearer token does not identify an individual and is never stored.
+If the daemon later gains a richer principal contract, that boundary may supply a stable
+principal id, but it never comes from model output. The audit row is written through StateDB
+in the D4 ordering. Events are append-only: confirmation and terminal result are separate
+rows with the same `target_id` and idempotency key, preserving the transition trail.
+
+Exact semantics:
+
+- If proposal or audit persistence is unavailable, mutate/execute/admin tools return
+  `audit_unavailable`; no application command is invoked.
+- If the pre-execution audit succeeds but final-result persistence fails, the command result
+  is not retried automatically. The proposal remains `executing`/indeterminate and the
+  idempotency key blocks duplicate execution until reconciliation determines the outcome.
+- Read-only tools may continue when their own data source is available. Frames and dock UI
+  show degraded durability/observability; they do not imply the conversation is fully
+  persisted when it is not.
+- Navigation/draft effects require durable effect/frame persistence. If that persistence is
+  unavailable, the model may describe the intended action in text but the backend does not
+  emit an untracked effect.
+- Ordinary cockpit navigation and typed application commands remain usable without the
+  operator dock. Model/provider failure never disables them.
+
+For the target seven-component subgraph—dock, HTTP/SSE adapter, coordinator, tool registry,
+application services, conversation store, and audit/effect bridge—with eight intended direct
+dependencies, `κ = 8/(7×6) = 0.19`, below 0.3. Direct dock→StateDB or model→endpoint edges
+would increase coupling and violate the boundary.
+
+Testability target is `τ ≥ 0.85` using a scripted model, fake application adapters, fake
+clock/store, frame-replay tests, restart recovery, effect acknowledgement, stale target,
+expiry, idempotency, audit-failure, EOF, and cancellation tests.
+
+## Consequences
+
+- The operator dock becomes durable and replayable rather than an ephemeral daemon demo.
+- Typed destinations, tools, proposals, and effects keep model output inside the same
+  application and IA boundaries as ordinary UI actions.
+- StateDB gains five protocol tables and explicit migration/recovery work. Sequence
+  allocation, provider cancellation, and indeterminate audit outcomes add state-machine
+  complexity.
+- Confirmation is slower than calling a model-authored endpoint directly. That delay buys
+  refreshed targets, explicit human intent, audit, and idempotency.
+- Clients must acknowledge effects and persist cursors locally; a simple text-only client
+  may ignore effects but must render them as unapplied.
+- Full history remains available to the operator while model context stays bounded.
+- Reversing the version-1 envelope after clients persist cursors is expensive and requires a
+  version negotiation/migration decision.
+
+## Alternatives considered
+
+### Keep the ephemeral Leo sessions and current SSE dictionaries
+
+This is already small, bounded, and safe from direct mutation. It lost because restart,
+silent LRU/idle eviction, missing replay, and absent acknowledgements make it unsuitable for
+a persistent cockpit capability. The prototype remains an implementation source, not the
+target contract.
+
+### Require WebSocket for version 1
+
+One duplex connection could carry turns, cancellation, confirmations, effects, and frames.
+It lost because HTTP commands plus authenticated fetch SSE already meet ordered server-to-
+client delivery and explicit client writes. WebSocket would front-load ticketing, heartbeat,
+backpressure, and replay without a demonstrated simultaneous duplex requirement.
+
+### Free-form model-authored URLs or CLI commands
+
+This would make tool coverage broad and easy to extend. It lost because it bypasses typed
+application validation, enables shell/endpoint injection, makes risk classification
+unreliable, and cannot guarantee confirmation refers to the executed command.
+
+### Browser executes the proposed endpoint after confirmation
+
+The current prototype points the browser at endpoint strings. This keeps the backend model
+agent read-only. It lost as the durable target because proposal, confirmation, target
+refresh, idempotency, audit, and result become split across two uncoordinated callers. The
+coordinator executes a typed application command only after durable confirmation.
+
+### Treat emitted UI commands as applied
+
+This would remove acknowledgement endpoints and reduce latency. It lost because route
+validation, disconnect, stale selection, and unsupported clients are observable rejection
+paths. The backend must distinguish requested from applied effects.
+
+### Reuse runtime `sessions` for operator conversations
+
+This would reuse message persistence and existing APIs. It lost because runtime sessions
+represent executions/branches, while operator conversations need proposals, effects,
+replay sequences, explicit retention, and one-active-turn semantics. Overloading the noun
+would create incompatible lifecycle rules in one table.
+
+### Auto-expire conversations after the prototype's two hours
+
+Automatic expiry bounds storage and mirrors current behavior. It lost because a persistent
+operator dock promises restart/history continuity; silently deleting a conversation based
+on idle time violates that promise. Explicit archive/delete keeps storage policy visible.
+
+### Continue mutation when audit storage is unavailable
+
+This maximizes availability. It lost because the inability to prove what was proposed,
+confirmed, and executed is precisely the unsafe state for natural-language mutation.
+Read-only explanation may degrade; state changes fail closed.

--- a/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
+++ b/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
@@ -1,0 +1,875 @@
+# ADR-0086: Local Tool Controls and Session Authorization Observation
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: governance
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0068, v0-0069, v0-0070
+
+## Context
+
+LionAGI ships useful controls around tool execution, but they grew at different layers and do
+not form one governance system. This ADR records those controls as they are. It deliberately
+does not reinterpret operational signals, mutable logs, or data adapters as evidence-backed
+governance.
+
+**P1 — Permission decisions have a local, untyped policy vocabulary.** Agent construction can
+attach a `PermissionPolicy` to tool preprocessors. Its result is a mutable dataclass whose
+`behavior` field is a string, and enforcement is ultimately a `PermissionError`. There is no
+policy version, operation ID, or durable decision identifier
+(`lionagi/agent/permissions.py`).
+
+**P2 — Security behavior depends on factory wiring.** `AgentSpec.coding()` adds destructive
+command and workspace-path guards when `secure=True`. `create_agent()` converts a configured
+permission policy into a security hook, attaches hooks while registering local tools, and
+orders security hooks around user argument transforms. The `Tool` itself does not know whether
+the factory performed this wiring (`lionagi/agent/spec.py`; `lionagi/agent/factory.py`;
+`lionagi/tools/coding.py`).
+
+**P3 — The callable boundary has processors, not an authorization protocol.** `Tool` exposes
+optional pre- and postprocessors. `FunctionCalling` invokes them around the callable and the
+generic `Event` lifecycle captures ordinary exceptions as a failed event. A preprocessor can
+enforce a local rule, but the result is not a typed verdict and alternate `ActionManager`
+entry points do not consult session authorization (`lionagi/protocols/action/tool.py`;
+`lionagi/protocols/action/function_calling.py`; `lionagi/protocols/action/manager.py`;
+`lionagi/protocols/generic/event.py`).
+
+**P4 — Session authorization is a separate optional plane.** A `SessionObserver` can hold one
+caller-supplied gate. The action operation asks the branch to authorize a `ToolInvocation`
+before it invokes `ActionManager`. A false result or an exception denies; a missing observer or
+gate allows. The gate has no declared identity, level, reason code, or policy provenance
+(`lionagi/session/control.py`; `lionagi/session/observer.py`;
+`lionagi/operations/act/act.py`).
+
+**P5 — Observation is lossy by design.** The same observer manages lifecycle signals,
+subscriptions, routes, and optional persistence to `session_signals`. Persistence is a
+subscriber and is explicitly best-effort. Payloads may be reduced or truncated, and a
+persistence failure cannot change a run outcome (`lionagi/session/signal.py`;
+`lionagi/session/observer.py`; `lionagi/state/schema.sql`; `lionagi/state/db.py`).
+
+**P6 — Adjacent facilities have narrower contracts.** The adapter package converts data
+representations. `DataLogger` holds mutable operational logs. `MemoryStore` stores caller
+content. `completion_evidence` probes local Git state to decide whether a run appears to have
+produced work. None supplies an immutable evidence chain, historical policy lookup, or process
+certificate (`lionagi/adapters/_base.py`; `lionagi/protocols/generic/log.py`;
+`lionagi/protocols/memory.py`; `lionagi/state/completion_evidence.py`).
+
+| Concern | Decision |
+|---|---|
+| Local permission vocabulary | D1: Retain `PermissionPolicy` as a per-tool, preprocessor-based control with its shipped matching semantics. |
+| Factory-installed guards | D2: Retain construction-time guard wiring: an explicit `PermissionPolicy` gets the security → user → security composition; the built-in coding guards register in the ordinary pre bucket and run once. |
+| Callable interception | D3: Treat `Tool` processors and `FunctionCalling` as local invocation mechanics, not a universal governance boundary. |
+| Session authorization | D4: Retain the optional, fail-closed-when-present session callback and its denied action response. |
+| Signals and persistence | D5: Treat observer flows and `session_signals` as best-effort operational observation only. |
+| Adjacent facilities | D6: Keep adapters, logs, memory, and completion evidence within their shipped narrow meanings. |
+
+This ADR does **not** decide:
+
+- The evidence-backed target architecture. ADR-0087 owns that aspirational design.
+- Authenticated actor identity or cross-caller isolation. No shipped control establishes either
+  property.
+- Policy authoring syntax or an external policy service. The current policy is an in-process
+  Python object.
+- A guarantee over direct calls to arbitrary Python functions. Only LionAGI invocation paths
+  described below are in scope.
+- A new persistence or migration format. The SQL shown here records the current observer table,
+  not a proposed evidence schema.
+
+## Decision
+
+### D1 — `PermissionPolicy` remains a local preprocessor policy
+
+The shipped permission contract is two dataclasses and a pre-hook adapter
+(`lionagi/agent/permissions.py`):
+
+```python
+@dataclass
+class PermissionDecision:
+    behavior: str  # "allow" | "deny" | "escalate"
+    tool_name: str
+    action: str
+    reason: str
+    matched_rule: str | None = None
+
+
+@dataclass
+class PermissionPolicy:
+    mode: str = "allow_all"  # "allow_all" | "deny_all" | "rules"
+    allow: dict[str, list[str]] = field(default_factory=dict)
+    deny: dict[str, list[str]] = field(default_factory=dict)
+    escalate: dict[str, list[str]] = field(default_factory=dict)
+    on_escalate: Callable | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PermissionPolicy: ...
+
+    @classmethod
+    def allow_all(cls) -> PermissionPolicy: ...
+
+    @classmethod
+    def deny_all(cls) -> PermissionPolicy: ...
+
+    @classmethod
+    def read_only(cls) -> PermissionPolicy: ...
+
+    @classmethod
+    def safe(cls) -> PermissionPolicy: ...
+
+    def check(self, tool_name: str, action: str, args: dict) -> PermissionDecision: ...
+
+    def to_pre_hook(self) -> Callable: ...
+```
+
+`from_dict()` reads `mode`, `allow`, `deny`, and `escalate`; missing values default to
+`"allow_all"` and empty rule maps. It does not restore an `on_escalate` callable. Rule-map keys
+normalize these aliases at construction time:
+
+```python
+_TOOL_ALIASES = {
+    "bash_tool": "bash",
+    "reader_tool": "reader",
+    "editor_tool": "editor",
+    "search_tool": "search",
+    "context_tool": "context",
+}
+```
+
+Exact semantics:
+
+- `mode == "allow_all"` returns `allow` immediately. It does not build a match string and
+  therefore does not reject shell-control operators on its own.
+- `mode == "deny_all"` returns `deny` immediately.
+- Every other mode value follows rules-mode behavior; the dataclass does not validate `mode`
+  against a closed enum.
+- Rules mode canonicalizes the requested tool name, then builds one match string. Bash uses
+  `str(args.get("command", ""))`; editor uses `file_path`; reader uses `path`; search joins
+  `pattern` and optional `path`; other tools join the action and argument values in mapping
+  iteration order.
+- In rules mode, a bash command containing a token matched by `_SHELL_CONTROL` becomes a deny
+  decision before wildcard rules are considered.
+- Matching is by `fnmatch` against the original text or a lowercase copy. `"*"` always matches.
+- All deny rules are checked first, then all allow rules, then all escalation rules. Tool-specific
+  rules precede `"*"` rules within each tier. The first match supplies `matched_rule`.
+- No match returns `PermissionDecision("deny", ..., "no matching rule, default deny")`.
+- `to_pre_hook()` returns an async hook. Allow returns `None`. Deny raises `PermissionError`.
+  Escalate calls `on_escalate(decision, args)` when present: literal `True` allows, a `dict`
+  replaces the downstream arguments, and every other result denies. With no handler it raises
+  `PermissionError` explaining that escalation is required.
+- Empty arguments are not special. They yield empty match strings for the named coding tools;
+  the configured rules determine the outcome, with rules mode defaulting to deny.
+- The policy is in-memory configuration. Reconstructing an agent after process restart requires
+  supplying the policy again; `AgentSpec.to_yaml()` does not serialize it.
+
+The presets are convenience constructors, not stronger policy types. `read_only()` allows
+reader, search, and context and denies editor and bash. `safe()` allows the non-bash coding
+tools, denies five bash pattern families, and escalates all remaining bash commands. The exact
+five `safe()` patterns are `rm *`, `sudo *`, `chmod *`, `kill *`, and `mkfs *`.
+
+Why this way: the dataclass and pre-hook conversion make a policy usable without changing
+`Tool` or `ActionManager`. They also preserve zero-configuration behavior through
+`allow_all`. The source records no stronger rationale for the string vocabulary or preset rule
+sets, so this ADR does not infer one.
+
+### D2 — Factory wiring chains policy and guard hooks per tool
+
+The relevant construction-time shape is the `AgentSpec` dataclass
+(`lionagi/agent/spec.py`):
+
+```python
+@dataclass
+class AgentSpec(HooksMixin):
+    profile: Profile
+    model: str | None = None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()
+    permissions: PermissionPolicy | None = None
+    grant_emissions: bool = True
+    emits: tuple | None = None
+    pack: str | Pack | None = "default"
+    lion_system: bool = True
+    extra_prompt: str | None = None
+    hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
+    cwd: str | None = None
+    yolo: bool = False
+    mcp_servers: list[str] | None = None
+    mcp_config_path: str | None = None
+    context_management: bool = True
+
+    @classmethod
+    def coding(
+        cls,
+        *,
+        model: str | None = None,
+        effort: str | None = "high",
+        system_prompt: str | None = None,
+        cwd: str | None = None,
+        secure: bool = True,
+        context_management: bool = True,
+        **kwargs: Any,
+    ) -> AgentSpec: ...
+```
+
+Hook registration uses string keys in `hook_handlers`:
+
+```python
+def pre(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+def post(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+def on_error(self, tool_name: str, handler: Callable) -> HooksMixin: ...
+
+# Stored keys:
+# pre:<tool>, post:<tool>, error:<tool>, and factory-added security_pre:<tool>
+```
+
+The factory entry point and pre-hook compositor are
+(`lionagi/agent/factory.py`):
+
+```python
+async def create_agent(
+    config: AgentSpec,
+    *,
+    load_settings: bool = True,
+    project_dir: str | None = None,
+    trust_project_settings: bool = False,
+    trusted_hook_modules: set[str] | frozenset[str] | None = None,
+    chat_model: Any = None,
+    log_config: Any = None,
+) -> Branch: ...
+
+
+def _chain_pre_hooks(
+    tool_name: str,
+    security_hooks: list[Callable],
+    user_hooks: list[Callable] | None = None,
+) -> Callable | None: ...
+```
+
+The effective preprocessor is equivalent to:
+
+```python
+user_hooks = user_hooks or []
+hooks = [*security_hooks, *user_hooks]
+if user_hooks:
+    hooks.extend(security_hooks)
+
+async def chained(args: dict, **_kw) -> dict:
+    for handler in hooks:
+        result = await handler(tool_name, args.get("action", ""), args)
+        if isinstance(result, dict):
+            args = result
+    return args
+```
+
+Exact semantics:
+
+- `permissions is None` adds no policy hook. A `PermissionPolicy` is inserted at the front of
+  `security_pre:*`; unsupported runtime values in the field are ignored by `_apply_permissions`.
+- `AgentSpec.coding(secure=True)` registers `guard_destructive` for bash and one `guard_paths`
+  instance for reader and editor (`_wire_secure_guards` in `lionagi/agent/spec.py`; the guards
+  are defined in `lionagi/agent/hooks.py`). These register through `.pre()` into the ordinary
+  `pre:<tool>` bucket — the user-hook position — not into `security_pre:<tool>`. The path
+  guard's only allowed root is `cwd`, or `Path.cwd()` when `cwd` is absent. `secure=False`
+  skips these three registrations.
+- Only hooks in the `security_pre:<tool>`/`security_pre:*` bucket participate in the
+  security → user → security composition, and the only factory writer of that bucket is
+  `_apply_permissions` installing an explicit `PermissionPolicy`. Those security hooks run
+  before user pre-hooks, and when at least one user pre-hook exists the same security chain
+  runs again against the final transformed argument mapping; with no user pre-hook it runs
+  once.
+- Consequently, under the default `coding()` path (no `PermissionPolicy` configured), the
+  built-in guards run exactly once in the pre chain and are NOT re-run after a later mutating
+  user hook — a user hook that rewrites `command` or a path argument after the guard has
+  passed is not rechecked. The mutation-gap recheck exists only for an explicitly configured
+  `PermissionPolicy` (`tests/agent/test_coding_preset_guard.py` pins `guard_destructive` to
+  the `pre:bash` bucket).
+- A hook return that is a `dict` replaces the argument mapping for later hooks and the callable.
+  Any other non-exception result leaves the current mapping unchanged.
+- `guard_destructive(tool_name, action, args)` inspects only `args["command"]` when present. It
+  rejects the compiled destructive pattern set with `PermissionError`; an empty or unmatched
+  command returns `None`.
+- `guard_paths(allowed_paths, denied_paths)` returns an async hook. No `path` or `file_path`
+  allows. Relative paths resolve under the first allowed root; absolute paths resolve directly.
+  Allowed roots accept the root itself or descendants. Absolute denied paths reject the path or
+  descendants; relative denied glob patterns match path components and plain relative text
+  matches the raw path or resolved filename.
+- Paths use `Path.resolve(strict=False)`, so normalization occurs even when the target does not
+  exist.
+- Factory hooks attach while local tools are registered. MCP tools loaded later by `_load_mcp()`
+  are registered directly on `ActionManager` and do not pass through `_attach_hooks`; the
+  factory policy must not be claimed to govern that later registration path.
+- `AgentSpec.to_yaml()` explicitly omits hook callables and also omits `permissions`. A process
+  restart or YAML round-trip therefore does not preserve these runtime controls unless the
+  caller supplies them again or loads them from trusted settings.
+
+Why this way: the second security pass closes the concrete mutation gap in which a user hook
+turns allowed arguments into denied arguments after the first check — but only for the
+`security_pre` bucket, i.e. an explicit `PermissionPolicy`. The built-in coding guards sit in
+the ordinary pre chain and do not get that recheck today; unifying the two (delta row 1's
+"each configured control runs exactly once" contract) is where that asymmetry gets resolved.
+Reusing `Tool.preprocessor` keeps the mechanism local to existing tool invocation. The cost is
+construction-path coupling: a tool registered outside that path does not inherit the controls
+automatically.
+
+### D3 — `Tool` processors are the local callable interception mechanism
+
+`Tool` is a Pydantic `Element` with these invocation-relevant fields
+(`lionagi/protocols/action/tool.py`):
+
+```python
+class Tool(Element):
+    func_callable: Callable[..., Any] = Field(..., exclude=True)
+    mcp_config: dict[str, dict[str, Any]] | None = None
+    tool_schema: dict[str, Any] | None = None
+    request_options: type | None = None
+    preprocessor: Callable[[Any], Any] | None = Field(default=None, exclude=True)
+    preprocessor_kwargs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    postprocessor: Callable[[Any], Any] | None = Field(default=None, exclude=True)
+    postprocessor_kwargs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    strict_func_call: bool = False
+```
+
+`FunctionCalling` supplies the executable event
+(`lionagi/protocols/action/function_calling.py`):
+
+```python
+class FunctionCalling(Event):
+    func_tool: Tool = Field(..., exclude=True)
+    arguments: dict[str, Any] | BaseModel
+
+    @property
+    def function(self): ...
+
+    async def _invoke(self) -> Any: ...
+
+    def to_dict(self, *args, **kw) -> dict[str, Any]: ...
+```
+
+The manager exposes the independent route
+(`lionagi/protocols/action/manager.py`):
+
+```python
+class ActionManager(Manager):
+    registry: dict[str, Tool]
+
+    def match_tool(
+        self,
+        action_request: ActionRequest | BaseModel | dict,
+    ) -> FunctionCalling: ...
+
+    async def invoke(
+        self,
+        func_call: BaseModel | ActionRequest,
+    ) -> FunctionCalling: ...
+```
+
+The annotation on `invoke()` is narrower than runtime behavior: it forwards to `match_tool()`,
+and tests exercise dictionaries successfully. This ADR records the accepted runtime input as
+`ActionRequest | BaseModel | dict` while retaining the source annotation above as shipped.
+
+Exact semantics:
+
+- A `Tool` must have exactly one callable source: a Python callable or a one-entry MCP config.
+  Providing both, a non-dict MCP config, or multiple MCP entries fails model validation.
+- When `tool_schema` is absent, it is generated from the callable and optional
+  `request_options` model. `strict_func_call=True` requires exactly the schema's required field
+  set; non-strict mode requires only Python parameters without defaults.
+- A Pydantic argument model is dumped with `exclude_unset=True`. `request_options`, when set,
+  validates and dumps the arguments again before invocation.
+- Invocation order is preprocessor → callable → postprocessor. The postprocessor is reached only
+  after the callable returns successfully.
+- Async detection uses `is_coro_func`. A synchronous callable or processor that returns a
+  coroutine object is not automatically awaited.
+- `Event.invoke()` changes `PENDING` to `PROCESSING`, captures ordinary `Exception` values in
+  `execution.error`, sets `FAILED`, records duration, and does not re-raise. `BaseException`
+  sets `CANCELLED` and is re-raised.
+- Consequently, `PermissionError` raised by a tool preprocessor becomes a failed
+  `FunctionCalling`. It is not the same outward shape as a session-gate denial. On the action
+  path, the error remains in `func_call.execution.error`; because `_act()` does not call
+  `assert_completed()`, its response payload is `func_call.response`, normally `None` when the
+  preprocessor failed before the callable.
+- Empty arguments are valid only when the callable has no required fields. Unknown tools fail in
+  `match_tool()` before a `FunctionCalling` is created.
+- `ActionManager.invoke()` does not consult `Branch.authorize()` or `SessionObserver`. A caller
+  holding `branch.acts` can invoke a registered tool directly and bypass the session plane.
+- `func_callable`, preprocessors, postprocessors, and their kwargs are excluded from serialized
+  `Tool` output. Serialization is not a restartable enforcement record.
+
+Why this way: processors are general transformation hooks and fit schema validation plus
+sync/async callables without adding another manager. Their generality is also the limitation:
+they have no common verdict or evidence contract and cannot make an authorization claim about
+routes that do not use the configured `Tool` instance.
+
+### D4 — Session authorization is optional and fail-closed only when installed
+
+The proposal passed to the gate is a frozen dataclass
+(`lionagi/session/control.py`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class ToolInvocation:
+    function: str
+    arguments: dict = field(default_factory=dict)
+    branch_id: str | None = None
+```
+
+The public installation and authorization surface is
+(`lionagi/session/session.py`; `lionagi/session/observer.py`;
+`lionagi/session/branch.py`):
+
+```python
+def Session.gate(self, check: Callable) -> SessionObserver: ...
+def SessionObserver.gate(self, check: Gate) -> SessionObserver: ...
+async def SessionObserver.authorize(self, action: Any) -> bool: ...
+async def Branch.authorize(self, action: Any) -> bool: ...
+```
+
+The action operation constructs the proposal and denial payload
+(`lionagi/operations/act/act.py`; `lionagi/operations/fields.py`):
+
+```python
+class ActionResponseModel(HashableModel):
+    function: str = Field(default_factory=str)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    output: Any = None
+
+
+ToolInvocation(
+    function=_request["function"],
+    arguments=_request["arguments"] if isinstance(_request["arguments"], dict) else {},
+    branch_id=str(branch.id),
+)
+
+{"error": "denied by governance gate", "function": _request["function"]}
+```
+
+Exact semantics:
+
+- `SessionObserver.gate(check)` stores exactly one callable and returns the observer. A later
+  call replaces the previous gate; there is no built-in composition.
+- A branch included in a `Session` receives that session's observer. Removing the branch clears
+  the observer reference. A standalone branch has no observer.
+- `Branch.authorize()` returns `True` when no observer exists. `SessionObserver.authorize()`
+  returns `True` when no gate exists.
+- With a gate, the observer calls it through `maybe_await`, converts its result with `bool()`,
+  and treats every raised `Exception` as `False`. It does not preserve a reason or exception in
+  the returned boolean.
+- On denial, `authorize()` adds `GateDenied(data=action)` directly to the observer's in-memory
+  `Flow` and returns `False`.
+- `_act()` performs authorization before `branch._action_manager.invoke()`. Denial therefore
+  creates no `FunctionCalling` and does not invoke the tool callable.
+- A denied action is represented as `ActionResponseModel.output` containing the fixed error
+  dictionary above. The action request and denial response are added to branch chat history so
+  a subsequent reasoning round can observe the denial.
+- When the incoming arguments are not already a dictionary, the gate sees `{}` even though the
+  original argument object remains on the later invocation path. The session gate therefore
+  must not claim inspection of non-dict argument models.
+- Direct `ActionManager.invoke()` and direct calls to the underlying Python function do not
+  execute this session check. An unattached `Branch` also permits by definition.
+- The installed callback and `GateDenied` flow are in memory. They are not restored after a
+  process restart.
+- The same `_gate` callable is also used by `SessionObserver.emit()`, but `emit()` passes an
+  event payload rather than a `ToolInvocation`. Callers that use both surfaces must accept both
+  input shapes themselves.
+
+Why this way: an optional observer callback adds a small pre-invocation stop without changing
+plain `Branch` construction. Returning a denial as a tool result lets iterative operations react
+instead of treating policy denial as an unexpected Python exception. The trade-off is that the
+check is tied to `_act()`, not to the callable boundary.
+
+### D5 — Signals are observation, not authority
+
+Signals inherit identity, timestamp, and metadata from `Element` and add this envelope
+(`lionagi/protocols/generic/element.py`; `lionagi/session/signal.py`):
+
+```python
+class Element(BaseModel, Observable):
+    id: UUID = Field(default_factory=uuid4, frozen=True)
+    created_at: float = Field(default_factory=lambda: now_utc().timestamp(), frozen=True)
+    metadata: dict = Field(default_factory=dict)
+
+
+SIGNAL_SCHEMA_VERSION: int = 1
+
+
+class Signal(Element):
+    data: Any = None
+    emitter_role: str | None = None
+    schema_version: int = SIGNAL_SCHEMA_VERSION
+
+
+class GateDenied(Signal):
+    pass
+```
+
+Observer and persistence contracts
+(`lionagi/session/observer.py`):
+
+```python
+_PAYLOAD_BYTE_CAP: int = 16_384
+
+async def SessionObserver.emit(self, event: Any) -> list[Any]: ...
+
+def SessionObserver.bind_db_persistence(
+    self,
+    session_id: str,
+    db: Any = None,
+) -> None: ...
+
+def SessionObserver.unbind_db_persistence(self) -> None: ...
+```
+
+The optional table is
+(`lionagi/state/schema.sql`; mirrored by `lionagi/state/schema_meta.py`):
+
+```sql
+CREATE TABLE IF NOT EXISTS session_signals (
+  id          TEXT    PRIMARY KEY,
+  session_id  TEXT    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  seq         INTEGER NOT NULL,
+  kind        TEXT    NOT NULL,
+  op_id       TEXT    NOT NULL DEFAULT '',
+  ts          REAL    NOT NULL,
+  payload     JSON    NOT NULL DEFAULT '{}'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_signals_seq
+  ON session_signals(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_session_signals_session_ts
+  ON session_signals(session_id, ts);
+```
+
+Exact semantics:
+
+- `emit()` wraps a non-`Observable` object in `Signal(data=event)`. For a `Signal`, filters and
+  the event gate see `signal.data`; other observable events are their own payload.
+- When an observer gate exists, a false result or exception denies dispatch. The event is still
+  added to the in-memory `Flow`, but routes and subscribers are skipped and `emit()` returns an
+  empty list.
+- Persistence is one ordinary `Signal` subscription. Therefore a gate-denied emitted signal is
+  not persisted because subscriber dispatch is skipped.
+- `authorize()` adds `GateDenied` directly to the flow rather than calling `emit()`. That denial
+  does not reach routes, subscribers, or the database persistence subscription.
+- `bind_db_persistence()` persists only `Signal` instances. With a supplied database handle it
+  reuses that handle. Without one it opens the default state database only if the path exists.
+- Every persistence exception is swallowed. Missing database state, serialization fallback, or
+  insert failure cannot alter the producing run.
+- Signal payloads are converted to JSON-safe data. `MessageAdded` stores only a compact
+  `message_ref` with available identity/role endpoints, not the message body. Unknown values
+  fall back to string or `repr` forms.
+- The payload column is capped at 16,384 serialized UTF-8 bytes. Oversize content becomes a
+  dictionary with `truncated`, `original_bytes`, and a clipped `data` string. The cap bounds the
+  stored payload; the surrounding SSE frame can be larger. The code records the bounding
+  purpose but no rationale for choosing exactly 16 KiB.
+- `insert_session_signal()` assigns a one-based `seq` as `MAX(seq)+1` inside the write
+  transaction. SQLite uses its immediate transaction serialization; PostgreSQL takes an
+  advisory transaction lock by session ID. Reads use `seq > after_seq`, ascending order, and a
+  default page limit of 500. Pagination bounds one read response; the source records no rationale
+  for selecting exactly 500.
+- Rows disappear when their parent session is deleted because of `ON DELETE CASCADE`. The table
+  is append-oriented operational history, not immutable evidence.
+- On restart, persisted rows remain when the selected database remains, but the observer flow,
+  subscriptions, routes, and gate must be rebuilt.
+
+Why this way: the observer bus prioritizes lifecycle progress and debugging without allowing
+telemetry failures to fail work. Payload reduction and best-effort writes are appropriate for
+that role. Those same properties preclude completeness, immutability, and authority claims.
+
+### D6 — Adapters, logs, memory, and completion evidence keep narrow meanings
+
+The generic adapter protocol converts representations
+(`lionagi/adapters/_base.py`):
+
+```python
+@runtime_checkable
+class Adapter(Protocol[T]):
+    adapter_key: ClassVar[str]
+    obj_key: ClassVar[str]
+
+    @classmethod
+    def from_obj(
+        cls,
+        subj_cls: type[T],
+        obj: Any,
+        /,
+        *,
+        many: bool = False,
+        adapt_meth: str | Callable = "model_validate",
+        adapt_kw: dict[str, Any] | None = None,
+        **kw: Any,
+    ) -> T | list[T]: ...
+
+    @classmethod
+    def to_obj(
+        cls,
+        subj: T | list[T],
+        /,
+        *,
+        many: bool = False,
+        adapt_meth: str | Callable = "model_dump",
+        adapt_kw: dict[str, Any] | None = None,
+        **kw: Any,
+    ) -> Any: ...
+```
+
+It defines no invocation wrapper, policy input, or execution lifecycle.
+
+Operational logging is configurable and mutable
+(`lionagi/protocols/generic/log.py`):
+
+```python
+class DataLoggerConfig(BaseModel):
+    persist_dir: str | Path = "./data/logs"
+    subfolder: str | None = None
+    file_prefix: str | None = None
+    capacity: int | None = None
+    extension: str = ".json"
+    use_timestamp: bool = True
+    hash_digits: int | None = Field(5, ge=0, le=10)
+    auto_save_on_exit: bool = True
+    clear_after_dump: bool = True
+```
+
+`DataLogger.dump()` clears entries after a successful dump when configured, and some JSON
+serialization failure paths also clear unless the caller explicitly passes `clear=False`.
+`DataLogger.adump()` snapshots under a lock, writes outside it, and clears only snapshot IDs
+after a successful write. `capacity=None` deliberately leaves collection size unbounded until a
+caller sets a cap. The five-digit filename hash default and accepted zero-to-ten range reduce
+filename collisions, but the source records no rationale for those exact numbers. These are
+operational retention choices, not append-only evidence.
+
+The memory protocol stores and searches caller content
+(`lionagi/protocols/memory.py`):
+
+```python
+@runtime_checkable
+class MemoryStore(Protocol):
+    async def store(self, item: MemoryItem) -> UUID: ...
+    async def retrieve(self, item_id: UUID) -> MemoryItem | None: ...
+    async def search(self, query: MemoryQuery) -> list[MemoryItem]: ...
+```
+
+It has no compare-and-append, ordered chain read, historical policy version, or verification
+operation.
+
+Completion evidence is a local Git-state result
+(`lionagi/state/completion_evidence.py`):
+
+```python
+_GIT_TIMEOUT = 5
+
+
+class CompletionEvidence(TypedDict):
+    checked: bool
+    ahead_of_base: bool | None
+    commits_ahead: int | None
+    dirty: bool | None
+    base_ref: str | None
+    reason: str
+
+
+def check_completion_evidence(
+    cwd: str | None,
+    *,
+    base_ref: str | None = None,
+) -> CompletionEvidence: ...
+
+
+def has_completion_evidence(evidence: CompletionEvidence) -> bool: ...
+```
+
+Exact completion semantics:
+
+- The probe runs fixed local Git commands with no shell and a five-second timeout per command.
+  The timeout exists to bound a local completion check; no recorded rationale selects exactly
+  five seconds.
+- Missing `cwd`, a non-repository directory, a failed status probe, or a failed decisive
+  revision-count probe returns `checked=False`. `has_completion_evidence()` then returns false,
+  meaning no opinion rather than proof of no work.
+- Base resolution tries a caller value, the remote default symbolic ref, then
+  `origin/main`, `origin/master`, `main`, and `master`.
+- With no resolvable base, the probe can still return `checked=True` and report working-tree
+  dirtiness while `ahead_of_base` and `commits_ahead` remain `None`.
+- Evidence is positive when the checked repository is ahead of the resolved base or dirty. It
+  carries no tool-call decisions, policy identity, chain hash, or verification method.
+
+Why this way: each facility solves a concrete local need—representation conversion, operational
+logging, recall, or completion signaling. Reusing their names for governance would broaden
+their contracts without changing the behaviors that make them non-authoritative.
+
+## Shipped component boundaries
+
+```mermaid
+flowchart LR
+    AS[AgentSpec] --> AF[create_agent]
+    PP[PermissionPolicy] --> AF
+    GH[Built-in and user hooks] --> AF
+    AF --> TL[Configured Tool]
+    ACT[act operation] --> SO[SessionObserver authorize]
+    SO -->|allow| AM[ActionManager]
+    SO -->|deny| DR[Denied action response]
+    AM --> FC[FunctionCalling]
+    TL --> FC
+    FC --> PY[Python or MCP callable]
+    SO --> FL[In-memory Flow]
+    SO -. allowed Signal subscriber .-> SS[(session_signals)]
+```
+
+The tool-local path and the session path meet only because `_act()` performs session
+authorization before invoking the configured `Tool`. Neither component owns the other.
+
+## Execution sequence as shipped
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Act as act operation
+    participant Obs as SessionObserver
+    participant AM as ActionManager
+    participant FC as FunctionCalling
+    participant Pre as Tool preprocessor
+    participant Tool as Python callable
+
+    Caller->>Act: action request
+    Act->>Obs: authorize(ToolInvocation)
+    alt no observer or no gate
+        Obs-->>Act: true
+    else gate false or raises
+        Obs-->>Act: false + in-memory GateDenied
+        Act-->>Caller: ActionResponseModel with denial payload
+    else gate allows
+        Obs-->>Act: true
+        Act->>AM: invoke(request)
+        AM->>FC: create and invoke
+        FC->>Pre: security → user → security
+        alt preprocessor raises
+            FC-->>AM: FAILED event with execution.error
+        else processors allow
+            FC->>Tool: call once
+            Tool-->>FC: result or exception
+            FC-->>AM: COMPLETED or FAILED event
+        end
+        AM-->>Act: FunctionCalling
+        Act-->>Caller: response field as action output
+    end
+```
+
+## Consequences
+
+Positive consequences:
+
+- D1 gives library callers allow-all, deny-all, rules, safe, and read-only choices without a
+  policy service.
+- D2 protects factory-wired coding tools before invocation; a configured `PermissionPolicy`
+  is additionally rechecked after user transforms, while the built-in guards are not.
+- D3 preserves one processor mechanism for both synchronous and asynchronous callables.
+- D4 lets an attached session deny a proposed action before `ActionManager` and returns a form
+  iterative operations can observe.
+- D5 provides typed lifecycle observation, in-memory routing, and optional ordered persistence
+  without making telemetry a run dependency.
+- D6 keeps generic infrastructure small and independently useful.
+
+Negative and maintenance consequences:
+
+- D1 and D4 expose different result types, reason behavior, and configuration owners. A
+  contributor debugging a denial must identify which plane fired.
+- D2 controls are properties of the constructed `Tool` instances. New registration paths must
+  opt into the same factory wiring or remain outside its coverage.
+- D3 captures processor exceptions inside `FunctionCalling`, while D4 returns a denial payload
+  before a `FunctionCalling` exists. Consumers cannot treat the two paths as one verdict.
+- D4 can be bypassed through direct manager invocation or a standalone branch. Reversing this
+  requires moving enforcement to the callable boundary, not merely adding another session
+  callback.
+- D5 cannot support an audit completeness claim: authorization denials do not pass through
+  persistence, gated emissions skip subscribers, payloads can be truncated, writes can fail
+  silently, and parent-session deletion cascades.
+- D6 means a future evidence system needs its own protocol and store rather than a mode flag on
+  an adjacent facility.
+
+Cost of reversal by decision:
+
+| Decision | Reversal cost |
+|---|---|
+| D1 | Medium: existing policy constructors and hook behavior are public library surface and need adapters or compatibility shims. |
+| D2 | Medium: hook ordering is regression-tested; changing it can reopen transformed-argument bypasses. |
+| D3 | High: the processor/callable lifecycle is shared by all tool invocation and MCP wrappers. |
+| D4 | Medium: denial response and standalone-allow behavior are visible to action callers and tests. |
+| D5 | Low for adding a separate authoritative store; high for trying to make the observer table itself authoritative. |
+| D6 | Low if new governance types remain separate; high if generic adapter, log, or memory protocols are widened. |
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Define one immutable `GateResult` contract and adapters for `PermissionPolicy`, built-in guards, and the session gate; accept when each configured control runs exactly once, an evaluator exception produces a recorded deny result, and every security-relevant control (built-in coding guards included) evaluates the final post-mutation arguments — closing the current asymmetry in which only an explicit `PermissionPolicy` is re-run after a mutating user pre-hook. Security-relevant. | M | (filled at issue-open time) |
+| 2 | Add a governed invocation controller at the callable boundary; accept when every LionAGI route to a policy-bound `Tool` reaches the controller and no raw manager or function-calling route can bypass it. | L | (filled at issue-open time) |
+| 3 | Add an append-only evidence store and verifier independent of `DataLogger` and session signals; accept when permit, denial, callable failure, and completion records verify as one chain, mutation is detected, and an append failure blocks governed execution. | L | (filled at issue-open time) |
+| 4 | Bind an immutable policy snapshot and operation provenance to governed execution; accept when concurrent calls cannot exchange gate results, every evidence record names the active policy version, and historical snapshots remain retrievable. | L | (filled at issue-open time) |
+| 5 | Mint a process certificate only at an explicit task boundary; accept when missing evidence, failed verification, or unavailable policy history prevents minting and an approved exception remains permanently marked degraded. | L | (filled at issue-open time) |
+| 6 | Project governance evidence into observer signals without making signals authoritative; accept when projections carry evidence identifiers, export failure cannot alter evidence, and ordinary lifecycle persistence remains best-effort. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### Keep only tool hooks as the long-term governance design
+
+This would reuse the smallest shipped mechanism and preserve local enforcement. It lost because
+hooks do not share a typed verdict, policy version, operation identity, or authoritative record;
+they also cannot describe callable failures after a preprocessor has returned. Alternate tool
+registration and invocation routes remain a concrete coverage gap.
+
+### Make the session gate the sole mandatory authorization layer
+
+This would produce one obvious callback at session scope and retain the explicit denied action
+response. It lost because standalone branches permit, removed branches lose the observer, direct
+`ActionManager.invoke()` does not consult the observer, and one callback is also reused for
+heterogeneous event payloads. Moving the same callback to more call sites would still leave no
+typed result or evidence chain.
+
+### Treat `session_signals` as the evidence store
+
+This would reuse ordered per-session sequence numbers and an existing database table. It lost
+because the persistence handler is best-effort, gate-denied emissions skip subscribers,
+authorization `GateDenied` values never call `emit()`, payloads are capped and can be lossy, and
+session deletion cascades to the rows. Those are observed storage semantics, not missing
+documentation.
+
+### Treat `DataLogger` as the evidence store
+
+This would reuse existing file persistence and immutable-on-deserialization `Log` entries. It
+lost because live logs are mutable collection members, dumping normally clears them, some
+serialization failures may also clear them, and there is no atomic chain append or verifier.
+
+### Treat `MemoryStore` as the evidence store
+
+This would provide an injected protocol and an in-memory reference backend. It lost because
+`store`/`retrieve`/`search` is caller-content storage with no ordered append, expected-head
+conflict rule, immutable policy history, or tamper verification. Widening it would couple recall
+and governance retention.
+
+### Reinterpret the generic adapter protocol as an execution wrapper
+
+This would reuse a registry and `from_obj`/`to_obj` extension points. It lost because adapters
+are stateless representation conversion. Adding invocation, authorization, and evidence
+lifecycle semantics would violate that stable boundary and force unrelated adapters to
+understand tools.
+
+### Use completion evidence as an audit record
+
+This would reuse a simple, local completion signal. It lost because the payload answers only
+whether a Git worktree is dirty or ahead of a base. Probe failure deliberately means “no
+opinion,” and no field identifies a tool call, policy decision, or causal chain.
+
+### Change the unconfigured default to deny
+
+This would reduce accidental execution when a caller forgets configuration. It lost for the
+retrospective contract because plain `Branch` and `AgentSpec` construction have established
+zero-configuration behavior. ADR-0087 instead makes fail-closed behavior conditional on an
+explicit governed binding, preserving ordinary library use.
+
+## Notes
+
+The two authorization planes are independent, not layered guarantees. A call can pass a session
+gate and fail a tool-local preprocessor, or bypass the session plane and still encounter a
+preprocessor. No current record binds both outcomes to one operation or policy snapshot.
+
+The public runtime defines no policy-scope, identity-isolation, evidence-chain, certificate, or
+governance-tracing contract. That absence is part of the retrospective truth, not a proposal to
+fill all adjacent concerns in this ADR.

--- a/docs/adr/ADR-0087-evidence-backed-governed-execution.md
+++ b/docs/adr/ADR-0087-evidence-backed-governed-execution.md
@@ -1,0 +1,958 @@
+# ADR-0087: Evidence-Backed Governed Execution
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: governance
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0039, v0-0041, v0-0042, v0-0043, v0-0044, v0-0045, v0-0046, v0-0047, v0-0048, v0-0049, v0-0050, v0-0051, v0-0052; extends ADR-0086
+
+## Context
+
+ADR-0086 records two shipped control planes: factory-installed tool processors and an optional
+session authorization callback. They can block individual calls, but they cannot prove which
+policy and checks governed one operation. Their denials have different representations,
+signals are non-authoritative, and concurrent operations have no immutable provenance record.
+
+**P1 — There is no common verdict.** `PermissionPolicy` returns a mutable string-valued
+`PermissionDecision`, processors raise exceptions, and the session gate collapses every result
+to `bool`. A certificate cannot summarize those incompatible shapes without first defining one
+typed result.
+
+**P2 — Enforcement can be bypassed inside LionAGI.** The action operation consults the session
+gate, but `ActionManager.invoke()` and direct `FunctionCalling` construction do not. A policy
+claim needs one interception point immediately before the callable, with a refusal path when a
+governed descriptor reaches an ungoverned route.
+
+**P3 — Current persistence cannot support an adherence claim.** `session_signals` persistence
+is best-effort and subscriber-based, `DataLogger` can clear entries, and `MemoryStore` has no
+ordered append or verifier. Governed execution requires an append failure to be part of control
+flow rather than an observability warning (`lionagi/session/observer.py`;
+`lionagi/protocols/generic/log.py`; `lionagi/protocols/memory.py`).
+
+**P4 — Policy and context must be pinned per operation.** A mutable session-global accumulator
+can leak gate results or policy versions between concurrent calls. Each invocation needs its own
+immutable operation ID, chain, parent reference, tool ID, and exact policy snapshot.
+
+**P5 — Evidence must be useful without collecting sensitive values by default.** Raw tool
+arguments and results can contain secrets or unrestricted caller content. The evidence contract
+needs canonical approved payloads and digests, with raw values excluded unless a caller
+deliberately supplies a redacted evidence field.
+
+**P6 — A process certificate has a narrow epistemic boundary.** It can establish that declared
+checks ran under a retrievable policy and that the referenced evidence chain verifies. It cannot
+establish that the tool result is correct, high-quality, safe, or legally compliant.
+
+**P7 — Existing controls must compose, not fork.** `PermissionPolicy`, built-in guards, user
+argument hooks, and the installed session gate are useful enforcement seams. A governed mode
+must adapt them into the common result rather than independently evaluating the same control on
+both old and new paths.
+
+**P8 — Later gate families have prerequisites.** Time-bounded permits, separation-of-duties
+checks, and break-glass require actor references, immutable policy versions, and authoritative
+evidence. Shipping those concepts before the foundation would create a stronger name than the
+implementation can support.
+
+The earlier governance corpus split evidence, certificates, tools, gates, overrides, permits,
+policy records, context, registries, and tracing into separate designs. Those concepts form one
+dependency chain: evidence precedes certificates; executable gate bindings precede policy
+activation; actor references and recorded decisions precede exceptional access; observation is
+a projection of all three. This ADR consolidates that chain and sequences it.
+
+| Concern | Decision |
+|---|---|
+| Package and interception boundary | D1: Add one optional governance package and a no-bypass controller for policy-bound tools. |
+| Immutable records and hashing | D2: Use frozen Python models, canonical JSON, and a versioned SHA-256 chain contract. |
+| Evidence persistence | D3: Inject an append-only `EvidenceStore` with per-chain atomic append and verification. |
+| Gate evaluation | D4: Adapt current controls once into `GateResult` and apply hard, soft, and advisory semantics fail-closed. |
+| Context and policy | D5: Pin immutable `OperationContext` and exact `PolicySnapshot` versions with deterministic binding resolution. |
+| Certificate minting | D6: Mint a process-only `TaskCertificate` only from a closed explicit boundary and verified evidence. |
+| Observation | D7: Project committed evidence identifiers to session signals without making signals authoritative. |
+| Later controls | D8: Defer permits, duty separation, break-glass, and external wrappers until the core contracts ship. |
+
+This ADR does **not** decide:
+
+- How actor references are authenticated. A supplied actor reference is policy input, not proof
+  of identity.
+- Cross-caller isolation. Scope labels and resource IDs do not create an isolation boundary.
+- An external policy service or mandatory database. All durable implementations are injected.
+- Governance of arbitrary Python calls made outside LionAGI.
+- Correctness or quality of tool outcomes.
+- The public convenience API for opening and closing task boundaries. D6 defines the internal
+  contract and retains that façade as a deferred choice.
+
+## Decision
+
+### D1 — One optional package owns governed invocation
+
+The target module tree is:
+
+```text
+lionagi/governance/
+├── __init__.py          public types and protocols
+├── models.py            immutable contexts, verdicts, records, policies, certificates
+├── canonical.py         approved-payload canonicalization and sha256-v1 hashing
+├── protocols.py         GateAdapter, EvidenceStore, PolicySnapshotStore
+├── evidence.py          verifier and InMemoryEvidenceStore reference backend
+├── policy.py            activation, binding resolution, historical lookup
+├── controller.py        InvocationController and no-bypass invocation token
+├── certificate.py       CertificateIssuer and mint validation
+├── projection.py        committed-evidence → observer signal projection
+└── deferred.py          type reservations for D8; no executable gate registration
+```
+
+The opt-in binding added to the existing construction surface is:
+
+```python
+@dataclass(frozen=True, slots=True)
+class GovernanceBinding:
+    policy_id: UUID
+    policy_version: str
+    task_boundary_id: UUID
+    evidence_store: EvidenceStore
+    policy_store: PolicySnapshotStore
+    gate_adapters: tuple[GateAdapter, ...]
+
+
+@dataclass
+class AgentSpec(HooksMixin):
+    # Existing fields remain unchanged.
+    governance: GovernanceBinding | None = None
+```
+
+`create_agent()` resolves the exact snapshot before returning a branch. When `governance is
+None`, tool registration and invocation remain byte-for-byte on the current path. When it is
+present, the factory installs one `InvocationController` on the branch's `ActionManager` and
+marks every tool registered on that manager with an excluded runtime descriptor:
+
+```python
+class GovernedToolBinding(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tool_id: str
+    policy_id: UUID
+    policy_version: str
+
+
+class Tool(Element):
+    governance_binding: GovernedToolBinding | None = Field(default=None, exclude=True)
+```
+
+The controller surface is:
+
+```python
+class InvocationController:
+    async def invoke(
+        self,
+        call: FunctionCalling,
+        *,
+        context: OperationContext,
+    ) -> Any: ...
+
+
+class ActionManager(Manager):
+    async def invoke(
+        self,
+        func_call: ActionRequest | BaseModel | dict,
+        *,
+        operation_context: OperationContext | None = None,
+    ) -> FunctionCalling: ...
+```
+
+Exact boundary semantics:
+
+- An unbound `Tool` follows the existing preprocessor → callable → postprocessor path and
+  produces no governance records.
+- A bound `Tool` always enters `InvocationController.invoke()` immediately before its callable.
+  `ActionManager.invoke()`, `_act()`, and direct `FunctionCalling.invoke()` all converge there.
+- A bound tool presented without its manager's controller, without an `OperationContext`, or
+  with a context pinned to a different tool or policy fails with `GovernanceBypassError` before
+  the callable.
+- The controller alone creates a private one-use invocation token accepted by the internal
+  callable helper. The token is consumed before the call and cannot be reused. This prevents a
+  second LionAGI route from calling the helper after governance evaluation.
+- Directly calling `tool.func_callable(...)` outside LionAGI remains possible and outside the
+  guarantee. The descriptor is a library boundary, not a Python sandbox.
+- Tools registered after branch construction inherit the manager's active binding. Registration
+  rejects a supplied conflicting `GovernedToolBinding`.
+- Process restart requires reconstructing the binding and injected stores. A durable evidence or
+  policy backend may preserve records; the in-memory reference backends do not.
+
+Why this way: the controller is a new responsibility but not a parallel dispatcher. Existing
+schema matching, `FunctionCalling`, and action response handling remain the invocation path.
+The descriptor makes accidental internal bypass detectable while preserving plain-tool
+compatibility.
+
+### D2 — Records are frozen and hashes have one canonical algorithm
+
+All public governance models use:
+
+```python
+class GovernanceModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+```
+
+Nested collections in authoritative records are tuples or canonical JSON strings, not mutable
+lists or dictionaries. Identifiers are opaque UUIDs. Time fields use Pydantic `AwareDatetime`,
+must have a UTC offset, and serialize as `YYYY-MM-DDTHH:MM:SS.ffffffZ`.
+
+The closed record taxonomy is:
+
+```python
+class EvidenceType(str, Enum):
+    POLICY_BOUND = "policy_bound"
+    OPERATION_STARTED = "operation_started"
+    GATE_EVALUATED = "gate_evaluated"
+    EXCEPTION_GRANTED = "exception_granted"
+    OPERATION_DENIED = "operation_denied"
+    CALLABLE_COMPLETED = "callable_completed"
+    CALLABLE_FAILED = "callable_failed"
+    TASK_CLOSED = "task_closed"
+    RECORD_SUPERSEDED = "record_superseded"
+```
+
+The evidence record is exact:
+
+```python
+Digest = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+
+
+class EvidenceRecord(GovernanceModel):
+    record_id: UUID
+    record_type: EvidenceType
+    chain_id: UUID
+    operation_id: UUID | None
+    sequence: int = Field(ge=0)
+    policy_id: UUID
+    policy_version: str
+    payload_json: str
+    payload_digest: Digest
+    previous_chain_hash: Digest | None
+    chain_hash: Digest
+    supersedes_record_id: UUID | None = None
+    created_at: AwareDatetime
+    hash_algorithm: Literal["sha256-v1"] = "sha256-v1"
+```
+
+Canonicalization and hashing semantics (`lionagi/governance/canonical.py`, target):
+
+- Approved payload input accepts only `None`, booleans, integers, strings, lists/tuples of
+  approved values, and mappings with string keys. Floats, bytes, arbitrary objects, and nonfinite
+  numbers are rejected. Durations are represented as integer microseconds.
+- UUIDs, enums, and aware datetimes are projected to strings before approval. Datetimes are
+  normalized to UTC with six fractional digits and a terminal `Z`.
+- `payload_json` is UTF-8 JSON produced with sorted keys, separators `(",", ":")`,
+  `ensure_ascii=False`, and no NaN values.
+- `payload_digest = sha256(payload_json.encode("utf-8")).hexdigest()`.
+- `chain_hash` is SHA-256 over canonical JSON containing every record field except
+  `chain_hash`, including `payload_digest` and `previous_chain_hash`. The genesis record uses
+  `previous_chain_hash=None`.
+- `sha256-v1` is the only algorithm accepted by the first verifier. The version is stored on
+  every record so a future algorithm can coexist without silently changing old verification.
+- Corrections never mutate a prior record. They append `RECORD_SUPERSEDED` with
+  `supersedes_record_id` and a payload explaining the corrected approved fields.
+- Raw arguments, results, secrets, and unrestricted free text are not approved evidence fields.
+  Adapters may add explicitly redacted strings, field-name lists, schema IDs, counts, tool IDs,
+  and digests.
+
+SHA-256 is selected because Python ships it in `hashlib`, every supported backend can reproduce
+it, and this workload does not need a new hashing dependency. This chain detects content or link
+changes relative to a trusted expected head; it is not a digital signature and does not prevent
+an actor with authority to rewrite the entire store and replace the trusted head.
+
+### D3 — `EvidenceStore` is append-only and authoritative
+
+The storage protocol and result shapes are:
+
+```python
+class VerificationFailureCode(str, Enum):
+    BROKEN_LINK = "broken_link"
+    CONTENT_MISMATCH = "content_mismatch"
+    MISSING_POLICY = "missing_policy"
+    UNSUPPORTED_ALGORITHM = "unsupported_algorithm"
+
+
+class AppendReceipt(GovernanceModel):
+    chain_id: UUID
+    record_id: UUID
+    sequence: int
+    head_hash: Digest
+
+
+class VerificationResult(GovernanceModel):
+    valid: bool
+    verified_head: Digest | None
+    checked_records: int = Field(ge=0)
+    failure_code: VerificationFailureCode | None = None
+    failed_record_id: UUID | None = None
+
+
+@runtime_checkable
+class EvidenceStore(Protocol):
+    async def append(self, record: EvidenceRecord) -> AppendReceipt: ...
+
+    async def read(
+        self,
+        chain_id: UUID,
+        *,
+        after_sequence: int = -1,
+    ) -> tuple[EvidenceRecord, ...]: ...
+
+    async def head(self, chain_id: UUID) -> Digest | None: ...
+
+    async def verify(
+        self,
+        chain_id: UUID,
+        expected_head: Digest,
+    ) -> VerificationResult: ...
+```
+
+There is intentionally no update or delete operation.
+
+Exact store semantics:
+
+- Append is atomic for one chain. A missing chain accepts only `sequence=0` and
+  `previous_chain_hash=None`. An existing chain accepts only the next integer sequence and a
+  `previous_chain_hash` equal to its current head.
+- The store recomputes payload and chain hashes before commit. Invalid content raises
+  `EvidenceIntegrityError`; a stale previous head, wrong sequence, duplicate record ID, or
+  duplicate chain hash raises `EvidenceConflictError`. Duplicate append is not treated as
+  idempotent success because replay would obscure whether the producing control ran twice.
+- Chains are independent. No cross-chain transaction is promised.
+- The controller owns one async append lock per active task chain. Head lookup, record
+  construction, and `append()` run under that lock; callable execution does not. Concurrent
+  operations may therefore interleave records but cannot manufacture the same next sequence in
+  one process. A conflict from an independent writer is not retried silently and fails closed.
+- `read()` returns ascending sequence order and an empty tuple on miss. `after_sequence=-1`
+  returns the full chain.
+- `verify()` treats an empty chain, nonzero first sequence, sequence gap, wrong previous hash, or
+  expected-head mismatch as `BROKEN_LINK`. Payload rehash failure is `CONTENT_MISMATCH`.
+  Unknown `hash_algorithm` is `UNSUPPORTED_ALGORITHM`. It stops at the first failure.
+- `checked_records` counts records fully verified before the failure, or the entire chain on
+  success. `verified_head` is the last verified hash, which is `None` when the first record
+  fails.
+- `MISSING_POLICY` is produced by certificate verification after chain verification when the
+  exact policy version cannot be retrieved; the evidence store itself does not depend on a
+  policy store.
+- `InMemoryEvidenceStore` uses one async lock per chain and implements the full conflict and
+  verifier contract. It is a semantic reference and test seam, not durable storage.
+- A durable implementation must commit the record and head compare in one backend transaction
+  and preserve records across restart. Durability beyond that transaction depends on the
+  injected backend.
+
+Controller failure behavior is also fixed:
+
+- A failure appending policy, context, gate, exception, or denial records before invocation
+  raises `GovernanceEvidenceError(call_executed=False)` and the callable is not reached.
+- After a callable succeeds, failure to append `CALLABLE_COMPLETED` raises
+  `GovernanceEvidenceError(call_executed=True)`; the callable is never retried automatically.
+- If the callable raises and `CALLABLE_FAILED` appends successfully, its original exception is
+  re-raised. If that append also fails, the controller raises `OutcomeEvidenceError` containing
+  both the callable and store exceptions and marks the operation uncertifiable.
+- Any missing terminal record prevents D6 minting. A process restart does not infer a terminal
+  state from absence.
+
+Why this way: compare-and-append makes conflicts explicit and gives the verifier one ordered
+history. Fail-open evidence would let a caller receive a result carrying a governance claim that
+the system cannot substantiate.
+
+### D4 — Existing controls adapt into one `GateResult`
+
+The common gate contract is:
+
+```python
+class GateLevel(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+    ADVISORY = "advisory"
+
+
+class GateDecision(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+class GateResult(GovernanceModel):
+    result_id: UUID
+    gate_id: str
+    level: GateLevel
+    decision: GateDecision
+    reason_code: str
+    detail: str | None
+    operation_id: UUID
+    policy_version: str
+    evaluated_at: AwareDatetime
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptedControlResult:
+    arguments: Mapping[str, Any]
+    gate_results: tuple[GateResult, ...]
+
+
+@runtime_checkable
+class GateAdapter(Protocol):
+    gate_id: str
+
+    async def evaluate(
+        self,
+        *,
+        tool: Tool,
+        arguments: dict[str, Any],
+        context: OperationContext,
+    ) -> AdaptedControlResult: ...
+```
+
+`arguments` is transient, not evidence. The controller makes a private dictionary copy after
+each adapter and never stores the mapping by reference. It can therefore preserve the current
+tool argument surface, including values that are intentionally outside D2's approved evidence
+payload types.
+
+Exact evaluation semantics:
+
+- Policy activation rejects a gate binding whose `gate_id` has no registered adapter. A
+  governed tool with no applicable gate binding denies with `policy.no_gate_binding`.
+- The controller invokes each applicable adapter once in snapshot order. It does not also run
+  the old session authorization or preprocessor path for the same control.
+- The built-in composite adapter preserves current hook phases: each security hook evaluates
+  original arguments, each user transform runs once, and—when a user transform exists—each
+  security hook evaluates the final arguments again. This is one composite-adapter invocation
+  with two intentional security phases, not evaluation from two dispatch paths.
+- `PermissionPolicy` allow/deny/escalate, destructive-command guards, path guards, and the
+  installed session callback each produce a distinct `GateResult` with their configured stable
+  `gate_id`.
+- A control returning normally produces `ALLOW`; a `PermissionError` or false session verdict
+  produces `DENY` with a stable adapter-owned `reason_code`; every other evaluator exception
+  produces `DENY` with `control.evaluator_error`. Exception text is not copied to evidence.
+- A hard deny appends `GATE_EVALUATED` and `OPERATION_DENIED`, then blocks.
+- A soft deny blocks unless a matching, attributable, unexpired exception record was appended
+  before evaluation. The exception and resulting allow remain visible and force a degraded
+  certificate.
+- An advisory deny is appended and may proceed. Advisory never changes to allow; the record
+  truthfully says the gate denied while policy allowed continuation.
+- Equal gate IDs in one resolved snapshot are invalid at activation. Gate result order follows
+  the snapshot's unique integer `order` fields.
+- The action layer maps `GovernanceDeniedError` to an action response containing `function`,
+  `operation_id`, and stable `reason_code`; it does not expose sanitized detail unless the caller
+  explicitly opts into that display.
+
+Why this way: binary decision and separate enforcement level avoid a third ambiguous decision
+state. The adapter preserves shipped controls while the controller becomes the only owner of
+when they run and when evidence commits.
+
+### D5 — Context and policy are immutable operation inputs
+
+The per-operation context is:
+
+```python
+class ActorRef(GovernanceModel):
+    kind: str
+    id: str
+
+
+class OperationContext(GovernanceModel):
+    operation_id: UUID
+    chain_id: UUID
+    task_boundary_id: UUID
+    session_id: UUID | None
+    branch_id: UUID | None
+    actor: ActorRef | None
+    parent_operation_id: UUID | None
+    tool_id: str
+    policy_id: UUID
+    policy_version: str
+    policy_digest: Digest
+    started_at: AwareDatetime
+
+    def child(self, *, operation_id: UUID, chain_id: UUID, tool_id: str) -> OperationContext: ...
+```
+
+`child()` returns a new model, retains the task and policy pin, and sets
+`parent_operation_id=self.operation_id`. Any other update uses `model_copy(update=...)` and
+revalidates; in-place assignment is forbidden.
+
+The policy shapes are:
+
+```python
+class PolicyReleaseState(str, Enum):
+    STAGED = "staged"
+    ACTIVE = "active"
+
+
+class PolicyScope(str, Enum):
+    GLOBAL = "global"
+    ROLE = "role"
+    RESOURCE = "resource"
+
+
+class ExecutableGateBinding(GovernanceModel):
+    gate_id: str
+    adapter_id: str
+    level: GateLevel
+    order: int = Field(ge=0)
+    tool_ids: tuple[str, ...]
+
+
+class PolicySnapshot(GovernanceModel):
+    policy_id: UUID
+    version: str
+    digest: Digest
+    gate_bindings: tuple[ExecutableGateBinding, ...]
+    release_state: PolicyReleaseState
+    activated_at: AwareDatetime | None = None
+    activated_by: ActorRef | None = None
+
+
+class PolicyBinding(GovernanceModel):
+    binding_id: UUID
+    scope: PolicyScope
+    selector: str | None
+    policy_id: UUID
+    policy_version: str
+    created_at: AwareDatetime
+
+
+@runtime_checkable
+class PolicySnapshotStore(Protocol):
+    async def put(self, snapshot: PolicySnapshot) -> None: ...
+
+    async def get(self, policy_id: UUID, version: str) -> PolicySnapshot | None: ...
+
+    async def activate(
+        self,
+        policy_id: UUID,
+        version: str,
+        *,
+        actor: ActorRef | None,
+        activated_at: AwareDatetime,
+    ) -> PolicySnapshot: ...
+
+    async def bind(self, binding: PolicyBinding) -> None: ...
+
+    async def resolve(
+        self,
+        *,
+        role: str | None,
+        resource: str | None,
+    ) -> PolicySnapshot: ...
+```
+
+Exact policy semantics:
+
+- `digest` covers policy ID, version, ordered executable gate bindings, levels, tool IDs, and
+  adapter IDs. It excludes release state and activation metadata. `put()` recomputes it.
+- Re-putting the exact `(policy_id, version, digest)` is idempotent. The same ID/version with a
+  different digest raises `PolicyConflictError`.
+- Activation is the only staged-to-active transition. It validates unique gate IDs, unique
+  order values, nonempty tool sets, and adapter availability; it returns a new frozen active
+  projection. Executable content never changes after activation.
+- Activation atomically replaces the staged release-state projection for that exact version;
+  `get()` returns the active projection afterward while executable content and its digest remain
+  unchanged. Every older policy version remains retrievable when the backend is durable.
+  Deleting historical snapshots is outside the protocol.
+- Bindings can reference only active versions. Activating a staged version affects bindings
+  created afterward; existing `OperationContext` values retain their exact pin.
+- Resolution matches supplied labels, with resource precedence over role and role over global.
+  More than one distinct candidate at the highest matching precedence raises
+  `AmbiguousPolicyError` and governed execution denies. No candidate raises
+  `PolicyNotFoundError` and denies.
+- `GLOBAL` requires `selector=None`; `ROLE` and `RESOURCE` require a nonempty selector. These
+  values are routing labels only and do not imply authenticated identity or isolation.
+- At invocation, the controller retrieves the exact version and compares its digest to the
+  context. Missing history or mismatch denies before any gate or callable.
+- Explicit context parameters are authoritative. A task-local `ContextVar` may bridge callbacks
+  that cannot accept a parameter, but the controller verifies its operation ID and resets it in
+  `finally`; it is never the record of truth.
+
+Why this way: pinning turns policy selection into an operation input instead of ambient mutable
+state. The three-scope resolver is the minimum explicit precedence needed by the first release;
+additional scope kinds require a later decision and tests.
+
+### D6 — Certificates mint only from closed, verified task evidence
+
+The certificate-side models are:
+
+```python
+class ProcessGrade(str, Enum):
+    FULL = "FULL"
+    DEGRADED = "DEGRADED"
+
+
+class ClosedTaskBoundary(GovernanceModel):
+    task_boundary_id: UUID
+    chain_id: UUID
+    policy_id: UUID
+    policy_version: str
+    opened_at: AwareDatetime
+    closed_at: AwareDatetime
+
+
+class GateSummary(GovernanceModel):
+    hard_allow: int = Field(ge=0)
+    hard_deny: int = Field(ge=0)
+    soft_allow: int = Field(ge=0)
+    soft_deny: int = Field(ge=0)
+    advisory_allow: int = Field(ge=0)
+    advisory_deny: int = Field(ge=0)
+    exception_count: int = Field(ge=0)
+
+
+class TaskCertificate(GovernanceModel):
+    certificate_id: UUID
+    task_boundary_id: UUID
+    policy_id: UUID
+    policy_version: str
+    evidence_chain_head: Digest
+    gate_summary: GateSummary
+    process_grade: ProcessGrade
+    minted_at: AwareDatetime
+
+
+class CertificateIssuer:
+    async def mint(
+        self,
+        boundary: ClosedTaskBoundary,
+        *,
+        expected_head: Digest,
+    ) -> TaskCertificate: ...
+```
+
+Exact mint semantics:
+
+- `closed_at` must be at or after `opened_at`; the chain must contain one matching
+  `TASK_CLOSED` record at the expected head.
+- The issuer calls `EvidenceStore.verify(chain_id, expected_head)` and refuses every invalid
+  result.
+- It retrieves the exact historical policy, recomputes its digest, and refuses absence or
+  mismatch with `VerificationFailureCode.MISSING_POLICY`.
+- Every `OPERATION_STARTED` under the task must have exactly one terminal
+  `OPERATION_DENIED`, `CALLABLE_COMPLETED`, or `CALLABLE_FAILED` record. Missing or duplicate
+  terminals prevent minting.
+- `GateSummary` is derived from committed `GATE_EVALUATED` records, never supplied by the
+  caller.
+- Any `EXCEPTION_GRANTED` record makes the grade permanently `DEGRADED`. A later correction may
+  explain the exception but cannot upgrade that certificate to `FULL`.
+- A chain with no exception records and complete required records mints `FULL`, including tasks
+  containing ordinary recorded denials or callable failures. Grade describes process adherence,
+  not successful outcome.
+- A certificate is frozen and can be serialized, but the first release does not call it a
+  signature. Authentication of a certificate requires a separately designed signing-key and
+  trust-root contract.
+
+**DEFERRED — public task-boundary façade.** The internal `ClosedTaskBoundary` and issuer contract
+are decided, but the convenience API that opens and closes a boundary is not. It must be selected
+before certificate implementation is exposed as usable. A session end, flow end, and individual
+operation are not interchangeable proofs. The retained candidates are:
+
+- `async with governed_task(...) as task:` — explicit and exception-safe, but adds a new context
+  manager to ordinary library code.
+- `controller.open_task()` / `controller.close_task()` — explicit and framework-neutral, but
+  callers can forget closure and need cleanup rules.
+- A required boundary argument on `Session.flow()` — natural for DAG work, but excludes direct
+  branch and manager use.
+
+The façade must produce a stable boundary ID at open, append `TASK_CLOSED` only once, reject
+double close, and make abandoned boundaries unmintable. No candidate is selected by this ADR.
+
+### D7 — Observation is a non-authoritative projection
+
+The target signal contains references, not evidence payloads:
+
+```python
+class GovernanceEvidenceProjected(Signal):
+    operation_id: str = ""
+    chain_id: str = ""
+    record_id: str = ""
+    record_type: str = ""
+    chain_hash: str = ""
+    policy_version: str = ""
+```
+
+The projector surface is:
+
+```python
+class ObservationProjector:
+    async def project(
+        self,
+        record: EvidenceRecord,
+        observer: SessionObserver | None,
+    ) -> None: ...
+```
+
+Exact semantics:
+
+- Projection occurs only after `EvidenceStore.append()` returns a receipt. An uncommitted record
+  is never announced.
+- The projector copies identifiers, record type, committed chain hash, and policy version. It
+  excludes `payload_json`, arguments, results, and sanitized detail.
+- Missing observer, observer gate denial, serialization error, subscriber error, or database
+  persistence failure is logged and swallowed. None changes the committed chain, callable
+  result, or certificate grade.
+- Projection may be sampled or disabled. A consumer that needs proof follows the identifiers to
+  the evidence store and verifies the expected head.
+- The generic adapter registry remains representation-conversion infrastructure. Any future
+  trace exporter consumes this signal or `EvidenceRecord` from a separate integration package.
+
+Why this way: operators retain lifecycle visibility without making a lossy transport part of
+the control or evidence plane.
+
+### D8 — Later gate families reuse the core and remain deferred
+
+These designs are retained but are **DEFERRED** until D1-D7 implementation gates pass.
+
+The common attributable exception shape is:
+
+```python
+class ExceptionGrant(GovernanceModel):
+    grant_id: UUID
+    actor: ActorRef
+    gate_id: str
+    tool_id: str
+    policy_id: UUID
+    policy_version: str
+    reason_code: str
+    issued_at: AwareDatetime
+    expires_at: AwareDatetime
+    max_uses: Literal[1] = 1
+    used_at: AwareDatetime | None = None
+```
+
+Deferred semantics:
+
+- **Time-bounded permit:** `expires_at` is mandatory and must be later than `issued_at`; there is
+  no default duration. Policy authors must choose and record the bound. A permit is actor-, tool-,
+  gate-, and policy-version-specific, can be consumed once, and denies on expiry, mismatch,
+  ambiguity, or unavailable evidence storage.
+- **Separation of duties:** a policy-selected hard `GateAdapter` compares caller-supplied actor
+  references against a closed tuple of incompatible duty IDs. Missing actor reference or
+  assignment history denies. The adapter makes no claim that the actor reference was
+  authenticated.
+- **Break-glass:** requires an attributable `ExceptionGrant` with an explicit expiry and reason.
+  The exception record must append before execution. It cannot override evidence or policy-store
+  failure and always forces `DEGRADED` for the task.
+- **Integration wrappers:** a wrapper for another agent framework calls
+  `InvocationController.invoke()` from a separate integration package and must pass the same
+  operation context. It does not modify `Adapter` or claim coverage over calls that bypass the
+  wrapper.
+
+The lack of a default permit or break-glass duration is intentional: no deployment evidence in
+the current library justifies a universal number. Encoding an inherited guess would make a
+security-sensitive budget look reasoned when it is not.
+
+## Component and dependency diagram
+
+The six target components and six directed dependencies are:
+
+```mermaid
+flowchart LR
+    IC[InvocationController] --> GA[GateAdapter]
+    IC --> ES[EvidenceStore]
+    IC --> PS[PolicySnapshotStore]
+    CI[CertificateIssuer] --> ES
+    CI --> PS
+    OP[ObservationProjector] --> ES
+```
+
+`κ = 6 / (6 × 5) = 0.20`. Stores and adapters are protocols; the reference evidence and policy
+stores are in memory, and canonicalization plus projection are pure. The isolated component-test
+target is `τ = 1.0` before integration tests.
+
+## Governed invocation sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant AM as ActionManager / FunctionCalling
+    participant GC as InvocationController
+    participant PS as PolicySnapshotStore
+    participant GA as GateAdapters
+    participant ES as EvidenceStore
+    participant Tool as Tool callable
+    participant Obs as ObservationProjector
+
+    Caller->>AM: invoke policy-bound Tool + OperationContext
+    AM->>GC: invoke(call, context)
+    GC->>PS: get exact policy version
+    PS-->>GC: frozen snapshot or error
+    GC->>ES: append policy_bound + operation_started
+    GC->>GA: evaluate applicable controls once
+    GA-->>GC: transformed arguments + GateResult tuple
+    GC->>ES: append gate_evaluated records
+    alt append or policy validation fails
+        GC-->>Caller: typed failure; callable not run
+    else hard or unresolved soft deny
+        GC->>ES: append operation_denied
+        GC-->>Caller: recorded GovernanceDeniedError
+    else permitted or advisory-only
+        GC->>Tool: invoke once with one-use token
+        alt callable returns
+            Tool-->>GC: result
+            GC->>ES: append callable_completed
+            GC-->>Obs: project committed identifiers
+            GC-->>Caller: result
+        else callable raises
+            Tool-->>GC: exception
+            GC->>ES: append callable_failed
+            GC-->>Obs: project committed identifiers
+            GC-->>Caller: original exception
+        end
+    end
+```
+
+## Implementation sequence and gates
+
+1. Ship D2-D3 immutable records, canonicalization, `InMemoryEvidenceStore`, and chain verifier
+   tests. Mutation, broken-link, stale-head, empty-chain, unsupported-algorithm, and concurrent
+   append tests must pass. No certificate type is exposed as usable before this gate.
+2. Ship D1 and D4 controller integration, adapters, `AgentSpec` binding, and no-bypass tests
+   across action, manager, and direct `FunctionCalling` entry points. Plain-tool compatibility
+   tests remain green, and each configured control runs only in its declared phases.
+3. Ship D5 immutable policy snapshots, historical lookup, deterministic activation and
+   resolution, and concurrent operation-context isolation tests. Missing and ambiguous policy
+   cases deny before callable execution.
+4. Ship D6 certificate verification and minting behind an explicitly selected task-boundary
+   façade. Include negative tests for open boundaries, missing terminals, changed content,
+   missing policy history, head mismatch, and permanent degraded grade.
+5. Ship D7 observation projection. Add D8 permits, duty separation, break-glass, integration
+   wrappers, and trace export only as consumers of the stable core contracts.
+
+## Consequences
+
+Positive consequences:
+
+- Governed deployments get one immutable decision vocabulary and causal per-operation records.
+- Compare-and-append plus an expected trusted head detects broken links and changed approved
+  payloads.
+- Exact historical policy versions make old chains verifiable after a new release activates.
+- The callable boundary closes LionAGI-internal manager and function-calling bypass routes for a
+  policy-bound `Tool`.
+- Injected protocols keep tests independent of a database or external policy service.
+- Certificates state a narrow process claim and retain exceptional paths as permanently
+  degraded.
+
+Negative and maintenance consequences:
+
+- The controller adds policy lookup, gate evaluation, hashing, and evidence writes to every
+  governed invocation. No latency budget is asserted until an implementation is measured.
+- Evidence storage becomes an intentional availability dependency. Before-call failure denies;
+  after-call failure can report that a side effect occurred without authoritative completion
+  evidence.
+- Policy authors must maintain stable gate IDs, reason codes, executable bindings, and historical
+  versions.
+- Canonical payload schemas require review whenever a new evidence type is added; storing “just
+  one more” raw field can violate the sensitive-value boundary.
+- A trusted expected head must come from outside the mutable chain for strong tamper detection.
+- Python descriptors prevent accidental framework bypass, not a caller deliberately invoking an
+  underlying callable.
+
+Reversal cost:
+
+| Decision | Reversal cost |
+|---|---|
+| D1 | High: every governed invocation route and tool descriptor depends on the controller boundary. |
+| D2 | High: changing canonicalization or hash input requires multi-algorithm verification for historical records. |
+| D3 | High: append and conflict semantics are backend compatibility contracts. |
+| D4 | Medium: adapters isolate current controls, but gate level and reason code are stored evidence. |
+| D5 | High: policy pins and resolution determine historical meaning. |
+| D6 | Medium before the public boundary façade is selected; high after certificates are externally retained. |
+| D7 | Low: projection is explicitly non-authoritative and replaceable. |
+| D8 | Low while deferred; each family requires its own acceptance gate before activation. |
+
+## Alternatives considered
+
+### Extend only `Tool.preprocessor`
+
+This would minimize changes and reuse current permission/guard wiring. It lost because a
+preprocessor cannot reliably record callable completion or failure, alternate manager routes can
+reach differently configured tools, and the processor contract returns transformed arguments
+rather than an authoritative operation outcome.
+
+### Add a parallel governed dispatcher
+
+This would keep current `ActionManager` untouched and make governed execution visibly separate.
+It lost because it duplicates schema matching, tool lookup, message projection, and error
+handling, while any caller selecting the old dispatcher keeps a bypass. The controller belongs
+inside the existing callable path.
+
+### Use session signals, `DataLogger`, or `MemoryStore` for evidence
+
+This would reduce the number of new protocols. It lost on observed contracts: signals are
+best-effort and can be skipped or truncated, logger dumps can clear entries, and memory has no
+ordered compare-and-append or verifier. Changing all three would couple unrelated lifecycle and
+retention policies.
+
+### Require an external policy engine and database
+
+This would provide durable deployment infrastructure and a mature policy language immediately.
+It lost because the library needs a testable optional capability and has no single required
+deployment stack. Protocol injection permits external implementations without making them the
+minimum runtime.
+
+### Keep one mutable context on `Session`
+
+This would make policy and gate results easy to access without threading parameters. It lost
+because concurrent calls can overwrite or observe each other's state, restart meaning is
+unclear, and historical evidence cannot prove which mutation was active. Explicit frozen
+contexts make the pin inspectable.
+
+### Make `ContextVar` authoritative
+
+This would reduce signature changes while preserving task-local behavior. It lost because task
+creation, callbacks, and copied contexts can propagate ambient values invisibly. A verified
+bridge remains allowed, but the explicit `OperationContext` is authoritative.
+
+### Store raw arguments and results in every record
+
+This would maximize forensic detail and let a verifier recompute more application behavior. It
+lost because arbitrary tool values can contain secrets and unrestricted content, and result
+correctness is outside the certificate claim. Approved canonical fields plus caller-supplied
+redaction provide a narrower, auditable surface.
+
+### Fail open when evidence is unavailable
+
+This would improve tool availability. It lost because a governed result without its required
+record cannot substantiate adherence. The selected behavior denies before the call and reports
+the irreversible “call executed, evidence missing” case after the call rather than silently
+calling it governed.
+
+### Use BLAKE3 or a pluggable algorithm from the first release
+
+This would offer faster hashing or early crypto agility. It lost because evidence records are
+small, SHA-256 is in the standard library, and `hash_algorithm` already creates a compatible
+future extension point. Multiple first-release algorithms would multiply verifier test cases
+without a measured need.
+
+### Make every certificate cryptographically signed
+
+This would let an external verifier authenticate an issuer when it trusts the key. It lost for
+the first release because key generation, custody, rotation, revocation, and trust roots are not
+defined. Calling an unsigned hash-chain summary a signature would overstate the contract.
+
+### Mint at every operation, session end, or flow end automatically
+
+Per-operation minting is precise but too narrow for a multi-operation task. Session-end minting
+can combine unrelated work. Flow-end minting excludes direct branch and manager use. None is
+selected implicitly; D6 retains an explicit boundary requirement and defers only its convenience
+façade.
+
+### Recreate current controls as new policy code
+
+This would give every gate a clean API immediately. It lost because it risks semantic drift from
+tested permission matching, path resolution, destructive patterns, and security-hook ordering.
+Adapters keep the current behavior visible while centralizing scheduling and evidence.
+
+### Put governance wrappers in the generic adapter package
+
+This would reuse an existing registry name and extension mechanism. It lost because the adapter
+protocol converts representations and has no execution lifecycle. A separate integration package
+can call the controller without changing that stable meaning.
+
+## Notes
+
+The six target components are `InvocationController`, `GateAdapter`, `EvidenceStore`,
+`PolicySnapshotStore`, `CertificateIssuer`, and `ObservationProjector`. The graph above contains
+six directed dependencies, so `κ = 0.20`; protocol injection and pure functions provide the
+`τ = 1.0` isolated-test target.
+
+The first implementation must settle the public task-boundary façade before exposing certificate
+minting as usable. All other core contracts in D1-D7 are committed by this proposal as the target
+shape; D8 remains deferred and may not be advertised as active.

--- a/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
+++ b/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
@@ -1,0 +1,598 @@
+# ADR-0090: Local Sandbox and Measured-Cell Backend Seams
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: substrates
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0079, v0-0080, v0-0089
+
+## Context
+
+Lionagi grew two related but non-equivalent local-execution surfaces. They share a Git-worktree
+implementation, but they answer different questions and have different callers.
+
+**P1 — “Sandbox” names two lifecycles.** `lionagi/tools/sandbox.py` is an interactive
+Git-worktree primitive used directly by `CodingToolkit`. `lionagi/tools/sandbox_backend.py` is a
+measured-cell adapter with provision, execute, collect, and teardown legs. Treating them as one
+universal abstraction hides the fact that the first can merge a branch while the second always
+tears a handle down without promotion.
+
+**P2 — Backend variance needs a typed boundary.** A local worktree and a Daytona workspace do
+not provision, execute, transfer files, or stream output the same way. The benchmark caller needs
+one contract that exposes those differences as capabilities rather than backend-class branches.
+
+**P3 — Prompt cells and exec cells have different authentication and execution placement.** A
+local prompt cell is a host subprocess in a worktree and rejects explicit cell environment
+variables. A Daytona adapter executes commands remotely and rejects prompt cells because it
+cannot keep their provider call host-side. Calling both simply “remote execution” would erase the
+load-bearing distinction.
+
+**P4 — Vocabulary is ahead of enforcement.** `ExecutionTarget` and `ExecutionLimits` describe
+host, worktree, remote, and process targets, but no flow, fanout, provider, or operation path reads
+them. `ExecutionLimits` is not consulted by either adapter. `Capabilities` describes cold-start,
+streaming, transfer, image-build, and prompt-cell support, but does not describe CPU, memory,
+disk, provision-resource, or timeout enforcement.
+
+**P5 — Lifecycle helpers expose partial-success states.** Diff collection stages changes; merge
+does not prove the repository root is on the recorded base branch; cleanup marks a session
+inactive even when removal fails; and the backend protocol returns no teardown result. A caller
+cannot infer transactional promotion or complete cleanup from these interfaces.
+
+**P6 — The measured-cell seam has one production-shaped consumer, not a control plane.** The
+only non-test client is `benchmarks/orchestration/harness/runner.py`. Its optional backend path
+provisions one workspace, runs one prompt-cell trial, collects one output artifact, and tears the
+handle down. It accepts the local adapter and rejects Daytona by capability. Normal benchmark
+entry points still call `run_once()` without a backend. `lionagi/operations/flow.py` and the CLI
+flow/fanout worker builders do not consume `ExecutionTarget` or `SandboxBackend`.
+
+The implemented module boundary is:
+
+```text
+lionagi/tools/
+├── coding.py             CodingToolkit.sandbox action facade
+├── sandbox.py            SandboxSession + five async worktree helpers
+├── sandbox_backend.py    measured-cell types, protocol, adapters, registry
+├── daytona.py            host-side async SDK wrapper
+└── _subprocess.py        bounded subprocess output + timeout handling
+
+benchmarks/orchestration/harness/
+├── runner.py             optional measured-cell consumer
+├── _cell_entry.py        prompt-cell subprocess entrypoint
+└── test_runner_backend.py
+```
+
+```mermaid
+flowchart LR
+    CT["CodingToolkit"] --> WS["sandbox.py\nlocal worktree primitive"]
+    BR["benchmark runner"] --> SB["SandboxBackend\nmeasured-cell contract"]
+    LW["LocalWorktreeBackend"] --> SB
+    LW --> WS
+    DB["DaytonaBackend"] --> SB
+    DB --> DW["daytona.py\nSDK wrapper"]
+```
+
+| Concern | Decision |
+|---|---|
+| Interactive local worktree lifecycle | D1: Keep `SandboxSession` and its five module-level helpers as the direct `CodingToolkit` primitive. |
+| Measured execution contract | D2: Keep the four-leg structural `SandboxBackend` protocol and its concrete Python data contracts. |
+| Cell placement, events, and artifacts | D3: Preserve the shipped prompt/exec distinction and each adapter's exact execution semantics. |
+| Backend selection | D4: Select registered adapters by name at construction and by `Capabilities` for workload suitability. |
+| Architectural boundary | D5: Treat execution targets and limits as descriptive vocabulary until an execution caller enforces them; do not present this seam as flow routing or a general control plane. |
+
+This ADR deliberately does **not** decide:
+
+- Per-worker orchestration isolation; ADR-0091 owns that target because worker ownership,
+  promotion, and restart recovery are not cell concerns.
+- Recursive experiment proposal, scoring, or promotion; no such loop is implemented in this
+  checkout, and the current seam must not imply one.
+- Additional registered adapters. The closed runtime registry contains only
+  `local_worktree | daytona`; other names fail.
+- Process, credential, network, or resource security. A worktree separates Git state, while the
+  local adapter still launches a host process with host filesystem reach.
+- Automatic merge or artifact promotion from `SandboxBackend.teardown()`. Teardown is disposal,
+  not acceptance of a result.
+
+## Decision
+
+### D1 — Keep the direct local-worktree lifecycle
+
+`lionagi/tools/sandbox.py` remains the source of truth for interactive worktrees. The public
+contract is a state-only dataclass plus five module-level async functions; `SandboxSession` has
+no lifecycle methods of its own.
+
+**The contract** (`lionagi/tools/sandbox.py`; `SandboxSession`, `create_sandbox`,
+`sandbox_diff`, `sandbox_commit`, `sandbox_merge`, `sandbox_discard`):
+
+```python
+@dataclass
+class SandboxSession:
+    worktree_path: str
+    branch_name: str
+    base_branch: str
+    repo_root: str
+    is_active: bool = True
+
+async def create_sandbox(
+    repo_root: str,
+    base_branch: str | None = None,
+    name: str | None = None,
+) -> SandboxSession: ...
+
+async def sandbox_diff(session: SandboxSession) -> dict: ...
+async def sandbox_commit(session: SandboxSession, message: str) -> dict: ...
+async def sandbox_merge(session: SandboxSession) -> dict: ...
+async def sandbox_discard(session: SandboxSession) -> dict: ...
+```
+
+The returned payloads are part of the shipped behavior:
+
+```python
+# sandbox_diff
+{
+    "files_changed": list[str],
+    "stat": str,
+    "patch": str,
+    "patch_truncated": bool,
+    "full_patch_chars": int,
+}
+
+# sandbox_commit, changed tree
+{"success": True, "commit": str, "message": str}
+
+# sandbox_commit, empty tree
+{"success": True, "message": "Nothing to commit"}
+
+# sandbox_commit, other failure
+{"success": False, "error": str}
+
+# sandbox_discard / cleanup fields merged into successful sandbox_merge
+{
+    "worktree_removed": bool,
+    "branch_deleted": bool,
+    "errors": list[str],
+}
+```
+
+**Exact semantics**:
+
+- On create with no `base_branch`, Git is asked for the current branch. An empty result falls
+  back to the literal `main`; the Git return code from that probe is not independently checked.
+- On create with no name, the branch is `sandbox-` plus eight random hexadecimal characters.
+  The worktree path is `<repo_root>/.worktrees/<branch_name>`.
+- `git worktree add -b <branch> <path> <base>` is authoritative. Any nonzero result raises
+  `RuntimeError("Failed to create worktree: ...")`; there is no fallback or retry.
+- Every Git subprocess has a fixed 30-second timeout inherited from `_run_git`. The module records
+  no rationale for 30 seconds and does not expose it as configuration.
+- Diff collection first runs `git add -A`. It therefore changes the index before reading the
+  cached stat, patch, and file list. It does not provide a read-only diff mode.
+- Diff collection does not inspect the return code of staging or any of the three diff commands;
+  a Git failure can therefore produce a partial or empty payload instead of a raised/typed error.
+- Diff returns at most 10,000 patch characters and records the original character count and a
+  truncation flag. The source records no rationale for 10,000; callers needing the complete patch
+  cannot obtain it from this helper.
+- Commit also stages all changes and does not inspect that staging command's result. “Nothing to
+  commit” in either stdout or stderr is treated as a successful no-op. Other commit errors are
+  returned, not raised.
+- Merge stages and attempts an automatic commit with message `sandbox: <branch>`, ignoring that
+  commit's result. It then runs `git merge --no-ff <branch>` in `repo_root`.
+- Merge does not check that `repo_root` currently has `session.base_branch` checked out and does
+  not compare the target head with a recorded base SHA. A merge failure returns
+  `{"success": False, "error": ...}` and leaves cleanup to the caller.
+- Successful merge calls cleanup. Cleanup force-removes the worktree, force-deletes the branch,
+  and then sets `session.is_active = False` even if either Git command failed.
+- Cleanup reports only stderr strings containing the word `error`; a nonzero command with a
+  differently worded diagnostic can yield a false-empty `errors` list. Repeated cleanup has no
+  idempotent-success contract.
+
+`CodingToolkit` owns one closure-local active session. `create` refuses a second active session;
+all other actions refuse a missing session; `commit` requires a message. It clears the closure
+state only after a successful merge, but clears it unconditionally after discard and wraps the
+discard payload in `success=True`, even when its cleanup booleans are false. Later editor, bash,
+or search calls are not automatically redirected to `session.worktree_path`; the tool response
+tells the caller where to operate.
+
+**Why this way**: the primitive is small, already covered by real temporary-repository tests, and
+directly serves an interactive coding workflow. Folding promotion behavior into the measured-cell
+protocol would make every backend pretend it can merge Git state, while replacing this primitive
+would break the existing tool contract without producing a second need.
+
+### D2 — Keep the four-leg measured-cell protocol
+
+`lionagi/tools/sandbox_backend.py` owns a structural, runtime-checkable protocol. Adapters do not
+inherit from a common base class; having the named methods is sufficient for runtime protocol
+recognition.
+
+**The contract** (`lionagi/tools/sandbox_backend.py`; data types and `SandboxBackend`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class ExecutionLimits:
+    timeout_s: int | None = None
+    cpu: int | None = None
+    memory_mb: int | None = None
+    disk_mb: int | None = None
+
+@dataclass(frozen=True, slots=True)
+class ExecutionTarget:
+    kind: Literal[
+        "host", "local_worktree", "daytona", "remote_agent", "process"
+    ] = "host"
+    cwd: str | None = None
+    repo: str | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    limits: ExecutionLimits = field(default_factory=ExecutionLimits)
+    sandbox_id: str | None = None
+    session_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def for_worker(
+        self, agent_id: str, *, cwd: str | None = None
+    ) -> ExecutionTarget: ...
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    cold_start: Literal["sub100ms", "seconds", "minutes"]
+    streaming: bool
+    mount_or_upload: Literal["mount", "upload"]
+    image_build: bool
+    hosts_prompt_cell_host_side: bool
+
+@dataclass(frozen=True, slots=True)
+class ProvisionSpec:
+    repo_root: str
+    base_branch: str | None = None
+    name: str | None = None
+    repo_url: str | None = None
+    ref: str | None = None
+    daytona_snapshot: str | None = None
+    daytona_image: Any | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    resources: Mapping[str, int] | None = None
+
+@dataclass(slots=True)
+class Handle:
+    backend: Literal["local_worktree", "daytona"]
+    remote_id: str | None
+    remote_repo_path: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    kind: Literal["prompt_cell", "exec_cell"]
+    entrypoint: str
+    seed_inputs: Mapping[str, str | bytes] = field(default_factory=dict)
+    artifact_manifest: Sequence[str] = ()
+    env: Mapping[str, str] = field(default_factory=dict)
+    timeout_s: int | None = None
+
+@dataclass(slots=True)
+class CellResult:
+    exit_code: int
+    stdout: str
+    stderr: str = ""
+    artifacts: dict[str, bytes] = field(default_factory=dict)
+    events: list[SubstrateStreamEvent] = field(default_factory=list)
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    async def provision(self, spec: ProvisionSpec) -> Handle: ...
+    async def run_cell(
+        self,
+        handle: Handle,
+        cell: Cell,
+        on_event: Callable[[SubstrateStreamEvent], None] | None = None,
+    ) -> CellResult: ...
+    async def collect(
+        self, handle: Handle, paths: Sequence[str]
+    ) -> dict[str, bytes]: ...
+    async def teardown(self, handle: Handle) -> None: ...
+    def capabilities(self) -> Capabilities: ...
+```
+
+`ExecutionTarget.for_worker()` copies every field, uses the supplied `cwd` when truthy, and adds
+`{"agent_id": agent_id}` to copied metadata. It does not provision anything and does not validate
+the worker identifier.
+
+**Exact lifecycle semantics**:
+
+- Provision returns backend-owned state in `Handle`. The local adapter stores a
+  `SandboxSession` at `metadata["session"]`; the Daytona adapter stores a `DaytonaSandbox` at
+  `metadata["sandbox"]`. These metadata keys are untyped and required by later legs.
+- `run_cell` writes all seed inputs before execution and collects the declared artifacts only
+  after the command returns. A nonzero exit is represented by `CellResult.exit_code`; it is not
+  raised as an exception by either adapter.
+- Exceptions from file writes, subprocess creation outside `_subprocess_sync`, remote execution,
+  collection, or teardown propagate. The protocol has no common exception type.
+- The protocol does not synthesize a teardown result. A caller that needs cleanup truth must use
+  adapter-specific evidence; the benchmark caller logs and swallows teardown exceptions so a
+  completed trial result is not masked.
+- A provisioned handle is expected to be paired with teardown in a caller-owned `finally` block.
+  The protocol does not enforce pairing, persist leases, or reconcile them after restart.
+- `DIFF_ARTIFACT = "__diff__"` is a sentinel understood by both adapters. It asks for the
+  workspace diff rather than a literal file with that name.
+
+**Why this way**: four lifecycle legs are the least common denominator shared by the two shipped
+adapters and the benchmark harness. `Handle` keeps backend state out of the protocol signature,
+and the typed `Cell` makes the unit of execution one trial rather than an unstructured command.
+The cost is an untyped metadata escape hatch, recorded as a delta rather than disguised.
+
+### D3 — Preserve shipped cell, event, and artifact semantics
+
+The adapters are deliberately not isolation-equivalent.
+
+**Event contract** (`lionagi/tools/sandbox_backend.py`; `SubstrateStreamEvent`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class SubstrateStreamEvent:
+    type: Literal["stdout", "stderr", "signal", "artifact", "result", "error"]
+    content: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+```
+
+The type vocabulary is wider than current emission. Both adapters emit `stdout`, optional
+`stderr`, and a final `result` with `{"exit_code": int}`. Neither current adapter emits
+`signal`, `artifact`, or `error` events. Operational exceptions are raised rather than converted
+to `error` events.
+
+#### Local adapter
+
+`LocalWorktreeBackend.provision()` delegates to D1 and returns the worktree path. Its declared
+capabilities are:
+
+```python
+Capabilities(
+    cold_start="sub100ms",
+    streaming=False,
+    mount_or_upload="mount",
+    image_build=False,
+    hosts_prompt_cell_host_side=True,
+)
+```
+
+`sub100ms` is a declared class inherited from the seam design, not a runtime measurement or SLA;
+the implementation contains no benchmark or recorded rationale for the threshold.
+
+Exact local execution cases:
+
+- A prompt cell with any non-empty `cell.env` raises `ValueError` before writing seed inputs.
+  Authentication remains host-side; only the explicit cell environment is forbidden.
+- Seed input strings are UTF-8 encoded; bytes are written unchanged. Parent directories are
+  created. Paths are joined as `Path(handle.remote_repo_path) / rel_path` without containment,
+  absolute-path, `..`, or symlink validation.
+- The subprocess runs with `shell=True` in the worktree. The host environment is not inherited
+  wholesale: only `PATH`, `HOME`, `PYTHONPATH`, and `VIRTUAL_ENV` are copied when present, then
+  `cell.env` is overlaid for exec cells.
+- Timeout is `float(cell.timeout_s or 300)`. Consequently `None` and `0` both mean 300 seconds.
+  The 300-second fallback is inherited and has no recorded rationale in this module.
+- `_subprocess_sync` caps captured stdout and stderr independently at 100,000 bytes while
+  continuing to drain the child. That cap protects the parent from unbounded captured output;
+  the exact value has no recorded rationale.
+- On timeout, the process group is terminated and the cell returns exit code `-1`, a timeout
+  stderr message, and ordinary stdout/stderr/result events. The adapter does not add a typed
+  timeout event.
+- Because `streaming=False`, callbacks are invoked only after the subprocess finishes: one stdout
+  event is always emitted, stderr only when non-empty, then result.
+- A missing regular-file artifact becomes `b""`; directories and absent paths are
+  indistinguishable. Artifact paths have the same unvalidated join behavior as seed inputs.
+- The diff sentinel delegates to D1, so collection stages all changes and returns only the
+  possibly 10,000-character-truncated patch as bytes.
+- Teardown is a no-op if `metadata.get("session")` is absent. When present, it delegates to
+  `sandbox_discard()` and discards that helper's cleanup payload.
+
+#### Daytona adapter
+
+`DaytonaBackend.provision()` calls `DaytonaSandbox.create()` with snapshot, image, environment,
+resources, and `delete_on_exit=False`. It uses the remote home directory directly unless
+`repo_url` is provided, in which case it clones into `<home>/repo`. A 40-character hexadecimal
+`ref` is passed as a detached commit; every other non-empty ref is passed as a branch.
+
+`DaytonaSandbox.create()` applies `resources` only when constructing from an image. Its snapshot
+and default-snapshot branches do not pass resources to the SDK, even though the adapter supplied
+the mapping. `ProvisionSpec.repo_root` is likewise not used by Daytona provisioning. These are
+current projection rules, not portable resource enforcement.
+
+Its declared capabilities are:
+
+```python
+Capabilities(
+    cold_start="sub100ms",
+    streaming=True,
+    mount_or_upload="upload",
+    image_build=True,
+    hosts_prompt_cell_host_side=False,
+)
+```
+
+Again, `sub100ms` is a declaration, not an enforced measurement.
+
+Exact remote execution cases:
+
+- Every prompt cell raises `ValueError`; there is no silent host or local fallback.
+- Seed inputs are uploaded to `<remote_repo_path>/<rel_path>` without adapter-side path
+  normalization or parent-directory creation.
+- Exec cells pass `cell.env` to the remote command and stream stdout/stderr callbacks as chunks.
+- `cell.timeout_s` is never read. `DaytonaSandbox.exec_stream()` has no timeout parameter, so a
+  supplied cell timeout is ignored.
+- A result event is emitted after remote completion. Exceptions propagate and do not produce a
+  `CellResult` or `error` event.
+- The diff sentinel calls `DaytonaSandbox.git_diff()`, which stages all changes before returning
+  the cached diff. Unlike the local helper, this path does not impose the 10,000-character cap.
+- Ordinary artifacts delegate to remote download. `DaytonaSandbox.download()` maps a remote
+  `None` payload to `b""`; remote SDK errors still propagate.
+- Teardown requires `metadata["sandbox"]` and calls `delete()`. It does not close the underlying
+  client in this adapter-owned lifecycle; `DaytonaSandbox.__aexit__` is not used by the adapter.
+
+`DaytonaSandbox.create()` itself defaults to a 15-minute automatic stop interval and a
+180-second create timeout. `DaytonaBackend` accepts those defaults. The wrapper records no
+rationale for either number, and neither is exposed by `ProvisionSpec`.
+
+**Why this way**: the prompt/exec fork prevents a caller from silently moving a host-authenticated
+prompt workload into a backend that cannot host it. Buffering local events reflects the
+underlying synchronous subprocess helper; streaming remote chunks reflects the remote SDK. A
+single stronger claim would be false for one of the adapters.
+
+### D4 — Use registry names for construction and capabilities for suitability
+
+The registered backend name is a closed literal:
+
+```python
+BackendName = Literal["local_worktree", "daytona"]
+
+def get_backend(name: BackendName) -> SandboxBackend: ...
+
+def select_backend_for_cell(
+    cell: Cell,
+    candidates: Sequence[SandboxBackend],
+) -> SandboxBackend: ...
+```
+
+**Exact semantics**:
+
+- `get_backend()` lazily constructs one process-global instance per name and returns the same
+  object on later calls. The shared registry has no reset, configuration, or concurrency API.
+- `local_worktree` constructs `LocalWorktreeBackend`; `daytona` constructs `DaytonaBackend`.
+  Any other runtime string raises `ValueError("unknown sandbox backend: ...")`.
+- `select_backend_for_cell()` reads `capabilities()` only. For a prompt cell it skips candidates
+  that cannot host the provider call host-side. For an exec cell, the first candidate wins.
+- Empty or unsuitable candidate lists raise `LookupError`; selection never provisions a fallback.
+- Capability selection does not inspect streaming, image-build, transfer, limits, or resources.
+  Those declarations remain available to callers but are not part of this selector's predicate.
+
+**Why this way**: a name is needed to construct a configured backend, while class inspection is
+the wrong suitability mechanism once an instance exists. First-match selection is deterministic
+and minimal for the one current workload predicate. More elaborate ranking has no current caller.
+
+### D5 — Keep the seam bounded to measured cells
+
+The benchmark contract is:
+
+```python
+async def run_once(
+    task: Task,
+    config: OrchestrationConfig,
+    trial: int,
+    *,
+    backend: str | None = None,
+) -> RunResult: ...
+```
+
+With `backend=None`, it calls the pre-existing in-process body. With a backend, it:
+
+1. resolves the registered adapter and rejects one without host-side prompt-cell support;
+2. provisions `ProvisionSpec(repo_root=os.getcwd())`;
+3. writes a pickled `(task, config, trial)` as `in.pkl`;
+4. runs `_cell_entry.py in.pkl out.pkl` as a prompt cell;
+5. uses `out.pkl` only when exit code is zero and the artifact is non-empty;
+6. converts cell failure into a `RunResult.error`, using at most the final 2,000 diagnostic
+   characters; and
+7. attempts teardown in `finally`, logging but swallowing teardown failure.
+
+The cell timeout is 1,800 seconds. The source gives the reason: a reactive flow may run many
+turns across several spawned workers, so this is a runaway-process ceiling rather than a normal
+trial duration target. The input/output pickle format is private to the same-process benchmark
+entrypoint and is not a general wire protocol.
+
+`ExecutionTarget` and `ExecutionLimits` remain codeless data. Repository search finds no consumer
+outside their definition and focused tests. `ProvisionSpec.resources` reaches Daytona creation,
+but `ExecutionLimits.cpu`, `memory_mb`, `disk_mb`, and `timeout_s` do not. Local provision ignores
+`ProvisionSpec.env`, `resources`, `repo_url`, `ref`, snapshot, and image fields; the dataclass
+explicitly permits backends to ignore fields they do not need.
+
+**Why this way**: the current evidence supports a measured-cell adapter and one benchmark path.
+Promoting the types into normal operation routing before a second production consumer exists
+would turn descriptive fields into misleading promises. ADR-0091 reuses only the target-safe
+worktree primitive and defines worker ownership independently.
+
+## Consequences
+
+The split keeps the direct coding workflow small while giving the benchmark harness a real,
+structural backend seam. Tests can exercise a fake backend, a real temporary Git worktree, and an
+injected fake Daytona object without importing or contacting the remote SDK.
+
+Maintainers must know that the two teardown verbs mean different things: `sandbox_merge()` can
+promote and then clean up, while `SandboxBackend.teardown()` only disposes. They must also inspect
+capabilities before choosing a prompt-cell backend and cannot assume that a supplied limit was
+enforced.
+
+The current design deliberately gives up uniform resource ceilings, a typed handle state, path
+containment, and restart reconciliation. Reversing D1 would break the public CodingToolkit action
+payloads and Git lifecycle. Reversing D2-D4 would affect the benchmark and adapter tests but not
+normal flow execution. Reversing D5 by routing orchestration through the seam is a broad change
+owned by a separate ADR because it would connect the flow kernel, provider configuration, and
+workspace lifecycle.
+
+Failure costs are concrete: a wrong checked-out branch can receive a merge; incomplete cleanup can
+be reported through an inactive session; an escaped seed/artifact path can reach outside the
+workspace; a remote cell can outlive its requested timeout; and benchmark teardown failure is
+only logged.
+
+Counting `CodingToolkit`, the worktree primitive, the backend contract, the two adapters, the
+Daytona wrapper, and the benchmark runner gives seven components; the six arrows in the component
+diagram are their directed dependencies. Therefore `κ = 6 / (7 × 6) = 0.14`. Static test-surface
+assessment is `τ = 0.86`: six of the seven component boundaries have focused unit or integration
+coverage; target-branch-safe promotion remains uncovered and is a delta below.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Make the local worktree lifecycle target-safe and truthful: record the base commit at creation, make diff collection non-staging, refuse promotion to an unverified target, and report idempotent cleanup success only after both worktree and branch cleanup complete. Acceptance: tests cover base advancement, wrong checked-out branch, merge conflict, repeated teardown, and partial cleanup failure without marking the lease clean. | M | (filled at issue-open time) |
+| 2 | Make execution limits enforceable or explicitly unsupported per backend. Acceptance: timeout, CPU, memory, disk, and provision-resource support are declared in capabilities; both adapters either enforce each supplied value or reject it before execution, and Daytona applies or rejects `Cell.timeout_s`. | M | (filled at issue-open time) |
+| 3 | Replace the untyped local-session entry in `Handle.metadata` with a typed lifecycle state or adapter-private handle. Acceptance: local provision, collect, and teardown no longer depend on `metadata["session"]`, and the fake-backend contract suite still exercises all four lifecycle legs. | S | (filled at issue-open time) |
+| 4 | Constrain seed-input and artifact-manifest paths to the provisioned workspace. Acceptance: both adapters reject absolute paths, `..` traversal, and local symlink escapes before write or collection, while valid nested relative paths retain current byte behavior. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### One universal execution-substrate package now
+
+A top-level substrate package containing worktrees, measured cells, provider routing, and flow
+execution would give one name to every execution concern and one place for future adapters. It
+lost because only the measured-cell contract has a real non-test client, while flow/fanout do not
+read the target types at all. The abstraction would couple unrelated lifecycles before their
+shared invariants are known.
+
+### Extend `SandboxSession` into the remote/backend handle
+
+Adding backend, remote id, metadata, and execution methods directly to `SandboxSession` would
+avoid a second lifetime type. It lost because the local primitive owns branch merge/discard state,
+whereas the backend handle owns provision/run/collect/teardown state. A remote adapter has no
+honest `base_branch` merge contract, and a measured-cell teardown must not imply promotion.
+
+### Select workload support by adapter name or class
+
+`if backend == "daytona"` is simple for two adapters and would make current selection explicit.
+It lost because prompt-cell placement is a capability, not an identity. Tests already prove a
+fake adapter can satisfy the protocol and participate in selection without inheriting either
+concrete class.
+
+### Route all flow/fanout operations through `SandboxBackend`
+
+This would make the dormant target vocabulary active and could eventually enforce resource
+limits. It lost for the current ADR because a cell carries seed inputs, one entrypoint, and an
+artifact manifest, while a worker operation carries Branch state, provider configuration,
+dependency context, spawning, and persistence hooks. ADR-0091 first defines the narrower source
+workspace lease needed by concurrent coding workers.
+
+### Treat unimplemented adapters and recursive measurement as current architecture
+
+Carrying earlier Docker, process-provider, or recursive-loop designs forward would preserve more
+aspiration. It lost because no corresponding registered backend, execution caller, or loop driver
+exists in this checkout. Retrospective architecture records shipped contracts; deferred products
+need fresh target ADRs when their callers exist.
+
+### Make diff collection non-staging and complete in this record
+
+That behavior would be safer for inspection and would remove the 10,000-character information
+loss. It is the preferred ideal, but changing shipped behavior belongs to implementation work and
+tests, not to a retrospective rewrite. The requirement is retained as delta 1.
+
+## Notes
+
+Interpretation uses *in pari materia* to resolve the overlapping sandbox records as one current
+area while keeping their two APIs distinct. *Last in time* treats the implemented measured-cell
+seam as authoritative over broader unimplemented executor and recursive-loop designs.
+
+Primary code anchors: `lionagi/tools/sandbox.py`; `lionagi/tools/sandbox_backend.py`;
+`lionagi/tools/daytona.py`; `lionagi/tools/_subprocess.py`; `lionagi/tools/coding.py`;
+`benchmarks/orchestration/harness/runner.py`; `benchmarks/orchestration/harness/_cell_entry.py`.

--- a/docs/adr/ADR-0091-per-worker-worktree-execution-isolation.md
+++ b/docs/adr/ADR-0091-per-worker-worktree-execution-isolation.md
@@ -1,0 +1,555 @@
+# ADR-0091: Per-Worker Worktree Execution Isolation
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: substrates
+- **Date**: 2026-07-09
+- **Relations**: extends ADR-0090; supersedes v0-0080 (in part)
+
+## Context
+
+Flow and fanout already create separate conversation branches and run-scoped artifact
+directories, but those boundaries do not give workers separate source trees.
+
+**P1 — Concurrent workers share one project checkout.**
+`lionagi/cli/orchestrate/_orchestration.py:build_worker_branch()` makes a per-worker artifact
+directory, sets the CLI provider's `repo` to that directory, and grants the same resolved project
+root to every worker through `add_dir`. Reactive workers are retargeted to their own artifact
+directory but receive that same project-root grant. Concurrent code-capable workers can therefore
+read and modify the same checkout.
+
+**P2 — The current executor has no workspace allocation phase.**
+`lionagi/operations/flow.py` pre-allocates Branch objects and invokes operations concurrently in
+the host process. Neither `DependencyAwareExecutor` nor the CLI worker builder accepts a
+workspace lease. A prompt instruction cannot create enforceable ownership when the runtime keeps
+granting the shared path.
+
+**P3 — The existing worktree primitive is useful but not safe enough for unattended ownership.**
+ADR-0090 records real create/diff/commit/merge/discard behavior, but the primitive does not record
+a base SHA, verify the target branch, return truthful idempotent cleanup, constrain seed paths, or
+reconcile leases after restart. Those deltas must close before it becomes the adapter beneath this
+policy.
+
+**P4 — Run identity is only partially propagated.**
+`RunDir` allocates `run_id` as `YYYYMMDDTHHMMSS-<six hex characters>` and inherits an existing
+`LIONAGI_RUN_ID` for subprocess handoff. Orchestration may construct a `Session` from
+`LIONAGI_SESSION_ID`. No `LIONAGI_WORKER_ID` exists in the source tree, and worker construction
+does not pin run/session identity into each worker environment. A retained patch, subprocess, or
+worktree therefore lacks one enforced run-to-worker attribution tuple.
+
+**P5 — Promotion has multiple terminal outcomes.** A successful worker can yield a reviewable
+patch without merging, or it can be validated and promoted. A failed worker needs diagnostics but
+must not merge. Target drift, merge conflict, cancellation, and cleanup failure are different
+states; reducing them all to “done” makes recovery unsafe.
+
+**P6 — Worktrees are source-state isolation, not a security sandbox.** A Git worktree has a
+different index, working tree, and branch. It does not isolate the worker's process, home
+directory, credentials, network, environment, or host resource usage. This ADR deliberately uses
+the narrow meaning because it is the minimum boundary needed to stop concurrent source edits
+from colliding.
+
+The target adds one coordinator port between orchestration and the target-safe local adapter:
+
+```mermaid
+flowchart LR
+    CLI["flow / fanout CLI"] -. "entry" .-> C["WorkerWorkspaceCoordinator"]
+    C --> A["target-safe worktree adapter"]
+    C --> B["worker branch builder"]
+    C --> E["flow executor"]
+    C --> R["artifact / terminal record"]
+    C --> P["completion / promotion policy"]
+    A --> L["WorkerWorktreeLease port"]
+    B --> L
+    P --> L
+```
+
+| Concern | Decision |
+|---|---|
+| Compatibility and opt-in | D1: Add `shared_host` and `worktree_per_worker` workspace modes; keep `shared_host` as the default. |
+| Identity and path grants | D2: Bind one sanitized `(run_id, worker_id)` to one branch, worktree, artifact directory, and pinned environment. |
+| Ownership and state | D3: Make a coordinator persist typed leases and terminal records; workers never merge or delete their own workspace. |
+| Completion and promotion | D4: Default isolated work to `patch_only`; allow `merge_validated` only after validation and target-head checks in dependency order. |
+| Restart and cleanup | D5: Reconcile nonterminal leases before new allocation and persist actual cleanup or bounded-retention outcomes. |
+
+This ADR deliberately does **not** decide:
+
+- Process, credential, network, home-directory, or CPU/memory isolation; a separate execution
+  substrate must own those guarantees.
+- Remote sandbox selection or the measured-cell contract from ADR-0090; worker Branch state is
+  not represented as a `Cell` in this first policy.
+- Automatic semantic conflict resolution. Git conflicts and unexpected target movement become
+  `needs_resolution` records.
+- Validation command contents. The flow or project supplies declared validation checks; this ADR
+  only defines the evidence needed before promotion.
+- Cross-run scheduling or distributed leases. The coordinator is local to one orchestration run
+  and one source repository.
+
+## Decision
+
+### D1 — Add an explicit workspace policy with a compatibility default
+
+`shared_host` remains the default and preserves current behavior. `worktree_per_worker` is opt-in
+until its adapter satisfies ADR-0090's target-safety deltas and the orchestration integration has
+contract tests.
+
+**The contract** (target, Python-native):
+
+```python
+import time
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+WorkspaceMode = Literal["shared_host", "worktree_per_worker"]
+CompletionPolicy = Literal["patch_only", "merge_validated"]
+WorkerLeaseState = Literal["allocated", "running", "frozen", "terminal"]
+WorkerTerminalStatus = Literal[
+    "promoted",
+    "discarded",
+    "retained",
+    "needs_resolution",
+    "teardown_failed",
+]
+
+class WorkspacePolicy(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    mode: WorkspaceMode = "shared_host"
+    completion: CompletionPolicy = "patch_only"
+    retain_worktree_on_resolution: bool = False
+    retention_until: float | None = None
+
+    @model_validator(mode="after")
+    def bounded_retention(self) -> "WorkspacePolicy":
+        if self.retain_worktree_on_resolution and self.retention_until is None:
+            raise ValueError("retained worktrees require retention_until")
+        if self.retention_until is not None and self.retention_until <= time.time():
+            raise ValueError("retention_until must be in the future")
+        return self
+```
+
+There is no inherited retention duration. The default is not to retain the worktree; the patch,
+artifact manifest, and diagnostics remain in run artifacts. If a caller opts into worktree
+retention, it must supply an absolute expiry. This avoids inventing a one-day or one-week lease
+with no evidence while still making unbounded retention unrepresentable.
+
+**Exact semantics**:
+
+- `shared_host` allocates no worktree lease and runs the current worker builder unchanged.
+- `worktree_per_worker` requires the coordinator described below. Failure to allocate is a worker
+  startup failure; there is no fallback to `shared_host` after the mode was explicitly selected.
+- `patch_only` is the isolated-mode default because it preserves a reviewable artifact without
+  mutating the target branch. `merge_validated` is an explicit higher-authority policy.
+- `retain_worktree_on_resolution=False` still produces `needs_resolution` when appropriate, but
+  keeps diagnostics as artifacts and removes the worktree. `True` requires a future timestamp and
+  produces `retained` only after the retention record is durable.
+- Policy is resolved once per run before the immutable base SHA is read. Workers cannot override
+  it through prompts or tool calls.
+
+**Why this way**: compatibility matters because current flow/fanout behavior is host-based. An
+opt-in mode creates a measurable migration boundary. Patch-first completion minimizes target-branch
+mutation while the new lease and recovery machinery proves itself.
+
+### D2 — Bind worker identity to paths and environment
+
+The coordinator resolves one target branch and immutable base commit before starting any isolated
+worker. It uses existing `RunDir` and `Session` identities rather than creating a second run-id
+system.
+
+**The lease contract**:
+
+```python
+from pathlib import Path
+
+class WorkerWorktreeLease(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    run_id: str
+    session_id: str
+    worker_id: str
+    target_branch: str
+    base_sha: str
+    expected_target_sha: str
+    branch_name: str
+    worktree_path: Path
+    artifact_path: Path
+    state_path: Path
+    state: WorkerLeaseState = "allocated"
+    created_at: float
+
+class WorkerPathBinding(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    cwd: Path
+    provider_repo: Path
+    source_roots: tuple[Path, ...]
+    writable_artifact_root: Path
+    env: dict[str, str]
+```
+
+The concrete layout is:
+
+```text
+<repo>/.worktrees/lionagi/<run_id>/<worker_id>/   # worktree_path
+<run.state_root>/workspaces/<worker_id>.json      # state_path
+<run.artifact_root>/<worker_id>/                  # artifact_path
+lionagi/<run_id>/<worker_id>                      # branch_name
+```
+
+`run_id` and `worker_id` must first pass the repository's path-component guard and a Git-ref
+component validator. The normalized pair must be injective: if two raw identifiers normalize to
+the same pair, allocation fails rather than reusing the path or branch. Existing worktree, branch,
+or state-record collisions also fail before the worker starts.
+
+The environment and provider binding are exact:
+
+```python
+WorkerPathBinding(
+    cwd=lease.worktree_path,
+    provider_repo=lease.worktree_path,
+    source_roots=(lease.worktree_path,),
+    writable_artifact_root=lease.artifact_path,
+    env={
+        "LIONAGI_RUN_ID": lease.run_id,
+        "LIONAGI_SESSION_ID": lease.session_id,
+        "LIONAGI_WORKER_ID": lease.worker_id,
+    },
+)
+```
+
+**Exact semantics**:
+
+- `base_sha` is the commit resolved from `target_branch` before any allocation. Every worker in
+  the run starts from this same SHA unless a future ADR defines staged-base allocation.
+- `expected_target_sha` initially equals `base_sha`. The coordinator may advance it only to a
+  commit promoted earlier by the same run in declared dependency order.
+- Worker child processes inherit the three identity variables exactly. They do not call
+  `allocate_run()` to create a new identity.
+- The worktree is the provider working directory and only source root. The artifact directory is
+  a separate writable non-source grant. The shared checkout and sibling worktrees/artifacts are
+  not placed in provider `add_dir` or tool allowlists.
+- Every code-capable tool must receive `WorkerPathBinding`, resolve relative paths under the
+  worktree or artifact root, and reject escapes. A prompt mentioning the host checkout does not
+  create a path grant.
+- Reactive workers receive a new lease keyed by their emitted `worker_id`; cloning a Branch does
+  not clone its parent's workspace binding.
+
+**Why this way**: the enforced tuple `(run_id, session_id, worker_id)` makes worktree, artifacts,
+subprocesses, and terminal records attributable. One immutable base allows deterministic patch
+comparison. Keeping artifacts outside the source tree avoids accidentally promoting diagnostic
+files.
+
+### D3 — Give the coordinator exclusive lease ownership
+
+Workers can operate inside a lease but cannot merge, discard, retain, or mark it clean. The
+coordinator owns every state transition and persists it before exposing the next phase.
+
+**The coordinator and record contracts**:
+
+```python
+class ValidationResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    passed: bool
+    exit_code: int | None = None
+    evidence_ref: str | None = None
+
+class WorkerCandidate(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    lease: WorkerWorktreeLease
+    patch_ref: str
+    patch_sha256: str
+    files_changed: tuple[str, ...]
+    artifact_manifest_ref: str
+    validations: tuple[ValidationResult, ...] = ()
+    worker_succeeded: bool
+    cancelled: bool = False
+
+class WorkerWorktreeRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    lease: WorkerWorktreeLease
+    policy: CompletionPolicy
+    status: WorkerTerminalStatus
+    patch_ref: str | None
+    promoted_commit: str | None
+    teardown_errors: list[str]
+    worktree_removed: bool
+    branch_deleted: bool
+    retention_until: float | None = None
+    completed_at: float
+
+class WorkerWorkspaceCoordinator(Protocol):
+    async def allocate(
+        self,
+        *,
+        run: RunDir,
+        session_id: str,
+        worker_id: str,
+        target_branch: str,
+        base_sha: str,
+    ) -> WorkerWorktreeLease: ...
+
+    async def mark_running(
+        self, lease: WorkerWorktreeLease
+    ) -> WorkerWorktreeLease: ...
+
+    async def freeze(
+        self,
+        lease: WorkerWorktreeLease,
+        *,
+        worker_succeeded: bool,
+        cancelled: bool,
+        validations: tuple[ValidationResult, ...],
+    ) -> WorkerCandidate: ...
+
+    async def complete(
+        self,
+        candidate: WorkerCandidate,
+        policy: WorkspacePolicy,
+    ) -> WorkerWorktreeRecord: ...
+
+    async def reconcile(
+        self, run: RunDir, policy: WorkspacePolicy
+    ) -> list[WorkerWorktreeRecord]: ...
+```
+
+The persisted state machine is:
+
+```mermaid
+stateDiagram-v2
+    [*] --> allocated: lease record fsynced
+    allocated --> running: worker path grants installed
+    running --> frozen: new actions stopped; patch and manifest captured
+    frozen --> terminal: completion policy and cleanup recorded
+    allocated --> terminal: startup failure / reconciliation
+    running --> terminal: cancellation / recovery failure
+```
+
+**Exact semantics**:
+
+- Allocation creates the branch and worktree from `base_sha`, then durably writes the lease before
+  returning it. If persistence fails, the coordinator removes what it created or records
+  `teardown_failed`; it never starts the worker with an unrecorded lease.
+- `mark_running` occurs only after provider and tool path grants match the lease.
+- `freeze` stops new worker operations first, then captures a complete, non-staging patch, changed
+  file list, artifact manifest, and declared validation evidence. Patch contents are stored as an
+  artifact; `patch_sha256` detects later mutation.
+- A missing patch is different from an empty patch. Missing capture is a completion failure;
+  an empty patch is a valid candidate and results in `discarded` with retained diagnostics.
+- Workers have no reference to coordinator promotion or teardown methods. Tool registration must
+  not expose D1's direct merge/discard helpers inside an isolated lease.
+- The orchestration caller wraps every returned lease in a `finally`-style completion path. If
+  worker startup, execution, freeze, or normal completion raises, the coordinator still captures
+  available diagnostics and attempts terminal cleanup; an exception cannot abandon an allocated
+  lease as an unrecorded side effect.
+- Every transition writes a replacement state record atomically. The terminal record is the
+  source of truth; in-memory session flags are not.
+
+**Why this way**: exclusive ownership prevents two workers from racing merges or cleanup. A
+frozen candidate gives completion policy immutable evidence and separates “worker finished” from
+“target mutated.”
+
+### D4 — Complete as patch-only or validated promotion
+
+Completion consumes a frozen candidate and yields exactly one terminal record.
+
+#### `patch_only`
+
+- The coordinator retains `patch_ref`, manifest, and diagnostics in run artifacts.
+- It does not commit or merge the worker branch.
+- It tears down the worktree and branch.
+- A fully successful cleanup records `discarded`; incomplete cleanup records `teardown_failed`.
+- Worker success does not change this outcome: patch-only means “produce reviewable evidence,” not
+  “promote.”
+
+#### `merge_validated`
+
+Promotion is permitted only when all of these are true:
+
+1. `worker_succeeded is True` and `cancelled is False`;
+2. at least the validations declared by the run are present, and every declared validation has
+   `passed=True`;
+3. the candidate patch hash still matches the frozen artifact;
+4. the repository is on `lease.target_branch`;
+5. the target head equals `lease.expected_target_sha`; and
+6. dependency predecessors have terminal records in the required order.
+
+When all checks pass, the coordinator commits the worker-owned change set on its branch, merges it
+with `--no-ff` into the verified target, records the resulting target commit as
+`promoted_commit`, advances the expected head for dependent promotions in this run, and tears the
+lease down. Full success records `promoted`; successful merge with incomplete cleanup records
+`teardown_failed` while retaining `promoted_commit` so the target mutation is not lost.
+
+**Failure and empty cases**:
+
+- Worker failure, cancellation, or failed validation never attempts a merge. Diagnostics and the
+  patch are retained as artifacts, cleanup runs, and the record is `discarded` unless cleanup is
+  incomplete.
+- An empty patch never creates an empty promotion commit; it follows the discarded cleanup path.
+- Unexpected target movement that was not a recorded earlier promotion in this run yields
+  `needs_resolution`. No rebase or merge is attempted automatically.
+- A merge conflict aborts the merge, captures conflict diagnostics, and yields
+  `needs_resolution`. It does not choose conflict resolutions or continue later promotions that
+  depend on this worker.
+- With default retention policy, `needs_resolution` retains artifacts but removes the worktree.
+  With explicit bounded retention, the coordinator records the expiry and yields `retained` only
+  after confirming the worktree and branch still exist.
+- Promotion ordering follows DAG dependency order, not worker completion time. Independent
+  candidates may be reviewed concurrently, but target mutation is serialized.
+
+**Why this way**: patch-only is reversible and reviewable. Validated promotion is useful, but it
+must be a coordinator decision based on immutable evidence and a verified target head. Serial
+target mutation is the smallest honest policy for Git, whose branch update is not a multi-worker
+transaction.
+
+### D5 — Reconcile restart, collision, and teardown truthfully
+
+Before allocating any new isolated worktree for a resumed run, the coordinator scans
+`<run.state_root>/workspaces/*.json` and reconciles every nonterminal lease.
+
+**Exact restart semantics**:
+
+- A lease record, branch, and worktree that all agree on run id, worker id, branch name, and base
+  ancestry may be recovered under the persisted policy. Recovery never changes the base SHA.
+- A recorded lease with a missing worktree is terminalized as `teardown_failed` unless both the
+  branch and worktree are provably already removed, in which case cleanup booleans record that
+  fact and the prior non-promotion outcome may complete as `discarded`.
+- An unrecorded matching worktree or multiple possible worktrees is ambiguous. The coordinator
+  does not adopt it; it records a diagnostic and refuses new allocation for that worker id.
+- A frozen candidate can resume completion only when the patch hash and artifact manifest still
+  match. It is never promoted merely because a commit exists on its branch.
+- A running lease has no proof that worker actions completed. It is frozen for diagnostics and
+  follows failure/cancellation policy; recovery does not restart arbitrary operations.
+- Expired retained worktrees are torn down before new allocation. Partial teardown remains
+  `teardown_failed` and is retried only through explicit reconciliation.
+- The `(run_id, worker_id)` pair is never reused, including after terminal cleanup. A rerun uses a
+  new worker identifier or run id.
+
+Teardown must independently record worktree removal and branch deletion. It marks the lease clean
+only when both are complete. Repeated teardown treats already-absent, record-matching resources as
+successful; a resource occupied by an unrelated branch or path is an error, not “already clean.”
+
+**Why this way**: restart is precisely when in-memory ownership disappears. Persisted, verified
+state prevents a resumed coordinator from promoting unvalidated changes or reusing ambient Git
+state. Truthful component cleanup makes operator action possible without claiming more than Git
+proved.
+
+The end-to-end sequence is:
+
+```mermaid
+sequenceDiagram
+    participant C as Run coordinator
+    participant W as Workspace coordinator
+    participant B as Worker branch
+    participant R as Run record/artifacts
+    participant P as Promotion policy
+
+    C->>C: resolve run id, session id, target, base SHA
+    C->>W: allocate(run, worker, target, base)
+    W->>R: persist allocated lease
+    W-->>C: lease + path binding
+    C->>B: start with pinned env and leased paths
+    B-->>C: success, failure, or cancellation
+    C->>W: freeze(lease, validations)
+    W->>R: persist patch, manifest, frozen state
+    C->>P: complete(candidate, policy)
+    P->>P: verify evidence and target head
+    P->>W: promote, discard, retain, or resolve
+    W->>R: persist terminal cleanup truth
+```
+
+## Consequences
+
+Concurrent workers gain separate Git source state, deterministic attribution, and coordinator-owned
+promotion without requiring a remote control plane. Artifact ownership and teardown outcomes
+become auditable, and a failed worker cannot silently merge into whichever branch happens to be
+checked out.
+
+Worktree creation, patch capture, state persistence, and serialized promotion add latency and
+failure modes. Workers based on the same SHA may conflict during ordered promotion. Disk use
+grows with concurrency and explicit retention, which is why retention requires an expiry and the
+default removes the worktree.
+
+Contributors must understand two roots per worker: the source worktree and the artifact directory.
+They must route every code-capable tool through the same binding, not merely configure the CLI
+provider. Reversing D1 is cheap while the mode is opt-in; reversing D2-D5 after terminal records
+exist requires a record migration and cleanup tooling because branch/path identity becomes durable.
+
+This mode does not protect host credentials or processes. Workloads requiring that protection
+need a separate execution-isolation policy rather than stronger claims about worktrees.
+
+Counting the coordinator, lease port, worktree adapter, worker builder, flow executor, artifact
+record, and promotion policy gives seven components. The coordinator depends on five ports, and
+the adapter, builder, and promotion policy each depend on the lease port, giving eight directed
+dependencies and `κ = 8 / (7 × 6) = 0.19`. Its testability target is `τ = 0.90`: allocation,
+identity propagation, path confinement, terminal policy, recovery, and teardown can use fake
+leases, while promotion conflicts require temporary-repository integration tests.
+
+## Alternatives considered
+
+### Keep one shared checkout and rely on artifact directories
+
+This preserves current behavior and has no worktree overhead. Per-worker artifacts do separate
+outputs, but they do not separate source edits because every worker receives the same project-root
+grant. It lost because P1 is specifically a source-collision problem.
+
+### Create one worktree for the whole run
+
+This would protect the host checkout from the run while keeping allocation and cleanup simple.
+It lost because concurrent workers would still share one index and working tree, so writes could
+overwrite each other and no worker-owned patch could be attributed reliably.
+
+### Copy the repository per worker
+
+Copies provide filesystem independence without Git worktree bookkeeping and can survive branch
+deletion. They lost because they duplicate repository data, lose a shared object database,
+complicate base/target ancestry checks, and still need a promotion protocol. Git worktrees already
+provide the source-state primitive with lower disk cost.
+
+### Serialize workers behind a shared-checkout lock
+
+A lock would prevent simultaneous writes and avoid promotion conflicts. It lost because it removes
+the concurrency flow/fanout is designed to provide, and it still leaves ownership, cancellation,
+restart, and wrong-target merge semantics unresolved.
+
+### Let each worker merge or discard its own worktree
+
+This reduces coordinator surface and makes the worker lifecycle self-contained. It lost because
+workers complete out of dependency order, can observe stale target heads, and cannot safely decide
+whether their own validation is sufficient. A prompt-driven worker must not hold target mutation
+authority.
+
+### Route the whole worker through `SandboxBackend`
+
+The measured-cell seam would provide provision/run/collect/teardown and a path toward other
+backends. It lost for the first local policy because a flow worker has Branch history, dependency
+context, spawning, persistence hooks, and provider/tool grants that a `Cell` does not carry.
+Worker workspace ownership is the smaller contract needed now; execution placement can compose
+later through a separate ADR.
+
+### Make `merge_validated` the isolated-mode default
+
+Automatic integration would reduce review steps and make successful runs immediately useful. It
+lost because the new path has not yet proved target-head validation, conflict retention, or restart
+reconciliation. `patch_only` preserves all work as an auditable artifact and keeps target mutation
+explicit.
+
+### Retain every failed or conflicted worktree indefinitely
+
+This maximizes debugging evidence. It lost because disk consumption grows with failures and stale
+worktrees block deterministic identifiers. Artifacts are the durable default; live worktree
+retention is explicit and must expire.
+
+## Notes
+
+Interpretation uses *contra proferentem* to keep “isolation” at the minimum source-workspace scope.
+The *constitutional* canon avoids connecting the flow kernel, provider routing, measured cells,
+and remote execution before those wider contracts have executable consumers.
+
+Current-code anchors used to define the insertion points:
+`lionagi/cli/orchestrate/_orchestration.py`; `lionagi/cli/orchestrate/flow.py`;
+`lionagi/cli/orchestrate/fanout.py`; `lionagi/cli/_runs.py`;
+`lionagi/operations/flow.py`; `lionagi/tools/sandbox.py`.

--- a/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
+++ b/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
@@ -1,0 +1,528 @@
+# ADR-0092: Minimal Branch and Session Memory Store
+
+- **Status**: Proposed
+- **Kind**: Retrospective
+- **Area**: substrates
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0090
+
+## Context
+
+Lionagi now has a small memory seam, but the word “memory” also appears near message persistence,
+embedding configuration, context compaction, and external prompt injection. This ADR records only
+the contract that actually ships and makes its semantic limits explicit.
+
+**P1 — A structural store needs a stable data shape.** An adapter cannot satisfy
+`store`/`retrieve`/`search` portably unless callers agree on item identity, content, tags,
+metadata, query fields, and return types.
+
+**P2 — Method compatibility is weaker than search equivalence.** The protocol-level tests can
+require a returned UUID, identity retrieval, and typed results, but they cannot truthfully require
+every backend to share `InMemoryStore`'s substring matching, tag logic, insertion order, or
+read-after-write search timing.
+
+**P3 — Branch/session ownership determines query scope.** A standalone `Branch` needs a default
+without setup; branches included in a `Session` need a shared default; an explicitly supplied
+branch store must not be overwritten during inclusion or reparenting. A query-level implicit scope
+would conflict with these object-ownership rules.
+
+**P4 — The default must stay independent of CLI persistence.** `StateDB` persists messages and
+run state for CLI/Studio surfaces, but a library `Branch` works without opening it. Making the
+default memory store depend on that lifecycle would turn a zero-configuration library feature
+into a file/schema concern.
+
+**P5 — Adjacent storage/embedding surfaces are disconnected.** `AppSettings` still defines seven
+storage and embedding fields with defaults, and the `messages` table still has a nullable
+`embedding` column. Repository search finds no runtime consumer of those settings and no producer
+that assigns message embeddings. They are not configuration for `MemoryStore`.
+
+**P6 — The seam is available but not automatic.** No normal branch operation, tool, engine, or
+CLI path calls `MemoryStore.store`, `retrieve`, or `search`. Applications opt in by accessing
+`.memory`; no conversational turn is auto-stored, embedded, recalled, or injected by this seam.
+
+The implemented component and ownership boundary is:
+
+```mermaid
+flowchart LR
+    MI["MemoryItem + MemoryQuery"] --> MS["MemoryStore Protocol"]
+    MI --> IMS["InMemoryStore"]
+    P["Pile[MemoryItem]"] --> IMS
+    MS --> B["Branch.memory"]
+    IMS --> B
+    MS --> S["Session.memory"]
+    IMS --> S
+    S --> B
+```
+
+| Concern | Decision |
+|---|---|
+| Data and public surface | D1: Keep `MemoryItem` and `MemoryQuery` as the public Python-native schemas and export all four memory names. |
+| Portable backend boundary | D2: Keep exactly three async `MemoryStore` methods and the narrow cross-backend contract fence. |
+| Built-in behavior | D3: Keep `InMemoryStore` as the sole built-in backend and record its exact `Pile`-based semantics. |
+| Branch/session ownership | D4: Keep lazy read-only direct references and “first claim wins” session sharing. |
+| Architectural exclusions | D5: Keep automatic recall, durability, lifecycle management, and disconnected config/schema surfaces outside the current memory seam. |
+
+This ADR deliberately does **not** decide:
+
+- External-adapter fidelity, projection, availability, or lifecycle contracts; ADR-0093 owns that
+  aspirational extension.
+- Graph traversal or relationship-aware knowledge operations. Three memory methods do not form a
+  graph-store API.
+- Message-history compaction. Context tooling changes a Branch's active message view and does not
+  implement `MemoryStore`.
+- Automatic turn storage, summarization, embedding, or recall. No current consumer requires or
+  invokes those behaviors.
+- A portable ranking formula or metadata filter vocabulary. The current open mapping needs a
+  follow-up delta before durable adapters can claim equivalent query behavior.
+
+## Decision
+
+### D1 — Keep the shipped item/query schemas and exports
+
+`lionagi/protocols/memory.py` is the source of truth. `MemoryItem` extends `Element`; it does not
+introduce a second identity hierarchy.
+
+**The contract** (`lionagi/protocols/memory.py`; `MemoryItem`, `MemoryQuery`):
+
+```python
+class Element(BaseModel, Observable):
+    id: UUID = Field(default_factory=uuid4, frozen=True)
+    created_at: float = Field(default_factory=<UTC timestamp>, frozen=True)
+    metadata: dict = Field(default_factory=dict)
+
+class MemoryItem(Element):
+    content: Any = None
+    tags: list[str] = Field(default_factory=list)
+
+class MemoryQuery(BaseModel):
+    text: str | None = None
+    tags: list[str] | None = None
+    filters: dict[str, Any] | None = None
+    limit: int = 20
+```
+
+`Element` also fixes these relevant semantics (`lionagi/protocols/generic/element.py`):
+
+- `id` accepts a UUID or UUID string at validation and serializes as a string.
+- `created_at` accepts a float, datetime, or parseable string and is stored as a UTC timestamp.
+- `metadata` is coerced to a dictionary where possible and rejects a mismatched `lion_class`.
+- Extra `MemoryItem` fields are forbidden through `Element.model_config`.
+- Element equality and hashing use only `id`; equality is not a field-by-field fidelity check.
+
+`MemoryQuery` has no explicit validators or constrained fields. In particular, `limit` has no
+minimum, and empty strings/lists/maps are valid inputs. D3 records what the reference backend does
+with those values rather than implying stronger validation.
+
+The names are re-exported from both public surfaces:
+
+```text
+lionagi.protocols.types
+├── MemoryItem
+├── MemoryQuery
+├── MemoryStore
+└── InMemoryStore
+
+lionagi (lazy import map and __all__)
+├── MemoryItem
+├── MemoryQuery
+├── MemoryStore
+└── InMemoryStore
+```
+
+**Exact empty/error semantics**:
+
+- `MemoryItem()` is valid with `content=None`, `tags=[]`, generated UUID and timestamp, and empty
+  metadata.
+- `MemoryQuery()` is valid and means no text/tag/filter predicates with a final limit of 20 in the
+  reference implementation.
+- The schemas do not validate that tags are unique or non-empty and do not define reserved
+  metadata/filter keys.
+- Schema validation errors are ordinary Pydantic errors; there is no memory-specific schema error.
+
+**Why this way**: `Element` supplies the same identity/provenance shape used elsewhere in the
+library, while a typed query avoids embedding a service-specific query-string grammar in core.
+The small schemas keep adapter entry cheap, but the unbounded filter mapping is explicitly a
+portability risk rather than an implicit universal DSL.
+
+### D2 — Keep exactly three async protocol methods
+
+**The contract** (`lionagi/protocols/memory.py`; `MemoryStore`):
+
+```python
+@runtime_checkable
+class MemoryStore(Protocol):
+    async def store(self, item: MemoryItem) -> UUID: ...
+    async def retrieve(self, item_id: UUID) -> MemoryItem | None: ...
+    async def search(self, query: MemoryQuery) -> list[MemoryItem]: ...
+```
+
+The protocol is structural. An adapter does not subclass `InMemoryStore` or register with a
+backend registry. Passing `isinstance(adapter, MemoryStore)` checks that the runtime-checkable
+members exist; it does not prove signature, async, fidelity, ordering, consistency, or failure
+semantics.
+
+The current cross-backend fence in `tests/protocols/test_memory.py` runs against
+`InMemoryStore` and a bare fake implementor. It pins only these portable observations:
+
+| Operation | Portable observation exercised today |
+|---|---|
+| Runtime shape | `isinstance(store, MemoryStore)` is true. |
+| `store(item)` | Returns a `UUID` equal to `item.id`. |
+| `retrieve(id)` after store | Returns a `MemoryItem` with matching `id`, `content`, and `tags`. |
+| `retrieve(unknown_uuid)` | Returns `None`. |
+
+It does **not** currently assert `created_at` or `metadata` fidelity. It also does not assert
+search ordering, matching rules, ranking, error mapping, immediate search visibility, or
+cross-process durability. Those omissions are intentional and are the reason ADR-0093 adds a
+declared fidelity profile for external adapters.
+
+**Exact method-boundary semantics**:
+
+- `store` is create-or-replace by identifier in the reference backend, but the protocol text does
+  not separately define insert conflicts or updates.
+- `retrieve` is identity lookup, not ranked recall. Unknown identity is the only portable miss
+  shape and returns `None`.
+- `search` returns a concrete list of `MemoryItem`, not an iterator, score tuple, or page object.
+- The protocol has no close, update, delete, transaction, batch, health, score, or namespace
+  method. Backends may expose extra APIs, but Branch and Session do not call them.
+- No exception hierarchy is defined. Backend exceptions currently propagate unchanged.
+
+**Why this way**: three methods are sufficient for the current access seam and easy to satisfy
+structurally. Adding lifecycle, ranking, mutation, or transaction methods before a core consumer
+exists would couple Branch/Session to service-specific concerns. The cost is that semantic
+interchangeability must be declared outside the base protocol.
+
+### D3 — Keep the `Pile`-backed reference semantics
+
+**The contract** (`lionagi/protocols/memory.py`; `InMemoryStore`):
+
+```python
+class InMemoryStore:
+    def __init__(self) -> None:
+        self._items: Pile[MemoryItem] = Pile(item_type={MemoryItem})
+
+    async def store(self, item: MemoryItem) -> UUID:
+        await self._items.ainclude(item)
+        return item.id
+
+    async def retrieve(self, item_id: UUID) -> MemoryItem | None:
+        return await self._items.aget(item_id, None)
+
+    async def search(self, query: MemoryQuery) -> list[MemoryItem]:
+        results = list(self._items.values())
+        if query.text:
+            needle = query.text.lower()
+            results = [r for r in results if needle in str(r.content).lower()]
+        if query.tags:
+            wanted = set(query.tags)
+            results = [r for r in results if wanted & set(r.tags)]
+        if query.filters:
+            results = [
+                r for r in results
+                if all(r.metadata.get(k) == v for k, v in query.filters.items())
+            ]
+        return results[: query.limit]
+```
+
+**Exact store/retrieve semantics**:
+
+- `Pile` accepts `MemoryItem` and subclasses because `strict_type` is not enabled.
+- First storage appends the UUID to `Pile.progression` and the item to the UUID-keyed collection.
+- Storing another item with the same UUID replaces the mapped object but does not append or move
+  the UUID in progression. The returned UUID is still the item's own id.
+- A stored object is visible to identity retrieval immediately in the same process.
+- Missing identity returns `None` because `aget` receives that default. The reference backend
+  does not log or distinguish “never existed” from “replaced/removed”; it has no removal method.
+- State is an instance field only. A fresh store or process restart is empty; there is no snapshot,
+  file, or migration path.
+
+**Exact search semantics**:
+
+- Search snapshots `Pile.values()` in progression order, then applies predicates in the order
+  text, tags, filters, limit.
+- Text matching is case-insensitive substring matching over `str(item.content)`. It is not token,
+  fuzzy, embedding, or semantic search.
+- `text=None` and `text=""` apply no text predicate because the check is truthiness-based.
+- Tags use **any-of** matching: the requested and item tag sets need at least one shared value.
+  Matching is case-sensitive and duplicate-insensitive because both sides are converted to sets.
+- `tags=None` and `tags=[]` apply no tag predicate.
+- Filters use **all-of** equality against `item.metadata.get(key)`. A missing key behaves like
+  value `None`, so a filter value of `None` matches both a missing key and an explicit `None`.
+- `filters=None` and `{}` apply no metadata predicate.
+- Different predicate groups combine with AND because each filters the prior result list.
+- With no predicates, search returns all items in progression order, truncated by the limit.
+- `limit=0` returns `[]`. A positive limit returns at most that many items. A negative limit uses
+  normal Python slicing and drops the final `abs(limit)` matches; it is not rejected. There is no
+  recorded rationale for permitting negative values, and delta 2 must resolve portable limit
+  validation before a durable adapter ships.
+- Search returns item objects, not copies. Mutating mutable fields on a returned `MemoryItem`
+  mutates the same object held by the in-process store.
+
+`Pile.ainclude()` and `aget()` use the Pile's async synchronization. `search()` calls
+`Pile.values()` and performs an in-process snapshot without acquiring the store's own explicit
+lock. This ADR therefore records thread/async-aware storage primitives but does not claim a
+linearizable search snapshot under concurrent mutation.
+
+**Why this way**: `Pile` is already a UUID-keyed ordered primitive in core and adds no dependency
+or setup. Its scan is simple and deterministic for small process-local use. Durability, semantic
+ranking, and strong concurrent snapshot semantics would require a materially different backend
+and are left to the seam.
+
+### D4 — Keep lazy, read-only ownership with first claim winning
+
+Branch and Session expose a direct `MemoryStore` reference. There is no proxy or manager between
+the caller and the store.
+
+**The Branch contract** (`lionagi/session/branch.py`; constructor and `memory`):
+
+```python
+class Branch(Element, Relational):
+    _memory: MemoryStore | None = PrivateAttr(None)
+
+    def __init__(
+        self,
+        *,
+        # other Branch parameters omitted
+        memory: MemoryStore | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._memory = memory
+        ...
+
+    @property
+    def memory(self) -> MemoryStore:
+        if self._memory is None:
+            self._memory = InMemoryStore()
+        return self._memory
+```
+
+**The Session contract** (`lionagi/session/session.py`; constructor, `memory`,
+`include_branches`, `remove_branch`):
+
+```python
+class Session(Node, Relational):
+    _memory: MemoryStore | None = PrivateAttr(default=None)
+
+    def __init__(self, *, memory: MemoryStore | None = None, **kwargs: Any): ...
+
+    @property
+    def memory(self) -> MemoryStore:
+        if self._memory is None:
+            self._memory = InMemoryStore()
+        return self._memory
+
+    def include_branches(self, branches):
+        # ownership preflight omitted
+        ...
+        if branch._memory is None:
+            branch._memory = self.memory
+        ...
+```
+
+**Exact ownership semantics**:
+
+- First access to `Branch.memory` creates and caches one private `InMemoryStore`; repeat access
+  returns the same object.
+- First access to `Session.memory` similarly creates and caches one store.
+- Session model validation creates a default Branch when none was supplied, includes it in the
+  branch pile, and runs the same inclusion wiring. A no-argument Session therefore shares one
+  store with its default Branch.
+- `Session(memory=explicit)` is applied after Pydantic model validation. If validation temporarily
+  created a default session store and wired branches to it, the constructor rewires only branches
+  still pointing at that temporary object to the explicit store.
+- `include_branches()` preflights the whole batch for ownership conflicts before mutating any
+  candidate. A Branch already owned by another Session raises `ValueError` and no earlier batch
+  member is partially claimed.
+- During inclusion, a Branch with `_memory is None` adopts the Session store. A Branch with an
+  explicit store or one adopted from an earlier Session keeps it: **first claim wins**.
+- `remove_branch()` clears session routing ownership, observer, hooks, operation manager, and
+  session user linkage, but deliberately leaves messages, logs, and `_memory` on the Branch.
+  Reparenting therefore preserves the previously adopted store.
+- Neither class has a public memory setter. Assigning `branch.memory = ...` or
+  `session.memory = ...` raises `AttributeError`.
+- Query scope follows object identity. Two branches sharing the same store see the same UUID
+  collection; a private branch store is isolated by being a different object, not by an implicit
+  branch filter in `MemoryQuery`.
+
+**Why this way**: constructor injection supports structural adapters, while lazy defaults make
+standalone Branch and Session immediately usable. Read-only properties avoid hot-swapping a
+network or in-process store beneath in-flight calls. Preserving a Branch's first store during
+reparenting avoids silent loss or scope expansion.
+
+### D5 — Do not infer automatic memory or connect dormant surfaces
+
+The memory seam is an application injection point. No current core path stores messages into it,
+searches it before a turn, closes it at Session teardown, or maps it onto `StateDB`.
+
+The disconnected settings contract is exact (`lionagi/config.py`; `AppSettings`):
+
+| Field | Default | Current `MemoryStore` consumer |
+|---|---:|---|
+| `LIONAGI_EMBEDDING_PROVIDER` | `"openai"` | none |
+| `LIONAGI_EMBEDDING_MODEL` | `"text-embedding-3-small"` | none |
+| `LIONAGI_AUTO_STORE_EVENT` | `False` | none |
+| `LIONAGI_STORAGE_PROVIDER` | `"async_qdrant"` | none |
+| `LIONAGI_AUTO_EMBED_LOG` | `False` | none |
+| `LIONAGI_QDRANT_URL` | `"http://localhost:6333"` | none |
+| `LIONAGI_DEFAULT_QDRANT_COLLECTION` | `"event_logs"` | none |
+
+The defaults are inherited legacy values; the current source records no rationale for their
+specific provider, model, URL, or collection values. `LIONAGI_STATE_DB_URL` is not in this list
+because StateDB does consume it.
+
+The adjacent message persistence shape is:
+
+```text
+messages
+├── id            Text, primary key
+├── created_at    Float, NOT NULL
+├── node_metadata JSON, nullable
+├── content       JSON, NOT NULL
+├── embedding     LargeBinary, nullable
+├── sender        Text, nullable
+├── recipient     Text, nullable
+├── channel       Text, nullable
+├── role          Text, NOT NULL
+└── lion_class    Integer, foreign key, NOT NULL
+```
+
+`Message` inherits `Node.embedding: list[float] | None`. `StateDB.insert_message()` binds
+`msg.get("embedding")` and updates that column on id conflict. Repository search finds no
+message-construction call that supplies an embedding; only generic Node tests and state payload
+tests exercise embedding values. The field and column do not provide storage or search for
+`MemoryItem`.
+
+**Exact non-behavior**:
+
+- Creating or sending a message does not call `MemoryStore.store()`.
+- `Branch.chat`, `run`, `operate`, tool execution, and Session flow do not call
+  `MemoryStore.search()`.
+- Process exit discards the default store.
+- Session/Branch teardown does not call a close method because none exists.
+- The configuration fields do not select an `InMemoryStore` replacement.
+- The message embedding column is not an index and is not queried by `MemoryStore`.
+
+**Why this way**: connecting dormant config or state schema to a new core seam would silently
+choose lifecycle, embedding, and persistence policy. The retrospective record keeps those deltas
+visible but does not pretend configuration names are implemented architecture.
+
+The ownership sequence is:
+
+```mermaid
+sequenceDiagram
+    participant A as Application
+    participant S as Session
+    participant B1 as Branch A
+    participant B2 as Branch B
+    participant M as MemoryStore
+
+    A->>S: Session(memory=M) or lazy access
+    S->>B1: include; assign M only if _memory is None
+    S->>B2: include; preserve existing store if already claimed
+    A->>B1: memory.store(item)
+    B1->>M: store(item)
+    A->>B2: memory.retrieve(item.id)
+    B2->>M: retrieve(item.id) when B2 shares M
+```
+
+## Consequences
+
+Library users receive a usable in-process store with no setup and can inject a structurally
+different implementation without changing Branch or Session. Session sharing is explicit by
+object identity, and the absence of a setter avoids hot-swapping a store beneath in-flight calls.
+
+The default loses all state at process exit and performs linear, non-semantic search. Returned
+objects are live references, negative limits have Python-slice behavior, and search does not claim
+a locked consistent snapshot. The open `filters` mapping can acquire incompatible meanings across
+adapters, while core supplies no close hook for a networked implementation. Applications that
+inject such a backend own its connection lifecycle until ADR-0093's target contract is adopted.
+
+Contributors must distinguish three adjacent surfaces: Branch/Session memory, message history in
+StateDB, and ContextProvider prompt injection. Reversing D1 or D2 is a public API break; reversing
+D3 changes the zero-config behavior; reversing D4 changes ownership and cross-branch visibility;
+cleaning the D5 fields/column requires settings compatibility and a state-schema migration but
+does not alter the memory protocol itself.
+
+Counting the item/query schema, protocol, reference store, `Pile`, `Branch`, and `Session` gives
+six components. The protocol depends on the schema; the store depends on the schema and `Pile`;
+`Branch` depends on the protocol and store; and `Session` depends on the protocol, store, and
+`Branch`. Thus `κ = 8 / (6 × 5) = 0.27`. Static test-surface assessment is `τ = 0.83`: the schema,
+protocol, reference store, Branch, and Session boundaries have focused tests; external lifecycle
+behavior is intentionally outside the current core.
+
+## Current-vs-ideal delta
+
+| # | Delta | Size | Issue |
+|---|---|---|---|
+| 1 | Remove or deprecate the inert storage, Qdrant, embedding-provider, auto-store, and auto-embed configuration fields together with the unused message-embedding persistence path. Acceptance: runtime configuration names only implemented storage surfaces, schema and adapter definitions no longer carry an always-unproduced message embedding, and compatibility behavior is covered by migration tests. | M | (filled at issue-open time) |
+| 2 | Make `MemoryQuery.filters` portability explicit before a durable adapter ships. Acceptance: portable filter keys and comparison semantics are documented, unsupported keys fail visibly, negative limits are rejected or normalized consistently, and the reusable conformance suite distinguishes shared guarantees from backend-declared search behavior. | M | (filled at issue-open time) |
+
+## Alternatives considered
+
+### No built-in backend
+
+Core could publish only the structural protocol and require applications to inject a store. This
+would keep persistence policy entirely external and avoid even process-local semantics. It lost
+because `Branch().memory` would not be usable without setup, leaving the public access surface as
+documentation rather than a working default.
+
+### Use `StateDB` as the default
+
+This would provide restart persistence and reuse an async SQL layer already present for CLI
+state. It lost because StateDB owns sessions, branches, messages, and run bookkeeping under a
+separate lifecycle. A library Branch that never uses the CLI should not open or migrate that
+database to gain memory.
+
+### Ship a second direct-SQLite default
+
+A dedicated stdlib SQLite table would avoid StateDB coupling and give persistence without a new
+third-party dependency. It lost as a default because it introduces path selection, cleanup,
+cross-process locking, schema, and migration questions that process-local `Pile` avoids. Such an
+adapter can satisfy `MemoryStore` externally once its lifecycle is explicit.
+
+### Add update, delete, list, transactions, embedding, and ranking to `MemoryStore`
+
+Those verbs would make the seam more service-complete and reduce adapter-specific APIs. They lost
+because no core consumer needs them, their failure/consistency semantics differ materially, and
+adding them would make every minimal adapter implement unused behavior.
+
+### Add a `MemoryManager` or Branch proxy
+
+A manager could inject branch/session scope, own backend lifecycle, and later add automatic recall.
+It lost because the store already exposes the complete three-method contract and Session can share
+the same instance directly. A proxy with no current behavior adds coupling and makes object
+identity less transparent.
+
+### Put branch or session scope in `MemoryQuery`
+
+Explicit scope fields would make one global store partitionable. They lost because current
+ownership already defines scope by store instance, and an adapter may use its own namespace or
+collection. Core cannot add an implicit global-store assumption without a consumer requiring it.
+
+### Wire the legacy configuration block into the seam
+
+Selecting a default by `LIONAGI_STORAGE_PROVIDER` would turn existing names into live behavior and
+could revive the embedding settings. It lost because no adapter implementation or dependency
+matches those values, and the settings do not define construction, credentials, lifecycle, or
+fidelity. Delta 1 removes or deprecates them instead.
+
+### Preserve the message embedding column for future semantic recall
+
+Keeping a nullable column is cheap and could avoid a future migration. It lost as current
+architecture because no producer, index, or query path exists. A future semantic-history design
+should land producer, storage, and retrieval contracts together rather than rely on permanently
+idle plumbing.
+
+## Notes
+
+Interpretation uses *in pari materia* to treat the protocol, reference backend, and Branch/Session
+ownership wiring as one current decision set because none provides the access seam independently.
+
+Primary code anchors: `lionagi/protocols/memory.py`;
+`lionagi/protocols/generic/element.py`; `lionagi/protocols/generic/pile.py`;
+`lionagi/protocols/generic/progression.py`; `lionagi/protocols/types.py`;
+`lionagi/__init__.py`; `lionagi/session/branch.py`; `lionagi/session/session.py`;
+`lionagi/config.py`; `lionagi/protocols/graph/node.py`;
+`lionagi/protocols/messages/message.py`; `lionagi/state/schema_meta.py`;
+`lionagi/state/db.py`.

--- a/docs/adr/ADR-0093-external-memory-adapter-fidelity-contract.md
+++ b/docs/adr/ADR-0093-external-memory-adapter-fidelity-contract.md
@@ -1,0 +1,546 @@
+# ADR-0093: External Memory Adapter Fidelity Contract
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: substrates
+- **Date**: 2026-07-09
+- **Relations**: supersedes v0-0091; extends ADR-0092
+
+## Context
+
+ADR-0092 intentionally keeps `MemoryStore` structural and small. That makes adapters easy to
+inject, but identical method names do not prove identical storage or search behavior.
+
+**P1 — Structural compatibility is not semantic compatibility.** A runtime-checkable Protocol
+can see `store`, `retrieve`, and `search`; it cannot see whether metadata is dropped, tags survive
+search, writes are immediately searchable, results are ranked, or a service error was silently
+converted into an empty result.
+
+**P2 — External services have asymmetric native shapes.** A service may accept tags on write but
+not return them in ranked hits, expose direct identity retrieval separately from recall, normalize
+timestamps, reject arbitrary metadata, or add native fields that do not fit `MemoryItem`. An
+adapter must declare that projection rather than imply a lossless round trip.
+
+**P3 — Query portability is incomplete.** `MemoryQuery.filters` is an open mapping. External
+services frequently support a closed filter set, different comparison operators, or no unfiltered
+scan. Unsupported keys must fail visibly; ignoring them would broaden a query and return records
+the caller intended to exclude.
+
+**P4 — Search and identity consistency can differ.** A successful store should support direct
+identity retrieval, while a secondary search index may be eventually consistent. Treating an
+immediate search miss as a failed write, or treating ranked recall as identity retrieval, produces
+incorrect recovery behavior.
+
+**P5 — Explicit persistence cannot use best-effort prompt-injection failure semantics.**
+`lionagi/tools/khive_injection.py` is a `ContextProvider`: it recalls and optionally composes text
+for a prompt, optionally writes selected events, and deliberately degrades to no injection on
+transport failure. It does not implement `MemoryStore`, return `MemoryItem`, or participate in
+Branch/Session store ownership. An explicit `store()` call must not appear successful when its
+transport failed.
+
+**P6 — Core must remain dependency-light.** An external adapter can live in a connector or
+service-owned package and be passed to `Branch(memory=...)` or `Session(memory=...)`. Lionagi core
+should not acquire service-specific clients, connection pools, retry policies, or field mappings
+to make that possible.
+
+The target boundary is:
+
+```mermaid
+flowchart LR
+    B["Branch / Session"] --> MS["MemoryStore"]
+    MS --> A["ExternalMemoryStore adapter"]
+    A --> S["external service"]
+    A --> M["MemoryAdapterManifest"]
+    T["conformance suite"] --> MS
+    T --> A
+    CP["ContextProvider"] --> S
+    CP -. "not a MemoryStore" .-> B
+```
+
+| Concern | Decision |
+|---|---|
+| Capability and fidelity declaration | D1: Every external adapter publishes an immutable typed manifest alongside `MemoryStore`. |
+| Executable evidence | D2: Every adapter runs a common conformance matrix against a deterministic fake and, separately, a live opt-in environment. |
+| Projection and query behavior | D3: Loss, normalization, consistency, filter support, misses, and limit behavior are explicit; unsupported semantics never degrade silently. |
+| Errors and lifecycle | D4: Persistence errors propagate through stable adapter exceptions; connection, pooling, timeout, retry, and close policy stay adapter-owned and documented. |
+| Adjacent khive integration | D5: A khive-backed store is the first named application but remains external and must not be confused with `KhiveInjectionProvider`; its concrete wire mapping is deferred until implementation can be verified against the external source. |
+
+This ADR deliberately does **not** decide:
+
+- Graph traversal, task lifecycle, messaging, or knowledge composition. Those operations do not
+  fit the three-method memory contract.
+- A service transport. MCP, HTTP, an SDK, or an embedded client may sit behind an adapter if the
+  manifest and tests remain true.
+- A core connection manager or close hook. Branch and Session continue accepting the smaller
+  `MemoryStore` Protocol.
+- One portable search score or ordering. External search may be ranked; callers decide whether a
+  declared adapter meets their needs.
+- The package, release, or installation mechanism for a concrete adapter. The interface is
+  independent of distribution.
+- Automatic prompt injection. `ContextProvider` owns that optional pre-turn concern.
+
+## Decision
+
+### D1 — Require an immutable fidelity manifest
+
+Every external adapter implements `MemoryStore` and a companion protocol with one immutable
+manifest property. The manifest is not added to the base Protocol, so existing core and minimal
+in-process stores remain valid.
+
+**The target contract**:
+
+```python
+from collections.abc import Iterable
+from typing import Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+MemoryItemField = Literal["id", "created_at", "metadata", "content", "tags"]
+SearchConsistency = Literal["immediate", "eventual"]
+Fidelity = Literal["full", "native_fields", "lossy"]
+
+class MemoryAdapterManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    adapter: str = Field(min_length=1)
+    native_item_fields: frozenset[MemoryItemField]
+    dropped_item_fields: frozenset[MemoryItemField]
+    supported_filters: frozenset[str]
+    search_consistency: SearchConsistency
+    retrieve_fidelity: Fidelity
+    search_fidelity: Fidelity
+    search_returns_tags: bool
+    preserves_metadata: bool
+
+    @model_validator(mode="after")
+    def coherent_projection(self) -> "MemoryAdapterManifest":
+        fields = {"id", "created_at", "metadata", "content", "tags"}
+        if self.native_item_fields & self.dropped_item_fields:
+            raise ValueError("native and dropped item fields must be disjoint")
+        if self.native_item_fields | self.dropped_item_fields != fields:
+            raise ValueError("every MemoryItem field must be classified")
+        if not {"id", "content", "tags"} <= self.native_item_fields:
+            raise ValueError("id, content, and tags are required native fields")
+        if self.preserves_metadata and "metadata" not in self.native_item_fields:
+            raise ValueError("preserved metadata must be a native field")
+        if self.retrieve_fidelity == "full" and (
+            self.dropped_item_fields or not self.preserves_metadata
+        ):
+            raise ValueError("full retrieve fidelity must preserve every item field")
+        if self.search_fidelity == "full" and (
+            self.dropped_item_fields
+            or not self.search_returns_tags
+            or not self.preserves_metadata
+        ):
+            raise ValueError("full search fidelity must preserve all fields and tags")
+        return self
+
+@runtime_checkable
+class ExternalMemoryStore(MemoryStore, Protocol):
+    @property
+    def manifest(self) -> MemoryAdapterManifest: ...
+```
+
+Field meanings are normative:
+
+| Field | Meaning |
+|---|---|
+| `adapter` | Stable adapter implementation identifier used in diagnostics and test reports; not a display label selected per request. |
+| `native_item_fields` | `MemoryItem` fields the service stores in a native field and the adapter can test on direct retrieval. |
+| `dropped_item_fields` | Fields the service cannot represent and the adapter does not persist. Every dropped field must also be described in adapter documentation. |
+| `supported_filters` | Exact accepted keys inside `MemoryQuery.filters`; the set does not silently expand through pass-through parameters. |
+| `search_consistency` | Whether a successful store must be visible to `search()` immediately or may appear after index convergence. |
+| `retrieve_fidelity` | Fidelity of direct identity retrieval. |
+| `search_fidelity` | Fidelity of ranked/list search hits, which may be lower than direct retrieval. |
+| `search_returns_tags` | Whether search-hit `MemoryItem.tags` contains the stored tags; independent of whether writes accept tags. |
+| `preserves_metadata` | Whether the arbitrary metadata mapping round-trips exactly. `True` requires metadata to be native; `False` permits metadata to be dropped or represented lossily as declared. |
+
+The fidelity values mean:
+
+- `full`: every `MemoryItem` field is represented and round-trips without adapter-defined loss.
+- `native_fields`: direct retrieval round-trips every field in `native_item_fields`; search
+  round-trips the operation's documented native projection, with tag presence governed by
+  `search_returns_tags`. Every globally dropped field is absent/defaulted as documented.
+- `lossy`: at least one accepted native field is normalized, truncated, synthesized, or otherwise
+  not exactly reconstructible. The transformation must have named test fixtures and documentation;
+  the enum alone is not sufficient disclosure.
+
+**Exact manifest semantics**:
+
+- The manifest is stable for the lifetime of an adapter instance. A runtime service downgrade
+  that invalidates it makes the adapter unavailable; the adapter does not mutate capabilities
+  mid-call.
+- The manifest describes adapter behavior, not service marketing or optional features that were
+  not configured for this instance.
+- Every `MemoryItem` field is classified exactly once. An adapter cannot omit an awkward field
+  from both sets.
+- Additional service-native fields are projected only into documented `MemoryItem` fields or
+  omitted. They do not appear as undeclared dynamic attributes.
+- Applications may reject an adapter before first use when its manifest does not meet required
+  fidelity, filter, consistency, tag, or metadata properties.
+
+**Why this way**: a typed manifest makes semantic differences machine-checkable without expanding
+the base core Protocol. Immutable instance-level truth prevents a caller from adopting an adapter
+under one contract and observing another later.
+
+### D2 — Make conformance executable
+
+An external package runs the same semantic matrix against two fixtures:
+
+1. a deterministic fake transport that can force misses, unsupported queries, eventual-index
+   delay, malformed responses, and transport failure; and
+2. an opt-in live service environment that checks the adapter's published manifest against the
+   deployed service version.
+
+The reusable suite consumes this harness shape:
+
+```python
+class MemoryAdapterHarness(Protocol):
+    async def make_store(self) -> ExternalMemoryStore: ...
+    async def reset(self) -> None: ...
+    async def make_search_index_visible(self) -> None: ...
+    async def make_transport_unavailable(self) -> None: ...
+    async def close(self) -> None: ...
+```
+
+The suite does not require the adapter itself to expose reset, index, or failure controls; those
+are test-harness capabilities over a disposable namespace or fake transport.
+
+**Required conformance matrix**:
+
+| Case | Required observation |
+|---|---|
+| Structural surface | Adapter satisfies both `MemoryStore` and `ExternalMemoryStore`; manifest validates. |
+| Store identifier | Successful `store(item)` returns `item.id` as `UUID`. |
+| Direct retrieval | Stored id returns a `MemoryItem`; every declared native field matches its fidelity contract. |
+| Unknown id | Returns `None`, not an empty item and not a search result. |
+| Wrong native kind | If the service identity resolves to a non-memory record, return `None`; never coerce it. |
+| Dropped write field | Reject before transport or list the field in `dropped_item_fields`; never silently drop an unclassified field. |
+| Typed search | Every result is `MemoryItem`; no native SDK object escapes. |
+| Limit | Positive `limit=N` returns at most N; zero returns `[]`; negative is visibly rejected. |
+| Empty query | Returns the backend's documented first page up to limit; it is not translated into an arbitrary magic search string. |
+| Unsupported filter | Raises `UnsupportedMemoryQuery` naming every rejected key; no remote query is issued. |
+| Supported filter | Fake transport proves the key and value are mapped as documented. |
+| Tag projection | Search-hit tags agree with `search_returns_tags`; direct retrieval agrees with retrieve fidelity. |
+| Metadata projection | Store/retrieve/search behavior agrees with `preserves_metadata` and field classification. |
+| Consistency | Immediate adapters surface a successful write at once; eventual adapters may miss before the harness exposes the index and must find it afterward. |
+| Transport outage | Explicit calls raise `MemoryAdapterUnavailable`; no empty-list/`None` fallback masquerades as a valid result. |
+| Rejected write | Raises `MemoryAdapterError` and returns no identifier. |
+| Manifest accuracy | Toggling every fake behavior causes the suite to fail when the manifest says the opposite. |
+
+The external package may add service-specific tests, but it cannot weaken or skip a shared case
+without changing its claim that the adapter satisfies this ADR. Live tests may be opt-in; fake
+tests are deterministic and required in ordinary CI.
+
+**Why this way**: prose capability declarations drift. A fake makes rare failure and eventual
+consistency paths repeatable, while a live check catches wire/schema drift the fake cannot. The
+separation avoids making routine core tests depend on external availability.
+
+### D3 — Make projection and query semantics explicit
+
+An adapter may be lossy, but never silently so.
+
+**Write contract**:
+
+- `store(item)` validates field support before issuing a remote write.
+- A field the adapter cannot represent is either rejected or included in
+  `manifest.dropped_item_fields`. Documentation states the default value observed on retrieval
+  and search.
+- `id`, `content`, and `tags` are the minimum direct-retrieval anchors already exercised by
+  ADR-0092's protocol fence. If the service cannot preserve them across store then retrieve, the
+  adapter rejects the write; it must not return a different id or silently lose tags while
+  claiming core conformance. Search hits may still omit tags when the manifest declares
+  `search_returns_tags=False`.
+- A rejected remote write raises `MemoryAdapterError` without returning a UUID. A successful
+  transport response that lacks a usable identity is also a write failure.
+- Retrying a write is adapter-owned. If the service cannot make repeated writes by the same UUID
+  idempotent, the adapter documents duplicate/conflict behavior; the portable layer does not
+  auto-retry.
+
+**Retrieve contract**:
+
+- `retrieve(item_id)` uses a direct identity operation, not ranked recall with the UUID as query
+  text.
+- Unknown identity returns `None`.
+- A service object with that identity but the wrong native record kind returns `None`; the adapter
+  does not coerce unrelated records into `MemoryItem`.
+- A successful `store()` must be directly retrievable according to the declared retrieve fidelity
+  without waiting for the search index. Otherwise the write is not acknowledged as successful.
+- Projection yields a new `MemoryItem` and no transport-native response object.
+
+**Search contract**:
+
+- `MemoryQuery.text`, `tags`, and positive `limit` are portable input axes. An adapter documents
+  its backend-specific ordering and tag-match semantics; ADR-0092 does not claim those are equal
+  to `InMemoryStore`.
+- `MemoryQuery.filters` accepts only keys in `manifest.supported_filters`. Validation considers
+  the full key set before transport so partial filtering cannot occur.
+- Unsupported keys raise `UnsupportedMemoryQuery` with all rejected keys sorted. They are never
+  ignored, stripped, or moved into free-form query text.
+- `limit=0` returns `[]` without transport. `limit<0` raises `UnsupportedMemoryQuery` naming
+  `limit`; external adapters do not reproduce the reference backend's negative-slice quirk.
+- Empty text/tags/filters is a valid request for the backend's documented first page. If a service
+  cannot express that operation, its adapter cannot claim conformance until it implements a safe
+  list path; substituting a wildcard with different scope is not allowed.
+- `search_consistency="eventual"` permits a newly stored item to be absent before index
+  convergence. It does not permit a stale direct `retrieve` or an empty result on transport error.
+- Search scores, rank breakdowns, and service-native query options do not enter `MemoryItem` or
+  `MemoryQuery` implicitly. They require a separately versioned extension.
+
+**Stable errors**:
+
+```python
+class MemoryAdapterError(RuntimeError):
+    """Base class for an explicit external MemoryStore operation failure."""
+
+class UnsupportedMemoryQuery(MemoryAdapterError):
+    def __init__(self, rejected_keys: Iterable[str]) -> None:
+        self.rejected_keys = tuple(sorted(set(rejected_keys)))
+        super().__init__(
+            "unsupported memory query keys: " + ", ".join(self.rejected_keys)
+        )
+
+class MemoryAdapterUnavailable(MemoryAdapterError):
+    """Transport or service availability prevented an explicit operation."""
+```
+
+Native exceptions are chained as causes but do not escape as the public error type. Validation
+errors in constructing `MemoryItem`, `MemoryQuery`, or the manifest remain Pydantic errors; these
+adapter exceptions describe operation semantics after valid input reaches the adapter boundary.
+
+**Why this way**: field loss and ignored predicates are correctness failures, not mere feature
+differences. Direct retrieval and eventual search answer different questions and need different
+miss semantics. Stable exceptions let applications distinguish “not found,” “unsupported,” and
+“temporarily unavailable” without knowing the service SDK.
+
+### D4 — Keep operational lifecycle adapter-owned and documented
+
+The base `MemoryStore` does not gain `open`, `close`, `health`, `retry`, or transaction methods.
+An external adapter owns any client, pool, authentication, namespace, timeout, and retry policy.
+
+Every adapter's companion documentation must state:
+
+- when connections are created (constructor, first call, or injected client);
+- whether one adapter instance is safe for concurrent Branch calls;
+- how the owning application closes it and whether close is idempotent;
+- request/connect timeout values and why those values were chosen;
+- retry count, backoff, jitter, and which operations are safe to retry;
+- namespace/collection scope and whether it is fixed at construction;
+- write-conflict and duplicate-id behavior; and
+- what availability/health evidence invalidates the manifest.
+
+There are no portable timeout, retry, pool-size, or connection-budget numbers in this ADR. The
+adapter package must provide real values with service evidence or explicitly state that it
+inherits client defaults with no recorded rationale. Core must not silently supply a universal
+retry loop: a retried write may duplicate state while a retried search is normally read-only.
+
+**Exact failure semantics**:
+
+- Transport creation failure raises `MemoryAdapterUnavailable` from the first explicit store,
+  retrieve, or search that requires it.
+- Mid-call transport failure raises `MemoryAdapterUnavailable`; it does not return `None`, `[]`,
+  or a generated UUID.
+- Malformed service payload raises `MemoryAdapterError` with the native error chained.
+- Close failure follows the adapter's documented owner lifecycle; it is never swallowed by Branch
+  or Session because they do not own close.
+- An adapter may expose an additional async context manager or `close()` method, but callers using
+  the base Protocol must still arrange ownership externally.
+- There is no fallback to `InMemoryStore` after an external write or read failure. Such fallback
+  would split state and make later retrieval nondeterministic.
+
+**Why this way**: lifecycle policy differs by transport and deployment. Adding it to the three
+method core Protocol would force the zero-dependency store to mimic network concerns and would not
+solve application ownership. Stable operation errors are portable; connection mechanics are not.
+
+### D5 — Keep the khive store target separate from prompt injection
+
+A khive-backed adapter is the first named application of D1-D4, but this ADR does not claim that
+it exists in this repository. It remains in an external package, satisfies `ExternalMemoryStore`,
+publishes a source-verified manifest, and maps store, identity retrieval, and ranked recall to
+their distinct native operations. The exact verb ids, request fields, response fields, defaults,
+and loss profile are **DEFERRED** until implementation time, when they can be verified against the
+external adapter and service source. Historical mappings are not treated as current wire truth.
+
+`KhiveInjectionProvider` is an adjacent, implemented `ContextProvider`. Its relevant current
+contract (`lionagi/tools/khive_injection.py`) is:
+
+```python
+class KhiveInjectionProvider:
+    def __init__(
+        self,
+        policy: KhiveInjectionPolicy,
+        mcp_config: dict | None = None,
+    ): ...
+
+    async def provide(
+        self, branch: Branch, instruction: Instruction
+    ) -> str | None: ...
+
+    async def writeback(
+        self, branch: Branch, action_responses: list
+    ) -> None: ...
+```
+
+Its policy defaults are also concrete:
+
+```python
+@dataclass(frozen=True)
+class RecallPolicy:
+    limit: int = 5
+    min_score: float = 0.4
+    max_tokens: int = 800
+
+@dataclass(frozen=True)
+class ComposePolicy:
+    enabled: bool = False
+    max_tokens: int = 2000
+
+@dataclass(frozen=True)
+class WritebackPolicy:
+    enabled: bool = False
+    salience_cap: float = 0.4
+    tags: tuple[str, ...] = ()
+```
+
+The query task text is truncated to 400 characters. Injection output is token-truncated to the
+recall cap plus the compose cap when enabled. These values are inherited implementation defaults;
+the module records no measured rationale for 5, 0.4, 800, 2,000, or 400. They are not memory-store
+limits and must not be copied into an adapter manifest.
+
+**Exact separation semantics**:
+
+- `provide()` returns rendered prompt text or `None`, never `MemoryItem`.
+- It calls recall and optional composition, and it swallows transport failure into no injection so
+  the conversational turn continues.
+- Optional writeback derives tool error/resolution pairs and issues memory writes. A writeback
+  failure is logged and stops the remaining writeback loop; it is not surfaced as an explicit
+  persistence result.
+- It can emit best-effort feedback after recall. Feedback failure is logged and does not fail the
+  injection.
+- It has cadence, token, and salience policy; it has no `MemoryAdapterManifest` and does not
+  participate in Session's first-claim store sharing.
+- A caller wanting explicit persistence injects the external adapter. A caller wanting optional
+  prompt enrichment registers the context provider. Using one does not prove the other exists.
+
+**Why this way**: prompt enrichment should degrade gracefully because it is optional context.
+Explicit persistence must surface failure because the caller relies on state. Sharing a transport
+or native service does not make those contracts interchangeable.
+
+The explicit operation sequence is:
+
+```mermaid
+sequenceDiagram
+    participant A as Application
+    participant M as ExternalMemoryStore
+    participant X as Manifest / validator
+    participant S as External service
+
+    A->>X: inspect fidelity and filter support
+    X-->>A: accept or reject adapter before use
+    A->>M: store(MemoryItem)
+    M->>M: validate field projection
+    M->>S: native write
+    S-->>M: native identity response
+    M-->>A: same UUID or typed error
+    A->>M: retrieve(UUID) or search(MemoryQuery)
+    M->>M: validate query/filter/limit
+    M->>S: identity read or ranked/list search
+    S-->>M: native payload
+    M-->>A: MemoryItem / list[MemoryItem] / None / typed error
+```
+
+## Consequences
+
+Applications can compare adapters by executable guarantees instead of assuming identical method
+names imply identical memory semantics. Core remains dependency-light, while lossy projection,
+eventual consistency, filter support, and service availability become visible adoption choices.
+
+Adapter authors must maintain an immutable manifest, deterministic fake, live compatibility
+check, field projection documentation, and error mapping as either side evolves. Search hits may
+still differ in ordering or rank even when two adapters both conform; the manifest is a capability
+contract, not a claim that all backends are interchangeable.
+
+Callers requiring full metadata, tags in search hits, immediate search visibility, or a specific
+filter set must reject a manifest that does not provide them. They must also own connection
+lifecycle because Branch and Session remain intentionally unaware of it.
+
+Reversing D1-D3 after adapters ship requires a manifest/schema version and conformance migration.
+Reversing D4 by adding lifecycle to core would change `MemoryStore` and every implementation.
+Reversing D5 would couple optional prompt enrichment to explicit persistence and create ambiguous
+failure semantics.
+
+Counting the core protocol, conformance suite, external adapter, external service, and context
+provider gives five components. The adapter depends on the protocol and service, the suite depends
+on the protocol and adapter, and the context provider depends directly on the service, giving five
+directed dependencies and `κ = 5 / (5 × 4) = 0.25`. Its testability target is `τ = 0.90`:
+protocol, projection, filters, consistency, and errors are testable through a fake transport, with
+only live-service compatibility requiring an opt-in integration environment.
+
+## Alternatives considered
+
+### Put service-specific adapters in lionagi core
+
+This would make installation and examples easy and could share Lionagi's connection utilities.
+It lost because every service client, wire change, credential mode, and retry policy would enter
+core's dependency and release surface. Constructor injection already provides the needed seam.
+
+### Add the manifest to base `MemoryStore`
+
+One universal protocol would let every caller inspect capabilities, including `InMemoryStore`.
+It lost because the existing core contract deliberately has three methods and structurally valid
+minimal stores need no service-fidelity declaration. `ExternalMemoryStore` extends rather than
+breaks that contract.
+
+### Treat direct context injection as a store adapter
+
+Both surfaces may call the same service, and prompt recall resembles search. It lost because the
+context provider returns rendered text, performs optional feedback/writeback, follows cadence and
+token budgets, and swallows transport errors. A store returns typed records and must surface
+explicit persistence failure.
+
+### Permit undocumented lossy projection
+
+This minimizes adapter code and lets callers inspect returned objects empirically. It lost because
+missing metadata or tags can alter provenance and filtering silently. The manifest and fixtures
+make the adoption tradeoff explicit before data is written.
+
+### Ignore unsupported filters and run the broader query
+
+Best-effort filter mapping would keep more services usable. It lost because dropping a predicate
+broadens result scope and can return records the caller explicitly excluded. Visible rejection is
+the only safe portable behavior.
+
+### Put arbitrary native query options in `MemoryQuery.filters`
+
+Pass-through options would expose every service feature without new types. It lost because filter
+keys would become an unversioned backend escape hatch and callers could no longer know which
+queries are portable. Native extensions require their own versioned API.
+
+### Rehydrate every search hit through identity retrieval
+
+This could upgrade low-fidelity search results, such as missing tags, into full `MemoryItem`s. It
+lost as a hidden default because one ranked call becomes N+1 service calls, changing latency,
+failure, and rate behavior. A caller may explicitly retrieve selected hits when needed.
+
+### Map identity retrieval onto ranked search
+
+Using one native recall operation would reduce adapter mapping work. It lost because rank search
+can miss a valid id, return a different record, or depend on index convergence. Identity miss and
+search miss have different contracts.
+
+### Fall back to `InMemoryStore` on external failure
+
+This would keep the application available during an outage. It lost because successful-looking
+writes would split across two stores and later retrieval would depend on which process handled the
+call. Availability cannot override persistence truth silently.
+
+## Notes
+
+Interpretation uses *expressio unius* to limit this contract to the three `MemoryStore` verbs and
+their fidelity. Graph traversal, task operations, prompt enrichment, and service-native features
+remain outside the seam unless separately specified.
+
+Primary current-code anchors: `lionagi/protocols/memory.py`;
+`tests/protocols/test_memory.py`; `lionagi/session/branch.py`;
+`lionagi/session/session.py`; `lionagi/tools/khive_injection.py`;
+`lionagi/protocols/context_providers.py`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -161,4 +161,57 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   and directory discovery
 - 0066-0067 — unused (intentional gaps)
 
+### scheduling-control-plane (0068-0075)
+
+- [ADR-0068](ADR-0068-three-public-orchestration-lanes.md) — Three public orchestration lanes
+- [ADR-0069](ADR-0069-reactive-flow-steering-and-recovery.md) — Reactive flow steering and
+  recovery
+- [ADR-0070](ADR-0070-studio-scheduling-and-dispatch-delivery.md) — Studio scheduling and
+  dispatch delivery
+- [ADR-0071](ADR-0071-durable-ad-hoc-task-queue.md) — Durable ad-hoc task queue
+- [ADR-0072](ADR-0072-unified-task-admission-and-lifecycle.md) — Unified task admission and
+  lifecycle
+- [ADR-0073](ADR-0073-fixed-workflow-definition-execution.md) — Fixed workflow-definition
+  execution
+- 0074-0075 — unused (intentional gaps)
+
+### studio (0076-0085)
+
+- [ADR-0076](ADR-0076-studio-daemon-route-registry-and-local-control-plane.md) — Studio
+  daemon route registry and local control plane
+- [ADR-0077](ADR-0077-studio-state-and-filesystem-boundary.md) — Studio state and filesystem
+  boundary
+- [ADR-0078](ADR-0078-studio-application-service-boundary.md) — Studio application-service
+  boundary
+- [ADR-0079](ADR-0079-studio-web-client-architecture-and-deployment.md) — Studio web client
+  architecture and deployment
+- [ADR-0080](ADR-0080-studio-six-space-cockpit-information-architecture.md) — Studio
+  six-space cockpit information architecture
+- [ADR-0081](ADR-0081-studio-execution-and-artifact-workspace-target.md) — Studio execution
+  and artifact workspace target
+- [ADR-0082](ADR-0082-vscode-studio-observability-client.md) — VS Code Studio observability
+  client
+- [ADR-0083](ADR-0083-studio-operator-command-protocol.md) — Studio operator-command protocol
+- 0084-0085 — unused (intentional gaps)
+
+### governance (0086-0089)
+
+- [ADR-0086](ADR-0086-local-tool-controls-and-session-authorization.md) — Local tool controls
+  and session authorization observation
+- [ADR-0087](ADR-0087-evidence-backed-governed-execution.md) — Evidence-backed governed
+  execution
+- 0088-0089 — unused (intentional gaps)
+
+### substrates (0090-0095)
+
+- [ADR-0090](ADR-0090-local-sandbox-and-measured-cell-backend-seams.md) — Local sandbox and
+  measured-cell backend seams
+- [ADR-0091](ADR-0091-per-worker-worktree-execution-isolation.md) — Per-worker worktree
+  execution isolation
+- [ADR-0092](ADR-0092-minimal-branch-and-session-memory-store.md) — Minimal Branch and
+  session memory store
+- [ADR-0093](ADR-0093-external-memory-adapter-fidelity-contract.md) — External memory adapter
+  fidelity contract
+- 0094-0095 — unused (intentional gaps)
+
 Remaining areas land here as their records are accepted.


### PR DESCRIPTION
Sixth and final area bundle of the ADR corpus: twenty records across four areas.

- **scheduling-control-plane (0068-0073)**: three public orchestration lanes, reactive flow steering and recovery, Studio scheduling and dispatch delivery, durable ad-hoc task queue, unified task admission and lifecycle, fixed workflow-definition execution.
- **studio (0076-0083)**: daemon route registry and local control plane, state and filesystem boundary, application-service boundary, web client architecture and deployment, six-space cockpit information architecture, execution and artifact workspace target, VS Code observability client, operator-command protocol.
- **governance (0086-0087)**: local tool controls and session authorization observation, evidence-backed governed execution.
- **substrates (0090-0093)**: local sandbox and measured-cell backend seams, per-worker worktree execution isolation, minimal Branch and session memory store, external memory adapter fidelity contract.

README index extended with the four area sections (0074-0075, 0084-0085, 0088-0089, 0094-0095 are intentional gaps). All records follow docs/adr/TEMPLATE.md, one kind each (retrospective or aspirational), every quoted contract checked against current source.

A follow-up corpus-completion PR will add `dispositions.yaml` (the archived-v0 disposition ledger) plus corpus-wide consistency passes (title casing, cross-references).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)