### PR TITLE
chore: condense docstrings in session and operations

### DIFF
--- a/lionagi/operations/ReAct/utils.py
+++ b/lionagi/operations/ReAct/utils.py
@@ -11,11 +11,8 @@ from lionagi.models import HashableModel
 class ReActAnalysis(HashableModel):
     """Chain-of-thought output for one ReAct round: analysis, extension flag, and action strategy.
 
-    The round budget below is framed as HEADROOM for planning, not a countdown —
-    "N steps left, be efficient" reads as scarcity and makes a model wrap up early.
-    Instead: remaining rounds are room to use not race, "efficiency" means
-    throughput-per-round (batching tool calls) not fewer rounds, and the only
-    failure is stopping while the task is incomplete.
+    Round budget is framed as headroom to use, not a countdown — scarcity framing
+    makes models wrap up early. See prompts below.
     """
 
     FIRST_EXT_PROMPT: ClassVar[str] = (

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -148,16 +148,11 @@ async def _apply_context_providers(
     instruction: JsonValue | Instruction,
     param: ChatParam,
 ) -> Instruction | None:
-    """Gather registered ContextProviders and stash their rendered blocks in
-    the branch's per-turn injection slot, read by `f(c)` in `_prepare_run_kwargs`
-    and cleared right after. Returns the pre-built Instruction (reused by
-    `_prepare_run_kwargs` to avoid rebuilding it) or None when no providers
-    are registered — the zero-overhead path.
-
-    Injections render into the system-guidance fold, so a branch with no
-    system message has no render target: providers are not invoked (no
-    wasted retrieval or tokens) and the turn's report marks every registered
-    provider as skipped, observable via `branch.last_context_report`."""
+    """Gather registered ContextProviders into the branch's per-turn injection
+    slot; returns the pre-built Instruction, or None when no providers are
+    registered (zero-overhead path). A branch with no system message has no
+    render target — providers are skipped, not invoked; see `branch.last_context_report`.
+    """
     if not branch._context_providers:
         return None
 

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -92,13 +92,9 @@ def _render_type(annotation: Any) -> str:
 
 
 def _render_target_spec(target: Any) -> str | None:
-    """Render the target model's fields as an LNDL ``Specs:`` line -- the
-    exact format LNDL_SYSTEM_PROMPT's own examples use to teach the model
-    the schema it must fill (rule 5: "Use the EXACT spec names declared in
-    the schema you are given"). Without this, a real model is never told
-    the target field names once the per-round chat call strips native
-    ``response_format``. Returns None for a plain-dict/no-target caller —
-    there's no structured spec to announce."""
+    """Render the target model's fields as an LNDL ``Specs:`` line, the format
+    LNDL_SYSTEM_PROMPT's examples use — required since the per-round chat
+    call strips native ``response_format``. None for a plain-dict/no-target caller."""
     model_fields = getattr(target, "model_fields", None)
     if not model_fields:
         return None
@@ -157,11 +153,8 @@ def _round_instruction(
     round_budget: int,
     prior_error: str | None,
 ) -> JsonValue | Instruction:
-    """Round 1 sends the caller's own instruction verbatim (the LNDL contract
-    rides in ``guidance`` instead, see ``build_lndl_middle``). Later rounds
-    send a short continuation notice — LNDL_SYSTEM_PROMPT's own MULTI-ROUND
-    MODE section teaches the model to read 'Round N of M.' as a continuation
-    signal, with tool results already visible in chat history."""
+    """Round 1 sends the instruction verbatim (LNDL contract rides in
+    ``guidance``); later rounds send a short 'Round N of M.' continuation notice."""
     if round_num == 1:
         return original_instruction
     notice = f"Round {round_num} of {round_budget}."
@@ -177,12 +170,9 @@ def _classify_round(
 ) -> tuple[RoundOutcome, list[ActionCall], dict[str, Any] | None]:
     """Parse and assemble one round's raw text into a RoundOutcome.
 
-    Returns ``(outcome, pending_action_calls, assembled_dict)``. ``pending``
-    is populated for a Continue round (every declared lact, executed
-    unconditionally per LNDL_SYSTEM_PROMPT's "tools execute every round") and
-    for a Success candidate (only the lacts actually reachable from OUT{},
-    via ``collect_actions``). ``assembled`` is populated only for a Success
-    candidate.
+    Returns ``(outcome, pending_action_calls, assembled_dict)``; ``pending`` is
+    every lact for Continue, only OUT{}-reachable lacts for Success; ``assembled``
+    is set only on Success.
     """
     blocks = extract_lndl_blocks(text)
     if not blocks:

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -321,11 +321,8 @@ class Branch(Element, Relational):
         return await self._observer.emit(event)
 
     async def _safe_emit(self, event: Any) -> None:
-        """Emit a lifecycle event, swallowing observer exceptions.
-
-        Policy: lifecycle observer failures must never alter run outcomes.
-        Exceptions are logged but not re-raised.
-        """
+        """Emit a lifecycle event; observer exceptions are logged, never re-raised
+        (lifecycle failures must not alter run outcomes)."""
         import logging as _logging
 
         try:
@@ -694,10 +691,9 @@ class Branch(Element, Relational):
         )
 
     async def chat_and_record(self, instruction: Instruction | JsonValue = None, **kwargs) -> str:
