### PR TITLE
ci(docs): check enumerated ADR status sets against the lifecycle policy registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       if: needs.changes.outputs.adr == 'true'
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
+        # The installer prefers XDG_BIN_HOME then ~/.local/bin; ~/.cargo/bin is
+        # a legacy fallback — put both on PATH so either layout resolves.
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Check ADR status sets against the lifecycle policy registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       run: scripts/ci.sh lint-python
 
   docs:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -46,6 +47,22 @@ jobs:
       with:
         args: "--no-progress --offline docs/ README.md AGENT.md CLAUDE.md CONTRIBUTING.md"
         fail: true
+
+    # Only when docs/adr/ or the lifecycle policy registry itself changed —
+    # this check compares the two against each other, so an unrelated docs
+    # PR has nothing new to verify.
+    - name: Install uv
+      if: needs.changes.outputs.adr == 'true'
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Check ADR status sets against the lifecycle policy registry
+      if: needs.changes.outputs.adr == 'true'
+      run: |
+        uv venv
+        uv sync --all-extras
+        uv run python scripts/check_adr_status_sets.py
 
   test:
     runs-on: ubuntu-latest
@@ -191,6 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       studio: ${{ steps.filter.outputs.studio }}
+      adr: ${{ steps.filter.outputs.adr }}
     steps:
     - uses: actions/checkout@v7
     - uses: dorny/paths-filter@v4
@@ -206,6 +224,9 @@ jobs:
             - 'marketplace/**'
             - '.claude-plugin/**'
             - '.github/workflows/ci.yml'
+          adr:
+            - 'docs/adr/**'
+            - 'lionagi/state/lifecycle/**'
 
   # Build the Studio image (Vite SPA + FastAPI single-origin) whenever its inputs
   # change, so a broken image is caught on the PR that breaks it instead of at

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -222,3 +222,7 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 - 0095 — unused (intentional gap)
 
 Remaining areas land here as their records are accepted.
+
+Status-set literals quoted in these records (terminal sets, valid-status vocabularies) are
+checked against the lifecycle policy registry in CI (`scripts/check_adr_status_sets.py`);
+a registry change that stale-ifies a quoted set fails the docs job.

