### PR TITLE
docs(adr): corpus completion — disposition ledger, title convention, shared metric definitions

### DIFF
--- a/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
+++ b/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
@@ -1,4 +1,4 @@
-# ADR-0001: Element Identity and Polymorphic Serialization Envelope
+# ADR-0001: Element identity and polymorphic serialization envelope
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
+++ b/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
@@ -1,4 +1,4 @@
-# ADR-0002: UUID-Keyed Ordered Collection Model
+# ADR-0002: UUID-keyed ordered collection model
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
+++ b/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0003: In-Process Event Execution Lifecycle
+# ADR-0003: In-process Event execution lifecycle
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0004-directed-graph-structural-invariants.md
+++ b/docs/adr/ADR-0004-directed-graph-structural-invariants.md
@@ -1,4 +1,4 @@
-# ADR-0004: Directed Graph Structural Invariants
+# ADR-0004: Directed graph structural invariants
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
+++ b/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
@@ -1,4 +1,4 @@
-# ADR-0006: Conversational Message Envelope and Ordered History
+# ADR-0006: Conversational message envelope and ordered history
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
+++ b/docs/adr/ADR-0007-canonical-turn-request-compilation-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0007: Canonical Turn-Request Compilation Boundary
+# ADR-0007: Canonical turn-request compilation boundary
 
 - **Status**: Proposed
 - **Kind**: Aspirational

--- a/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
+++ b/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
@@ -1,4 +1,4 @@
-# ADR-0008: Pre-Turn Context-Provider Execution and Attribution
+# ADR-0008: Pre-turn context-provider execution and attribution
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -79,6 +79,10 @@ This ADR deliberately does **not** decide:
 - durable report retention, redaction, or privacy policy; these remain explicit deltas; or
 - whether systemless branches should invoke providers. The current skip is descriptive, not an
   aspirational resolution.
+
+See also ADR-0016 D3, which records the same provider registry from the Branch-aggregate side
+(lifetime, cloning, and persistence semantics alongside the other branch-scoped extensions).
+This ADR owns pre-turn execution ordering, budgeting, and attribution.
 
 ## Decision
 

--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -1,4 +1,4 @@
-# ADR-0011: Function Tool Descriptor and Branch Registry
+# ADR-0011: Function tool descriptor and Branch registry
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
+++ b/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0012: Branch Action Execution and Event Lifecycle
+# ADR-0012: Branch action execution and event lifecycle
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
+++ b/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
@@ -1,4 +1,4 @@
-# ADR-0013: Built-in Tool Provider and Branch Binding
+# ADR-0013: Built-in tool provider and Branch binding
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
+++ b/docs/adr/ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0016: Branch Conversation Aggregate and Attachment Boundary
+# ADR-0016: Branch conversation aggregate and attachment boundary
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -220,8 +220,10 @@ def memory(self) -> MemoryStore:
 
 #### Context-provider contract
 
-`providers` lazily creates one `ContextProviderRegistry`. The registry and report shapes are
-(`lionagi/protocols/context_providers.py`):
+`providers` lazily creates one `ContextProviderRegistry`. Pre-turn execution ordering,
+budgeting, and attribution semantics for this registry are recorded in ADR-0008; this section
+owns its lifetime and persistence semantics within the Branch aggregate. The registry and
+report shapes are (`lionagi/protocols/context_providers.py`):
 
 ```python
 class ContextProvider(Protocol):

--- a/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
+++ b/docs/adr/ADR-0017-session-membership-and-coordination-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0017: Session Membership and Coordination Boundary
+# ADR-0017: Session membership and coordination boundary
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
+++ b/docs/adr/ADR-0018-turn-scoped-branch-execution-state.md
@@ -1,4 +1,4 @@
-# ADR-0018: Turn-Scoped Branch Execution State
+# ADR-0018: Turn-scoped Branch execution state
 
 - **Status**: Proposed
 - **Kind**: Aspirational

--- a/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
+++ b/docs/adr/ADR-0021-branch-operation-facade-and-turn-adapters.md
@@ -1,4 +1,4 @@
-# ADR-0021: Branch operation façade and turn-adapter contract
+# ADR-0021: Branch operation facade and turn-adapter contract
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -15,12 +15,12 @@ live under `lionagi/operations/`. The split grew around five concrete problems.
 transport, structured parsing, action execution, composed operation, interpretation, and reasoning
 loops all need the same branch managers. Publishing those functions only as unrelated
 module calls would make callers assemble and pass that state themselves; implementing them directly
-on `Branch` would make an already stateful façade own every algorithm.
+on `Branch` would make an already stateful facade own every algorithm.
 
 **P2 — Operation implementations and `Branch` would form a runtime import cycle.** Implementations
-need a branch instance, while the façade needs to expose the implementations. The shipped direction
+need a branch instance, while the facade needs to expose the implementations. The shipped direction
 is a type-only dependency from operation modules to `Branch` and a lazy, method-local import from
-the façade to the implementation (`lionagi/session/branch.py`; `lionagi/operations/types.py`).
+the facade to the implementation (`lionagi/session/branch.py`; `lionagi/operations/types.py`).
 
 **P3 — Named extensions must resolve the same way from direct calls and graph nodes.** A session can
 register a coroutine by name, and an `Operation` graph node stores only an operation name and
@@ -45,7 +45,7 @@ message (`lionagi/operations/types.py`; `lionagi/operations/run/run.py`;
 
 | Concern | Decision |
 |---------|----------|
-| Public operation boundary | D1: `Branch` remains the façade and lazily delegates to operation modules. |
+| Public operation boundary | D1: `Branch` remains the facade and lazily delegates to operation modules. |
 | Named extension lookup | D2: one session-owned async registry serves direct and graph dispatch, after built-ins. |
 | Model-facing transport behavior | D3: `chat`, `chat_and_record`, `communicate`, `run`, and `run_and_collect` retain distinct persistence and failure semantics. |
 | Lifecycle and cleanup ownership | D4: the wrapper or stream that owns an exchange owns its lifecycle and cleanup signals. |
@@ -59,20 +59,20 @@ This ADR deliberately does **not** decide:
   graph execution kernel.
 - LNDL syntax or its specific multi-round policy; ADR-0024 records the operations adapter only.
 - Provider endpoint implementation, request serialization, rate limiting, or credentials; those are
-  service-provider concerns below the operation façade.
+  service-provider concerns below the operation facade.
 - Durable branch/session persistence; the operations layer emits and records state but does not
   choose a persistence substrate.
 
 ## Decision
 
-### D1 — `Branch` is the public façade and operation modules are the implementation layer
+### D1 — `Branch` is the public facade and operation modules are the implementation layer
 
 The shipped dependency shape is:
 
 ```text
 lionagi/
 ├── session/
-│   ├── branch.py                 # public façade; lazy imports inside verb methods
+│   ├── branch.py                 # public facade; lazy imports inside verb methods
 │   └── session.py                # branch collection and shared operation manager
 └── operations/
     ├── types.py                  # parameter dataclasses and Middle protocol
@@ -84,7 +84,7 @@ lionagi/
     ├── operate/operate.py        # composed coordinator (ADR-0022)
     ├── act/act.py
     ├── parse/parse.py
