### PR TITLE
docs: repoint context_providers module docstring to ADR-0008

### DIFF
--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -3,7 +3,7 @@
 
 """Pre-turn context injection: an ordered ContextProvider registry that
 renders ephemeral knowledge into the first-message guidance fold — never
-the durable message record. See ADR-0100."""
+the durable message record. See ADR-0008."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
One-line docstring fix: `lionagi/protocols/context_providers.py` cited ADR-0100, which is now archived under `docs/_archive/v0/`. Per `docs/adr/dispositions.yaml`, v0-0100 is merged into ADR-0008 — the canonical record for pre-turn provider execution, budgeting, and attribution.

Closes #1955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)