### PR TITLE
chore: condense comments in session and operations

### DIFF
--- a/lionagi/operations/ReAct/utils.py
+++ b/lionagi/operations/ReAct/utils.py
@@ -9,14 +9,15 @@ from lionagi.models import HashableModel
 
 
 class ReActAnalysis(HashableModel):
-    """Chain-of-thought output for one ReAct round: analysis, extension flag, and action strategy."""
+    """Chain-of-thought output for one ReAct round: analysis, extension flag, and action strategy.
 
-    # Standard ReAct strings. The round budget is given as HEADROOM for planning, not
-    # as a countdown: "you have N steps left, be efficient" reads as scarcity and makes
-    # a model wrap up early and declare done before the task is finished. We instead (a)
-    # frame the remaining rounds as room it need not fill or race, (b) redirect
-    # "efficiency" to throughput-per-round (batch independent tool calls) rather than
-    # fewer rounds, and (c) make the only failure stopping while the task is incomplete.
+    The round budget below is framed as HEADROOM for planning, not a countdown —
+    "N steps left, be efficient" reads as scarcity and makes a model wrap up early.
+    Instead: remaining rounds are room to use not race, "efficiency" means
+    throughput-per-round (batching tool calls) not fewer rounds, and the only
+    failure is stopping while the task is incomplete.
+    """
+
     FIRST_EXT_PROMPT: ClassVar[str] = (
         "This is a multi-step task. You have room for up to {extensions} reason-act "
         "rounds — that is headroom to do the job well, not a target to fill or a clock "
@@ -65,8 +66,8 @@ class ReActAnalysis(HashableModel):
         ),
     )
 
-    # Note: action_requests and action_responses are added dynamically by Step.request_operative()
-    # when actions=True, so they don't need to be defined here. The operate() function will add them.
+    # action_requests/action_responses are added dynamically by Step.request_operative()
+    # when actions=True — not defined here.
 
 
 class Analysis(HashableModel):