-    ├── select/select.py             # module exists; no Branch.select façade is shipped
+    ├── select/select.py             # module exists; no Branch.select facade is shipped
     ├── interpret/interpret.py
     └── ReAct/ReAct.py
 ```
@@ -163,7 +163,7 @@ class Branch:
 
 Exact semantics:
 
-- A façade method receives an already constructed `Branch`; operation implementations do not create
+- A facade method receives an already constructed `Branch`; operation implementations do not create
   or attach a branch or session.
 - `chat_model` and `parse_model` default through the branch's `iModelManager`; callers may override
   them on the methods that expose those parameters.
@@ -172,8 +172,8 @@ Exact semantics:
 - The public annotation on `Branch.chat()` says it returns the instruction/response tuple, but its
   default runtime path returns response text. The implementation-level `chat()` correctly declares
   the union. `return_ins_res_message` is therefore the authoritative runtime discriminator; the
-  façade annotation is currently under-specified.
-- `BranchOperations` and the actual façade drift in both directions. The literal lists `select`,
+  facade annotation is currently under-specified.
+- `BranchOperations` and the actual facade drift in both directions. The literal lists `select`,
   although no `Branch.select()` method is shipped; it omits the public `run()` and
   `chat_and_record()` methods. `select` resolves only if a session registers that name, while the
   omitted public methods resolve through normal attribute lookup. The graph node consequently uses
@@ -185,7 +185,7 @@ Exact semantics:
   to 100. The bounds prevent an extension loop from growing without limit, but the operations code
   records no empirical rationale for exactly 3 or 100 (`lionagi/operations/ReAct/ReAct.py`).
 - An exception from the delegated implementation propagates unless that implementation documents a
-  more specific conversion. The façade does not turn arbitrary failures into values.
+  more specific conversion. The facade does not turn arbitrary failures into values.
 
 **Why this way.** `Branch` already owns the managers required by every verb, so it is the coherent
 caller boundary. Method-local delegation preserves that discoverability without reversing the
@@ -262,7 +262,7 @@ Exact semantics:
 
 **Why this way.** Session ownership matches the intended lifetime: named extensions coordinate a
 set of branches, and graph nodes need them after branch cloning or allocation. Built-in precedence
-keeps the stable façade from being silently redefined by registration. Reusing the same lookup from
+keeps the stable facade from being silently redefined by registration. Reusing the same lookup from
 direct and graph dispatch makes an operation name one contract rather than two.
 
 ### D3 — API one-shot, explicit recording, recorded API, CLI stream, and collection remain distinct
@@ -501,9 +501,9 @@ execution.
 - Contributors must understand that lifecycle ownership is intentionally split. Adding a wrapper at
   the wrong layer can duplicate start/terminal signals or end a run before a generator is consumed.
 - Reversing D1 or D2 is high-cost because public callers and graph dispatch both depend on the
-  façade/lookup contract. Replacing a `Middle` is low-cost when it honors D5. Unifying D3 would be
+  facade/lookup contract. Replacing a `Middle` is low-cost when it honors D5. Unifying D3 would be
   high-risk because it changes persistence and cancellation behavior.
-- The façade and `flow.py` depend on the operation model, but the measured eight-component
+- The facade and `flow.py` depend on the operation model, but the measured eight-component
   operations architecture remains `κ = 12 / (8 × 7) = 0.214`, below the 0.3 target. The decision
   boundaries remain testable through injected models, registered coroutine operations, and custom
   `Middle` callables (`τ ≈ 0.9` for the area; static tests do not establish provider reliability).
@@ -513,14 +513,14 @@ execution.
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
 | 1 | Replace the `Middle` one-turn wording with a logical-exchange contract that states message-recording, streaming, bounded-loop, native-tool, and validation responsibilities; add conformance tests for `communicate`, `run_and_collect`, and LNDL. | M | (filled at issue-open time) |
-| 2 | Make the branch-operation vocabulary explicitly extensible or align it with the façade by adding or removing `select` and including `run` and `chat_and_record`; publish the intended registry and adapter exports from one canonical namespace. | S | (filled at issue-open time) |
+| 2 | Make the branch-operation vocabulary explicitly extensible or align it with the facade by adding or removing `select` and including `run` and `chat_and_record`; publish the intended registry and adapter exports from one canonical namespace. | S | (filled at issue-open time) |
 | 3 | Document the session ownership of the named-operation registry in its type and public API, preserving built-in precedence and asynchronous registration checks. | S | (filled at issue-open time) |
 | 4 | Represent lifecycle ownership for API turns, CLI streams, and nested operations in an explicit internal contract and add tests that prevent duplicate start or terminal signals. | M | (filled at issue-open time) |
 | 5 | Correct the public `Branch.chat()` return annotation so it expresses response text by default and the instruction/response tuple when `return_ins_res_message=True`; add typing coverage for both call forms. | S | (filled at issue-open time) |
 
 ## Alternatives considered
 
-### Publish operation functions instead of a `Branch` façade
+### Publish operation functions instead of a `Branch` facade
 
 This would make dependency direction obvious and keep `Branch` smaller. It lost because every call
 would still require the caller to select and pass the branch's managers, models, observer, hooks,
@@ -545,7 +545,7 @@ manager gives one lifetime and one lookup truth.
 
 This would make the extension mechanism maximally flexible. It lost because a registration could
 silently redefine a stable public verb for all branches in a session. `update=True` intentionally
-means replace a registry entry, not replace `Branch.operate` or another façade method.
+means replace a registry entry, not replace `Branch.operate` or another facade method.
 
 ### Collapse API and CLI calls into one transport primitive
 
@@ -554,7 +554,7 @@ single awaited event while a CLI invocation is an async-generator resource whose
 iteration and consumer abandonment. A single primitive would either hide the stream or force every
 API call through streaming lifecycle machinery.
 
-### Make the façade record every model call automatically
+### Make the facade record every model call automatically
 
 This would make history behavior superficially uniform. It lost because `chat()` is intentionally a
 non-recording primitive used when a caller needs a request without conversation mutation.

--- a/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
+++ b/docs/adr/ADR-0022-composed-branch-operation-pipeline.md
@@ -13,7 +13,7 @@ ask for generated structured fields, expose actions to a model, validate the ret
 accepted action requests, and attach action results. Four problems force the current coordinator
 shape.
 
-**P1 — A broad public call must become a small typed internal request.** The façade accepts an
+**P1 — A broad public call must become a small typed internal request.** The facade accepts an
 `Instruct` or loose instruction/guidance/context values, model overrides, response types, field
 specifications, action controls, persistence controls, and an optional `Middle`. Passing that bag
 through every stage would make precedence and defaults implicit. `prepare_operate_kw()` resolves it
@@ -158,7 +158,7 @@ Exact normalization semantics:
 - At the public `Branch.operate()` boundary, `action_strategy` itself defaults to the truthy value
   `"concurrent"` and is always forwarded. Consequently an `Instruct(actions=True,
   action_strategy="sequential")` does **not** select sequential execution when the caller omits the
-  loose keyword: the façade default wins. The intended-looking instruction fallback is reachable
+  loose keyword: the facade default wins. The intended-looking instruction fallback is reachable
   only through a direct internal preparer call that supplies a falsey strategy. The public API
   cannot currently distinguish “keyword omitted” from “explicitly concurrent.”
 - Public `tool_schemas` are copied into the initial chat/run parameter, but D2 replaces the effective
@@ -412,7 +412,7 @@ Augmentation preserves the model's original reasoning and fields alongside obser
   distinguishable and are attached after execution.
 - Explicit action enablement is required. Merely returning text that resembles a call, or returning
   `action_requests` when no `ActionParam` exists, causes no tool side effect.
-- An instruction-embedded sequential strategy is currently shadowed by the façade's truthy
+- An instruction-embedded sequential strategy is currently shadowed by the facade's truthy
   `"concurrent"` default unless the loose keyword is also supplied. Callers must set
   `action_strategy="sequential"` explicitly at the branch boundary.
 - Validation policy can prevent side effects: a caller-model mismatch returns or raises before
@@ -438,7 +438,7 @@ Augmentation preserves the model's original reasoning and fields alongside obser
 | 1 | Deprecate and remove the ignored public `operative` argument, or define and implement a precedence rule that honors it while preserving generated request and response fields. | S | (filled at issue-open time) |
 | 2 | Expose `Structure` through the chosen public branch APIs and parameter builders, or mark it internal and remove it from public parameter types; add one end-to-end public-path test. | S | (filled at issue-open time) |
 | 3 | Split the raw-result shortcut into explicit validation and post-processing controls, or rename and document `skip_validation` so callers know that it also disables outer action execution. | S | (filled at issue-open time) |
-| 4 | Make action-strategy precedence distinguish an omitted façade keyword from explicit `"concurrent"`, then add a public-path test proving that `Instruct.action_strategy` either governs execution or is deliberately removed. | S | (filled at issue-open time) |
+| 4 | Make action-strategy precedence distinguish an omitted facade keyword from explicit `"concurrent"`, then add a public-path test proving that `Instruct.action_strategy` either governs execution or is deliberately removed. | S | (filled at issue-open time) |
 
 ## Alternatives considered
 

--- a/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
+++ b/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
@@ -230,7 +230,7 @@ class DependencyAwareExecutor:
     async def execute(self) -> dict[str, Any]: ...
 ```
 
-The session façade defaults to `max_concurrent=5`; the module-level `flow()` accepts `None`, which
+The session facade defaults to `max_concurrent=5`; the module-level `flow()` accepts `None`, which
 the executor interprets as `UNLIMITED_CONCURRENCY`. The name means “use a high configured bound,” not
 literal infinity: its inherited environment default is 10,000. `parallel=False` at the `flow()`
 boundary forces `max_concurrent=1`. The code records no benchmark or dependency-capacity rationale

--- a/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
+++ b/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
@@ -1,4 +1,4 @@
-# ADR-0027: Model-service façade and endpoint resolution
+# ADR-0027: Model-service facade and endpoint resolution
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -66,7 +66,7 @@ EndpointRegistry ---> EndpointMeta ---> Endpoint | AgenticEndpoint
 
 | Concern | Decision |
 |---------|----------|
-| Caller-facing lifecycle and model registry | D1: `iModel` owns one resolved endpoint, executor, hook registry, and provider session; `iModelManager` owns named façades. |
+| Caller-facing lifecycle and model registry | D1: `iModel` owns one resolved endpoint, executor, hook registry, and provider session; `iModelManager` owns named facades. |
 | Provider/endpoint discovery | D2: `EndpointRegistry` is the sole resolver, populated by provider decorators and a fixed lazy bootstrap list. |
 | Generic execution boundary | D3: `Endpoint` and `AgenticEndpoint` execute through `APICalling` and normalize streams as `StreamChunk`; HTTP-only mechanics stay on `Endpoint`. |
 | Vendor ownership | D4: provider packages own request schemas, defaults, mappings, event grammars, and agentic mechanics. |
@@ -81,11 +81,11 @@ This retrospective ADR deliberately does **not** decide:
   target.
 - General hook composition or event-bus behavior; the hooks ADR owns call-boundary hook policy.
 - Final package ownership for token estimation or MCP client security. Their consumers and failure
-  contracts differ, so they remain migration deltas rather than part of this façade decision.
+  contracts differ, so they remain migration deltas rather than part of this facade decision.
 
 ## Decision
 
-### D1 — `iModel` is the model-service lifecycle façade
+### D1 — `iModel` is the model-service lifecycle facade
 
 `iModel` is the object callers construct, invoke, stream, copy, serialize, and close. Callers do not
 instantiate provider classes as the normal model API. The shipped constructor is
@@ -167,8 +167,8 @@ class iModelManager(Manager):
   and `base_url` overwrite the resolved configuration after construction.
 - **Identity.** `id` is normalized through `ID.get_id`; otherwise a new UUID is generated.
   `created_at` must be a float timestamp when supplied; otherwise current UTC time is stored.
-- **Executor ownership.** Each façade creates exactly one `RateLimitedAPIExecutor`; copies receive a
-  fresh façade id and executor. The endpoint config is deep-copied, while the existing retry and
+- **Executor ownership.** Each facade creates exactly one `RateLimitedAPIExecutor`; copies receive a
+  fresh facade id and executor. The endpoint config is deep-copied, while the existing retry and
   circuit-breaker objects are passed to the copied endpoint. Provider runtime handlers are copied
   through `Endpoint.copy_runtime_state_to()`.
 - **Event construction.** `create_event()` optionally runs a pre-create hook, builds an
@@ -214,10 +214,10 @@ Current numeric defaults are recorded rather than rationalized after the fact:
 | `invoke()` wait `10` seconds | Safety wait before the event is popped and returned. | Inherited; source records the behavior but no numeric rationale. |
 | Manager close `10` seconds per model | Prevents one close from blocking all other closes. | Isolation is documented; the exact number is inherited. |
 
-**Why this way.** A single façade keeps provider selection, event creation, hook attachment,
+**Why this way.** A single facade keeps provider selection, event creation, hook attachment,
 executor lifetime, serialization, and session state from being reimplemented by Branch and every
 operation. `iModelManager` adds only named ownership and shutdown rather than another dispatch
-abstraction. The cost is a broad façade: admission defects and provider-session details can leak
+abstraction. The cost is a broad facade: admission defects and provider-session details can leak
 into an object that callers otherwise treat as a model client.
 
 ### D2 — `EndpointRegistry` is the sole endpoint resolver
