### PR TITLE
docs(adr): accept eight verified retrospective ADRs in the core protocols area

### DIFF
--- a/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
+++ b/docs/adr/ADR-0001-element-identity-and-polymorphic-serialization-envelope.md
@@ -1,6 +1,6 @@
 # ADR-0001: Element identity and polymorphic serialization envelope
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: core-data-model
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
+++ b/docs/adr/ADR-0002-uuid-keyed-ordered-collection-model.md
@@ -1,6 +1,6 @@
 # ADR-0002: UUID-keyed ordered collection model
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: core-data-model
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
+++ b/docs/adr/ADR-0003-in-process-event-execution-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-0003: In-process Event execution lifecycle
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: core-data-model
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0004-directed-graph-structural-invariants.md
+++ b/docs/adr/ADR-0004-directed-graph-structural-invariants.md
@@ -1,6 +1,6 @@
 # ADR-0004: Directed graph structural invariants
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: core-data-model
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
+++ b/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
@@ -1,6 +1,6 @@
 # ADR-0006: Conversational message envelope and ordered history
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: messages-context
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
+++ b/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
@@ -1,6 +1,6 @@
 # ADR-0008: Pre-turn context-provider execution and attribution
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: messages-context
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -1,6 +1,6 @@
 # ADR-0011: Function tool descriptor and Branch registry
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: actions-tools
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
+++ b/docs/adr/ADR-0012-branch-action-execution-and-event-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-0012: Branch action execution and event lifecycle
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: actions-tools
 - **Date**: 2026-07-09


### PR DESCRIPTION
Flips **Status: Proposed → Accepted** for eight retrospective ADRs whose central design claims were verified against source at commit `354f46cf5`.

| ADR | Claims verified |
|---|---|
| ADR-0001 element identity & serialization envelope | 4/4 |
| ADR-0002 UUID-keyed ordered collection model | 6/6 |
| ADR-0003 in-process event execution lifecycle | 6/6 |
| ADR-0004 directed graph structural invariants | 5/5 (incl. empirical repro of the described round-trip failure) |
| ADR-0006 conversational message envelope & history | 6/6 |
| ADR-0008 pre-turn context provider execution | 7/7 |
| ADR-0011 function tool descriptor & branch registry | 4/4 |
| ADR-0012 branch action execution & event lifecycle | 6/6 |

Zero contradicted claims. Every claim was resolved to file:line evidence; the gaps each ADR records in its Current-vs-ideal delta table are tracked as issues (see the Issue columns) and are not papered over by acceptance.

**ADR-0007** (canonical turn-request compilation) is deliberately **not** flipped: it is self-declared Aspirational and none of its proposed types (`TurnRequest`, `CompiledChatRequest`, `compile_chat_request`, …) exist in the tree yet — it stays Proposed until implementation gates.

Docs-only; 8 single-line Status changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)