### PR TITLE
chore: condense comments in studio backend

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -95,10 +95,9 @@ def _start_claude_mirror() -> tuple[asyncio.Event, asyncio.Task] | tuple[None, N
     )
 
     def _log_unexpected_exit(t: asyncio.Task) -> None:
-        # The task handle is retained (returned, awaited only at shutdown), so a
-        # task that raises never triggers asyncio's "exception was never
-        # retrieved" warning — its failure is otherwise completely silent and the
-        # studio runs on with no live mirroring. Surface it loudly here instead.
+        # The retained task handle suppresses asyncio's "exception was never
+        # retrieved" warning, so a raised failure is otherwise silent; surface
+        # it loudly here instead.
         if t.cancelled():
             return
         exc = t.exception()
@@ -169,13 +168,11 @@ async def lifespan(app_instance):
 
     _emit_startup_warnings()
     await scheduler.start()
-    # Reconciliation corrects phantom / stale-status session and invocation rows
-    # that stateful /api routes (sessions, runs, stats) read directly, so it must
-    # complete before we serve — keep it pre-yield.
+    # Corrects phantom/stale-status rows that stateful /api routes read
+    # directly, so it must complete before we serve.
     await run_startup_reconciliation()
     mirror_stop, mirror_task = _start_claude_mirror()
-    # The WAL checkpoint is pure maintenance and the main first-run cost; defer it
-    # to a background task so readiness is not gated on it.
+    # WAL checkpoint is pure maintenance; defer so readiness isn't gated on it.
     warmup_task = asyncio.create_task(_startup_warmup(), name="studio-startup-warmup")
     yield
     from .services.launches import shutdown_launches
@@ -303,9 +300,7 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
 
     @application.exception_handler(404)
     async def _spa_fallback(request: Request, exc: Exception) -> FileResponse | JSONResponse:
-        # /api/* paths that reach here (no route matched) stay 404 JSON —
-        # browsers never navigate to /api/* directly, only JavaScript does,
-        # so returning HTML there would surface a confusing error.
+        # /api/* paths that reach here stay 404 JSON, not the SPA HTML shell.
         path = request.url.path
         if path.startswith("/api/") or path == "/api":
             return JSONResponse({"detail": "Not Found"}, status_code=404)
@@ -342,23 +337,17 @@ def create_app() -> FastAPI:
 
     @application.middleware("http")
     async def require_studio_bearer_token(request: Request, call_next):
-        # CORS preflight requests arrive without an Authorization header by
-        # design. Let them pass through so CORSMiddleware can respond with
-        # the correct Allow-* headers; blocking them here would prevent
-        # browsers from ever reaching authenticated endpoints from a
-        # separate frontend origin.
+        # CORS preflight arrives without an Authorization header by design;
+        # let it through so CORSMiddleware can answer with Allow-* headers.
         if request.method == "OPTIONS":
             return await call_next(request)
         token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
         path = request.url.path
         if token and request.headers.get("authorization") != f"Bearer {token}":
-            # All /api/* paths (any method) and the FastAPI schema/docs
-            # endpoints are protected when a token is configured. Non-API
-            # GET/HEAD — the SPA shell, hashed assets, and liveness probes —
-            # stay public: browsers navigate without an Authorization
-            # header, so gating the shell would make the UI unloadable in
-            # authed mode. Every byte behind those paths is the static
-            # frontend bundle; all data lives under /api.
+            # All /api/* paths and the FastAPI schema/docs endpoints are
+            # gated. Non-API GET/HEAD (SPA shell, hashed assets, liveness)
+            # stay public -- browsers navigate without an Authorization
+            # header, so gating the shell would make the UI unloadable.
             is_api = path == "/api" or path.startswith("/api/")
             is_guarded_non_api = path in _GUARDED_NON_API_PATHS
             is_public_static = (
@@ -404,28 +393,21 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, Any]:
         return {"status": "ok"}
 
-    # Mount the SPA if a dist/ exists. Assets mount must happen BEFORE
-    # CORSMiddleware is added so _collect_cors_methods sees the Mount entry.
-    # The 404 exception handler is registered on the app object and takes
-    # effect after all route resolution — CORSMiddleware position doesn't
-    # affect it.
+    # Mount the SPA before CORSMiddleware so _collect_cors_methods sees the
+    # Mount entry (the 404 handler itself is order-independent).
     dist = _resolve_frontend_dist()
     if dist is not None:
         _mount_spa(application, dist)
 