@@ -544,8 +544,8 @@ The package boundary is:
 
 ```text
 lionagi/service/
-├── imodel.py                         façade and session ownership
-├── manager.py                        named façade lifecycle
+├── imodel.py                         facade and session ownership
+├── manager.py                        named facade lifecycle
 ├── rate_limited_processor.py         current admission/executor
 ├── resilience.py                     generic retry and circuit policy
 └── connections/
@@ -609,7 +609,7 @@ the shared agentic output and cleanup contract.
 
 ## Consequences
 
-- API, subprocess, in-process, and remote-agent providers share one public `iModel` façade and one
+- API, subprocess, in-process, and remote-agent providers share one public `iModel` facade and one
   `APICalling`/`StreamChunk` event model. Existing public `iModel`, `Endpoint`, `AgenticEndpoint`,
   `APICalling`, and `StreamChunk` names remain stable.
 - Provider selection and construction are inspectable at one resolver. A new provider must still
@@ -619,7 +619,7 @@ the shared agentic output and cleanup contract.
   use the HTTP helpers because those helpers fail explicitly.
 - Reversing D1 would require changing Branch, operation, serialization, and lifecycle call sites;
   it is high cost. Replacing D2's registration mechanism is medium cost if `match_endpoint()` remains
-  the façade. Splitting D3's event model is high cost because operations consume `APICalling` and
+  the facade. Splitting D3's event model is high cost because operations consume `APICalling` and
   `StreamChunk`. Moving a vendor grammar under service is mechanically easy but raises ongoing
   coupling.
 - Maintainers must know that `queue_capacity` is not a physical queue limit, `stream()` bypasses
@@ -637,7 +637,7 @@ the shared agentic output and cleanup contract.
 | 2 | Route `invoke()` and `stream()` through one bounded admission lifecycle that applies request, token, and concurrency limits before provider work; propagate one deadline through queueing, retries, and transport; and prove that cancellation leaves no queued or active orphan. | L | (filled at issue-open time) |
 | 3 | Apply retry and circuit policy to HTTP stream establishment before the first emitted chunk, prohibit automatic replay after output begins, and add tests for pre-first-byte failure, mid-stream failure, normal EOF, and caller cancellation. | M | (filled at issue-open time) |
 | 4 | Publish an agentic-adapter conformance contract for request construction, normalized chunks, error classification, resume identifiers, and transport cleanup; run it against every subprocess, in-process, and remote adapter while retaining vendor parsers beside their vendors. | M | (filled at issue-open time) |
-| 5 | Move named-vendor identity, effort, bypass, and safety tables out of generic service ownership while preserving `parse_model_spec()` as a compatibility façade and testing every existing provider alias. | M | (filled at issue-open time) |
+| 5 | Move named-vendor identity, effort, bypass, and safety tables out of generic service ownership while preserving `parse_model_spec()` as a compatibility facade and testing every existing provider alias. | M | (filled at issue-open time) |
 | 6 | Freeze neutral interfaces for token estimation and MCP client security, then move them below protocol callers with compatibility re-exports and unchanged action-layer tool-registration behavior. | M | (filled at issue-open time) |
 
 ## Alternatives considered
@@ -679,7 +679,7 @@ Callers could pass `module:Class` and bypass aliases and bootstrap. That would s
 extensions without a central list. It lost for the primary API because model specs and public aliases
 would become Python package paths, provider availability could not be inspected uniformly, and every
 caller would become responsible for validating the imported type. A validated catalog can accept
-declarative external inventory later without changing the resolver façade.
+declarative external inventory later without changing the resolver facade.
 
 ### Make resolution strict immediately
 

--- a/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
+++ b/docs/adr/ADR-0028-validated-provider-adapter-catalog.md
@@ -114,7 +114,7 @@ def match_endpoint(
 
 `config_overrides` accepts only declared `EndpointConfig.model_fields`. `request_defaults` accepts
 only fields in the selected request model when one exists; for a deliberately schema-less compatible
-endpoint it accepts arbitrary JSON-serializable values. `iModel` remains a compatibility façade:
+endpoint it accepts arbitrary JSON-serializable values. `iModel` remains a compatibility facade:
 it classifies its legacy `**kwargs` against endpoint-config fields and the selected request model,
 warns during the deprecation window when an unclassified value would previously have entered
 `EndpointConfig.kwargs`, and then requires the caller to use `request_defaults` explicitly.
@@ -245,8 +245,8 @@ lionagi/providers/
 
 lionagi/service/connections/
 ├── catalog.py                   validation + immutable CatalogSnapshot
-├── registry.py                  EndpointRegistry façade over snapshot
-└── match_endpoint.py            public compatibility façade
+├── registry.py                  EndpointRegistry facade over snapshot
+└── match_endpoint.py            public compatibility facade
 ```
 
 **Exact semantics**
@@ -415,7 +415,7 @@ def parse_model_spec(spec: str) -> ModelSpec: ...
 
 **Why this way.** Lookup, inspection, and model parsing must not answer provider identity from
 different tables. Provider-local policy keeps vendor additions local; the registry remains the
-validator and projection point. Keeping the `parse_model_spec()` façade prevents a package move from
+validator and projection point. Keeping the `parse_model_spec()` facade prevents a package move from
 becoming an unrelated public API break.
 
 ## Consequences
@@ -435,7 +435,7 @@ becoming an unrelated public API break.
 - Provider additions stop requiring a generic bootstrap edit and, after policy migration, stop
   requiring changes to `service/providers.py`.
 - Reversing D1/D2 is medium cost because provider declarations must be rewritten, but the resolver
-  façade remains stable. Reversing D4 after warnings ship is high cost because callers will rely on
+  facade remains stable. Reversing D4 after warnings ship is high cost because callers will rely on
   typed failure. Adding a future inventory source is low cost if it emits the same two spec types.
 - Maintainers must treat snapshot validation as a closed-world operation: local registration success
   is insufficient until global provider and endpoint key spaces validate.
@@ -490,7 +490,7 @@ and pass the same validator.
 
 This avoids moving `BACKENDS`, effort, bypass, and fast-mode mappings and keeps one familiar module.
 It lost because it preserves a second provider identity authority. Parity tests and the retained
-`parse_model_spec()` façade make ownership movement safer than continued split truth.
+`parse_model_spec()` facade make ownership movement safer than continued split truth.
 
 ### Add a separate executor-provider registry
 

--- a/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
+++ b/docs/adr/ADR-0029-unified-request-admission-deadline-and-resilience-policy.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-ADR-0027 records one public model façade but two materially different execution lifecycles. This
+ADR-0027 records one public model facade but two materially different execution lifecycles. This
 ADR defines one target lifecycle for both result shapes.
 
 **P1 — `invoke()` can detach pending work.** Non-streaming `iModel.invoke()` appends an
@@ -47,7 +47,7 @@ provider streams have no replay cursor
 
 **P6 — Terminal state and cleanup have multiple owners.** `Event` already has `PENDING`,
 `PROCESSING`, `COMPLETED`, `FAILED`, `SKIPPED`, `CANCELLED`, and `ABORTED` states plus a completion
-signal. The processor, façade, event, endpoint, and operation nevertheless each own part of queueing,
+signal. The processor, facade, event, endpoint, and operation nevertheless each own part of queueing,
 cancellation, error capture, or generator close. No invariant currently prevents an event from being
 removed while non-terminal (`lionagi/protocols/generic/event.py`; `Event`, `EventStatus`).
 

--- a/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
+++ b/docs/adr/ADR-0030-agentic-provider-adapter-boundary.md
@@ -107,7 +107,7 @@ This ADR deliberately does **not** decide:
 - Provider catalog keys, aliases, bootstrap, or availability diagnostics. ADR-0028 owns selection.
 - A universal agent protocol or remote-agent wire format. NLIP remains one adapter, not the generic
   shape every in-process or subprocess provider must implement.
-- Durable provider sessions. This ADR moves confirmed identifiers between requests in one façade;
+- Durable provider sessions. This ADR moves confirmed identifiers between requests in one facade;
   persistence and cross-process recovery require a separate state contract.
 - Whether thinking content is shown to end users. The boundary transports normalized thinking
   chunks; presentation belongs to the consuming operation.

--- a/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
+++ b/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0033: Operation-Graph Orchestration Boundary
+# ADR-0033: Operation-graph orchestration boundary
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -94,7 +94,7 @@ flowchart TD
 
 ## Decision
 
-### D1 — One Session façade and execution kernel
+### D1 — One Session facade and execution kernel
 
 Every initial operation graph enters through `Session.flow()`. The Session resolves
 the default branch and delegates without redefining scheduling semantics.
@@ -172,7 +172,7 @@ class FlowEvent:
   it is not part of scheduling.
 
 **Why this way**: Session already owns branches, the observer, and registered
-operations. Keeping execution immediately below that façade gives every surface
+operations. Keeping execution immediately below that facade gives every surface
 the same branch and signal context while leaving initial plan construction outside
 the kernel.
 
@@ -488,7 +488,7 @@ likewise install observation and persistence around `Session.flow()`.
 **Shipped boundary**:
 
 ```text
-lionagi/session/session.py             public flow façade
+lionagi/session/session.py             public flow facade
 lionagi/operations/flow.py             scheduling and live admission
 lionagi/orchestration/patterns.py       library role/task planning and graph construction
 lionagi/engines/flow_signals.py         optional callback-to-signal adapter
@@ -543,7 +543,7 @@ entry point.
 |---|-------|------|-------|
 | 1 | Make sequential linking explicit in `OperationGraphBuilder`, migrate CLI fan-out and dependency-free DAG roots to independent-node construction, and add topology tests proving that no undeclared worker-to-worker edges exist. | M | (filled at issue-open time) |
 | 2 | Implement one `TaskAssignment.depends_on` normalizer for pattern and CLI builders, document whether forward ordinal references are accepted, and validate the normalized graph for cycles before execution. | S | (filled at issue-open time) |
-| 3 | Move callback-to-node-signal conversion from `engines` to a neutral flow/session module, expose a named observed-flow façade, and migrate EngineRun, Studio, CLI fan-out, CLI synthesis, and main CLI flow without changing signal ordering or result shape. | M | (filled at issue-open time) |
+| 3 | Move callback-to-node-signal conversion from `engines` to a neutral flow/session module, expose a named observed-flow facade, and migrate EngineRun, Studio, CLI fan-out, CLI synthesis, and main CLI flow without changing signal ordering or result shape. | M | (filled at issue-open time) |
 | 4 | Parameterize the shared role-task builders with branch, instruction, identity, and artifact decorators, then remove CLI-owned duplicate edge wiring while preserving checkpoint and artifact identities. | M | (filled at issue-open time) |
 
 ## Alternatives considered

--- a/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
+++ b/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
@@ -1,4 +1,4 @@
-# ADR-0034: Domain-Engine Coordination and Autonomy Safeguards
+# ADR-0034: Domain-engine coordination and autonomy safeguards
 
 - **Status**: Proposed
 - **Kind**: Retrospective
@@ -467,7 +467,7 @@ async def EngineRun.run_dag(
 - `max_spawn=50` and `max_concurrent=5` mirror the ADR-0033 defaults. No separate
   engine rationale is recorded.
 - The method's generic placement on every `EngineRun` is current package debt. The
-  neutral observed-flow façade in ADR-0033's delta is the intended generic owner.
+  neutral observed-flow facade in ADR-0033's delta is the intended generic owner.
 
 ## Consequences
 
@@ -494,7 +494,7 @@ async def EngineRun.run_dag(
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
 | 1 | Define and implement an event-retention or compaction policy for long-running `EngineRun` instances, with a test proving that required audit and terminal-summary events survive compaction. | M | (filled at issue-open time) |
-| 2 | Change `EngineRun.run_dag()` into a compatibility delegator over the neutral observed-flow façade and document the façade, rather than the engine method, as the generic graph-observation surface. | S | (filled at issue-open time) |
+| 2 | Change `EngineRun.run_dag()` into a compatibility delegator over the neutral observed-flow facade and document the facade, rather than the engine method, as the generic graph-observation surface. | S | (filled at issue-open time) |
 | 3 | Add one conformance suite that exercises agent budget, deadline cancellation, emission repair, judge failure, and terminal degradation across every concrete engine shape. | M | (filled at issue-open time) |
 
 ## Alternatives considered

--- a/docs/adr/ADR-0035-persisted-run-completion-contract.md
+++ b/docs/adr/ADR-0035-persisted-run-completion-contract.md
@@ -1,4 +1,4 @@
-# ADR-0035: Persisted Run-Completion Contract
+# ADR-0035: Persisted run-completion contract
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0036-casts-role-palettes-as-playstyle.md
+++ b/docs/adr/ADR-0036-casts-role-palettes-as-playstyle.md
@@ -1,4 +1,4 @@
-# ADR-0036: Casts Role Palettes as Playstyle
+# ADR-0036: Casts role palettes as playstyle
 
 - **Status**: Proposed
 - **Kind**: Aspirational

--- a/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
+++ b/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
@@ -1,4 +1,4 @@
-# ADR-0037: Resident Engine Host and Task Queue
+# ADR-0037: Resident engine host and task queue
 
 - **Status**: Proposed
 - **Kind**: Aspirational
@@ -300,7 +300,7 @@ default because task cost varies materially by engine and provider.
   flow. A Task whose lease cannot cover its deadline fails with `invalid_task`.
 - Session creation or runner setup failure is `invalid_task` when caused by Task
   data and `flow_failed` otherwise.
-- `run_task` must await the selected Engine or ADR-0033 observed-flow façade. The
+- `run_task` must await the selected Engine or ADR-0033 observed-flow facade. The
   host does not inspect or schedule individual graph nodes.
 - `should_stop_claiming()` true stops new claims but does not cancel active Tasks.
   `drain()` awaits all active jobs and returns only after their cooperative ack

--- a/docs/adr/ADR-0038-escalation-tier-routing.md
+++ b/docs/adr/ADR-0038-escalation-tier-routing.md
@@ -1,4 +1,4 @@
-# ADR-0038: Escalation Tier Routing
+# ADR-0038: Escalation tier routing
 
 - **Status**: Proposed
 - **Kind**: Aspirational
@@ -328,7 +328,7 @@ The root operation has escalation rung zero. Each accepted tier child increments
 that trusted metadata by one. A lineage may accept at most two escalation
 children.
 
-**The target executor and façade parameters**
+**The target executor and facade parameters**
 (`lionagi/operations/flow.py`; `lionagi/session/session.py`):
 
 ```python
