### PR TITLE
docs(state): fix wrong ADR reference in transitions module docstring

### DIFF
--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Guarded compare-and-swap state transitions (ADR-0092 slice 1, spec-gate ruling 1).
 
-ADR-0062's ``transition()`` API (entity-agnostic, idempotency-key-deduplicated)
+ADR-0058's ``transition()`` API (entity-agnostic, idempotency-key-deduplicated)
 is proposed and unbuilt. This module ships a minimal fallback carrying the same
 request/result shape and reason-code discipline so 0062 can absorb it later as
 a refactor, not a migration. Scoped to ``entity_type='dispatch'``

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -4,7 +4,7 @@
 
 ADR-0058's ``transition()`` API (entity-agnostic, idempotency-key-deduplicated)
 is proposed and unbuilt. This module ships a minimal fallback carrying the same
-request/result shape and reason-code discipline so 0062 can absorb it later as
+request/result shape and reason-code discipline so 0058 can absorb it later as
 a refactor, not a migration. Scoped to ``entity_type='dispatch'``
 (``dispatch_outbox``) and ``entity_type='schedule_run'`` (``schedule_runs``)
 only — it is not a general TransitionStore.


### PR DESCRIPTION
One-line docstring fix: the entity-agnostic, idempotency-key-deduplicated `transition()` design described in `lionagi/state/transitions.py`'s module docstring belongs to ADR-0058 (unified lifecycle transition service), not ADR-0062 (CLI command surface ownership). `docs/adr/dispositions.yaml` maps the design lineage to ADR-0058, and ADR-0062 contains no transition API. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)