### PR TITLE
docs(adr): accept ADR-0059/0062/0063/0064/0071/0073; reconcile lifecycle-registry text

### DIFF
--- a/docs/adr/ADR-0058-unified-lifecycle-transition-service.md
+++ b/docs/adr/ADR-0058-unified-lifecycle-transition-service.md
@@ -623,6 +623,10 @@ migration, making parity defects harder to isolate.
 
 ## Notes
 
-This is a target-state ADR. The dataclasses, package, registry, and service named here do not exist
-in the current source. Implementation is complete only when the phase gates pass; merely adding the
-types without routing all policy and writes through them does not satisfy the decision.
+This is a target-state ADR, partially implemented. The first two phases shipped in the proposed
+module layout (`lionagi/state/lifecycle/{models,policy,service,adapters}.py`): the contract types,
+the policy registry covering all seven entity types, the guarded algorithm, and the
+facade-preserving wrappers — both `StateDB.update_status()` and the guarded transition adapter now
+route through the service. Still open: creation-path initialization (`initialize_in_transaction`
+has no call sites outside the package) and the remaining migration phases. Implementation is
+complete only when the phase gates pass; the record stays Proposed until then.

--- a/docs/adr/ADR-0059-durable-dispatch-outbox.md
+++ b/docs/adr/ADR-0059-durable-dispatch-outbox.md
@@ -421,7 +421,7 @@ Code anchors: `lionagi/dispatch/outbox.py`; `lionagi/state/transitions.py`.
 - The dispatch adapter enforces the registered closed edge graph
   (`lionagi/state/lifecycle/policy.py:360-399`): `acked` is reachable only from `pending` and
   `delivering`, `dead_letter` and `expired` re-enter `pending` only through an operator-gated
-  edge, and terminal statuses have no outgoing edges. An ack attempt against any other current
+  edge, and `delivered`/`acked` have no outgoing edges. An ack attempt against any other current
   status raises before the CAS runs.
 - Tokens are stored in clear text in the state database and shown by the full-row inspection path.
   This ADR treats them as capability values for local operational use, not as hashed credentials.

--- a/docs/adr/ADR-0059-durable-dispatch-outbox.md
+++ b/docs/adr/ADR-0059-durable-dispatch-outbox.md
@@ -1,6 +1,6 @@
 # ADR-0059: Durable dispatch outbox
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: persistence-state
 - **Date**: 2026-07-09
@@ -418,9 +418,11 @@ Code anchors: `lionagi/dispatch/outbox.py`; `lionagi/state/transitions.py`.
   requested, and `ValueError` for a token mismatch.
 - After token validation, acknowledgement uses the status read from the row as its CAS source. A
   concurrent status change returns `False`.
-- The current dispatch adapter has no legal-edge graph, so a correct token can move an ack-required
-  row from any current six-value status to `acked` if its CAS wins. It is not restricted to the
-  post-send `pending` state.
+- The dispatch adapter enforces the registered closed edge graph
+  (`lionagi/state/lifecycle/policy.py:360-399`): `acked` is reachable only from `pending` and
+  `delivering`, `dead_letter` and `expired` re-enter `pending` only through an operator-gated
+  edge, and terminal statuses have no outgoing edges. An ack attempt against any other current
+  status raises before the CAS runs.
 - Tokens are stored in clear text in the state database and shown by the full-row inspection path.
   This ADR treats them as capability values for local operational use, not as hashed credentials.
 
@@ -618,6 +620,8 @@ schedule vocabulary and SQLite compatibility migration. The library call proves 
 expanding scheduler schema.
 
 ## Notes
+
+An earlier revision of this record transcribed the pre-registry validator behavior; the unified lifecycle policy registry (`lionagi/state/lifecycle/policy.py`) reconciled the schedule-run and dispatch vocabularies, terminal sets, and edge graphs, and the corrected text above reflects that registry.
 
 `DispatchSignal.attempt` and the row's `attempt` currently diverge after the first claim. Consumers
 must use outbox inspection for current attempt count. A future payload rewrite or per-attempt

--- a/docs/adr/ADR-0062-cli-command-surface-ownership.md
+++ b/docs/adr/ADR-0062-cli-command-surface-ownership.md
@@ -1,6 +1,6 @@
 # ADR-0062: CLI command-surface ownership
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: cli-surface
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0063-project-attribution-cascade.md
+++ b/docs/adr/ADR-0063-project-attribution-cascade.md
@@ -1,6 +1,6 @@
 # ADR-0063: Project attribution cascade
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: cli-surface
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0064-cli-execution-outcome-and-completion-record.md
+++ b/docs/adr/ADR-0064-cli-execution-outcome-and-completion-record.md
@@ -1,6 +1,6 @@
 # ADR-0064: CLI execution outcome and completion record
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: cli-surface
 - **Date**: 2026-07-09