@@ -671,7 +671,7 @@ lionagi/
 │   └── __init__.py                   public escalation exports
 ├── operations/flow.py                rung checks, builder call, attempt ledger
 ├── session/
-│   ├── session.py                    façade pass-through
+│   ├── session.py                    facade pass-through
 │   └── signal.py                     additive NodeEscalated fields
 ├── engines/engine.py                 run_dag pass-through
 └── cli/orchestrate/flow.py           route setup, templates, persistence projection

--- a/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
+++ b/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
@@ -513,7 +513,7 @@ because each Role-backed caller would have to reproduce prompt ordering, provide
 settings trust, tool attachment, MCP discovery, and emission grants. The existing CLI already shows
 why direct construction is appropriate only when no Role contract exists.
 
-### Make `AgentSpec` the live agent façade
+### Make `AgentSpec` the live agent facade
 
 The spec could hold a Branch internally and forward chat and tool methods. That would provide one
 user-facing object, but it would combine reusable configuration with one mutable conversation

--- a/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
+++ b/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
@@ -1,4 +1,4 @@
-# ADR-0086: Local Tool Controls and Session Authorization Observation
+# ADR-0086: Local tool controls and session authorization observation
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0087-evidence-backed-governed-execution.md
+++ b/docs/adr/ADR-0087-evidence-backed-governed-execution.md
@@ -1,4 +1,4 @@
-# ADR-0087: Evidence-Backed Governed Execution
+# ADR-0087: Evidence-backed governed execution
 
 - **Status**: Proposed
 - **Kind**: Aspirational
@@ -78,7 +78,7 @@ This ADR does **not** decide:
 - Governance of arbitrary Python calls made outside LionAGI.
 - Correctness or quality of tool outcomes.
 - The public convenience API for opening and closing task boundaries. D6 defines the internal
-  contract and retains that façade as a deferred choice.
+  contract and retains that facade as a deferred choice.
 
 ## Decision
 
@@ -638,7 +638,7 @@ Exact mint semantics:
   signature. Authentication of a certificate requires a separately designed signing-key and
   trust-root contract.
 
-**DEFERRED — public task-boundary façade.** The internal `ClosedTaskBoundary` and issuer contract
+**DEFERRED — public task-boundary facade.** The internal `ClosedTaskBoundary` and issuer contract
 are decided, but the convenience API that opens and closes a boundary is not. It must be selected
 before certificate implementation is exposed as usable. A session end, flow end, and individual
 operation are not interchangeable proofs. The retained candidates are:
@@ -650,7 +650,7 @@ operation are not interchangeable proofs. The retained candidates are:
 - A required boundary argument on `Session.flow()` — natural for DAG work, but excludes direct
   branch and manager use.
 
-The façade must produce a stable boundary ID at open, append `TASK_CLOSED` only once, reject
+The facade must produce a stable boundary ID at open, append `TASK_CLOSED` only once, reject
 double close, and make abandoned boundaries unmintable. No candidate is selected by this ADR.
 
 ### D7 — Observation is a non-authoritative projection
@@ -810,7 +810,7 @@ sequenceDiagram
    resolution, and concurrent operation-context isolation tests. Missing and ambiguous policy
    cases deny before callable execution.
 4. Ship D6 certificate verification and minting behind an explicitly selected task-boundary
-   façade. Include negative tests for open boundaries, missing terminals, changed content,
+   facade. Include negative tests for open boundaries, missing terminals, changed content,
    missing policy history, head mismatch, and permanent degraded grade.
 5. Ship D7 observation projection. Add D8 permits, duty separation, break-glass, integration
    wrappers, and trace export only as consumers of the stable core contracts.
@@ -853,7 +853,7 @@ Reversal cost:
 | D3 | High: append and conflict semantics are backend compatibility contracts. |
 | D4 | Medium: adapters isolate current controls, but gate level and reason code are stored evidence. |
 | D5 | High: policy pins and resolution determine historical meaning. |
-| D6 | Medium before the public boundary façade is selected; high after certificates are externally retained. |
+| D6 | Medium before the public boundary facade is selected; high after certificates are externally retained. |
 | D7 | Low: projection is explicitly non-authoritative and replaceable. |
 | D8 | Low while deferred; each family requires its own acceptance gate before activation. |
 
@@ -932,7 +932,7 @@ defined. Calling an unsigned hash-chain summary a signature would overstate the 
 Per-operation minting is precise but too narrow for a multi-operation task. Session-end minting
 can combine unrelated work. Flow-end minting excludes direct branch and manager use. None is
 selected implicitly; D6 retains an explicit boundary requirement and defers only its convenience
-façade.
+facade.
 
 ### Recreate current controls as new policy code
 
