### PR TITLE
test(service): pin endpoint routing and ollama transport behavior

### DIFF
--- a/tests/service/connections/providers/test_ollama.py
+++ b/tests/service/connections/providers/test_ollama.py
@@ -263,7 +263,29 @@ class TestOllamaModelManagement:
 
 
 class TestOllamaCall:
-    """Test Ollama call method and integration."""
+    """Test Ollama call method against the real base HTTP transport.
+
+    Only Ollama's own model listing/pulling SDK calls (``ollama.list`` /
+    ``ollama.pull``) are faked here. ``Endpoint.call`` and ``_call_aiohttp``
+    run for real against a local ``aiohttp`` server, so these tests prove the
+    wrapper actually sends a request over the wire and decodes a realistic
+    response, not merely that it delegates to its parent class.
+    """
+
+    @staticmethod
+    async def _start_chat_completions_server(response_body: dict, received: list):
+        from aiohttp import web
+        from aiohttp.test_utils import TestServer
+
+        async def handler(request):
+            received.append(await request.json())
+            return web.json_response(response_body)
+
+        app = web.Application()
+        app.router.add_post("/chat/completions", handler)
+        server = TestServer(app)
+        await server.start_server()
+        return server
 
     @pytest.mark.asyncio
     @patch("lionagi.providers.ollama.chat._HAS_OLLAMA", True)
@@ -282,21 +304,37 @@ class TestOllamaCall:
 
         endpoint = OllamaChatEndpoint()
 
-        # Mock parent call method
-        with patch.object(
-            endpoint.__class__.__bases__[0], "call", new_callable=AsyncMock
-        ) as mock_super_call:
-            mock_super_call.return_value = {"response": "test"}
-
+        response_body = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "model": "llama2",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi there"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        received: list = []
+        server = await self._start_chat_completions_server(response_body, received)
+        endpoint.config.base_url = f"http://127.0.0.1:{server.port}"
+        try:
             request = {
                 "model": "llama2",
                 "messages": [{"role": "user", "content": "hello"}],
             }
+            result = await endpoint.call(request)
+        finally:
+            await server.close()
 
-            await endpoint.call(request)
-
-            # Verify super().call() was invoked
-            mock_super_call.assert_called_once()
+        # Model was already available: no pull, and the wrapper must have
+        # actually sent one request carrying the model and messages.
+        mock_ollama.pull.assert_not_called()
+        assert len(received) == 1
+        assert received[0]["model"] == "llama2"
+        assert received[0]["messages"] == [{"role": "user", "content": "hello"}]
+        assert result == response_body
 
     @pytest.mark.asyncio
     @patch("lionagi.providers.ollama.chat._HAS_OLLAMA", True)
@@ -315,21 +353,38 @@ class TestOllamaCall:
 
         endpoint = OllamaChatEndpoint()
 
