### PR TITLE
fix(agent): guard_paths delegates containment to the canonical path-safety helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `lionagi.cli._runs.teardown_orchestration_persist` is now an async wrapper that emits a `DeprecationWarning` and delegates unchanged to `teardown_persist`; use `teardown_persist` instead.
 - `lionagi.cli.orchestrate._common.TEAM_WORKER_SYSTEM` is deprecated; use `TEAM_COORD_SECTION` appended to a worker's own system prompt instead.
 
+### Fixed
+
+- `guard_paths()` now delegates workspace containment to the canonical `lionagi.libs.path_safety.resolve_workspace_path` helper instead of its own parent-walk check: a direct symlink under an allowed root is refused before it is followed (even when its target is inside the workspace), an intermediate directory symlink that resolves outside the workspace is denied on containment, and a fixed set of protected basenames (`.env`, `.netrc`, SSH private keys, `.htpasswd`) is denied even when the caller supplies no `denied_paths`. This closes a gap where only caller-supplied deny rules were enforced and symlink escapes were not checked at all. Multi-root and custom `denied_paths` composition, the `guard_paths()` signature, and deny-only behavior when no `allowed_paths` are configured are unchanged.
+
 ## [0.28.0] - 2026-07-08
 
 ### Added

--- a/docs/api/agent-config.md
+++ b/docs/api/agent-config.md
@@ -328,8 +328,17 @@ def guard_paths(
 
 Factory that returns a pre-hook restricting file access by path. Applied to `reader` and `editor`.
 
-- `allowed_paths`: if set, any path outside these roots raises `PermissionError`.
+- `allowed_paths`: if set, any path outside these roots raises `PermissionError`. A relative
+  path resolves against the first allowed root; an absolute path is accepted if it resolves
+  under any configured root.
 - `denied_paths`: patterns (absolute paths, filenames, or substrings) that are always blocked.
+
+Workspace containment delegates to `lionagi.libs.path_safety.resolve_workspace_path`: a direct
+symlink (even one whose target is inside the workspace) is refused before it is followed, and a
+fixed set of protected basenames (`.env`, `.netrc`, SSH private keys, `.htpasswd`) is denied even
+when no `denied_paths` are supplied. With no `allowed_paths` configured, path access is
+deny-only — the process working directory is never treated as an implicit allowlist — but the
+same symlink refusal and protected-basename floor still apply before `denied_paths` is checked.
 
 ```python
 spec.pre("reader", guard_paths(allowed_paths=["/Users/me/project/"]))

--- a/docs/api/agent-config.md
+++ b/docs/api/agent-config.md
@@ -329,16 +329,22 @@ def guard_paths(
 Factory that returns a pre-hook restricting file access by path. Applied to `reader` and `editor`.
 
 - `allowed_paths`: if set, any path outside these roots raises `PermissionError`. A relative
-  path resolves against the first allowed root; an absolute path is accepted if it resolves
-  under any configured root.
+  path resolves against the first allowed root, and the resulting candidate — like any
+  absolute path — is accepted if it resolves under any configured root.
 - `denied_paths`: patterns (absolute paths, filenames, or substrings) that are always blocked.
 
 Workspace containment delegates to `lionagi.libs.path_safety.resolve_workspace_path`: a direct
 symlink (even one whose target is inside the workspace) is refused before it is followed, and a
 fixed set of protected basenames (`.env`, `.netrc`, SSH private keys, `.htpasswd`) is denied even
-when no `denied_paths` are supplied. With no `allowed_paths` configured, path access is
+when no `denied_paths` are supplied, matched case-insensitively so a spelling like `.ENV` is
+denied on case-insensitive filesystems too. With no `allowed_paths` configured, path access is
 deny-only — the process working directory is never treated as an implicit allowlist — but the
 same symlink refusal and protected-basename floor still apply before `denied_paths` is checked.
+
+This guard validates a pathname at check time; it does not hold a descriptor across the check
+and the tool's later I/O. A racing filesystem mutation between the check and that I/O (for
+example, swapping a validated regular file for a symlink) is outside this guard's threat model —
+it assumes a cooperative filesystem, not an adversarial one under concurrent write access.
 
 ```python
 spec.pre("reader", guard_paths(allowed_paths=["/Users/me/project/"]))

--- a/lionagi/agent/hooks.py
+++ b/lionagi/agent/hooks.py
@@ -10,7 +10,7 @@ import re
 import warnings
 from pathlib import Path
 
-from lionagi.libs.path_safety import DENIED_NAMES, resolve_workspace_path
+from lionagi.libs.path_safety import is_protected_name, resolve_workspace_path
 
 __all__ = (
     "auto_format_python",
@@ -55,8 +55,15 @@ def _is_hard_floor_error(exc: PermissionError) -> bool:
     return "symlink" in msg or "protected path" in msg
 
 
-def _resolve_against_any_root(raw_path: str, expanded: Path, allowed_roots: list[Path]) -> Path:
-    """Absolute-path case: accept iff resolve_workspace_path succeeds for >=1 root.
+def _resolve_against_any_root(raw_path: str, candidate: Path, allowed_roots: list[Path]) -> Path:
+    """Accept iff resolve_workspace_path succeeds for >=1 root.
+
+    `candidate` is already absolute here — either the caller-supplied absolute
+    path, or a relative path pre-joined to the first allowed root — so every
+    root is tried purely as a containment check. This restores the
+    pre-existing multi-root contract: a relative path formed against the
+    first root is accepted as long as the resolved location falls under *any*
+    configured root, not only the first.
 
     A symlink or protected basename fails the same way against every root (the
     check runs before containment), so it can never be masked by trying another
@@ -65,7 +72,7 @@ def _resolve_against_any_root(raw_path: str, expanded: Path, allowed_roots: list
     hard_floor_error: PermissionError | None = None
     for root in allowed_roots:
         try:
-            return resolve_workspace_path(expanded, root)
+            return resolve_workspace_path(candidate, root)
         except PermissionError as exc:
             if hard_floor_error is None and _is_hard_floor_error(exc):
                 hard_floor_error = exc
@@ -79,7 +86,7 @@ def _deny_only_floor(raw_path: str, expanded: Path) -> Path:
     if expanded.is_symlink():
         raise PermissionError(f"Refusing to access symlink: {raw_path!r}")
     resolved = expanded.resolve(strict=False)
-    if resolved.name in DENIED_NAMES:
+    if is_protected_name(resolved.name):
         raise PermissionError(f"Refusing to access protected path: {resolved.name!r}")
     return resolved
 
@@ -88,7 +95,13 @@ def guard_paths(
     allowed_paths: list[str] | None = None,
     denied_paths: list[str] | None = None,
 ):
-    """Factory: return a pre-hook that enforces allowed/denied path constraints."""
+    """Factory: return a pre-hook that enforces allowed/denied path constraints.
+
+    Validation happens at check time only: a filesystem mutation racing this
+    check and the tool's later I/O on the same path (e.g. swapping a
+    validated regular file for a symlink after the check passes) is out of
+    scope for this pathname-based guard.
+    """
 
     allowed_roots = [Path(p).expanduser().resolve(strict=False) for p in (allowed_paths or [])]
 
@@ -100,12 +113,12 @@ def guard_paths(
         expanded = Path(raw_path).expanduser()
 
         if allowed_roots:
-            if expanded.is_absolute():
-                resolved = _resolve_against_any_root(raw_path, expanded, allowed_roots)
-            else:
-                # Documented workspace-relative rule: relative paths resolve
-                # against the first allowed root, not the process cwd.
-                resolved = resolve_workspace_path(expanded, allowed_roots[0])
+            # Documented workspace-relative rule: relative paths resolve
+            # against the first allowed root, not the process cwd. The
+            # resulting absolute candidate is then, like any absolute path,
+            # accepted if it is contained by *any* configured allowed root.
+            candidate = expanded if expanded.is_absolute() else allowed_roots[0] / expanded
+            resolved = _resolve_against_any_root(raw_path, candidate, allowed_roots)
         else:
             resolved = _deny_only_floor(raw_path, expanded)
 

--- a/lionagi/agent/hooks.py
+++ b/lionagi/agent/hooks.py
@@ -10,6 +10,8 @@ import re
 import warnings
 from pathlib import Path
 
+from lionagi.libs.path_safety import DENIED_NAMES, resolve_workspace_path
+
 __all__ = (
     "auto_format_python",
     "guard_destructive",
@@ -47,6 +49,41 @@ async def guard_destructive(tool_name: str, action: str, args: dict) -> dict | N
     return None
 
 
+def _is_hard_floor_error(exc: PermissionError) -> bool:
+    """True for the symlink/protected-name floor, false for plain containment misses."""
+    msg = str(exc)
+    return "symlink" in msg or "protected path" in msg
+
+
+def _resolve_against_any_root(raw_path: str, expanded: Path, allowed_roots: list[Path]) -> Path:
+    """Absolute-path case: accept iff resolve_workspace_path succeeds for >=1 root.
+
+    A symlink or protected basename fails the same way against every root (the
+    check runs before containment), so it can never be masked by trying another
+    root — surface that reason instead of a generic denial when it occurs.
+    """
+    hard_floor_error: PermissionError | None = None
+    for root in allowed_roots:
+        try:
+            return resolve_workspace_path(expanded, root)
+        except PermissionError as exc:
+            if hard_floor_error is None and _is_hard_floor_error(exc):
+                hard_floor_error = exc
+    if hard_floor_error is not None:
+        raise hard_floor_error
+    raise PermissionError(f"Path not in allowed list: {raw_path}")
+
+
+def _deny_only_floor(raw_path: str, expanded: Path) -> Path:
+    """No allowed roots: keep deny-only mode, but still refuse symlinks/protected names."""
+    if expanded.is_symlink():
+        raise PermissionError(f"Refusing to access symlink: {raw_path!r}")
+    resolved = expanded.resolve(strict=False)
+    if resolved.name in DENIED_NAMES:
+        raise PermissionError(f"Refusing to access protected path: {resolved.name!r}")
+    return resolved
+
+
 def guard_paths(
     allowed_paths: list[str] | None = None,
     denied_paths: list[str] | None = None,
@@ -61,16 +98,17 @@ def guard_paths(
             return None
 
         expanded = Path(raw_path).expanduser()
-        if not expanded.is_absolute() and allowed_roots:
-            # Resolve relative paths against the workspace root, not the process
-            # cwd — otherwise an in-workspace path would never match allowed_roots.
-            resolved = (allowed_roots[0] / expanded).resolve(strict=False)
-        else:
-            resolved = expanded.resolve(strict=False)
 
         if allowed_roots:
-            if not any(resolved == root or root in resolved.parents for root in allowed_roots):
-                raise PermissionError(f"Path not in allowed list: {raw_path}")
+            if expanded.is_absolute():
+                resolved = _resolve_against_any_root(raw_path, expanded, allowed_roots)
+            else:
+                # Documented workspace-relative rule: relative paths resolve
+                # against the first allowed root, not the process cwd.
+                resolved = resolve_workspace_path(expanded, allowed_roots[0])
+        else:
+            resolved = _deny_only_floor(raw_path, expanded)
+
         if denied_paths:
             for denied in denied_paths:
                 denied_path = Path(denied).expanduser()

--- a/lionagi/libs/path_safety.py
+++ b/lionagi/libs/path_safety.py
@@ -12,6 +12,21 @@ DENIED_NAMES: frozenset[str] = frozenset(
     {".env", ".netrc", "id_rsa", "id_ed25519", "id_ecdsa", ".htpasswd"}
 )
 
+_DENIED_NAMES_CASEFOLD: frozenset[str] = frozenset(name.casefold() for name in DENIED_NAMES)
+
+
+def is_protected_name(name: str) -> bool:
+    """True if name matches a protected basename, case-insensitively.
+
+    Filesystems (notably default macOS/Windows volumes) are case-insensitive,
+    so a case-sensitive membership test against DENIED_NAMES can be bypassed
+    with a spelling like ".ENV" that still resolves to the same file as
+    ".env". This is the one primitive both resolve_workspace_path and the
+    deny-only hook floor use for the protected-basename check.
+    """
+    return name.casefold() in _DENIED_NAMES_CASEFOLD
+
+
 DANGEROUS_CHARS: frozenset[str] = frozenset("/\\\x00")
 
 GLOB_CHARS: frozenset[str] = frozenset("*?[]{}~")
@@ -28,7 +43,11 @@ def resolve_workspace_path(path: str | Path, workspace_root: Path) -> Path:
     """Resolve a tool-supplied path against workspace root with full safety checks.
 
     Checks: expanduser, symlink detection pre-resolve, containment, denied names.
-    Raises PermissionError on any violation.
+    Raises PermissionError on any violation. Validation happens at check time only:
+    a concurrent filesystem mutation between this check and a later I/O call on the
+    same path (e.g. swapping a regular file for a symlink) is out of scope — callers
+    that need a stronger guarantee against a racing filesystem must perform the
+    final I/O through a root-anchored, no-follow file descriptor instead.
     """
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
@@ -39,7 +58,7 @@ def resolve_workspace_path(path: str | Path, workspace_root: Path) -> Path:
         resolved.relative_to(workspace_root)
     except ValueError as e:
         raise PermissionError(f"Path escapes workspace root: {path!r}") from e
-    if resolved.name in DENIED_NAMES:
+    if is_protected_name(resolved.name):
         raise PermissionError(f"Refusing to access protected path: {resolved.name!r}")
     return resolved
 

--- a/tests/agent/test_coding_preset_guard.py
+++ b/tests/agent/test_coding_preset_guard.py
@@ -359,6 +359,48 @@ async def test_coding_preset_evaluator_exception_fails_closed(tmp_path):
         await bash_tool.preprocessor({"action": "run", "command": "echo hi"})
 
 
+# ---------------------------------------------------------------------------
+# Symlink-escape tests driven through the bound AgentSpec.coding() preprocessor
+# (proves the canonical containment helper is wired end-to-end via the
+# security_pre / GateResult path, not just the guard_paths() factory closure
+# in isolation).
+# ---------------------------------------------------------------------------
+
+
+async def test_coding_preset_reader_blocks_symlink_escaping_workspace(tmp_path):
+    """A symlink inside the workspace pointing outside it must be blocked by
+    the bound reader preprocessor."""
+    outside = tmp_path.parent / "outside-secret.txt"
+    outside.write_text("secret")
+    link = tmp_path / "link.txt"
+    link.symlink_to(outside)
+
+    spec = AgentSpec.coding(cwd=str(tmp_path))
+    branch = await _make_branch(spec)
+
+    with pytest.raises(PermissionError, match="symlink"):
+        await _invoke_pre_hooks(branch, "reader", {"action": "read", "path": str(link)})
+
+
+async def test_coding_preset_editor_blocks_symlink_escaping_workspace(tmp_path):
+    """A symlink inside the workspace pointing outside it must be blocked by
+    the bound editor preprocessor."""
+    outside = tmp_path.parent / "outside-target.txt"
+    outside.write_text("secret")
+    link = tmp_path / "link.txt"
+    link.symlink_to(outside)
+
+    spec = AgentSpec.coding(cwd=str(tmp_path))
+    branch = await _make_branch(spec)
+
+    with pytest.raises(PermissionError, match="symlink"):
+        await _invoke_pre_hooks(
+            branch,
+            "editor",
+            {"action": "write", "file_path": str(link), "content": "bad"},
+        )
+
+
 async def test_permission_policy_evaluator_exception_fails_closed(tmp_path):
     """An explicit PermissionPolicy whose escalation handler raises must also
     fail closed via a recorded deny, not an uncaught exception."""

--- a/tests/agent/test_hooks.py
+++ b/tests/agent/test_hooks.py
@@ -116,9 +116,10 @@ async def test_guard_paths_glob_deny_allows_non_matching(tmp_path):
 
 
 async def test_guard_paths_glob_deny_blocks_dotenv(tmp_path):
-    """'.env' pattern blocks /project/.env via fnmatch component matching."""
+    """A literal '.env' basename is denied by the DENIED_NAMES hard floor, even
+    though a redundant caller '.env' deny pattern is also configured."""
     hook = guard_paths(denied_paths=[".env"])
-    with pytest.raises(PermissionError, match="deny rule"):
+    with pytest.raises(PermissionError, match="protected path"):
         await hook("reader", "read", {"path": str(tmp_path / ".env")})
 
 
@@ -146,4 +147,109 @@ async def test_guard_paths_tilde_deny_allows_unrelated(tmp_path):
     """'secret~' deny must not block a path that does not contain 'secret~'."""
     hook = guard_paths(denied_paths=["secret~"])
     result = await hook("reader", "read", {"path": str(tmp_path / "config.py")})
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Canonical workspace containment: symlink escapes and DENIED_NAMES floor
+# ---------------------------------------------------------------------------
+
+
+async def test_guard_paths_blocks_direct_symlink_escaping_workspace(tmp_path):
+    """A direct file symlink inside the workspace pointing outside it is denied."""
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    link = allowed / "link.txt"
+    link.symlink_to(outside)
+
+    hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="symlink"):
+        await hook("reader", "read", {"path": str(link)})
+
+
+async def test_guard_paths_blocks_intermediate_symlink_escaping_workspace(tmp_path):
+    """An intermediate directory symlink inside the workspace pointing outside it is denied."""
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "leaked.txt").write_text("secret")
+    link_dir = allowed / "linkdir"
+    link_dir.symlink_to(outside_dir)
+
+    hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="allowed list"):
+        await hook("reader", "read", {"path": str(link_dir / "leaked.txt")})
+
+
+async def test_guard_paths_denies_direct_symlink_to_in_workspace_target(tmp_path):
+    """A direct symlink is denied by the pre-resolve symlink rule even when its
+    target is inside the workspace."""
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    real = allowed / "real.txt"
+    real.write_text("ok")
+    link = allowed / "link.txt"
+    link.symlink_to(real)
+
+    hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="symlink"):
+        await hook("reader", "read", {"path": str(link)})
+
+
+async def test_guard_paths_denies_broken_symlink(tmp_path):
+    """A broken direct symlink is denied before it is ever followed."""
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    link = allowed / "broken.txt"
+    link.symlink_to(allowed / "does-not-exist.txt")
+
+    hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="symlink"):
+        await hook("reader", "read", {"path": str(link)})
+
+
+@pytest.mark.parametrize("basename", [".env", ".netrc", "id_rsa"])
+async def test_guard_paths_denies_protected_basenames_without_denied_paths(tmp_path, basename):
+    """Protected basenames are denied even when the caller supplies no denied_paths,
+    both with and without allowed roots configured."""
+    protected = tmp_path / basename
+
+    deny_only_hook = guard_paths()
+    with pytest.raises(PermissionError, match="protected path"):
+        await deny_only_hook("reader", "read", {"path": str(protected)})
+
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    protected_in_root = allowed / basename
+    allow_root_hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="protected path"):
+        await allow_root_hook("reader", "read", {"path": str(protected_in_root)})
+
+
+async def test_guard_paths_allows_relative_path_under_first_root(tmp_path):
+    """A normal relative path resolves against and is allowed under the first root."""
+    allowed = tmp_path / "project"
+    allowed.mkdir()
+    hook = guard_paths(allowed_paths=[str(allowed)])
+
+    result = await hook("reader", "read", {"path": "src/main.py"})
+    assert result is None
+
+
+async def test_guard_paths_absolute_second_root_allowed_relative_resolves_first(tmp_path):
+    """An absolute path under a second allowed root is allowed, while a relative
+    path continues to resolve under the first allowed root."""
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    hook = guard_paths(allowed_paths=[str(first), str(second)])
+
+    result = await hook("reader", "read", {"path": str(second / "under_second.py")})
+    assert result is None
+
+    result = await hook("reader", "read", {"path": "under_first.py"})
     assert result is None

--- a/tests/agent/test_hooks.py
+++ b/tests/agent/test_hooks.py
@@ -8,6 +8,7 @@ import inspect
 import pytest
 
 from lionagi.agent.hooks import auto_format_python, guard_destructive, guard_paths
+from lionagi.libs.path_safety import DENIED_NAMES
 
 
 async def test_guard_paths_returns_callable_hook(tmp_path):
@@ -229,6 +230,28 @@ async def test_guard_paths_denies_protected_basenames_without_denied_paths(tmp_p
         await allow_root_hook("reader", "read", {"path": str(protected_in_root)})
 
 
+@pytest.mark.parametrize("basename", sorted(DENIED_NAMES))
+@pytest.mark.parametrize("casing", ["upper", "title"])
+async def test_guard_paths_denies_protected_basenames_case_variants(tmp_path, basename, casing):
+    """Every DENIED_NAMES member is denied under an uppercase/mixed-case spelling
+    too, in both deny-only and allow-root modes — not just the exact lowercase
+    spelling — so a case-insensitive filesystem alias (e.g. '.ENV' for '.env')
+    cannot bypass the protected-basename floor."""
+    variant = basename.upper() if casing == "upper" else basename.title()
+
+    protected = tmp_path / variant
+    deny_only_hook = guard_paths()
+    with pytest.raises(PermissionError, match="protected path"):
+        await deny_only_hook("reader", "read", {"path": str(protected)})
+
+    allowed = tmp_path / "project"
+    allowed.mkdir(exist_ok=True)
+    protected_in_root = allowed / variant
+    allow_root_hook = guard_paths(allowed_paths=[str(allowed)])
+    with pytest.raises(PermissionError, match="protected path"):
+        await allow_root_hook("reader", "read", {"path": str(protected_in_root)})
+
+
 async def test_guard_paths_allows_relative_path_under_first_root(tmp_path):
     """A normal relative path resolves against and is allowed under the first root."""
     allowed = tmp_path / "project"
@@ -253,3 +276,35 @@ async def test_guard_paths_absolute_second_root_allowed_relative_resolves_first(
 
     result = await hook("reader", "read", {"path": "under_first.py"})
     assert result is None
+
+
+async def test_guard_paths_cross_root_relative_path_accepted(tmp_path):
+    """Pre-existing multi-root contract: a relative path is formed against the
+    first allowed root, but the resulting candidate is accepted if it resolves
+    under *any* configured root — not rejected outright just because it escapes
+    the first root. With roots [src, docs], '../docs/guide.md' (relative to
+    src) must resolve into docs and be allowed."""
+    src = tmp_path / "src"
+    docs = tmp_path / "docs"
+    src.mkdir()
+    docs.mkdir()
+    (docs / "guide.md").write_text("hello")
+    hook = guard_paths(allowed_paths=[str(src), str(docs)])
+
+    result = await hook("reader", "read", {"path": "../docs/guide.md"})
+    assert result is None
+
+
+async def test_guard_paths_relative_path_outside_all_roots_still_denied(tmp_path):
+    """A relative path that escapes every configured root remains denied."""
+    src = tmp_path / "src"
+    docs = tmp_path / "docs"
+    outside = tmp_path / "outside"
+    src.mkdir()
+    docs.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("nope")
+    hook = guard_paths(allowed_paths=[str(src), str(docs)])
+
+    with pytest.raises(PermissionError, match="allowed list"):
+        await hook("reader", "read", {"path": "../outside/secret.txt"})


### PR DESCRIPTION
Security hardening for `guard_paths()`: workspace containment now delegates to `lionagi.libs.path_safety.resolve_workspace_path`, which adds pre-resolve symlink refusal and the protected-basename (`DENIED_NAMES`) floor that the hook's hand-rolled parent-walk check lacked. Public signature, multi-root composition, and custom `denied_paths` semantics unchanged.

- Deny-only mode (no allowed roots) keeps its semantics but gains the symlink + protected-name hard floor.
- Absolute paths accepted iff resolution succeeds against at least one allowed root; symlink/protected-name refusals can't be masked by another root.
- New adversarial tests: direct/intermediate/broken symlink escapes, protected basenames (`.env`, `.netrc`, SSH keys) with no caller deny rules, multi-root cases, plus symlink escapes driven through `AgentSpec.coding(cwd=...)`'s bound preprocessors (real gate path).
- `tests/agent` + `tests/hooks` + `tests/tools`: 761 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)