### PR TITLE
chore: condense docstrings in cli, tools, and engines

### DIFF
--- a/lionagi/_class_registry.py
+++ b/lionagi/_class_registry.py
@@ -41,12 +41,9 @@ __all__ = (
 
 
 def get_class(class_name: str) -> type:
-    """Retrieve a class by name.
-
-    Resolution order: LION_CLASS_REGISTRY lookup (fully-qualified name) ->
-    dotted-path import (any importable "module.Class" string) -> legacy
-    short-name lookup among the built-in modules (for data persisted before
-    the full-qualified-name convention). Raises ValueError if not found.
+    """Retrieve a class by name: LION_CLASS_REGISTRY lookup (fully-qualified
+    name), then dotted-path import, then legacy short-name lookup among the
+    built-in modules. Raises ValueError if not found.
     """
     if class_name in LION_CLASS_REGISTRY:
         return LION_CLASS_REGISTRY[class_name]

--- a/lionagi/cli/_context_from.py
+++ b/lionagi/cli/_context_from.py
@@ -306,25 +306,17 @@ _BLOCK_SEPARATOR = "\n\n"
 def build_context_block(candidates: Sequence[ContextCandidate], budget_tokens: int) -> str:
     """Assemble the XML-delimited context block(s), argv order, total-not-per-ref budget.
 
-    The budget bounds the COMBINED injected block, including the XML wrapper
-    (open/close tags) and the inter-block separator — not just the distilled
-    payload text. Wrapper + loud-marker overhead is reserved FIRST, in argv
-    order, before the remaining budget is handed to the distillation ladder
-    for payload text.
+    `budget_tokens` bounds the COMBINED injected block (XML wrapper +
+    separators included, not just distilled payload text); wrapper/marker
+    overhead is reserved first, in argv order, before payload text.
 
-    A single ref always yields at least one loud-marker-only block (never an
-    empty result) even at a budget too tight to fit it, including
-    `budget_tokens == 0` (an explicit "marker only, no payload" request, not
-    "no budget passed"): there is nothing left to drop it in favor of, and a
-    silently-missing context block is worse than a slightly over-budget loud
-    marker for the one ref the caller asked for.
-
-    With multiple refs, the total budget is a hard ceiling: wrapper +
-    separator + minimum loud-marker overhead is reserved for each ref, in
-    argv order, and any ref (and all after it, since the reserved budget only
-    shrinks) that cannot fit even that minimum is dropped entirely rather
-    than pushing the combined block over budget. If even the first ref
-    cannot fit, injection is skipped entirely (no block at all).
+    A single ref always yields at least one loud-marker-only block, even at
+    `budget_tokens == 0` — a slightly over-budget marker beats silently
+    dropping the one ref the caller asked for. With multiple refs, the total
+    budget is a hard ceiling: any ref that can't fit even its minimum
+    marker overhead is dropped (and everything after it, since the reserved
+    budget only shrinks). If even the first ref can't fit, injection is
+    skipped entirely.
     """
     from lionagi.cli._logging import warn
 

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -93,13 +93,11 @@ class _FileState:
 class _Lineage:
     """Cross-session conversation-lineage detector, kept across poll passes.
 
-    A continued conversation (after compaction, ``--resume``, or a new window that
-    resumes an earlier thread) opens a fresh transcript whose first message points
-    — via ``parentUuid`` — at the last message of the session it continues. We
-    index each file's current leaf uuid and, when a file's root parent resolves to
-    a *different* session's leaf, record a provenance link. It almost never fires
-    on today's transcripts (continuations are rare), so it is insurance + the
-    substrate for showing conversation provenance, not a hot path.
+    A continued conversation opens a fresh transcript whose first message
+    points — via ``parentUuid`` — at the last message of the session it
+    continues. Indexes each file's current leaf uuid and, when a file's
+    root parent resolves to a different session's leaf, records a
+    provenance link.
     """
 
     leaf_owner: dict[str, str] = field(default_factory=dict)  # event uuid -> session_uid

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -182,11 +182,9 @@ async def _query_active_shows(
 ) -> list[dict[str, Any]]:
     """Active only by default; with since, all statuses in the window.
 
-    Unlike sessions and plays, `repo` on a show is a filesystem path (or a
-    path with a trailing remote annotation) copied verbatim from the play's
-    `_show.md`, not a project slug — so it cannot be matched against
-    `--project` in SQL. Project-scoping for shows happens in Python, in
-    _gather_table_rows, via the same detect_project() cascade sessions use.
+    `repo` on a show is a filesystem path, not a project slug, so it can't
+    be matched against `--project` in SQL — that scoping happens in Python
+    (_gather_table_rows) via detect_project().
     """
     query = "SELECT * FROM shows WHERE 1=1"  # noqa: S608
     params: list[Any] = []
@@ -208,10 +206,8 @@ async def _query_running_plays(
 ) -> list[dict[str, Any]]:
     """In-flight statuses only by default; with since, all statuses in the window.
 
-    The plays table has no project column, so project-scoping matches
-    against the project of the play's linked session (session_id) — the
-    same source of truth _query_running_sessions filters on. A play with
-    no linked session has no project to match and is excluded.
+    Plays have no project column; project-scoping joins through the
+    linked session (session_id). A play with no linked session is excluded.
     """
     query = (
         "SELECT plays.*, "  # noqa: S608
@@ -303,10 +299,7 @@ def _trunc(s: str, n: int) -> str:
 
 
 def _stdout_is_tty() -> bool:
-    """Evaluated at call time (not cached at import time) so a render
-    still reflects the actual stdout of the process at that moment —
-    e.g. stdout redirected after import, or a module imported once and
-    reused across both TTY and piped invocations."""
+    """Evaluated at call time, not cached, so it reflects stdout redirection after import."""
     return sys.stdout.isatty()
 
 
@@ -321,16 +314,10 @@ _NON_TTY_MAX_COL_WIDTH = 200
 
 
 def _format_table(rows: list[dict[str, Any]]) -> str:
-    """Render a table of entity rows.
+    """Render a table of entity rows (keys: id, type, project, status, phase, elapsed, agents).
 
-    Expected keys per row: id, type, project, status, phase, elapsed, agents.
-
-    On a TTY, identifying columns (id, project, phase) are truncated to
-    fixed widths for a compact dashboard. Piped/redirected output (not a
-    TTY — e.g. `li monitor | grep`) never truncates: columns widen to fit
-    the longest value (up to _NON_TTY_MAX_COL_WIDTH) so a grep against a
-    project name or id can never false-negative on a value cut short by a
-    fixed column width.
+    On a TTY, identifying columns truncate to fixed widths. Piped output
+    never truncates, so grep against a project name or id can't false-negative.
     """
     if not rows:
         return _dim("(no running entities)")
@@ -500,13 +487,7 @@ async def _fetch_branches(db: Any, session_id: str) -> list[dict[str, Any]]:
 
 
 def _render_branch_lines(rows: list[dict[str, Any]], *, indent: str = "  ") -> list[str]:
-    """One line per branch (agent leg) — orchestration engines like `li o
-    flow` (which `li play` compiles to) name each branch after its role
-    (e.g. "reviewer", "claude-code") and update its status/timestamps as
-    the leg runs (see flow.py's _update_branch_status). Surfacing that
-    here makes sub-step transitions poll-visible via `li monitor <id>`
-    without any new tracking mechanism.
-    """
+    """One line per branch (agent leg), named after its role (e.g. "reviewer")."""
     if not rows:
         return []
     lines = [_dim(f"{indent}-- branches --")]
@@ -717,20 +698,15 @@ _TRAILING_ANNOTATION_RE = re.compile(r"\s*\([^)]*\)\s*$")
 
 @cache
 def _cached_detect_project(repo: str) -> tuple[str | None, str | None]:
-    """Cache detect_project() results by bare repo path — the derivation is
-    stable for the lifetime of a monitor process, and this is called per
-    active show per render tick under --watch."""
+    """Cache detect_project() results by bare repo path (stable per monitor process)."""
     return detect_project(Path(repo))
 
 
 def _show_project_matches(show: dict[str, Any], project: str) -> bool:
-    """A show's `repo` column is a filesystem path (sometimes with a
-    trailing remote annotation), not a project slug, so it cannot be
-    compared to `--project` directly — derive its slug via the same
-    detect_project() cascade sessions use and compare that. A show with a
-    missing, empty, or unresolvable repo path derives (None, None) and is
-    excluded under --project — the same orphan semantics as a play with no
-    linked session.
+    """A show's `repo` is a filesystem path, not a project slug — derive its
+    slug via detect_project() and compare. A missing/unresolvable repo path
+    excludes the show under --project (same orphan semantics as a play with
+    no linked session).
     """
     repo = show.get("repo")
     if not repo:
@@ -862,9 +838,8 @@ def _watch_loop(
 ) -> int:
     """Repeatedly clear screen and reprint; exit cleanly on SIGINT/SIGTERM.
 
-    The since cutoff is re-derived from the window string every tick so the
-    window slides with the clock; a cutoff frozen at launch would accumulate
-    terminal rows for the life of the watch.
+    The since cutoff is re-derived every tick so the window slides with the
+    clock instead of accumulating rows for the life of the watch.
     """
     from lionagi.ln.concurrency import run_async
 
@@ -935,9 +910,7 @@ _MAX_CHAIN_DEPTH = 10
 
 
 def _split_watched_ids(raw: list[str]) -> list[str]:
-    """Flatten comma-separated and/or space-separated id tokens into one
-    ordered, deduped list — `li monitor run a,b` and `li monitor run a b`
-    (and any mix) must resolve identically."""
+    """Flatten comma/space-separated id tokens into one ordered, deduped list."""
     seen: dict[str, None] = {}
     for token in raw:
         for piece in token.split(","):
@@ -948,10 +921,8 @@ def _split_watched_ids(raw: list[str]) -> list[str]:
 
 
 async def _resolve_schedule_run(db: Any, raw_id: str) -> dict[str, Any] | None:
-    """Exact match then prefix match, mirroring _find_entity's convention.
-    schedule_run ids are 12-char hex (uuid4().hex[:12]), not 36-char UUIDs,
-    so the length-36 prefix heuristic used elsewhere in this codebase
-    (resolve_entity in _util.py) does not apply here.
+    """Exact match then prefix match. schedule_run ids are 12-char hex, not
+    36-char UUIDs, so _util.py's length-36 prefix heuristic doesn't apply.
     """
     row = await db.get_schedule_run(raw_id)
     if row:
@@ -980,25 +951,12 @@ def _format_session_wait_line(row: dict[str, Any]) -> str:
 
 
 async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, Any]:
