### PR TITLE
chore: condense comments in cli, tools, and engines

### DIFF
--- a/lionagi/_errors.py
+++ b/lionagi/_errors.py
@@ -119,7 +119,7 @@ class ResourceError(LionError):
 
 
 class RateLimitError(LionError):
-    __slots__ = ("retry_after",)  # one extra attr
+    __slots__ = ("retry_after",)
     default_message = "Rate limit exceeded"
     default_status_code = 429
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -253,14 +253,12 @@ async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | 
         ("play", "plays"),
     ]
     for entity_type, table in searches:
-        # Exact match
         row = await db.fetch_one(
             f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
             (entity_id,),
         )
         if row:
             return entity_type, row
-        # Prefix match (user might type short prefix)
         row = await db.fetch_one(
             f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
             (entity_id + "%",),
@@ -563,14 +561,12 @@ async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
                 else:
                     lines.append(f"    {ev}")
 
-    # Branches (agent legs) — count plus per-leg status/elapsed
     branch_rows = await _fetch_branches(db, sess["id"])
     lines.append(f"  branches:  {len(branch_rows)}")
     if branch_rows:
         lines.append("")
         lines.extend(_render_branch_lines(branch_rows))
 
-    # Stream tail from run dir
     run_dir = RUNS_ROOT / sess["id"]
     if run_dir.exists():
         branches_dir = run_dir / "branches"
@@ -604,7 +600,6 @@ async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
             f"  started:       {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(started))}"
         )
 
