### PR TITLE
chore: condense comments in protocols and ln

### DIFF
--- a/lionagi/ln/_async_call.py
+++ b/lionagi/ln/_async_call.py
@@ -314,10 +314,8 @@ class BcallParams(AlcallParams):
 
     async def __call__(self, input_: list[Any], func: Callable[..., T], **kw) -> list[T]:
         kwargs = {**self.default_kw(), **kw}
-        # batch_size is a positional arg to bcall; remove it from kwargs to
-        # avoid "multiple values for argument 'batch_size'" TypeError.
+        # batch_size is positional in bcall; drop it to avoid a duplicate-arg TypeError.
         kwargs.pop("batch_size", None)
-        # bcall is an async generator — collect all batches into one flat list.
         results: list[T] = []
         async for batch in bcall(input_, func, self.batch_size, **kwargs):
             results.extend(batch)

--- a/lionagi/ln/_hash.py
+++ b/lionagi/ln/_hash.py
@@ -52,8 +52,8 @@ _TYPE_MARKER_LIST = 1
 _TYPE_MARKER_TUPLE = 2
 _TYPE_MARKER_SET = 3
 _TYPE_MARKER_FROZENSET = 4
-_TYPE_MARKER_PYDANTIC = 5  # Distinguishes dumped Pydantic models
-_TYPE_MARKER_MSGSPEC = 6  # Distinguishes msgspec Structs
+_TYPE_MARKER_PYDANTIC = 5
+_TYPE_MARKER_MSGSPEC = 6
 
 
 def _generate_hashable_representation(item: Any) -> Any:
@@ -120,7 +120,6 @@ def _generate_hashable_representation(item: Any) -> Any:
             tuple(_generate_hashable_representation(elem) for elem in sorted_elements),
         )
 
-    # Fallback for other types
     with contextlib.suppress(Exception):
         return str(item)
     with contextlib.suppress(Exception):

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -27,8 +27,7 @@ __all__ = [
     "json_lines_iter",
 ]
 
-# Types orjson already serializes natively at C/Rust speed.
-# (We only route them through default() when passthrough is requested.)
+# Types orjson serializes natively; routed through default() only when passthrough is requested.
 _NATIVE = (dt.datetime, dt.date, dt.time, UUID)
 _SERIALIZATION_METHODS = ("model_dump", "to_dict", "dict")
 