--- a/scripts/check_adr_status_sets.py
+++ b/scripts/check_adr_status_sets.py
@@ -1,0 +1,186 @@
+"""Check that enumerated status sets in docs/adr/ match the lifecycle policy registry.
+
+Scope is deliberately narrow: only status vocabularies and terminal-status sets,
+not general ADR prose. Two shapes are checked:
+
+- Python code-block assignments like ``SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({...})``
+  or ``VALID_SESSION_STATUSES = frozenset({...})``.
+- Wait-surface-style markdown tables with a "Terminal statuses" column and rows
+  like ``| `schedule_run` | `completed`, `failed`, ... | ... |``.
+
+A symbol/row is compared against ``lionagi.state.lifecycle.policy.DEFAULT_REGISTRY``
+only when its name/kind resolves to a known entity_type; unrecognized symbols are
+skipped rather than treated as errors. Usage: ``uv run scripts/check_adr_status_sets.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from lionagi.state.lifecycle.policy import DEFAULT_REGISTRY
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ADR_DIR = REPO_ROOT / "docs" / "adr"
+
+_CODE_BLOCK_RE = re.compile(r"```(?:python|py)\n(.*?)```", re.S)
+_ASSIGNMENT_RE = re.compile(r"([A-Z][A-Z0-9_]*)\s*=\s*frozenset\(\{(.*?)\}\)", re.S)
+_QUOTED_STATUS_RE = re.compile(r'"([A-Za-z0-9_]+)"')
+_BACKTICK_STATUS_RE = re.compile(r"`([a-z0-9_]+)`")
+_BACKTICK_LIST_RE = re.compile(r"`[a-z0-9_]+`(?:,\s*`[a-z0-9_]+`)*")
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: Path
+    label: str
+    line: int
+    kind: str  # "terminal" or "vocab"
+    entity_type: str
+    doc_statuses: frozenset[str]
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _resolve_symbol(name: str) -> tuple[str, str] | None:
+    """Map a Python symbol name to (category, entity_type), or None if unrecognized."""
+    if name.endswith("_TERMINAL_STATUSES"):
+        core = name[: -len("_TERMINAL_STATUSES")]
+        return "terminal", core.lower()
+    if name.endswith("_STATUSES"):
+        core = name[: -len("_STATUSES")]
+        if core.startswith("VALID_"):
+            core = core[len("VALID_") :]
+        return "vocab", core.lower()
+    return None
+
+
+def _iter_python_findings(path: Path, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for block in _CODE_BLOCK_RE.finditer(text):
+        block_text = block.group(1)
+        block_offset = block.start(1)
+        for match in _ASSIGNMENT_RE.finditer(block_text):
+            name, body = match.group(1), match.group(2)
+            resolved = _resolve_symbol(name)
+            if resolved is None:
+                continue
+            kind, entity_type = resolved
+            if entity_type not in DEFAULT_REGISTRY:
+                continue
+            statuses = frozenset(_QUOTED_STATUS_RE.findall(body))
+            if not statuses:
+                continue
+            line = _line_of(text, block_offset + match.start(1))
+            findings.append(Finding(path, name, line, kind, entity_type, statuses))
+    return findings
+
+
+def _iter_table_findings(path: Path, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = text.split("\n")
+    terminal_col: int | None = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            terminal_col = None
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if terminal_col is None:
+            # Candidate header row: look for a column mentioning "terminal".
+            header_col = next((i for i, c in enumerate(cells) if "terminal" in c.lower()), None)
+            if header_col is None:
+                continue
+            # Next non-blank line must be a markdown table separator.
+            if idx + 1 >= len(lines) or not re.fullmatch(r"\|?[\s:|-]+\|?", lines[idx + 1].strip()):
+                continue
+            terminal_col = header_col
+            continue
+        if terminal_col >= len(cells):
+            continue
+        kind_match = re.fullmatch(r"`([a-z0-9_]+)`", cells[0])
+        if kind_match is None:
+            continue
+        entity_type = kind_match.group(1)
+        if entity_type not in DEFAULT_REGISTRY:
+            continue
+        cell = cells[terminal_col]
+        # Only treat the cell as an enumerated status list when it is nothing
+        # but a comma-separated run of backtick-quoted statuses; prose like
+        # "all except `running`" or "same as Session" is not an enumeration
+        # of the set and is intentionally skipped, not flagged.
+        if _BACKTICK_LIST_RE.fullmatch(cell) is None:
+            continue
+        statuses = frozenset(_BACKTICK_STATUS_RE.findall(cell))
+        if not statuses:
+            continue
+        findings.append(
+            Finding(path, f"table row `{entity_type}`", idx + 1, "terminal", entity_type, statuses)
+        )
+    return findings
+
+
+def check_file(path: Path) -> list[str]:
+    text = path.read_text()
+    errors: list[str] = []
+    for finding in _iter_python_findings(path, text) + _iter_table_findings(path, text):
+        policy = DEFAULT_REGISTRY.get(finding.entity_type)
+        registry_statuses = (
+            policy.terminal_statuses if finding.kind == "terminal" else policy.statuses
+        )
+        if finding.doc_statuses == registry_statuses:
+            continue
+        missing = sorted(registry_statuses - finding.doc_statuses)
+        extra = sorted(finding.doc_statuses - registry_statuses)
+        errors.append(
+            f"{finding.file}:{finding.line}: {finding.label} ({finding.kind} statuses for "
+            f"entity_type={finding.entity_type!r}) does not match "
+            f"lionagi.state.lifecycle.policy.DEFAULT_REGISTRY\n"
+            f"  missing from doc: {missing}\n"
+            f"  extra in doc:     {extra}"
+        )
+    return errors
+
+
+def check_paths(paths: list[Path]) -> list[str]:
+    errors: list[str] = []
+    for path in paths:
+        if path.is_dir():
+            files = sorted(path.rglob("*.md"))
+        else:
+            files = [path]
+        for file in files:
+            errors.extend(check_file(file))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_ADR_DIR],
+        help="Markdown files or directories to check (default: docs/adr/)",
+    )
+    args = parser.parse_args(argv)
+
+    errors = check_paths(args.paths)
+    if errors:
+        print("ADR status-set check FAILED:\n", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+            print(file=sys.stderr)
+        return 1
+
+    print("ADR status-set check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/docs/test_adr_status_sets.py
+++ b/tests/docs/test_adr_status_sets.py
@@ -1,0 +1,78 @@
+"""Verify docs/adr/ status-set literals stay aligned with the lifecycle policy registry."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_adr_status_sets import DEFAULT_ADR_DIR, check_file, check_paths
+
+DOCS_ADR_DIR = DEFAULT_ADR_DIR
+
+
+def test_current_corpus_has_zero_mismatches():
+    errors = check_paths([DOCS_ADR_DIR])
+    assert errors == [], "\n\n".join(errors)
+
+
+def test_schedule_run_terminal_frozenset_missing_timed_out(tmp_path: Path):
+    doc = tmp_path / "drift.md"
+    doc.write_text(
+        "```python\n"
+        "SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({\n"
+        '    "completed", "failed", "skipped", "cancelled"\n'
+        "})\n"
+        "```\n"
+    )
+    errors = check_file(doc)
+    assert len(errors) == 1
+    assert "schedule_run" in errors[0]
+    assert "timed_out" in errors[0]
+
+
+def test_schedule_run_wait_table_row_missing_timed_out(tmp_path: Path):
+    doc = tmp_path / "drift.md"
+    doc.write_text(
+        "| Kind | Terminal statuses | Success statuses |\n"
+        "|------|-------------------|-------------------|\n"
+        "| `schedule_run` | `completed`, `failed`, `skipped`, `cancelled` | `completed` |\n"
+    )
+    errors = check_file(doc)
+    assert len(errors) == 1
+    assert "schedule_run" in errors[0]
+    assert "timed_out" in errors[0]
+
+
+def test_vocabulary_block_containing_pending(tmp_path: Path):
+    doc = tmp_path / "drift.md"
+    doc.write_text(
+        "```python\n"
+        "VALID_SCHEDULE_RUN_STATUSES = frozenset({\n"
+        '    "queued", "waiting_dependency", "running", "retry_wait",\n'
+        '    "completed", "failed", "timed_out", "skipped", "cancelled", "pending"\n'
+        "})\n"
+        "```\n"
+    )
+    errors = check_file(doc)
+    assert len(errors) == 1
+    assert "schedule_run" in errors[0]
+    assert "pending" in errors[0]
+
+
+def test_unknown_symbol_is_skipped_not_errored(tmp_path: Path):
+    doc = tmp_path / "clean.md"
+    doc.write_text('```python\nSOME_UNRELATED_STATUSES = frozenset({\n    "foo", "bar"\n})\n```\n')
+    assert check_file(doc) == []
+
+
+def test_prose_terminal_cell_is_not_treated_as_enumeration(tmp_path: Path):
+    doc = tmp_path / "prose.md"
+    doc.write_text(
+        "| Entity | Declared/current values | Terminal set |\n"
+        "|--------|--------------------------|---------------|\n"
+        "| `session` | `running`, `completed` | all except `running` |\n"
+    )
+    assert check_file(doc) == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #2034.