-    # List child sessions
     child_rows = await db.fetch_all(
         "SELECT id, status, model, started_at FROM sessions WHERE invocation_id = ? ORDER BY created_at",
         (inv["id"],),
@@ -630,7 +625,6 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
     lines.append(f"  branch:  {show.get('base_branch') or '-'}")
     lines.append(f"  goal:    {(show.get('goal') or '-')[:80]}")
 
-    # Plays breakdown
     plays = await _query_plays_for_show(db, show["id"])
     if plays:
         lines.append("")
@@ -666,7 +660,6 @@ async def _detail_play(db: Any, play: dict[str, Any]) -> str:
     if started:
         lines.append(f"  started:  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(started))}")
 
-    # Gate result
     gp = play.get("gate_passed")
     if gp is not None:
         gate_str = _green("PASS") if gp else _red("FAIL")
@@ -675,7 +668,6 @@ async def _detail_play(db: Any, play: dict[str, Any]) -> str:
         if feedback:
             lines.append(f"  feedback: {_trunc(str(feedback), 80)}")
 
-    # Linked session details
     session_id = play.get("session_id")
     if session_id:
         srow = await db.fetch_one(
@@ -691,13 +683,11 @@ async def _detail_play(db: Any, play: dict[str, Any]) -> str:
             lines.append(f"    provider: {srow['provider'] or '-'}")
             lines.append(f"    effort:   {srow['effort'] or '-'}")
 
-            # Branches (agent legs) — poll-visible sub-step progress
             branch_rows = await _fetch_branches(db, session_id)
             if branch_rows:
                 lines.append("")
                 lines.extend(_render_branch_lines(branch_rows, indent="    "))
 
-            # Stream tail
             run_dir = RUNS_ROOT / session_id
             if run_dir.exists():
                 branches_dir = run_dir / "branches"

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -358,8 +358,8 @@ class CodingRun(ChainRun):
         self.diff: str = ""
         self.export_dir: Path | None = None
         self._test_runs: int = 0
-        # Pre-implement workspace snapshot: maps path → porcelain XY status.
-        # None means the snapshot could not be taken (non-git or spawn failure).
+        # Pre-implement workspace snapshot: path → porcelain XY status; None
+        # means the snapshot could not be taken (non-git or spawn failure).
         self._ws_baseline: dict[str, str] | None = {}
         # Paths newly changed/added since the baseline (populated by _run).
         self._ws_delta: list[str] = []
@@ -560,7 +560,7 @@ class CodingEngine(Engine):
             run.export_dir.mkdir(parents=True, exist_ok=True)
 
         # Collector first: stamps eids before anything reads them. The pipeline
-        # is sequential (no reactive spawning), so observers only stamp + store.
+        # is sequential (no reactive spawning), so the observer only stamps + stores.
         run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
 
         lint_warnings = _lint_spec(task_text, workspace=run.workspace, strict=self.strict_spec)
@@ -570,8 +570,8 @@ class CodingEngine(Engine):
             run._spec_lint_warnings = lint_warnings
 
         plan = await self._plan(run)
-        # Snapshot workspace state before the implementer runs so the post-
-        # implement check computes a delta, not an absolute status read.
+        # Snapshot before the implementer runs so the post-implement check
+        # computes a delta, not an absolute status read.
         run._ws_baseline = await self._capture_ws_baseline(run)
         change = await self._implement(run, plan)
         if run._aborted:
@@ -599,8 +599,8 @@ class CodingEngine(Engine):
                     run, plan, passed=False, caveat="implementer emitted no change"
                 )
             else:
-                # Work detected in workspace despite emission failure.  Synthesize
-                # a minimal ChangeProposed and proceed; emission failure is a warning.
+                # Work detected despite emission failure — synthesize a minimal
+                # ChangeProposed and proceed; treat the emission gap as a warning.
                 run.notify("metadata_missing", work_detected=True, files=delta)
                 change = run.collect(
                     ChangeProposed(
@@ -637,8 +637,7 @@ class CodingEngine(Engine):
             )
         plan = run.last(WorkPlanned)
         if plan is None:
-            # Degrade rather than crash: a planless run still implements against
-            # the raw task, so the stage's emission is best-effort.
+            # Degrade rather than crash: implement against the raw task.
             plan = run.collect(WorkPlanned(approach=run.task_text))
             run.notify("plan_missing", eid=plan.eid)
         return plan
@@ -791,8 +790,7 @@ class CodingEngine(Engine):
         round_no = 0
         while not tests.passed and round_no < self.max_fix_rounds and agent is not None:
             round_no += 1
-            # Classify: mechanical if auto-repair commands are configured and the
-            # previous failure looks like a pure fmt/lint failure.
+            # Mechanical iff auto-repair is configured and the failure looks pure fmt/lint.
             is_mechanical = bool(self.auto_repair_cmds) and _looks_mechanical(tests)
             if is_mechanical:
                 run.notify("fix_mechanical", round=round_no)
@@ -805,8 +803,7 @@ class CodingEngine(Engine):
                     break
             before = len(run.events_of(ChangeProposed))
             if is_mechanical:
-                # Mechanical rounds skip re-prompting the worker: auto_repair_cmds
-                # already corrected the workspace.  Re-test directly.
+                # auto_repair_cmds already corrected the workspace — re-test directly.
                 pass
             else:
                 async with run._sem:
@@ -825,8 +822,8 @@ class CodingEngine(Engine):
                     run.notify("fix_no_change", round=round_no)
                     break
                 change = new_change
-            # Incremental gate: fast_test_cmd for intermediate substantive rounds;
-            # always run the full test_cmd as the final ground-truth leg.
+            # fast_test_cmd gates intermediate substantive rounds; the full
+            # test_cmd always runs as the final ground-truth leg.
             if (
                 not is_mechanical
                 and self.fast_test_cmd is not None
@@ -834,8 +831,7 @@ class CodingEngine(Engine):
             ):
                 fast = await self._fast_test(run, change, round_no=round_no)
                 if fast is not None and not fast.passed:
-                    # Fast gate failed — update tests for the fix instruction but
-                    # do not count this as the authoritative result yet.
+                    # Not yet the authoritative result — only feeds the fix instruction.
                     tests = fast
                     continue
             tests = await self._test(run, change, round_no=round_no)
@@ -849,8 +845,7 @@ class CodingEngine(Engine):
         run.diff = await self._capture_diff(run)
         emits = (VerifyResult,)
         async with run._sem:
-            # exempt: the verdict must report even when the expansion budget
-            # (fix-round agents) is spent — degrade, don't lose the verdict.
+            # exempt: the verdict must report even if the fix-round budget is spent.
             agent = await run.make_agent(
                 self.verify_role,
                 name="verify",
@@ -898,8 +893,7 @@ class CodingEngine(Engine):
         }
         if run._spec_lint_warnings:
             measurements["spec_lint_warnings"] = run._spec_lint_warnings
-        # Record active tool grants so dataset consumers can correlate grant
-        # configuration with outcome — worker grants only, judge context excluded.
+        # Worker grants only (judge context excluded) so outcome correlates with them.
         if self.worker_extra_tools or self.worker_mcp_servers:
             measurements["worker_grants"] = {
                 "extra_tools": list(self.worker_extra_tools),
@@ -1058,16 +1052,13 @@ class CodingEngine(Engine):
         result = await run_sync(_subprocess_sync, ["git", "diff"], False, 30.0, run.workspace)
         tracked = result.get("stdout", "") if int(result.get("returncode", -1)) == 0 else ""
 
-        # Candidate set: union of all files any ChangeProposed claimed to touch
-        # plus the initial workspace delta (covers emission-failure rewrites).
-        # This is evaluated at verify time so fix-round additions are included.
-        #
-        # Normalize to workspace-relative POSIX before intersecting: the coding
-        # tool schema asks for absolute file_path values, so files_touched often
-        # carries absolute paths while git ls-files --others returns repo-relative
-        # ones.  Absolute paths under workspace are stripped to relative; relative
-        # paths are normalized (resolve ./.. components); absolute paths that
-        # escape the workspace are dropped — they cannot be untracked files here.
+        # Candidate set: union of the initial workspace delta (covers emission-
+        # failure rewrites) and every file any ChangeProposed claimed to touch,
+        # evaluated at verify time so fix-round additions are included.
+        # Normalized to workspace-relative POSIX before intersecting: files_touched
+        # often carries absolute paths (the coding tool schema asks for them) while
+        # git ls-files --others returns repo-relative ones; paths that escape the
+        # workspace are dropped since they can't be untracked files here.
         raw_candidates: set[str] = set(run._ws_delta)
         final_change = run.last(ChangeProposed)
         if final_change is not None:
@@ -1085,8 +1076,7 @@ class CodingEngine(Engine):
             except ValueError:
                 pass  # absolute path outside workspace — drop
 
-        # Intersect with currently-untracked files to avoid double-counting
-        # paths that were later staged or committed during the run.
+        # Intersect with currently-untracked files: skip paths later staged/committed.
         untracked_result = await run_sync(
             _subprocess_sync,
             ["git", "ls-files", "--others", "--exclude-standard"],
@@ -1109,8 +1099,7 @@ class CodingEngine(Engine):
                 30.0,
                 run.workspace,
             )
-            # --no-index exits 1 when files differ (always true here); that is
-            # the normal success case, not an error.
+            # --no-index exits 1 when files differ (always true here) — normal, not an error.
             content = r.get("stdout", "")
             if content:
                 parts.append(content)
@@ -1161,7 +1150,6 @@ def _parse_porcelain(output: str) -> dict[str, str]:
             continue
         xy = line[:2]
         rest = line[3:]
-        # Rename lines: "old -> new" — track the destination path.
         path = rest.split(" -> ", 1)[-1].strip()
         if path:
             mapping[path] = xy

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -196,17 +196,14 @@ class EngineRun:
         self._t0 = monotonic()
         self._deadline = None if engine.deadline_s is None else self._t0 + engine.deadline_s
         self._budget_notified = False
-        # Holds the asyncio.Task wrapping the engine's _run() coroutine.
-        # Set by Engine.run() before awaiting; the deadline watchdog cancels it
-        # so in-flight sequential work (operate_with_repair, branch.operate) is
-        # interrupted promptly rather than continuing past the deadline.
+        # Wraps the engine's _run() coroutine; the deadline watchdog cancels this
+        # to interrupt in-flight sequential work promptly, not just spawned tasks.
         self._run_task: asyncio.Task | None = None
-        # Collects emission-missing diagnostics so the CLI can write them to
-        # the engine_runs.error column even when the overall status is "completed".
-        # Each entry is a string like "<agent> x<attempts>".
+        # Emission-missing diagnostics for the CLI's engine_runs.error column,
+        # e.g. "<agent> x<attempts>", even when overall status is "completed".
         self._emission_failures: list[str] = []
-        # Collects terminal sub-agent failures (e.g. missing API key) so a run
-        # where every agent errored can be surfaced as failed instead of green.
+        # Terminal sub-agent failures (e.g. missing API key), so a run where
+        # every agent errored can be surfaced as failed instead of green.
         self._agent_errors: list[str] = []
 
     @property
@@ -278,8 +275,8 @@ class EngineRun:
         mcp_servers: list[str] | None = None,
         extra_prompt: str | None = None,
     ) -> Branch:
-        # ``exempt`` is for terminal stages (synthesis/verdict) that must run
-        # even when the expansion budget is gone — degrade, don't lose the run.
+        # exempt = terminal stages (synthesis/verdict) that must run even when
+        # the expansion budget is gone — degrade, don't lose the run.
         if not exempt and not self.budget_left():
             self._notify_budget_once("make_agent")
             raise EngineBudgetError(
@@ -324,7 +321,7 @@ class EngineRun:
         """Operate then re-prompt up to *retries* times while *arrived*() is false; CLI workers get a full fenced-JSON example, API workers get key hints."""
         res = await branch.operate(instruction=instruction)
         attempt = 0
-        # Determine repair template once: CLI workers need the full example form.
+        # CLI workers emit prose, not fenced JSON — they need the full example form.
         is_cli = bool(getattr(getattr(branch, "chat_model", None), "is_cli", False))
         hint = emission_keys(emits)
         while not arrived() and attempt < retries:
@@ -416,9 +413,8 @@ class EngineRun:
         if delay > 0:
             await asyncio.sleep(delay)
         self._notify_budget_once("deadline_watchdog")
-        # Cancel _run_task first so the in-flight sequential stage
-        # (branch.operate / operate_with_repair) is interrupted promptly.
-        # Spawned tasks (_active) are drained in Engine.run()'s finally block.
+        # Cancel _run_task to interrupt the in-flight sequential stage promptly;
+        # spawned tasks (_active) are drained separately in Engine.run()'s finally block.
         if self._run_task is not None and not self._run_task.done():
             self._run_task.cancel()
 
@@ -667,14 +663,12 @@ class Engine:
         timed out (logged, not raised) — CancelledError from an external cancel
         during the shielded phase still propagates.
         """
-        # Cancel any background tasks spawned via run.spawn() so synthesis
-        # sees a stable snapshot and no work burns tokens past budget
-        # exhaustion.  cancel_active() is a no-op if _active is already empty.
+        # Cancel background tasks so synthesis sees a stable snapshot and no
+        # work burns tokens past budget exhaustion (no-op if _active is empty).
         if run._active:
             await run.cancel_active()
-        # Synthesize and export under asyncio.shield so the await runs outside
-        # the cancelled scope.  A hard timeout bounds the phase so a hung
-        # synthesis call cannot extend the run indefinitely.
+        # asyncio.shield keeps the export running outside the cancelled scope;
+        # the hard timeout bounds it so a hung synthesis call can't extend the run.
         partial_coro = self._partial_export(run, *args, **kwargs)
         partial_task = asyncio.ensure_future(partial_coro)
         try:
@@ -683,11 +677,9 @@ class Engine:
                 timeout=_PARTIAL_EXPORT_TIMEOUT_S,
             )
         except asyncio.CancelledError:
-            # The caller cancelled Engine.run() while we were in the
-            # partial-export phase.  wait_for converts its own internal
-            # timeout into TimeoutError, so a CancelledError here is always
-            # external — clean up partial_task and re-raise so the caller's
-            # cancellation is honoured.
+            # wait_for converts its own timeout into TimeoutError, so a
+            # CancelledError here is always an external cancel of run() itself
+            # — clean up partial_task and re-raise to honour it.
             if not partial_task.done():
                 partial_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -724,17 +716,15 @@ class Engine:
     ) -> Any:
         """Execute the engine pipeline; on internal budget cancellation calls _partial_export instead of raising. External cancellation propagates as CancelledError."""
         run = self.new_run(session=session, on_event=on_event, on_branch_created=on_branch_created)
-        # Reset per-run diagnostics on the engine instance so a reused engine
-        # never carries emission failures from a previous run into the next one.
+        # Reset so a reused engine never carries diagnostics from a prior run.
         self._emission_failures: list[str] = []
         self._agent_errors: list[str] = []
         self._total_agent_failure: bool = False
         watchdog: asyncio.Task | None = None
         if run._deadline is not None:
             watchdog = asyncio.ensure_future(run._deadline_watchdog())
-        # Wrap _run() in a task so the deadline watchdog can cancel it.
-        # This is what makes the deadline bound *all* in-flight work — not just
-        # spawned background tasks, but also sequential awaits inside _run().
+        # Wrapping _run() in a task lets the deadline bound *all* in-flight work —
+        # sequential awaits inside _run(), not just spawned background tasks.
         run_task = asyncio.ensure_future(self._run(run, *args, **kwargs))
         run._run_task = run_task
         result: Any = _UNSET
@@ -742,30 +732,27 @@ class Engine:
         degrade_reason: str = ""
         try:
             result = await run_task
-            # R5: a run that reached the success path may still have silently
-            # dropped a discretionary budget-capped subtree (wait_quiescence
-            # filters EngineBudgetError out of task_errors) — flag it rather
-            # than returning a clean-looking result that hides the truncation.
+            # A run that reached the success path may still have silently dropped
+            # a discretionary budget-capped subtree (wait_quiescence filters
+            # EngineBudgetError out of task_errors) — flag it so a clean-looking
+            # result doesn't hide the truncation.
             if run._budget_notified:
                 degrade_reason = "budget"
         except asyncio.CancelledError:
-            # Distinguish internal cancellation (engine's own deadline/budget
-            # watchdog) from external cancellation (the caller cancelled run()).
-            # The watchdog sets _budget_notified before cancelling run_task.
-            # On Python >=3.11, task.cancelling() > 0 additionally detects a
-            # simultaneous external cancel (caller + watchdog fire at the same
-            # instant).  On Python 3.10, task.cancelling() does not exist, so
-            # we fall back to _budget_notified alone.  The concrete consequence
-            # on 3.10: if the caller cancels at the exact instant the budget is
-            # hit, _budget_notified wins and partial export runs instead of
-            # raising — an acceptable edge-case given the platform limitation.
+            # Distinguish internal cancellation (the watchdog, which sets
+            # _budget_notified before cancelling run_task) from external
+            # cancellation (the caller cancelled run()). task.cancelling() > 0
+            # (Python >=3.11 only) additionally detects a simultaneous external
+            # cancel; on 3.10 we fall back to _budget_notified alone, so a
+            # caller cancel landing at the exact instant the budget is hit
+            # runs partial export instead of raising — an acceptable edge case.
             current = asyncio.current_task()
             caller_cancelled = (
                 current is not None and hasattr(current, "cancelling") and current.cancelling() > 0
             )
             if run._budget_notified and not caller_cancelled:
-                # Internal cancellation only — the deadline watchdog is the
-                # only thing that cancels run_task, so this is a deadline hit.
+                # The watchdog is the only thing that cancels run_task, so
+                # internal-only cancellation here means a deadline hit.
                 degrade_reason = "deadline"
                 partial_result = await self._degrade_export(run, args, kwargs)
             else:
@@ -773,25 +760,22 @@ class Engine:
                 raise
         except (EngineBudgetError, ExceptionGroup) as exc:
             # A root-level (non-spawned) make_agent() call hit the budget and
-            # raised straight out of _run() — e.g. a review's dimension
-            # fan-out gather, or a sequential plan/implement stage. Route to
-            # partial-export instead of letting it crash the run. Masking
-            # guard: a non-budget leaf anywhere in the group (including
-            # nested groups) must not be laundered into a partial — re-raise
-            # so the real error surfaces.
+            # raised straight out of _run() — route to partial-export instead of
+            # crashing the run. Masking guard: a non-budget leaf anywhere in the
+            # group (including nested groups) must not be laundered into a
+            # partial — re-raise so the real error surfaces.
             if not _is_all_budget_error(exc):
                 raise
             degrade_reason = "budget"
             partial_result = await self._degrade_export(run, args, kwargs)
         finally:
-            # Copy per-run emission diagnostics back onto the engine instance so
-            # the CLI read site (getattr(engine, "_emission_failures", [])) sees
-            # the real list regardless of which return/exception path was taken.
-            # Uses a fresh list copy so no shared-reference aliasing between runs.
+            # Copy per-run diagnostics back onto the engine instance (fresh list,
+            # no shared-reference aliasing) so the CLI read site
+            # (getattr(engine, "_emission_failures", [])) sees them regardless of
+            # which return/exception path was taken.
             self._emission_failures = list(run._emission_failures)
-            # Copy per-run agent-failure diagnostics the same way; flag total
-            # failure only when every agent made for this run terminally
-            # errored, so partial/soft-empty runs are never over-flagged.
+            # Flag total failure only when every agent made for this run
+            # terminally errored, so partial/soft-empty runs aren't over-flagged.
             self._agent_errors = list(run._agent_errors)
             self._total_agent_failure = (
                 run.agents_made > 0 and len(run._agent_errors) >= run.agents_made
@@ -800,12 +784,11 @@ class Engine:
                 watchdog.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await watchdog
-            # Drain any tasks still in _active so nothing leaks past run().
-            # Runs whether _run() succeeded, failed, or was cancelled by the
-            # deadline watchdog.  The drain is shielded so it completes even
-            # if the caller cancels run() mid-cleanup, but that external
-            # CancelledError is re-raised — swallowing it would hand the
-            # caller a stale _run() result and break structured cancellation.
+            # Drain any tasks still in _active so nothing leaks past run(),
+            # regardless of whether _run() succeeded, failed, or was cancelled.
+            # Shielded so it completes even if the caller cancels run()
+            # mid-cleanup — but that external CancelledError is still re-raised;
+            # swallowing it would hand the caller a stale result.
             if run._active:
                 drain = asyncio.ensure_future(run.cancel_active())
                 try:
@@ -813,10 +796,9 @@ class Engine:
                 except asyncio.CancelledError:
                     if drain.cancelled():
                         raise
-                    # External cancellation of run() itself.  The drain keeps
-                    # running under shield — wait it out (absorbing repeated
-                    # cancellations) so no run-owned task outlives run() from
-                    # the caller's perspective, then surface the cancellation.
+                    # External cancel of run() itself: wait the shielded drain
+                    # out (absorbing repeated cancellations) so no run-owned
+                    # task outlives run(), then surface the cancellation.
                     while not drain.done():
                         try:
                             await asyncio.shield(drain)

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -78,8 +78,7 @@ async def flow_progress_signals(
         parent_id = meta.get("parent_id")
         depends_on = meta.get("depends_on", [])
         # Prefer the authored node id so every lifecycle signal maps back to the
-        # designer DAG; fall back to the executor's callback name for nodes with
-        # no reference_id (e.g. an engine's own ops, or reactive spawns).
+        # designer DAG; fall back to the executor's name (engine's own ops, reactive spawns).
         sig_name = meta.get("name") or name
         if status == "queued":
             sig: Any = NodeQueued(
@@ -107,10 +106,9 @@ async def flow_progress_signals(
             )
         else:
             return
-        # on_progress is sync (called from inside the executor); fan the signal
-        # onto the async bus. Collected so the caller can await the observers
-        # before reading state they populate. suppress guards the
-        # no-running-loop case (nothing would observe anyway).
+        # on_progress is sync (called from inside the executor); fan the signal onto
+        # the async bus, collected so the caller can await observers before reading
+        # what they wrote. suppress guards the no-running-loop case.
         with contextlib.suppress(RuntimeError):
             emits.append(asyncio.ensure_future(session.emit(sig)))
 

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -501,8 +501,7 @@ class HypothesisEngine(Engine):
         if events_collected == 0:
             return ""
         report = await self._synthesize(run)
-        # Prepend the budget-exhausted status marker so the report is
-        # self-describing even without the events.jsonl context.
+        # Prepend so the report is self-describing without the events.jsonl context.
         status_header = (
             "**status: budget_exhausted** — "
             f"run terminated by deadline/budget before completion "
@@ -599,8 +598,8 @@ class HypothesisEngine(Engine):
             run.notify("stage_error", stage=stage, error=str(exc))
 
     async def _extract(self, run: HypothesisRun, f: FindingPosted) -> None:
-        # Seeds are caller-provided; back-edge findings (gen > 0) came from an
-        # agent and pass the judge before spending more budget.
+        # Seeds (gen 0) are caller-provided; agent-sourced findings (gen > 0)
+        # pass the judge before spending more budget.
         if f.gen > 0 and not await self.judge(run, f.eid, _label(f)):
             return
         emits = (QuestionRaised,)
@@ -735,8 +734,7 @@ class HypothesisEngine(Engine):
                 model=self.model_for("apply"),
                 emits=(ApplicationMapped,),
             )
-            # No repair: "bears on nothing -> emit nothing" is a legitimate
-            # outcome for this stage.
+            # No repair: "bears on nothing -> emit nothing" is legitimate here.
             await agent.operate(instruction=_apply_instruction(c, run.decisions))
 
     async def _synthesize(self, run: HypothesisRun) -> str:

--- a/lionagi/engines/planning.py
+++ b/lionagi/engines/planning.py
@@ -69,9 +69,8 @@ class PlanningEngine(Engine):
 
         assignments = await self._plan(run, prompt, max_ops)
 
-        # One role-template branch per distinct assignee; build_dag_graph runs
-        # each assignment on a clone. Every assignee role may grow the live DAG
-        # when reactive.
+        # One role-template branch per distinct assignee; build_dag_graph runs each
+        # assignment on a clone. Every assignee role may grow the live DAG when reactive.
         assignees = {ta.assignee for ta in assignments}
         spawners = tuple(assignees) if self.reactive else ()
         roles = await spawn_roles(run.session, {a: a for a in assignees}, spawners=spawners)

--- a/lionagi/engines/research.py
+++ b/lionagi/engines/research.py
@@ -203,8 +203,8 @@ class ResearchEngine(Engine):
     async def _explore(self, run: EngineRun, topic: str, depth: int) -> None:
         if depth > self.max_depth or run.seen(topic):
             return
-        # Depth expansion spends a whole team — gate it on the quality judge
-        # (off-topic / duplicative / trivial sub-questions stop here).
+        # Depth expansion spends a whole team — gate on the judge (off-topic /
+        # duplicative / trivial sub-questions stop here).
         jid = f"d{depth}-" + re.sub(r"[^a-zA-Z0-9]+", "-", topic).strip("-")[:32]
         if not await self.judge(run, jid, f"deeper exploration (depth {depth}): {topic}"):
             return
@@ -253,8 +253,8 @@ class ResearchEngine(Engine):
 
         if arrived():
             return
-        # Node-level backstop: every per-stage repair turn failed — try once
-        # more with the last member before giving up on this node entirely.
+        # Backstop: every per-stage repair failed — try once more with the last
+        # member before giving up on this node entirely.
         await run.operate_with_repair(
             team[-1],
             instruction,

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -142,14 +142,13 @@ class ReviewEngine(Engine):
         run.root = artifact
         run.observe(IssueFound, lambda i, _c: self._on_issue(run, i))
 
-        # Fan out: one reviewer per dimension, in parallel.
-        # Using ln_gather (structured concurrency) so a dimension failure cancels
-        # siblings and no coroutine outlives this scope.
+        # Fan out one reviewer per dimension; ln_gather's structured concurrency
+        # cancels siblings on a dimension failure so no coroutine outlives this scope.
         try:
             await ln_gather(*(self._review_dimension(run, artifact, d) for d in dims))
         except BaseException:
-            # Cancel any verifier tasks that were spawned before the failure so
-            # no background work keeps mutating shared run state after _run exits.
+            # Cancel any verifier tasks spawned before the failure so no
+            # background work mutates shared run state after _run exits.
             await run.cancel_active()
             raise
         # Drain any adversarial verifiers spawned by high-severity issues.
@@ -176,8 +175,7 @@ class ReviewEngine(Engine):
                 emits=emits,
             )
             # Repair re-prompts a reviewer that emitted prose instead of fenced
-            # issues — it requests an emission, never fabricates one, so a
-            # genuinely clean dimension simply emits nothing again.
+            # issues; it never fabricates one, so a clean dimension emits nothing again.
             await run.operate_with_repair(
                 agent,
                 _dimension_instruction(artifact, dimension),

--- a/lionagi/tools/code/check.py
+++ b/lionagi/tools/code/check.py
@@ -17,9 +17,8 @@ from lionagi.protocols.action.tool import Tool
 
 from ..base import LionTool
 
-# Runtime availability of the ruff binary is checked lazily via shutil.which.
-# No hard Python import is required — if the binary is absent the tool degrades
-# to status='unavailable' with an actionable install message.
+# ruff availability is checked lazily via shutil.which (no hard import);
+# an absent binary degrades to status='unavailable' with an install hint.
 
 
 class CodeDiagnostic(BaseModel):
@@ -245,10 +244,8 @@ class CodeCheckTool(LionTool):
     async def handle_request(self, request: CodeCheckRequest) -> CodeCheckResponse:
         if isinstance(request, dict):
             request = CodeCheckRequest(**request)
-        # Enforce workspace containment before any subprocess call.  An empty
-        # paths list would let ruff fall back to scanning the process working
-        # directory, which may lie outside the workspace — default it to the
-        # workspace root instead.
+        # An empty paths list would let ruff scan the process cwd (possibly
+        # outside the workspace) — default to the workspace root instead.
         paths = request.paths or [str(self.workspace_root)]
         resolved_paths, err = _resolve_check_paths(paths, self.workspace_root)
         if err is not None:

--- a/lionagi/tools/code/search.py
+++ b/lionagi/tools/code/search.py
@@ -170,13 +170,9 @@ class SearchTool(LionTool):
 
     def __init__(self, workspace_root: str | None = None) -> None:
         self._tool = None
-        # Resolve the containment root ONCE, at construction, against the cwd
-        # in effect now. Storing the raw (possibly relative) value would let a
-        # later os.chdir() move the boundary — e.g. a relative "ws" would be
-        # re-resolved against whatever cwd is current when a search runs, so a
-        # search could escape the originally intended root. Resolving here
-        # freezes the boundary to an absolute path; re-resolving it downstream
-        # is then idempotent.
+        # Resolve to an absolute path ONCE here — a stored relative root would
+        # re-resolve against a later os.chdir()'d cwd and could escape the
+        # intended boundary.
         self._workspace_root = (
             str(Path(workspace_root).resolve()) if workspace_root is not None else None
         )

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -453,10 +453,8 @@ class CodingToolkit(LionTool):
                 else:
                     read_tracked.discard(resolved)
 
-        # Cache for documents opened via action='open' (docling conversion).
-        # Keyed by path; values are (text, cached_at) tuples — same layout as
-        # the standalone ReaderTool cache so _read_cached/_evict_expired work
-        # without modification.
+        # Docling conversion cache, keyed by path — same (text, cached_at)
+        # layout as ReaderTool's cache so _read_cached/_evict_expired reuse it.
         _open_cache: dict[str, tuple[str, float]] = {}
 
         async def reader(

--- a/lionagi/tools/file/reader.py
+++ b/lionagi/tools/file/reader.py
@@ -195,9 +195,8 @@ def _open_sync(
     workspace_root: Path,
     allowed_url_hosts: frozenset[str],
 ) -> ReaderResponse:
-    # NOTE: docling import is intentionally deferred until AFTER all URL/SSRF
-    # validation so that the security checks remain testable without the
-    # optional docling dependency installed.
+    # docling import deferred until after URL/SSRF validation so the
+    # security checks stay testable without the optional dependency.
     parsed = urlparse(path)
     if parsed.scheme in ("http", "https", "ftp"):
         if parsed.scheme != "https" or (parsed.hostname or "") not in allowed_url_hosts:

--- a/lionagi/tools/sandbox_backend.py
+++ b/lionagi/tools/sandbox_backend.py
@@ -199,12 +199,9 @@ class SandboxBackend(Protocol):
 # local_worktree backend — wraps sandbox.py's SandboxSession lifecycle.
 # ---------------------------------------------------------------------------
 
-#: ``run_cell``'s subprocess never blanket-inherits the host environment (a
-#: credential-leak vector: any secret in this process's env would otherwise be
-#: visible to the cell's command). Only these host variables are forwarded —
-#: enough to resolve the interpreter/tool chain and locate a home directory —
-#: plus whatever ``cell.env`` explicitly allow-lists (empty for prompt-cells,
-#: enforced below).
+#: ``run_cell``'s subprocess never blanket-inherits the host environment
+#: (credential-leak vector). Only these variables are forwarded, plus
+#: whatever ``cell.env`` explicitly allow-lists.
 _SAFE_ENV_KEYS = ("PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV")
 
 


### PR DESCRIPTION
## Summary
Comment-only sweep of `lionagi/cli/`, `lionagi/tools/`, `lionagi/engines/`, and top-level modules under the repo comment policy. 14 files touched (~10 narration comments deleted, ~55 condensed). Files owned by in-flight PRs and the state/dispatch/agent packages are excluded (swept after those PRs merge). Zero behavior change: AST-equality (modulo docstrings) verified against main for every touched file.

## Testing
- `pytest tests/cli tests/tools tests/engines` — 2122 passed, 6 skipped.
- ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)