-    # Middleware registration order (Starlette wraps LIFO: the most-recently-added
-    # middleware is the first to see an incoming request). CORSMiddleware is added
-    # after every router, the direct /health endpoint, and the optional SPA mount
-    # so its method allowlist is derived from the complete route table (see
-    # _collect_cors_methods). Host validation is added AFTER CORSMiddleware and so
-    # runs OUTERMOST: every request -- including CORS preflight OPTIONS -- has its
-    # Host header checked before CORS can answer, closing the window where an
-    # invalid-Host request could still receive a successful preflight response.
-    # Execution order for an incoming request is therefore: Host validation ->
-    # CORS (answers valid-Host preflight) -> Content-Type/CSRF check -> bearer-token
-    # gate -> route. The bearer-token and Content-Type middlewares let every
-    # OPTIONS through; a real preflight never reaches them because CORSMiddleware
-    # answers it first.
+    # Starlette wraps middleware LIFO (most-recently-added sees the request
+    # first). CORSMiddleware is added after every router/mount so its method
+    # allowlist reflects the full route table. Host validation is added
+    # after CORS, making it OUTERMOST: every request -- including preflight
+    # OPTIONS -- has its Host checked before CORS can answer, closing the
+    # window where an invalid-Host request could get a valid preflight
+    # response. Request order: Host validation -> CORS -> Content-Type/CSRF
+    # check -> bearer-token gate -> route. A real preflight never reaches the
+    # bearer-token/Content-Type middlewares because CORS answers it first.
     application.add_middleware(
         CORSMiddleware,
         allow_origins=CORS_ORIGINS,

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -72,59 +72,26 @@ class GithubPollResult(NamedTuple):
 
 _client: httpx.AsyncClient | None = None
 
-# Last token known to have actually authenticated against the GitHub API
-# (set after any non-401 response). Checked before _get_gh_token() so a
-# poll that already knows the working credential doesn't re-check
-# GITHUB_TOKEN or shell out to `gh auth token` on every tick -- only a
-# fresh 401 clears it and forces re-resolution.
+# Last token known to have authenticated (set after any non-401 response).
+# Checked before _get_gh_token() so a healthy poll skips GITHUB_TOKEN /
+# `gh auth token`; a fresh 401 clears it to force re-resolution.
 _cached_token: str | None = None
 
-# Merged-PR mode's dispatch key (merged_at) differs from the API's sort key
-# (updated_at): a page full of closed-but-never-merged PRs produces no item
-# at all (see the pr_merged branch in github_poll), so it can push an older,
-# still-undispatched merged PR out of the first page and, without
-# pagination, past the poller's reach permanently -- the cursor would never
-# learn the merge happened. _MERGED_MODE_MAX_PAGES bounds how far
-# github_poll() will page forward hunting for it: worst case
-# _MERGED_MODE_MAX_PAGES * per_page (100) closed PRs inspected in one poll.
-# A merge event buried deeper than that in a single burst is simply not
-# found *this* poll -- the cursor never advances past anything unseen, so
-# it is found on a later poll once the shallower unmerged noise ages out of
-# GitHub's "recently updated" ordering. Bounded latency, not bounded
-# correctness.
-#
-# That "cursor never advances past anything unseen" guarantee only holds
-# when the scan reaches a SAFE boundary (a short page, no next link, or the
-# stored cursor was reached): pages are sorted by updated_at desc, so
-# stopping there proves every unfetched PR has an older updated_at, and
-# merged_at <= updated_at, than everything already scanned. Stopping for an
-# UNSAFE reason instead -- the page cap above, or a pagination fetch/status
-# error -- proves nothing about what lies beyond the last fetched page.
-# github_poll() tracks this as GithubPollResult.scan_complete and drops any
-# item too close to that unproven boundary (see the truncation-safety
-# filter below) rather than risk advancing the cursor past an event an
-# unfetched page might still hold.
+# Bounds how many pages github_poll() will fetch hunting for an older,
+# still-undispatched merged PR (merged_at can trail the API's updated_at
+# sort key -- see GithubPollResult.scan_complete). Worst case
+# _MERGED_MODE_MAX_PAGES * per_page (100) PRs inspected per poll; anything
+# buried deeper is picked up on a later poll once the noise ages out.
+# Bounded latency, not bounded correctness.
 _MERGED_MODE_MAX_PAGES = 5
 
 _LINK_NEXT_RE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
 
-# CWE-918 defense-in-depth: github_repo must be exactly "owner/name" -- one
-# slash, no path traversal sequences, no URL-special chars.
-#
-# Owner and repo segments have DIFFERENT rules (empirically verified against
-# the GitHub API -- e.g. https://api.github.com/repos/github/.github returns
-# 200, so a repo CAN start with '.'):
-#
-#   Owner: alphanumeric start, alphanumeric or '-' interior, alphanumeric end
-#          (GitHub's user/org naming rule), max 39 chars.
-#          Single-char owners (e.g. "a") are valid -- inner group is optional.
-#
-#   Repo:  letters/digits/'-'/'_'/'.' allowed, may start with '.' (e.g.
-#          .github), but must NOT be the traversal singletons '.' or '..'.
-#          Max 100 chars.
-#
-# These are the single sources of truth; services/schedules.py imports and
-# delegates to _validate_github_repo rather than duplicating them.
+# CWE-918 defense-in-depth: github_repo must be exactly "owner/name" (one
+# slash, no traversal/URL-special chars). Owner and repo segments have
+# different rules (verified against the GitHub API -- a repo may start with
+# '.', e.g. github/.github). Single source of truth: services/schedules.py
+# delegates to _validate_github_repo rather than duplicating these.
 _GITHUB_OWNER_MAX = 39
 _GITHUB_REPO_MAX = 100
 
@@ -267,10 +234,9 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     if not repo:
         return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
-    # Defense-in-depth: validate format before interpolating into the API URL.
-    # The service write boundary applies the same check via _svc_validate_github_repo
-    # in services/schedules.py, but we re-check here so that any schedule dict
-    # that reaches this function (regardless of origin) cannot retarget the path.
+    # Defense-in-depth: re-validate here (services/schedules.py checks this too)
+    # so any schedule dict reaching this function, regardless of origin,
+    # cannot retarget the URL.
     try:
         _validate_github_repo(repo)
     except ValueError:
@@ -295,7 +261,6 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    # Use stored ETag for conditional requests
     node_meta = schedule.get("node_metadata") or {}
     etag = node_meta.get("github_etag") if isinstance(node_meta, dict) else None
     if etag:
@@ -325,12 +290,8 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         _log.exception("GitHub API request failed for %s", repo)
         return GithubPollResult(items=[], scan_complete=True, poll_status="error")
 
-    # A 401 means the token we used is bad — most often a cached or
-    # GITHUB_TOKEN-env credential that was valid earlier but has since
-    # expired. Fall through to a freshly-fetched gh-CLI token (skipping the
-    # env var and any cache) and retry once, so a stale credential can't pin
-    # the poller to a dead token and leave it silently blind on every
-    # subsequent poll.
+    # 401 means the cached/env token has expired. Retry once with a freshly
+    # fetched gh-CLI token so a stale credential doesn't pin the poller blind.
     if resp.status_code == 401:
         cli_token = await _get_gh_token(prefer_cli=True)
         if cli_token and cli_token != token:
@@ -359,9 +320,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         )
         return GithubPollResult(items=[], scan_complete=True, poll_status="auth_error")
 
