### PR TITLE
fix(operations): write branch snapshots atomically to keep interrupted runs resumable

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from collections.abc import AsyncGenerator
 from dataclasses import fields
+from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -37,6 +40,30 @@ from lionagi.operations._observe import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _write_branch_snapshot(branch: Branch, snapshot_dir: str | Path) -> None:
+    """Atomically write ``branch``'s current state to ``snapshot_dir/{branch.id}.json``.
+
+    Writes to a sibling temp file first, then renames it into place. A plain
+    ``open(..., "w") + write`` truncates the target before the new content
+    lands — a process kill (SIGTERM/SIGKILL) mid-write would leave a
+    zero-byte or partially-written snapshot that ``find_branch`` locates but
+    ``json.loads`` can't parse, making the branch unresumable even though a
+    snapshot file exists. ``os.replace`` is atomic on POSIX and Windows, so a
+    reader always sees either the previous complete snapshot or the new one,
+    never a torn write.
+    """
+    fp = await acreate_path(
+        snapshot_dir,
+        str(branch.id),
+        ".json",
+        file_exist_ok=True,
+    )
+    tmp_fp = anyio.Path(str(fp) + ".tmp")
+    async with await anyio.open_file(tmp_fp, "w") as f:
+        await f.write(json_dumps(branch.to_dict()))
+    await anyio.to_thread.run_sync(partial(os.replace, str(tmp_fp), str(fp)))
 
 
 async def _stream_with_deadline(model, api_call, deadline: float | None):