@@ -216,7 +216,7 @@ TERMINAL_STATUSES_BY_ENTITY_TYPE = {
         "completed", "completed_empty", "failed",
         "timed_out", "aborted", "cancelled",
     }),
-    "schedule_run": frozenset({"completed", "failed", "skipped", "cancelled"}),
+    "schedule_run": frozenset({"completed", "failed", "timed_out", "skipped", "cancelled"}),
     "show": frozenset({"completed", "aborted"}),
     "play": frozenset({
         "merged", "escalated", "gate_failed", "blocked", "aborted_after_finish",
@@ -284,11 +284,12 @@ EXIT_CODE_BY_STATUS = {
 - `source` must be one of `executor`, `agent`, `admin`, or `system`.
 - `li wait` supports session, invocation, play, and schedule-run records. Show and team
   terminal sets exist in StateDB but are not wait-target kinds.
-- The `schedule_runs` table also admits `timed_out`, `waiting_dependency`, and
-  `retry_wait`, but the terminal and valid-status maps used by `update_status` do not
-  fully include that schema vocabulary. In particular, `li wait` does not currently
-  recognize a `timed_out` schedule run as terminal. This is current code behavior and a
-  delta, not a redefinition of schedule lifecycle.
+- The terminal and valid-status maps used by `update_status` are sourced from the
+  lifecycle policy registry (`lionagi/state/db.py:254-291`,
+  `lionagi/state/lifecycle/policy.py:305-320`), which carries the full schema
+  vocabulary including `timed_out`, `waiting_dependency`, and `retry_wait`. `li wait`
+  reads the same registry-sourced terminal map, so a `timed_out` schedule run is
+  recognized as terminal (`lionagi/cli/wait.py:180`).
 
 **Why this way.** A small status vocabulary supports reliable automation, while reason
 codes and evidence retain the cause without proliferating statuses. Denormalizing the
@@ -756,7 +757,7 @@ claiming the derived path or reused row is a complete execution model.
 | 1 | Bind every CLI execution to one persisted run id and workspace, write a minimal manifest before streaming, and store the workspace link on the execution record; acceptance: `li wait`, monitor tails, context import, and state import resolve the stored link and never synthesize an unverified path. | M | (filled at issue-open time) |
 | 2 | Separate reusable conversation branches from immutable execution outcomes; acceptance: every manual resume creates or deliberately appends to a modeled execution record, and its final outcome is persisted before the command returns an exit code. | M | (filled at issue-open time) |
 | 3 | Introduce a lifecycle-owned persistence scope for CLI and Studio execution; acceptance: one-shot cleanup retains its connection/thread reclamation tests while concurrent long-lived runs cannot close one another's StateDB handle. | M | (filled at issue-open time) |
-| 4 | Align the schedule-run schema, `VALID_STATUSES_BY_ENTITY_TYPE`, and `TERMINAL_STATUSES_BY_ENTITY_TYPE`; acceptance: every schema-valid terminal schedule status, including `timed_out`, is writable through `update_status` and causes `li wait` to terminate with the documented success/failure class. | S | (filled at issue-open time) |
+| 4 | Align the schedule-run schema, `VALID_STATUSES_BY_ENTITY_TYPE`, and `TERMINAL_STATUSES_BY_ENTITY_TYPE`; acceptance: every schema-valid terminal schedule status, including `timed_out`, is writable through `update_status` and causes `li wait` to terminate with the documented success/failure class. | S | Resolved on main (`lionagi/state/lifecycle/policy.py`) |
 
 ## Alternatives considered
 
@@ -823,6 +824,8 @@ implements neither representation. The delta requires a separate decision before
 changes.
 
 ## Notes
+
+An earlier revision of this record transcribed the pre-registry validator behavior; the unified lifecycle policy registry (`lionagi/state/lifecycle/policy.py`) reconciled the schedule-run and dispatch vocabularies, terminal sets, and edge graphs, and the corrected text above reflects that registry.
 
 The current `artifact_dir` field name is historical and stronger than its implementation:
 it is a derived run-directory candidate, not the session's stored `artifacts_path` and

--- a/docs/adr/ADR-0071-durable-ad-hoc-task-queue.md
+++ b/docs/adr/ADR-0071-durable-ad-hoc-task-queue.md
@@ -1,6 +1,6 @@
 # ADR-0071: Durable ad-hoc task queue
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-09
@@ -245,19 +245,20 @@ async def transition(
 ) -> TransitionResult: ...
 ```
 
-The shipped schedule-run graph is:
+The shipped schedule-run graph is registered in the lifecycle policy registry
+(`lionagi/state/lifecycle/policy.py:302-350`):
 
 ```text
-queued ──► running ──► completed
-  │           ├──────► failed
-  │           └──────► queued      (lease-expiry reaper only by convention)
-  └──────► cancelled
+queued ──► waiting_dependency | running | skipped | cancelled
+waiting_dependency ──► queued | cancelled
+running ──► completed | failed | timed_out | retry_wait | queued | cancelled
+retry_wait ──► queued | cancelled
 
-completed, failed, cancelled ──► no outgoing edges
+completed, failed, timed_out, skipped, cancelled ──► no outgoing edges
 ```
 
-Although the table admits `waiting_dependency`, `retry_wait`, `timed_out`, and `skipped`, the
-transition vocabulary has no task-path edges for them. An undeclared edge raises `ValueError`.
+The registered terminal set carries all five terminal statuses, including `timed_out` and
+`skipped`. An undeclared edge raises `ValueError`.
 
 Exact compare-and-swap semantics:
 
@@ -546,7 +547,9 @@ known queue claim overlap without pretending to replace the OS resource lock.
 
 ## Notes
 
-The current transition module's top docstring still describes an earlier dispatch-only fallback,
-but `_ENTITY_TABLES`, the vocabulary, and production callers include `schedule_run`. The executable
+An earlier revision of this record transcribed the pre-registry validator behavior; the unified lifecycle policy registry (`lionagi/state/lifecycle/policy.py`) reconciled the schedule-run and dispatch vocabularies, terminal sets, and edge graphs, and the corrected text above reflects that registry.
+
+The transition module's top docstring names both `dispatch` and `schedule_run`, and
+`_ENTITY_TABLES`, the vocabulary, and production callers include `schedule_run`. The executable
 contract is the code shape recorded above, including its deliberately restricted graph and inactive
 idempotency-key field.

--- a/docs/adr/ADR-0073-fixed-workflow-definition-execution.md
+++ b/docs/adr/ADR-0073-fixed-workflow-definition-execution.md
@@ -1,6 +1,6 @@
 # ADR-0073: Fixed workflow-definition execution
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-09


### PR DESCRIPTION
## Summary

Retrospective acceptance, fifth batch: six records whose Decision-section claims were verified against source at main `19b949074` flip from Proposed to Accepted — ADR-0059 (durable dispatch outbox), ADR-0062 (CLI command surface ownership), ADR-0063 (project attribution cascade), ADR-0064 (CLI execution outcome and completion record), ADR-0071 (durable ad-hoc task queue), ADR-0073 (fixed workflow definition execution).

## Corrections folded in (callouts)

Three of the flipped records carried passages transcribed from the pre-registry lifecycle validators, superseded when the unified lifecycle policy registry (`lionagi/state/lifecycle/policy.py`) reconciled the schedule-run and dispatch vocabularies, terminal sets, and edge graphs:

- **ADR-0064**: the schedule_run terminal-set literal gains `timed_out` (matching `policy.py:320`); the terminal-map passage now describes the registry-sourced maps (`db.py:254-291`) and that `li wait` treats a timed_out schedule run as terminal (`wait.py:180`); delta row 4 is marked resolved on main (its acceptance criterion is met).
- **ADR-0059**: the "no legal-edge graph" passage is rewritten — the dispatch adapter enforces the registered closed edge graph (`policy.py:360-399`): `acked` only from `pending`/`delivering`, operator-gated `dead_letter`/`expired` requeue, no outgoing edges from terminals.
- **ADR-0071**: the shipped schedule-run graph block is rewritten to the registered edges (`policy.py:302-350`) and the five-member terminal set; a stale Notes line about the transition module's docstring is corrected.

Each corrected record's Notes names the registry reconciliation as the source the updated text reflects.

- **ADR-0058** (stays Proposed): its Notes claimed the lifecycle service "does not exist in the current source", which is no longer true — the first two phases shipped in the proposed module layout and both legacy surfaces route through the service. The Notes now state the true partial-implementation status; the record stays Proposed because its own completion bar (all phase gates, including creation-path initialization) is unmet.

## Verification

Every flipped record's central Decision claims were resolved to current file:line anchors; the corrected passages were verified against `lionagi/state/lifecycle/policy.py`, `lionagi/state/db.py`, and `lionagi/cli/wait.py` at the pinned SHA. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)