### PR TITLE
chore: condense docstrings in studio backend

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -126,17 +126,9 @@ async def _stop_claude_mirror(stop: asyncio.Event | None, task: asyncio.Task | N
 
 
 async def _startup_warmup() -> None:
-    """Deferred startup maintenance that must not gate readiness: the WAL
-    checkpoint. Kept off the critical path so /health serves as soon as
-    reconciliation completes (not waiting on the checkpoint), and so the
-    checkpoint does not block readiness while contending with the mirror's
-    first connection open on a cold first-run DB. The whole body
-    (including the import) is guarded so an unexpected failure is logged, not
-    silently dropped when the task is finalized at shutdown.
-
-    Stale-session reconciliation is deliberately NOT deferred — it runs pre-yield
-    in lifespan() because stateful /api routes read the session rows it corrects.
-    """
+    """Deferred WAL checkpoint, kept off the critical path so /health serves as
+    soon as reconciliation completes rather than waiting on it. Guarded so an
+    unexpected failure is logged, not silently dropped, at shutdown."""
     try:
         from .services.db_maintenance import checkpoint_state_db
 
@@ -146,9 +138,8 @@ async def _startup_warmup() -> None:
 
 
 async def _finalize_warmup(task: asyncio.Task | None) -> None:
-    """Settle the background warmup task before shutdown proceeds: cancel it if
-    still running, then await so it is retrieved (never a pending/un-retrieved
-    task warning). An unexpected failure is logged rather than silently dropped."""
+    """Cancel the warmup task if still running, then await it so it's retrieved
+    (avoids an un-retrieved-task warning); a failure is logged, not dropped."""
     if task is None:
         return
     if not task.done():
@@ -211,19 +202,12 @@ def _parse_host_authority(raw_host: str) -> str | None:
 
 
 async def validate_host_header(request: Request, call_next):
-    """Reject requests whose Host header doesn't match an expected value.
-
-    Without this check, a malicious web page could point a browser at
-    http://127.0.0.1:<port> with an attacker-controlled Host header (DNS
-    rebinding) and, once past CORS/auth, reach the daemon as if it were a
-    same-origin request. The browser sets Host to the actual connection
-    target it resolved, so validating it here catches rebound requests that
-    same-origin checks alone don't cover. This dispatch is registered LAST
-    (outermost, outside even CORSMiddleware) so every request -- including
-    CORS preflight OPTIONS -- gets its Host checked before anything answers;
-    a legitimate preflight from the hosted SPA carries the loopback Host it
-    actually connected to and passes unaffected.
-    """
+    """Reject requests whose Host header doesn't match an expected value —
+    defends against DNS rebinding, where a malicious page points a browser at
+    http://127.0.0.1:<port> with an attacker-controlled Host and, once past
+    CORS/auth, reaches the daemon as if same-origin. Registered outermost
+    (outside CORSMiddleware) so every request, including preflight, is checked
+    before anything answers."""
     hostname = _parse_host_authority(request.headers.get("host", ""))
     bind_host = os.getenv("LIONAGI_STUDIO_HOST", HOST)
     allowed_hosts = {"localhost", "127.0.0.1", "::1"}
@@ -316,15 +300,9 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
 
 
 def create_app() -> FastAPI:
-    """Build and return a fresh Studio FastAPI app instance.
-
-    Everything the module used to do at import time (construct FastAPI,
-    register exception handlers/middleware/routes, mount the SPA) lives here
-    instead, so a caller that needs a clean app -- most notably tests that
-    monkeypatch service module globals before the app captures them -- can
-    get one without `importlib.reload`-ing this module and mutating the
-    shared singleton every other importer holds a reference to.
-    """
+    """Build and return a fresh Studio FastAPI app instance, so callers that
+    need a clean app (notably tests that monkeypatch service globals first) can
+    get one without `importlib.reload`-ing this module's shared singleton."""
     application = FastAPI(title="Lion Studio Server", lifespan=lifespan)
 
     @application.exception_handler(LionError)

--- a/lionagi/studio/scheduler/capabilities.py
+++ b/lionagi/studio/scheduler/capabilities.py
@@ -2,26 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """ADR-0101 D4: capability-class matching.
 
-A small declarative token -> class map, not a policy engine. Every
-capability token used in ``required_capabilities``/``advertised_capabilities``
+Declarative token -> class map, not a policy engine. Every capability token
 falls into exactly one class:
 
-- ``eligibility`` (default for any token not listed below): a plain
-  subset-match routing filter -- the worker must advertise the token for a
-  task carrying it to be claimable at all.
-- ``serialization`` (e.g. an exclusive-GPU token): folds into the task's
-  host-scoped ``concurrency_key`` at submit time, so ADR-0061 concurrency
-  admission queues at most one such task per host. The queue orders
-  admission ADVISORILY only -- a worker-side host lock (an OS flock the
-  worker takes before touching the resource) stays authoritative; this
-  module never arbitrates the machine lock itself.
-- ``affinity`` (e.g. a warmed-cache token): a soft ordering preference among
-  otherwise-eligible candidates. It never filters -- a worker that does not
-  advertise the affinity token still claims a matching task when it is the
-  only eligible worker running.
+- ``eligibility`` (default): plain subset-match filter -- worker must
+  advertise the token to claim a task carrying it.
+- ``serialization`` (e.g. exclusive-GPU): folds into the task's host-scoped
+  ``concurrency_key`` at submit time (ADR-0061 admission queues at most one
+  such task per host). Admission ordering is ADVISORY only -- a worker-side
+  OS flock stays authoritative; this module never arbitrates the machine lock.
+- ``affinity`` (e.g. warmed-cache): soft ordering preference, never a filter
+  -- a worker lacking the token still claims the task if it's the only
+  eligible one running.
 
-Both the submit path (``task_applications._derive_concurrency_key``) and the
-claim path (``worker.claim_and_execute``) import this module rather than
+Submit path (``task_applications._derive_concurrency_key``) and claim path
+(``worker.claim_and_execute``) both import this module rather than
 duplicating the token->class policy.
 """
 

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -19,17 +19,15 @@ _log = logging.getLogger(__name__)
 class GithubPollItem:
     """One PR observed by a poll, past the previously stored cursor.
 
-    ``event`` is always populated (even when ``dispatchable`` is False) so a
+    ``event`` is always populated, even when ``dispatchable`` is False, so a
     caller can log which PR was seen without firing it. ``updated_at`` is the
-    cursor high-water-mark field for this item -- normally the PR's raw
-    GitHub ``updated_at``, but under ``github_filter={"event": "pr_merged"}``
-    it holds ``merged_at`` instead, since that's what the merged-PR mode
-    compares against the persisted cursor (the event dict's own
-    ``updated_at`` key still carries the PR's real ``updated_at`` either way,
-    for template rendering). ``dispatchable`` is False when ``github_filter``
-    (e.g. a draft filter) excludes the PR from firing -- it is still
-    returned, not silently dropped, so the caller can advance the cursor
-    past it without the PR being re-listed on every subsequent poll.
+    cursor high-water-mark field for this item -- the PR's raw GitHub
+    ``updated_at``, except under ``github_filter={"event": "pr_merged"}``
+    where it holds ``merged_at`` instead (the event dict's own ``updated_at``
+    key still carries the PR's real ``updated_at`` for template rendering).
+    ``dispatchable`` is False when ``github_filter`` (e.g. a draft filter)
+    excludes the PR from firing -- it is still returned so the caller can
+    advance the cursor past it without re-listing it every poll.
     """
 
     event: dict[str, Any]
@@ -40,29 +38,23 @@ class GithubPollItem:
 class GithubPollResult(NamedTuple):
     """Return shape of ``github_poll()``.
 
-    ``scan_complete`` is False only when merged-mode pagination stopped for
-    an UNSAFE reason -- the ``_MERGED_MODE_MAX_PAGES`` cap was hit, or a
-    pagination fetch/status error truncated the scan -- rather than a safe
-    boundary (a short page, no ``rel="next"`` link, or the stored cursor was
-    reached). ``items`` has already had any event that could not be proven
-    complete filtered out in that case (see the truncation-safety filter in
-    ``github_poll``), so a caller does not need to re-derive that from item
-    counts; ``scan_complete`` exists for observability -- e.g. logging that
-    some events near the cursor boundary are being held for a later poll,
-    when a deeper or safely-bounded scan may resolve them.
+    ``scan_complete`` is False only when merged-mode pagination stopped for an
+    UNSAFE reason (the ``_MERGED_MODE_MAX_PAGES`` cap hit, or a pagination
+    fetch/status error) rather than a safe boundary (short page, no
+    ``rel="next"``, or the stored cursor reached). ``items`` already has any
+    event that couldn't be proven complete filtered out in that case -- a
+    caller does not need to re-derive that from item counts; the flag exists
+    for observability (e.g. logging that boundary events are held for a
+    later poll).
 
-    ``poll_status`` distinguishes a healthy-but-empty poll from a poll that
-    couldn't actually see GitHub -- ``items == []`` alone is ambiguous
-    between "nothing new" and "blind" (a 401 or a network failure also
-    returns no items). ``"ok"`` is any 2xx or 304 (not-modified, itself a
-    successful authenticated read); ``"auth_error"`` is a 401 that survived
-    the gh-CLI-token fallback retry; ``"error"`` covers everything else that
-    prevented a real poll (network exception, missing/invalid github_repo,
-    no token available, or a non-200/304/401 status). The caller
-    (``SchedulerEngine._tick_github``) uses this to stamp the schedule's
-    observer-self-health columns. Defaults to ``"ok"`` so existing call
-    sites that construct a ``GithubPollResult`` directly (tests, mocks)
-    don't need updating.
+    ``poll_status`` distinguishes a healthy-but-empty poll from one that
+    couldn't see GitHub -- ``items == []`` alone is ambiguous between
+    "nothing new" and "blind" (a 401 or network failure also returns no
+    items). ``"ok"`` = any 2xx or 304; ``"auth_error"`` = a 401 that survived
+    the gh-CLI-token fallback retry; ``"error"`` = anything else that
+    prevented a real poll. ``SchedulerEngine._tick_github`` uses this to
+    stamp the schedule's observer-self-health columns. Defaults to ``"ok"``
+    so direct-construction call sites (tests, mocks) don't need updating.
     """
 
     items: list[GithubPollItem]
@@ -104,11 +96,10 @@ _GITHUB_REPO_TRAVERSAL = frozenset({".", ".."})
 
 
 def _validate_github_repo(repo: str) -> None:
-    """Raise ValueError if *repo* is not a safe GitHub owner/name pair (CWE-918).
+    """Raise ValueError if *repo* is not a safe ``owner/name`` pair (CWE-918).
 
-    Defense-in-depth at URL-construction time; service write boundary applies the
-    same check via services/schedules._svc_validate_github_repo.  Rules: exactly
-    one '/' separator, valid owner/repo segments per the regex constants above.
+    Defense-in-depth at URL-construction time; the service write boundary
+    applies the same check via ``services/schedules._svc_validate_github_repo``.
     """
     if not repo or "/" not in repo:
         raise ValueError(
@@ -157,12 +148,9 @@ def _validate_github_repo(repo: str) -> None:
 
 
 def _next_page_url(resp: httpx.Response) -> str | None:
-    """Extract the RFC 5988 ``rel="next"`` URL from a GitHub API response's
-    ``Link`` header, or ``None`` on the last page.
-
-    Parsed with a plain regex rather than ``httpx.Response.links`` so a
-    lightweight test double (a bare ``headers`` dict) works the same as a
-    real ``httpx.Response``.
+    """Extract the RFC 5988 ``rel="next"`` URL from the response's ``Link``
+    header, or ``None`` on the last page. Regex-parsed (not
+    ``httpx.Response.links``) so a bare-dict test double works too.
     """
     link_header = resp.headers.get("link")
     if not link_header:
@@ -199,11 +187,9 @@ async def _gh_cli_token() -> str | None:
 async def _get_gh_token(prefer_cli: bool = False) -> str | None:
     """Get a GitHub token from the environment or the gh CLI.
 
-    By default ``GITHUB_TOKEN`` wins. Set ``prefer_cli=True`` to skip the env
-    var and read a fresh token from ``gh auth token`` instead — used to recover
-    from a ``GITHUB_TOKEN`` that was valid at daemon launch but has since
-    expired (the poller would otherwise stay pinned to the dead credential and
-    go silently blind on every poll).
+    ``GITHUB_TOKEN`` wins by default. ``prefer_cli=True`` skips it and reads a
+    fresh token from ``gh auth token`` instead -- used to recover from a
+    ``GITHUB_TOKEN`` that was valid at daemon launch but has since expired.
     """
     import os
 
@@ -217,18 +203,16 @@ async def _get_gh_token(prefer_cli: bool = False) -> str | None:
 async def github_poll(schedule: dict) -> GithubPollResult:
     """Poll GitHub for PRs newer than the stored cursor.
 
-    Returns items ordered oldest-``updated_at``-first (the GitHub API itself
-    returns them newest-first) so a caller advancing the persisted cursor
-    incrementally, one dispatched item at a time, stays monotone.
+    Returns items ordered oldest-``updated_at``-first (the API itself returns
+    newest-first) so a caller advancing the persisted cursor incrementally
+    stays monotone.
 
-    Does NOT persist ``github_cursor`` -- that is the caller's job now
+    Does NOT persist ``github_cursor`` -- that is the caller's job
     (``SchedulerEngine._tick_github``). Fire-per-event budget gating means
-    some of the dispatchable items returned here may not actually get fired
-    this poll (max_runs/global-slot exhaustion), and those must be re-listed
-    on the next poll rather than silently skipped, so only the caller -- who
-    knows what it actually dispatched -- can decide how far the cursor is
-    safe to advance. See ``GithubPollResult.scan_complete`` for the
-    equivalent truncation-safety concern in merged mode.
+    some dispatchable items may not actually get fired this poll
+    (max_runs/global-slot exhaustion) and must be re-listed on the next poll
+    rather than silently skipped, so only the caller -- who knows what it
+    actually dispatched -- can decide how far the cursor is safe to advance.
     """
     repo = schedule.get("github_repo")
     if not repo:

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -44,11 +44,7 @@ _IDENT_RE = _MODEL_RE
 
 
 def _validate_action_model(model: str) -> None:
-    """Raise ValueError if *model* could inject CLI flags (CWE-88).
-
-    A value starting with '-' is interpreted as a flag by the spawned li process.
-    Fail loudly so callers discover bad data at write time, not fire time.
-    """
+    """Raise ValueError if *model* could inject a CLI flag into the spawned li process (CWE-88)."""
     if not model:
         return
     if model.startswith("-"):
@@ -64,11 +60,7 @@ def _validate_action_model(model: str) -> None:
 
 
 def _validate_identifier(value: str, field_name: str) -> None:
-    """Raise ValueError if *value* starts with '-' (covers action_agent/project/playbook).
-
-    A leading '-' causes argparse to misinterpret the value as a flag (CWE-88).
-    Fail loudly at write time, same policy as _validate_action_model.
-    """
+    """Raise ValueError if *value* starts with '-' — argparse would misinterpret it as a flag (CWE-88)."""
     if not value:
         return
     if value.startswith("-"):
@@ -86,10 +78,7 @@ def _validate_identifier(value: str, field_name: str) -> None:
 def _validate_extra_args(extra: list) -> None:
     """Raise ValueError if any element starts with '-' (CWE-88 flag injection).
 
-    Extra tokens are appended verbatim to argv; a leading '-' would toggle a flag
-    in the spawned li process. Fail loudly with the offending element named.
-
-    Note: agent/flow/fanout parsers do not accept extra positionals; non-empty
+    Note: agent/flow/fanout parsers don't accept extra positionals; non-empty
     action_extra_args causes those subcommands to exit rc 2 at fire time.
     """
     for item in extra:
@@ -140,12 +129,11 @@ def _validate_engine_options(opts: object) -> None:
 
 
 def _validate_prompt(prompt: str) -> None:
-    """Raise ValueError if *prompt* is the literal end-of-options sentinel '--'.
+    """Raise ValueError if *prompt* is exactly the end-of-options sentinel '--'.
 
-    build_argv places '--' before positionals, so a prompt value of '--' would be
-    consumed by argparse as the separator token rather than reaching the runner.
-    All other content (including leading '-') is safe. Only the exact singleton
-    '--' is forbidden; '-- text' or '--' embedded in a longer string are fine.
+    build_argv places '--' before positionals, so a prompt value of exactly
+    '--' would be consumed by argparse as the separator, never reaching the
+    runner. All other content (including leading '-') is safe.
     """
     if prompt == "--":
         raise ValueError(
@@ -191,11 +179,9 @@ def resolve_li_executable() -> tuple[list[str] | None, str | None]:
     """Resolve an absolute argv prefix for launching the ``li`` CLI.
 
     ``uv run li`` depends on ``uv`` discovering a project/venv from the
-    *current working directory*; a daemon started from a directory with no
-    discoverable ``pyproject.toml`` (e.g. the filesystem root) fails to spawn
-    with an opaque ENOENT for ``li``, unrelated to the schedule's own working
-    directory. Resolving an absolute executable path here sidesteps that
-    cwd-dependent lookup entirely.
+    daemon's cwd, which fails with an opaque ENOENT when the daemon starts
+    somewhere with no discoverable ``pyproject.toml``. An absolute path here
+    sidesteps that cwd-dependent lookup entirely.
 
     Tries, in order:
       1. ``shutil.which("li")`` — the `li` script on PATH.

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -3,23 +3,20 @@
 """ADR-0101 D3/D4: the local (host-only) worker/claim loop with capability
 matching.
 
-v1 ships ONE worker — the Studio daemon engine itself — claiming everything
-it can serve. A claim is one guarded CAS through
-``lionagi.state.transitions.transition()`` (``queued -> running``) that sets
-``leased_by``/``lease_expires_at``/``lease_attempts`` in the same guarded
-UPDATE the status move performs; there is no second write and no parallel
-CAS path (ADR-0101's scope fence). Execution resolves through the existing
-subprocess launcher (``lionagi.studio.scheduler.subprocess``) — this module
-never spawns a process itself.
+v1 ships ONE worker — the Studio daemon engine itself. A claim is one guarded
+CAS through ``lionagi.state.transitions.transition()`` (``queued -> running``)
+that also sets ``leased_by``/``lease_expires_at``/``lease_attempts`` in the
+same UPDATE — no second write, no parallel CAS path (ADR-0101 scope fence).
+Execution resolves through ``lionagi.studio.scheduler.subprocess``; this
+module never spawns a process itself.
 
 D4 adds the ``workers`` registry: ``worker_tick`` upserts this worker's
 heartbeat before every claim pass, and the claim predicate matches a queued
 row's ``required_capabilities``/``execution_target`` against the calling
-worker's advertised capabilities/execution targets (``capabilities.py``'s
-token->class map) instead of the D3-era "capability-free only" exclusion. A
-row this worker cannot serve is left ``queued``, never faked. Remote
-execution targets and workflow-registry resolution remain later slices
-(ADR-0102 and a remote worker binding).
+worker's advertised capabilities/execution targets. A row this worker cannot
+serve is left ``queued``, never faked. Remote execution targets and
+workflow-registry resolution remain later slices (ADR-0102, remote worker
+binding).
 """
 
 from __future__ import annotations
@@ -150,12 +147,8 @@ ExecuteFn = Callable[[dict[str, Any]], Awaitable[tuple[int, str]]]
 
 
 def _normalize_json_list(value: Any) -> list[Any]:
-    """StateDB JSON columns come back as strings on SQLite but as native
-    Python values on Postgres (the cross-dialect contract documented on
-    ``StateDB``'s query surface). Every JSON-column read in the claim path
-    goes through this so it works identically on both backends: NULL/empty
-    -> ``[]``, a string -> ``json.loads`` it, a native list -> pass through.
-    """
+    """Normalize a JSON column that is a string on SQLite but a native list
+    on Postgres: NULL/empty -> ``[]``, string -> ``json.loads``, list -> passthrough."""
     if not value:
         return []
     if isinstance(value, str):
@@ -166,14 +159,8 @@ def _normalize_json_list(value: Any) -> list[Any]:
 def _matching_candidates(
     page: Any, *, advertised: list[str], targets: set[str]
 ) -> list[tuple[Any, list[str]]]:
-    """Filter one page of queued rows to those this worker can serve.
-
-    Pulled out of ``claim_and_execute`` so the D4 match rule (subset-match
-    on ``required_capabilities`` + ``execution_target`` membership) is
-    directly testable against a row shaped either the SQLite way (a JSON
-    string) or the Postgres way (a native list/None) without a live
-    connection of either dialect.
-    """
+    """Filter one page of queued rows to those this worker can serve (subset-match
+    on ``required_capabilities`` + ``execution_target`` membership)."""
     candidates: list[tuple[Any, list[str]]] = []
     for row in page:
         required = _normalize_json_list(row["required_capabilities"])
@@ -194,13 +181,9 @@ async def register_heartbeat(
     execution_targets: list[str] | None = None,
     now: float | None = None,
 ) -> None:
-    """Upsert *worker_id*'s ``workers`` row and bump ``last_heartbeat_at``.
-
-    Called once per ``worker_tick`` before the claim pass, so a worker
-    ticking regularly never reads its own heartbeat as stale. A worker that
-    stops ticking falls behind ``DEFAULT_HEARTBEAT_TTL_SECONDS`` and becomes
-    ineligible for new claims until it heartbeats again.
-    """
+    """Upsert *worker_id*'s ``workers`` row and bump ``last_heartbeat_at``. A worker
+    that stops calling this falls behind ``DEFAULT_HEARTBEAT_TTL_SECONDS`` and
+    becomes ineligible for new claims until it heartbeats again."""
     now = now if now is not None else time.time()
     async with db._tx() as conn:
         await conn.execute(
@@ -220,10 +203,8 @@ async def register_heartbeat(
 async def _worker_is_stale(
     db: StateDB, *, worker_id: str, now: float, heartbeat_ttl: float
 ) -> bool:
-    """True iff *worker_id* has a ``workers`` row whose heartbeat is older
-    than *heartbeat_ttl*. A worker with no row yet (never heartbeated) is
-    treated as not-stale -- there is no signal to distrust, and every
-    existing D3 caller that never wrote to ``workers`` keeps claiming."""
+    """True iff *worker_id*'s heartbeat is older than *heartbeat_ttl*. A worker
+    with no row yet (never heartbeated) is treated as not-stale."""
     async with db._read() as conn:
         row = (
             (await conn.execute(text(_WORKER_HEARTBEAT_SQL), {"worker_id": worker_id}))
@@ -236,13 +217,9 @@ async def _worker_is_stale(
 
 
 async def default_execute(row: dict[str, Any]) -> tuple[int, str]:
-    """Resolve *row*'s action_kind through the existing subprocess launcher.
-
-    Reuses the scheduler's own action_kind vocabulary and argv builder
-    rather than a second launcher: the task application's ``action_args``
-    payload carries the same ``action_*``-named keys a schedule dict would
-    (``action_model``/``action_prompt``/``action_agent``/...).
-    """
+    """Resolve *row*'s action_kind through the existing subprocess launcher. The
+    task's ``action_args`` payload carries the same ``action_*``-named keys a
+    schedule dict would (``action_model``/``action_prompt``/``action_agent``/...)."""
     action_args = row.get("action_args") or {}
     schedule_like = {"action_kind": row["action_kind"], **action_args}
     li_prefix, li_resolve_error = _subprocess.resolve_li_executable()
@@ -257,15 +234,11 @@ async def default_execute(row: dict[str, Any]) -> tuple[int, str]:
 
 
 async def reap_expired_leases(db: StateDB, *, now: float | None = None) -> dict[str, int]:
-    """Recover or fail rows whose lease has lapsed.
-
-    A row under ``MAX_LEASE_ATTEMPTS`` goes back to ``queued`` (recovery,
-    clearing the lease columns); at or beyond the bound it goes to
-    ``failed`` (terminal) — unbounded requeue is impossible by construction.
-    A live (unexpired) lease is never touched: the guard on
-    ``lease_expires_at`` closes the race between this pass's read and its
-    own guarded write.
-    """
+    """Recover or fail rows whose lease has lapsed. A row under
+    ``MAX_LEASE_ATTEMPTS`` goes back to ``queued`` (lease columns cleared); at
+    or beyond the bound it goes to ``failed`` (terminal). A live (unexpired)
+    lease is never touched — the guard on ``lease_expires_at`` closes the race
+    between this pass's read and its own guarded write."""
     now = now if now is not None else time.time()
     counts = {"requeued": 0, "failed": 0}
 
@@ -334,37 +307,29 @@ async def claim_and_execute(
 ) -> int:
     """Claim every eligible queued row this worker can serve, then execute each.
 
-    D4 match rule: a queued row R is claimable by this worker iff R's
-    eligibility∪serialization capability tokens are a subset of
-    *advertised_capabilities* AND R's execution_target is in
-    *execution_targets* (a NULL/empty execution_target is claimable by any
-    worker). Candidates are then ordered by affinity match (a row whose
-    affinity tokens this worker also advertises is preferred), ties broken
-    by ``queued_at`` (the SQL order is preserved by a stable sort). A row
+    D4 match rule: row R is claimable iff its capability tokens are a subset
+    of *advertised_capabilities* AND its execution_target is in
+    *execution_targets* (NULL/empty target = claimable by anyone). Candidates
+    are then ordered by affinity match, ties broken by ``queued_at``. A row
     sharing a ``concurrency_key`` with another row already ``running`` (or
-    already claimed earlier in this same pass) is skipped -- advisory
-    admission only; the worker-side host lock stays authoritative.
+    claimed earlier in this pass) is skipped -- advisory admission only; the
+    worker-side host lock stays authoritative.
 
-    Candidates are collected by paging the queued rows oldest-first through
-    a ``(queued_at, id)`` keyset cursor until *limit* eligible candidates
-    are found or the queue is exhausted (bounded defensively by
-    ``_MAX_CLAIM_SCAN_ROWS`` -- a fairness/latency cap on how much one pass
-    scans, not a correctness cap: nothing scanned past it is hidden, a later
-    pass resumes the same oldest-first order). This means a long prefix of
-    rows this worker cannot serve never permanently hides an eligible row
-    behind it, unlike a single fixed-size prefetch window.
+    Candidates are paged oldest-first through a ``(queued_at, id)`` keyset
+    cursor until *limit* eligible candidates are found or the queue is
+    exhausted, bounded by ``_MAX_CLAIM_SCAN_ROWS`` (a fairness/latency cap,
+    not a correctness cap -- a later pass resumes the same order). A long
+    prefix of unservable rows never permanently hides an eligible row behind
+    it, unlike a fixed-size prefetch window.
 
-    If *worker_id* has a ``workers`` row whose heartbeat is older than
-    *heartbeat_ttl*, this pass claims nothing (assignment eligibility gate;
-    in-flight leases are unaffected and still recover via
-    ``reap_expired_leases``). A worker with no heartbeat history yet (never
-    called ``register_heartbeat``/``worker_tick``) is not treated as stale.
+    If *worker_id*'s heartbeat is older than *heartbeat_ttl*, this pass
+    claims nothing (in-flight leases still recover via
+    ``reap_expired_leases``). A worker with no heartbeat history yet is not
+    treated as stale.
 
     Returns the number of rows claimed (regardless of execution outcome).
-    Each claim is one guarded CAS (``queued -> running``) that atomically
-    sets ``leased_by``/``lease_expires_at``/``lease_attempts``; a lost race
-    or a row another caller already moved (e.g. cancelled) is skipped, not
-    retried within this pass.
+    Each claim is one guarded CAS (``queued -> running``); a lost race or a
+    row another caller already moved is skipped, not retried within this pass.
     """
     execute = execute if execute is not None else default_execute
     now = now if now is not None else time.time()
@@ -515,14 +480,9 @@ async def worker_tick(
     execution_targets: list[str] | None = None,
     heartbeat_ttl: float = DEFAULT_HEARTBEAT_TTL_SECONDS,
 ) -> dict[str, int]:
-    """One worker tick: heartbeat, then reaper pass, then claim pass.
-
-    Split from any sleep loop so tests (and the Studio daemon's own tick)
-    can drive a single pass directly without a timer. The heartbeat upsert
-    runs first every tick, so a worker ticking regularly is never stale for
-    its own claim pass -- ``heartbeat_ttl`` only bites a worker that stops
-    ticking.
-    """
+    """One worker tick: heartbeat, then reaper pass, then claim pass. Split from
+    any sleep loop so tests (and the Studio daemon's own tick) can drive a
+    single pass directly without a timer."""
     now = now if now is not None else time.time()
     await register_heartbeat(
         db,

--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -15,7 +15,6 @@ _ACTIVE_CONNECTIONS: int = 0
 
 
 def get_active_connection_count() -> int:
-    """Return the number of currently open aiosqlite connections."""
     return _ACTIVE_CONNECTIONS
 
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -122,14 +122,11 @@ def process_liveness(
     artifacts_path: Path | None,
     ps_snapshot: str | None = None,
 ) -> bool | None:
-    """Tri-state process liveness for a running session.
-
-    True = observed alive; False = confirmed dead (a recorded pid that is no
-    longer running, with start-time verification when one was recorded);
-    None = unknown (no recorded pid and no process match — normal for
-    externally-driven sessions that expose no matchable pid). Limitation:
-    a bare recycled pid (no recorded start time) reads alive — rare, and it
-    fails toward treating the session as live rather than falsely dead.
+    """Tri-state process liveness for a running session: True = observed alive;
+    False = confirmed dead (recorded pid no longer running, start-time verified
+    when recorded); None = unknown (no recorded pid, no process match — normal
+    for externally-driven sessions). Limitation: a bare recycled pid with no
+    recorded start time reads alive, failing toward live rather than falsely dead.
     """
     pid: int | None = None
     create_time: float | None = None
@@ -662,12 +659,8 @@ async def prune_sessions(session_ids: list[str]) -> int:
 
 
 async def prune_phantom_sessions(*, stale_hours: float = 1.0) -> int:
-    """Transition phantom sessions to 'failed' via the sanctioned status path.
-
-    Session rows are preserved so reason history and artifacts remain
-    inspectable. Delegates to :func:`reap_phantom_sessions` from the
-    lifecycle service.
-    """
+    """Transition phantom sessions to 'failed' via the sanctioned status path;
+    rows are preserved so reason history and artifacts stay inspectable."""
     from lionagi.studio.services.lifecycle import reap_phantom_sessions
 
     return await reap_phantom_sessions(stale_hours=stale_hours, actor="admin_prune")
@@ -758,11 +751,8 @@ async def prune_old_data_route(body: PruneOldDataBody) -> dict[str, int]:
     name="run_maintenance",
 )
 async def run_maintenance_route(body: MaintenanceBody) -> dict[str, Any]:
-    """Run a DB maintenance action (vacuum | checkpoint | prune).
-
-    Returns 409 when SQLite cannot acquire the write lock (busy/locked); this is
-    intentional policy so the operator sees a retryable error instead of a generic 500.
-    """
+    """Run a DB maintenance action (vacuum | checkpoint | prune). Returns 409,
+    not 500, when SQLite can't acquire the write lock — a retryable signal."""
     from ..services.db_maintenance import (
         checkpoint_state_db,
         prune_old_data,

--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -4,29 +4,21 @@
 
 An action is proposed (pending) -> a human grants or denies it -> the real
 endpoint consumes the granted approval exactly once. Expiry and single-use
-are enforced here, not by the caller's convention: a granted approval that
-is expired, already consumed, or whose params don't hash-match the action
-being executed is rejected.
+are enforced here, not by caller convention: a granted approval that is
+expired, already consumed, or whose params don't hash-match the action being
+executed is rejected.
 
-Principal separation (grant/deny only): these two routes require the
-request to carry no operator/service principal marker. The studio frontend
-never sends that header (see api.ts fetchJson -- only Authorization and
-Content-Type are set), so a legitimate browser confirm click always passes.
-Any caller presenting the marker -- including a future in-process operator
-service context or a spawned driver CLI that learned an approval id -- is
-rejected before the row is touched. The marker is additive to the existing
-bearer-token gate, not a replacement for it.
+Principal separation (grant/deny only): a request carrying the
+operator/service principal marker header is rejected before the row is
+touched -- the studio frontend never sends that header, so a legitimate
+browser confirm click always passes. Additive to the bearer-token gate, not
+a replacement for it.
 
-Evidence chain: every lifecycle event (proposed/granted/denied/consumed/
-expired) appends a row to `approval_evidence` in the same transaction as the
-status change, hash-chained to the prior row (chain_hash = sha256(content_hash
-+ previous_hash), genesis previous_hash = "0"*64). Evidence rows store hashes,
-kinds, statuses, timestamps, and justification only -- never raw params (the
-approvals row already holds the params_hash; raw params never enter the
-chain). Optional HMAC-SHA256 signing over the chain is OFF by default; set
-LIONAGI_STUDIO_EVIDENCE_HMAC_KEY to turn it on -- without a key, the chain
-still detects tampering, it just doesn't require possession of a secret to
-forge (chain-only integrity vs. chain+key integrity).
+Evidence chain: every lifecycle event appends a hash-chained row to
+`approval_evidence` in the same transaction as the status change
+(chain_hash = sha256(content_hash + previous_hash), genesis = "0"*64).
+Evidence rows never store raw params. Optional HMAC-SHA256 signing is OFF by
+default; set LIONAGI_STUDIO_EVIDENCE_HMAC_KEY to turn it on.
 """
 
 from __future__ import annotations
@@ -142,12 +134,9 @@ def _is_service_principal(request: Request) -> bool:
 
 
 def _require_human_principal(request: Request) -> None:
-    """Grant/deny are reserved for the human principal: the browser session's
-    bearer credential. Enforced positively — the caller must PRESENT the
-    configured token — not by trusting callers to identify themselves. With no
-    token configured there is no human credential to distinguish, so granting
-    is unavailable entirely (fail closed) rather than open to any local caller.
-    The service-marker header check stays as defense in depth."""
+    """Grant/deny require the caller to PRESENT the configured bearer token. With
+    no token configured, granting is unavailable entirely (fail closed) rather
+    than open to any local caller."""
     if _is_service_principal(request):
         raise HTTPException(
             status_code=403,
@@ -209,13 +198,10 @@ async def _write_evidence(
     justification_class: str | None = None,
     justification_reason: str | None = None,
 ) -> dict[str, Any]:
-    """Append one evidence row to the chain.
-
-    Caller MUST already hold the write lock on *db* (e.g. via a preceding
-    `BEGIN IMMEDIATE` on this same connection, in the same transaction as the
-    approvals status change) so the tail read below is race-free -- this
-    function does not open its own transaction.
-    """
+    """Append one evidence row to the chain. Caller MUST already hold the write
+    lock on *db* (a preceding `BEGIN IMMEDIATE` in the same transaction as the
+    approvals status change) so the tail read is race-free -- this function
+    does not open its own transaction."""
     cur = await db.execute(
         "SELECT sequence, chain_hash FROM approval_evidence ORDER BY sequence DESC LIMIT 1"
     )
@@ -498,13 +484,12 @@ async def deny_approval(
 async def require_approval(
     approval_id: str, *, action_kind: str, params: dict[str, Any]
 ) -> dict[str, Any]:
-    """Validate a granted approval for exactly this action and consume it atomically.
-
-    Not wired into any route yet -- a future mutating route calls this before
-    performing its side effect, passing the same action_kind/params it is
-    about to act on. Raises HTTPException (404/409/422) on any failure; the
-    approval is consumed only when every check passes.
-    """
+    """Validate a granted approval for exactly this action and consume it
+    atomically. Not wired into any route yet -- a future mutating route calls
+    this before performing its side effect, passing the same
+    action_kind/params it is about to act on. Raises HTTPException
+    (404/409/422) on any failure; the approval is consumed only when every
+    check passes."""
     row = await get_approval(approval_id)
     if row is None:
         raise HTTPException(status_code=404, detail=f"approval {approval_id!r} not found")

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -207,10 +207,8 @@ async def save_definition(
 ) -> dict[str, Any]:
     """Persist a definition version: DB write first, then disk (ADR-0016 §"Save semantics").
 
-    DB write must succeed before the file is written — propagate any exception
-    rather than returning success without a row.  Per-(kind, name) asyncio.Lock
-    spans both operations so concurrent saves for the same definition are
-    serialised.  Returns the new version info.
+    DB write must succeed before the file is written; per-(kind, name) lock
+    serialises concurrent saves for the same definition.
     """
     # Validate at the service boundary — reject traversal sequences, path
     # separators, NUL, and glob metacharacters.
@@ -330,12 +328,10 @@ _EXTENSIONS = (".md", ".playbook.yaml", ".yaml")
 def _find_definition_file(base: Path, name: str) -> Path | None:
     """Locate the on-disk file for a definition.
 
-    ``name`` MUST be pre-validated by ``validate_name_component`` (callers'
-    responsibility).  Candidates are literal-path joins — not glob patterns —
-    so metacharacters in *name* cannot expand across the filesystem.  Symlinks
-    may target outside ``base`` (e.g. ``~/.lionagi/agents/*.md`` → ``firm/agents/``);
-    we intentionally do not resolve-and-restrict, as that breaks every symlinked
-    agent definition.
+    ``name`` must be pre-validated by ``validate_name_component``. Candidates
+    are literal-path joins, not glob patterns. Symlinks outside ``base`` are
+    intentionally left unresolved-and-unrestricted — restricting them would
+    break symlinked agent definitions.
     """
     # Fast path 1: direct child (base/<name><ext>)
     for ext in _EXTENSIONS:

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -150,7 +150,6 @@ def build_branch() -> Any:
 
 
 def _all_tools() -> list:
-    """Return all Leo tool callables."""
     return [
         tool_list_runs,
         tool_list_invocations,

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -33,11 +33,9 @@ _REAPABLE_PLAY_STATUSES = frozenset({"running", "running_complete", "prepared", 
 
 
 def _deadline_for_kind(action_kind: str | None, global_default: int) -> int:
-    """Resolve the effective deadline for an invocation's action_kind.
-
-    Checks ``LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS`` first;
-    falls back to *global_default* when the env var is absent or the kind
-    is None.
+    """Resolve the effective deadline: checks
+    ``LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS`` first, falling back
+    to *global_default* when absent or *action_kind* is None.
     """
     if action_kind:
         env_key = f"LIONAGI_STUDIO_INVOCATION_DEADLINE_{action_kind.upper()}_SECONDS"

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -189,12 +189,9 @@ def get_builtin_playbook(name: str) -> dict[str, Any] | None:
 
 
 def install_builtin_playbook(name: str) -> dict[str, Any]:
-    """Idempotently materialize a built-in template into the user's own
-    playbooks directory (``~/.lionagi/playbooks``), so it becomes a normal,
-    user-editable playbook and ``li play <name>`` can find it.
-
-    A no-op (``installed: False``) when the destination already exists —
-    this never clobbers a playbook the user has since customized.
+    """Idempotently copy a built-in template into ``~/.lionagi/playbooks`` so
+    it becomes a normal, user-editable playbook ``li play <name>`` can find.
+    No-op (``installed: False``) when the destination already exists.
     """
     stem = name.removesuffix(".playbook.yaml").removesuffix(".yaml")
     safe_path_join(_BUILTIN_PLAYBOOKS_ROOT, f"{stem}.playbook.yaml")

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -154,11 +154,7 @@ def _plugin_detail(
 
 
 def _resolve_marketplace_source(source_rel: str) -> Path | None:
-    """Resolve a marketplace manifest source path, rejecting escape attempts.
-
-    Rejects empty, absolute, parent-traversal, and symlink-escaped paths so
-    a malicious marketplace.json cannot reference files outside the repo.
-    """
+    """Resolve a marketplace manifest source path; None if it escapes the repo."""
     if not source_rel:
         return None
     source_path = Path(source_rel)
@@ -208,8 +204,8 @@ def _find_plugin_dir_for(name: str) -> Path | None:
 def _iter_thirdparty_plugins() -> list[tuple[Path, str, str, str]]:
     """Return (plugin_dir, name, description, marketplace_name) for installed plugins.
 
-    Layout: ~/.claude/plugins/cache/{marketplace}/{plugin_name}/{version}/
-    Takes the lexicographically latest version directory per plugin.
+    Layout: ~/.claude/plugins/cache/{marketplace}/{plugin_name}/{version}/ —
+    takes the lexicographically latest version directory per plugin.
     """
     if not THIRDPARTY_DIR.exists():
         return []

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -448,11 +448,10 @@ def _session_liveness(s: dict[str, Any], ps_snapshot: str | None = None) -> bool
 
 
 def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None) -> dict[str, Any]:
-    """The canonical Run row shape. Shared by the list and detail routes so the
-    two can never drift out of contract (the detail route used to drop fields the
-    list route emits, e.g. invocation_id). Caller supplies a session dict carrying
+    """The canonical Run row shape, shared by list and detail routes so they
+    can't drift out of contract. Caller supplies a session dict carrying
     branch_count / message_count / last_message_at, plus tri-state process
-    liveness (None = unknown) so a process-dead run cannot render as healthy.
+    liveness (None = unknown) so a process-dead run can't render as healthy.
     """
     from lionagi.state.health import classify_session_health
 
@@ -568,14 +567,13 @@ async def get_run(
     message_limit: int = _sessions_svc.DEFAULT_MESSAGE_LIMIT,
     message_cursor: str | None = None,
 ) -> dict[str, Any] | None:
-    """Return run detail from StateDB; flat-file run.json path was removed (write_manifest had zero callers).
+    """Run detail from StateDB (flat-file run.json path removed, no callers).
 
-    The response is a superset of the list Run row (via _run_row) plus detail-only
-    fields. get_session() omits the JOIN aggregates (branch_count / message_count),
-    so they are derived from the hydrated branches here; last_message_at is read
-    straight from get_session()'s session-table aggregate.
-    Fields absent from DB (state_root, artifact_root, task, error, cwd, manifest)
-    return None/""/{} to keep the frontend contract unchanged.
+    Superset of the list Run row (via _run_row) plus detail-only fields.
+    branch_count / message_count are derived here since get_session() omits
+    those JOIN aggregates. Fields absent from DB (state_root, artifact_root,
+    task, error, cwd, manifest) return None/""/{} to keep the frontend
+    contract unchanged.
     """
     session = await _sessions_svc.get_session(
         run_id, message_limit=message_limit, message_cursor=message_cursor
@@ -666,16 +664,13 @@ async def get_run(
 def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
     """Build a steps list from DB-hydrated branch dicts.
 
-    `messages` on each branch is a tail-windowed display page; `message_count`
-    and `roles` must reflect the full branch progression, so they are read
-    from the branch's full-session `message_stats` (falling back to
-    `message_total` and finally the windowed page length for legacy payloads
-    that predate message_stats).
-
-    The `message_stats.message_count` fallback is KEY-PRESENCE based, not
-    truthiness based: a stale progression referencing pruned/never-persisted
-    message ids legitimately aggregates to 0, and `0 or fallback` would
-    silently replace that correct zero with the (wrong) progression length.
+    `messages` per branch is a tail-windowed display page; `message_count`/
+    `roles` are read from the branch's full-session `message_stats` instead
+    (falling back to `message_total`, then windowed page length, for legacy
+    payloads predating message_stats). The `message_stats.message_count`
+    check is KEY-PRESENCE based, not truthiness: a legitimate 0 (stale
+    progression referencing pruned message ids) must not fall through to
+    `0 or fallback`, which would replace it with the wrong count.
     """
     if not branches:
         return None

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -253,12 +253,8 @@ def _window_message_ids(
     cursor_anchors: dict[str, str] | None,
     legacy_offset: int,
 ) -> tuple[list[str], bool, str | None]:
-    """Return (window_ids, has_older, next_anchor) for one branch's progression.
-
-    `cursor_anchors` is None when the caller passed no message_cursor at all; an
-    empty-of-this-branch cursor (branch id absent from the map) means the prior
-    page already reached this branch's oldest message, so it yields nothing more.
-    """
+    """Return (window_ids, has_older, next_anchor); cursor_anchors=None means no
+    cursor was passed, an anchor-less branch entry means that branch is exhausted."""
     if cursor_anchors is not None:
         anchor = cursor_anchors.get(branch_id)
         if anchor is None:
@@ -282,13 +278,8 @@ def _window_message_ids(
 
 
 def _short_lion_class(lion_class: str) -> str:
-    """Strip a fully-qualified lion_class path down to its bare class name.
-
-    Persisted rows carry the canonical dotted path (see message_types seed data
-    in state/schema.sql), e.g. 'lionagi.protocols.messages.action_request.ActionRequest';
-    older/legacy rows may carry just 'ActionRequest'. Compare on the short form so both
-    shapes match.
-    """
+    """Strip a fully-qualified lion_class path to its bare class name, so legacy
+    short-name rows and canonical dotted-path rows compare equal."""
     return lion_class.rsplit(".", 1)[-1] if lion_class else lion_class
 
 
@@ -359,13 +350,8 @@ async def _fetch_role_counts(db: aiosqlite.Connection, msg_ids: list[str]) -> di
 async def _fetch_action_messages(
     db: aiosqlite.Connection, msg_ids: list[str]
 ) -> list[dict[str, Any]]:
-    """Hydrate only the ActionRequest/ActionResponse rows among msg_ids, in progression order.
-
-    Tool/error/file aggregates only ever need these two message kinds; skipping every
-    other message keeps the full-session aggregate pass cheap regardless of session size.
-    Matches both the canonical fully-qualified lion_class paths persisted by the runtime
-    (state/schema.sql message_types seed) and legacy short-name values.
-    """
+    """Hydrate only the ActionRequest/ActionResponse rows among msg_ids, in progression
+    order — the only kinds tool/error/file aggregates need, keeping the pass cheap."""
     if not msg_ids:
         return []
     class_placeholders = ",".join("?" for _ in _ACTION_LION_CLASSES)
@@ -407,11 +393,7 @@ def _branch_message_stats(
     roles: dict[str, int],
     action_messages: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Full-branch stats computed over the full progression, never a display window.
-
-    `message_count`/`roles` come from SQL aggregates; `action_messages` holds only the
-    ActionRequest/ActionResponse rows, since tool/error/file summaries never need anything else.
-    """
+    """Full-branch stats over the full progression, never a display window."""
     from .runs import _detect_status
 
     response_by_id: dict[str, dict[str, Any]] = {

--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -103,12 +103,8 @@ async def _list_shows_db() -> list[dict[str, Any]]:
             "path": public_path(Path(row["show_dir"])),
             "play_count": row["play_count"],
             "latest_status": row["status"],
-            # ADR-0011 §"Show status provenance": status_source field.
-            # The status_source column is defined in ADR-0011's schema block but
-            # is absent from the current schema.sql (deferred migration — tracked
-            # separately; adding it requires ALTER TABLE and a backfill pass that
-            # is out of scope for this fix PR).  We derive it in code: db-loaded
-            # rows get "sqlite", filesystem fallback rows get "filesystem".
+            # ADR-0011: status_source is derived in code, not a DB column
+            # (schema migration deferred). db rows -> "sqlite".
             "status_source": "sqlite",
             "last_update": row["latest_play_update"] or row["updated_at"],
             "goal": row["goal"],
@@ -242,9 +238,7 @@ async def get_show(topic: str) -> dict[str, Any] | None:
     else:
         plays = []
 
-    # ADR-0011 §"Show status provenance": status_source mirrors the
-    # derivation in list_shows() — "sqlite" when the row came from the DB,
-    # "filesystem" for filesystem fallback (show_row is None).
+    # ADR-0011: same status_source derivation as list_shows().
     status_source = "sqlite" if show_row else "filesystem"
 
     return {
@@ -533,9 +527,8 @@ _SHOW_DONE_STABLE_SECS = 60.0
 async def watch_show(topic: str) -> AsyncGenerator[str]:
     """SSE stream of file changes under a show directory.
 
-    ADR-0006 reconnect semantics: emits ``{"type":"done"}`` when the show is
-    terminal (completed or aborted) AND no file has changed for 60 seconds.
-    Emits done immediately when the show directory does not exist (Docker deployments).
+    ADR-0006: emits ``{"type":"done"}`` once the show is terminal and stable
+    for 60s, or immediately if the show directory doesn't exist.
     """
     try:
         topic_dir = safe_join(SHOWS_ROOT, topic)
@@ -596,10 +589,9 @@ async def list_shows_route() -> list[dict[str, Any]]:
     return await list_shows()
 
 
-# ADR-0011 §"Migration": import_shows is a state-mutating operation
-# (INSERT OR IGNORE into shows + plays); it must use POST, not GET.
-# ADR-0011 specifies this as a CLI maintenance command (`li state import-shows`).
-# The POST endpoint is retained as a Studio convenience trigger.
+# ADR-0011: state-mutating (INSERT OR IGNORE), so POST not GET. The CLI
+# maintenance command (`li state import-shows`) is canonical; this route is
+# a Studio convenience trigger.
 @studio_route(
     "/shows/import", method="POST", area="shows", tags=["shows", "shows"], name="import_shows"
 )

--- a/lionagi/studio/services/task_applications.py
+++ b/lionagi/studio/services/task_applications.py
@@ -98,12 +98,9 @@ def _validate(app: TaskApplication) -> str:
 
 
 def _derive_concurrency_key(required_capabilities: list[str]) -> str | None:
-    """D4's host-scoped rule: only the serialization-class tokens among
-    *required_capabilities* (capabilities.py's declarative token->class map)
-    fold into a concurrency_key scoped to this host, so ADR-0061 admission
-    serializes same-host claims for that resource. Eligibility and affinity
-    tokens never gate concurrency: an eligibility-only or affinity-only task
-    gets no concurrency_key at all.
+    """D4's host-scoped rule: only serialization-class tokens (per
+    capabilities.py's token->class map) fold into a host-scoped
+    concurrency_key. Eligibility/affinity-only tasks get no concurrency_key.
     """
     return capabilities.host_scoped_concurrency_key(socket.gethostname(), required_capabilities)
 

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -135,11 +135,8 @@ def _validate_node(node: ast.AST) -> None:
 def _resolve_node_cwd(node_id: str, raw_cwd: Any, base_dir: str | None) -> str:
     """Resolve and contain a node's config.cwd against the run's base_dir.
 
-    Order matters: the raw-string traversal check runs before any path
-    resolution (so a hostile '..' segment is rejected even when base_dir is
-    absent), symlinks are resolved before the containment check (so a
-    contained-looking path that resolves outside base_dir through a symlink
-    is caught), and the resolved directory must actually exist.
+    Order matters: raw-string traversal check before path resolution, then
+    symlink resolution before the containment check, then existence check.
     """
     if not isinstance(raw_cwd, str) or not raw_cwd:
         raise WorkflowCompileError(
@@ -575,10 +572,8 @@ def build_early_graph(spec: dict[str, Any]) -> dict[str, Any]:
 def _derive_engine_input(context: dict[str, Any] | None) -> str:
     """Heuristic mapping from upstream flow context to an engine's main positional input.
 
-    Prefers an upstream predecessor's textual result (the ``{pred_id}_result``
-    keys `_prepare_operation` injects); falls back to the flow-level inputs.
-    Underspecified in the spec (WorkflowEngineConfig has no explicit prompt/
-    input-mapping field) — this is the compile-time call made for v1.
+    Prefers an upstream predecessor's textual result (``{pred_id}_result``
+    keys), falling back to flow-level inputs.
     """
     if not context:
         return ""

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Run a compiled WorkflowDef through lionagi's Session.flow, persisted like any other run.
 
-Deliberately does NOT reuse `lionagi.cli.orchestrate._orchestration.setup_orchestration_persist`
-/ `teardown_persist` verbatim: those helpers open the connection via
-`register_shared_db()`/`close_shared_db()`, a PROCESS-WIDE singleton meant for one-shot CLI
-processes that open it once and exit. The Studio server is long-lived and can have several
-workflow runs (or other StateDB users) in flight at once; teardown_persist's finally block
-closing the *entire* shared registry would tear down every concurrent run's connection, not
-just this one. This module opens and closes its own request-scoped StateDB connection instead,
-while still reusing the session-row/branch-hook/teardown-reason logic those helpers are built on.
+Deliberately does NOT reuse `_orchestration.setup_orchestration_persist`/`teardown_persist`
+verbatim: those helpers close a PROCESS-WIDE shared StateDB singleton meant for one-shot CLI
+processes, but the Studio server is long-lived with several runs in flight at once -- closing
+the shared registry would tear down every concurrent run's connection. This module opens and
+closes its own request-scoped StateDB connection instead, reusing only the session-row/
+branch-hook/teardown-reason logic those helpers are built on.
 """
 
 from __future__ import annotations
@@ -122,19 +120,14 @@ async def run_workflow_def(
 ) -> dict[str, Any]:
     """Load, compile, and execute a WorkflowDef; return ``{run_id, status}``.
 
-    ``run_id`` is the lionagi Session id — the same primary key GET
-    /api/sessions/{id} and the Fleet/History list already read, so the run
-    shows up exactly like any other flow run. Raises WorkflowNotFoundError
-    (404) or WorkflowCompileError (422, carries node_id/edge_id) on failure
-    to compile; never a bare 500 for those two cases.
+    ``run_id`` is the lionagi Session id, so the run shows up like any other
+    flow run via GET /api/sessions/{id}. Raises WorkflowNotFoundError (404)
+    or WorkflowCompileError (422, carries node_id/edge_id) on compile
+    failure -- never a bare 500 for those two cases.
 
     ``base_dir`` is a run-level containment root for node ``config.cwd``
-    values (never a spec field — see compile_workflow_def). A node with no
-    cwd runs unaffected whether or not base_dir is supplied.
-
-    ``_session`` is a private testability seam (inject a Session with a
-    mocked default branch to avoid real provider calls in tests); real
-    callers (the run route) never pass it and get a fresh Session().
+    values (never a spec field). ``_session`` is a private testability seam
+    (inject a Session with a mocked branch); real callers never pass it.
     """
     from lionagi.session.session import Session
 


### PR DESCRIPTION
Round-2 docstring pass of the comment-hygiene sweep: ~60 docstrings condensed across 19 studio backend files (route handlers, scheduler, services). Docstring-only — AST verified identical after docstring strip. 893 studio server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)