@@ -299,16 +326,13 @@ async def run(
         bfp = None
 
         if param.stream_persist:
-            # snapshot_dir for find_branch() lookups; persist_dir for the live JSONL buffer
+            # snapshot_dir for find_branch() lookups; persist_dir for the live JSONL buffer.
+            # Written here, before the stream starts, so a branch killed at any
+            # point during a long-running turn (e.g. SIGTERM mid-stream) still
+            # has a resumable checkpoint — the finally block below overwrites
+            # it with the completed turn's state on a clean exit.
             snapshot_dir = param.snapshot_dir or param.persist_dir
-            fp = await acreate_path(
-                snapshot_dir,
-                str(branch.id),
-                ".json",
-                file_exist_ok=True,
-            )
-            async with await anyio.open_file(fp, "w") as f:
-                await f.write(json_dumps(branch.to_dict()))
+            await _write_branch_snapshot(branch, snapshot_dir)
 
             bfp = await acreate_path(
                 param.persist_dir,
@@ -534,14 +558,7 @@ async def run(
             model.streaming_process_func = prev_stream_func
             if param.stream_persist:
                 snapshot_dir = param.snapshot_dir or param.persist_dir
-                fp = await acreate_path(
-                    snapshot_dir,
-                    str(branch.id),
-                    ".json",
-                    file_exist_ok=True,
-                )
-                async with await anyio.open_file(fp, "w") as f:
-                    await f.write(json_dumps(branch.to_dict()))
+                await _write_branch_snapshot(branch, snapshot_dir)
                 if bfp is not None:
                     bfp_path = anyio.Path(bfp)
                     if await bfp_path.exists():

--- a/tests/cli/test_agent_first_turn_checkpoint.py
+++ b/tests/cli/test_agent_first_turn_checkpoint.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the first-turn checkpoint: a branch killed (e.g.
+SIGTERM) before its first turn completes still leaves a resumable snapshot.
+
+`lionagi.operations.run.run.run()` writes the branch's JSON snapshot to
+`snapshot_dir` *before* the model stream starts (see `_write_branch_snapshot`),
+not only when the turn finishes cleanly. These tests pin the two things a
+resumer actually depends on:
+
+  * `find_branch()` locates a pre-turn checkpoint under `<run>/branches/`
+    exactly like it would a post-turn one.
+  * `li agent -r <id>` (via `_run_agent`'s resume branch) loads such a
+    checkpoint and proceeds without crashing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _write_pre_turn_snapshot(branches_dir: Path) -> str:
+    """Simulate the early snapshot `run()` writes before streaming starts:
+    a branch with only the instruction message recorded, no assistant
+    response — the state that exists the instant a long CLI turn is killed.
+    """
+    from lionagi import Branch
+
+    b = Branch()
+    b.msgs.add_message(instruction="do the long-running thing")
+    branch_id = str(b.id)
+    branches_dir.mkdir(parents=True, exist_ok=True)
+    (branches_dir / f"{branch_id}.json").write_text(json.dumps(b.to_dict()))
+    return branch_id
+
+
+def test_find_branch_locates_pre_turn_checkpoint(tmp_path, monkeypatch):
+    """find_branch() must locate a checkpoint written before the turn ever
+    completed — the same lookup a completed-turn snapshot uses.
+    """
+    import lionagi.cli._runs as runs_mod
+
+    run_dir = tmp_path / "runs" / "r1"
+    branches_dir = run_dir / "branches"
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+
+    branch_id = _write_pre_turn_snapshot(branches_dir)
+
+    found_run_id, found_path = runs_mod.find_branch(branch_id)
+    assert found_run_id == "r1"
+    assert found_path == branches_dir / f"{branch_id}.json"
+
+    # And it must be valid, parseable JSON — not a torn write.
+    data = json.loads(found_path.read_text())
+    assert data["id"] == branch_id
+
+
+def test_find_branch_prefix_match_on_pre_turn_checkpoint(tmp_path, monkeypatch):
+    """A truncated id (as a user might paste) still prefix-matches a
+    pre-turn checkpoint."""
+    import lionagi.cli._runs as runs_mod
+
+    run_dir = tmp_path / "runs" / "r1"
+    branches_dir = run_dir / "branches"
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+
+    branch_id = _write_pre_turn_snapshot(branches_dir)
+
+    found_run_id, found_path = runs_mod.find_branch(branch_id[:8])
+    assert found_run_id == "r1"
+    assert found_path.name == f"{branch_id}.json"
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
+    """Monkeypatch all external I/O in _run_agent so tests run without real I/O.
+
+    Mirrors the helper in test_agent_resume_model_override.py.
+    """
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    async def fake_operate(self, instruction=None, **kw):
+        return operate_return
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_on_pre_turn_checkpoint_does_not_crash(tmp_path, monkeypatch):
+    """`li agent -r <id>` against a checkpoint from an interrupted first turn
+    (instruction recorded, no assistant response) must load the branch and
+    run the next turn — not raise FileNotFoundError or crash on the
+    incomplete history.
+    """
+    branches_dir = tmp_path / "src_branches"
+    branch_id = _write_pre_turn_snapshot(branches_dir)
+    branch_path = branches_dir / f"{branch_id}.json"
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="continuing the long-running thing")
+
+    from lionagi.cli.agent import _run_agent
+
+    result, provider, resumed_branch_id, terminal_status, _sid = await _run_agent(
+        None,
+        "continue and conclude the task",
+        resume=branch_id,
+    )
+
+    assert terminal_status == "completed"
+    assert result == "continuing the long-running thing"
+    assert resumed_branch_id == branch_id
+    # No model override was given — the branch's own persisted provider/model wins.
+    assert provider == "openai"

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
 import types
 from unittest.mock import AsyncMock
 
@@ -18,6 +21,7 @@ from lionagi.protocols.messages import (
     ActionResponse,
     AssistantResponse,
     AssistantResponseContent,
+    Instruction,
 )
 from lionagi.service.imodel import iModel
 from lionagi.service.types.stream_chunk import StreamChunk
@@ -347,6 +351,83 @@ async def test_run_stream_persist_snapshot_dir_default_falls_back_to_persist_dir
 
     # Snapshot is in persist_dir
     assert list(tmp_path.glob("*.json"))
+
+
+async def test_run_stream_persist_snapshot_survives_mid_stream_cancellation(tmp_path):
+    """A branch checkpoint exists and is loadable even if the turn is killed
+    before the model produces a single chunk (e.g. SIGTERM mid-stream on a
+    long-running CLI turn). The snapshot is written before streaming starts,
+    not only on clean completion, so `find_branch` + `Branch.from_dict`
+    can resume a branch whose first turn never finished.
+    """
+    import anyio as _anyio
+
+    branches_dir = tmp_path / "branches"
+    branches_dir.mkdir()
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    m.endpoint = types.SimpleNamespace(
+        is_cli=True, session_id=None, to_dict=lambda: {"type": "fake_cli"}
+    )
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    hang = _anyio.Event()
+
+    async def stream(api_call=None):
+        await hang.wait()  # never set — simulates a subprocess still running
+        yield StreamChunk(type="text", content="unreachable")  # pragma: no cover
+
+    m.stream = stream
+    branch = Branch()
+    branch.chat_model = m
+
+    param = RunParam(stream_persist=True, persist_dir=branches_dir, snapshot_dir=branches_dir)
+    gen = run(branch, "long-running instruction", param)
+
+    first = await gen.__anext__()
+    assert isinstance(first, Instruction)
+
+    task = asyncio.ensure_future(gen.__anext__())
+    await asyncio.sleep(0.05)  # let it run past the pre-stream snapshot write
+
+    snaps = list(branches_dir.glob("*.json"))
+    assert snaps, "checkpoint must exist before the stream produces any output"
+
+    # A resumer must be able to parse it — not a torn/partial write.
+    data = json.loads(snaps[0].read_text())
+    assert data  # non-empty, valid JSON
+
+    task.cancel()
+    with contextlib.suppress(BaseException):
+        await task
+    with contextlib.suppress(Exception):
+        await gen.aclose()
+
+    # Still there (and still valid) after the simulated kill.
+    snaps_after = list(branches_dir.glob("*.json"))
+    assert snaps_after
+    data_after = json.loads(snaps_after[0].read_text())
+    assert data_after["id"] == str(branch.id)
+
+    # The instruction was recorded even though no assistant response arrived —
+    # the checkpoint carries what a resumer needs (find_branch + json.loads
+    # both succeed; the fake CLI endpoint used here isn't a real serializable
+    # Endpoint, so this asserts against the message record directly rather
+    # than round-tripping the whole branch through Branch.from_dict).
+    msg_classes = [
+        entry["metadata"].get("lion_class") for entry in data_after["messages"]["collections"]
+    ]
+    assert any(cls == "lionagi.protocols.messages.instruction.Instruction" for cls in msg_classes)
+    assert not any(
+        cls == "lionagi.protocols.messages.assistant_response.AssistantResponse"
+        for cls in msg_classes
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -14,7 +14,13 @@ from unittest.mock import AsyncMock
 import pytest
 from pydantic import BaseModel
 
-from lionagi.operations.run.run import RunParam, _stream_with_deadline, run, run_and_collect
+from lionagi.operations.run.run import (
+    RunParam,
+    _stream_with_deadline,
+    _write_branch_snapshot,
+    run,
+    run_and_collect,
+)
 from lionagi.operations.types import ChatParam
 from lionagi.protocols.messages import (
     ActionRequest,
@@ -428,6 +434,84 @@ async def test_run_stream_persist_snapshot_survives_mid_stream_cancellation(tmp_
         cls == "lionagi.protocols.messages.assistant_response.AssistantResponse"
         for cls in msg_classes
     )
+
+
+async def test_write_branch_snapshot_torn_write_keeps_prior_snapshot(tmp_path, monkeypatch):
+    """A kill landing mid-write must never corrupt an existing snapshot.
+
+    The write is staged through a sibling .tmp file, so a failure while the
+    bytes are going out tears only the staging file — the target keeps the
+    previous complete, parseable snapshot. Under a direct open('w') write the
+    target itself would be truncated/torn, so this test pins the staging
+    behavior: it fails if the helper ever writes the target in place again.
+    """
+    import anyio as _anyio
+
+    branch = Branch()
+    await _write_branch_snapshot(branch, tmp_path)
+
+    target = tmp_path / f"{branch.id}.json"
+    v1 = target.read_text()
+    assert json.loads(v1)["id"] == str(branch.id)
+
+    real_open_file = _anyio.open_file
+
+    def torn_open_file(path, mode="r", *args, **kwargs):
+        class _TornCtx:
+            async def __aenter__(self):
+                self._f = await real_open_file(path, mode, *args, **kwargs)
+                await self._f.__aenter__()
+
+                class _TornFile:
+                    def __init__(self, inner):
+                        self._inner = inner
+
+                    async def write(self, data):
+                        await self._inner.write(data[: len(data) // 2])
+                        raise OSError("simulated kill mid-write")
+
+                return _TornFile(self._f)
+
+            async def __aexit__(self, *exc):
+                return await self._f.__aexit__(*exc)
+
+        async def _make():
+            return _TornCtx()
+
+        return _make()
+
+    monkeypatch.setattr(_anyio, "open_file", torn_open_file)
+
+    with pytest.raises(OSError, match="simulated kill mid-write"):
+        await _write_branch_snapshot(branch, tmp_path)
+
+    # The target is byte-identical to the prior complete snapshot — not torn.
+    assert target.read_text() == v1
+    assert json.loads(target.read_text())["id"] == str(branch.id)
+
+
+async def test_write_branch_snapshot_failed_replace_keeps_prior_snapshot(tmp_path, monkeypatch):
+    """If the final rename fails, the target must be untouched — pinning that
+    the helper publishes via os.replace rather than writing the target
+    directly (a direct write would have already clobbered it by this point,
+    and os.replace would never be reached at all).
+    """
+    import os as _os
+
+    branch = Branch()
+    await _write_branch_snapshot(branch, tmp_path)
+    target = tmp_path / f"{branch.id}.json"
+    v1 = target.read_text()
+
+    def failing_replace(src, dst):
+        raise OSError("simulated kill before publish")
+
+    monkeypatch.setattr(_os, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="simulated kill before publish"):
+        await _write_branch_snapshot(branch, tmp_path)
+
+    assert target.read_text() == v1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Investigating a report that a `li agent` leg killed mid-first-turn was unresumable showed the pre-stream branch snapshot already exists on current main (written before the CLI subprocess stream starts, verified with a hung-stream repro). The remaining real gap: both snapshot write sites used plain `open(..., 'w') + write`, which truncates the target before new content lands — a SIGTERM/SIGKILL landing in that window leaves a zero-byte or torn JSON that `find_branch()` locates but can't load, defeating resume even though a snapshot file exists.

- Both write sites (pre-stream and post-turn) factored into one `_write_branch_snapshot()` helper: write to a sibling `.tmp`, then `os.replace()` into place — atomic on POSIX and Windows; readers always see either the previous complete snapshot or the new one.
- New regression coverage: mid-stream-cancellation checkpoint survival, `find_branch()` exact/prefix lookup on a pre-turn checkpoint, and a resume smoke test against a checkpoint with an instruction but no assistant response.

## Testing

- `uv run pytest tests/cli/ tests/session/ tests/operations/` — 2513 passed
- New tests alone: 32 passed; ruff format/check clean; pyright introduces zero new errors on run.py (baseline diffed before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)