### PR TITLE
docs(adr): accept six verified ADRs in the casts, hooks, and persistence areas

### DIFF
--- a/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
+++ b/docs/adr/ADR-0037-resident-engine-host-and-task-queue.md
@@ -4,7 +4,7 @@
 - **Kind**: Aspirational
 - **Area**: orchestration
 - **Date**: 2026-07-09
-- **Relations**: supersedes v0-0098; extends ADR-0033, ADR-0034
+- **Relations**: supersedes v0-0098; extends ADR-0033, ADR-0034; overlaps v0-0101 (the shipped schedule_runs task-application queue covers the durable-queue problem under a different architecture)
 
 ## Context
 

--- a/docs/adr/ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md
+++ b/docs/adr/ADR-0042-casts-pattern-catalog-and-typed-role-authoring.md
@@ -1,6 +1,6 @@
 # ADR-0042: Casts pattern catalog and typed role authoring
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: agent-roles
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
+++ b/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
@@ -1,6 +1,6 @@
 # ADR-0047: Hook mechanism scopes and canonical ownership
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: hooks
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0052-supported-validation-and-testing-surfaces.md
+++ b/docs/adr/ADR-0052-supported-validation-and-testing-surfaces.md
@@ -1,6 +1,6 @@
 # ADR-0052: Supported validation and testing surfaces
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: utilities
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0055-operational-state-persistence-boundary.md
+++ b/docs/adr/ADR-0055-operational-state-persistence-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0055: Operational state persistence boundary
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: persistence-state
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0056-statedb-sqlalchemy-core-backend.md
+++ b/docs/adr/ADR-0056-statedb-sqlalchemy-core-backend.md
@@ -1,6 +1,6 @@
 # ADR-0056: StateDB SQLAlchemy Core backend
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: persistence-state
 - **Date**: 2026-07-09
@@ -171,10 +171,11 @@ StateDB.open()
        1. _reconcile_columns()
        2. SQLite: rebuild legacy sessions status CHECK if present
        3. SQLite: rebuild legacy schedules action-kind CHECK if present
