### PR TITLE
chore: condense docstrings in protocols and ln

### DIFF
--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -29,13 +29,10 @@ def terminate_process_group(
 ) -> None:
     """Send sig_first to the process group AND the direct child.
 
-    If grace is None, send SIGKILL immediately with no prior SIGTERM.  The
-    sync variant only sends the first signal; callers are responsible for
-    waiting and escalating to SIGKILL (use aterminate_process_group for the
-    full async SIGTERM-wait-SIGKILL cycle).  Swallows ProcessLookupError,
-    PermissionError, and OSError so an already-dead process never raises.
-    The pid-guard suppresses os.killpg for proc.pid None/0/<=1; the direct
-    child is still signalled via proc.terminate()/kill().
+    grace=None sends SIGKILL immediately with no prior SIGTERM. Otherwise
+    sends only sig_first; the caller must wait and escalate to SIGKILL (see
+    aterminate_process_group for the full cycle). Swallows ProcessLookupError,
+    PermissionError, and OSError — an already-dead process never raises.
     """
     pgid = _safe_pgid(proc)
     if grace is None:
@@ -63,10 +60,8 @@ async def aterminate_process_group(
 ) -> None:
     """Async: signal the process group AND the direct child, wait up to grace, then SIGKILL.
 
-    If grace is None, send SIGKILL immediately with no prior signal.  Swallows
-    ProcessLookupError, PermissionError, and OSError.  The pid-guard suppresses
-    os.killpg for proc.pid None/0/<=1; the direct child is still signalled via
-    proc.terminate()/kill().
+    grace=None sends SIGKILL immediately with no prior signal. Swallows
+    ProcessLookupError, PermissionError, and OSError throughout.
     """
     pgid = _safe_pgid(proc)
     if grace is None:

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -78,12 +78,9 @@ def consume_sigterm_received() -> bool:
 class SigtermInterrupt(BaseException):
     """Raised by run_async() when the process received SIGTERM mid-run.
 
-    Not a KeyboardInterrupt subclass: that type is the SIGINT/Ctrl-C
-    convention and callers treat it as user-initiated. SIGTERM is an
-    external termination request (a supervisor, a process-group kill)
-    and needs a distinct signal so callers can log/exit differently.
-    Subclasses BaseException, like KeyboardInterrupt, so a bare
-    ``except Exception:`` elsewhere doesn't silently swallow it.
+    Deliberately not a KeyboardInterrupt subclass (that's the SIGINT/user
+    convention); subclasses BaseException instead so a bare
+    ``except Exception:`` can't silently swallow it.
     """
 
 

--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -132,12 +132,10 @@ class ContextProviderRegistry:
         return report
 
     async def gather_writeback(self, branch: Branch, action_responses: list) -> None:
-        """POST-turn after-hook: providers that declare an optional
-        `writeback(branch, action_responses)` method get a chance to persist a
-        rule-based extraction from the turn's action responses. Same containment
-        discipline as `gather`: a raising provider is warned + skipped, never
-        blocks the turn. Off by default — a provider only does this when its own
-        policy opts in."""
+        """POST-turn hook: providers with an optional `writeback(branch, action_responses)`
+        method get a chance to persist from the turn's action responses. Same
+        containment as `gather` — a raising provider is warned + skipped, never
+        blocks the turn."""
         for entry in self._entries:
             hook = getattr(entry.provider, "writeback", None)
             if hook is None:


### PR DESCRIPTION
Round-2 docstring pass of the comment-hygiene sweep: 3 verbose docstrings condensed (process-group termination helpers, SigtermInterrupt, gather_writeback); rest of the package was already tight. Docstring-only — AST verified identical after docstring strip. 1822 protocols/ln tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)