### PR TITLE
docs(adr): accept five verified ADRs in the services, orchestration, and agent-spec areas

### DIFF
--- a/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
+++ b/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
@@ -1,6 +1,6 @@
 # ADR-0027: Model-service facade and endpoint resolution
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: service-providers
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
+++ b/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0033: Operation-graph orchestration boundary
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: orchestration
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
+++ b/docs/adr/ADR-0034-domain-engine-coordination-and-autonomy-safeguards.md
@@ -1,6 +1,6 @@
 # ADR-0034: Domain-engine coordination and autonomy safeguards
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: orchestration
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0035-persisted-run-completion-contract.md
+++ b/docs/adr/ADR-0035-persisted-run-completion-contract.md
@@ -1,6 +1,6 @@
 # ADR-0035: Persisted run-completion contract
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: orchestration
 - **Date**: 2026-07-09
@@ -99,7 +99,7 @@ SESSION_TERMINAL_STATUSES = frozenset({
 
 INVOCATION_TERMINAL_STATUSES = SESSION_TERMINAL_STATUSES
 SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({
-    "completed", "failed", "skipped", "cancelled"
+    "completed", "failed", "timed_out", "skipped", "cancelled"
 })
 PLAY_TERMINAL_STATUSES = frozenset({
     "merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"
@@ -122,7 +122,7 @@ The wait surface supports four of those kinds:
 | `session` | `completed`, `completed_empty`, `failed`, `timed_out`, `aborted`, `cancelled` | `completed` |
 | `invocation` | same as Session | `completed` |
 | `play` | `merged`, `escalated`, `gate_failed`, `blocked`, `aborted_after_finish` | `merged` |
-| `schedule_run` | `completed`, `failed`, `skipped`, `cancelled` | `completed` |
+| `schedule_run` | `completed`, `failed`, `timed_out`, `skipped`, `cancelled` | `completed` |
 
 **Exact semantics**:
 

--- a/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
+++ b/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
@@ -1,6 +1,6 @@
 # ADR-0041: Agent specification and Branch construction boundary
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: agent-roles
 - **Date**: 2026-07-09


### PR DESCRIPTION
Flips five ADRs from Proposed to Accepted after per-claim source verification at SHA 354f46cf5:

- ADR-0027 model service facade and endpoint resolution — 6/6 central decision claims verified
- ADR-0033 operation-graph orchestration boundary — 6/6 verified
- ADR-0034 domain engine coordination and autonomy safeguards — 5/5 verified
- ADR-0035 persisted run completion contract — 5/6 verified; the sixth was a transcription omission in the ADR text, corrected in this PR (see below)
- ADR-0041 agent specification and branch construction — 14/14 verified

**Correction folded in (ADR-0035)**: the ADR's `SCHEDULE_RUN_TERMINAL_STATUSES` block and the wait-surface table both omitted `timed_out`, which the implementation includes (`lionagi/state/lifecycle/policy.py`). The code is self-consistent; the ADR text was the error. A consumer following the documented set would have treated a timed-out schedule run as non-terminal in `li wait`. Both occurrences now match the implementation.

ADR-0028, ADR-0029, and ADR-0030 in the same area remain Proposed: their proposed constructs have no implementation in the tree (verified by per-construct search plus a check for partial adoption under different names), so acceptance would be premature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)