-       4. SQLite: rebuild legacy invocations status CHECK if present
-       5. SQLite: rebuild legacy schedule_runs CHECK/nullability if present
-       6. metadata.create_all()
-       7. seed schema_meta version/created_at and message_types rows
+       4. SQLite: rebuild legacy schedules action-kind CHECK to admit `command` if present
+       5. SQLite: rebuild legacy invocations status CHECK if present
+       6. SQLite: rebuild legacy schedule_runs CHECK/nullability if present
+       7. metadata.create_all()
+       8. seed schema_meta version/created_at and message_types rows
 ```
 
 `schema_meta.py` currently declares these tables from one `MetaData` object:

--- a/docs/adr/ADR-0057-operational-lifecycle-and-transition-audit.md
+++ b/docs/adr/ADR-0057-operational-lifecycle-and-transition-audit.md
@@ -1,6 +1,6 @@
 # ADR-0057: Operational lifecycle and transition audit
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: persistence-state
 - **Date**: 2026-07-09
@@ -118,13 +118,15 @@ Code anchors: `lionagi/state/db.py`; `lionagi/state/reasons.py`;
 - Session and invocation deliberately share the same seven values and terminal set.
 - A same-status write is permitted even when the value is terminal; it refreshes current reason and
   appends history rather than counting as leaving terminal.
-- The current schedule-run declarations disagree. Its schema admits nine values. The
-  `StateDB.update_status()` validator admits terminal values `completed`, `failed`, `skipped`, and
-  `cancelled` plus `pending`, `running`, and `queued`; it omits `waiting_dependency`, `retry_wait`,
-  and `timed_out` and includes `pending`, which the schema CHECK does not admit.
-- The smaller guarded adapter declares only `queued -> {cancelled, running}`,
-  `running -> {completed, failed, queued}`, and no outgoing edges from `completed`, `failed`, or
-  `cancelled`. Other schedule-run schema states have no declared outgoing edge in that adapter.
+- The schedule-run declarations are reconciled through the lifecycle policy registry. Both the
+  `StateDB.update_status()` validator and the guarded adapter source the nine-value vocabulary and
+  the five-value terminal set (which includes `timed_out`) from the registered policy
+  (`lionagi/state/db.py:284-291`, `lionagi/state/lifecycle/policy.py:305-320`); `pending` is not
+  admitted by either surface.
+- The registered schedule-run edge graph declares `queued -> {waiting_dependency, running, skipped,
+  cancelled}`, `waiting_dependency -> {queued, cancelled}`, `running -> {completed, failed,
+  timed_out, retry_wait, queued, cancelled}`, and `retry_wait -> {queued, cancelled}`; terminal
+  states have no outgoing edges (`lionagi/state/lifecycle/policy.py:321-326`).
 - Dispatch is absent from `VALID_ENTITY_TYPES`; its adapter maps it directly to
   `dispatch_outbox` and validates only its reason code plus database CHECK at write time.
 
@@ -449,8 +451,9 @@ Code anchors: `lionagi/state/transitions.py`; `lionagi/state/db.py`.
 - Dispatch has no adapter-level allowed-edge graph. Any current-to-target pair that passes the
   caller's CAS and the table's six-value CHECK can be written through this function.
 - Schedule run has the partial closed graph described in D1.
-- `StateDB.update_status()` and this adapter both cover `schedule_run`, with different vocabularies,
-  guard/patch allowlists, return types, and terminal behavior.
+- `StateDB.update_status()` and this adapter both cover `schedule_run`. Both source the vocabulary
+  and terminal set from the lifecycle policy registry; they still differ in guard/patch allowlists,
+  return types, and edge-enforcement behavior.
 - Branches and engine runs have stored statuses but are not in the six-type reason registry.
 - Initial entity inserts do not use either transition API, except `enqueue_dispatch()`, which
   explicitly inserts its initial transition in the same transaction.


### PR DESCRIPTION
Flips six ADRs from Proposed to Accepted after per-claim source verification at SHA fff96bb50:

- ADR-0042 casts pattern catalog and typed role authoring — 5/5 central decision claims verified, plus the 40-role/14-mode catalog counts
- ADR-0047 hook mechanism scopes and canonical ownership — 8/8 verified (full-claim pass)
- ADR-0052 supported validation and testing surfaces — 8/8 verified (full-claim pass)
- ADR-0055 operational state persistence boundary — 6/6 verified
- ADR-0056 StateDB SQLAlchemy Core backend — 6/7 verified; one enumeration omission corrected in this PR
- ADR-0057 operational lifecycle and transition audit — 6/7 verified; one stale passage updated in this PR

**Corrections folded in:**

*ADR-0056*: the enumerated `open()` sequence listed four SQLite legacy-CHECK rebuild steps; `_apply_schema()` runs five. The missing step (rebuilding the schedules action-kind CHECK to admit `command`) is now listed and the sequence renumbered.

*ADR-0057*: the D1 passage describing schedule-run declarations as disagreeing (a validator omitting `timed_out`, `waiting_dependency`, and `retry_wait` while admitting `pending`) predates the lifecycle policy registry. Both surfaces now source the nine-value vocabulary and five-value terminal set from the registered policy (`lionagi/state/db.py:284-291`, `lionagi/state/lifecycle/policy.py:305-320`), so the passage now describes the reconciled state, including the registered edge graph that replaced the adapter's previously narrower one. The D5 bullet claiming the two APIs use different vocabularies is narrowed accordingly: they share the registry's vocabulary and terminal set and still differ in guard/patch allowlists, return types, and edge enforcement.

**Also included**: ADR-0037 (which remains Proposed) gains a Relations cross-reference to the archived v0-0101 record, whose shipped schedule_runs task-application queue covers the durable-queue problem under a different architecture. The two designs overlap in problem space, and the corpus should say so.

ADR-0036, ADR-0038, and ADR-0043 in the same areas remain Proposed: their proposed constructs have no implementation in the tree (verified per construct, plus a check for partial adoption under different names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)