--- a/lionagi/operations/_visualize_graph.py
+++ b/lionagi/operations/_visualize_graph.py
@@ -49,12 +49,10 @@ def visualize_graph(
         node_id = str(node.id)[:8]
         G.add_node(node_id)
 
-        # Determine level based on dependencies
         in_edges = [e for e in graph.internal_edges.values() if str(e.tail)[:8] == node_id]
         if not in_edges:
-            level = 0  # Root nodes
+            level = 0
         else:
-            # Get max level of predecessors + 1
             pred_levels = []
             for edge in in_edges:
                 pred_id = str(edge.head)[:8]
@@ -72,19 +70,19 @@ def visualize_graph(
         node_labels[node_id] = label
 
         if node.id in builder._executed:
-            node_colors.append("#90EE90")  # Light green
+            node_colors.append("#90EE90")
             node_sizes.append(4000)
         elif node.metadata.get("expansion_source"):
-            node_colors.append("#87CEEB")  # Sky blue
+            node_colors.append("#87CEEB")
             node_sizes.append(3500)
         elif node.metadata.get("aggregation"):
-            node_colors.append("#FFD700")  # Gold
+            node_colors.append("#FFD700")
             node_sizes.append(4500)
         elif node.metadata.get("is_condition_check"):
-            node_colors.append("#DDA0DD")  # Plum
+            node_colors.append("#DDA0DD")
             node_sizes.append(3500)
         else:
-            node_colors.append("#E0E0E0")  # Light gray
+            node_colors.append("#E0E0E0")
             node_sizes.append(3000)
 
     edge_colors = []
@@ -101,15 +99,15 @@ def visualize_graph(
         edge_labels[(head_id, tail_id)] = edge_label
 
         if "expansion" in edge_label:
-            edge_colors.append("#4169E1")  # Royal blue
+            edge_colors.append("#4169E1")
             edge_styles.append("dashed")
             edge_widths.append(2)
         elif "aggregate" in edge_label:
-            edge_colors.append("#FF6347")  # Tomato
+            edge_colors.append("#FF6347")
             edge_styles.append("dotted")
             edge_widths.append(2.5)
         else:
-            edge_colors.append("#808080")  # Gray
+            edge_colors.append("#808080")
             edge_styles.append("solid")
             edge_widths.append(1.5)
 
@@ -162,7 +160,7 @@ def visualize_graph(
     for i, (u, v) in enumerate(G.edges()):
         u_pos = pos[u]
         v_pos = pos[v]
-        if abs(u_pos[0] - v_pos[0]) > 5:  # Far apart horizontally
+        if abs(u_pos[0] - v_pos[0]) > 5:
             connectionstyle = "arc3,rad=0.2"
         else:
             connectionstyle = "arc3,rad=0.1"

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -40,7 +40,6 @@ async def chat(
         raise ExecutionError(f"API call failed: {api_call.execution.error}")
 
     if return_ins_res_message:
-        # Wrap result in `AssistantResponse` and return
         return ins, AssistantResponse.from_response(
             api_call.response,
             sender=branch.id,

--- a/lionagi/operations/communicate/communicate.py
+++ b/lionagi/operations/communicate/communicate.py
@@ -55,7 +55,6 @@ def prepare_communicate_kw(
         )
         num_parse_retries = 5
 
-    # Build contexts
     chat_param = ChatParam(
         guidance=guidance,
         context=context,
@@ -117,7 +116,6 @@ async def communicate(
     if skip_validation:
         return res.response
 
-    # Handle response_format with parse
     if parse_param and chat_param.response_format:
         from lionagi.protocols.messages.assistant_response import AssistantResponse
 
@@ -134,12 +132,10 @@ async def communicate(
                 res.metadata["model_response"] = res2.model_response
             return out
         except ValueError as e:
-            # Re-raise with more context
             raise ValueError(
                 f"Failed to parse model response into {chat_param.response_format}: {e}"
             ) from e
 
-    # Handle request_fields with fuzzy validation
     if request_fields is not None:
         _d = fuzzy_validate_mapping(
             res.response,

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -46,9 +46,8 @@ __all__ = ("DEFAULT_ROUND_BUDGET", "build_lndl_middle", "lndl_middle")
 
 DEFAULT_ROUND_BUDGET = 3
 
-# Shared by every round's action bridge — concurrent, error-suppressed (a
-# failed tool call surfaces as a tool result the model can react to next
-# round, not an exception that aborts the whole LNDL run).
+# Shared by every round's action bridge: concurrent, error-suppressed so a
+# failed tool call becomes a result the model reacts to, not an aborting exception.
 _ACTION_PARAM = ActionParam(
     action_call_params=get_default_action_call(),
     tools=None,
@@ -224,10 +223,8 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
         if clear_messages:
             branch.msgs.clear_messages()
 
-        # operate() always hands us the only model type it ever constructs —
-        # either the caller's bare response_format (via a direct communicate()
-        # call) or the operative-wrapped subclass (via operate()). Either way
-        # it's what assemble()+model_validate() below must target.
+        # The only model type operate()/communicate() ever hands us; what
+        # assemble()+model_validate() below must target.
         target = chat_param.response_format
         base_guidance = chat_param.guidance or ""
         guidance_parts = [get_lndl_system_prompt()]
@@ -237,10 +234,8 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
         if base_guidance:
             guidance_parts.append(base_guidance)
         lndl_guidance = "\n\n".join(guidance_parts)
-        # Strip native tool-calling and JSON-schema auto-rendering from the
-        # per-round chat call: LNDL uses a free-text <lact>/OUT{} protocol,
-        # not native function-calling, and it's assemble()+model_validate()
-        # below — not the per-round chat call — that targets response_format.
+        # LNDL uses a free-text <lact>/OUT{} protocol, not native
+        # function-calling, so strip tool schemas and response_format here.
         stripped_chat_param = chat_param.with_updates(tool_schemas=[], response_format=None)
 
         action_results: dict[str, Any] = {}
@@ -282,11 +277,8 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
                 last_error = str(e)
                 continue
 
-        # Exhausted(last_error): round budget hit without a valid OUT{}. Raise
-        # rather than return the raw error (or None, for an all-Continue run)
-        # -- a caller expecting a validated model must never receive a bare
-        # str/None through operate(), and Failed/Exhausted are the only two
-        # RoundOutcome variants that end the run without a value to return.
+        # Round budget exhausted without a valid OUT{}: raise rather than
+        # return a bare str/None, which a validated-model caller must never see.
         detail = f": {last_error}" if last_error else " (no OUT{} block was produced)"
         raise LNDLError(
             f"LNDL round budget ({round_budget}) exhausted without a valid OUT{{}}{detail}"

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -87,7 +87,6 @@ def prepare_operate_kw(
     chat_model = chat_model or branch.chat_model
     parse_model = parse_model or chat_model
 
-    # Convert dict-based instructions
     if isinstance(instruct, dict):
         instruct = Instruct(**instruct)
 

--- a/lionagi/operations/operate/operative.py
+++ b/lionagi/operations/operate/operative.py
@@ -109,7 +109,6 @@ class Operative:
             if strict:
                 raise e
 
-            # Try fuzzy validation if auto-retry enabled
             if self.auto_retry_parse and not strict:
                 try:
                     self.response_model = adapter_cls.validate_response(

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -99,7 +99,6 @@ async def parse(
             )
             return result if not return_res_message else (result, None)
     else:
-        # Try direct validation first
         with contextlib.suppress(Exception):
             result = _validate_dict_or_model(
                 text, parse_param.response_format, parse_param.fuzzy_match_params

--- a/lionagi/operations/select/select.py
+++ b/lionagi/operations/select/select.py
@@ -31,7 +31,6 @@ async def select(
     if verbose:
         logger.debug("Starting selection with up to %d choices.", max_num_selections)
 
-    # Handle branch creation for backwards compatibility
     if branch is None and branch_kwargs:
         from lionagi.session.branch import Branch
 

--- a/lionagi/operations/select/utils.py
+++ b/lionagi/operations/select/utils.py
@@ -76,7 +76,6 @@ def get_choice_representation(choice: Any) -> str:
     if isinstance(choice, Enum):
         return get_choice_representation(choice.value)
 
-    # Handle other types (int, dict, etc.) by converting to string
     return str(choice)
 
 

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -883,12 +883,8 @@ class Branch(Element, Relational):
             k: v for k, v in kwargs.items() if k not in {"verbose_analysis", "verbose_action"}
         }
 
-        # Emit lifecycle signals directly rather than through _observed_run so
-        # that exactly ONE RunStart is emitted per ReAct call.  Using
-        # _observed_run would be correct today, but if operate() inside
-        # ReActStream were ever wrapped with its own _observed_run, the outer
-        # wrapper here would produce N+1 RunStart events.  Inlining the
-        # emission removes that coupling.
+        # Emitted directly (not via _observed_run) to guarantee exactly ONE
+        # RunStart per ReAct call, decoupled from operate()'s own emission.
         import time as _time  # noqa: PLC0415
 
         has_observer = self._observer is not None
@@ -896,9 +892,8 @@ class Branch(Element, Relational):
             from .signal import RunStart
 
             await self._safe_emit(RunStart())
-        # Suppress nested lifecycle emission from run() calls inside ReActStream
-        # using a task-scoped ContextVar so that concurrent runs on the SAME
-        # branch are never affected — each asyncio task carries its own copy.
+        # Task-scoped ContextVar suppresses nested run() emission inside
+        # ReActStream without affecting concurrent runs on the same branch.
         from ._lifecycle_ctx import suppress_lifecycle_var
 
         _t0_react = _time.monotonic()

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -53,16 +53,9 @@ class Session(Node, Relational):
 
     def __init__(self, *, memory: MemoryStore | None = None, **kwargs: Any):
         super().__init__(**kwargs)
-        # `_initialize_branches` (a model validator) already ran inside
-        # `super().__init__()` and, via `include_branches()`, may have read
-        # the `.memory` property and lazily created a store, wiring it into
-        # every branch taken in at construction time (including the default
-        # branch). When an explicit store is supplied here, swap it in and
-        # rewire any branch still holding that temporary store so the whole
-        # session — not just `self._memory` — ends up pointing at the
-        # explicit store. When no explicit store is supplied, leave
-        # `self._memory` as whatever `_initialize_branches` already set, so
-        # it stays the same instance every branch was wired to.
+        # `_initialize_branches` may have already lazily created a store and
+        # wired it into branches; an explicit store here overrides it and
+        # rewires any branch still holding that temp store.
         temp = self._memory
         if memory is not None:
             self._memory = memory
@@ -104,10 +97,8 @@ class Session(Node, Relational):
             if self._hooks is not None:
                 branch._hooks = self._hooks
             if branch._memory is None:
-                # A branch keeps an explicitly supplied or previously
-                # adopted store; first claim wins. Reading the property
-                # lazily creates the session's own store on first use, then
-                # shares that one instance across every branch taken in.
+                # First claim wins; reading self.memory lazily creates and
+                # shares one store instance across every branch taken in.
                 branch._memory = self.memory
             if not self.exchange.has(branch.id):
                 self.exchange.register(branch.id)

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -155,11 +155,9 @@ class DispatchSignal(Signal):
 
 
 # -- Extended node lifecycle (ADR-0083) ---------------------------------------
-# Three signals completing the canonical per-node lifecycle:
-#   queued → running → awaiting_approval → succeeded | failed | escalated
-#
-# NodeStarted / NodeCompleted / NodeFailed (above) cover running/succeeded/
-# failed already; these three cover the remaining states.
+# queued → running → awaiting_approval → succeeded | failed | escalated
+# NodeStarted/NodeCompleted/NodeFailed (above) cover running/succeeded/failed;
+# these three cover the remaining states.
 
 
 class NodeQueued(Signal):


### PR DESCRIPTION
## Summary
Comment-only sweep of `lionagi/session/` and `lionagi/operations/` under the repo comment policy: inline comments are kept only where they state a non-obvious constraint or invariant, long-form rationale is condensed to one or two lines (or folded into the relevant docstring where it documents public intent), and comments that narrate the next line are deleted.

- 13 files touched; ~13 blocks condensed, ~9 narration comments deleted.
- The ReAct round-budget prompt rationale moved into the `ReActAnalysis` class docstring (it documents intent behind a public prompt template).
- Zero behavior change: AST-equality (modulo docstrings) verified against main for every touched file.

## Testing
- `pytest tests/session tests/operations` — 970 passed.
- ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)