-    """A profile-typed session (`li agent -a <profile>`) that teardown linked to a
-    claude/codex-mirror engine session (node_metadata.linked_engine_session_id, see
-    lionagi/cli/_runs.py) can be pinned at status="running" indefinitely once teardown
-    observed the engine alive but couldn't yet confirm a terminal state — nothing
-    later revisits that row to flip it. The linked engine row is the ground truth for
-    completion, so follow it here on every poll rather than trusting the profile row's
-    own (possibly stale) status column.
-
-    When the linked row has reached a terminal status, PERSIST that status onto the
-    profile row through StateDB.update_status() (CAS-guarded on the status this call
-    just read) before returning — otherwise the synthesized in-memory value here is
-    the only place the reconciliation ever lands, and the DB row itself stays stuck
-    at "running" forever even after this function reports the true terminal status.
-
-    A profile row that is ALREADY terminal is authoritative and is never rewritten:
-    ADR-0094's terminal guard exists precisely to stop a persisted terminal status
-    (e.g. "failed") from being silently flipped to a different terminal status the
-    linked engine happens to report later (e.g. "completed"). Reconciliation only
-    ever advances a non-terminal profile row to the engine's terminal status.
+    """Reconcile a profile session's status against its linked engine session
+    (node_metadata.linked_engine_session_id), which can otherwise stay pinned
+    at "running" forever after teardown. When the linked row is terminal,
+    persists that status onto the profile row via CAS-guarded update_status()
+    so the DB reflects it, not just the return value. An already-terminal
+    profile row is authoritative and never rewritten (ADR-0094 terminal guard).
     """
     from lionagi.state.db import SESSION_TERMINAL_STATUSES, TransitionRejectedError
     from lionagi.state.reasons import RunReasons
@@ -1083,15 +1041,10 @@ async def _poll_pending_sessions_once(
 async def _resolve_watched_runs(
     db: Any, ids: list[str]
 ) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
-    """Resolve every requested id once, up front. schedule_run ids are
-    already-fired-run identifiers a caller obtained elsewhere (e.g. `li
-    schedule trigger`), not something that might come into existence later,
-    so — unlike the --follow discovery scan below — resolution itself is
-    not retried on every poll tick.
-
-    An id that isn't a schedule_run is also tried against the sessions table
-    (agent/li agent run ids) so `li monitor run <session_id>` can drill into
-    an agent run's terminal status + artifacts, not just scheduler runs.
+    """Resolve every requested id once, up front (not retried per poll tick,
+    unlike the --follow discovery scan below). Ids that aren't schedule_runs
+    are also tried against sessions, so `li monitor run <session_id>` can
+    drill into an agent run, not just scheduler runs.
     """
     pending: dict[str, dict[str, Any]] = {}
     session_pending: dict[str, dict[str, Any]] = {}
@@ -1132,22 +1085,13 @@ async def _poll_pending_once(
     done: list[dict[str, Any]],
 ) -> None:
     """Check every still-pending run once; print, record into `done`, and
-    drop from `pending` any that are now terminal. Printing happens
-    immediately per row, not batched, so a harness tailing stdout sees each
-    result the moment it lands rather than waiting for the whole watched
-    set to finish.
+    drop from `pending` any that are now terminal. Prints immediately per
+    row (not batched) so a harness tailing stdout sees each result as it lands.
 
-    `done` is mutated in place rather than returned: a coroutine only ever
-    suspends at an `await`, and there is no `await` between the print/
-    append/delete below, so that trio is atomic with respect to task
-    cancellation — a row can never leave `pending` without also landing in
-    `done`, even if the caller (run_async, see _dispatch_wait) discards
-    this coroutine's actual return value because a SIGINT raced its
-    completion.
-
-    This is the primitive's testable inner tick: exercising "terminal
-    across different poll iterations" only needs two direct calls to this
-    function with a DB row mutated in between — no real sleeping required.
+    `done` is mutated in place: the print/append/delete trio has no `await`
+    between them, so it's atomic wrt task cancellation — a row can't leave
+    `pending` without also landing in `done`, even if a SIGINT discards this
+    coroutine's return value.
     """
     from ._logging import log_error
 
@@ -1184,9 +1128,7 @@ async def _schedule_declares_chain_action(
     cache: dict[str, dict[str, Any] | None],
 ) -> bool:
     """True if `schedule_id` declares an on_success/on_fail action matching
-    the outcome that just landed — i.e. the engine *will* attempt to fire a
-    chain child, so a grace wait for it is warranted. A schedule with no
-    matching action needs no grace wait at all."""
+    the outcome that just landed, i.e. a grace wait for the chain child is warranted."""
     if schedule_id not in cache:
         cache[schedule_id] = await db.get_schedule(schedule_id)
     sched = cache[schedule_id] or {}
@@ -1194,11 +1136,8 @@ async def _schedule_declares_chain_action(
 
 
 def _new_chain_state(pending: dict[str, dict[str, Any]], *, chain: bool) -> dict[str, Any]:
-    """Build the bookkeeping dict `_advance_chains` mutates tick over tick —
-    each originally-watched id in `pending` starts out owning itself as its
-    own root. Factored out so tests can drive `_advance_chains` directly the
-    same way they drive `_poll_pending_once`, without duplicating its
-    internal shape."""
+    """Build the bookkeeping dict `_advance_chains` mutates tick over tick;
+    each originally-watched id in `pending` starts out owning itself as its own root."""
     return {
         "root_of": {rid: {rid} for rid in pending},
         "chain_tail_exit": {},
@@ -1232,31 +1171,18 @@ async def _advance_chains(
 ) -> int:
     """Fold the newly-terminal tail of `done` (index `processed` onward)
     into chain bookkeeping: extend `pending` with any already-fired
