### PR TITLE
feat(orchestrate): in-process team messaging via Exchange + messenger tool

### DIFF
--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -141,6 +141,29 @@ After this round, teammates or the orchestrator can follow up:
 TEAM_WORKER_SYSTEM = BARE_WORKER_SYSTEM + "\n\n" + TEAM_COORD_SECTION
 
 
+def _build_worker_operate_node(
+    builder,
+    *,
+    branch,
+    instruction,
+    context: list,
+    messenger_bound: bool,
+    depends_on: list[str] | None = None,
+) -> str:
+    """Add the static `operate` node for a worker branch (shared by fanout.py
+    and flow.py). Passes `actions=True` only when this worker actually got
+    the in-process messenger tool bound (team messaging active AND a
+    non-CLI worker), so Branch.operate() serializes branch.acts for it."""
+    return builder.add_operation(
+        "operate",
+        branch=branch,
+        depends_on=depends_on,
+        instruction=instruction,
+        context=context,
+        **({"actions": True} if messenger_bound else {}),
+    )
+
+
 def _create_fanout_team(
     team_name: str,
     worker_names: list[str],

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from lionagi.casts.pack import Pack
+    from lionagi.session.exchange import Exchange
+    from lionagi.tools.communication.messenger import LionMessenger
 
 from lionagi import Branch, Session
 from lionagi._errors import ConfigurationError
@@ -309,6 +313,12 @@ class OrchestrationEnv:
     cwd: str | None
     team_data: dict | None = None
 
+    # In-process team messaging (parallel to team_data's file-based channel).
+    # All three are set together when team mode is active; None otherwise.
+    exchange: Exchange | None = None
+    messenger: LionMessenger | None = None
+    roster: dict[str, UUID] | None = None
+
     # None falls through to the default pack for role_config / resolve_modes.
     pack: Pack | None = None
 
@@ -557,6 +567,17 @@ async def build_worker_branch(
 
     if env._live_persist:
         register_branch_hook(env._live_persist, wb)
+
+    # In-process team messaging: only API-model workers can call tools
+    # (operate() only surfaces branch.acts for non-CLI providers); CLI
+    # workers keep the existing file-based `li team` channel untouched.
+    exchange = getattr(env, "exchange", None)
+    messenger = getattr(env, "messenger", None)
+    if exchange is not None and messenger is not None and not getattr(w_imodel, "is_cli", False):
+        exchange.register(wb.id)
+        env.roster[wname] = wb.id
+        msg_tool = messenger.bind(wb, env.roster, sender_name=wname)
+        wb.register_tools(msg_tool)
 
     return wb, w_model, w_profile
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -461,8 +461,14 @@ async def build_worker_branch(
     system_prompt_override: str | None = None,
     grant_spawn: bool = False,
     modes: list[str] | None = None,
-) -> tuple[Branch, str, AgentProfile | None]:
-    """Resolve model/profile/system and build a worker Branch."""
+) -> tuple[Branch, str, AgentProfile | None, bool]:
+    """Resolve model/profile/system and build a worker Branch.
+
+    The fourth return value is ``messenger_bound``: True when this worker
+    actually got the in-process messenger tool registered (team messaging
+    active AND a non-CLI worker), so callers building `operate` DAG nodes
+    know to enable action serialization for this branch.
+    """
     from ._common import BARE_WORKER_SYSTEM
 
     # Pack per-role config (ADR-0074): model/effort/modes defaults for casts
@@ -573,13 +579,15 @@ async def build_worker_branch(
     # workers keep the existing file-based `li team` channel untouched.
     exchange = getattr(env, "exchange", None)
     messenger = getattr(env, "messenger", None)
+    messenger_bound = False
     if exchange is not None and messenger is not None and not getattr(w_imodel, "is_cli", False):
         exchange.register(wb.id)
         env.roster[wname] = wb.id
         msg_tool = messenger.bind(wb, env.roster, sender_name=wname)
         wb.register_tools(msg_tool)
+        messenger_bound = True
 
-    return wb, w_model, w_profile
+    return wb, w_model, w_profile, messenger_bound
 
 
 def finalize_orchestration(

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 import time
 
 from lionagi._errors import TimeoutError as LionTimeoutError
-from lionagi.ln.concurrency import CancelScope, move_on_after
+from lionagi.ln.concurrency import CancelScope, create_task_group, move_on_after
 from lionagi.orchestration import plan
 from lionagi.orchestration.prompts import SYNTHESIS_INSTRUCTION
+from lionagi.session.exchange import Exchange
+from lionagi.tools.communication.messenger import LionMessenger
 
 from .._logging import log_error, progress
 from .._providers import parse_model_spec
@@ -184,6 +186,9 @@ async def _run_fanout_inner(
 
     if team_name:
         env.team_data = _create_fanout_team(team_name, worker_names)
+        env.exchange = Exchange()
+        env.messenger = LionMessenger(env.exchange)
+        env.roster = {}
         progress(f"Team '{team_name}' created ({env.team_data['id']}): {', '.join(worker_names)}")
 
     if _shared is not None:
@@ -217,11 +222,25 @@ async def _run_fanout_inner(
 
     t1 = time.monotonic()
     conc = max_concurrent if max_concurrent > 0 else len(fanned_nodes)
-    result2 = await env.session.flow(
-        env.builder.get_graph(),
-        max_concurrent=conc,
-        verbose=env.verbose,
-    )
+    if env.exchange is not None:
+        async with create_task_group() as tg:
+            tg.start_soon(env.exchange.run, 0.5)
+            try:
+                result2 = await env.session.flow(
+                    env.builder.get_graph(),
+                    max_concurrent=conc,
+                    verbose=env.verbose,
+                )
+            finally:
+                env.exchange.stop()
+        # Route any final outbox sends left over after the last collect tick.
+        await env.exchange.collect_all()
+    else:
+        result2 = await env.session.flow(
+            env.builder.get_graph(),
+            max_concurrent=conc,
+            verbose=env.verbose,
+        )
     t_fanout = time.monotonic() - t1
 
     op_results = result2.get("operation_results", {})

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -17,6 +17,7 @@ from .._logging import log_error, progress
 from .._providers import parse_model_spec
 from .._util import classify_exception
 from ._common import (
+    _build_worker_operate_node,
     _create_fanout_team,
     _format_result_json,
     _format_result_text,
@@ -208,12 +209,12 @@ async def _run_fanout_inner(
             explicit_name=wname,
             modes=ta.modes or None,
         )
-        node = env.builder.add_operation(
-            "operate",
+        node = _build_worker_operate_node(
+            env.builder,
             branch=w_branch,
             instruction=ta.task,
             context=[{"overall_task": prompt}],
-            **({"actions": True} if messenger_bound else {}),
+            messenger_bound=messenger_bound,
         )
         fanned_nodes.append(node)
         fanned_labels.append(w_model)

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -200,7 +200,7 @@ async def _run_fanout_inner(
     for i, ta in enumerate(assignments):
         model_override = pool[i % len(pool)] if pool else None
         wname = worker_names[i]
-        w_branch, w_model, _ = await build_worker_branch(
+        w_branch, w_model, _, messenger_bound = await build_worker_branch(
             env,
             agent_id=wname,
             role=ta.assignee,
@@ -213,6 +213,7 @@ async def _run_fanout_inner(
             branch=w_branch,
             instruction=ta.task,
             context=[{"overall_task": prompt}],
+            **({"actions": True} if messenger_bound else {}),
         )
         fanned_nodes.append(node)
         fanned_labels.append(w_model)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -446,7 +446,7 @@ async def _build_dag(
     role_artifact_defaults: dict[str, dict | None] = {}
 
     for i, ta in enumerate(assignments):
-        w_branch, w_model, w_profile = await build_worker_branch(
+        w_branch, w_model, w_profile, messenger_bound = await build_worker_branch(
             env,
             agent_id=agent_ids[i],
             role=ta.assignee,
@@ -509,6 +509,7 @@ async def _build_dag(
             depends_on=dep_nodes or None,
             instruction=instruction,
             context=ctx,
+            **({"actions": True} if messenger_bound else {}),
         )
         node_ids.append(node)
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -19,6 +19,8 @@ from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.casts.emission import SpawnRequest, TaskAssignment
 from lionagi.ln.concurrency import CancelScope, move_on_after
 from lionagi.orchestration import plan, role_node_builder
+from lionagi.session.exchange import Exchange
+from lionagi.tools.communication.messenger import LionMessenger
 
 from .._logging import progress
 from .._logging import warn as _warn
@@ -951,6 +953,8 @@ async def _execute_dag(
     t_exec = time.monotonic()
     _hb_task = _asyncio.ensure_future(_heartbeat_loop())
     _ctl_task = _asyncio.ensure_future(_control_poll_loop())
+    _exchange = getattr(env, "exchange", None)
+    _exch_task = _asyncio.ensure_future(_exchange.run(0.5)) if _exchange is not None else None
     try:
         dag_result = await eng_run.run_dag(
             env.builder.get_graph(),
@@ -975,6 +979,12 @@ async def _execute_dag(
             await _hb_task
         with contextlib.suppress(_asyncio.CancelledError):
             await _ctl_task
+        if _exch_task is not None:
+            _exchange.stop()
+            with contextlib.suppress(_asyncio.CancelledError):
+                await _exch_task
+            # Route any final outbox sends left over after the last collect tick.
+            await _exchange.collect_all()
     t_exec_elapsed = time.monotonic() - t_exec
 
     # Drain every scheduled checkpoint write before returning — the whole
@@ -1736,6 +1746,11 @@ async def _run_flow_inner(
     elif team_name:
         env.team_data = _create_fanout_team(team_name, agent_ids)
         progress(f"Team '{team_name}' created ({env.team_data['id']})")
+
+    if env.team_data:
+        env.exchange = Exchange()
+        env.messenger = LionMessenger(env.exchange)
+        env.roster = {}
 
     budget_preambles: dict[int, str] = {}
     if env.total_budget and assignments:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -28,6 +28,7 @@ from .._providers import parse_model_spec
 from .._util import classify_exception
 from ._checkpoint import CheckpointWriter, FlowResumeError, resolve_checkpoint_target
 from ._common import (
+    _build_worker_operate_node,
     _create_fanout_team,
     _format_result_json,
     _format_result_text,
@@ -503,13 +504,13 @@ async def _build_dag(
 
         instruction = budget_preambles.get(i, "") + ta.task
         dep_nodes = [node_ids[j] for j in dep_indices[i]]
-        node = env.builder.add_operation(
-            "operate",
+        node = _build_worker_operate_node(
+            env.builder,
             branch=w_branch,
             depends_on=dep_nodes or None,
             instruction=instruction,
             context=ctx,
-            **({"actions": True} if messenger_bound else {}),
+            messenger_bound=messenger_bound,
         )
         node_ids.append(node)
 

--- a/lionagi/session/exchange.py
+++ b/lionagi/session/exchange.py
@@ -141,8 +141,14 @@ class Exchange(Element):
         return await self.collect_all()
 
     async def run(self, interval: float = 1.0) -> None:
-        """Continuous sync loop. Call stop() to exit."""
-        self._stop = False
+        """Continuous sync loop. Call stop() to exit.
+
+        Does not reset ``_stop`` on entry: a stop() issued before this
+        coroutine gets its first turn (e.g. the DAG it watches over failed
+        immediately) must make run() return right away instead of clearing
+        that signal and looping forever. Construct a fresh Exchange for a new
+        run rather than reusing one that has already been stopped.
+        """
         while not self._stop:
             await self.sync()
             await sleep(interval)

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -24,6 +24,7 @@ __all__ = ("LionMessenger",)
 
 class MessengerAction(str, Enum):
     send = "send"
+    receive = "receive"
     done = "done"
     finished = "finished"
     wakeup = "wakeup"
@@ -35,6 +36,7 @@ class MessengerRequest(BaseModel):
         description=(
             "Action to perform. One of:\n"
             "- 'send': Send a message to one or more recipients.\n"
+            "- 'receive': Read and consume pending messages from teammates.\n"
             "- 'done': Signal you've finished your part (can be woken later).\n"
             "- 'finished': Permanently done, cannot be woken.\n"
             "- 'wakeup': Wake a teammate who is in done state."
@@ -91,9 +93,28 @@ class LionMessenger(LionTool):
                 branch.msgs.messages.include(msg)
 
         def messenger(action: str, to: str | list[str] = None, content: str = None) -> str:
-            """Send messages to teammates, signal done/finished, or wake a
-            teammate. action in {'send', 'done', 'finished', 'wakeup'}; to
-            (name or list of names) and content are required for send/wakeup."""
+            """Send messages to teammates, receive pending ones, signal
+            done/finished, or wake a teammate. action in {'send', 'receive',
+            'done', 'finished', 'wakeup'}; to (name or list of names) and
+            content are required for send/wakeup, neither is required for
+            receive."""
+            if action == "receive":
+                pending = exchange.receive(sender_id)
+                if not pending:
+                    return "No new messages."
+                name_by_id = {v: k for k, v in roster.items()}
+                senders = {m.sender for m in pending}
+                drained: list[Message] = []
+                for s in senders:
+                    while (m := exchange.pop_message(owner_id=sender_id, sender=s)) is not None:
+                        drained.append(m)
+                drained.sort(key=lambda m: m.created_datetime)
+                lines = []
+                for m in drained:
+                    from_name = name_by_id.get(m.sender, str(m.sender)[:8])
+                    lines.append(f"[{from_name}] {m.content}")
+                return "\n".join(lines)
+
             if action == "send":
                 if not to or not content:
                     return "Error: 'send' requires both 'to' and 'content'."

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -685,7 +685,7 @@ async def test_resume_skips_planner_and_still_calls_finalize_with_zero_pending_o
     with (
         patch(
             "lionagi.cli.orchestrate.flow.build_worker_branch",
-            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None),
+            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None, False),
         ),
         patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
         patch("lionagi.cli.orchestrate.flow.plan") as plan_mock,
@@ -755,7 +755,7 @@ async def test_resume_seeds_executor_with_checkpointed_flow_context(tmp_path: Pa
     with (
         patch(
             "lionagi.cli.orchestrate.flow.build_worker_branch",
-            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None),
+            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None, False),
         ),
         patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
         patch("lionagi.cli.orchestrate.flow.plan"),
@@ -825,7 +825,7 @@ async def test_resumed_checkpoint_carries_restored_flow_context_across_zero_comp
     with (
         patch(
             "lionagi.cli.orchestrate.flow.build_worker_branch",
-            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None),
+            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None, False),
         ),
         patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
         patch("lionagi.cli.orchestrate.flow.plan"),
@@ -879,7 +879,7 @@ async def test_resume_refuses_checkpoint_with_spawned_entries(tmp_path: Path):
     with (
         patch(
             "lionagi.cli.orchestrate.flow.build_worker_branch",
-            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None),
+            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None, False),
         ),
         patch("lionagi.cli.orchestrate.flow.plan") as plan_mock,
         pytest.raises(FlowResumeError, match="spawned-node-xyz"),
@@ -928,7 +928,7 @@ async def test_resume_missing_artifact_still_flips_status_to_failed(
 
     with patch(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
-        return_value=(Branch(name="worker"), "claude", None),
+        return_value=(Branch(name="worker"), "claude", None, False),
     ):
         dag_state = await _build_dag(env, "write the brief", plan_result, reactive_spec="off")
 

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -176,7 +176,7 @@ async def test_build_dag_populates_node_ids(tmp_path):
 
     with patch(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
-        return_value=(_FakeBranch("researcher"), "codex/gpt-5.5", None),
+        return_value=(_FakeBranch("researcher"), "codex/gpt-5.5", None, False),
     ):
         dag_state = await _build_dag(env, "do stuff", plan_result, reactive_spec="off")
 
@@ -204,7 +204,7 @@ async def test_build_dag_deps_by_node_format(tmp_path):
 
     with patch(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
-        return_value=(_FakeBranch(), "codex/gpt-5.5", None),
+        return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
         dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
 
@@ -228,7 +228,7 @@ async def test_build_dag_reactive_all_grants_spawn(tmp_path):
 
     with patch(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
-        return_value=(_FakeBranch(), "codex/gpt-5.5", None),
+        return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
         dag_state = await _build_dag(env, "task", plan_result, reactive_spec="all")
 
@@ -256,7 +256,7 @@ async def test_build_dag_pool_override_passes_to_worker(tmp_path):
 
     async def fake_build(env, *, agent_id, role, model_override=None, **kw):
         calls.append({"role": role, "model_override": model_override})
-        return _FakeBranch(role), model_override or "default", None
+        return _FakeBranch(role), model_override or "default", None, False
 
     with patch("lionagi.cli.orchestrate.flow.build_worker_branch", side_effect=fake_build):
         await _build_dag(env, "task", plan_result, reactive_spec="off")

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1566,7 +1566,7 @@ async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fai
 
     with patch(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
-        return_value=(Branch(name="reviewer"), "codex/gpt-5.5", None),
+        return_value=(Branch(name="reviewer"), "codex/gpt-5.5", None, False),
     ):
         await _build_dag(env, "review this PR", plan_result, reactive_spec="off")
 

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""In-process team messaging wiring: build_worker_branch <-> Exchange/LionMessenger."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from lionagi import iModel
+from lionagi.cli.orchestrate._orchestration import OrchestrationEnv, build_worker_branch
+from lionagi.session.exchange import Exchange
+from lionagi.tools.communication.messenger import LionMessenger
+
+
+class _FakeSession:
+    def __init__(self):
+        self.branches: list = []
+
+    def include_branches(self, branch):
+        self.branches.append(branch)
+
+
+def _make_env(tmp_path, *, exchange=None, messenger=None, roster=None):
+    name_counts: dict = {}
+
+    def assign_name(role: str) -> str:
+        name_counts[role] = name_counts.get(role, 0) + 1
+        n = name_counts[role]
+        return f"{role}-{n}" if n > 1 else role
+
+    def register_name(name: str) -> None:
+        pass
+
+    env = OrchestrationEnv(
+        run=SimpleNamespace(agent_artifact_dir=lambda a: tmp_path / a),
+        session=_FakeSession(),
+        orc_branch=SimpleNamespace(),
+        builder=SimpleNamespace(),
+        orc_profile=None,
+        default_model_spec="openai/gpt-4o-mini",
+        bare=True,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=str(tmp_path),
+    )
+    env.assign_name = assign_name
+    env.register_name = register_name
+    env.exchange = exchange
+    env.messenger = messenger
+    env.roster = roster
+    return env
+
+
+def _api_imodel(*_a, **_kw):
+    return iModel(provider="openai", model="gpt-4o-mini", api_key="dummy-key")
+
+
+def _cli_imodel(*_a, **_kw):
+    return iModel(provider="claude_code", api_key="dummy-key")
+
+
+@pytest.mark.asyncio
+async def test_api_worker_gets_registered_and_bound(tmp_path):
+    """Non-CLI worker: exchange.register + roster entry + messenger tool on branch.acts."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile = await build_worker_branch(
+            env, agent_id="alice", role="researcher", explicit_name="alice"
+        )
+
+    assert exchange.has(wb.id)
+    assert roster["alice"] == wb.id
+    assert any(t.function == "messenger" for t in wb.acts.registry.values())
+
+
+@pytest.mark.asyncio
+async def test_cli_worker_skips_messenger_binding(tmp_path):
+    """CLI worker: no exchange registration, no roster entry, no messenger tool."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_cli_imodel,
+    ):
+        wb, _model, _profile = await build_worker_branch(
+            env, agent_id="cli-worker", role="researcher", explicit_name="cli-worker"
+        )
+
+    assert not exchange.has(wb.id)
+    assert "cli-worker" not in roster
+    assert not any(t.function == "messenger" for t in wb.acts.registry.values())
+
+
+@pytest.mark.asyncio
+async def test_no_exchange_configured_skips_binding_entirely(tmp_path):
+    """team mode inactive (env.exchange/messenger/roster all None): no-op, no crash."""
+    env = _make_env(tmp_path)  # exchange/messenger/roster default None
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile = await build_worker_branch(
+            env, agent_id="solo", role="researcher", explicit_name="solo"
+        )
+
+    assert not any(t.function == "messenger" for t in wb.acts.registry.values())
+
+
+@pytest.mark.asyncio
+async def test_send_collect_receive_roundtrip_renders_sender_name(tmp_path):
+    """Worker A sends -> collect_all() routes it -> worker B's receive renders A by name."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        branch_a, _, _ = await build_worker_branch(
+            env, agent_id="alice", role="researcher", explicit_name="alice"
+        )
+        branch_b, _, _ = await build_worker_branch(
+            env, agent_id="bob", role="implementer", explicit_name="bob"
+        )
+
+    tool_a = next(t for t in branch_a.acts.registry.values() if t.function == "messenger")
+    tool_b = next(t for t in branch_b.acts.registry.values() if t.function == "messenger")
+
+    send_result = tool_a.func_callable(action="send", to="bob", content="ping from alice")
+    assert "Sent to bob" in send_result
+
+    await exchange.collect_all()
+
+    receive_result = tool_b.func_callable(action="receive")
+    assert receive_result == "[alice] ping from alice"
+
+    # roster is the SAME shared dict passed to both binds — later-registered
+    # bob is visible to alice's already-bound tool without rebinding.
+    assert roster == {"alice": branch_a.id, "bob": branch_b.id}

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -12,6 +12,7 @@ import pytest
 
 from lionagi import iModel
 from lionagi.cli.orchestrate._orchestration import OrchestrationEnv, build_worker_branch
+from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
@@ -79,13 +80,14 @@ async def test_api_worker_gets_registered_and_bound(tmp_path):
         "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
         side_effect=_api_imodel,
     ):
-        wb, _model, _profile = await build_worker_branch(
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
             env, agent_id="alice", role="researcher", explicit_name="alice"
         )
 
     assert exchange.has(wb.id)
     assert roster["alice"] == wb.id
     assert any(t.function == "messenger" for t in wb.acts.registry.values())
+    assert messenger_bound is True
 
 
 @pytest.mark.asyncio
@@ -100,13 +102,14 @@ async def test_cli_worker_skips_messenger_binding(tmp_path):
         "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
         side_effect=_cli_imodel,
     ):
-        wb, _model, _profile = await build_worker_branch(
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
             env, agent_id="cli-worker", role="researcher", explicit_name="cli-worker"
         )
 
     assert not exchange.has(wb.id)
     assert "cli-worker" not in roster
     assert not any(t.function == "messenger" for t in wb.acts.registry.values())
+    assert messenger_bound is False
 
 
 @pytest.mark.asyncio
@@ -118,11 +121,12 @@ async def test_no_exchange_configured_skips_binding_entirely(tmp_path):
         "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
         side_effect=_api_imodel,
     ):
-        wb, _model, _profile = await build_worker_branch(
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
             env, agent_id="solo", role="researcher", explicit_name="solo"
         )
 
     assert not any(t.function == "messenger" for t in wb.acts.registry.values())
+    assert messenger_bound is False
 
 
 @pytest.mark.asyncio
@@ -137,10 +141,10 @@ async def test_send_collect_receive_roundtrip_renders_sender_name(tmp_path):
         "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
         side_effect=_api_imodel,
     ):
-        branch_a, _, _ = await build_worker_branch(
+        branch_a, _, _, _ = await build_worker_branch(
             env, agent_id="alice", role="researcher", explicit_name="alice"
         )
-        branch_b, _, _ = await build_worker_branch(
+        branch_b, _, _, _ = await build_worker_branch(
             env, agent_id="bob", role="implementer", explicit_name="bob"
         )
 
@@ -158,3 +162,95 @@ async def test_send_collect_receive_roundtrip_renders_sender_name(tmp_path):
     # roster is the SAME shared dict passed to both binds — later-registered
     # bob is visible to alice's already-bound tool without rebinding.
     assert roster == {"alice": branch_a.id, "bob": branch_b.id}
+
+
+def _add_worker_operate_node(
+    builder: OperationGraphBuilder, *, branch, instruction, messenger_bound
+):
+    """Mirrors the exact node-creation conditional used by fanout.py/flow.py:
+    pass `actions=True` only when this worker actually got the messenger tool."""
+    return builder.add_operation(
+        "operate",
+        branch=branch,
+        instruction=instruction,
+        context=[{"overall_task": "t"}],
+        **({"actions": True} if messenger_bound else {}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_operate_node_carries_actions_kwarg_when_team_messaging_active(tmp_path):
+    """API worker + active team messaging: the static operate node's request
+    includes actions=True, so Branch.operate() serializes branch.acts."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+    builder = OperationGraphBuilder()
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
+            env, agent_id="alice", role="researcher", explicit_name="alice"
+        )
+
+    node_id = _add_worker_operate_node(
+        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    )
+    node = builder._operations[node_id]
+
+    assert messenger_bound is True
+    assert node.request.get("actions") is True
+
+
+@pytest.mark.asyncio
+async def test_operate_node_omits_actions_kwarg_when_team_mode_off(tmp_path):
+    """No exchange/messenger configured (team mode off): the operate node's
+    request has no actions kwarg — unchanged default (actions=False) behavior."""
+    env = _make_env(tmp_path)  # exchange/messenger/roster default None
+    builder = OperationGraphBuilder()
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
+            env, agent_id="solo", role="researcher", explicit_name="solo"
+        )
+
+    node_id = _add_worker_operate_node(
+        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    )
+    node = builder._operations[node_id]
+
+    assert messenger_bound is False
+    assert "actions" not in node.request
+
+
+@pytest.mark.asyncio
+async def test_operate_node_omits_actions_kwarg_for_cli_worker(tmp_path):
+    """Team messaging active but this worker is a CLI provider: no messenger
+    binding, so the operate node's request must not carry actions=True either."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+    builder = OperationGraphBuilder()
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_cli_imodel,
+    ):
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
+            env, agent_id="cli-worker", role="researcher", explicit_name="cli-worker"
+        )
+
+    node_id = _add_worker_operate_node(
+        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    )
+    node = builder._operations[node_id]
+
+    assert messenger_bound is False
+    assert "actions" not in node.request

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 from lionagi import iModel
+from lionagi.cli.orchestrate._common import _build_worker_operate_node
 from lionagi.cli.orchestrate._orchestration import OrchestrationEnv, build_worker_branch
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.session.exchange import Exchange
@@ -164,24 +165,11 @@ async def test_send_collect_receive_roundtrip_renders_sender_name(tmp_path):
     assert roster == {"alice": branch_a.id, "bob": branch_b.id}
 
 
-def _add_worker_operate_node(
-    builder: OperationGraphBuilder, *, branch, instruction, messenger_bound
-):
-    """Mirrors the exact node-creation conditional used by fanout.py/flow.py:
-    pass `actions=True` only when this worker actually got the messenger tool."""
-    return builder.add_operation(
-        "operate",
-        branch=branch,
-        instruction=instruction,
-        context=[{"overall_task": "t"}],
-        **({"actions": True} if messenger_bound else {}),
-    )
-
-
 @pytest.mark.asyncio
 async def test_operate_node_carries_actions_kwarg_when_team_messaging_active(tmp_path):
-    """API worker + active team messaging: the static operate node's request
-    includes actions=True, so Branch.operate() serializes branch.acts."""
+    """API worker + active team messaging: the REAL static-node builder shared
+    by fanout.py and flow.py (`_build_worker_operate_node`) produces a request
+    with actions=True, so Branch.operate() serializes branch.acts."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}
@@ -196,8 +184,12 @@ async def test_operate_node_carries_actions_kwarg_when_team_messaging_active(tmp
             env, agent_id="alice", role="researcher", explicit_name="alice"
         )
 
-    node_id = _add_worker_operate_node(
-        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    node_id = _build_worker_operate_node(
+        builder,
+        branch=wb,
+        instruction="do the task",
+        context=[{"overall_task": "t"}],
+        messenger_bound=messenger_bound,
     )
     node = builder._operations[node_id]
 
@@ -207,8 +199,8 @@ async def test_operate_node_carries_actions_kwarg_when_team_messaging_active(tmp
 
 @pytest.mark.asyncio
 async def test_operate_node_omits_actions_kwarg_when_team_mode_off(tmp_path):
-    """No exchange/messenger configured (team mode off): the operate node's
-    request has no actions kwarg — unchanged default (actions=False) behavior."""
+    """No exchange/messenger configured (team mode off): the REAL static-node
+    builder's request has no actions kwarg — unchanged default behavior."""
     env = _make_env(tmp_path)  # exchange/messenger/roster default None
     builder = OperationGraphBuilder()
 
@@ -220,8 +212,12 @@ async def test_operate_node_omits_actions_kwarg_when_team_mode_off(tmp_path):
             env, agent_id="solo", role="researcher", explicit_name="solo"
         )
 
-    node_id = _add_worker_operate_node(
-        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    node_id = _build_worker_operate_node(
+        builder,
+        branch=wb,
+        instruction="do the task",
+        context=[{"overall_task": "t"}],
+        messenger_bound=messenger_bound,
     )
     node = builder._operations[node_id]
 
@@ -232,7 +228,8 @@ async def test_operate_node_omits_actions_kwarg_when_team_mode_off(tmp_path):
 @pytest.mark.asyncio
 async def test_operate_node_omits_actions_kwarg_for_cli_worker(tmp_path):
     """Team messaging active but this worker is a CLI provider: no messenger
-    binding, so the operate node's request must not carry actions=True either."""
+    binding, so the REAL static-node builder's request must not carry
+    actions=True either."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}
@@ -247,10 +244,111 @@ async def test_operate_node_omits_actions_kwarg_for_cli_worker(tmp_path):
             env, agent_id="cli-worker", role="researcher", explicit_name="cli-worker"
         )
 
-    node_id = _add_worker_operate_node(
-        builder, branch=wb, instruction="do the task", messenger_bound=messenger_bound
+    node_id = _build_worker_operate_node(
+        builder,
+        branch=wb,
+        instruction="do the task",
+        context=[{"overall_task": "t"}],
+        messenger_bound=messenger_bound,
     )
     node = builder._operations[node_id]
 
     assert messenger_bound is False
     assert "actions" not in node.request
+
+
+@pytest.mark.asyncio
+async def test_fanout_and_flow_call_sites_use_the_same_shared_node_builder():
+    """Regression guard for the exact bug class this module protects against:
+    if either fanout.py or flow.py stopped routing its static operate-node
+    construction through the shared `_build_worker_operate_node` helper (e.g.
+    reverting to an inline, independently-editable conditional), this fails."""
+    import lionagi.cli.orchestrate.fanout as fanout_mod
+    import lionagi.cli.orchestrate.flow as flow_mod
+    from lionagi.cli.orchestrate._common import _build_worker_operate_node
+
+    assert fanout_mod._build_worker_operate_node is _build_worker_operate_node
+    assert flow_mod._build_worker_operate_node is _build_worker_operate_node
+
+
+@pytest.mark.asyncio
+async def test_bound_worker_operate_serializes_messenger_tool_schema(tmp_path):
+    """End-to-end: build a real bound worker branch, construct its operate
+    node through the real shared builder, then drive the EXACT request dict
+    produced by production through Branch.operate() with a capturing middle.
+    Confirms actions=True flows through Operation._invoke() -> operate() ->
+    action_param construction -> get_tool_schema(), and that the messenger
+    tool's schema is what gets serialized to the model."""
+    exchange = Exchange()
+    messenger = LionMessenger(exchange)
+    roster: dict = {}
+    env = _make_env(tmp_path, exchange=exchange, messenger=messenger, roster=roster)
+    builder = OperationGraphBuilder()
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
+            env, agent_id="alice", role="researcher", explicit_name="alice"
+        )
+    assert messenger_bound is True
+
+    node_id = _build_worker_operate_node(
+        builder,
+        branch=wb,
+        instruction="do the task",
+        context=[{"overall_task": "t"}],
+        messenger_bound=messenger_bound,
+    )
+    node = builder._operations[node_id]
+    node._branch = wb
+
+    captured: dict = {}
+
+    async def capturing_middle(b, ins, cctx, pctx, clear, **kw):
+        captured["tool_schemas"] = cctx.tool_schemas
+        return "ok"
+
+    await wb.operate(**node.request, middle=capturing_middle, skip_validation=True)
+
+    schemas = captured.get("tool_schemas") or []
+    assert any(s.get("function", {}).get("name") == "messenger" for s in schemas)
+
+
+@pytest.mark.asyncio
+async def test_unbound_worker_operate_does_not_serialize_any_tool_schema(tmp_path):
+    """Team mode off: the real shared builder's request carries no actions
+    kwarg, so Branch.operate() never touches branch.acts at all — no tool
+    schemas get serialized regardless of what is registered on the branch."""
+    env = _make_env(tmp_path)  # exchange/messenger/roster default None
+    builder = OperationGraphBuilder()
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        wb, _model, _profile, messenger_bound = await build_worker_branch(
+            env, agent_id="solo", role="researcher", explicit_name="solo"
+        )
+    assert messenger_bound is False
+
+    node_id = _build_worker_operate_node(
+        builder,
+        branch=wb,
+        instruction="do the task",
+        context=[{"overall_task": "t"}],
+        messenger_bound=messenger_bound,
+    )
+    node = builder._operations[node_id]
+    node._branch = wb
+
+    captured: dict = {}
+
+    async def capturing_middle(b, ins, cctx, pctx, clear, **kw):
+        captured["tool_schemas"] = cctx.tool_schemas
+        return "ok"
+
+    await wb.operate(**node.request, middle=capturing_middle, skip_validation=True)
+
+    assert not captured.get("tool_schemas")

--- a/tests/session/test_exchange.py
+++ b/tests/session/test_exchange.py
@@ -363,6 +363,65 @@ class TestExchangeEdgeCases:
         assert result is None
 
     @pytest.mark.anyio
+    async def test_stop_before_first_tick_task_group_exits_promptly(self):
+        """Mirrors fanout.py's task-group shape: exchange.run() is scheduled via
+        start_soon, then the DAG body raises immediately (before run() gets its
+        first turn). stop() in `finally` must make run() return right away
+        instead of clearing the stop signal and looping forever."""
+        from lionagi.ln.concurrency import create_task_group, fail_after
+
+        exchange = Exchange()
+
+        async def _failing_dag():
+            raise RuntimeError("boom")
+
+        # anyio's task group wraps a body-raised exception in an
+        # ExceptionGroup even with a single failure — same as the real
+        # fanout.py call site. fail_after(2) is the regression guard: before
+        # the fix, exchange.run() cleared the stop signal on its first turn
+        # and looped forever, so the task group's __aexit__ never returned
+        # and this would hit the deadline instead of raising promptly.
+        with pytest.raises(BaseException) as exc_info:
+            with fail_after(2):
+                async with create_task_group() as tg:
+                    tg.start_soon(exchange.run, 0.01)
+                    try:
+                        await _failing_dag()
+                    finally:
+                        exchange.stop()
+
+        raised = exc_info.value
+        sub_exceptions = getattr(raised, "exceptions", (raised,))
+        assert any(isinstance(e, RuntimeError) and str(e) == "boom" for e in sub_exceptions)
+        assert exchange._stop is True
+
+    @pytest.mark.anyio
+    async def test_stop_before_first_tick_ensure_future_await_completes(self):
+        """Mirrors flow.py's ensure_future + explicit-await shape: exchange.run()
+        is scheduled as a task, the DAG raises before it ticks, stop() fires in
+        `finally`, and awaiting the runner task must complete promptly (not hang
+        forever) so the original exception still propagates to the caller."""
+        import asyncio
+
+        from lionagi.ln.concurrency import fail_after
+
+        exchange = Exchange()
+        exch_task = asyncio.ensure_future(exchange.run(0.01))
+
+        async def _failing_dag():
+            raise RuntimeError("boom")
+
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                await _failing_dag()
+        finally:
+            exchange.stop()
+            with fail_after(2):
+                await exch_task
+
+        assert exch_task.done()
+
+    @pytest.mark.anyio
     async def test_collect_empty_outbox(self):
         exchange = Exchange()
         owner_id = uuid4()

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -17,31 +17,27 @@ from lionagi.tools.communication.messenger import (
 )
 
 
-def _make_branch(exchange: Exchange):
+# `msg not in branch.msgs.messages` → checks membership on included list
+class _MsgsView:
+    def __init__(self, store):
+        self._store = store
+
+    def __iter__(self):
+        return iter(self._store)
+
+    def __contains__(self, item):
+        return item in self._store
+
+    def include(self, msg):
+        self._store.append(msg)
+
+
+def _make_branch(exchange: Exchange, branch_id=None):
     included = []
-    messages = SimpleNamespace(
-        include=lambda msg: included.append(msg),
-        messages=included,  # for `msg in branch.msgs.messages`
-    )
-
-    # `msg not in branch.msgs.messages` → checks membership on included list
-    class _MsgsView:
-        def __init__(self, store):
-            self._store = store
-
-        def __iter__(self):
-            return iter(self._store)
-
-        def __contains__(self, item):
-            return item in self._store
-
-        def include(self, msg):
-            self._store.append(msg)
-
     view = _MsgsView(included)
     msgs = SimpleNamespace(messages=view)
 
-    branch_id = uuid4()
+    branch_id = branch_id or uuid4()
     exchange.register(branch_id)
     return SimpleNamespace(id=branch_id, msgs=msgs, _included=included)
 
@@ -49,6 +45,7 @@ def _make_branch(exchange: Exchange):
 class TestMessengerActionEnum:
     def test_enum_values(self):
         assert MessengerAction.send == "send"
+        assert MessengerAction.receive == "receive"
         assert MessengerAction.done == "done"
         assert MessengerAction.finished == "finished"
         assert MessengerAction.wakeup == "wakeup"
@@ -251,6 +248,82 @@ class TestMessengerBindWakeup:
         tool = m.bind(branch, roster={"alice": alice_id})
         result = tool.func_callable(action="wakeup", to=["alice", "bob"], content="rise")
         assert "Woke up alice" in result
+
+
+class TestMessengerBindReceive:
+    def test_receive_empty_inbox(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={})
+        result = tool.func_callable(action="receive")
+        assert result == "No new messages."
+
+    def test_receive_single_sender(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        bob = _make_branch(ex)
+        alice = _make_branch(ex)
+
+        alice_tool = m.bind(alice, roster={"bob": bob.id}, sender_name="alice")
+        alice_tool.func_callable(action="send", to="bob", content="hi bob")
+
+        import asyncio
+
+        asyncio.run(ex.collect(alice.id))
+
+        bob_tool = m.bind(bob, roster={"alice": alice.id}, sender_name="bob")
+        result = bob_tool.func_callable(action="receive")
+        assert result == "[alice] hi bob"
+
+        # second call drains an empty inbox
+        result2 = bob_tool.func_callable(action="receive")
+        assert result2 == "No new messages."
+
+    def test_receive_multi_sender_drains_all(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        bob = _make_branch(ex)
+        alice = _make_branch(ex)
+        carol = _make_branch(ex)
+
+        alice_tool = m.bind(alice, roster={"bob": bob.id}, sender_name="alice")
+        carol_tool = m.bind(carol, roster={"bob": bob.id}, sender_name="carol")
+        alice_tool.func_callable(action="send", to="bob", content="from alice")
+        carol_tool.func_callable(action="send", to="bob", content="from carol")
+
+        import asyncio
+
+        asyncio.run(ex.collect(alice.id))
+        asyncio.run(ex.collect(carol.id))
+
+        bob_tool = m.bind(bob, roster={"alice": alice.id, "carol": carol.id}, sender_name="bob")
+        result = bob_tool.func_callable(action="receive")
+        lines = result.splitlines()
+        assert "[alice] from alice" in lines
+        assert "[carol] from carol" in lines
+        assert len(lines) == 2
+
+        # fully drained
+        assert bob_tool.func_callable(action="receive") == "No new messages."
+
+    def test_receive_unknown_sender_falls_back_to_uuid_prefix(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        bob = _make_branch(ex)
+        ghost = _make_branch(ex)
+
+        ghost_tool = m.bind(ghost, roster={"bob": bob.id}, sender_name="ghost")
+        ghost_tool.func_callable(action="send", to="bob", content="mystery")
+
+        import asyncio
+
+        asyncio.run(ex.collect(ghost.id))
+
+        # bob's roster doesn't include ghost's name -> fallback to uuid prefix
+        bob_tool = m.bind(bob, roster={}, sender_name="bob")
+        result = bob_tool.func_callable(action="receive")
+        assert result == f"[{str(ghost.id)[:8]}] mystery"
 
 
 class TestMessengerBindUnknownAction:


### PR DESCRIPTION
## Summary

Wires the exchange-bound messenger into the static fanout/flow team topology. When team mode is active, the orchestration env carries a shared `Exchange`, a `LionMessenger`, and a name-to-UUID roster; each API-model worker branch is registered on the exchange and gets a bound messenger tool at creation, and its `operate` DAG node enables action serialization so the tool is actually callable. CLI-driven workers keep the existing file-based team channel unchanged (tool schemas are not surfaced to CLI providers).

- messenger gains a `receive` action so workers can drain their inboxes (previously send-only); senders render by roster name
- fanout runs the exchange sync loop in a task group around `session.flow()`; flow.py follows its existing ensure_future/cancel idiom alongside the heartbeat and control-poll loops; a final `collect_all()` routes any last outbox sends before results reach the team file
- `Exchange.run()` no longer clears a pre-issued stop signal on entry, so a DAG that fails before the sync loop's first tick can't hang teardown
- worker `operate` node construction is shared between both DAG builders via one helper; tests drive a built node's request through `Branch.operate()` with a capturing middle and assert the messenger schema is (and is not) serialized end-to-end

## Testing

- 378 passed across `tests/cli/orchestrate/`, `tests/session/test_exchange.py`, `tests/tools/test_messenger.py`
- New coverage: receive-action drain semantics, exchange registration/roster/binding per worker class, CLI-worker and team-off neutrality, stop-before-first-tick teardown for both runner lifecycles, end-to-end tool-schema serialization capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)