### PR TITLE
chore: deprecate the legacy select() wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `lionagi.ln.to_uuid` now emits a `DeprecationWarning` at call time. It is not equivalent to `lionagi.protocols.ids.to_uuid` or `lionagi.protocols.ids.canonical_id`; use `lionagi.protocols.ids.to_uuid` for raw UUID/string values and `lionagi.protocols.ids.canonical_id` for generic Observable-like objects.
 - `lionagi.cli._runs.teardown_orchestration_persist` is now an async wrapper that emits a `DeprecationWarning` and delegates unchanged to `teardown_persist`; use `teardown_persist` instead.
 - `lionagi.cli.orchestrate._common.TEAM_WORKER_SYSTEM` is deprecated; use `TEAM_COORD_SECTION` appended to a worker's own system prompt instead.
+- `lionagi.operations.select.select.select` now emits a `DeprecationWarning` at call time; use `Branch.operate()` with an explicit caller-owned response model instead. Behavior and signature are unchanged; `select_v1` remains undeprecated for internal use.
 
 ## [0.28.0] - 2026-07-08
 

--- a/lionagi/operations/select/select.py
+++ b/lionagi/operations/select/select.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,13 @@ async def select(
     **kwargs: Any,
 ) -> SelectionModel | tuple[SelectionModel, "Branch"]:
     """Legacy wrapper around select_v1; supports deprecated branch_kwargs and optional return_branch tuple."""
+    warnings.warn(
+        "lionagi.operations.select.select.select is deprecated; use "
+        "Branch.operate() with an explicit caller-owned response model "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if verbose:
         logger.debug("Starting selection with up to %d choices.", max_num_selections)
 

--- a/tests/operations/select_ops/test_select.py
+++ b/tests/operations/select_ops/test_select.py
@@ -3,6 +3,7 @@
 
 """Comprehensive tests for select operations."""
 
+import warnings
 from enum import Enum
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -665,3 +666,128 @@ class TestSelectV1Integration:
         )
 
         assert "Optimized for reliability" in result.selected
+
+
+class TestSelectDeprecation:
+    """Regression tests for the legacy select() wrapper's deprecation warning."""
+
+    @pytest.mark.asyncio
+    async def test_select_warns_deprecation_warning(self):
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["option1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await select(
+                branch=branch,
+                instruct={"instruction": "Choose"},
+                choices=["option1", "option2"],
+            )
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert "lionagi.operations.select.select.select" in str(deprecations[0].message)
+        assert "Branch.operate()" in str(deprecations[0].message)
+
+    @pytest.mark.asyncio
+    async def test_select_stacklevel_identifies_caller(self):
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["option1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await select(  # this exact line
+                branch=branch,
+                instruct={"instruction": "Choose"},
+                choices=["option1", "option2"],
+            )
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert deprecations[0].filename == __file__
+
+    @pytest.mark.asyncio
+    async def test_select_result_unchanged_under_warning(self):
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["option1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = await select(
+                branch=branch,
+                instruct={"instruction": "Choose"},
+                choices=["option1", "option2"],
+            )
+
+        assert isinstance(result, SelectionModel)
+        assert result.selected == ["option1"]
+
+    @pytest.mark.asyncio
+    async def test_select_return_branch_unchanged_under_warning(self):
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["choice1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result, returned_branch = await select(
+                branch=branch,
+                instruct={"instruction": "Select"},
+                choices=["choice1", "choice2"],
+                return_branch=True,
+            )
+
+        assert isinstance(result, SelectionModel)
+        assert returned_branch == branch
+
+    @pytest.mark.asyncio
+    async def test_select_v1_does_not_warn(self):
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["choice1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await select_v1(
+                branch=branch,
+                instruct={"instruction": "Select"},
+                choices=["choice1", "choice2"],
+            )
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 0
+
+    @pytest.mark.asyncio
+    async def test_unrelated_branch_operate_does_not_warn(self):
+        """Branch.operate() itself must not pick up a select() deprecation warning."""
+        branch = MagicMock(spec=Branch)
+
+        async def mock_operate(**kwargs):
+            return SelectionModel(selected=["choice1"])
+
+        branch.operate = AsyncMock(side_effect=mock_operate)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await branch.operate(instruction="unrelated call")
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 0


### PR DESCRIPTION
Adds a `DeprecationWarning` to the legacy `lionagi.operations.select.select.select()` wrapper, pointing callers at `Branch.operate()` with an explicit response model. Behavior and signature unchanged; `select_v1` (the operate-based implementation) is untouched.

- 6 new tests pin warning category, stacklevel, unchanged selection result, `return_branch` behavior, and no warning leakage into unrelated `operate()` calls.
- `tests/operations` + `tests/session`: 984 passed.

Part of the deprecation-notices lane; removal is a later, release-gated slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)