-    children, resolve roots whose schedule has no matching chain action
-    immediately, and start/advance a grace countdown for roots that do
-    declare one but whose child hasn't fired yet. Returns the new
-    `processed` index.
+    children, resolve roots with no matching chain action immediately, and
+    start/advance a grace countdown for roots awaiting one. Returns the new
+    `processed` index. Mutates `pending` in place, tick-by-tick, like
+    `_poll_pending_once` mutates `done`.
 
-    Mutates `pending` in place exactly like `_poll_pending_once` mutates
-    `done` — so a caller (the real dispatch loop, or a test) can drive this
-    function tick-by-tick with direct DB mutations in between, no real
-    sleeping required, the same way `_poll_pending_once` is tested above.
-
-    `chain_state` keys: root_of (run_id -> set of originally-watched roots
-    that run currently accounts for — a run can own more than one root when
-    an overlapping watch set passes both a run and one of its own chain
-    descendants as separate roots, see below), chain_tail_exit (root id ->
-    most recent terminal exit_code seen for that chain), awaiting_grace
-    (run_id -> {roots, ticks_left}), resolved_roots (root ids whose chain
-    has concluded), schedule_cache (memoized `db.get_schedule` lookups),
-    chain (bool — chain-following on/off; when off, every terminal row
-    resolves its root immediately, matching --no-chain's "watch only the
-    literal ids given"), done_ids (run ids already folded into the above
-    once — lets discovery tell an already-processed child apart from one
-    still waiting in `pending`), exit_of (run id -> its own folded
-    exit_code), handoff (parent run id -> the chain child its grace window
-    handed off to — followed forward when an ancestor discovers an
-    already-processed link, see below).
+    `chain_state` keys: root_of (run_id -> watched roots it accounts for),
+    chain_tail_exit (root id -> most recent terminal exit_code),
+    awaiting_grace (run_id -> {roots, ticks_left}), resolved_roots (roots
+    whose chain concluded), schedule_cache (memoized schedule lookups),
+    chain (bool, chain-following on/off), done_ids (already-folded run
+    ids), exit_of (run id -> its folded exit_code), handoff (parent run id
+    -> the chain child its grace window handed off to).
     """
     root_of = chain_state["root_of"]
     chain_tail_exit = chain_state["chain_tail_exit"]
@@ -1394,31 +1320,15 @@ def _dispatch_wait(
 
     Chain-following (default on; `chain=False` for --no-chain): a watched
     run going terminal extends the watch frontier with any scheduler
-    on_success/on_fail chain children (see module comment above
-    _TERMINAL_SCHEDULE_RUN_STATUSES and _advance_chains). The aggregate exit
-    code is final-link-wins per chain, not every link along the way — with
-    chain-following off, that collapses back to the original one-run-one-
-    link behavior.
+    on_success/on_fail chain children (see _advance_chains). The aggregate
+    exit code is final-link-wins per chain, not every link along the way.
 
-    Shaped like _watch_loop above (own signal handlers on the main thread,
-    run_async per discrete tick, chunked time.sleep for cadence) rather
-    than one run_async call wrapping a long-lived asyncio.sleep loop:
-    run_async installs its own SIGINT handler for the duration of any call
-    it wraps and never touches SIGTERM at all, so a single all-encompassing
-    call cannot give this command the dual-signal clean exit it needs —
-    per-tick calls, exactly like the dashboard's --watch, can. Unlike
-    _watch_loop's default multi-second refresh, --interval is often
-    sub-second here, so a much larger share of wall-clock time is spent
-    inside individual run_async() calls rather than between them — a SIGINT
-    landing mid-call surfaces as KeyboardInterrupt at the call site (see
-    _run_tick below) far more often than it does for the dashboard, so that
-    case is folded into the same clean-exit path instead of left to crash.
+    Ticks via per-call run_async (not one long-lived asyncio.sleep loop) so
+    both SIGINT and SIGTERM get a clean exit — see _watch_loop for why.
 
-    max_wait: None (the default, whether left unset by a Python caller or by
-    an unset --max-wait on the CLI) applies the bounded `_DEFAULT_MAX_WAIT_SECONDS`
-    fallback — a stuck session or run must not hang this call forever. Pass 0
-    (or a negative value) to opt into the old unbounded wait explicitly; any
-    positive value overrides the default bound.
+    max_wait: None (the default) applies the bounded
+    `_DEFAULT_MAX_WAIT_SECONDS` fallback so a stuck run can't hang this call
+    forever. Pass 0 (or negative) for the old unbounded wait explicitly.
     """
     from lionagi.ln.concurrency import run_async
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -727,12 +727,9 @@ def add_orchestrate_subparser(
 
 
 def _resolve_model_and_prompt(query: list[str]) -> tuple[str | None, str | None] | None:
-    """Assign a 0-2 token positional bucket to (model, prompt).
-
-    Mirrors the `li agent` [MODEL] PROMPT convention: a single token is the
-    prompt (model comes from -a/--agent, a spec file, or a playbook); two
-    tokens are (model, prompt) in order. Returns None after logging a clear
-    error when more than two positionals are given (e.g. an unquoted prompt).
+    """Assign a 0-2 token positional bucket to (model, prompt), mirroring the
+    `li agent` [MODEL] PROMPT convention: one token is the prompt, two are
+    (model, prompt). Returns None (after logging) for >2 positionals.
     """
     if len(query) > 2:
         log_error(
@@ -750,8 +747,8 @@ def _resolve_model_and_prompt(query: list[str]) -> tuple[str | None, str | None]
 def _run_orch_command(coro, *, verbose: bool, extra_handlers: tuple = ()) -> tuple[object, int]:
     """Run an orchestration coroutine, map shared exceptions to exit codes.
 
-    Returns (result, exit_code).  extra_handlers is a tuple of (ExcType, exit_code)
-    pairs checked before the shared map, allowing callers to handle pattern-specific
+    Returns (result, exit_code). extra_handlers is a tuple of (ExcType,
+    exit_code) pairs checked before the shared map, for pattern-specific
     exceptions without repeating the common mapping.
     """
     try:

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -35,10 +35,9 @@ class FlowResumeError(LionError):
 class CheckpointWriter:
     """Serializes checkpoint writes so concurrent op completions never tear the file on disk.
 
-    The in-memory `ops` map is the source of truth for the run; every write
-    serializes the FULL current state to a unique temp name and renames it
-    into place, so a reader only ever sees a complete file, and a lock held
-    across serialize-write-rename keeps renames in acquisition order.
+    Every write serializes the FULL current state to a unique temp name and
+    renames it into place, so a reader only ever sees a complete file; a lock
+    held across serialize-write-rename keeps renames in acquisition order.
     """
 
     path: Path
@@ -75,8 +74,8 @@ class CheckpointWriter:
         """Record one planned op's outcome and persist the whole checkpoint atomically.
 
         flow_context, when given, replaces the writer's snapshot of the
-        executor's shared context workspace as of this completion — the
-        latest one wins, since it is a running accumulation, not per-op data.
+        shared context workspace — latest wins, since it accumulates rather
+        than being per-op data.
         """
         async with self._lock:
             self.ops[agent_id] = {"agent_id": agent_id, "status": status, "response": response}
@@ -95,9 +94,8 @@ class CheckpointWriter:
         """Record one reactively spawned node's outcome, keyed by its own node id.
 
         Spawned nodes must never share the `ops` keyspace: a spawned child's
-        branch can carry a name identical to a planned agent_id's (clones
-        inherit the source branch's name), and using that name as the `ops`
-        key would silently overwrite the planned op's checkpoint entry.
+        branch can carry a name identical to a planned agent_id's, so using
+        that name as the key would silently overwrite the planned entry.
         """
         async with self._lock:
             entry = {"node_id": node_id, "status": status, "response": response}
@@ -147,11 +145,10 @@ def _find_run_dir_by_id(run_id: str) -> RunDir | None:
 async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]]:
     """Resolve a run_id, or a session/invocation/play id, to (RunDir, checkpoint dict).
 
-    A run_id matches a directory under RUNS_ROOT directly — no DB lookup needed,
-    since the original session_id travels inside the checkpoint payload itself.
-    Anything else is resolved as a session/invocation/play id (same resolution
-    `li o ctl status` uses) to its backing session, whose node_metadata carries
-    the run_id every flow run stamps at startup.
+    A run_id matches a directory under RUNS_ROOT directly, no DB lookup
+    needed. Anything else is resolved as a session/invocation/play id (same
+    resolution `li o ctl status` uses) to its backing session, whose
+    node_metadata carries the run_id every flow run stamps at startup.
     """
     run_dir = _find_run_dir_by_id(target)
     if run_dir is not None and run_dir.checkpoint_path.exists():

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -2,21 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """`li o ctl pause|resume|msg` — enqueue session_controls rows for a running flow.
 
-These commands are pure writers: they resolve the target session (accepting
-a session id, an invocation id, or a play id — same id shapes `li o ctl
-status` accepts, see lionagi/cli/status.py) and insert one row into
-session_controls. They do not wait for the control to apply — a control
-poller task running alongside the target flow's own heartbeat loop
-(cli/orchestrate/flow.py `_execute_dag`) is the only consumer, and applies
-each row against the live executor on its own poll cycle. Use `li o ctl
-status <id>` to see whether a queued control has applied yet.
+Pure writers: resolve the target session (id/invocation id/play id, same
+shapes `li o ctl status` accepts) and insert one row into session_controls.
+They do not wait for the control to apply — the poller in
+cli/orchestrate/flow.py `_execute_dag` is the only consumer; use
+`li o ctl status <id>` to check whether it landed.
 
-Only context-mode `msg` ships in this slice (ADR-0085 §3): the poller
-deep-merges the message into the executor's flow workspace, visible to ops
-that have not yet started. Op-mode (`--as-op`, injecting the message as a
-first-class reactive DAG node) lands with a later slice.
-
-See docs/_archive/v0/ADR-0085-flow-control-plane.md sections 1-3.
+Only context-mode `msg` ships in this slice: the poller deep-merges the
+message into the flow workspace, visible to ops not yet started. Op-mode
+(`--as-op`) lands with a later slice. See ADR-0085 sections 1-3.
 """
 
 from __future__ import annotations

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -4,18 +4,16 @@
 invocation reaches its terminal status.
 
 Resolved from `.lionagi/settings.yaml` (`notify.on_terminal`, project
-overrides global) or an explicit `--notify` override. lionagi ships no
-messaging integration here — the hook is just a shell command template with
-three substitution variables (`{payload}`, `{status}`, `{invocation_id}`).
+overrides global) or an explicit `--notify` override — just a shell command
+template with three substitution variables (`{payload}`, `{status}`,
+`{invocation_id}`).
 
-The substituted values never touch the shell command line as text: each
-placeholder is replaced with a reference to an environment variable set on
-the subprocess (e.g. `{payload}` → `"$LIONAGI_NOTIFY_PAYLOAD"`), so a quote
-or shell metacharacter inside a payload field (a playbook name, a path) can
-never break out of the template. The hook runs with a short timeout, and
-every failure mode — a malformed template, a missing/unreadable settings
-file, a nonzero exit, a timeout — is logged and swallowed: none of them may
-affect the run's own terminal status or exit code.
+Substituted values never touch the shell command line as text: each
+placeholder becomes a reference to an environment variable set on the
+subprocess, so a quote or shell metacharacter in a payload field can never
+break out of the template. Every failure mode (malformed template, missing
+settings, nonzero exit, timeout) is logged and swallowed — none may affect
+the run's own terminal status or exit code.
 """
 
 from __future__ import annotations
@@ -78,10 +76,9 @@ async def fire_terminal_notify(
     """Fire the configured terminal-notify hook exactly once, best-effort.
 
     `override_command` (the CLI `--notify` flag) wins over the settings
-    value. No template configured on either side is a silent no-op.
-    `invocation_id` is nullable — an invocation-less run (no `--invocation`)
-    still fires the hook the caller asked for; the payload just carries
-    `"invocation_id": null`.
+    value; no template configured on either side is a silent no-op.
+    `invocation_id` is nullable — an invocation-less run still fires the
+    hook, with `"invocation_id": null` in the payload.
     """
     command = override_command
     if not command:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -120,21 +120,14 @@ _CONTROL_UNSTAMPED = "unstamped"
 
 
 async def _apply_session_control(db, executor, row: dict) -> str | None:
-    """Apply one session_controls row against *executor*; returns the finalize
-    result string, or None if the row was left untouched (message already
-    mid-apply from a prior poller crash).
+    """Apply one session_controls row against *executor*. Returns the finalize
+    result, or None if left untouched (mid-apply from a prior poller crash).
 
-    pause/resume are idempotent: apply, then stamp 'applied' — a poller crash
-    between the two is harmless, since re-applying on the next poll is a no-op.
-    message is not idempotent: stamp 'applying' first, then attempt the
-    (checked, not assumed) injection, then finalize — a crash between stamp
-    and apply leaves a visible 'applying' row (surfaced by `li o ctl status`)
-    rather than risking a double injection on the next poll (at-most-once).
-
-    Never raises: apply failures are recorded as a rejected result so a bad
-    control row can never crash the run it rides alongside. Finalize failures
-    after a successful apply never mislabel the row as rejected — the 'applied'
-    stamp is retried, then the row is left for the next tick.
+    pause/resume are idempotent (safe to re-apply after a crash). message is
+    at-most-once: stamped 'applying' before injection so a crash mid-apply is
+    visible via `li o ctl status` rather than risking a double injection.
+    Never raises — apply/finalize failures are recorded as rejected so a bad
+    control row can't crash the run it rides alongside.
     """
     control_id = row["id"]
     verb = row["verb"]
@@ -197,11 +190,8 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
 
 async def _finalize_applied(db, control_id: str) -> str:
     """Stamp 'applied' after a successful apply; never mislabel it rejected.
-
-    A finalize failure here means the effect landed but the stamp did not:
-    retry once, then hand the row back to the poller via the unstamped
-    sentinel — pause/resume re-apply idempotently next tick, and a message
-    row stays 'applying' so it is skipped rather than double-injected.
+    On finalize failure, retry once then return the unstamped sentinel so the
+    poller hands the row back for the next tick.
     """
     for _ in range(2):
         try:
@@ -607,25 +597,15 @@ def _apply_checkpoint_precompletion(
     checkpoint_spawned: list[dict] | None = None,
 ) -> None:
     """Mark nodes the checkpoint recorded as terminal so the executor's
-    pre-completed seam (DependencyAwareExecutor._execute_operation's
-    terminal-status skip) short-circuits them outright instead of re-running.
+    pre-completed seam short-circuits them instead of re-running.
 
-    completed ops restore their response and are treated as done; failed ops
-    are restored as terminal FAILED rather than silently re-run — a failed op
-    may already have produced side effects or partial artifacts before the
-    process died, so resume must never guess at retry semantics on its own.
-
-    A pending op that declared inherit_context expects its predecessor's
-    actual conversation history, which resume does not restore (v1: results
-    flow through parameters exactly as live, message history does not) — that
-    combination is refused loudly unless the caller passes
-    allow_degraded_context, naming every affected op so it is an informed
-    choice rather than a silent correctness trap.
-
-    checkpoint_spawned refuses resume outright when non-empty: reactively
-    spawned nodes are not replayed by this version (their DAG position and
-    branch aren't reconstructible from the persisted plan alone), so silently
-    proceeding would drop completed spawned work without telling anyone.
+    completed ops restore their response; failed ops are restored as terminal
+    FAILED rather than silently re-run (they may have had side effects before
+    the process died). A pending op with inherit_context is refused unless the
+    caller passes allow_degraded_context — resume restores results-context
+    only, not conversation history (v1). checkpoint_spawned refuses resume
+    outright when non-empty: reactively spawned nodes aren't replayable from
+    the persisted plan, and silently proceeding would drop completed work.
     """
     from lionagi.protocols.types import EventStatus
 
@@ -684,16 +664,11 @@ async def _execute_dag(
 ) -> _ExecResult:
     """Drive the planning engine over the DAG and collect per-agent results.
 
-    checkpoint_config is the opt-in gate for the whole checkpoint writer:
-    only when it is not None is a CheckpointWriter constructed and wired
-    into the completion/failure observers below. Tests that stub
-    env.run/env.builder with MagicMock (no checkpoint_config passed) are
-    unaffected — the writer, and every os.replace() it would do, never exists.
-
-    checkpoint_flow_context seeds the executor's shared context workspace on
-    resume with whatever was accumulated (via operation.response["context"])
-    before the crash — without it, pending ops on a resumed run would see an
-    empty workspace instead of what they would have seen live.
+    checkpoint_config is the opt-in gate for the checkpoint writer: only when
+    not None is a CheckpointWriter constructed and wired into the
+    completion/failure observers. checkpoint_flow_context seeds the
+    executor's shared context workspace on resume with what was accumulated
+    before the crash, so pending ops see the same workspace they would live.
     """
     assignments = plan_result.assignments
     agent_ids = plan_result.agent_ids
@@ -814,15 +789,10 @@ async def _execute_dag(
     def _checkpoint_record(sig, status: str) -> None:
         """Fire-and-forget the checkpoint write for one op's outcome.
 
-        sig.name is the agent_id (explicit_name at add_operation time) for a
-        PLANNED node only — a reactively spawned node's branch can carry a
-        name identical to a planned agent_id's (clones inherit the source
-        branch's name), so sig.name is never trustworthy as a checkpoint key
-        on its own. sig.op_id (the stringified node UUID) against
-        known_node_strs is the only reliable way to tell a planned node from
-        a spawned one; spawned nodes are recorded separately by node id via
-        record_spawned so they can never collide with / overwrite a planned
-        op's `ops` entry.
+        sig.name is untrustworthy as a key on its own (a spawned node's clone
+        can share a planned agent_id's name), so sig.op_id is checked against
+        known_node_strs to route planned nodes to record() and spawned nodes
+        to record_spawned(), preventing them from colliding.
         """
         if _checkpoint_writer is None:
             return
@@ -951,23 +921,18 @@ async def _execute_dag(
 
     def _decorate_spawn_instruction(req: SpawnRequest, spawn_id: str) -> str:
         """Give a reactively spawned node the same artifact-dir + REQUIRED
-        text a planned leg gets (env.run.agent_artifact_dir + this leg's
-        role_defaults) — the mirror of the ctx["artifact_instructions"]
-        block _build_dag composes above, via the shared helpers."""
+        text a planned leg gets, mirroring the block _build_dag composes."""
         role_defaults = dag_state.role_artifact_defaults.get(req.assignee) if req.assignee else None
         leg_expected = _leg_artifact_entries(spawn_id, role_defaults)
         note = _artifact_directive(env.run, spawn_id, leg_expected)
         return f"{req.instruction}\n\n{note}"
 
     def _spawn_branch_setup(operation: Any, branch: Any) -> None:
-        """A reactively-spawned node's cloned branch inherits the emitting
-        leg's CLI workspace (chat_model.endpoint.config.kwargs["repo"]) via
-        Branch.clone — but the artifact contract this leg is told about in
-        _decorate_spawn_instruction points at its own spawn_id subdir, a
-        sibling of the emitter's. Without retargeting, the spawned CLI child
-        can only write inside the emitter's directory, not its own, unless
-        running fully unsandboxed. Only CLI-backed chat models carry a
-        writable-root concept; anything else is a no-op."""
+        """Retarget a spawned node's cloned CLI workspace to its own
+        spawn_id subdir — Branch.clone inherits the emitter's repo kwarg, but
+        the artifact contract points at a sibling dir, so without this the
+        spawned CLI child can only write into the emitter's directory.
+        No-op for non-CLI chat models (no writable-root concept)."""
         spawn_id = operation.metadata.get("spawn_id") if operation is not None else None
         if not spawn_id:
             return
@@ -1864,11 +1829,10 @@ async def _resume_flow(
 ) -> tuple[str, str]:
     """Resolve a checkpointed run/session id and replay it through _run_flow.
 
-    dry_run/show_graph come from the CURRENT invocation, not the checkpoint —
-    they are presentation flags, not part of what already happened. Every
-    other _run_flow kwarg replays the persisted config verbatim. notify is
-    also a current-invocation override — like dry_run/show_graph it steers
-    presentation of this replay, not the plan that already happened.
+    dry_run/show_graph/notify come from the CURRENT invocation, not the
+    checkpoint — presentation overrides for the replay, not part of what
+    already happened. Every other _run_flow kwarg replays the persisted
+    config verbatim.
     """
     _run_dir, checkpoint = await resolve_checkpoint_target(target)
     config = dict(checkpoint.get("config") or {})

--- a/lionagi/cli/stats.py
+++ b/lionagi/cli/stats.py
@@ -45,16 +45,11 @@ def _validate_group_by(raw: str) -> list[str]:
 def _reject_non_positive_since(window: str) -> None:
     """Reject a `--since` window that isn't strictly positive.
 
-    Monitor's shared `_since_timestamp()` parses `0d` (cutoff = now) and
-    `-1d` (cutoff = a future timestamp) without complaint — reasonable for
-    its own "everything running, or since this window" semantics, but for an
-    aggregate report a non-positive window silently produces a false-empty
-    (0d) or nonsensical (negative -> future cutoff, matches nothing) result
-    instead of failing loudly. This only tightens `li stats runs`; monitor's
-    own behavior/callers are untouched.
-
-    A malformed value (bad unit, non-numeric) is left to `_since_timestamp`
-    itself, which already raises a clear error for those.
+    Monitor's shared `_since_timestamp()` accepts `0d`/`-1d` without
+    complaint (fine for its own semantics), but for an aggregate report
+    that silently produces a false-empty or nonsensical result instead of
+    failing loudly — this only tightens `li stats runs`. Malformed values
+    (bad unit, non-numeric) are left to `_since_timestamp` to reject.
     """
     try:
         value = int(window[:-1])

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """`li agent status` / `li play status` / `li o ctl status` — read-only lifecycle surfaces.
 
-Pure reads over sessions/invocations/plays/session_signals. Resolves an id
-(or the latest matching run) regardless of terminal state, so a finished run
-is inspectable without already knowing whether it is still active — a plain
-`li monitor` table view only lists running/active rows. See
+Pure reads over sessions/invocations/plays/session_signals. Resolves an id (or
+the latest matching run) regardless of terminal state, unlike `li monitor`
+which only lists running/active rows. See
 docs/_archive/v0/ADR-0085-flow-control-plane.md section 6.
 
-`--json` emits a single flat object with this stable key set (documented
-here since other lambdas/tools parse it):
+`--json` emits a flat object with this stable key set (parsed by other
+lambdas/tools):
 
   id, entity_type, command, status, terminal, exit_class, exit_code,
   current_phase, progress_completed, progress_total, model, provider,
@@ -19,15 +18,13 @@ here since other lambdas/tools parse it):
   pending_controls
 
 Exit codes: 0 terminal-success, 1 terminal-failure, 3 still running/active,
-2 lookup failed (unknown id, or state.db unreachable) — argparse itself
-owns exit code 2 for usage errors, so this reuses that convention for any
-other "could not produce a status" outcome.
+2 lookup failed (unknown id, or state.db unreachable; also argparse's own
+usage-error code).
 
-`pending_controls` lists unapplied session_controls rows (id, verb,
-created_at) for the resolved backing session, oldest first — queued via
-`li o ctl pause|resume|msg` and consumed by the control poller running
-alongside a live flow's heartbeat loop (ADR-0085 part 1). Always `[]` when
-there is no backing session or nothing queued.
+`pending_controls`: unapplied session_controls rows (id, verb, created_at)
+for the resolved session, oldest first — queued via `li o ctl
+pause|resume|msg`, consumed by the control poller alongside a live flow's
+heartbeat (ADR-0085 part 1). `[]` when no backing session or nothing queued.
 """
 
 from __future__ import annotations

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -10,11 +10,10 @@ prints one frozen, tab-delimited line per run on stdout:
         artifact_dir=<run_dir>\texit_code=<n>
 
 Stdout carries contract lines only; every diagnostic goes to stderr via
-``_logging``. `wait_for_terminal()` is the reusable, importable core — it
-takes no CLI concerns (no argv, no signal handling, no printing) so other
-surfaces can await completion without shelling out; `run_wait()` is the thin
-CLI shim that resolves argv, drives the poll loop with clean SIGINT/SIGTERM
-handling (mirroring `li monitor run`'s `_dispatch_wait`), and prints.
+``_logging``. `wait_for_terminal()` is the reusable, importable core (no
+argv, signal handling, or printing) so other surfaces can await completion
+without shelling out; `run_wait()` is the thin CLI shim that resolves
+argv, drives the poll loop with clean SIGINT/SIGTERM handling, and prints.
 """
 
 from __future__ import annotations
@@ -53,11 +52,8 @@ _SUCCESS_STATUS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
 
 async def _resolve_wait_target(db: Any, raw_id: str) -> tuple[str, dict[str, Any]] | None:
     """Any-kind resolver: session, invocation, play (`_resolve_any_target`,
-    which also falls back to a branch_id), then schedule_run.
-
-    Terminal-state definitions are never hard-coded here — see
-    TERMINAL_STATUSES_BY_ENTITY_TYPE (lionagi/state/db.py), which lives with
-    the record schema per ADR-0094.
+    which also falls back to a branch_id), then schedule_run. Terminal-state
+    definitions live in TERMINAL_STATUSES_BY_ENTITY_TYPE (lionagi/state/db.py, ADR-0094).
     """
     hit = await _resolve_any_target(db, raw_id)
     if hit is not None:
@@ -82,11 +78,9 @@ async def _refetch(db: Any, kind: str, entity_id: str) -> dict[str, Any] | None:
 
 
 async def _artifact_dir_for(db: Any, kind: str, row: dict[str, Any]) -> str | None:
-    """The run directory (the manifest container holding `run.json`) backing
-    *row* — always ``RUNS_ROOT / <a session id>``, never a per-kind artifact
-    layout. Resolved via the backing/primary session id, whether or not that
-    directory happens to exist on disk yet; only returns ``None`` when there
-    is no backing session id to anchor on."""
+    """The run directory backing *row* — always ``RUNS_ROOT / <session id>``,
+    resolved via the backing/primary session id (may not exist on disk yet).
+    Returns ``None`` only when there is no backing session id to anchor on."""
     if kind == "session":
         return str(RUNS_ROOT / row["id"])
     if kind == "invocation":
@@ -149,14 +143,12 @@ async def wait_for_terminal(
     outcome dict per id, in the order given (ADR-0094 completion contract).
 
     Importable and awaitable directly — no CLI concerns (argv, signals,
-    printing) live here; `run_wait()` below is the CLI shim over this core,
-    so a future push-backed mode (ADR-0092) can share the same outcome shape.
+    printing) live here; `run_wait()` below is the CLI shim over this core.
 
     *on_result* is called once per resolved run, the moment it goes terminal
-    (or is found unresolvable), so a caller driving its own stdout can print
-    incrementally instead of waiting for the whole set to drain.
-    *should_stop* is polled between ticks so a CLI wrapper can wire SIGINT/
-    SIGTERM into a clean early return instead of blocking forever.
+    (or is found unresolvable), so a caller can print incrementally instead
+    of waiting for the whole set to drain. *should_stop* is polled between
+    ticks so a CLI wrapper can wire SIGINT/SIGTERM into a clean early return.
     """
     from lionagi.state.db import StateDB
 

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -183,9 +183,8 @@ class WorkerActivity(EngineEvent):
 class AutoRepairApplied(EngineEvent):
     """Emitted when the harness auto-applies a repair command before a test gate.
 
-    Distinct from a worker fix round: the worker produced the change; the harness
-    normalized it mechanically (e.g. ``cargo fmt --all``).  The dataset records
-    both so analysis can separate worker-produced vs harness-normalized diffs.
+    Distinct from a worker fix round: the harness normalized the diff
+    mechanically (e.g. ``cargo fmt --all``), the worker didn't produce it.
     """
 
     cmd: str = Field(description="The auto-repair command that was run.")
@@ -680,11 +679,7 @@ class CodingEngine(Engine):
     async def _apply_auto_repairs(
         self, run: CodingRun, *, round_no: int
     ) -> list[AutoRepairApplied]:
-        """Run each auto_repair_cmd in sequence; emit AutoRepairApplied per command.
-
-        Returns the list of events emitted.  Errors are notified but never raise
-        — a failed auto-repair command is surfaced as a notification, not a crash.
-        """
+        """Run each auto_repair_cmd in sequence, emitting AutoRepairApplied per command; a failed command is notified, never raised."""
         if not self.auto_repair_cmds:
             return []
         applied: list[AutoRepairApplied] = []
@@ -765,11 +760,7 @@ class CodingEngine(Engine):
     async def _fast_test(
         self, run: CodingRun, change: ChangeProposed, *, round_no: int
     ) -> TestsRan | None:
-        """Run fast_test_cmd as an incremental gate for intermediate fix rounds.
-
-        Returns None when fast_test_cmd is not configured.  Auto-repair is NOT
-        run here — it fires in _test() which is always the authoritative leg.
-        """
+        """Run fast_test_cmd as an incremental gate; None if unconfigured. Auto-repair does NOT run here — only in _test(), the authoritative leg."""
         if self.fast_test_cmd is None:
             return None
         return await self._run_subprocess_gate(
@@ -781,10 +772,9 @@ class CodingEngine(Engine):
     ) -> tuple[ChangeProposed, TestsRan]:
         """Re-prompt the implementer on failure and re-test, bounded by max_fix_rounds.
 
-        Mechanical rounds (failure attributable solely to fmt/lint output, satisfied
-        after auto-repair) skip the judge gate.  Substantive rounds pass through the
-        judge as before.  When fast_test_cmd is configured, intermediate rounds gate
-        on it first; the full test_cmd is always the final ground-truth leg.
+        Mechanical rounds (fixed by auto-repair alone) skip the judge gate;
+        substantive rounds go through it. fast_test_cmd, if configured, gates
+        intermediate rounds; test_cmd is always the final ground-truth leg.
         """
         agent = getattr(run, "_implementer", None)
         round_no = 0
@@ -921,11 +911,7 @@ class CodingEngine(Engine):
     # -- worker helpers -------------------------------------------------------
 
     def _wrap_turn_timeout(self, agent: Any, run: CodingRun) -> Any:
-        """Return a proxy whose operate() is bounded by turn_timeout_s.
-
-        On TimeoutError the proxy emits a turn_timeout notification and returns
-        None so operate_with_repair sees arrived()=False and enters the fix path.
-        """
+        """Return a proxy whose operate() is bounded by turn_timeout_s; on timeout it notifies and returns None, driving operate_with_repair into the fix path."""
         if self.turn_timeout_s is None:
             return agent
         timeout_s = self.turn_timeout_s
@@ -948,11 +934,7 @@ class CodingEngine(Engine):
         return _Proxy()
 
     def _start_heartbeat(self, run: CodingRun, *, stage: str) -> asyncio.Task | None:
-        """Start a background task that emits WorkerHeartbeat at the configured interval.
-
-        Also emits WorkerActivity whenever a file in the workspace changes mtime.
-        Returns None when heartbeat_interval_s is None (disabled).
-        """
+        """Start a background task emitting WorkerHeartbeat on interval and WorkerActivity on file mtime changes; None if heartbeat_interval_s is unset."""
         if self.heartbeat_interval_s is None:
             return None
         t0 = run._t0
@@ -1124,11 +1106,7 @@ _RE_MECHANICAL = re.compile(
 
 
 def _looks_mechanical(tests: TestsRan) -> bool:
-    """Return True when the test failure output looks like a pure fmt/lint failure.
-
-    Heuristic only — used to skip the judge gate for mechanical rounds; the
-    authoritative result is always the full test_cmd exit code.
-    """
+    """True when the test failure output looks like a pure fmt/lint failure (heuristic, used to skip the judge gate; test_cmd exit code stays authoritative)."""
     if tests.passed:
         return False
     tail = tests.output_tail

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -375,13 +375,9 @@ class EngineRun:
     async def cancel_active(self) -> None:
         """Cancel and await all in-flight spawned tasks.
 
-        Waits up to ``engine.cancel_timeout_s`` for tasks to finish after
-        cancellation is requested.  Tasks that do not settle within that window
-        (e.g. they catch CancelledError and loop) are abandoned: a loud warning
-        is logged naming the count, and cancel_active() returns so the caller's
-        lifetime guarantee is preserved.  Cooperative tasks that finish before
-        the deadline are awaited normally — the timeout path only fires when at
-        least one task remains after the window expires.
+        Waits up to ``engine.cancel_timeout_s``; tasks that don't settle in
+        that window (e.g. catch CancelledError and loop) are abandoned with a
+        logged warning so the caller's lifetime guarantee is preserved.
         """
         if not self._active:
             return
@@ -406,7 +402,7 @@ class EngineRun:
         self._active.clear()
 
     async def _deadline_watchdog(self) -> None:
-        """Sleep until the deadline, then cancel _run_task (and spawned tasks via Engine.run's finally block)."""
+        """Sleep until the deadline, then cancel _run_task."""
         if self._deadline is None:
             return
         delay = self._deadline - monotonic()
@@ -419,11 +415,10 @@ class EngineRun:
             self._run_task.cancel()
 
     async def wait_quiescence(self) -> None:
-        """Block until all spawned tasks settle; re-raise any non-cancellation, non-budget failures.
+        """Block until all spawned tasks settle; re-raise non-cancellation, non-budget failures.
 
-        A spawned task hitting EngineBudgetError is a benign "expansion
-        stopped" signal (discretionary work declined, not a crash) — the same
-        grace already given to asyncio.CancelledError here.
+        EngineBudgetError is a benign "expansion stopped" signal (discretionary
+        work declined, not a crash) and is swallowed like CancelledError.
         """
         task_errors: list[BaseException] = []
         while self._active:
@@ -658,10 +653,9 @@ class Engine:
     async def _degrade_export(self, run: EngineRun, args: tuple, kwargs: dict) -> Any:
         """Cancel in-flight spawned tasks, then run _partial_export shielded + timeout-bounded.
 
-        Shared by the deadline (CancelledError) and root-budget (EngineBudgetError)
-        degrade paths in run(). Returns _UNSET if the export itself failed or
-        timed out (logged, not raised) — CancelledError from an external cancel
-        during the shielded phase still propagates.
+        Shared by the deadline and root-budget degrade paths in run(). Returns
+        _UNSET if the export failed or timed out (logged, not raised); an
+        external cancel during the shielded phase still propagates.
         """
         # Cancel background tasks so synthesis sees a stable snapshot and no
         # work burns tokens past budget exhaustion (no-op if _active is empty).

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -1,14 +1,10 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Persist per-node lifecycle signals for a ``Session.flow`` run.
+"""Turn ``DependencyAwareExecutor`` node transitions and ``NodeSpawned`` bus
+events into ``NodeQueued``/``NodeStarted``/``NodeCompleted``/``NodeFailed``
+session-bus signals, so a ``Session.flow`` run's DAG can be rendered live.
 
-``DependencyAwareExecutor`` reports queued/started/completed/failed node
-transitions through an ``on_progress`` callback and announces reactive spawns as
-``NodeSpawned`` bus events. This module turns those into ``NodeQueued`` /
-``NodeStarted`` / ``NodeCompleted`` / ``NodeFailed`` signals on the session bus so
-a run's DAG can be rendered moving through its lifecycle.
-
-Shared by the engine's own DAG run and by Studio's ``workflow_run`` — both drive
+Shared by the engine's own DAG run and Studio's ``workflow_run`` — both drive
 ``session.flow`` directly and need the same node-progress signals.
 """
 
@@ -32,13 +28,11 @@ __all__ = ("flow_progress_signals",)
 
 
 def _build_node_edge_meta(graph: Any) -> dict[str, dict]:
-    """Map each Operation node's id to its {parent_id, depends_on, name} from the graph.
+    """Map each Operation node id to {parent_id, depends_on, name} from the graph.
 
-    ``name`` is the node's authored id (``metadata['reference_id']``) when set —
-    e.g. the Studio designer box id ``chat1`` — or None. It is preferred over the
-    executor-supplied callback name so every lifecycle signal (not just queued)
-    maps back to the authored DAG; the executor names started/completed/failed
-    after the branch, which need not match the authored id.
+    ``name`` is the authored id (``metadata['reference_id']``, e.g. Studio's
+    ``chat1``) when set, preferred over the executor's callback name (which
+    the executor renames after the branch for started/completed/failed).
     """
     from lionagi.operations.node import Operation
 
@@ -61,13 +55,11 @@ async def flow_progress_signals(
 ) -> AsyncIterator[Callable[[str, str, str, float], None]]:
     """Yield an ``on_progress`` callback that persists node-lifecycle signals.
 
-    Usage::
+    Usage: ``async with flow_progress_signals(session, graph) as on_progress:
+    await session.flow(graph, on_progress=on_progress, ...)``.
 
-        async with flow_progress_signals(session, graph) as on_progress:
-            await session.flow(graph, on_progress=on_progress, ...)
-
-    Tracks reactive spawns (``NodeSpawned``) so late-added nodes carry their
-    parent/depends_on edges, and on exit awaits every emitted signal so the
+    Tracks reactive ``NodeSpawned`` events so late-added nodes carry their
+    parent/depends_on edges, and awaits every emitted signal on exit so
     observers finish persisting before the caller reads what they wrote.
     """
     emits: list[asyncio.Future] = []

--- a/lionagi/tools/_subprocess.py
+++ b/lionagi/tools/_subprocess.py
@@ -48,12 +48,9 @@ def _subprocess_sync(
     timeout_ms: int | None = None,
     env: Mapping[str, str] | None = None,
 ) -> dict:
-    """Run ``cmd`` synchronously. ``env=None`` (the default) inherits the full
-    parent environment, matching every pre-existing caller. Pass an explicit
-    ``env`` mapping to run the child with only those variables — callers that
-    execute less-trusted or workspace-scoped commands (e.g. the ADR-0089
-    sandbox-backend seam) should build a minimal, named environment rather
-    than rely on this default."""
+    """Run ``cmd`` synchronously. ``env=None`` inherits the full parent
+    environment; pass an explicit mapping to scope less-trusted commands
+    (e.g. the ADR-0089 sandbox-backend seam) to a minimal environment."""
     try:
         proc = subprocess.Popen(  # noqa: S603
             cmd,

--- a/lionagi/tools/code/ast_search.py
+++ b/lionagi/tools/code/ast_search.py
@@ -187,25 +187,20 @@ class AstSearchTool(LionTool):
 
             async def ast_search(**kwargs):
                 """
-                Search source code by AST shape using ast-grep (sg binary).
+                Search source code by AST shape using ast-grep (sg binary) —
+                structural patterns rather than text (e.g. 'except: pass'
+                regardless of whitespace, or all calls with a None first arg).
 
-                Finds structural patterns rather than text patterns — catches 'except: pass'
-                regardless of whitespace, or all calls where the first argument is None.
-                Faster and more precise than regex for syntax-aware queries.
-
-                Requires the 'sg' or 'ast-grep' binary in PATH.
-                Returns status='unavailable' if absent — not an error.
+                Requires the 'sg' or 'ast-grep' binary in PATH; returns
+                status='unavailable' if absent (not an error).
 
                 Pattern syntax: https://ast-grep.github.io/reference/pattern.html
                   '$X'    — matches any single AST node, captured as X
                   '$$$'   — matches zero or more nodes (variadic)
                   '...'   — elides sub-patterns (wildcard for bodies)
 
-                Result status values:
-                - 'ok': no matches
-                - 'matches': one or more matches (see matches list)
-                - 'unavailable': sg binary not installed
-                - 'error': tool failed unexpectedly
+                Result status: 'ok' (no matches) | 'matches' (see matches list)
+                | 'unavailable' (sg not installed) | 'error' (tool failed)
                 """
                 return (await self.handle_request(AstSearchRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/check.py
+++ b/lionagi/tools/code/check.py
@@ -268,26 +268,18 @@ class CodeCheckTool(LionTool):
 
             async def code_check(**kwargs):
                 """
-                Run static analysis on Python files and return structured diagnostics.
-
-                Call this after editing a file to get immediate IDE-grade feedback.
-                Each diagnostic is returned as file:line:col with code and message so
-                the agent can locate and fix the issue without re-reading the file.
-
-                Composability (edit -> check workflow):
-                  1. editor(action='edit', file_path=..., old_string=..., new_string=...)
-                  2. code_check(paths=[<same file_path>])
-                  3. Diagnostics list gives actionable file:line:col entries to fix next.
+                Run static analysis on Python files and return structured
+                diagnostics. Call after editing a file for immediate feedback;
+                each diagnostic is file:line:col with code and message so the
+                agent can locate and fix the issue without re-reading the file.
 
                 Supported tools:
                 - 'ruff': fast Python linter (default). Requires ruff in PATH.
                   Returns status='unavailable' if the binary is absent — not an error.
 
-                Result status values:
-                - 'ok': no issues found
-                - 'diagnostics': one or more issues found (see diagnostics list)
-                - 'unavailable': tool binary not installed
-                - 'error': tool failed unexpectedly
+                Result status: 'ok' (no issues) | 'diagnostics' (issues found,
+                see diagnostics list) | 'unavailable' (tool not installed)
+                | 'error' (tool failed unexpectedly)
                 """
                 return (await self.handle_request(CodeCheckRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -393,12 +393,9 @@ class CodingToolkit(LionTool):
         self._bound_nudge_engine = engine
 
         def _invalidate_stale_reads() -> None:
-            """Drop file_state entries whose backing reader-read result was evicted/compacted.
-
-            Prevents a silent unsoundness: without this, evicting a verbose read
-            result still leaves the read-before-edit guard satisfied, letting the
-            model edit a file it no longer has in view.
-            """
+            """Drop file_state entries whose backing reader-read result was
+            evicted/compacted — otherwise the read-before-edit guard stays
+            satisfied for a read the model can no longer see."""
             if not read_tracked:
                 return
             active = branch.progression
@@ -855,16 +852,10 @@ class CodingToolkit(LionTool):
             tool: str = "ruff",
             max_diagnostics: int = 50,
         ) -> dict:
-            """Run static analysis on Python files and return structured diagnostics.
-
-            Call this after editing a file to get immediate IDE-grade feedback.
-            Each diagnostic is returned as file:line:col with code and message so
-            the agent can locate and fix the issue without re-reading the file.
-
-            Composability (edit -> check workflow):
-              1. editor(action='edit', file_path=..., old_string=..., new_string=...)
-              2. code_check(paths=[<same file_path>])
-              3. Diagnostics list gives actionable file:line:col entries to fix next.
+            """Run static analysis on Python files and return structured
+            diagnostics. Call after editing a file for immediate feedback;
+            each diagnostic is file:line:col with code and message so the
+            agent can locate and fix the issue without re-reading the file.
 
             Supported tools:
             - 'ruff': fast Python linter (default). Requires ruff in PATH.

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -91,16 +91,9 @@ class LionMessenger(LionTool):
                 branch.msgs.messages.include(msg)
 
         def messenger(action: str, to: str | list[str] = None, content: str = None) -> str:
-            """Send messages to teammates, signal done/finished, or wake a teammate.
-
-            Args:
-                action: One of 'send', 'done', 'finished', 'wakeup'.
-                to: Recipient name or list of names. Required for send/wakeup.
-                content: Message body (send/wakeup) or reason (done/finished).
-
-            Returns:
-                Confirmation string.
-            """
+            """Send messages to teammates, signal done/finished, or wake a
+            teammate. action in {'send', 'done', 'finished', 'wakeup'}; to
+            (name or list of names) and content are required for send/wakeup."""
             if action == "send":
                 if not to or not content:
                     return "Error: 'send' requires both 'to' and 'content'."

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -60,15 +60,13 @@ class KhiveInjectionPolicy:
     """Policy block controlling pre-turn khive injection (ADR-0100).
 
     ``namespace``, when set, is threaded onto every khive verb this policy's
-    provider emits (recall, compose, auto_feedback, remember). This is the
-    bench-arm isolation mechanism: auto_feedback is a WRITE to the live brain
-    store, so an "M1 read-only" arm without a pinned namespace still mutates
-    posteriors and contaminates the M0/M1 comparison — pinning a namespace is
-    required, not optional, for any bench arm with ``enabled=True``. Note:
-    today only the khive write verb honors a namespace argument; the read
-    verbs reject unknown params, so an injection-enabled arm cannot actually
-    execute until the khive surface grows namespace-scoped reads. The
-    threading is in place so it works the day that lands.
+    provider emits (recall, compose, auto_feedback, remember) — the bench-arm
+    isolation mechanism. auto_feedback WRITES to the live brain store, so an
+    unpinned "M1 read-only" arm still mutates posteriors and contaminates the
+    M0/M1 comparison: pinning a namespace is required, not optional, for any
+    enabled bench arm. Currently only the write verb honors namespace (read
+    verbs reject unknown params), so this is forward-wired for when reads
+    grow namespace scoping too.
     """
 
     profile_id: str


### PR DESCRIPTION
Round-2 docstring pass of the comment-hygiene sweep: ~60 docstrings condensed across 21 files in cli/, tools/, engines/, and top-level modules. LLM-facing tool docstrings keep full contracts (statuses, required args); only narration and recipes cut. Docstring-only — AST verified identical after docstring strip. 2126 cli/tools/engines tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)