--- a/lionagi/ln/_lazy_init.py
+++ b/lionagi/ln/_lazy_init.py
@@ -46,9 +46,7 @@ def lazy_import(
     module_path, import_name = module_map[name]
     import importlib
 
-    # Resolve the parent package for relative imports.
-    # If *package* is "lionagi.operations.fields" (a module, not a package),
-    # we need "lionagi" as the anchor for relative resolution.
+    # Anchor relative imports on the parent package (package may be a module, not a package).
     pkg = globs.get("__package__") or package.rpartition(".")[0]
     mod = importlib.import_module(f".{module_path}", pkg)
     obj = getattr(mod, import_name or name)

--- a/lionagi/ln/_list_call.py
+++ b/lionagi/ln/_list_call.py
@@ -26,7 +26,6 @@ def lcall(
     **kwargs: Any,
 ) -> list[R]:
     """Sync map of func over input with optional input/output flatten/dropna/unique transforms."""
-    # Validate and extract callable function
     if not callable(func):
         try:
             func_list = list(func)
@@ -36,11 +35,9 @@ def lcall(
         except TypeError as e:
             raise ValueError("func must be callable or iterable with one callable.") from e
 
-    # Validate output processing options
     if output_unique and not (output_flatten or output_dropna):
         raise ValueError("unique_output requires flatten or dropna for post-processing.")
 
-    # Process input based on sanitization flag
     if input_flatten or input_dropna:
         input_ = to_list(
             input_,
@@ -57,7 +54,6 @@ def lcall(
             except TypeError:
                 input_ = [input_]
 
-    # Process elements and collect results
     out = []
     append = out.append
 
@@ -70,7 +66,6 @@ def lcall(
         except Exception:
             raise
 
-    # Apply output processing if requested
     if output_flatten or output_dropna:
         out = to_list(
             out,

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -13,12 +13,9 @@ from typing import Any
 def _safe_pgid(proc: Any) -> int | None:
     """Return the process-group id to signal, or None when unsafe."""
     pid = getattr(proc, "pid", None)
-    # Guard: pid must be a real int greater than 1.
-    # pid==0 targets the caller's own group; pid==1 is init/the session leader
-    # on CI runners, which would SIGKILL the test harness itself.  A MagicMock
-    # whose .pid coerces to 1 via __index__ is therefore a silent no-op here.
-    # os.killpg is POSIX-only; on Windows leave None so callers fall back to
-    # proc.terminate()/kill() rather than raising AttributeError.
+    # pid must be int > 1: pid==0 is our own group, pid==1 is init/session leader
+    # on CI (would SIGKILL the harness itself; also catches MagicMock.pid==1).
+    # killpg is POSIX-only; None here makes callers fall back to proc.terminate()/kill().
     if not (hasattr(os, "killpg") and isinstance(pid, int) and pid > 1):
         return None
     return pid
@@ -42,18 +39,15 @@ def terminate_process_group(
     """
     pgid = _safe_pgid(proc)
     if grace is None:
-        # SIGKILL-only path: signal the group (when available) AND the direct
-        # child. The child is normally a member of the killed group so proc.kill()
-        # is a suppressed no-op, but signalling only the group orphans the child
-        # when killpg is unavailable (Windows) or the group is already reaped.
+        # Signal group AND direct child: proc.kill() is normally a no-op (child is
+        # in the killed group) but prevents orphaning it when killpg is unavailable.
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):
             proc.kill()
         return
-    # sig_first only — signal the group (when available) AND the direct child;
-    # the caller drives the wait + SIGKILL escalation.
+    # sig_first only; caller drives the wait + SIGKILL escalation.
     if pgid is not None:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(pgid, sig_first)
@@ -76,14 +70,13 @@ async def aterminate_process_group(
     """
     pgid = _safe_pgid(proc)
     if grace is None:
-        # SIGKILL-only path (no SIGTERM, no wait): group AND direct child.
+        # No prior SIGTERM/wait: signal group AND direct child directly.
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):
             proc.kill()
         return
-    # SIGTERM-then-wait-then-SIGKILL path: signal group AND direct child.
     if pgid is not None:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(pgid, sig_first)

--- a/lionagi/ln/concurrency/_compat.py
+++ b/lionagi/ln/concurrency/_compat.py
@@ -8,17 +8,14 @@ from __future__ import annotations
 import sys
 from collections.abc import Sequence
 
-# ExceptionGroup compatibility for Python 3.10
 if sys.version_info >= (3, 11):
-    # Python 3.11+ has built-in BaseExceptionGroup and ExceptionGroup
     from builtins import BaseExceptionGroup, ExceptionGroup
 
 else:
-    # Python 3.10: Use exceptiongroup backport
     try:
         from exceptiongroup import BaseExceptionGroup, ExceptionGroup
     except ImportError:
-        # Fallback implementation for environments without exceptiongroup
+
         class BaseExceptionGroup(BaseException):  # type: ignore
             """Minimal BaseExceptionGroup implementation for Python 3.10 without exceptiongroup."""
 

--- a/lionagi/ln/concurrency/errors.py
+++ b/lionagi/ln/concurrency/errors.py
@@ -26,9 +26,8 @@ __all__ = (
     "split_cancellation",
 )
 
-# Module-level cache populated by ``cache_cancelled_exc_class()`` from inside
-# a running event loop.  Falls back to ``(asyncio.CancelledError,)`` when
-# called outside a loop (e.g. during teardown after the loop has stopped).
+# Populated by cache_cancelled_exc_class() inside a running loop; falls back to
+# (asyncio.CancelledError,) when called outside one (e.g. post-loop teardown).
 _CANCELLED_EXC_CLASS: tuple[type[BaseException], ...] | None = None
 
 
@@ -39,12 +38,10 @@ def cache_cancelled_exc_class() -> None:
         return
     try:
         cls = anyio.get_cancelled_exc_class()
-        # Build a tuple that covers both asyncio and the backend-specific type
-        # (they may be the same, but de-dup to avoid CPython isinstance quirks).
+        # De-dup: asyncio.CancelledError and the backend-specific type may be identical.
         _CANCELLED_EXC_CLASS = tuple({asyncio.CancelledError, cls})
     except Exception:
-        # If anyio itself raises here (shouldn't happen inside a loop, but be
-        # defensive), record the asyncio baseline so the cache is populated.
+        # Shouldn't happen inside a loop; fall back to the asyncio baseline defensively.
         _CANCELLED_EXC_CLASS = (asyncio.CancelledError,)
 
 
@@ -52,7 +49,6 @@ def cancelled_exc_classes() -> tuple[type[BaseException], ...]:
     """Cached cancellation exception types; falls back to asyncio.CancelledError if never primed."""
     if _CANCELLED_EXC_CLASS is not None:
         return _CANCELLED_EXC_CLASS
-    # Graceful degradation: no cache yet → use asyncio baseline.
     return (asyncio.CancelledError,)
 
 

--- a/lionagi/ln/concurrency/patterns.py
+++ b/lionagi/ln/concurrency/patterns.py
@@ -45,7 +45,7 @@ async def gather(*aws: Awaitable[T], return_exceptions: bool = False) -> list[T 
         except BaseException as exc:
             results[idx] = exc
             if not return_exceptions:
-                raise  # Propagate to the TaskGroup
+                raise
 
     try:
         async with create_task_group() as tg:
@@ -173,9 +173,8 @@ class CompletionStream:
                     assert self._send is not None
                     await self._send.send((i, res))  # type: ignore[arg-type]
                 except anyio.ClosedResourceError:
-                    # The consumer closed the receive end early (e.g., break after
-                    # first result). Discard this result silently — this is expected
-                    # in early-exit streaming scenarios.
+                    # Consumer closed the receive end early (e.g. break after first
+                    # result) — discard silently, this is expected early-exit behavior.
                     pass
             finally:
                 if limiter:

--- a/lionagi/ln/fuzzy/_extract_json.py
+++ b/lionagi/ln/fuzzy/_extract_json.py
@@ -8,7 +8,6 @@ from ._fuzzy_json import MAX_JSON_INPUT_SIZE, fuzzy_json
 
 logger = logging.getLogger(__name__)
 
-# Precompile the regex for extracting JSON code blocks
 _JSON_BLOCK_PATTERN = re.compile(r"```json\s*(.*?)\s*```", re.DOTALL)
 
 
@@ -28,7 +27,6 @@ def extract_json(
                     f"Input size ({len(item)} bytes) exceeds maximum ({max_size} bytes)"
                 )
 
-    # If input_data is a list, join into a single string
     if isinstance(input_data, list):
         input_str = "\n".join(input_data)
     else:
@@ -50,7 +48,6 @@ def extract_json(
     if not matches:
         return []
 
-    # If only one match, return single dict; if multiple, return list of dicts
     if return_one_if_single and len(matches) == 1:
         data_str = matches[0]
         try:
@@ -69,6 +66,5 @@ def extract_json(
             else:
                 results.append(orjson.loads(m))
         except Exception:  # noqa: S112  # intentional parser fallback: skip unparseable JSON blocks, not an error
-            # Skip invalid JSON blocks
             continue
     return results

--- a/lionagi/ln/fuzzy/_fuzzy_json.py
+++ b/lionagi/ln/fuzzy/_fuzzy_json.py
@@ -4,9 +4,7 @@ from typing import Any
 
 import orjson
 
-# Security limit: Maximum input string size for JSON parsing.
-# Large inputs can cause memory exhaustion during parsing and regex operations.
-# Default: 10MB - generous for most use cases while preventing DoS.
+# Security limit: caps input size to avoid memory exhaustion during parsing/regex ops.
 MAX_JSON_INPUT_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
@@ -219,17 +217,14 @@ def fix_json_string(str_to_parse: str, /) -> str:
             open_brackets.append(brackets[char])
         elif char in brackets.values():
             if not open_brackets:
-                # Extra closing bracket
-                # Better to raise error than guess
+                # Better to raise than guess at the intended structure.
                 raise ValueError("Extra closing bracket found.")
             if open_brackets[-1] != char:
-                # Mismatched bracket
                 raise ValueError("Mismatched brackets.")
             open_brackets.pop()
 
         pos += 1
 
-    # Add missing closing brackets if any
     if open_brackets:
         str_to_parse += "".join(reversed(open_brackets))
 

--- a/lionagi/ln/fuzzy/_fuzzy_match.py
+++ b/lionagi/ln/fuzzy/_fuzzy_match.py
@@ -35,14 +35,11 @@ def fuzzy_match_keys(
     strict: bool = False,
 ) -> dict[str, Any]:
     """Remap dict keys to expected keys via exact + fuzzy matching; handle_unmatched controls missing/extra key policy."""
-    # Input validation
     if not isinstance(d_, dict):
         raise TypeError("First argument must be a dictionary")
     if keys is None:
         raise TypeError("Keys argument cannot be None")
-    # A bare str is a Sequence[str] but iterating it yields single characters,
-    # not key names.  Reject it early with a clear message rather than silently
-    # producing wrong results.
+    # A bare str is a Sequence[str] but iterates as characters, not key names — reject early.
     if isinstance(keys, str):
         raise TypeError(
             "keys must be a Mapping (dict) or a non-string Sequence of key names "
@@ -51,18 +48,15 @@ def fuzzy_match_keys(
     if not 0.0 <= similarity_threshold <= 1.0:
         raise ValueError("similarity_threshold must be between 0.0 and 1.0")
 
-    # Extract expected keys: Mapping types expose their keys via .keys();
-    # all other Sequence types (list, tuple, frozenset, …) are iterable directly.
+    # Mapping types expose expected keys via .keys(); other Sequence types are iterable directly.
     fields_set = set(keys.keys()) if isinstance(keys, Mapping) else set(keys)
     if not fields_set:
-        return d_.copy()  # Return copy of original if no expected keys
+        return d_.copy()
 
-    # Initialize output dictionary and tracking sets
     corrected_out = {}
     matched_expected = set()
     matched_input = set()
 
-    # Get similarity function
     if isinstance(similarity_algo, str):
         if similarity_algo not in SIMILARITY_ALGO_MAP:
             raise ValueError(f"Unknown similarity algorithm: {similarity_algo}")
@@ -103,7 +97,6 @@ def fuzzy_match_keys(
             elif handle_unmatched == "ignore":
                 corrected_out[key] = d_[key]
 
-    # Handle unmatched keys based on handle_unmatched parameter
     unmatched_input = set(d_.keys()) - matched_input
     unmatched_expected = fields_set - matched_expected
 
@@ -115,7 +108,6 @@ def fuzzy_match_keys(
             corrected_out[key] = d_[key]
 
     elif handle_unmatched in ("fill", "force"):
-        # Fill missing expected keys
         for key in unmatched_expected:
             if fill_mapping and key in fill_mapping:
                 corrected_out[key] = fill_mapping[key]
@@ -127,7 +119,6 @@ def fuzzy_match_keys(
             for key in unmatched_input:
                 corrected_out[key] = d_[key]
 
-    # Check strict mode
     if strict and unmatched_expected:
         raise ValueError(f"Missing required keys: {unmatched_expected}")
 

--- a/lionagi/ln/fuzzy/_fuzzy_validate.py
+++ b/lionagi/ln/fuzzy/_fuzzy_validate.py
@@ -64,7 +64,6 @@ def fuzzy_validate_mapping(
     if d is None:
         raise TypeError("Input cannot be None")
 
-    # Try converting to dictionary
     try:
         if isinstance(d, str):
             try:
@@ -87,7 +86,6 @@ def fuzzy_validate_mapping(
         else:
             raise ValueError(f"Failed to convert input to dictionary: {e}") from e
 
-    # Validate the dictionary
     return fuzzy_match_keys(
         dict_input,
         keys,

--- a/lionagi/ln/fuzzy/_to_dict.py
+++ b/lionagi/ln/fuzzy/_to_dict.py
@@ -287,7 +287,6 @@ def to_dict(
                 prioritize_model_dump=prioritize_model_dump,
             )
 
-        # Final top-level conversion
         return _convert_top_level_to_dict(
             obj,
             fuzzy_parse=fuzzy_parse,

--- a/lionagi/ln/types/base.py
+++ b/lionagi/ln/types/base.py
@@ -30,7 +30,7 @@ class Enum(_Enum):
 class KeysDict(TypedDict, total=False):
     """TypedDict for keys dictionary."""
 
-    key: Any  # Represents any key-type pair
+    key: Any
 
 
 @dataclass(slots=True, frozen=True)
@@ -59,14 +59,12 @@ class Params:
     _allowed_keys: ClassVar[set[str]] = field(default=set(), init=False, repr=False)
 
     def __init__(self, **kwargs: Any):
-        # Set all attributes from kwargs, allowing for sentinel values
         for k, v in kwargs.items():
             if k in self.allowed():
                 object.__setattr__(self, k, v)
             else:
                 raise ValueError(f"Invalid parameter: {k}")
 
-        # Validate after setting all attributes
         self._validate()
 
     @classmethod
@@ -104,10 +102,9 @@ class Params:
             _validate_strict(k)
 
     def default_kw(self) -> Any:
-        # create a partial function with the current parameters
         dict_ = self.to_dict()
 
-        # handle kwargs if present, handle both 'kwargs' and 'kw'
+        # Merge both 'kwargs' and 'kw' conventions into a single flat dict.
         kw_ = {}
         kw_.update(dict_.pop("kwargs", {}))
         kw_.update(dict_.pop("kw", {}))
@@ -216,10 +213,8 @@ class DataClass:
         return hash(self) == hash(other)
 
 
-# Concrete key-container types accepted by fuzzy_match_keys.
-# Bare ``str`` is intentionally excluded: iterating a str yields individual
-# characters, not key names.  Generic Sequences other than list/tuple are also
-# excluded because the runtime guard rejects them.
+# Concrete key-container types accepted by fuzzy_match_keys. Bare ``str`` is
+# intentionally excluded: iterating a str yields characters, not key names.
 KeysLike = list[str] | tuple[str, ...] | set[str] | frozenset[str] | KeysDict
 
 

--- a/lionagi/ln/types/operable.py
+++ b/lionagi/ln/types/operable.py
@@ -30,18 +30,15 @@ class Operable:
         # Import here to avoid circular import
         from .spec import Spec
 
-        # Convert to tuple if list
         if isinstance(specs, list):
             specs = tuple(specs)
 
-        # Validate all items are Spec objects
         for i, item in enumerate(specs):
             if not isinstance(item, Spec):
                 raise TypeError(
                     f"All specs must be Spec objects, got {type(item).__name__} at index {i}"
                 )
 
-        # Check for duplicate names
         names = [s.name for s in specs if s.name is not None]
         if len(names) != len(set(names)):
             from collections import Counter

--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -19,7 +19,7 @@ from .base import Meta
 # Global cache for annotated types with bounded size
 _MAX_CACHE_SIZE = int(os.environ.get("LIONAGI_FIELD_CACHE_SIZE", "10000"))
 _annotated_cache: OrderedDict[tuple[type, tuple[Meta, ...]], type] = OrderedDict()
-_cache_lock = threading.RLock()  # Thread-safe access to cache
+_cache_lock = threading.RLock()
 
 
 __all__ = ("Spec", "CommonMeta")

--- a/lionagi/protocols/_concepts.py
+++ b/lionagi/protocols/_concepts.py
@@ -101,6 +101,3 @@ class Ordering(ABC, Generic[E]):
     @abstractmethod
     def exclude(self, item, /):
         pass
-
-
-# File: lionagi/protocols/_concepts.py

--- a/lionagi/protocols/action/function_calling.py
+++ b/lionagi/protocols/action/function_calling.py
@@ -85,6 +85,3 @@ class FunctionCalling(Event):
         dict_["function"] = self.function
         dict_["arguments"] = self.arguments
         return dict_
-
-
-# File: lionagi/protocols/action/function_calling.py

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -51,11 +51,9 @@ class ActionManager(Manager):
             elif callable(tool):
                 name = tool.__name__
             elif isinstance(tool, dict):
-                # For MCP config, extract the tool name (first key)
                 name = list(tool.keys())[0] if tool else None
             raise ValueError(f"Tool {name} is already registered.")
 
-        # Convert to Tool object based on type
         if callable(tool):
             tool = Tool(func_callable=tool)
         elif isinstance(tool, dict):
@@ -182,16 +180,12 @@ class ActionManager(Manager):
                 self.register_tool(tool, update=update)
                 registered_tools.append(tool_name)
         else:
-            # Auto-discover tools from the server
             from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
-            # Get client and discover tools
             client = await MCPConnectionPool.get_client(server_config, security=security)
             tools = await client.list_tools()
 
-            # Register each discovered tool with qualified name
             for tool in tools:
-                # Store original tool name in config for MCP calls
                 config_with_metadata = dict(server_config)
                 config_with_metadata["_original_tool_name"] = tool.name
 
@@ -334,5 +328,3 @@ async def load_mcp_tools(
 
 
 __all__ = ["ActionManager", "load_mcp_tools"]
-
-# File: lionagi/protocols/action/manager.py

--- a/lionagi/protocols/action/tool.py
+++ b/lionagi/protocols/action/tool.py
@@ -23,7 +23,7 @@ class Tool(Element):
     """Wraps a callable with optional pre/postprocessing; auto-generates tool_schema from the function signature."""
 
     func_callable: Callable[..., Any] = Field(
-        ...,  # ... indicates required field
+        ...,
         description="The callable function to be wrapped by the tool",
         exclude=True,
     )
@@ -152,5 +152,3 @@ FuncToolRef: TypeAlias = FuncTool | str
 
 ToolRef: TypeAlias = FuncToolRef | list[FuncToolRef] | bool
 """One or more tool references, or a bool (True=all, False=none)."""
-
-# File: lionagi/protocols/action/tool.py

--- a/lionagi/protocols/contracts.py
+++ b/lionagi/protocols/contracts.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-# Keep legacy nominal ABC for places that need issubclass checks (e.g., Pile)
-# Do NOT remove – Pile and others rely on issubclass(..., Observable) nominal checks.
+# Do NOT remove: Pile and others rely on issubclass(..., Observable) nominal checks.
 from ._concepts import Observable as LegacyObservable
 
 __all__ = (

--- a/lionagi/protocols/generic/element.py
+++ b/lionagi/protocols/generic/element.py
@@ -76,20 +76,17 @@ class Element(BaseModel, Observable):
         if isinstance(val, dt.datetime):
             return val.timestamp()
         if isinstance(val, str):
-            # Parse datetime string from database
             try:
-                # Handle datetime strings like "2025-08-30 10:54:59.310329"
-                # Convert space to T for ISO format, but handle timezone properly
+                # e.g. "2025-08-30 10:54:59.310329" -> ISO by swapping space for T
                 iso_string = val.replace(" ", "T")
                 parsed_dt = dt.datetime.fromisoformat(iso_string)
 
-                # If parsed as naive datetime (no timezone), treat as UTC to avoid local timezone issues
+                # Naive datetime (no timezone) is treated as UTC.
                 if parsed_dt.tzinfo is None:
                     parsed_dt = parsed_dt.replace(tzinfo=dt.timezone.utc)
 
                 return parsed_dt.timestamp()
             except ValueError:
-                # Try parsing as float string as fallback
                 try:
                     return float(val)
                 except ValueError:
@@ -163,11 +160,9 @@ class Element(BaseModel, Observable):
     @classmethod
     def from_dict(cls, data: dict) -> Element:
         """Deserialize dict into Element or the subclass named by lion_class in metadata."""
-        # Shallow copy to avoid mutating the caller's dict. The nested metadata
-        # dict is also copied because we pop from it (lion_class extraction).
+        # Shallow copy so we don't mutate the caller's dict; metadata is popped from below.
         data = dict(data)
 
-        # Preprocess database format if needed
         metadata = {}
 
         if "node_metadata" in data:
@@ -178,14 +173,12 @@ class Element(BaseModel, Observable):
             subcls: str = metadata.pop("lion_class")
             if subcls != Element.class_name(full=True):
                 try:
-                    # get_class resolves both fully-qualified names (registry
-                    # hit or dotted-path import) and legacy short names (data
-                    # persisted before the full-name convention was adopted).
+                    # get_class resolves both fully-qualified names and legacy
+                    # short names (data persisted before full-name adoption).
                     subcls_type: type[Element] = get_class(subcls)
-                    # Delegate when there is a custom from_dict OR when the
-                    # concrete type differs from cls (so model_validate uses the
-                    # right schema). Restore metadata before the recursive call
-                    # so the delegate sees a self-consistent dict.
+                    # Delegate to the subclass's from_dict when it has a custom
+                    # one, or when the concrete type differs so model_validate
+                    # uses the right schema.
                     if hasattr(subcls_type, "from_dict") and (
                         subcls_type.from_dict.__func__ != cls.from_dict.__func__
                         or subcls_type is not cls
@@ -282,6 +275,3 @@ class ID(Generic[E]):
             return True
         except ValueError:
             return False
-
-
-# File: lionagi/protocols/generic/element.py

--- a/lionagi/protocols/generic/event.py
+++ b/lionagi/protocols/generic/event.py
@@ -217,8 +217,8 @@ class Event(Element):
 
     q: ClassVar[_EventQuery] = _EventQuery()
 
-    # TODO(#1043 Phase 2): migrate to anyio.Event (needs .clear() audit first)
     # Lazily-created asyncio.Event signalled on terminal status transitions.
+    # TODO: migrate to anyio.Event (needs .clear() audit first).
     _completion_event: asyncio.Event | None = PrivateAttr(default=None)
 
     # Terminal statuses that signal completion.
@@ -359,6 +359,3 @@ class Event(Element):
             "created_at": self.created_at,
         }
         return fresh
-
-
-# File: lionagi/protocols/generic/event.py

--- a/lionagi/protocols/generic/flow.py
+++ b/lionagi/protocols/generic/flow.py
@@ -95,7 +95,6 @@ class Flow(Element, Generic[E, P]):
         items = cls._coerce_pile(data.pop("items", None)) or Pile()
         progressions = cls._coerce_pile(data.pop("progressions", None)) or Pile()
 
-        # Validate referential integrity
         item_ids = set(items.keys())
         for prog in progressions:
             missing = set(prog) - item_ids

--- a/lionagi/protocols/generic/log.py
+++ b/lionagi/protocols/generic/log.py
@@ -110,7 +110,6 @@ class DataLogger:
             self.logs = Pile(collections=logs, item_type=Log, strict_type=True)
         self._config = _config
 
-        # Auto-dump on exit
         if self._config.auto_save_on_exit:
             atexit.register(self.save_at_exit)
 
@@ -154,12 +153,11 @@ class DataLogger:
             if do_clear:
                 self.logs.clear()
         except Exception as e:
-            # Check if it's a JSON serialization error with complex objects
+            # JSON serialization errors on complex objects are swallowed, not raised
             if "JSON serializable" in str(e):
                 logger.debug(f"Could not serialize logs to JSON: {e}")
-                # Don't raise for JSON serialization issues during dumps
                 if clear is not False:
-                    self.logs.clear()  # Still clear if requested
+                    self.logs.clear()
             else:
                 logger.error(f"Failed to dump logs: {e}")
                 raise
@@ -227,8 +225,7 @@ class DataLogger:
             try:
                 self.dump(clear=self._config.clear_after_dump)
             except Exception as e:
-                # Only log debug level for JSON serialization errors during exit
-                # These are non-critical and often occur with complex objects
+                # JSON serialization errors during exit are non-critical, log at debug
                 if "JSON serializable" in str(e):
                     logger.debug(f"Could not serialize logs to JSON: {e}")
                 else:

--- a/lionagi/protocols/graph/node_factory.py
+++ b/lionagi/protocols/graph/node_factory.py
@@ -101,7 +101,6 @@ def create_node(
         immutable_content=immutable_content,
     )
 
-    # Build field annotations and defaults
     annotations: dict[str, type] = {}
     namespace: dict[str, Any] = {
         "node_config": config,
@@ -142,6 +141,5 @@ def create_node(
     if doc:
         namespace["__doc__"] = doc
 
-    # Create the subclass
     cls = type(name, (Node,), namespace)
     return cls

--- a/lionagi/protocols/messages/action_request.py
+++ b/lionagi/protocols/messages/action_request.py
@@ -48,7 +48,6 @@ class ActionRequestContent(MessageContent):
         """Construct ActionRequestContent from a dict; handles legacy nested action_request key."""
         function, arguments = _unwrap_action_data(data, "action_request")
 
-        # Handle callable
         if isinstance(function, Callable):
             function = function.__name__
         if hasattr(function, "function"):
@@ -56,7 +55,6 @@ class ActionRequestContent(MessageContent):
         if not isinstance(function, str):
             raise ValueError("Function must be a string or callable")
 
-        # Normalize arguments
         arguments = copy(arguments)
         if not isinstance(arguments, dict):
             try:

--- a/lionagi/protocols/messages/base.py
+++ b/lionagi/protocols/messages/base.py
@@ -62,9 +62,8 @@ def validate_sender_recipient(value: Any, /) -> SenderRecipient:
     if value in ["system", "user", "unset", "assistant", "action"]:
         return MessageRole(value)
 
-    # Accept plain strings (user names, identifiers, etc)
+    # Plain strings (user names, identifiers, etc): try to parse as ID, else keep as-is.
     if isinstance(value, str):
-        # Try to parse as ID first, but allow plain strings as fallback
         try:
             return ID.get_id(value)
         except Exception:

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -86,14 +86,8 @@ class InstructionContent(MessageContent):
         return DataClass.to_dict(self, exclude=frozenset(base_exclude))
 
     def with_updates(self, **kwargs: Any) -> InstructionContent:
-        # to_dict excludes response_format/structure for type/BaseModel refs
-        # (they can't survive a JSON round-trip), so the generic with_updates —
-        # which goes through to_dict → constructor — silently drops the response
-        # schema (and its rendered "ResponseFormat" / action_requests section).
-        # Carry them over for in-memory copies (e.g. _prepare folding the system
-        # message into the instruction's guidance), UNLESS the caller overrides
-        # them explicitly (a None passed for response_format intentionally
-        # clears it — that path strips prior turns' schemas in chat prep).
+        # to_dict can't round-trip type/BaseModel response_format/structure, so carry
+        # them forward here unless the caller explicitly overrides (None clears them).
         if "response_format" not in kwargs and self.response_format is not None:
             kwargs["response_format"] = self.response_format
             if "structure" not in kwargs and self.structure is not None:
@@ -203,7 +197,6 @@ class InstructionContent(MessageContent):
             validate_image_url(idx)
             url = idx
         elif idx.startswith("data:"):
-            # Accept only well-formed inline image data URIs.
             if not _DATA_IMAGE_RE.match(idx):
                 raise ValueError(
                     f"Rejected data: URI — only data:image/*;base64,… is allowed. Got: {idx[:80]!r}"

--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -102,7 +102,6 @@ def prepare_messages_for_chat(
     scratchpad: dict[str, str] | None = None,
 ) -> list[MessageContent] | list[dict[str, Any]]:
     """Prepare a message Pile for the chat API: embed system, fold action outputs into context, merge consecutive assistant turns, append new_instruction."""
-    # Resolve message sequence — apply progression ordering if provided.
     to_use: Pile[Message] = messages if progression is None else messages[progression]
 
     if len(to_use) == 0:

--- a/lionagi/protocols/messages/system.py
+++ b/lionagi/protocols/messages/system.py
@@ -39,7 +39,6 @@ class SystemContent(MessageContent):
         )
         system_datetime = data.get("system_datetime")
 
-        # Handle datetime generation
         if system_datetime is True:
             system_datetime = now_utc().isoformat(timespec="minutes")
         elif system_datetime is False or system_datetime is None:

--- a/lionagi/protocols/messages/validators.py
+++ b/lionagi/protocols/messages/validators.py
@@ -38,9 +38,8 @@ def validate_image_url(url: str) -> None:
     if not parsed.netloc:
         raise ValueError(f"Image URL missing domain: {url}")
 
-    # SSRF guard: reject hosts that resolve to private, loopback, or link-local
-    # ranges (e.g. the cloud metadata endpoint 169.254.169.254). Fail-closed:
-    # unresolvable hosts are also rejected. is_ssrf_safe expects a bare host.
+    # SSRF guard: reject hosts resolving to private/loopback/link-local ranges
+    # (e.g. cloud metadata 169.254.169.254). Fail-closed: unresolvable hosts too.
     if not is_ssrf_safe(parsed.hostname or ""):
         raise ValueError(
             f"Image URL host {parsed.hostname!r} is not allowed: it resolves to a "


### PR DESCRIPTION
## Summary
Comment-only sweep of `lionagi/protocols/` and `lionagi/ln/` under the repo comment policy: keep only ambiguity-reducing inlines, condense long rationale to one or two lines, delete next-line narration, stray file-path footers, and a stale issue-number reference (tracking lives in the issue itself).

- 33 files touched (~65 comments deleted or condensed); load-bearing gotcha comments preserved (signal-handling latch design, pid guard, falsy-Observable note, naive-datetime-as-UTC rationale, security defaults).
- Zero behavior change: AST-equality (modulo docstrings) verified against main for every touched file.

## Testing
- `pytest tests/protocols tests/ln` — 1822 passed.
- ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)