-    # Any non-401 response proves `token` actually authenticated -- cache it
-    # so the next poll can skip both the env-var check and a `gh auth token`
-    # shell-out, until a future 401 invalidates it again.
+    # Any non-401 response proves `token` authenticated; cache until the next 401.
     _cached_token = token
 
     if resp.status_code == 304:
@@ -380,26 +339,14 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     page = resp.json()
     prs = list(page)
 
-    # True once the scan has reached a boundary that PROVES no unfetched
-    # page could hold an event this poll needs to worry about (see the
-    # scan_complete docstring on GithubPollResult). Flipped to False below
-    # only when the loop stops for a reason that does NOT prove that.
+    # True once the scan reached a boundary that proves no unfetched page
+    # could hold an event this poll needs (see GithubPollResult.scan_complete).
     scan_complete = True
 
     if merged_mode:
-        # Page forward while the most recently fetched page was full (a
-        # short page means there's nothing more) AND its oldest PR (last in
-        # updated_at-desc order) is still newer than the cursor -- once an
-        # item's updated_at has fallen to or below the cursor, every PR
-        # further back is too (the API is sorted by updated_at desc), and
-        # merged_at <= updated_at always holds for a merged PR, so nothing
-        # beyond that point could be an undispatched merge either.
-        #
-        # The safe-boundary check runs at the TOP of every pass, including
-        # the pass evaluating the last page the cap allows fetching -- the
-        # cap alone never marks the scan unsafe; a page is only unsafe when
-        # it is full, has a next link, AND the cursor hasn't been reached,
-        # i.e. there is real, unproven data beyond it.
+        # Page forward while the last page was full and its oldest PR (API
+        # sorts updated_at desc) is still newer than the cursor -- past that
+        # point every remaining PR is already-seen ground.
         pages_fetched = 1
         while True:
             is_short_page = len(page) < per_page
@@ -407,15 +354,11 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             cursor_reached = bool(cursor) and oldest_updated <= cursor
             next_url = _next_page_url(resp)
             if is_short_page or cursor_reached or not next_url:
-                # This page itself proves the boundary: nothing beyond it
-                # matters (short/no-next), or everything beyond it is
-                # already-seen ground (cursor reached). Safe regardless of
-                # how many pages the cap allowed fetching.
+                # Boundary proven safe regardless of how many pages were fetched.
                 break
             if pages_fetched >= _MERGED_MODE_MAX_PAGES:
-                # This page is full, links to a next page, and the cursor
-                # hasn't been reached -- real, unproven data likely exists
-                # beyond it, but the cap forbids fetching further.
+                # Full page, more to fetch, cursor not reached: unproven data
+                # may remain beyond the cap.
                 scan_complete = False
                 break
             try:
@@ -432,9 +375,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
                 break
             if resp.status_code != 200:
                 if resp.status_code == 401:
