### PR TITLE
docs(adr): accept 14 verified records; reconcile scheduler-cwd, guard-bucket, and pipeline-primitive text

### DIFF
--- a/docs/adr/ADR-0050-foundational-utility-and-typed-adaptation-strata.md
+++ b/docs/adr/ADR-0050-foundational-utility-and-typed-adaptation-strata.md
@@ -1,6 +1,6 @@
 # ADR-0050: Foundational utility and typed adaptation strata
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: utilities
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0051-lndl-language-and-operations-boundary.md
+++ b/docs/adr/ADR-0051-lndl-language-and-operations-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0051: LNDL language and operations boundary
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: utilities
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0065-marketplace-catalog-and-directory-discovery.md
+++ b/docs/adr/ADR-0065-marketplace-catalog-and-directory-discovery.md
@@ -1,6 +1,6 @@
 # ADR-0065: Marketplace catalog and directory discovery
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: cli-surface
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -1,6 +1,6 @@
 # ADR-0069: Reactive flow steering and recovery
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
+++ b/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
@@ -1,6 +1,6 @@
 # ADR-0070: Studio scheduling and dispatch delivery
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-09
@@ -157,14 +157,17 @@ CREATE TABLE schedules (
   github_cursor       TEXT,
   poll_interval_sec   INTEGER,
   action_kind         TEXT NOT NULL
-                      CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml')),
+                      CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml', 'command')),
   action_model        TEXT,
   action_prompt       TEXT,
   action_agent        TEXT,
   action_playbook     TEXT,
   action_flow_yaml    TEXT,
   action_project      TEXT,
+  action_cwd          TEXT,
   action_extra_args   JSON DEFAULT '[]',
+  action_command      TEXT,
+  action_command_args JSON DEFAULT '[]',
   on_success          JSON,
   on_fail             JSON,
   last_fired_at       REAL,
@@ -344,7 +347,7 @@ async def spawn_and_wait(
 ) -> tuple[int, str]: ...
 ```
 
-Launcher vocabulary is the schedule table's five kinds plus `engine` for the shared launcher;
+Launcher vocabulary is the schedule table's six kinds plus `engine` for the shared launcher;
 `playbook` maps to `play` only inside `build_argv()`. `build_argv()` validates model/identifier
 tokens, forbids flag-like extra arguments, renders prompt templates, inserts `--` before free-form
 positionals, and uses `create_subprocess_exec` rather than a shell. `flow_yaml` is written to a
@@ -352,9 +355,12 @@ temporary file and removed after execution.
 
 Cwd resolves in order:
 
-1. registered `action_project` path when it exists;
-2. valid `LIONAGI_SCHEDULER_CWD`;
-3. `None`, inheriting daemon cwd with a warning.
+1. persisted `action_cwd` — the schedule's own execution root, snapshotted once at creation
+   time — when it still exists on disk;
+2. registered `action_project` path when it exists;
+3. valid `LIONAGI_SCHEDULER_CWD`;
+4. `None`, inheriting daemon cwd with a deprecation warning (reachable only by pre-migration
+   rows that never had `action_cwd` set).
 
 The `li` executable resolves independently of the eventual child cwd. Failure to resolve an
 absolute executable path is a launch error rather than silently using a cwd-dependent prefix.
@@ -543,7 +549,7 @@ consumer would appear to own work already committed by the producer.
 
 | # | Delta | Size | Issue |
 |---|---|---|---|
-| 1 | Require a stable execution root for every new schedule and migrate existing schedules off inherited daemon cwd; acceptance: schedule behavior is unchanged when Studio starts from a different directory. | S | (filled at issue-open time) |
+| 1 | Require a stable execution root for every new schedule and migrate existing schedules off inherited daemon cwd; acceptance: schedule behavior is unchanged when Studio starts from a different directory. | S | Resolved on main (`lionagi/studio/scheduler/engine.py::_resolve_action_cwd`) |
 | 2 | Align `li schedule create` with the persisted action vocabulary; acceptance: every supported stored action is creatable by its canonical public name or explicitly rejected as internal. | S | (filled at issue-open time) |
 | 3 | Split trigger/admission, subprocess execution, and follow-up policy behind characterization tests; acceptance: each concern can be tested without starting the complete scheduler loop. | M | (filled at issue-open time) |
 | 4 | Route scheduled fires through the queued admission contract in ADR-0072; acceptance: a due trigger writes `queued` and execution starts only after a worker wins a lease. | M | (filled at issue-open time) |

--- a/docs/adr/ADR-0076-studio-daemon-route-registry-and-local-control-plane.md
+++ b/docs/adr/ADR-0076-studio-daemon-route-registry-and-local-control-plane.md
@@ -1,6 +1,6 @@
 # ADR-0076: Studio daemon route registry and local control plane
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: studio
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0077-studio-state-and-filesystem-boundary.md
+++ b/docs/adr/ADR-0077-studio-state-and-filesystem-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0077: Studio state and filesystem boundary
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: studio
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0079-studio-web-client-architecture-and-deployment.md
+++ b/docs/adr/ADR-0079-studio-web-client-architecture-and-deployment.md
@@ -1,6 +1,6 @@
 # ADR-0079: Studio web client architecture and deployment
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: studio
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0080-studio-six-space-cockpit-information-architecture.md
+++ b/docs/adr/ADR-0080-studio-six-space-cockpit-information-architecture.md
@@ -1,6 +1,6 @@
 # ADR-0080: Studio six-space cockpit information architecture
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: studio
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0082-vscode-studio-observability-client.md
+++ b/docs/adr/ADR-0082-vscode-studio-observability-client.md
@@ -1,6 +1,6 @@
 # ADR-0082: VS Code Studio observability client
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: studio
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
+++ b/docs/adr/ADR-0086-local-tool-controls-and-session-authorization.md
@@ -1,6 +1,6 @@
 # ADR-0086: Local tool controls and session authorization observation
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: governance
 - **Date**: 2026-07-09
@@ -265,22 +265,23 @@ Exact semantics:
   `security_pre:*`; unsupported runtime values in the field are ignored by `_apply_permissions`.
 - `AgentSpec.coding(secure=True)` registers `guard_destructive` for bash and one `guard_paths`
   instance for reader and editor (`_wire_secure_guards` in `lionagi/agent/spec.py`; the guards
-  are defined in `lionagi/agent/hooks.py`). These register through `.pre()` into the ordinary
-  `pre:<tool>` bucket — the user-hook position — not into `security_pre:<tool>`. The path
+  are defined in `lionagi/agent/hooks.py`). These register through `.security_pre()` into the
+  `security_pre:<tool>` bucket, so the built-in guards participate in the security → user →
+  security composition the same way an explicit `PermissionPolicy` does. The path
   guard's only allowed root is `cwd`, or `Path.cwd()` when `cwd` is absent. `secure=False`
   skips these three registrations.
 - Only hooks in the `security_pre:<tool>`/`security_pre:*` bucket participate in the
-  security → user → security composition, and the only factory writer of that bucket is
-  `_apply_permissions` installing an explicit `PermissionPolicy`. Those security hooks run
+  security → user → security composition; the factory writers of that bucket are
+  `_apply_permissions` (an explicit `PermissionPolicy`) and `_wire_secure_guards` (the
+  built-in coding guards). Those security hooks run
   before user pre-hooks, and when at least one user pre-hook exists the same security chain
   runs again against the final transformed argument mapping; with no user pre-hook it runs
   once.
-- Consequently, under the default `coding()` path (no `PermissionPolicy` configured), the
-  built-in guards run exactly once in the pre chain and are NOT re-run after a later mutating
-  user hook — a user hook that rewrites `command` or a path argument after the guard has
-  passed is not rechecked. The mutation-gap recheck exists only for an explicitly configured
-  `PermissionPolicy` (`tests/agent/test_coding_preset_guard.py` pins `guard_destructive` to
-  the `pre:bash` bucket).
+- Consequently, a user hook that rewrites `command` or a path argument after a security hook
+  has passed is rechecked against the final transformed mapping — for the built-in coding
+  guards as well as an explicitly configured `PermissionPolicy`
+  (`tests/agent/test_coding_preset_guard.py` pins `guard_destructive` to the
+  `security_pre:bash` bucket and asserts the post-mutation recheck).
 - A hook return that is a `dict` replaces the argument mapping for later hooks and the callable.
   Any other non-exception result leaves the current mapping unchanged.
 - `guard_destructive(tool_name, action, args)` inspects only `args["command"]` when present. It
@@ -758,8 +759,8 @@ Positive consequences:
 
 - D1 gives library callers allow-all, deny-all, rules, safe, and read-only choices without a
   policy service.
-- D2 protects factory-wired coding tools before invocation; a configured `PermissionPolicy`
-  is additionally rechecked after user transforms, while the built-in guards are not.
+- D2 protects factory-wired coding tools before invocation; both a configured
+  `PermissionPolicy` and the built-in guards are rechecked after user transforms.
 - D3 preserves one processor mechanism for both synchronous and asynchronous callables.
 - D4 lets an attached session deny a proposed action before `ActionManager` and returns a form
   iterative operations can observe.

--- a/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
+++ b/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
@@ -1,6 +1,6 @@
 # ADR-0090: Local sandbox and measured-cell backend seams
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: substrates
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
+++ b/docs/adr/ADR-0092-minimal-branch-and-session-memory-store.md
@@ -1,6 +1,6 @@
 # ADR-0092: Minimal Branch and session memory store
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Retrospective
 - **Area**: substrates
 - **Date**: 2026-07-09

--- a/docs/adr/ADR-0094-automated-pr-review-pipeline.md
+++ b/docs/adr/ADR-0094-automated-pr-review-pipeline.md
@@ -1,6 +1,6 @@
 # ADR-0094: Automated PR-review pipeline over github-poll schedules
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-10
@@ -46,10 +46,10 @@ A workflow that auto-runs an agent against a PR head must never do so for fork P
 the diff is attacker-controlled input, and an agent that reads it is an injection
 target. Exclusion must hold *before* anything spawns.
 
-The poll event dict today carries `pr_number, pr_title, pr_url, pr_author, updated_at,
-head_sha, draft` — no head-repository identity, so the trigger layer cannot currently
+The poll event dict originally carried `pr_number, pr_title, pr_url, pr_author, updated_at,
+head_sha, draft` — no head-repository identity, so the trigger layer could not
 distinguish a same-repo branch from a fork. The poller therefore gains three event
-fields and one filter:
+fields and one filter (now shipped):
 
 ```text
 head_repo:         "owner/name" | null   # null when the API's head.repo is null (deleted fork source)
@@ -70,8 +70,8 @@ check exposes nothing to attacker-controlled content.
 
 ## D2 — Two generic engine primitives, no review-specific engine code
 
-The engine's action-kind set is closed: `{agent, flow, fanout, play, flow_yaml,
-engine}`. None can invoke an external tool with per-event arguments — `play` is
+The engine's action-kind set was closed over `{agent, flow, fanout, play, flow_yaml,
+engine}`. None could invoke an external tool with per-event arguments — `play` is
 positional-only with no template surface, and `agent` spawns an LLM branch. The review
 workflow needs deterministic per-event setup (fork check, dedup) *before* any LLM
 exists, so pushing the workflow into an `agent`-kind prompt is not an option: it would
@@ -301,3 +301,12 @@ Single-repo pilot with the command allow-list restricted to the wrapper binary, 
 extend the sweep's repo list. The wrapper CLI contract (this document's D5/D6/D7
 surfaces) is implemented in the companion tooling repo; engine-side work is limited to
 the two primitives in D2.
+
+## Notes
+
+This record was written 2026-07-10 as a target-state design. The two engine-surface
+additions it specifies — the head-repo identity fields with the `same_repo_only` filter,
+and the allow-listed `command` action kind — landed on main shortly afterward under the
+exact shapes above, which is why the D1/D2 sentences describing the pre-change engine
+read in the past tense. The wrapper-side surfaces (D5-D7) live in the companion tooling
+repo and are tracked there.


### PR DESCRIPTION
## Summary

Retrospective acceptance, sixth batch: fourteen records whose central Decision-section claims were verified against source flip from Proposed to Accepted — ADR-0050 (utility/typed-adaptation strata), ADR-0051 (LNDL boundary), ADR-0065 (marketplace catalog), ADR-0069 (reactive flow steering), ADR-0070 (studio scheduling/dispatch), ADR-0076 (daemon route registry), ADR-0077 (state/filesystem boundary), ADR-0079 (web client architecture), ADR-0080 (six-space cockpit IA), ADR-0082 (VS Code observability client), ADR-0086 (local tool controls/session authorization), ADR-0090 (sandbox/measured-cell seams), ADR-0092 (minimal memory store), ADR-0094 (automated PR-review pipeline).

## Corrections folded in (callouts)

- **ADR-0070**: three passages predated the schedule execution-root and command-action work now on main. The quoted schedules DDL gains the `command` action kind in its CHECK, the `action_cwd` column, and the `action_command`/`action_command_args` columns (matching `lionagi/state/schema.sql`); the launcher-vocabulary sentence counts six kinds; the cwd resolution order now lists the persisted `action_cwd` tier first (matching `lionagi/studio/scheduler/engine.py::_resolve_action_cwd`); delta row 1's acceptance criterion is met and the row is marked resolved.
- **ADR-0086**: the D2 prose described the built-in coding guards as registering into the ordinary `pre:<tool>` bucket with no post-mutation recheck — contradicting the ADR's own delta row 1, which is marked resolved on main. The guards register via `security_pre` (`lionagi/agent/spec.py`) and participate in the security → user → security recheck exactly as an explicit `PermissionPolicy` does (`tests/agent/test_coding_preset_guard.py` pins both the bucket and the recheck). Three D2 bullets and one Consequences bullet rewritten to the shipped state.
- **ADR-0094**: both engine primitives the record specifies (head-repo identity fields + `same_repo_only` filter; allow-listed `command` action kind) shipped after the record was written, under the exact proposed shapes. The D1/D2 sentences describing the pre-change engine move to past tense and a new Notes section records the provenance. Wrapper-side surfaces live in the companion tooling repo.

## Verification

Every flipped record's central claims were resolved to current file:line anchors at a pinned SHA, with the corrected passages re-verified against `lionagi/state/schema.sql`, `lionagi/studio/scheduler/engine.py`, `lionagi/agent/spec.py`, and the pinned guard tests. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)