@@ -953,6 +953,6 @@ The six target components are `InvocationController`, `GateAdapter`, `EvidenceSt
 six directed dependencies, so `κ = 0.20`; protocol injection and pure functions provide the
 `τ = 1.0` isolated-test target.
 
-The first implementation must settle the public task-boundary façade before exposing certificate
+The first implementation must settle the public task-boundary facade before exposing certificate
 minting as usable. All other core contracts in D1-D7 are committed by this proposal as the target
 shape; D8 remains deferred and may not be advertised as active.

--- a/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
+++ b/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
@@ -1,4 +1,4 @@
-# ADR-0090: Local Sandbox and Measured-Cell Backend Seams
+# ADR-0090: Local sandbox and measured-cell backend seams
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0091-per-worker-worktree-execution-isolation.md
+++ b/docs/adr/ADR-0091-per-worker-worktree-execution-isolation.md
@@ -1,4 +1,4 @@
-# ADR-0091: Per-Worker Worktree Execution Isolation
+# ADR-0091: Per-worker worktree execution isolation
 
 - **Status**: Proposed
 - **Kind**: Aspirational

--- a/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
+++ b/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
@@ -1,4 +1,4 @@
-# ADR-0092: Minimal Branch and Session Memory Store
+# ADR-0092: Minimal Branch and session memory store
 
 - **Status**: Proposed
 - **Kind**: Retrospective

--- a/docs/adr/ADR-0093-external-memory-adapter-fidelity-contract.md
+++ b/docs/adr/ADR-0093-external-memory-adapter-fidelity-contract.md
@@ -1,4 +1,4 @@
-# ADR-0093: External Memory Adapter Fidelity Contract
+# ADR-0093: External memory adapter fidelity contract
 
 - **Status**: Proposed
 - **Kind**: Aspirational

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,8 +2,8 @@
 
 This directory is the canonical ADR corpus for lionagi. It replaces the earlier corpus now
 preserved at `docs/_archive/v0/` (moved there intact, original filenames kept). Every archived
-record receives an explicit disposition — carried forward into a new ADR, merged into one, or
-retired — recorded in `dispositions.yaml` in this directory once the corpus is complete.
+record has an explicit disposition — carried forward into a new ADR, merged into one, or
+retired — recorded in `dispositions.yaml` in this directory (one row per archived record).
 
 Each ADR follows `TEMPLATE.md` and is exactly one of two kinds:
 
@@ -13,6 +13,17 @@ Each ADR follows `TEMPLATE.md` and is exactly one of two kinds:
 
 A gap between a retrospective truth and an aspirational target is an issue, never a blurred
 document.
+
+## Architecture-quality figures (κ and τ)
+
+Several ADRs report two figures in their Consequences sections. κ is a coupling density:
+directed dependencies divided by n × (n − 1) over the components that ADR's own design diagram
+names, where a component is a named box and an edge is a direct dependency drawn in that
+diagram. τ is an estimated fraction of components testable in isolation through their declared
+seams. Both are the author's structural reading of the recorded design: arithmetically
+consistent within each ADR, not independently re-derived from source, and not comparable
+across ADRs whose component maps differ in granularity. Read them as review aids for the
+specific component map shown, not as corpus-wide measurements.
 
 ## Numbering
 
@@ -35,9 +46,9 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 ### core-data-model (0001-0005)
 
 - [ADR-0001](ADR-0001-element-identity-and-polymorphic-serialization-envelope.md) — Element
-  identity and the polymorphic serialization envelope
+  identity and polymorphic serialization envelope
 - [ADR-0002](ADR-0002-uuid-keyed-ordered-collection-model.md) — UUID-keyed ordered collection
-  model (Pile and Progression)
+  model
 - [ADR-0003](ADR-0003-in-process-event-execution-lifecycle.md) — In-process Event execution
   lifecycle
 - [ADR-0004](ADR-0004-directed-graph-structural-invariants.md) — Directed graph structural
@@ -50,61 +61,56 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   message envelope and ordered history
 - [ADR-0007](ADR-0007-canonical-turn-request-compilation-boundary.md) — Canonical turn-request
   compilation boundary
-- [ADR-0008](ADR-0008-pre-turn-context-provider-execution-and-attribution.md) — Pre-turn
-  context-provider execution and attribution
+- [ADR-0008](ADR-0008-pre-turn-context-provider-execution-and-attribution.md) — Pre-turn context-
+  provider execution and attribution
 - 0009-0010 — unused (intentional gaps)
 
 ### actions-tools (0011-0015)
 
-- [ADR-0011](ADR-0011-function-tool-descriptor-and-branch-registry.md) — Function tool
-  descriptor and Branch registry
-- [ADR-0012](ADR-0012-branch-action-execution-and-event-lifecycle.md) — Branch action
-  execution and event lifecycle
-- [ADR-0013](ADR-0013-built-in-tool-provider-and-branch-binding.md) — Built-in tool provider
-  and Branch binding
+- [ADR-0011](ADR-0011-function-tool-descriptor-and-branch-registry.md) — Function tool descriptor
+  and Branch registry
+- [ADR-0012](ADR-0012-branch-action-execution-and-event-lifecycle.md) — Branch action execution
+  and event lifecycle
+- [ADR-0013](ADR-0013-built-in-tool-provider-and-branch-binding.md) — Built-in tool provider and
+  Branch binding
 - 0014-0015 — unused (intentional gaps)
 
 ### session-branch (0016-0020)
 
 - [ADR-0016](ADR-0016-branch-conversation-aggregate-and-attachment-boundary.md) — Branch
   conversation aggregate and attachment boundary
-- [ADR-0017](ADR-0017-session-membership-and-coordination-boundary.md) — Session membership
-  and coordination boundary
-- [ADR-0018](ADR-0018-turn-scoped-branch-execution-state.md) — Turn-scoped Branch execution
-  state
+- [ADR-0017](ADR-0017-session-membership-and-coordination-boundary.md) — Session membership and
+  coordination boundary
+- [ADR-0018](ADR-0018-turn-scoped-branch-execution-state.md) — Turn-scoped Branch execution state
 - 0019-0020 — unused (intentional gaps)
 
 ### operations (0021-0026)
 
-- [ADR-0021](ADR-0021-branch-operation-facade-and-turn-adapters.md) — Branch operation facade
-  and turn adapters
-- [ADR-0022](ADR-0022-composed-branch-operation-pipeline.md) — Composed branch operation
-  pipeline
+- [ADR-0021](ADR-0021-branch-operation-facade-and-turn-adapters.md) — Branch operation facade and
+  turn-adapter contract
+- [ADR-0022](ADR-0022-composed-branch-operation-pipeline.md) — Composed branch operation pipeline
 - [ADR-0023](ADR-0023-dependency-aware-operation-graph-execution-kernel.md) — Dependency-aware
-  operation graph execution kernel
+  operation-graph execution kernel
 - [ADR-0024](ADR-0024-lndl-operate-integration-adapter.md) — LNDL operate integration adapter
 - 0025-0026 — unused (intentional gaps)
 
 ### service-providers (0027-0032)
 
-- [ADR-0027](ADR-0027-model-service-facade-and-endpoint-resolution.md) — Model-service facade
-  and endpoint resolution
-- [ADR-0028](ADR-0028-validated-provider-adapter-catalog.md) — Validated provider-adapter
-  catalog
+- [ADR-0027](ADR-0027-model-service-facade-and-endpoint-resolution.md) — Model-service facade and
+  endpoint resolution
+- [ADR-0028](ADR-0028-validated-provider-adapter-catalog.md) — Validated provider-adapter catalog
 - [ADR-0029](ADR-0029-unified-request-admission-deadline-and-resilience-policy.md) — Unified
   request admission, deadline, and resilience policy
-- [ADR-0030](ADR-0030-agentic-provider-adapter-boundary.md) — Agentic provider-adapter
-  boundary
+- [ADR-0030](ADR-0030-agentic-provider-adapter-boundary.md) — Agentic provider-adapter boundary
 - 0031-0032 — unused (intentional gaps)
 
 ### orchestration (0033-0040)
 
-- [ADR-0033](ADR-0033-operation-graph-orchestration-boundary.md) — Operation-graph
-  orchestration boundary
+- [ADR-0033](ADR-0033-operation-graph-orchestration-boundary.md) — Operation-graph orchestration
+  boundary
 - [ADR-0034](ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md) — Domain-engine
   coordination and autonomy safeguards
-- [ADR-0035](ADR-0035-persisted-run-completion-contract.md) — Persisted run-completion
-  contract
+- [ADR-0035](ADR-0035-persisted-run-completion-contract.md) — Persisted run-completion contract
 - [ADR-0036](ADR-0036-casts-role-palettes-as-playstyle.md) — Casts role palettes as playstyle
 - [ADR-0037](ADR-0037-resident-engine-host-and-task-queue.md) — Resident engine host and task
   queue
@@ -113,39 +119,38 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 
 ### agent-roles (0041-0046)
 
-- [ADR-0041](ADR-0041-agent-specification-and-branch-construction.md) — Agent specification
-  and Branch construction boundary
-- [ADR-0042](ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md) — Casts pattern
-  catalog and typed role authoring
-- [ADR-0043](ADR-0043-per-role-configuration-resolution.md) — Per-role configuration
-  resolution
+- [ADR-0041](ADR-0041-agent-specification-and-branch-construction.md) — Agent specification and
+  Branch construction boundary
+- [ADR-0042](ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md) — Casts pattern catalog
+  and typed role authoring
+- [ADR-0043](ADR-0043-per-role-configuration-resolution.md) — Per-role configuration resolution
 - [ADR-0044](ADR-0044-agent-prompt-directives-and-executable-permissions.md) — Agent prompt
   directives and executable permissions
 - 0045-0046 — unused (intentional gaps)
 
 ### hooks (0047-0049)
 
-- [ADR-0047](ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md) — Hook mechanism
-  scopes and canonical ownership
+- [ADR-0047](ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md) — Hook mechanism scopes
+  and canonical ownership
 - 0048-0049 — unused (intentional gaps)
 
 ### utilities (0050-0054)
 
-- [ADR-0050](ADR-0050-foundational-utility-and-typed-adaptation-strata.md) — Foundational
-  utility and typed adaptation strata
-- [ADR-0051](ADR-0051-lndl-language-and-operations-boundary.md) — LNDL language and
-  operations boundary
-- [ADR-0052](ADR-0052-supported-validation-and-testing-surfaces.md) — Supported validation
-  and testing surfaces
+- [ADR-0050](ADR-0050-foundational-utility-and-typed-adaptation-strata.md) — Foundational utility
+  and typed adaptation strata
+- [ADR-0051](ADR-0051-lndl-language-and-operations-boundary.md) — LNDL language and operations
+  boundary
+- [ADR-0052](ADR-0052-supported-validation-and-testing-surfaces.md) — Supported validation and
+  testing surfaces
 - 0053-0054 — unused (intentional gaps)
 
 ### persistence-state (0055-0061)
 
-- [ADR-0055](ADR-0055-operational-state-persistence-boundary.md) — Operational state
-  persistence boundary
+- [ADR-0055](ADR-0055-operational-state-persistence-boundary.md) — Operational state persistence
+  boundary
 - [ADR-0056](ADR-0056-statedb-sqlalchemy-core-backend.md) — StateDB SQLAlchemy Core backend
-- [ADR-0057](ADR-0057-operational-lifecycle-and-transition-audit.md) — Operational lifecycle
-  and transition audit
+- [ADR-0057](ADR-0057-operational-lifecycle-and-transition-audit.md) — Operational lifecycle and
+  transition audit
 - [ADR-0058](ADR-0058-unified-lifecycle-transition-service.md) — Unified lifecycle transition
   service
 - [ADR-0059](ADR-0059-durable-dispatch-outbox.md) — Durable dispatch outbox
@@ -155,10 +160,10 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 
 - [ADR-0062](ADR-0062-cli-command-surface-ownership.md) — CLI command-surface ownership
 - [ADR-0063](ADR-0063-project-attribution-cascade.md) — Project attribution cascade
-- [ADR-0064](ADR-0064-cli-execution-outcome-and-completion-record.md) — CLI execution outcome
-  and completion record
-- [ADR-0065](ADR-0065-marketplace-catalog-and-directory-discovery.md) — Marketplace catalog
-  and directory discovery
+- [ADR-0064](ADR-0064-cli-execution-outcome-and-completion-record.md) — CLI execution outcome and
+  completion record
+- [ADR-0065](ADR-0065-marketplace-catalog-and-directory-discovery.md) — Marketplace catalog and
+  directory discovery
 - 0066-0067 — unused (intentional gaps)
 
 ### scheduling-control-plane (0068-0075)
@@ -166,8 +171,8 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 - [ADR-0068](ADR-0068-three-public-orchestration-lanes.md) — Three public orchestration lanes
 - [ADR-0069](ADR-0069-reactive-flow-steering-and-recovery.md) — Reactive flow steering and
   recovery
-- [ADR-0070](ADR-0070-studio-scheduling-and-dispatch-delivery.md) — Studio scheduling and
-  dispatch delivery
+- [ADR-0070](ADR-0070-studio-scheduling-and-dispatch-delivery.md) — Studio scheduling and dispatch
+  delivery
 - [ADR-0071](ADR-0071-durable-ad-hoc-task-queue.md) — Durable ad-hoc task queue
 - [ADR-0072](ADR-0072-unified-task-admission-and-lifecycle.md) — Unified task admission and
   lifecycle
@@ -177,39 +182,37 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 
 ### studio (0076-0085)
 
-- [ADR-0076](ADR-0076-studio-daemon-route-registry-and-local-control-plane.md) — Studio
-  daemon route registry and local control plane
+- [ADR-0076](ADR-0076-studio-daemon-route-registry-and-local-control-plane.md) — Studio daemon
+  route registry and local control plane
 - [ADR-0077](ADR-0077-studio-state-and-filesystem-boundary.md) — Studio state and filesystem
   boundary
 - [ADR-0078](ADR-0078-studio-application-service-boundary.md) — Studio application-service
   boundary
 - [ADR-0079](ADR-0079-studio-web-client-architecture-and-deployment.md) — Studio web client
   architecture and deployment
-- [ADR-0080](ADR-0080-studio-six-space-cockpit-information-architecture.md) — Studio
-  six-space cockpit information architecture
-- [ADR-0081](ADR-0081-studio-execution-and-artifact-workspace-target.md) — Studio execution
-  and artifact workspace target
-- [ADR-0082](ADR-0082-vscode-studio-observability-client.md) — VS Code Studio observability
-  client
+- [ADR-0080](ADR-0080-studio-six-space-cockpit-information-architecture.md) — Studio six-space
+  cockpit information architecture
+- [ADR-0081](ADR-0081-studio-execution-and-artifact-workspace-target.md) — Studio execution and
+  artifact workspace target
+- [ADR-0082](ADR-0082-vscode-studio-observability-client.md) — VS Code Studio observability client
 - [ADR-0083](ADR-0083-studio-operator-command-protocol.md) — Studio operator-command protocol
 - 0084-0085 — unused (intentional gaps)
 
 ### governance (0086-0089)
 
-- [ADR-0086](ADR-0086-local-tool-controls-and-session-authorization.md) — Local tool controls
-  and session authorization observation
-- [ADR-0087](ADR-0087-evidence-backed-governed-execution.md) — Evidence-backed governed
-  execution
+- [ADR-0086](ADR-0086-local-tool-controls-and-session-authorization.md) — Local tool controls and
+  session authorization observation
+- [ADR-0087](ADR-0087-evidence-backed-governed-execution.md) — Evidence-backed governed execution
 - 0088-0089 — unused (intentional gaps)
 
 ### substrates (0090-0095)
 
 - [ADR-0090](ADR-0090-local-sandbox-and-measured-cell-backend-seams.md) — Local sandbox and
   measured-cell backend seams
-- [ADR-0091](ADR-0091-per-worker-worktree-execution-isolation.md) — Per-worker worktree
-  execution isolation
-- [ADR-0092](ADR-0092-minimal-branch-and-session-memory-store.md) — Minimal Branch and
-  session memory store
+- [ADR-0091](ADR-0091-per-worker-worktree-execution-isolation.md) — Per-worker worktree execution
+  isolation
+- [ADR-0092](ADR-0092-minimal-branch-and-session-memory-store.md) — Minimal Branch and session
+  memory store
 - [ADR-0093](ADR-0093-external-memory-adapter-fidelity-contract.md) — External memory adapter
   fidelity contract
 - 0094-0095 — unused (intentional gaps)

--- a/docs/adr/dispositions.yaml
+++ b/docs/adr/dispositions.yaml
@@ -1,0 +1,808 @@
+# Disposition ledger for the archived v0 ADR corpus (docs/_archive/v0/).
+# One row per archived record. disposition is one of:
+#   carried-forward-as — the record's substance continues as the named new ADR(s)
+#   merged-into        — the record is one input among several to the named new ADR(s)
+#   retired            — the record's substance was never implemented and is not carried
+# target names ADRs in THIS directory (the new corpus). v0_status strings are quoted
+# verbatim from the archived records; any ADR id embedded inside a v0_status string
+# refers to the OLD v0 namespace, never to the new corpus.
+
+- v0: "0001"
+  title: "lion-studio as Internal Monorepo App"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0076", "ADR-0079"]
+  reason: "the package and monorepo boundary survives, split between the daemon and the Vite\
+  \ client records"
+
+- v0: "0002"
+  title: "Lion Studio Tech Stack"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0076", "ADR-0079"]
+  reason: "FastAPI and port 8765 survive while the stale Next.js claim is replaced by the shipped\
+  \ Vite client"
+
+- v0: "0003"
+  title: "Claude Code Marketplace"
+  v0_status: "Amended (v2 catalog \u2014 see below)"
+  disposition: merged-into
+  target: ["ADR-0065"]
+  reason: "The marketplace structure remains, but the current catalog is one orchestrate bundle\
+  \ rather than the v0 four-plugin inventory."
+
+- v0: "0004"
+  title: "Data Layer \u2014 Filesystem + SQLite Hybrid"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0055"]
+  reason: "The filesystem/operational-database boundary survives, narrowed to current backend-neutral\
+  \ and artifact semantics."
+
+- v0: "0005"
+  title: "Playbooks Naming Convention"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0079"]
+  reason: "the checked-in client and API use playbook vocabulary while legacy Worker-prefixed\
+  \ graph types remain internal"
+
+- v0: "0006"
+  title: "Live Update Transport \u2014 SSE + Interval Refresh"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0076"]
+  reason: "endpoint-specific SSE is shipped, but the broader unified live-update contract is\
+  \ not"
+
+- v0: "0007"
+  title: "Plugin Manifest Layout and Auto-Discovery Convention"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0065"]
+  reason: "Metadata-only plugin manifests and directory-based skill and agent discovery remain\
+  \ the repository convention."
+
+- v0: "0008"
+  title: "Lion Studio Scope \u2014 CLI-Primary, Definition-Editable, Localhost"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0076"]
+  reason: "local-first operation survives, but Studio is now a write-capable authenticated control\
+  \ plane rather than a CLI-secondary viewer"
+
+- v0: "0009"
+  title: "SQLite State Layer for Core Data Model"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0056"]
+  reason: "The relational state intent remains, while SQLite exclusivity is superseded by the\
+  \ shared SQLAlchemy backend."
+
+- v0: "0010"
+  title: "Plugin-Aware Studio UI"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0079"]
+  reason: "plugin and skill discovery endpoints and the Library browsing surface are present"
+
+- v0: "0011"
+  title: "Shows Data Model \u2014 Hybrid SQLite + Filesystem"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0077"]
+  reason: "shows still combine StateDB structural state with operationally significant filesystem\
+  \ content"
+
+- v0: "0012"
+  title: "Studio Execution Lineage & UX Redesign"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0077", "ADR-0081"]
+  reason: "shipped lineage data is retained in the state record and unshipped viewer unification\
+  \ becomes an explicit target"
+
+- v0: "0013"
+  title: "Zero Component-Library UI"
+  v0_status: "Superseded by [ADR-0035](ADR-0035-design-system-and-component-library.md) for product\
+  \ surfaces"
+  disposition: retired
+  target: []
+  reason: "the supersession chain is internally inconsistent and the current source-owned component\
+  \ practice is recorded directly in ADR-0079"
+
+- v0: "0014"
+  title: "CLI-Primary, Studio-Secondary"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0062"]
+  reason: "The CLI remains the operator surface, narrowed to allow explicit delegation to daemon-owned\
+  \ services such as scheduling."
+
+- v0: "0015"
+  title: "Runs List Design \u2014 Identity, Filters, Pagination"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0080", "ADR-0081"]
+  reason: "the standalone Runs IA is retired while its operational listing needs move into History\
+  \ and Fleet"
+
+- v0: "0016"
+  title: "Definition Write Path and Versioning"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0077"]
+  reason: "DB-first versioning followed by a file write is implemented for agent and playbook\
+  \ definitions, with reconciliation recorded as a delta"
+
+- v0: "0017"
+  title: "Session Lifecycle and Status Derivation"
+  v0_status: "Partially superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md) \u2014\
+  \ see Supersession Notice"
+  disposition: merged-into
+  target: ["ADR-0057"]
+  reason: "Implemented session lifecycle values are consolidated into the actual per-entity\
+  \ lifecycle contract."
+
+- v0: "0018"
+  title: "Studio Distribution and Local Access"
+  v0_status: "Accepted (decision); **Implementation deferred** \u2014 this PR does not ship the\
+  \ packaged Studio wheel, the `li studio` no-arg launcher, or the `StaticFiles` mount\
+  \ described below. The frontend remains a separate Next.js dev app on port 3000\
+  \ and `apps/studio/server/app.py` only exposes API routers + `/health`. The pieces\
+  \ specified here (move/package server under `lionagi/studio/`, bundle built static\
+  \ assets in the wheel, mount static after `/api/*`, make `li studio` start the server)\
+  \ are tracked as follow-up work and are NOT a hard contract for this PR."
+  disposition: merged-into
+  target: ["ADR-0076", "ADR-0079"]
+  reason: "current API-only, Vite-development, and daemon-hosted-dist modes replace the deferred\
+  \ Next.js packaging plan"
+
+- v0: "0019"
+  title: "Teams DB Migration and Run Lifecycle Management"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0077"]
+  reason: "only the implemented shared-state and lifecycle boundary is retained; the proposed\
+  \ teams migration is not declared shipped"
+
+- v0: "0020"
+  title: "Skill Invocations \u2014 Tracking the Orchestration Layer"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0077", "ADR-0081"]
+  reason: "invocation rows are implemented as lineage plumbing but the noun is removed from\
+  \ the cockpit's user-facing IA"
+
+- v0: "0021"
+  title: "Skill Artifacts, Structured Output, and Reactive Chaining"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0077", "ADR-0081"]
+  reason: "implemented artifact metadata is retained while the unshipped reactive-chaining design\
+  \ is retired"
+
+- v0: "0022"
+  title: "Run Step Provenance \u2014 Model, Agent, and Provider Disclosure"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0077", "ADR-0081"]
+  reason: "partial provenance fields and display requirements are retained without claiming\
+  \ complete per-step disclosure"
+
+- v0: "0023"
+  title: "Unified Hook System and Agent-Level Configuration"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0047"]
+  reason: "The shipped session HookBus is retained while the unimplemented universal-consolidation\
+  \ claim is replaced by scoped ownership."
+
+- v0: "0024"
+  title: "Session Health Classification and Admin Surface"
+  v0_status: "Proposed \u2014 extended by [ADR-0033](ADR-0033-unified-entity-state-model.md)"
+  disposition: merged-into
+  target: ["ADR-0057"]
+  reason: "The shipped pure session-health classifier is retained without claiming the wider\
+  \ proposed admin surface."
+
+- v0: "0025"
+  title: "Session Status Vocabulary"
+  v0_status: "Superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md)"
+  disposition: merged-into
+  target: ["ADR-0057"]
+  reason: "The implemented vocabulary, including the later completed_empty value, is recorded\
+  \ with current transition behavior."
+
+- v0: "0026"
+  title: "Project Detection for Session Organization"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0063"]
+  reason: "The attribution cascade is implemented, with its current ancestor-walk and path-prefix\
+  \ gaps recorded honestly."
+
+- v0: "0027"
+  title: "Scheduled Runs and Event-Triggered Invocations"
+  v0_status: "**Status**: Proposed"
+  disposition: carried-forward-as
+  target: ["ADR-0070"]
+  reason: "The implemented Studio trigger, subprocess, invocation-linkage, and bounded follow-up\
+  \ behavior is recorded with corrected paths and scope."
+
+- v0: "0028"
+  title: "Status Reason Model"
+  v0_status: "Phase 2 Shipped \u2014 extended by [ADR-0033](ADR-0033-unified-entity-state-model.md)"
+  disposition: merged-into
+  target: ["ADR-0057"]
+  reason: "The shipped six-entity current-reason and transition-history model is consolidated\
+  \ with its actual coverage limits."
+
+- v0: "0029"
+  title: "Artifact Contract"
+  v0_status: "Proposed \u2014 extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) and\
+  \ referenced by [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)"
+  disposition: merged-into
+  target: ["ADR-0064"]
+  reason: "The implemented artifact snapshot and teardown verification are part of the canonical\
+  \ CLI execution outcome record."
+
+- v0: "0030"
+  title: "Attention Queue"
+  v0_status: "**Status**: Proposed \u2014 depends on [ADR-0033](ADR-0033-unified-entity-state-model.md),\
+  \ extended to include knowledge events per [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)"
+  disposition: retired
+  target: []
+  reason: "No attention queue or dismissal projection exists, and operator projections are deferred\
+  \ until stable source transitions exist."
+
+- v0: "0031"
+  title: "Entity Header Pattern"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0080", "ADR-0081"]
+  reason: "orientation and action semantics move into the cockpit master-detail contract rather\
+  \ than a universal unshipped header payload"
+
+- v0: "0032"
+  title: "Navigation Reorganization"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0080"]
+  reason: "the pre-cockpit four-group navigation is superseded by the binding six-space cockpit"
+
+- v0: "0033"
+  title: "Unified Entity State Model"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0058"]
+  reason: "The unimplemented universal NormalizedState proposal is replaced by a narrower aspirational\
+  \ lifecycle service."
+
+- v0: "0034"
+  title: "Frontend Data & State Architecture"
+  v0_status: "Proposed"
+  disposition: retired
+  target: []
+  reason: "TanStack Query, Zustand, and the central event stream are absent; freshness remains\
+  \ a new decision after current needs are measured"
+
+- v0: "0035"
+  title: "Design System and Component Library"
+  v0_status: "Proposed"
+  disposition: retired
+  target: []
+  reason: "the proposed shadcn, Radix, and components/lion architecture is absent; current source-owned\
+  \ components are recorded in ADR-0079"
+
+- v0: "0039"
+  title: "Knowledge Substrate Minimal Interface"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "The evidence-first insight is retained, while the unbuilt KnowledgeStore manager\
+  \ is not a governance prerequisite."
+
+- v0: "0041"
+  title: "Immutable Evidence Nodes"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Append-only content-addressed evidence and superseding corrections become the foundation\
+  \ of the consolidated target."
+
+- v0: "0042"
+  title: "Task Certificate \u2014 Signed Proof of Process Adherence"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Certificates are retained as process-only records sequenced after evidence verification\
+  \ and policy history."
+
+- v0: "0043"
+  title: "Governed Tool Declaration"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "The mandatory governed invocation idea is retained as one optional controller at\
+  \ the real Tool/FunctionCalling boundary."
+
+- v0: "0044"
+  title: "Tool Gates \u2014 Three-Tier Binary Enforcement"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Hard, soft, and advisory levels share one immutable binary GateResult and fail-closed\
+  \ evaluator behavior."
+
+- v0: "0045"
+  title: "Break-Glass Protocol \u2014 DEGRADED-Defensibility Override"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Break-glass is retained as a later attributable exception gate that permanently degrades\
+  \ the process certificate."
+
+- v0: "0046"
+  title: "JIT Tool Grant \u2014 No Standing Capability for High-Risk Tools"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Time-bounded single-use permits are retained as a later gate family after identity\
+  \ and evidence prerequisites."
+
+- v0: "0047"
+  title: "Agent Charter \u2014 Enforceable Governance Document"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Code-bound immutable policy snapshots replace the standalone unimplemented charter\
+  \ object as the activation contract."
+
+- v0: "0048"
+  title: "Agent Segregation of Duties (SoD)"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Duty separation is retained as a later policy-selected gate after actor references\
+  \ and evidence storage exist."
+
+- v0: "0049"
+  title: "Log Tier Governance"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Authoritative evidence moves to its own append-only store instead of extending the\
+  \ mutable DataLogger contract."
+
+- v0: "0050"
+  title: "Operation Context \u2014 Active Assertion in Evidence"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Per-operation immutable provenance and explicit propagation are retained without\
+  \ mutable session-global accumulation."
+
+- v0: "0051"
+  title: "Tool Registry Allowlists"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Executable gate bindings and resource policy remain in versioned snapshots; a separate\
+  \ registry is deferred until needed."
+
+- v0: "0052"
+  title: "Policy Resolution and Staged Release"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0087"]
+  reason: "Immutable releases, historical lookup, deterministic selection, and deny-on-ambiguity\
+  \ are retained without tenant semantics."
+
+- v0: "0053"
+  title: "Artifact Persistence in State Database"
+  v0_status: "proposed"
+  disposition: retired
+  target: []
+  reason: "Immutable file-capture columns and insert_file_artifact were not implemented; current\
+  \ artifacts are mutable structured upserts."
+
+- v0: "0054"
+  title: "Local State File Cleanup and DB Migration Completion"
+  v0_status: "proposed"
+  disposition: retired
+  target: []
+  reason: "The proposed snapshot, cleanup-ledger, archive-gate, and DB-first migration model\
+  \ is not present in the current state package."
+
+- v0: "0055"
+  title: "Studio Artifact Viewer and File Reference Resolution"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0077", "ADR-0081"]
+  reason: "existing artifact metadata is recorded retrospectively and the authenticated DB-first\
+  \ viewer remains an explicit target"
+
+- v0: "0056"
+  title: "Play Control API - Runner Control Plane"
+  v0_status: "Status: proposed"
+  disposition: retired
+  target: []
+  reason: "The runner-neutral handle and control plane did not ship; current control is executor-local\
+  \ and recorded separately."
+
+- v0: "0057"
+  title: "Remote Sandbox Execution Behind PlayRunner"
+  v0_status: "proposed"
+  disposition: retired
+  target: []
+  reason: "The PlayRunner, remote control plane, credential vending, and provider-runner design\
+  \ did not land; the narrower current worktree seam and new worker-isolation target\
+  \ are recorded independently."
+
+- v0: "0058"
+  title: "Play Cost Tracking"
+  v0_status: "Status: proposed"
+  disposition: merged-into
+  target: ["ADR-0070"]
+  reason: "Only scheduler future-fire cost and token gates are present; the broader usage ledger\
+  \ and fallback policy are not carried forward."
+
+- v0: "0059"
+  title: "Postgres State Backend"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0056"]
+  reason: "Its backend intent shipped through the single SQLAlchemy Core implementation accepted\
+  \ in v0-0086."
+
+- v0: "0060"
+  title: "Unified Config Resolution"
+  v0_status: "Status: proposed"
+  disposition: retired
+  target: []
+  reason: "The proposed shared configuration resolver is not implemented and is not scheduling-control-plane\
+  \ authority."
+
+- v0: "0061"
+  title: "Universal Scheduler - `li schedule` for Any Flow"
+  v0_status: "Status: accepted \u2014 activated by ADR-0101 (task-application surface & durable\
+  \ queue), 2026-07-08"
+  disposition: merged-into
+  target: ["ADR-0071", "ADR-0072"]
+  reason: "Implemented lease and queue slices are recorded retrospectively; universal queued\
+  \ admission remains an explicit target."
+
+- v0: "0062"
+  title: "Scheduled Item State Machine"
+  v0_status: "Status: accepted \u2014 activated by ADR-0101 (task-application surface & durable\
+  \ queue), 2026-07-08"
+  disposition: merged-into
+  target: ["ADR-0071", "ADR-0072"]
+  reason: "The restricted schedule-run CAS graph is current, while the full lifecycle and transition-event\
+  \ owner remains aspirational."
+
+- v0: "0063"
+  title: "Task Board - Operator Work Center for Lion Studio"
+  v0_status: "Status: proposed"
+  disposition: retired
+  target: []
+  reason: "No work-item source, projection, route, or operator board exists."
+
+- v0: "0064"
+  title: "Work System Integration"
+  v0_status: "**Status**: accepted"
+  disposition: retired
+  target: []
+  reason: "The described work engine and worker types did not ship; live WorkForm and RuleSet\
+  \ utilities do not constitute a control plane."
+
+- v0: "0065"
+  title: "Task Board Schema"
+  v0_status: "**Status**: proposed"
+  disposition: retired
+  target: []
+  reason: "No work_tasks persistence projection exists, and the durable queue is not a task\
+  \ board."
+
+- v0: "0066"
+  title: "Unified Execution Viewer"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0081"]
+  reason: "partial graph and detail components exist, but the unshipped unified viewer is retained\
+  \ only as a scoped aspirational workspace"
+
+- v0: "0067"
+  title: "Studio Command Chat - Universal AI-Powered Control Panel"
+  v0_status: "proposed"
+  disposition: merged-into
+  target: ["ADR-0083"]
+  reason: "the safety and typed-effect requirements survive while the unshipped WebSocket and\
+  \ broad tool catalog are replaced by a transport-independent target"
+
+- v0: "0068"
+  title: "Zero-Rewrite Governed Adapter Protocol"
+  v0_status: "accepted"
+  disposition: merged-into
+  target: ["ADR-0086"]
+  reason: "The retrospective records the shipped conversion-only adapter boundary and corrects\
+  \ the absent governed-wrapper claim."
+
+- v0: "0069"
+  title: "Tenant Scope Boundary"
+  v0_status: "accepted"
+  disposition: merged-into
+  target: ["ADR-0086"]
+  reason: "The retrospective records that current OSS has no policy-scope, identity, or isolation\
+  \ runtime contract."
+
+- v0: "0070"
+  title: "Governance Tracing and Observability"
+  v0_status: "accepted"
+  disposition: merged-into
+  target: ["ADR-0086"]
+  reason: "The shipped session signal stream and best-effort persistence replace the absent\
+  \ governance tracer implementation claim."
+
+- v0: "0071"
+  title: "Cognitive Mode Model"
+  v0_status: "accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0042"]
+  reason: "The implemented Pattern, Mode, Role, and Profile contracts are recorded in the typed\
+  \ casts catalog ADR."
+
+- v0: "0072"
+  title: "Reactive Capability Bus"
+  v0_status: "accepted"
+  disposition: merged-into
+  target: ["ADR-0047"]
+  reason: "Its SessionObserver transport role is incorporated into the hook taxonomy; capability\
+  \ emissions remain outside hook execution."
+
+- v0: "0074"
+  title: "Role Composition & Pack-Based Per-Role Configuration"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0043", "ADR-0044"]
+  reason: "Its partially implemented resolution design and ambiguous policy model are split\
+  \ into explicit configuration and enforcement decisions."
+
+- v0: "0075"
+  title: "Domain-Specific Agent Engines"
+  v0_status: "Proposed \u2014 infrastructure landed, engines pending"
+  disposition: merged-into
+  target: ["ADR-0034"]
+  reason: "The implemented engine layer is recorded with its later autonomy safeguards in one\
+  \ retrospective ADR."
+
+- v0: "0076"
+  title: "Observer as the Canonical Hook Transport"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0047"]
+  reason: "Its observer-backed session transport is retained, while its deferred service migration\
+  \ is replaced by explicit scope boundaries."
+
+- v0: "0077"
+  title: "Engine Autonomy Protections and the Hypothesis Engine"
+  v0_status: "Accepted \u2014 implemented"
+  disposition: merged-into
+  target: ["ADR-0034"]
+  reason: "Its shipped budgets, repair, judge, routing, guards, and chain engine are part of\
+  \ the canonical engine record."
+
+- v0: "0078"
+  title: "The Casts Conceptual Model and Module Coherence"
+  v0_status: "Accepted \u2014 implemented"
+  disposition: merged-into
+  target: ["ADR-0041", "ADR-0042"]
+  reason: "Its implemented agent-construction and casts-model decisions are separated into focused\
+  \ retrospective records."
+
+- v0: "0079"
+  title: "Substrate Executor Provider Interface"
+  v0_status: "Superseded in part by [ADR-0089](ADR-0089-sandbox-backend-seam-and-measurement-loop.md)\
+  \ (its `ExecutionTarget`/`ExecutionLimits` types are adopted there; the `ExecutorProvider`\
+  \ protocol half is parked, not carried forward)"
+  disposition: merged-into
+  target: ["ADR-0090"]
+  reason: "Its landed ExecutionTarget and ExecutionLimits vocabulary belongs to the retrospective\
+  \ measured-cell seam; the unimplemented executor-provider protocol is not carried\
+  \ forward."
+
+- v0: "0080"
+  title: "Remote Sandbox Substrate Execution"
+  v0_status: "Superseded by [ADR-0089](ADR-0089-sandbox-backend-seam-and-measurement-loop.md) (backend\
+  \ contract absorbed; the flow/play `DependencyAwareExecutor` integration is deferred\
+  \ to a future ADR, not carried by ADR-0089)"
+  disposition: merged-into
+  target: ["ADR-0090", "ADR-0091"]
+  reason: "Its landed backend vocabulary is recorded retrospectively, while its deferred flow/fanout\
+  \ need is narrowed to the worktree-per-worker target."
+
+- v0: "0081"
+  title: "Configurable Flow Planning"
+  v0_status: "Proposed"
+  disposition: retired
+  target: []
+  reason: "Its superseded substrate foundations and proposed planning configuration were never\
+  \ implemented."
+
+- v0: "0082"
+  title: "Role to Substrate Routing Policy"
+  v0_status: "Proposed"
+  disposition: retired
+  target: []
+  reason: "Pack-based model precedence shipped, but the ADR's substrate target and superseded\
+  \ foundations did not."
+
+- v0: "0083"
+  title: "Canonical Per-Node Lifecycle Signal Contract"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0033"]
+  reason: "The implemented node vocabulary and its uneven observation bridge are recorded with\
+  \ the graph execution boundary."
+
+- v0: "0084"
+  title: "VS Code Extension as a Native Client over the Studio API"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0082"]
+  reason: "the native read-only client, local daemon lifecycle, REST reads, and SSE observation\
+  \ are implemented"
+
+- v0: "0085"
+  title: "Flow Control Plane \u2014 Pause/Resume, Message Injection, Checkpoint Resume, Status,\
+  \ Usage, Fallback"
+  v0_status: "**Status**: Proposed"
+  disposition: merged-into
+  target: ["ADR-0069"]
+  reason: "Implemented reactive controls and checkpoint recovery are retained without the unimplemented\
+  \ universal usage and fallback claims."
+
+- v0: "0086"
+  title: "StateDB SQLAlchemy-Core backend unification"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0056"]
+  reason: "The accepted SQLAlchemy Core, SQLite-default, PostgreSQL-capable backend is implemented\
+  \ and remains current."
+
+- v0: "0087"
+  title: "LNDL operate() Seam, Scratchpad-as-Tool, and the Measurement Gate"
+  v0_status: "Accepted (gated scope, 2026-07-03)"
+  disposition: carried-forward-as
+  target: ["ADR-0024"]
+  reason: "the implemented operate seam is carried forward as a narrower retrospective record;\
+  \ unimplemented language-package and measurement commitments are not asserted"
+
+- v0: "0088"
+  title: "Flow-Steering Control-Plane Mechanisms"
+  v0_status: "**Status**: Accepted with conditions (2026-07-03)"
+  disposition: carried-forward-as
+  target: ["ADR-0069"]
+  reason: "The labeled context-mode steering path is implemented; operation-node injection remains\
+  \ outside the current contract."
+
+- v0: "0089"
+  title: "Sandbox Backend Seam and Recursive Measurement Loop"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0090"]
+  reason: "The implemented backend protocol, two adapters, capability selection, and benchmark\
+  \ client form the required retrospective spine; unimplemented loop and roster claims\
+  \ are excluded."
+
+- v0: "0090"
+  title: "Minimal Memory Contract and Pluggable Backend Seam"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0092"]
+  reason: "The protocol, reference backend, public exports, and Branch/Session ownership surface\
+  \ are implemented and restated as current architecture."
+
+- v0: "0091"
+  title: "khive as a Pluggable lionagi MemoryStore Backend"
+  v0_status: "Accepted"
+  disposition: carried-forward-as
+  target: ["ADR-0093"]
+  reason: "Its external-adapter intent is retained as an aspirational fidelity and conformance\
+  \ contract without claiming that the named adapter exists in this repository."
+
+- v0: "0092"
+  title: "Durable Dispatch Outbox and Named Resource Gates"
+  v0_status: "Accepted (design review completed 2026-07-04; decisions folded below)"
+  disposition: merged-into
+  target: ["ADR-0059"]
+  reason: "The implemented persistence-area outbox slice is consolidated here; resource-gate\
+  \ behavior belongs to execution architecture."
+
+- v0: "0093"
+  title: "Studio Three-Surface Information Architecture"
+  v0_status: "Proposed (Amendment 1 applied \u2014 see below)"
+  disposition: carried-forward-as
+  target: ["ADR-0080"]
+  reason: "Amendment 1's shipped six-space cockpit is canonical; the original three-route contract\
+  \ is retired within the replacement"
+
+- v0: "0094"
+  title: "Run Completion Contract and Machine-Consumable Orchestration"
+  v0_status: "Proposed"
+  disposition: carried-forward-as
+  target: ["ADR-0035"]
+  reason: "The wait grammar and state-integrity floor are implemented and are restated retrospectively."
+
+- v0: "0095"
+  title: "Reactive Spawn Observability and Orchestration DX"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0033"]
+  reason: "The shipped rejected-injection ledger is part of the canonical reactive execution\
+  \ contract."
+
+- v0: "0096"
+  title: "Engine Result and Degradation Contract"
+  v0_status: "Accepted"
+  disposition: merged-into
+  target: ["ADR-0034"]
+  reason: "The shipped structured engine result with degradation marking and budget-exceeded\
+  \ signaling is part of the canonical engine record."
+
+- v0: "0097"
+  title: "CI Gate Taxonomy And Fail-Closed Aggregation"
+  v0_status: "**Status**: Proposed"
+  disposition: retired
+  target: []
+  reason: "CI gate taxonomy has no scheduling-control-plane implementation or ownership."
+
+- v0: "0098"
+  title: "Resident Engine Work Queue (Warm Host Loop)"
+  v0_status: "Proposed"
+  disposition: carried-forward-as
+  target: ["ADR-0037"]
+  reason: "The unimplemented host-plane intent is retained as a concise aspirational queue and\
+  \ isolation decision."
+
+- v0: "0099"
+  title: "Escalation node_builder Tier Bump"
+  v0_status: "Proposed"
+  disposition: carried-forward-as
+  target: ["ADR-0038"]
+  reason: "The unimplemented tier bump is retained with a separate builder and a typed host\
+  \ handoff boundary."
+
+- v0: "0100"
+  title: "Pre-Turn Context Injection Providers"
+  v0_status: "Proposed"
+  disposition: merged-into
+  target: ["ADR-0008"]
+  reason: "The pre-turn provider registry is recorded in the messages-context provider ADR;\
+  \ the shipped registry belongs to Branch and operations rather than AgentSpec construction."
+
+- v0: "0101"
+  title: "Task-Application Surface & Durable Queue"
+  v0_status: "**Status**: Accepted"
+  disposition: merged-into
+  target: ["ADR-0071", "ADR-0072"]
+  reason: "The in-process ad-hoc queue and worker are current; public bindings, idempotency,\
+  \ and scheduled-fire convergence remain target state."
+
+- v0: "0102"
+  title: "Workflow Library Registry"
+  v0_status: "**Status**: Accepted"
+  disposition: merged-into
+  target: ["ADR-0073"]
+  reason: "The versioned workflow registry has not shipped and is retained only as a fixed-lane\
+  \ migration delta."
+
+- v0: "0103"
+  title: "Fixed-flow workflow engine v1.1 contract (li flow run, per-node cwd, per-node model,\
+  \ artifact_dir)"
+  v0_status: "**Status**: Accepted (2026-07-09)"
+  disposition: merged-into
+  target: ["ADR-0068", "ADR-0073"]
+  reason: "Implemented fixed compilation, model, and cwd behavior is recorded as current; the\
+  \ missing CLI, registry provenance, artifacts, and controls remain explicit deltas."

--- a/docs/adr/dispositions.yaml
+++ b/docs/adr/dispositions.yaml
@@ -3,9 +3,11 @@
 #   carried-forward-as — the record's substance continues as the named new ADR(s)
 #   merged-into        — the record is one input among several to the named new ADR(s)
 #   retired            — the record's substance was never implemented and is not carried
-# target names ADRs in THIS directory (the new corpus). v0_status strings are quoted
-# verbatim from the archived records; any ADR id embedded inside a v0_status string
-# refers to the OLD v0 namespace, never to the new corpus.
+# target names ADRs in THIS directory (the new corpus). v0_status strings are condensed
+# from the archived records' status lines; the archived file retains each record's full
+# original status wording, and it is authoritative where the two differ. Any ADR id
+# embedded inside a v0_status string refers to the OLD v0 namespace, never to the new
+# corpus.
 
 - v0: "0001"
   title: "lion-studio as Internal Monorepo App"
@@ -745,7 +747,8 @@
 
 - v0: "0096"
   title: "Engine Result and Degradation Contract"
-  v0_status: "Accepted"
+  v0_status: "Accepted with amendment (gated review 2026-07-06; the success-path amendment is\
+  \ folded into the archived record)"
   disposition: merged-into
   target: ["ADR-0034"]
   reason: "The shipped structured engine result with degradation marking and budget-exceeded\


### PR DESCRIPTION
Completes the ADR corpus assembly. Not byte-comparable to prior content — four distinct changes:

1. **`dispositions.yaml`** (new): the disposition ledger for the archived v0 corpus. One row per archived record — 98 rows, validated 1:1 against `docs/_archive/v0/` (no duplicates, no misses), every `target` exists in this corpus, closed vocabulary {carried-forward-as, merged-into, retired}, retired rows have empty targets and non-retired rows all have targets. The v0-0100 row targets ADR-0008 (the pre-turn provider record that carries its content); the per-area drafting schema could not name another block's id. The file header documents the vocabulary and one ingester rule: ids embedded inside verbatim `v0_status` strings refer to the old v0 namespace, never this corpus.
2. **Title convention**: all H1s and README index entries unified on sentence case (39 of 61 already were; the 25 Title Case H1s convert; class/product names — Element, UUID, Event, Branch, Session, Casts, Studio — keep capitalization). `façade` → `facade` corpus-wide, matching filenames and the index. README index entry text is regenerated from the final H1s so index and titles cannot diverge.
3. **README**: shared one-paragraph definition of the κ (coupling density over the ADR's own component diagram) and τ (isolated-testability estimate) figures that many Consequences sections report, so the numbers are interpretable corpus-wide; disposition sentence moved to present tense.
4. **Context-provider cross-reference**: the subsystem is legitimately recorded twice at different depths — ADR-0008 (pre-turn execution ordering, budgeting, attribution) and ADR-0016 D3 (lifetime/persistence within the Branch aggregate). Each now carries a see-also naming the other's half, so neither reads as the sole record.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)