Adds a narrow docs check that keeps hand-transcribed status vocabularies in docs/adr/ in sync with the lifecycle policy registry, the single source of truth that keeps evolving.

**What it checks**: `*_STATUSES` / `*_TERMINAL_STATUSES` frozenset literals inside python-fenced code blocks in docs/adr/*.md, plus wait-surface-style table rows whose terminal column is a pure comma-separated list of backticked statuses. Extracted sets are compared by membership against `DEFAULT_REGISTRY` in `lionagi/state/lifecycle/policy.py`. Unknown symbols and kinds are skipped; mismatches print the file, line, symbol, and two-way set difference, and fail with exit 1.

**Tests**: the pytest suite asserts zero mismatches on the live corpus, replays the three historical drift shapes as synthetic fixtures (terminal frozenset missing `timed_out`; wait-table row missing `timed_out`; vocabulary block containing stray `pending`) asserting each is caught, and guards against false positives on prose-shaped table cells ("all except `running`") and unknown symbols.

**CI wiring**: reuses the existing paths-filter job — two conditional steps in the `docs` job run only when a PR touches `docs/adr/**` or `lionagi/state/lifecycle/**`. No new required checks.

**Known out-of-scope drift**: one ADR carries the schedule_run terminal set inside a dict literal, which this deliberately narrow pattern does not parse; that instance has a documentation correction already in review, and extending the checker to dict-literal values is a possible follow-up once the corpus is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)