-        # Mock parent call method
-        with patch.object(
-            endpoint.__class__.__bases__[0], "call", new_callable=AsyncMock
-        ) as mock_super_call:
-            mock_super_call.return_value = {"response": "test"}
-
+        response_body = {
+            "id": "chatcmpl-test-2",
+            "object": "chat.completion",
+            "model": "mistral",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi there"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        received: list = []
+        server = await self._start_chat_completions_server(response_body, received)
+        endpoint.config.base_url = f"http://127.0.0.1:{server.port}"
+        try:
             request = {
                 "model": "mistral",
                 "messages": [{"role": "user", "content": "hello"}],
             }
 
             with caplog.at_level("DEBUG", logger="lionagi.providers.ollama.chat"):
-                await endpoint.call(request)
+                result = await endpoint.call(request)
+        finally:
+            await server.close()
 
-            assert "not found locally" in caplog.text
+        assert "not found locally" in caplog.text
+        mock_ollama.pull.assert_called_once()
+        assert len(received) == 1
+        assert received[0]["model"] == "mistral"
+        assert received[0]["messages"] == [{"role": "user", "content": "hello"}]
+        assert result == response_body
 
 
 class TestOllamaConfig:

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -150,7 +150,7 @@ class TestMatchEndpoint:
 
         assert isinstance(endpoint, OpenaiChatEndpoint)
 
-    def test_provider_case_insensitive(self):
+    def test_provider_case_sensitive_routing(self):
         from lionagi.providers.openai.chat import OpenaiChatEndpoint
 
         endpoint_lower = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -9,53 +9,65 @@ from lionagi.service.connections.match_endpoint import match_endpoint
 
 
 class TestMatchEndpoint:
-    """Test the match_endpoint function for provider matching logic."""
+    """Test the match_endpoint function for provider matching logic.
+
+    ``EndpointRegistry.match`` always returns either a registered endpoint
+    instance or the generic fallback ``Endpoint`` — it never returns
+    ``None``. Guards like ``if endpoint is None: pytest.skip(...)`` are
+    therefore unreachable dead code that can silently mask a routing
+    regression as a skip. These tests assert the concrete registered
+    endpoint class rather than only ``isinstance(endpoint, Endpoint)``, so a
+    regression that quietly falls through to the generic fallback fails
+    loudly.
+    """
 
     def test_openai_chat_endpoint(self):
+        from lionagi.providers.openai.chat import OpenaiChatEndpoint
+
         endpoint = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")
 
-        assert isinstance(endpoint, Endpoint)
+        assert isinstance(endpoint, OpenaiChatEndpoint)
         assert endpoint.config.provider == "openai"
-        # The actual endpoint might be different than the input endpoint
-        # OpenAI compatible flag may be set differently based on implementation
 
     def test_anthropic_messages_endpoint(self):
+        from lionagi.providers.anthropic.messages import AnthropicMessagesEndpoint
+
         endpoint = match_endpoint(
             provider="anthropic",
             endpoint="chat",
             model="claude-3-opus-20240229",
         )
 
-        assert isinstance(endpoint, Endpoint)
+        assert isinstance(endpoint, AnthropicMessagesEndpoint)
         assert endpoint.config.provider == "anthropic"
         assert endpoint.config.default_headers["anthropic-version"] == "2023-06-01"
 
     def test_perplexity_endpoint(self):
+        from lionagi.providers.perplexity.chat import PerplexityChatEndpoint
+
         endpoint = match_endpoint(
             provider="perplexity",
             endpoint="chat",
             model="llama-3.1-sonar-small-128k-online",
         )
 
-        assert isinstance(endpoint, Endpoint)
+        assert isinstance(endpoint, PerplexityChatEndpoint)
         assert endpoint.config.provider == "perplexity"
 
-    # def test_ollama_endpoint(self):
-    #     """Test matching Ollama endpoint."""
-    #     endpoint = match_endpoint(
-    #         provider="ollama", endpoint="chat", model="llama2"
-    #     )
+    def test_ollama_endpoint(self):
+        from lionagi.providers.ollama.chat import OllamaChatEndpoint
 
-    #     assert isinstance(endpoint, Endpoint)
-    #     assert endpoint.config.provider == "ollama"
+        endpoint = match_endpoint(provider="ollama", endpoint="chat", model="llama2")
+
+        assert isinstance(endpoint, OllamaChatEndpoint)
+        assert endpoint.config.provider == "ollama"
 
     def test_exa_search_endpoint(self):
+        from lionagi.providers.exa.search import ExaSearchEndpoint
+
         endpoint = match_endpoint(provider="exa", endpoint="search", query="test query")
 
-        # Exa endpoint may not be supported yet
-        if endpoint is None:
-            pytest.skip("Exa endpoint not implemented")
-        assert isinstance(endpoint, Endpoint)
+        assert isinstance(endpoint, ExaSearchEndpoint)
         assert endpoint.config.provider == "exa"
 
     def test_custom_base_url(self):
@@ -82,10 +94,9 @@ class TestMatchEndpoint:
     def test_unknown_provider_fallback(self):
         endpoint = match_endpoint(provider="unknown_provider", endpoint="chat", model="some-model")
 
-        # Unknown providers may return None
-        if endpoint is None:
-            pytest.skip("Unknown provider not supported")
-        assert isinstance(endpoint, Endpoint)
+        # An unregistered provider must route to the generic openai-compatible
+        # fallback endpoint, not raise and not return None.
+        assert type(endpoint).__name__ == "Endpoint"
         assert endpoint.config.provider == "unknown_provider"
 
     def test_model_parameter_filtering(self):
@@ -109,8 +120,6 @@ class TestMatchEndpoint:
     def test_openai_compatibility(self, provider, expected_compatible):
         endpoint = match_endpoint(provider=provider, endpoint="chat", model="test-model")
 
-        if endpoint is None:
-            pytest.skip(f"{provider} endpoint not implemented")
         assert endpoint.config.openai_compatible == expected_compatible
 
     def test_endpoint_with_api_key(self):
@@ -135,23 +144,38 @@ class TestMatchEndpoint:
         assert endpoint.config.default_headers["anthropic-version"] == "2023-06-01"
 
     def test_endpoint_params_inheritance(self):
+        from lionagi.providers.openai.chat import OpenaiChatEndpoint
+
         endpoint = match_endpoint(provider="openai", endpoint="chat")
 
-        if endpoint is None:
-            pytest.skip("OpenAI endpoint not supported")
-        # Endpoint params structure may vary
-        assert isinstance(endpoint, Endpoint)
+        assert isinstance(endpoint, OpenaiChatEndpoint)
 
     def test_provider_case_insensitive(self):
+        from lionagi.providers.openai.chat import OpenaiChatEndpoint
+
         endpoint_lower = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")
 
         endpoint_upper = match_endpoint(provider="OPENAI", endpoint="chat", model="gpt-4.1-mini")
 
-        if endpoint_lower is None or endpoint_upper is None:
-            pytest.skip("Provider case insensitive not supported")
-        assert endpoint_lower.config.provider == endpoint_upper.config.provider
+        # EndpointRegistry.match compares provider strings exactly, so an
+        # exact-case "openai" routes to the concrete registered endpoint
+        # while a differently-cased "OPENAI" misses the registry entry and
+        # falls through to the generic fallback Endpoint. `EndpointConfig`
+        # separately lower-cases `config.provider` on validation, so both
+        # instances still report `config.provider == "openai"` — asserting
+        # only that string equality is too weak, because it stays true even
+        # when the uppercase input silently misses registered routing. The
+        # class-identity checks below are what actually distinguish
+        # registered routing from the generic fallback.
+        assert isinstance(endpoint_lower, OpenaiChatEndpoint)
+        assert type(endpoint_upper).__name__ == "Endpoint"
+        assert type(endpoint_lower) is not type(endpoint_upper)
+        assert endpoint_lower.config.provider == endpoint_upper.config.provider == "openai"
 
     def test_multiple_providers_isolation(self):
+        from lionagi.providers.anthropic.messages import AnthropicMessagesEndpoint
+        from lionagi.providers.openai.chat import OpenaiChatEndpoint
+
         openai_endpoint = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")
 
         anthropic_endpoint = match_endpoint(
@@ -160,8 +184,8 @@ class TestMatchEndpoint:
             model="claude-3-opus-20240229",
         )
 
-        if openai_endpoint is None or anthropic_endpoint is None:
-            pytest.skip("One or both endpoints not supported")
+        assert isinstance(openai_endpoint, OpenaiChatEndpoint)
+        assert isinstance(anthropic_endpoint, AnthropicMessagesEndpoint)
 
         # Should be different instances with different configurations
         assert openai_endpoint is not anthropic_endpoint


### PR DESCRIPTION
Test-only hardening so routing and transport regressions actually fail:

- `test_match_endpoint.py`: removes unreachable `None`-skip guards (`EndpointRegistry.match` never returns None), asserts concrete registered endpoint classes instead of base-class isinstance, and pins the current case-sensitivity behavior — uppercase provider strings miss the registry and get the generic fallback `Endpoint`, now regression-visible instead of silently passing a weak string check.
- `test_ollama.py`: the call tests now drive `Endpoint.call` through a real local aiohttp test server (exact wire body + decoded response asserted) instead of patching `Endpoint.call` wholesale; only the SDK's model listing/pulling stays mocked.

`tests/service/connections`: 357 passed. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)