-        """Like ``chat()``, but also adds the turn to the branch through the
-        hooked async add-path (mirrors ``communicate()``'s recording), so
-        anything observing ``on_message_added`` — e.g. persistence — sees it.
-        """
+        """Like ``chat()``, but adds the turn via the hooked async add-path
+        (mirrors ``communicate()``), so ``on_message_added`` observers (e.g.
+        persistence) see it."""
         kwargs.pop("return_ins_res_message", None)
         ins, res = await self.chat(instruction, return_ins_res_message=True, **kwargs)
         await self.msgs.a_add_message(instruction=ins)

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -139,11 +139,10 @@ class MessageAdded(Signal):
 
 
 class DispatchSignal(Signal):
-    """Outbound dispatch payload contract (ADR-0092). schema_version rides Signal.
+    """Outbound dispatch payload contract (ADR-0092); schema_version rides Signal.
 
-    The notify template substitutes ``to_dict(mode="json")`` of this signal as
-    the payload: one stable envelope shared by every dispatch kind, so the
-    transport template never churns per-kind.
+    One stable envelope (``to_dict(mode="json")``) shared by every dispatch kind,
+    so the transport template never churns per-kind.
     """
 
     dispatch_id: str = ""
@@ -248,10 +247,8 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
 
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
     """Sum provider-reported usage across all AssistantResponse messages on branch.
-
-    Returns dict with keys: input_tokens, output_tokens, total_cost_usd, num_turns.
-    All zero when no provider data is available (subscription runs, tests).
-    """
+    Keys: input_tokens, output_tokens, total_cost_usd, num_turns; all zero when
+    no provider data is available (subscription runs, tests)."""
     input_tokens = 0
     output_tokens = 0
     total_cost_usd = 0.0
@@ -285,13 +282,10 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
 
 
 def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
-    """Sum provider-reported usage across multiple branches (multi-leg DAG runs).
+    """Sum _collect_branch_usage across multiple branches (multi-leg DAG runs).
 
-    Applies _collect_branch_usage to each branch and adds the per-branch totals
-    together. Same key shape as _collect_branch_usage: input_tokens,
-    output_tokens, total_cost_usd, num_turns. duration_ms is deliberately not
-    included here — wall-clock across parallel legs isn't simply summable, so
-    the CLI teardown path leaves it unset for orchestration sessions too.
+    Same keys as _collect_branch_usage. duration_ms is deliberately excluded —
+    wall-clock across parallel legs isn't simply summable.
     """
     input_tokens = 0
     output_tokens = 0


### PR DESCRIPTION
Round-2 docstring pass of the comment-hygiene sweep: condense verbose docstrings to their contracts (internal helpers to one line; multi-paragraph narration cut to what callers can rely on). Docstring-only — AST verified identical after docstring strip. 970 session/operations tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)