-                    # The token authenticated the first page but has since been
-                    # rejected mid-pagination; drop it so the next poll
-                    # re-resolves instead of reusing a proven-dead credential.
+                    # Rejected mid-pagination; drop the token so the next poll re-resolves.
                     _cached_token = None
                 _log.warning(
                     "GitHub API returned %d for %s during merged-PR pagination; "
@@ -450,15 +391,10 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             prs.extend(page)
             pages_fetched += 1
 
-    # In merged mode, once the scan is truncated (unsafe boundary), any
-    # fetched PR whose cursor field (merged_at) sits at or past the oldest
-    # updated_at we actually fetched cannot be safely dispatched: we can't
-    # prove an unfetched page doesn't hold an older, still-undispatched
-    # merge, and the cursor can't advance past this PR without risking that
-    # merge being skipped forever. Deferring it (dropping it from this
-    # poll's items entirely, not just marking it non-dispatchable) also
-    # avoids a duplicate fire -- since the cursor stays behind it, it is
-    # re-fetched and reconsidered on a later poll instead.
+    # Once the scan is truncated, any PR whose cursor field sits at or past
+    # the oldest fetched updated_at can't be proven safe to dispatch -- drop
+    # it entirely (not just mark non-dispatchable) so it's re-fetched and
+    # reconsidered on a later poll instead of risking a skipped merge.
     unsafe_floor: str | None = None
     if merged_mode and not scan_complete and prs:
         unsafe_floor = min(pr.get("updated_at", "") for pr in prs)
@@ -470,11 +406,8 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         if merged_mode:
             merged_at = pr.get("merged_at")
             if not merged_at:
-                # Closed but never merged -- not a "PR merged" event under
-                # this filter. It never fires and has no merge time to
-                # compare against the cursor, so it's simply not an item;
-                # it naturally drops off the API's top-N-by-updated window
-                # once nothing about it changes further.
+                # Closed but never merged -- not a "PR merged" event; drops
+                # off the API's top-N-by-updated window on its own.
                 continue
             cursor_at = merged_at
         else:
@@ -504,11 +437,8 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             event["pr_merged_at"] = merged_at
         items.append(GithubPollItem(event=event, updated_at=cursor_at, dispatchable=dispatchable))
 
-    # The API returns PRs sorted by updated_at desc, which is the cursor
-    # field itself in the default mode but only a close correlate of it in
-    # merged mode (merging a PR bumps updated_at, but the two aren't
-    # contractually identical) -- sort explicitly by the cursor field so the
-    # caller's incremental cursor advance stays monotone in both modes,
-    # rather than relying on a bare reversal of API order.
+    # API order (updated_at desc) isn't contractually identical to the
+    # cursor field in merged mode; sort explicitly so cursor advance stays
+    # monotone in both modes.
     items.sort(key=lambda it: it.updated_at)
     return GithubPollResult(items=items, scan_complete=scan_complete, poll_status="ok")

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -160,17 +160,13 @@ def _render_template(template: str, context: dict) -> str:
 
     def _replace(m: re.Match) -> str:
         key = m.group(1)
-        # Look in github events first
-        events = context.get("github_events", [])
+        events = context.get("github_events", [])  # check github events first
         if events and isinstance(events, list) and isinstance(events[0], dict):
             val = events[0].get(key)
             if val is not None:
                 return str(val)
-        # A present-but-non-string value (e.g. the numeric metric/value/
-        # threshold fields threshold-alert fires put directly on
-        # trigger_context) must be stringified same as the github_events
-        # branch above -- re.sub's replacement callback requires a str
-        # return, and returning the raw value crashes on anything but str.
+        # Stringify non-string values too (e.g. numeric threshold-alert
+        # fields) -- re.sub's replacement callback requires a str return.
         if key in context:
             return str(context[key])
         return m.group(0)
@@ -218,12 +214,9 @@ def resolve_li_executable() -> tuple[list[str] | None, str | None]:
     if which_path and os.path.isabs(which_path):
         return [which_path], None
     if which_path:
-        # A relative PATH entry (e.g. "." or "relbin") makes shutil.which
-        # return a relative hit. Accepting it as-is would make the child's
-        # argv[0] resolve against whatever cwd the spawn ends up using
-        # (not the daemon environment that found it) — reintroducing
-        # cwd-dependent spawn behavior and a PATH-hijack surface. Reject
-        # and fall through to the next strategy instead.
+        # A relative PATH entry (e.g. "." or "relbin") would resolve the
+        # child's argv[0] against the spawn-time cwd, reintroducing
+        # cwd-dependent spawn / PATH-hijack risk. Reject and fall through.
         tried.append(
             f"shutil.which('li') found a non-absolute path ({which_path}); "
             "rejected to avoid cwd-dependent spawn/PATH-hijack"
@@ -231,10 +224,8 @@ def resolve_li_executable() -> tuple[list[str] | None, str | None]:
     else:
         tried.append("shutil.which('li') found nothing on PATH")
 
-    # Both remaining strategies invoke sys.executable directly as the
-    # interpreter in the returned argv, so both require it to be absolute —
-    # a relative sys.executable would leak a relative prefix through either
-    # one, the same cwd-dependent/PATH-hijack problem as tier 1 above.
+    # Both remaining strategies invoke sys.executable directly, so both
+    # require it to be absolute (same cwd-dependent/PATH-hijack risk as tier 1).
     python_path = Path(sys.executable) if sys.executable else None
     python_is_absolute = python_path is not None and python_path.is_absolute()
 
@@ -284,8 +275,7 @@ def build_argv(
     must be deleted after the subprocess exits (only set for ``flow_yaml``).
     """
     kind = schedule["action_kind"]
-    # Normalize legacy alias and validate against the closed set.
-    kind = _ALIAS_ACTION_KINDS.get(kind, kind)
+    kind = _ALIAS_ACTION_KINDS.get(kind, kind)  # normalize legacy alias
     if kind not in _VALID_ACTION_KINDS:
         raise ValueError(
             f"Unknown action_kind {kind!r}. Valid kinds: {sorted(_VALID_ACTION_KINDS)}"
@@ -297,13 +287,10 @@ def build_argv(
     project = schedule.get("action_project")
     extra = schedule.get("action_extra_args") or []
 
-    # Reject flag-injection vectors before touching argv (mirrors service-layer
-    # boundary in services/schedules.py for defense-in-depth).
-    #
-    # action_prompt is validated AFTER rendering: a stored '{{payload}}' passes
-    # pre-render checks but could render to the forbidden '--' sentinel when the
-    # trigger context supplies {"payload": "--"}.  Other fields are NOT templated,
-    # so validating them before rendering is correct and sufficient.
+    # Reject flag-injection vectors before touching argv (defense-in-depth,
+    # mirrors services/schedules.py). action_prompt is validated AFTER
+    # rendering below since a templated '{{payload}}' can render to the
+    # forbidden '--' sentinel; other fields aren't templated.
     _validate_action_model(model)
     if agent:
         _validate_identifier(agent, "action_agent")
@@ -327,35 +314,24 @@ def build_argv(
     argv = list(executable_prefix) if executable_prefix is not None else list(_DEFAULT_LI_PREFIX)
     tmp_path: str | None = None
 
-    # CWE-88 hardening: named flags first, then '--' end-of-options sentinel,
-    # then positionals (model, prompt).  The sentinel makes action_prompt
-    # injection-proof: '--bypass' is parsed as the prompt value, not a flag.
-    #
-    # flow_yaml omits the prompt positional entirely — the CLI reads prompt from
-    # the -f spec file and overwrites args.prompt, so a positional would only
-    # open a second injection surface.  Shape: li o flow -f <tmp> -- <model>
+    # CWE-88 hardening: named flags first, then the '--' end-of-options
+    # sentinel, then positionals (model, prompt) — makes action_prompt
+    # injection-proof (e.g. '--bypass' parses as prompt text, not a flag).
+    # flow_yaml omits the prompt positional (CLI reads it from -f instead)
+    # to avoid a second injection surface.
 
     if kind == "agent":
-        # Named flags first (--agent must come before --)
         flags: list[str] = []
         if agent:
             flags += ["--agent", agent]
         if project:
             flags += ["--project", project]
-        # Omit the model positional entirely when action_model is unset: `li
-        # agent` treats a single positional as the prompt and falls through to
-        # the --agent profile's own default model. Passing an empty string as
-        # the model positional would instead be parsed as an explicit (blank)
-        # model spec, overriding the profile default and crashing Branch init.
-        #
-        # But omitting the model positional only holds the "extra positionals
-        # are rejected loudly" invariant when there are no extra args to
-        # append: with model omitted, a single action_extra_args token brings
-        # the positional count back up to 2 (the same arity as [model,
-        # prompt]), so the CLI's resolver would silently reparse the real
-        # prompt as MODEL and the extra-args token as PROMPT instead of
-        # failing. Reject that combination here rather than let it corrupt
-        # argument positions at fire time.
+        # Omit the model positional when unset -- `li agent` then falls
+        # through to the profile's default model instead of an explicit
+        # blank spec that would crash Branch init. But with model omitted, a
+        # single extra-args token brings positional arity back to 2 (matching
+        # [model, prompt]), which would silently misroute the real prompt as
+        # MODEL -- reject that combination instead of corrupting positions.
         if not model and isinstance(extra, list) and extra:
             raise ValueError(
                 "action_extra_args is not supported together with an empty "
@@ -389,30 +365,23 @@ def build_argv(
             argv.append(playbook)
 
     elif kind == "flow_yaml":
-        # Extra positionals have nowhere safe to land here: this launch emits
-        # no positionals at all (the spec file carries prompt and model), so
-        # `li o flow` would soak extra tokens into its optional model/prompt
-        # slots and silently override the model merged into the spec below.
-        # Fail at build time so no invocation row is created for a launch
-        # that cannot honor them.
+        # No positionals at all here (spec file carries prompt/model), so
+        # extra tokens would soak into flow's optional model/prompt slots
+        # and silently override the merged model below; fail at build time.
         if isinstance(extra, list) and extra:
             raise ValueError(
                 "flow_yaml launches do not accept action_extra_args; "
                 "set model/prompt inside the flow spec instead"
             )
-        # Write the inline YAML spec to a temp file so `li o flow -f <path>`
-        # can read it.  The caller is responsible for deleting tmp_path after
-        # the subprocess exits.
+        # Write the inline YAML spec to a temp file for `li o flow -f <path>`.
+        # Caller deletes tmp_path after the subprocess exits.
         yaml_text = schedule.get("action_flow_yaml") or ""
         if model:
-            # An explicit action_model is merged into the spec itself, never
-            # passed as a positional: when the file supplies its own model or
-            # agent, `li o flow -f` reclassifies a lone model positional as
-            # prompt text, so a positional cannot reliably override the file.
-            # Merging into the spec wins deterministically and leaves no
-            # positional surface at all. Unparseable or non-mapping specs are
-            # written unchanged — `li o flow` rejects them with its own parse
-            # error, which names the file.
+            # Merge action_model into the spec rather than pass it as a
+            # positional: when the file has its own model/agent, `li o flow
+            # -f` reclassifies a lone model positional as prompt text, so a
+            # positional can't reliably override it. Unparseable/non-mapping
+            # specs are written unchanged -- `li o flow` reports its own error.
             import yaml
 
             try:
@@ -429,19 +398,15 @@ def build_argv(
         except Exception:
             os.unlink(tmp_path)
             raise
-        # Named flags first (-f must come before --), then the -- sentinel.
-        # No positionals at all: the YAML file supplies the prompt, and any
-        # explicit model was merged into the spec above.
+        # No positionals: the YAML file supplies the prompt; model was merged above.
         flags = ["-f", tmp_path]
         if project:
             flags += ["--project", project]
         argv += ["o", "flow", *flags, "--"]
 
     elif kind == "engine":
-        # engine def launch: argv shape is
-        #   uv run li engine run [named flags] -- <engine_kind> <spec>
-        # action_agent carries the engine kind (e.g. "research"); action_prompt
-        # carries the engine spec.  Named flags go first (CWE-88 hardening).
+        # argv shape: uv run li engine run [named flags] -- <engine_kind> <spec>
+        # action_agent = engine kind (e.g. "research"); action_prompt = spec.
         if not agent:
             raise ValueError("engine launches require action_agent (the engine kind)")
         if not prompt:
@@ -506,22 +471,18 @@ async def spawn_and_wait(
         stderr=asyncio.subprocess.PIPE,
         env=env,
         cwd=cwd,
-        # `uv run li` forks the real worker (and that worker may fork
-        # further). Put the whole tree in its own session/process group so a
-        # cancel can signal the GROUP, not just the direct child — otherwise
-        # grandchildren survive scheduler shutdown as orphans.
+        # `uv run li` may fork further; own session/process group lets a
+        # cancel signal the whole GROUP, not just the direct child --
+        # otherwise grandchildren survive scheduler shutdown as orphans.
         start_new_session=True,
     )
-    # Pgid == proc.pid (start_new_session=True). The pid-guard and platform
-    # check live in aterminate_process_group.
+    # Pgid == proc.pid; pid-guard and platform check live in aterminate_process_group.
 
     try:
         _, stderr = await proc.communicate()
     except asyncio.CancelledError:
-        # Cancellation (e.g. scheduler shutdown) must not leave the spawned
-        # `uv run li` tree detached. SIGTERM the whole group, give it a moment
-        # to exit, then SIGKILL the group, before re-raising so the caller can
-        # record the cancel.
+        # SIGTERM then SIGKILL the whole group before re-raising, so a
+        # cancelled poll doesn't leave the spawned tree detached.
         _log.warning("spawn_and_wait cancelled; terminating child for %s", invocation_id)
         await aterminate_process_group(proc, grace=5.0)
         raise

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -77,24 +77,14 @@ _DEFAULT_EXECUTION_TARGETS: tuple[str, ...] = ("host",)
 MAX_LEASE_ATTEMPTS = 3
 
 # CLAIM CANDIDATES (D4): non-workflow, ad-hoc (schedule_id IS NULL) queued
-# rows, oldest first with a stable (queued_at, id) tie-break for determinism.
-# Capability/execution-target matching against the calling worker's advertised
-# set happens in Python (claim_and_execute) -- SQL only narrows to rows any
-# worker could conceivably serve. Scheduler-fired rows (schedule_id NOT NULL)
-# are never touched -- that path is governed by SchedulerEngine._fire, not
-# this worker.
+# rows, oldest first, (queued_at, id) tie-break for determinism. SQL only
+# narrows to rows any worker could conceivably serve; capability/target
+# matching happens in Python (see claim_and_execute docstring for the full
+# keyset-paging rationale). Scheduler-fired rows (schedule_id NOT NULL) are
+# never touched here -- governed by SchedulerEngine._fire instead.
 #
-# Paged via a (queued_at, id) keyset cursor rather than a single fixed
-# LIMIT: a persistent prefix of ineligible older rows must never hide a
-# later eligible row forever, so claim_and_execute keeps requesting pages
-# past whatever (queued_at, id) it has already scanned until it has
-# collected enough eligible candidates or the queue is exhausted.
-#
-# The first page carries no cursor parameters at all (separate statement):
-# a nullable ":cursor IS NULL OR ..." bind cannot be typed by asyncpg on
-# Postgres ("could not determine data type of parameter $1"), so the
-# cursor-less first page is its own query rather than a NULL-signalled
-# branch of one query.
+# First page has no cursor params (separate statement): a nullable
+# ":cursor IS NULL OR ..." bind can't be typed by asyncpg on Postgres.
 _CLAIM_FIRST_PAGE_SQL = """
     SELECT id, action_kind, action_args, lease_attempts, required_capabilities,
            execution_target, concurrency_key, queued_at
@@ -124,11 +114,9 @@ _CLAIM_NEXT_PAGE_SQL = """
 # Rows scanned per page while paging for eligible candidates.
 _CLAIM_PAGE_SIZE = 50
 
-# Fairness/latency bound, NOT a correctness cap: how many queued rows one
-# claim_and_execute pass will scan (across pages) before giving up for this
-# tick. A queue this deep in ineligible rows still gets scanned to
-# completion over a bounded number of ticks -- nothing here is permanently
-# hidden, unlike a fixed single-window prefetch.
+# Fairness/latency bound, not a correctness cap: rows scanned across pages
+# per claim_and_execute pass before giving up for this tick. A deep queue
+# of ineligible rows is still scanned to completion over bounded ticks.
 _MAX_CLAIM_SCAN_ROWS = 5000
 
 # D4: same-concurrency_key rows currently 'running' block admission of a new
@@ -421,9 +409,8 @@ async def claim_and_execute(
     # Stable sort: preserves the SQL's queued_at ASC order among equal
     # affinity scores, only reordering across different scores.
     candidates.sort(key=lambda item: -capabilities.affinity_score(item[1], advertised))
-    # `limit` caps claim ATTEMPTS this pass (matching D3's original meaning),
-    # applied after filtering/reordering so it never truncates before
-    # affinity gets a chance to reorder.
+    # `limit` caps claim attempts, applied after affinity reordering so it
+    # never truncates before affinity gets a chance to reorder.
     candidates = candidates[:limit]
 
     claimed = 0
@@ -459,11 +446,9 @@ async def claim_and_execute(
             # Advisory: nothing else in this same pass may claim a row
             # sharing this key, even after this row finishes executing.
             running_keys.add(concurrency_key)
-        # The claim's lease identity travels to the terminal write: if this
-        # worker's lease lapses mid-execution and the reaper hands the row to
-        # another claimant, the stale worker's completed/failed guard
-        # mismatches and its write is dropped instead of clobbering the live
-        # lease.
+        # Lease identity travels to the terminal write: if it lapses mid-run
+        # and the reaper reassigns the row, this write's guard mismatches
+        # and is dropped instead of clobbering the live lease.
         lease_guard = {"leased_by": worker_id, "lease_expires_at": now + lease_ttl}
         await _execute_claimed(db, run_id, row, execute, lease_guard)
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -518,24 +518,19 @@ async def transition_sessions(
                     )
 
             # CAS: swap running→target only if the snapshot still holds, then
-            # record the transition atomically. transaction() opens BEGIN
-            # IMMEDIATE; a clean exit commits, any exception rolls back.
+            # record the transition atomically (transaction() = BEGIN
+            # IMMEDIATE; commit on clean exit, rollback on exception).
             #
-            # This is an intentional, specialized snapshot-CAS write, not a
-            # bypass of the shared update_status() chokepoint: it can only
-            # ever move a session running→target (a legal forward transition;
-            # running is never terminal), so it can never overwrite a terminal
-            # status and never crosses the integrity floor. `WHERE
-            # status='running'` in the UPDATE below is the LOAD-BEARING guard
-            # for that — do not widen or drop that predicate. The additional
-            # last_message_at/updated_at snapshot equality guards are also
-            # load-bearing: they stop this reconcile from clobbering a session
-            # that became active again between health-classification and this
-            # write (the oscillation fix). Routing this through update_status()
-            # would regress that protection, since update_status()'s
-            # expected_statuses guard only compares on status, not on these
-            # snapshot columns. The transition is recorded into
-            # status_transitions below, same as update_status() would do.
+            # Intentional specialized CAS, not a bypass of the shared
+            # update_status() chokepoint: `WHERE status='running'` can only
+            # ever move running->target (a legal forward transition, never
+            # overwriting a terminal status) -- do not widen or drop that
+            # predicate. The last_message_at/updated_at equality guards are
+            # equally load-bearing: they stop this reconcile from clobbering
+            # a session that went active again between classification and
+            # write (the oscillation fix) -- update_status()'s
+            # expected_statuses guard doesn't compare on these columns, so
+            # routing through it would regress that protection.
             async with db.transaction() as conn:
                 result = await conn.execute(
                     text(
@@ -788,11 +783,9 @@ async def run_maintenance_route(body: MaintenanceBody) -> dict[str, Any]:
         return {"action": "prune", **result}
 
     except (sqlite3.OperationalError, _SAOperationalError) as exc:
-        # Only genuine lock/busy contention is retry-able. Open/path failures
-        # ("unable to open database file") are configuration problems and must
-        # not tell the operator to retry shortly — let them surface as 500.
-        # SQLAlchemy wraps the driver error; inspect .orig too in case the
-        # wrapper message omits the underlying "database is locked" text.
+        # Only genuine lock/busy contention is retryable; open/path failures
+        # are config problems that should surface as 500. Inspect .orig too
+        # since SQLAlchemy's wrapper message can omit the driver's own text.
         msg = str(exc).lower()
         orig = getattr(exc, "orig", None)
         if orig is not None:

--- a/lionagi/studio/services/projects.py
+++ b/lionagi/studio/services/projects.py
@@ -224,7 +224,6 @@ async def assign_sessions_to_project(
         await db.commit()
         count = cur.rowcount
 
-        # Ensure the project row exists
         now = time.time()
         await db.execute(
             """INSERT INTO projects (name, source, created_at, updated_at, last_seen_at)

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -760,12 +760,8 @@ async def get_run_route(
     return run
 
 
-# ADR-0008: removed /api/runs/{id}/events SSE route — it read
-# stream/*.buffer.jsonl files forbidden by ADR-0004.  Live monitoring uses
-# /api/sessions/{id}/stream instead.
-#
-# ADR-0008 Write Policy: removed POST /{run_id}/rerun and
-# DELETE /{run_id} stub routes.  Run data is explicitly read-only per
-# ADR-0008.  Re-running requires switching to the terminal (`li play ...`).
-# If re-run support is ever reconsidered, it requires an ADR-0008 amendment
-# before the route is added back.
+# ADR-0008: /api/runs/{id}/events SSE (read stream/*.buffer.jsonl, forbidden
+# by ADR-0004) and the rerun/delete stub routes were removed — run data is
+# read-only per ADR-0008. Live monitoring: /api/sessions/{id}/stream;
+# re-running: the terminal (`li play ...`). Restoring either requires an
+# ADR-0008 amendment.

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -811,10 +811,9 @@ async def get_session_route(
     response_class=None,
 )
 async def stream_session_route(session_id: str):
-    # ADR-0006: pre-flight 404 guard before opening the stream.
-    # Without this, a non-existent session silently returns no messages and
-    # then waits 60s before emitting done — client hangs with no indication.
-    # The shows router already does this at shows.py:34-35; we mirror that pattern.
+    # ADR-0006: pre-flight 404 guard. Without it a non-existent session
+    # silently returns no messages and waits 60s before "done" — the client
+    # hangs with no indication. Mirrors the shows router's pattern.
     if not await session_exists(session_id):
         raise NotFoundError(f"Session '{session_id}' not found")
 
@@ -861,8 +860,7 @@ async def stream_session_route(session_id: str):
     response_class=None,
 )
 async def stream_signals(session_id: str) -> Any:
-    # Pre-flight 404 guard before opening the stream — mirrors the pattern
-    # at sessions.py:35-36 (ADR-0006).
+    # Pre-flight 404 guard before opening the stream (ADR-0006).
     if not await session_exists(session_id):
         raise NotFoundError(f"Session '{session_id}' not found")
 

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -279,12 +279,9 @@ class StudioExprCondition(EdgeCondition):
     _tree: Any = PrivateAttr(default=None)
 
     def __init__(self, **data: Any) -> None:
-        # Parse BEFORE pydantic's own validation machinery runs: a plain
-        # model_validator would still raise UnsafeExpressionError, but pydantic
-        # wraps every validator exception into pydantic_core.ValidationError,
-        # which callers matching `except UnsafeExpressionError` (this class's
-        # documented contract, and compile_workflow_def's edge-id mapping)
-        # would silently fail to catch.
+        # Parse BEFORE pydantic's validation machinery runs: a model_validator
+        # would have its UnsafeExpressionError wrapped into pydantic_core.
+        # ValidationError, breaking callers that match on UnsafeExpressionError.
         tree = _parse_expr(data.get("expr", ""))
         super().__init__(**data)
         self._tree = tree
@@ -345,18 +342,16 @@ async def compile_workflow_def(
         kind = n["kind"]
         node_id = n["id"]
         if kind == "input":
-            # Compile-time marker only — not an Operation. Its data reaches every
-            # op uniformly via session.flow(context=...), so no graph edge is needed.
+            # Compile-time marker only, not an Operation -- data reaches every
+            # op via session.flow(context=...), so no graph edge is needed.
             continue
 
         config = n.get("config")
         if config is None:
             config = {}
         elif not isinstance(config, dict):
-            # A saved spec can carry a non-mapping config (e.g. config: "bad")
-            # that _validate_spec does not shape-check for every kind. Reject it
-            # here so the run route returns a structured 422 rather than letting
-            # config.get(...) raise AttributeError as an unstructured 500.
+            # _validate_spec doesn't shape-check config for every kind; reject
+            # here for a structured 422 instead of an AttributeError 500.
             raise WorkflowCompileError(
                 f"node config must be a mapping, got {type(config).__name__}",
                 node_id=node_id,
@@ -375,21 +370,17 @@ async def compile_workflow_def(
                         "Use provider/model, e.g. openai/gpt-4.1-mini.",
                         node_id=node_id,
                     )
-                # Built here at compile time rather than passed through as a bare
-                # string: chat_and_record forwards its kwargs straight into
-                # Branch.chat(), whose model-override parameter is `imodel` (an
-                # iModel instance), not a string.
+                # Built here, not passed as a bare string: chat_and_record
+                # forwards kwargs into Branch.chat(), whose model-override
+                # parameter is `imodel` (an iModel instance), not a string.
                 from lionagi.service.imodel import iModel
 
                 chat_kwargs["imodel"] = iModel(model=model)
-            # "chat_and_record", not the native "chat" operation: Branch.chat()
-            # does not add messages to the branch (by design — see its
-            # docstring), so a plain "chat" node would run through the
-            # persistence hook wired up in workflow_run.py without ever
-            # producing a message for it to persist. chat_and_record() records
-            # the turn through the same hooked a_add_message path communicate()
-            # uses, and returns the assistant response text for downstream
-            # routing/context.
+            # "chat_and_record", not the native "chat" op: Branch.chat() does
+            # not add messages to the branch by design, so a plain "chat" node
+            # would leave nothing for workflow_run.py's persistence hook to
+            # record. chat_and_record() records via the same hooked
+            # a_add_message path communicate() uses.
             op_id = builder.add_operation(
                 "chat_and_record", node_id=node_id, instruction=prompt, **chat_kwargs
             )
@@ -404,13 +395,11 @@ async def compile_workflow_def(
                 raise WorkflowCompileError(
                     f"unknown engine_def_id {engine_def_id!r}", node_id=node_id
                 )
-            # A node's config overrides (options, max_depth, max_agents) are
-            # author-supplied and never went through the checks engine_defs
-            # enforces at def creation (allowed option keys, string-only, no
-            # leading-dash CLI-flag injection, no shell metacharacters, kind
-            # requirements, budgets in [1, 100]). Re-validate the effective
-            # values so a saved workflow can't smuggle a shell-control test_cmd
-            # into a coding engine or set an unbounded agent/depth budget.
+            # Node-level config overrides never went through engine_defs'
+            # creation-time checks (allowed keys, no CLI-flag/shell-metachar
+            # injection, budgets in [1, 100]); re-validate the effective
+            # values so a saved workflow can't smuggle a hostile test_cmd or
+            # an unbounded agent/depth budget.
             from .engine_defs import (
                 _validate_budget,
                 _validate_kind_options,
@@ -419,8 +408,8 @@ async def compile_workflow_def(
 
             node_options = config.get("options")
             if node_options is not None and not isinstance(node_options, dict):
-                # A non-mapping options value would raise TypeError on the **
-                # unpack below, escaping the ValueError wrapper as a 500.
+                # Non-mapping would raise TypeError on the ** unpack below,
+                # escaping the ValueError wrapper as a 500.
                 raise WorkflowCompileError(
                     "engine node config.options must be a mapping, got "
                     f"{type(node_options).__name__}",
@@ -428,8 +417,8 @@ async def compile_workflow_def(
                 )
             engine_options = {**(defn.get("options") or {}), **(node_options or {})}
 
-            # A node override of None must fall back to the def's value rather
-            # than discard the (stricter) stored budget.
+            # None override falls back to the def's value rather than
+            # discarding the (stricter) stored budget.
             node_depth = config.get("max_depth")
             engine_max_depth = defn.get("max_depth") if node_depth is None else node_depth
             node_agents = config.get("max_agents")
@@ -443,14 +432,10 @@ async def compile_workflow_def(
             except ValueError as exc:
                 raise WorkflowCompileError(str(exc), node_id=node_id) from exc
 
-            # Per-node working directory. Containment is enforced
-            # here (raw-string traversal check + symlink-resolving
-            # relative_to(base_dir) + must-exist-and-be-a-dir); v1.1 only
-            # wires the resolved cwd through to a 'coding' engine node's
-            # run(workspace=...) — the only engine run() signature that
-            # accepts a working directory today (research/review/planning
-            # take no such kwarg and would crash at run time, not compile,
-            # if one were smuggled in).
+            # Per-node working directory, contained via _resolve_node_cwd.
+            # v1.1 only wires it to a 'coding' node's run(workspace=...) --
+            # other engine kinds have no such kwarg and would crash at run
+            # time (not compile) if one were smuggled in.
             engine_workspace: str | None = None
             node_cwd = config.get("cwd")
             if node_cwd is not None:
@@ -477,8 +462,7 @@ async def compile_workflow_def(
         else:  # pragma: no cover — unreachable, prefiltered above
             raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=node_id)
 
-        # Edges are wired by hand below from WorkflowEdge, not the builder's
-        # own depends_on/sequential auto-chaining — sever it after every node.
+        # Edges are wired by hand below; sever the builder's own auto-chaining.
         builder._current_heads = []
         id_map[node_id] = op_id
 
@@ -494,12 +478,9 @@ async def compile_workflow_def(
             )
         src_op = id_map.get(src_wf)
         if src_op is None:
-            # Source is an 'input' node — no Operation-level edge is created.
-            # A condition on such an edge cannot gate anything (the edge is
-            # dropped), so the target would run unconditionally — silently
-            # ignoring the guard. Reject it rather than compile a misleading
-            # unconditional run; gating on input must go through an
-            # intermediate executable node that carries the condition.
+            # Source is an 'input' node -- no Operation-level edge is created,
+            # so a condition here would be silently dropped and the target
+            # would run unconditionally. Reject; gate via an intermediate node.
             if e.get("condition"):
                 raise WorkflowCompileError(
                     "a condition on an edge from an 'input' node is not "


### PR DESCRIPTION
## Summary
Comment-only sweep of `lionagi/studio/` (Python backend) under the repo comment policy: keep only ambiguity-reducing inlines, condense long rationale to two-to-four line summaries that preserve the invariant and the why, delete narration and self-referential file:line pointers.

- 9 files touched (176 insertions, 351 deletions), concentrated in the scheduler's pagination/cursor-safety and subprocess injection-defense blocks.
- Files owned by in-flight PRs were excluded.
- Zero behavior change: AST-equality (modulo docstrings) verified against main for every touched file.

## Testing
- `pytest tests/apps_studio_server` — 893 passed.
- ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)