### PR TITLE
chore: condense comments in service and providers

### DIFF
--- a/lionagi/providers/ag2/agent.py
+++ b/lionagi/providers/ag2/agent.py
@@ -141,10 +141,7 @@ async def run_beta_agent(
     if agent is not None:
         if config is not None:
             logger.info("run_beta_agent: pre-built agent provided; agent_config is ignored.")
-        # Use the caller-supplied agent as-is.
-        # AG2 stream imports still needed for the subscription machinery below.
     else:
-        # Config-driven path: build a fresh Agent from AgentConfig.
         if config is None:
             raise ValueError(
                 "run_beta_agent requires either a pre-built 'agent' or a non-None 'config'."
@@ -274,7 +271,6 @@ async def run_beta_agent(
         stream.unsubscribe(sub_results)
         if not task.done():
             task.cancel()
-            # Suppress CancelledError and any agent.ask error during teardown.
             try:
                 await task
             except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001 — intentional teardown reap
@@ -330,8 +326,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
         if not prompt:
             raise ValueError("AG2BetaEndpoint requires a non-empty prompt or at least one message.")
 
-        # Resolve the pre-built agent (if any) and the agent_config.
-        # Pre-built agent takes precedence; agent_config is the fallback.
+        # Pre-built agent takes precedence over agent_config.
         prebuilt_agent = request_obj.agent or kwargs.get("agent")
 
         if prebuilt_agent is None:
@@ -339,8 +334,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
             if agent_config is None:
                 agent_config = AgentConfig(**kwargs.get("agent_config", self._agent_config))
         else:
-            # Pre-built agent path: agent_config may be None; that's fine.
-            agent_config = request_obj.agent_config  # kept for metadata only
+            agent_config = request_obj.agent_config  # pre-built path: may be None, metadata only
 
         llm_config = kwargs.get("llm_config", self._llm_config)
         tool_registry = kwargs.get("tool_registry", self._tool_registry)
@@ -350,8 +344,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
 
         model_config = _resolve_model_config(llm_config) if llm_config is not None else None
 
-        # Build system chunk metadata. When a pre-built agent is used the
-        # config fields are not authoritative; surface what we know.
+        # Pre-built agent: config fields aren't authoritative; surface what we know.
         if prebuilt_agent is not None:
             agent_name = getattr(prebuilt_agent, "name", "pre-built")
             system_meta: dict = {
@@ -372,7 +365,6 @@ class AG2BetaEndpoint(AgenticEndpoint):
 
         yield StreamChunk(type="system", metadata=system_meta)
 
-        # Agent name used in per-event metadata below.
         _agent_name = system_meta["agent"]
 
         try:

--- a/lionagi/providers/ag2/groupchat.py
+++ b/lionagi/providers/ag2/groupchat.py
@@ -172,9 +172,7 @@ def build_group_chat(
 
     for agent_spec in spec.agents:
         if agent_spec.nlip_url:
-            # SSRF guard: validate the caller-supplied URL before handing it
-            # to NlipRemoteAgent, which opens its own HTTP connection and
-            # bypasses the Endpoint transport guards.
+            # SSRF guard: NlipRemoteAgent opens its own HTTP connection, bypassing Endpoint transport guards.
             from lionagi.providers.ag2.nlip import _assert_nlip_url_safe
 
             _assert_nlip_url_safe(agent_spec.nlip_url)

--- a/lionagi/providers/ag2/nlip.py
+++ b/lionagi/providers/ag2/nlip.py
@@ -91,7 +91,6 @@ async def call_nlip_remote(
     max_retries: int = 3,
 ) -> dict[str, Any]:
     """Call a remote NLIP endpoint; applies SSRF guard then falls back to direct httpx if nlip_sdk is absent."""
-    # SSRF guard: reject calls to private/reserved IP ranges.
     _assert_nlip_url_safe(url)
     try:
         return await _call_nlip_sdk(url, messages, timeout, max_retries)

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -347,7 +347,6 @@ class ClaudeCodeRequest(BaseModel):
 
             prompt = "\n".join(prompts)
 
-        # 3. assemble the request data
         data_: dict[str, Any] = dict(
             prompt=prompt,
             resume=resume,
@@ -495,8 +494,7 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
     workspace = request.cwd()
     workspace.mkdir(parents=True, exist_ok=True)
     cmd = [CLAUDE_CLI, *request.as_cmd_args()]
-    # Pass the repair callback so a malformed-but-repairable final JSON object
-    # is recovered rather than silently dropped (matches pre-refactor behaviour).
+    # tail_repair recovers a malformed-but-repairable final JSON object instead of dropping it.
     async with contextlib.aclosing(
         ndjson_from_cli(cmd, cwd=workspace, tail_repair=_claude_tail_repair)
     ) as stream:

--- a/lionagi/providers/anthropic/messages.py
+++ b/lionagi/providers/anthropic/messages.py
@@ -188,7 +188,6 @@ class AnthropicMessagesEndpoint(Endpoint):
         extra_headers: dict | None = None,
         **kwargs,
     ):
-        # Extract system message before validation if present
         request_dict = request if isinstance(request, dict) else request.model_dump()
         system = None
 
@@ -196,13 +195,11 @@ class AnthropicMessagesEndpoint(Endpoint):
             first_message = request_dict["messages"][0]
             if first_message.get("role") == "system":
                 system = first_message["content"]
-                # Remove system message before validation
                 request_dict["messages"] = request_dict["messages"][1:]
                 request = request_dict
 
         payload, headers = super().create_payload(request, extra_headers=extra_headers, **kwargs)
 
-        # Remove api_key from payload if present
         payload.pop("api_key", None)
 
         if "cache_control" in payload:
@@ -222,7 +219,6 @@ class AnthropicMessagesEndpoint(Endpoint):
                     [last_message] if not isinstance(last_message, list) else last_message
                 )
 
-        # If we extracted a system message earlier, add it to payload
         if system:
             system = [{"type": "text", "text": system}]
             payload["system"] = system

--- a/lionagi/providers/deepseek/chat.py
+++ b/lionagi/providers/deepseek/chat.py
@@ -40,8 +40,7 @@ class DeepseekChatCompletionsRequest(OpenAIChatCompletionsRequest):
 
     @model_validator(mode="after")
     def _normalize_deepseek_reasoning(self):
-        # DeepSeek accepts: low, medium, high, max.
-        # Map lionagi/OpenAI effort names to DeepSeek equivalents.
+        # DeepSeek accepts only low/medium/high/max; map lionagi/OpenAI effort names onto that set.
         if self.reasoning_effort in {"low", "medium"}:
             self.reasoning_effort = "high"
         elif self.reasoning_effort == "xhigh":

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -87,11 +87,9 @@ CONTEXT_WINDOWS: dict[str, int] = {
 
 # --------------------------------------------------------------------------- model mapping
 
-# `agy --model` takes a human-readable name plus an effort qualifier (verified
-# against `agy models`). lionagi callers pass legacy Gemini CLI model strings
-# (`gemini-3-flash-preview`, `gemini-3-pro-preview`) or bare family names; map
-# those onto the exact strings agy understands. Unknown values pass through so
-# agy surfaces a clear error rather than us silently forcing a default.
+# `agy --model` wants an exact display name + effort suffix; map legacy Gemini
+# CLI strings / bare family names onto it. Unknown values pass through so agy
+# surfaces a clear error rather than us silently forcing a default.
 _AGY_MODELS: frozenset[str] = frozenset(
     {
         "Gemini 3.5 Flash (Medium)",
@@ -420,11 +418,10 @@ async def stream_gemini_cli(
                 yield sys_sc
 
             if session.is_error:
-                # The error chunk must never impersonate the response: a
-                # degraded termination (e.g. timeout after a complete final
-                # message) would otherwise surface the delivered content AS
-                # the error. Lead with the status; keep a bounded detail so
-                # quota/auth patterns still classify.
+                # Error chunk must lead with status, not delivered content —
+                # a degraded termination after a complete response otherwise
+                # impersonates the response. Bounded detail keeps quota/auth
+                # patterns classifiable.
                 detail = f": {response[:500]}" if response else ""
                 msg = f"agy returned status={status or 'UNKNOWN'}{detail}"
                 sc = StreamChunk(type="error", content=msg, is_error=True, metadata=obj)

--- a/lionagi/providers/ollama/chat.py
+++ b/lionagi/providers/ollama/chat.py
@@ -57,7 +57,6 @@ class OllamaChatEndpoint(Endpoint):
         if model:
             await run_sync(self._check_model, model)
 
-        # Skip payload creation — already done above.
         return await super().call(
             payload,
             cache_control=cache_control,

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -325,12 +325,10 @@ class CodexCodeRequest(BaseModel):
         else:
             args.extend(["--disable", "tool_search"])
 
-        # System prompt → -c developer_instructions=<val>
-        # (Codex CLI has no --system-prompt flag; uses developer_instructions)
+        # Codex CLI has no --system-prompt flag; uses -c developer_instructions.
         if self.system_prompt:
             args.extend(["-c", f"developer_instructions={self.system_prompt}"])
 
-        # Reasoning effort → -c reasoning_effort=<val>
         if self.reasoning_effort:
             args.extend(["-c", f"reasoning_effort={self.reasoning_effort}"])
         if self.plan_mode_reasoning_effort:
@@ -341,15 +339,12 @@ class CodexCodeRequest(BaseModel):
                 ]
             )
 
-        # Fast mode → -c service_tier=fast
         if self.fast_mode:
             args.extend(["-c", "service_tier=fast"])
 
-        # Images (repeat -i per image)
         for image in self.images:
             args.extend(["-i", image])
 
-        # Config overrides (-c key=value)
         for key, value in self.config_overrides.items():
             serialized = json.dumps(value) if not isinstance(value, str) else value
             args.extend(["-c", f"{key}={serialized}"])
@@ -463,12 +458,10 @@ async def stream_codex_cli(
                     obj.get("session_id", obj.get("id")),
                 )
                 session.model = obj.get("model")
-                # Codex's own event carries "thread_id" (thread.started) rather
-                # than "session_id" — normalize it into the metadata key every
-                # CLI provider's system chunk is expected to carry (mirrors
-                # claude_code.py), so run.py's engine-session-id capture
-                # (endpoint.session_id, used to link a profile-typed session
-                # to its engine-typed mirror at teardown) works for Codex too.
+                # Codex uses "thread_id" not "session_id"; normalize into the
+                # metadata key every CLI provider's system chunk carries
+                # (mirrors claude_code.py) so run.py's engine-session-id
+                # capture works for Codex too.
                 sc = StreamChunk(type="system", metadata={**obj, "session_id": session.session_id})
                 session.chunks.append(sc)
                 yield sc
@@ -636,19 +629,13 @@ async def stream_codex_cli(
             elif typ in ("turn.failed", "error"):
                 session.is_error = True
                 err = obj.get("error", {})
-                # The CLI puts the human-readable message in different spots
-                # depending on event type: "error" events carry a TOP-LEVEL
-                # "message" with no "error" key (e.g. usage-limit errors), while
-                # "turn.failed" nests it under error.message.  Check both —
-                # otherwise a top-level-message error renders as the useless
-                # str() of an empty dict and the actionable text is discarded.
-                # Normalise null/missing error payloads: JSON "error": null
-                # arrives as None here (obj.get returns the default only when the
-                # key is absent, not when it is explicitly null).
-                # IMPORTANT: capture the raw value BEFORE normalising.  The
-                # benign-EOS predicate below must see the original value; a null
-                # payload normalised to {} would otherwise match the empty-dict
-                # sentinel and silently swallow a real (malformed) provider error.
+                # Message location varies by event type: "error" events carry
+                # a top-level "message" with no "error" key; "turn.failed"
+                # nests it under error.message. Check both.
+                # Capture the raw value before null-normalising: the
+                # benign-EOS check below must distinguish an explicit
+                # "error": null (malformed envelope, real error) from the
+                # bare {} sentinel (benign EOF) — see below.
                 _raw_err = err
                 if err is None:
                     err = {}
@@ -665,26 +652,14 @@ async def stream_codex_cli(
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )
-                # Detect a benign end-of-stream sentinel: some codex CLI versions
-                # emit ``{"type": "error", "error": {}}`` when a resumed session
-                # ends normally rather than with a real failure.  Tag these
-                # explicitly so run() can treat them as clean EOS rather than
-                # propagating them as RunFailed.
-                #
-                # Narrowing criteria (must ALL hold):
-                #   1. Event type is "error" — "turn.failed" events are NEVER benign
-                #      regardless of their error payload, because they signal an
-                #      explicit model-side failure (e.g. rate_limit, context_overflow).
-                #   2. The error payload is EXACTLY the empty dict in the RAW event.
-                #      A structured payload with falsy values ({"message": ""},
-                #      {"message": None}) is a real failure whose detail happens to be
-                #      empty — only the bare {} sentinel is produced by a resumed-session
-                #      EOF.  Crucially, ``"error": null`` (raw value = None) is NOT the
-                #      sentinel: it indicates a malformed/unexpected provider envelope
-                #      and must surface as a real error.  We test _raw_err (the value
-                #      before null-normalisation) to preserve this distinction.
-                #   3. The top-level event carries no failure indicators beyond the
-                #      known EOF envelope (no "code", "message", or "status" keys).
+                # Some codex CLI versions emit {"type": "error", "error": {}}
+                # when a resumed session ends normally (benign EOS, not a real
+                # failure) — tag it so run() treats it as clean EOS rather
+                # than RunFailed. All must hold: type == "error" ("turn.failed"
+                # is never benign); the RAW payload is exactly {} (a
+                # structured-but-empty payload or explicit null is a real,
+                # if sparse, failure — test _raw_err, pre null-normalisation);
+                # no other failure keys (code/message/status) present.
                 _is_benign_eos = (
                     typ == "error"
                     and "error" in obj  # a bare {"type": "error"} is malformed, not EOF

--- a/lionagi/providers/pi/cli.py
+++ b/lionagi/providers/pi/cli.py
@@ -60,13 +60,11 @@ PiThinkingLevel = Literal[
 
 __all__ = ("PiChunk", "PiCodeRequest", "PiSession", "stream_pi_cli", "PiCLIEndpoint")
 
-# Model name prefix → pi --provider value.
-# Longest prefixes first to avoid false matches.
-# Model prefix → pi --provider. Only unambiguous prefixes where the
-# model name uniquely identifies the provider. strip=True removes the
-# prefix from the model (needed for openrouter/ routing).
-# Ambiguous names (llama, gemma, mistral — available on multiple
-# providers) are omitted; set provider explicitly or let pi resolve.
+# Model prefix → pi --provider. Only unambiguous prefixes (model name
+# uniquely identifies the provider); ambiguous names (llama, gemma,
+# mistral — available on multiple providers) are omitted, so set provider
+# explicitly or let pi resolve. strip=True removes the prefix from the
+# model (needed for openrouter/ routing).
 _PI_MODEL_PROVIDER_MAP: list[tuple[str, str, bool]] = [
     ("openrouter/", "openrouter", True),
     ("deepseek-", "deepseek", False),
@@ -241,10 +239,8 @@ class PiCodeRequest(BaseModel):
         """Build argument list for ``pi`` invocation: ``-p --mode json [flags] [prompt] [@files...]``."""
         args: list[str] = ["-p", "--mode", "json"]
 
-        # declarative flags
         args.extend(self._build_declarative_args())
 
-        # file references before prompt
         for f in self.file_args:
             args.append(f"@{f}" if not f.startswith("@") else f)
 

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -67,7 +67,6 @@ class EndpointConfig(BaseModel):
             if isinstance(self.api_key, SecretStr):
                 self._api_key = self.api_key.get_secret_value()
             elif isinstance(self.api_key, str):
-                # Skip settings lookup for special cases
                 if self.provider == "ollama" and self.api_key == "ollama_key":
                     self._api_key = "ollama_key"
                 elif self.api_key.startswith("dummy-key"):
@@ -96,7 +95,6 @@ class EndpointConfig(BaseModel):
 
     @field_validator("request_options", mode="before")
     def _validate_request_options(cls, v):
-        # Create a simple empty model if None is provided
         if v is None:
             return None
 
@@ -123,16 +121,13 @@ class EndpointConfig(BaseModel):
 
     def update(self, **kwargs):
         """Update the config with new values."""
-        # Handle the special case of kwargs dict
         if "kwargs" in kwargs:
-            # Merge the kwargs dicts
             self.kwargs.update(kwargs.pop("kwargs"))
 
         for key, value in kwargs.items():
             if hasattr(self, key):
                 setattr(self, key, value)
             else:
-                # Add to kwargs dict if not a direct attribute
                 self.kwargs[key] = value
 
     def validate_payload(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/lionagi/service/connections/header_factory.py
+++ b/lionagi/service/connections/header_factory.py
@@ -38,7 +38,6 @@ class HeaderFactory:
             dict_ = HeaderFactory.get_content_type_header(content_type)
 
         if auth_type == "none":
-            # No authentication needed
             pass
         elif not api_key:
             raise ValueError("API key is required for authentication")

--- a/lionagi/service/hooks/hook_registry.py
+++ b/lionagi/service/hooks/hook_registry.py
@@ -35,9 +35,7 @@ def _normalize_hook_key(key: HookEventTypes | str) -> HookEventTypes | str:
             "pre_invoke": HookEventTypes.PreInvocation,
             "post_invoke": HookEventTypes.PostInvocation,
             "pre_event_create": HookEventTypes.PreEventCreate,
-            # Legacy alias — decorator name on HookRegistry is
-            # `pre_event_create_hook`, so callers constructing via dict often
-            # use this string. Preserve both spellings for backward compat.
+            # Legacy alias matching the decorator name; kept for backward compat.
             "pre_event_create_hook": HookEventTypes.PreEventCreate,
         }
         if key in aliases:

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -297,7 +297,7 @@ class iModel:  # noqa: N801
                         timeout=10.0,
                     )
                 except asyncio.TimeoutError:
-                    pass  # Fall through — same as old ctr>100 break
+                    pass
 
             completed_call = self.executor.pile.pop(api_call.id)
             if (
@@ -385,8 +385,7 @@ class iModel:  # noqa: N801
             provider=endpoint.config.provider,
             endpoint=endpoint.config.endpoint,
         ):
-            # Preserve the API key from the freshly matched endpoint
-            # (reads from env), then apply the serialized config on top
+            # Preserve the freshly resolved (env-sourced) API key before overwriting config
             fresh_api_key = e1.config._api_key
             e1.config = endpoint.config
             if e1.config._api_key is None and fresh_api_key:


### PR DESCRIPTION
## Summary
Comment-only sweep of `lionagi/service/` and `lionagi/providers/` under the repo comment policy: keep only ambiguity-reducing inlines (non-obvious constraints, invariants, gotchas), condense long rationale to one or two lines, delete comments that narrate the next line.

- 14 files touched; ~30 narration comments deleted, ~9 long blocks condensed (SSRF-guard rationale, provider CLI quirks, hook-registry legacy alias, etc.). Load-bearing invariants preserved in tightened form.
- Files owned by in-flight PRs were excluded from this sweep.
- Zero behavior change: AST-equality (modulo docstrings) verified against main for every touched file.

## Testing
- `pytest tests/service` — 958 passed.
- ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)