### PR TITLE
feat(agent): opt-in profile role wiring with fail-closed policy binding + claude_code MCP forwarding

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from lionagi._errors import ConfigurationError
 from lionagi.session.branch import Branch
 
 from .spec import AgentSpec
@@ -107,6 +108,7 @@ async def create_agent(
     _apply_permissions(spec)
     _register_tools(branch, spec)
     await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
+    _forward_mcp_to_cli_request(branch, spec, trust_project_settings=trust_project_settings)
 
     if op := spec.emission_operable():
         branch.grant_capabilities(op)
@@ -279,38 +281,68 @@ def _register_coding_tools(branch: Branch, spec: AgentSpec) -> None:
     branch.register_tools(tools)
 
 
+def _resolve_mcp_path(spec: AgentSpec, *, trust_project_settings: bool = False) -> str | None:
+    """Resolve the ``.mcp.json`` path an AgentSpec's MCP fields point at.
+
+    Shared by ``_load_mcp`` (island 1: lionagi-native ``branch.acts`` tools) and
+    ``_forward_mcp_to_cli_request`` (island 2: the CLI-native request) so
+    both islands agree on which file is authoritative and under what trust
+    gate. An explicit ``spec.mcp_config_path`` always wins; otherwise a
+    project-scoped ``.lionagi/.mcp.json`` / ``.mcp.json`` is only considered
+    when ``trust_project_settings=True`` (mirrors the settings-loading trust
+    gate), while the user-home ``~/.lionagi/.mcp.json`` candidate is trusted
+    unconditionally, since it lives in the user's own home directory rather
+    than an arbitrary project checkout.
+
+    An explicit ``spec.mcp_config_path`` that does not resolve to an existing
+    file raises ``ConfigurationError`` — the caller declared intent, so a
+    missing/typo'd path is a configuration error, not a soft no-op. Only the
+    auto-discovered candidates below fall through silently when none exist.
+    """
+    from pathlib import Path
+
+    if spec.mcp_config_path is not None:
+        # Presence check, not truthiness: an explicit empty string is still a
+        # declared path and must fail loudly below, never fall through into
+        # auto-discovery (which could silently load a different config).
+        p = Path(spec.mcp_config_path)
+        if p.is_file():
+            return str(p)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "spec.mcp_config_path=%r does not resolve to an existing file",
+            spec.mcp_config_path,
+        )
+        raise ConfigurationError(
+            f"spec.mcp_config_path={spec.mcp_config_path!r} does not resolve to an existing file"
+        )
+
+    candidates = []
+    cwd = Path(spec.cwd) if spec.cwd else Path.cwd()
+
+    if trust_project_settings:
+        for parent in [cwd, *cwd.parents]:
+            candidates.append(parent / ".lionagi" / ".mcp.json")
+            candidates.append(parent / ".mcp.json")
+            if (parent / ".lionagi").is_dir():
+                break
+
+    candidates.append(Path.home() / ".lionagi" / ".mcp.json")
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
 async def _load_mcp(
     branch: Branch,
     spec: AgentSpec,
     *,
     trust_project_settings: bool = False,
 ) -> None:
-    from pathlib import Path
-
-    mcp_path = None
-
-    if spec.mcp_config_path:
-        p = Path(spec.mcp_config_path)
-        if p.is_file():
-            mcp_path = str(p)
-    else:
-        candidates = []
-        cwd = Path(spec.cwd) if spec.cwd else Path.cwd()
-
-        if trust_project_settings:
-            for parent in [cwd, *cwd.parents]:
-                candidates.append(parent / ".lionagi" / ".mcp.json")
-                candidates.append(parent / ".mcp.json")
-                if (parent / ".lionagi").is_dir():
-                    break
-
-        candidates.append(Path.home() / ".lionagi" / ".mcp.json")
-
-        for candidate in candidates:
-            if candidate.is_file():
-                mcp_path = str(candidate)
-                break
-
+    mcp_path = _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
     if mcp_path is None:
         return
 
@@ -318,3 +350,129 @@ async def _load_mcp(
         mcp_path,
         server_names=spec.mcp_servers,
     )
+
+
+def _forward_mcp_to_cli_request(
+    branch: Branch,
+    spec: AgentSpec,
+    *,
+    trust_project_settings: bool = False,
+) -> None:
+    """Forward AgentSpec MCP fields into the claude_code CLI's own request.
+
+    ``_load_mcp`` above only reaches island 1 (lionagi-native ``branch.acts``
+    tools, consulted by API function-calling endpoints) — inert for CLI
+    providers, which spawn their own subprocess and parse only that
+    subprocess's own tool_use/tool_result chunks, never calling back into
+    ``branch.acts``. This reaches island 2: the per-turn request kwargs a CLI
+    provider builds (``ClaudeCodeRequest.mcp_servers``, which ``as_cmd_args()``
+    turns into a literal ``--mcp-config`` flag for the ``claude`` CLI
+    subprocess). Setting it onto the chat_model endpoint's ``config.kwargs``
+    makes it land in every per-turn payload (``Endpoint.create_payload``
+    starts from ``config.kwargs`` and merges the per-call request on top),
+    the same mechanism already used for provider-specific extras like a
+    placeholder ``api_key``.
+
+    Why ``mcp_servers`` (dict) rather than ``mcp_config`` (path): although
+    ``as_cmd_args()`` prefers ``mcp_config`` over ``mcp_servers`` when both
+    are set, ``mcp_config``'s field validator
+    (``claude_code.py`` ``_validate_path_fields`` -> ``check_path_safe``)
+    unconditionally rejects absolute paths, and both resolved candidates
+    here (``~/.lionagi/.mcp.json`` and a project ``.mcp.json`` found via
+    parent-directory search) are absolute and not generally repo-relative —
+    so setting ``mcp_config`` would raise a ValidationError on the very next
+    turn for the common case. ``mcp_servers`` (a plain dict field) carries no
+    such validator, so this always loads the resolved file and forwards the
+    (optionally filtered) dict — never the path.
+
+    Only ``claude_code`` has an MCP-capable request model today; other
+    providers get a logged warning
+    rather than a silent no-op — but only when there is actually something
+    to forward (a resolvable config), so a caller can tell "no passthrough
+    exists" apart from "nothing was configured" (mirrors ``_load_mcp``,
+    which no-ops the same way for island 1 when nothing resolves).
+
+    ``spec.mcp_servers`` set (even to an explicit empty list) is itself
+    caller intent independent of whether any config file resolves: an
+    explicit allowlist must be enforced regardless of config presence, so a
+    ``claude_code`` leg with ``mcp_servers=[]`` and no resolvable
+    ``.mcp.json`` anywhere still forwards ``{}`` (filtering nothing against
+    an empty selection), forcing zero MCP servers rather than leaving the
+    per-turn request untouched and letting the CLI fall back to its own MCP
+    discovery.
+    """
+    mcp_path = _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
+    if mcp_path is None and spec.mcp_servers is None:
+        # Nothing configured at all: no config file resolves and no explicit
+        # server-name filter was set. Nothing to forward.
+        return
+
+    provider = getattr(branch.chat_model.endpoint.config, "provider", None)
+
+    if provider != "claude_code":
+        if mcp_path is not None:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "MCP config present in AgentSpec but the active provider (%s) has "
+                "no MCP passthrough; MCP servers will not be reachable for this "
+                "run.",
+                provider,
+            )
+        # provider != claude_code has no MCP-capable request model to forward
+        # into at all — an explicit mcp_servers filter with no resolvable
+        # config file has nothing to filter and nowhere to land, so this
+        # stays a silent no-op (mirrors _load_mcp's own no-op shape).
+        return
+
+    if mcp_path is None:
+        # claude_code + an explicit spec.mcp_servers filter (possibly empty)
+        # but no config file resolves: there is nothing to read, so the
+        # "servers available" set is empty — filtering it by the allowlist
+        # is still {}, which is exactly the explicit-empty-allowlist case.
+        servers: dict = {}
+    else:
+        import json
+        from pathlib import Path
+
+        try:
+            data = json.loads(Path(mcp_path).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Could not read/parse MCP config %r for forwarding to the "
+                "claude_code CLI request (%s: %s); MCP servers will not be "
+                "reachable for this run.",
+                mcp_path,
+                type(exc).__name__,
+                exc,
+            )
+            if spec.mcp_config_path:
+                # An explicitly configured path (as opposed to an auto-discovered
+                # candidate) failing to read/parse is a configuration error, not
+                # a soft "nothing to forward" — the caller declared intent.
+                raise ConfigurationError(
+                    f"spec.mcp_config_path={spec.mcp_config_path!r} could not be "
+                    f"read or parsed as JSON: {type(exc).__name__}: {exc}"
+                ) from exc
+            return
+        servers = data.get("mcpServers", {}) if isinstance(data, dict) else {}
+
+    if spec.mcp_servers is not None:
+        # A server-name filter is set (possibly an explicit empty list): the
+        # two islands must agree on selection (mirrors _load_mcp's
+        # server_names semantics, where server_names=[] loads nothing).
+        servers = {name: cfg for name, cfg in servers.items() if name in spec.mcp_servers}
+
+    # Mutating config.kwargs in place would corrupt any OTHER branch sharing
+    # this same iModel instance (Branch.__init__ keeps a caller-supplied
+    # chat_model by reference, not by copy — two create_agent calls given the
+    # same iModel would otherwise cross-contaminate each other's MCP server
+    # filter through the shared config.kwargs dict). Give this branch its own
+    # copy of the chat_model/endpoint/config before mutating so the change is
+    # branch-local. share_session/share_executor keep the copy's CLI session
+    # and the caller-supplied rate limiter/queue shared with the original —
+    # only the endpoint config (and thus the MCP filter) is branch-local.
+    branch.chat_model = branch.chat_model.copy(share_session=True, share_executor=True)
+    branch.chat_model.endpoint.config.kwargs["mcp_servers"] = servers

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -118,6 +118,7 @@ class AgentSpec(HooksMixin):
     def coding(
         cls,
         *,
+        role: str = "implementer",
         model: str | None = None,
         effort: str | None = "high",
         system_prompt: str | None = None,
@@ -128,11 +129,15 @@ class AgentSpec(HooksMixin):
     ) -> AgentSpec:
         """Preset for a coding agent; ``secure=True`` wires guard_destructive + guard_paths.
 
+        ``role`` defaults to ``"implementer"`` (every existing caller relies on this
+        default). Pass a different role name to compose the preset's tools/hooks
+        around another role's own body and policy block instead.
+
         ``context_management=False`` drops the context tool from the default coding
         toolset and skips the context-curation one-liner in the system prompt.
         """
         spec = cls.compose(
-            "implementer",
+            role,
             model=model,
             effort=effort,
             tools=["coding"],
@@ -218,9 +223,22 @@ class AgentSpec(HooksMixin):
         pack = _load_pack(self.pack)
         if pack is None:
             return ""
-        policy = pack.policy(self.profile.role.name)
+        role_name = self.profile.role.name
+        policy = pack.policy(role_name)
         if policy is None:
-            return ""
+            # A role that loads (Role.load succeeded) but has no entry in the
+            # active pack must not silently run unconstrained — that is a
+            # privilege gap, not a no-op. A role genuinely meant to run with
+            # no authority/boundary/escalation constraints says so explicitly
+            # via an empty-but-present entry in the pack yaml (e.g. `roles:
+            # {my-role: {}}`), which resolves to an empty RolePolicy here, not
+            # None — distinct from the role being absent from `roles:` entirely.
+            raise ValueError(
+                f"Role {role_name!r} has no policy entry in pack {pack.name!r}. "
+                "Add an entry under `roles:` in the pack yaml — an empty entry "
+                "(e.g. `{}`) is the explicit way to run this role unconstrained; "
+                "a missing entry is treated as a configuration error, not intent."
+            )
 
         lines: list[str] = []
         if policy.authority:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -64,11 +64,12 @@ def _make_coding_preset(
     cwd: str | None = None,
     effort: str | None = "high",
     system_prompt: str | None = None,
+    role: str = "implementer",
 ):
     """Construct an AgentSpec.coding() instance; isolated for test monkeypatching."""
     from lionagi.agent.spec import AgentSpec
 
-    return AgentSpec.coding(cwd=cwd, effort=effort, system_prompt=system_prompt)
+    return AgentSpec.coding(cwd=cwd, effort=effort, system_prompt=system_prompt, role=role)
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +271,33 @@ async def _run_agent(
         if profile.resume_on_timeout and not resume_on_timeout:
             resume_on_timeout = True
 
+    # Validate a declared profile `role:` key up front, before the
+    # resume/new-branch split — a malformed profile must fail loudly on every
+    # invocation shape, not only when a new branch is composed. The value
+    # itself is only USED when composing a new branch (a resumed branch keeps
+    # its persisted system message). A declared key must be a non-empty
+    # string: `role: ""`, `role: false`, or `role: 0` parse to falsy Python
+    # values, and a truthiness fallback would silently grant the implementer
+    # role (and its coding authority) instead of surfacing the malformed
+    # config. The "implementer" default applies ONLY when the key is
+    # genuinely absent (bare `--preset coding` with no declared role).
+    profile_role_extra = (getattr(profile, "extra", None) or {}) if profile else {}
+    has_role_key = "role" in profile_role_extra
+    profile_role = profile_role_extra.get("role") if has_role_key else None
+    if has_role_key and (not isinstance(profile_role, str) or not profile_role.strip()):
+        raise ConfigurationError(
+            f"agent profile {getattr(profile, 'name', '<unknown>')!r} declares a "
+            f"`role` key but its value {profile_role!r} is not a non-empty "
+            "string; set it to a valid role name, or remove the key to keep "
+            "the plain profile path (no role/policy composition)."
+        )
+
+    # Set True only when a NEW branch takes the create_agent path (either
+    # --preset coding or an opted-in profile `role:` key) — the profile
+    # system-prompt block below must not double-add via add_message in that
+    # case (the profile extension was already composed into the spec).
+    took_create_agent_path = False
+
     branch: Branch | None = None
     if continue_last:
         _, branch_id = load_last_branch()
@@ -330,7 +358,21 @@ async def _run_agent(
         chat_model = build_chat_model(provider, model, yolo, verbose, theme, effort, fast, bypass)
         effort = resolve_persisted_effort(provider, chat_model, effort)
 
-        if preset == "coding":
+        # Opt-in profile frontmatter key `role`: an explicit `role:` in the
+        # profile's frontmatter (parsed into AgentProfile.extra by
+        # _parse_profile) switches a plain `-a <profile>` leg onto the same
+        # create_agent path `--preset coding` uses, parameterized with the
+        # profile's own role instead of the hardcoded "implementer" default —
+        # so a reviewer profile gets the reviewer policy block, not the
+        # implementer's. `role` is read ONLY from this explicit key — it is
+        # NEVER defaulted from the profile name, since many deployed profiles
+        # name no matching built-in Role and would hit Role.load's fail-closed
+        # ValueError the moment they were defaulted into this path. A profile
+        # without the key keeps today's plain Branch(...) path byte-for-byte.
+        # (The key was already validated as a non-empty string right after
+        # profile load, before the resume/new-branch split.)
+        if preset == "coding" or has_role_key:
+            took_create_agent_path = True
             # 3a: use create_agent so CodingToolkit tools and path-guards are
             # fully wired (guard_destructive on bash, guard_paths on
             # reader/editor).  The factory installs the full system message via
@@ -357,7 +399,17 @@ async def _run_agent(
                 cwd=cwd,
                 effort=effort or "high",
                 system_prompt=profile_extra or None,
+                role=profile_role if has_role_key else "implementer",
             )
+            # AgentSpec.coding()/compose() default lion_system=True regardless
+            # of the profile's own frontmatter — propagate an explicit
+            # `lion_system: false` opt-out onto the spec, or a role profile
+            # can never suppress the LION system preamble once it takes this
+            # path (unlike the non-preset path, where _parse_profile already
+            # folds lion_system into profile.system_prompt before this code
+            # ever runs).
+            if profile is not None and not profile.lion_system:
+                spec.lion_system = False
             branch = await create_agent(
                 spec,
                 chat_model=chat_model,
@@ -408,11 +460,21 @@ async def _run_agent(
         if fast:
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
 
-    # Profile system prompt for the non-preset path only.
-    # On the preset path the profile extension was already composed into the
-    # spec before create_agent ran (add_message would call set_system and
+    # Profile system prompt for a brand-new, non-preset branch only.
+    # On the preset/role path the profile extension was already composed into
+    # the spec before create_agent ran (add_message would call set_system and
     # replace the preset system message — see protocols/messages/manager.py:385).
-    if profile and profile.system_prompt and preset is None:
+    # A resumed or continued branch (-r / --continue-last / the automatic
+    # timeout-resume leg) already carries its persisted system message —
+    # which, for a role/preset branch, is the composed role+policy block, not
+    # the bare profile body — so add_message must not run for it either, or
+    # it clobbers that persisted message via set_system.
+    if (
+        profile
+        and profile.system_prompt
+        and not took_create_agent_path
+        and not (resume or continue_last)
+    ):
         branch.msgs.add_message(system=profile.system_prompt)
 
     if timeout is not None:

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -245,10 +245,14 @@ class ActionManager(Manager):
         if mcp_security is None:
             mcp_security = MCPSecurityConfig(allow_commands=True, allow_urls=True)
 
-        MCPConnectionPool.load_config(config_path)
+        loaded_names = MCPConnectionPool.load_config(config_path)
 
         if server_names is None:
-            server_names = list(MCPConnectionPool._configs.keys())
+            # Default to the servers declared in THIS config file. The pool
+            # accumulates configs process-globally across loads, so
+            # enumerating the pool here would silently re-register every
+            # server from previously loaded, unrelated configs.
+            server_names = loaded_names
         all_tools = {}
         for server_name in server_names:
             try:

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -190,8 +190,13 @@ class ClaudeCodeRequest(BaseModel):
         default=False,
         json_schema_extra=_cli("--strict-mcp-config", 51, "bool"),
     )
-    # Legacy: if set and mcp_config is absent, serialised to --mcp-config JSON
-    mcp_servers: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    # Legacy: if set and mcp_config is absent, serialised to --mcp-config JSON.
+    # Default is None (not {}) so a request that never touched this field is
+    # distinguishable from a caller that explicitly forwarded an empty server
+    # selection — the latter must still emit `--mcp-config {"mcpServers":{}}`
+    # to force zero MCP servers rather than silently falling back to the CLI's
+    # own MCP discovery (see as_cmd_args below).
+    mcp_servers: dict[str, Any] | None = Field(default=None, exclude=True)
 
     # ── agents (order 60–69) ──────────────────────────────────────
     agent: str | None = Field(
@@ -459,8 +464,12 @@ class ClaudeCodeRequest(BaseModel):
             else:
                 args.append("--debug")
 
-        # Legacy mcp_servers dict → serialise as --mcp-config JSON inline
-        if self.mcp_servers and not self.mcp_config:
+        # Legacy mcp_servers dict → serialise as --mcp-config JSON inline.
+        # `is not None` (not truthiness) so an explicitly forwarded empty
+        # selection (mcp_servers={}) still emits the flag — forcing zero MCP
+        # servers — rather than silently omitting it and letting the CLI fall
+        # back to its own MCP discovery.
+        if self.mcp_servers is not None and not self.mcp_config:
             args.extend(
                 [
                     "--mcp-config",

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -185,8 +185,14 @@ class MCPConnectionPool:
         await self.cleanup()
 
     @classmethod
-    def load_config(cls, path: str = ".mcp.json") -> None:
-        """Load MCP server configurations from a .mcp.json file."""
+    def load_config(cls, path: str = ".mcp.json") -> list[str]:
+        """Load MCP server configurations from a .mcp.json file.
+
+        Returns the server names declared in THIS file. The pool accumulates
+        configs across loads (``_configs`` is process-global), so callers
+        that mean "the servers from the file I just loaded" must use this
+        return value rather than enumerating ``_configs``.
+        """
         config_path = Path(path)
         if not config_path.exists():
             raise FileNotFoundError(f"MCP config file not found: {path}")
@@ -207,6 +213,7 @@ class MCPConnectionPool:
             raise ValueError("mcpServers must be a dictionary")
 
         cls._configs.update(servers)
+        return list(servers.keys())
 
     @classmethod
     async def get_client(

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -334,8 +334,19 @@ class iModel:  # noqa: N801
     async def close(self) -> None:
         await self.executor.stop()
 
-    def copy(self, share_session: bool = False) -> iModel:
-        """Create a new iModel with same config but fresh ID and executor."""
+    def copy(self, share_session: bool = False, share_executor: bool = False) -> iModel:
+        """Create a new iModel with the same config but a fresh ID.
+
+        ``share_session=True`` carries the CLI provider's session_id onto the
+        copy (cross-turn continuation is preserved). ``share_executor=True``
+        reuses this SAME ``RateLimitedAPIExecutor`` instance instead of
+        building a fresh one, so a caller-supplied executor's rate limits and
+        queue capacity stay shared between the original and the copy. Default
+        (False) gives the copy its own independent executor — what
+        ``Branch.clone()`` wants for CLI providers, where each cloned branch
+        should get its own session and queue rather than contending on the
+        parent's.
+        """
         endpoint_cls = type(self.endpoint)
         new_endpoint = endpoint_cls(
             config=self.endpoint.config.model_copy(deep=True),
@@ -349,7 +360,7 @@ class iModel:  # noqa: N801
             and isinstance(self.endpoint, AgenticEndpoint)
         ):
             new_endpoint.session_id = self.endpoint.session_id
-        return iModel(
+        new = iModel(
             endpoint=new_endpoint,
             provider_metadata=self.provider_metadata.copy(),
             streaming_process_func=self.streaming_process_func,
@@ -357,6 +368,9 @@ class iModel:  # noqa: N801
             exit_hook=self.exit_hook,
             **self.executor.config,
         )
+        if share_executor:
+            new.executor = self.executor
+        return new
 
     def to_dict(
         self,

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -3,6 +3,8 @@
 
 """Tests for create_agent: wiring tools, permissions, hooks."""
 
+import json
+
 import pytest
 
 from lionagi.agent.factory import create_agent
@@ -616,6 +618,428 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Search tool workspace containment wiring (regression)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Forwarding AgentSpec MCP fields into the claude_code CLI's own request
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_mcp_pool_state():
+    """MCPConnectionPool accumulates configs process-globally; tests here load
+    real config files through create_agent, so snapshot and restore the pool's
+    class-level state to keep those loads from leaking into other test files
+    on the same worker."""
+    from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+    saved_configs = dict(MCPConnectionPool._configs)
+    saved_security = dict(MCPConnectionPool._server_security)
+    yield
+    MCPConnectionPool._configs.clear()
+    MCPConnectionPool._configs.update(saved_configs)
+    MCPConnectionPool._server_security.clear()
+    MCPConnectionPool._server_security.update(saved_security)
+
+
+def _write_mcp_config(tmp_path, servers: dict) -> str:
+    import json
+
+    p = tmp_path / ".mcp.json"
+    p.write_text(json.dumps({"mcpServers": servers}))
+    return str(p)
+
+
+async def test_forward_mcp_populates_claude_code_request_mcp_servers(tmp_path):
+    """Test plan item 5: claude_code leg + mcp_config_path -> ClaudeCodeRequest
+    carries the same servers, and --mcp-config shows up in as_cmd_args()."""
+    from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+    mcp_path = _write_mcp_config(tmp_path, {"khive": {"command": "khive-mcp"}})
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = mcp_path
+    branch = await create_agent(config, load_settings=False)
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    assert kwargs.get("mcp_servers") == {"khive": {"command": "khive-mcp"}}
+
+    payload, _ = branch.chat_model.endpoint.create_payload({"prompt": "hi"})
+    request = payload["request"]
+    assert isinstance(request, ClaudeCodeRequest)
+    args = request.as_cmd_args()
+    assert "--mcp-config" in args
+    assert json.loads(args[args.index("--mcp-config") + 1]) == {
+        "mcpServers": {"khive": {"command": "khive-mcp"}}
+    }
+
+
+async def test_forward_mcp_filters_by_spec_mcp_servers(tmp_path):
+    """spec.mcp_servers is a name filter, consistent with island 1's server_names."""
+    mcp_path = _write_mcp_config(
+        tmp_path,
+        {"khive": {"command": "khive-mcp"}, "other": {"command": "other-mcp"}},
+    )
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = mcp_path
+    config.mcp_servers = ["khive"]
+    branch = await create_agent(config, load_settings=False)
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    assert kwargs.get("mcp_servers") == {"khive": {"command": "khive-mcp"}}
+
+
+async def test_forward_mcp_noop_when_spec_has_no_mcp_fields(tmp_path, monkeypatch):
+    """No explicit mcp fields and nothing auto-resolvable (isolated HOME/cwd
+    with no .mcp.json anywhere) -> no forwarding, no warning."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    config = AgentSpec.compose(
+        "reviewer", model="claude_code/sonnet", cwd=str(tmp_path / "elsewhere")
+    )
+    branch = await create_agent(config, load_settings=False)
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+
+
+async def test_forward_mcp_noop_for_non_claude_code_when_no_mcp_fields(tmp_path, monkeypatch):
+    """Provider without MCP passthrough + nothing auto-resolvable: no warning fires
+    (mirrors _load_mcp's own no-op — nothing to forward at all, not a passthrough gap)."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    config = AgentSpec.compose("reviewer", model="codex/gpt-5.5", cwd=str(tmp_path / "elsewhere"))
+    branch = await create_agent(config, load_settings=False)
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+
+
+async def test_forward_mcp_codex_provider_warns_and_noops(tmp_path, caplog):
+    """Test plan item 6: codex/gemini provider + MCP fields set -> logged
+    warning, no passthrough field populated (no MCP field exists to set)."""
+    import logging
+
+    mcp_path = _write_mcp_config(tmp_path, {"khive": {"command": "khive-mcp"}})
+
+    config = AgentSpec.compose("reviewer", model="codex/gpt-5.5")
+    config.mcp_config_path = mcp_path
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.agent.factory"):
+        branch = await create_agent(config, load_settings=False)
+
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+    assert any(
+        "no MCP passthrough" in rec.message and "codex" in rec.message for rec in caplog.records
+    )
+
+
+async def test_forward_mcp_gemini_provider_warns_and_noops(tmp_path, caplog):
+    import logging
+
+    mcp_path = _write_mcp_config(tmp_path, {"khive": {"command": "khive-mcp"}})
+
+    config = AgentSpec.compose("reviewer", model="gemini_code/gemini-3.5-flash")
+    config.mcp_config_path = mcp_path
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.agent.factory"):
+        branch = await create_agent(config, load_settings=False)
+
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+    assert any(
+        "no MCP passthrough" in rec.message and "gemini_code" in rec.message
+        for rec in caplog.records
+    )
+
+
+async def test_forward_mcp_gated_by_trust_project_settings_for_project_scope(tmp_path, monkeypatch):
+    """LC3: a project-scoped .mcp.json only forwards when trust_project_settings=True
+    (mirrors _load_mcp's own gate); the global ~/.lionagi/.mcp.json candidate is
+    trusted by default and forwards unconditionally."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_mcp_config(project, {"proj-server": {"command": "x"}})
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet", cwd=str(project))
+    branch_untrusted = await create_agent(config, load_settings=False, trust_project_settings=False)
+    assert "mcp_servers" not in branch_untrusted.chat_model.endpoint.config.kwargs
+
+    config2 = AgentSpec.compose("reviewer", model="claude_code/sonnet", cwd=str(project))
+    branch_trusted = await create_agent(config2, load_settings=False, trust_project_settings=True)
+    assert branch_trusted.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "proj-server": {"command": "x"}
+    }
+
+
+async def test_forward_mcp_global_candidate_trusted_by_default(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    lionagi_dir = home / ".lionagi"
+    lionagi_dir.mkdir(parents=True)
+    _write_mcp_config(lionagi_dir, {"global-server": {"command": "y"}})
+    monkeypatch.setenv("HOME", str(home))
+
+    config = AgentSpec.compose(
+        "reviewer", model="claude_code/sonnet", cwd=str(tmp_path / "elsewhere")
+    )
+    branch = await create_agent(config, load_settings=False, trust_project_settings=False)
+    assert branch.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "global-server": {"command": "y"}
+    }
+
+
+async def test_forward_mcp_explicit_empty_allowlist_forces_zero_servers(tmp_path):
+    """spec.mcp_servers=[] is an EXPLICIT empty selection, not 'no filter'.
+
+    Before the fix, `if spec.mcp_servers:` treated an empty list the same as
+    None (no filter at all) and forwarded every configured server; here it
+    must forward zero servers, and the resulting ClaudeCodeRequest must still
+    emit `--mcp-config {"mcpServers": {}}` (not silently omit the flag and
+    let the claude CLI fall back to its own MCP discovery).
+    """
+    from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+    mcp_path = _write_mcp_config(
+        tmp_path,
+        {"khive": {"command": "khive-mcp"}, "other": {"command": "other-mcp"}},
+    )
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = mcp_path
+    config.mcp_servers = []  # explicit empty allowlist, distinct from None
+    branch = await create_agent(config, load_settings=False)
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    assert kwargs.get("mcp_servers") == {}, (
+        "explicit empty allowlist must forward zero servers, not every configured server"
+    )
+
+    payload, _ = branch.chat_model.endpoint.create_payload({"prompt": "hi"})
+    request = payload["request"]
+    assert isinstance(request, ClaudeCodeRequest)
+    args = request.as_cmd_args()
+    assert "--mcp-config" in args, (
+        "an explicit empty selection must still emit --mcp-config (forcing zero "
+        "servers), not fall back to the CLI's own MCP discovery"
+    )
+    assert json.loads(args[args.index("--mcp-config") + 1]) == {"mcpServers": {}}
+
+
+async def test_forward_mcp_explicit_empty_allowlist_enforced_with_no_resolvable_config(
+    tmp_path, monkeypatch
+):
+    """spec.mcp_servers=[] must be enforced even when NO config file resolves.
+
+    Before the fix, an unresolvable mcp_path made `_forward_mcp_to_cli_request`
+    return early, leaving `mcp_servers` unset on the request entirely — the
+    claude CLI would then fall back to its OWN MCP discovery instead of
+    honoring the explicit zero-server allowlist. Isolated HOME + cwd with no
+    .mcp.json anywhere (nothing auto-discoverable) reproduces "no resolvable
+    config" while spec.mcp_servers=[] still declares explicit caller intent.
+    """
+    from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    config = AgentSpec.compose(
+        "reviewer", model="claude_code/sonnet", cwd=str(tmp_path / "elsewhere")
+    )
+    config.mcp_servers = []  # explicit zero-server allowlist, no config file exists anywhere
+    branch = await create_agent(config, load_settings=False)
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    assert kwargs.get("mcp_servers") == {}, (
+        "an explicit empty allowlist must be enforced even with no resolvable "
+        "MCP config file, not silently left unset"
+    )
+
+    payload, _ = branch.chat_model.endpoint.create_payload({"prompt": "hi"})
+    request = payload["request"]
+    assert isinstance(request, ClaudeCodeRequest)
+    args = request.as_cmd_args()
+    assert "--mcp-config" in args, (
+        "with no config file present, an explicit empty allowlist must still "
+        "emit --mcp-config (forcing zero servers) rather than omitting the "
+        "flag and letting the claude CLI fall back to its own MCP discovery"
+    )
+    assert json.loads(args[args.index("--mcp-config") + 1]) == {"mcpServers": {}}
+
+
+async def test_forward_mcp_does_not_mutate_shared_chat_model_across_branches(tmp_path):
+    """Two create_agent calls sharing one iModel must get independent MCP filters.
+
+    Branch.__init__ keeps a caller-supplied chat_model by reference (no copy),
+    so mutating branch.chat_model.endpoint.config.kwargs in place would leak
+    one branch's MCP server selection into the other's payload.
+    """
+    from lionagi.service.imodel import iModel
+
+    mcp_path = _write_mcp_config(
+        tmp_path,
+        {"khive": {"command": "khive-mcp"}, "other": {"command": "other-mcp"}},
+    )
+
+    shared_chat_model = iModel(provider="claude_code", model="sonnet", api_key="dummy")
+
+    config_a = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config_a.mcp_config_path = mcp_path
+    config_a.mcp_servers = ["khive"]
+    branch_a = await create_agent(config_a, load_settings=False, chat_model=shared_chat_model)
+
+    config_b = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config_b.mcp_config_path = mcp_path
+    config_b.mcp_servers = ["other"]
+    branch_b = await create_agent(config_b, load_settings=False, chat_model=shared_chat_model)
+
+    assert branch_a.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "khive": {"command": "khive-mcp"}
+    }, "branch_a's filter must not have been overwritten by branch_b's create_agent call"
+    assert branch_b.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "other": {"command": "other-mcp"}
+    }
+    # The original caller-supplied iModel itself must be untouched — both
+    # branches must have been given their own copy before mutation.
+    assert "mcp_servers" not in shared_chat_model.endpoint.config.kwargs
+
+
+async def test_forward_mcp_preserves_shared_executor_and_session(tmp_path):
+    """Branch-local MCP filtering must not silently drop the caller-supplied
+    iModel's shared rate limiter or CLI session_id.
+
+    Before the fix, ``branch.chat_model.copy()`` (with no share_session/
+    share_executor kwargs) always built a FRESH RateLimitedAPIExecutor and,
+    since share_session defaulted False, dropped any pre-existing CLI
+    session_id — silently changing the runtime semantics of a caller-supplied
+    iModel that two branches were meant to share (rate limits/queue capacity,
+    and mid-session continuation).
+    """
+    from lionagi.service.imodel import iModel
+
+    mcp_path = _write_mcp_config(
+        tmp_path,
+        {"khive": {"command": "khive-mcp"}, "other": {"command": "other-mcp"}},
+    )
+
+    shared_chat_model = iModel(provider="claude_code", model="sonnet", api_key="dummy")
+    shared_chat_model.endpoint.session_id = "session-abc"
+    original_executor = shared_chat_model.executor
+
+    config_a = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config_a.mcp_config_path = mcp_path
+    config_a.mcp_servers = ["khive"]
+    branch_a = await create_agent(config_a, load_settings=False, chat_model=shared_chat_model)
+
+    config_b = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config_b.mcp_config_path = mcp_path
+    config_b.mcp_servers = ["other"]
+    branch_b = await create_agent(config_b, load_settings=False, chat_model=shared_chat_model)
+
+    # (a) independent mcp_servers kwargs per branch, sharing one caller iModel.
+    assert branch_a.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "khive": {"command": "khive-mcp"}
+    }
+    assert branch_b.chat_model.endpoint.config.kwargs.get("mcp_servers") == {
+        "other": {"command": "other-mcp"}
+    }
+
+    # (b) the branch's model retains the caller's executor (shared rate
+    # limiter/queue) and the caller's CLI session_id.
+    assert branch_a.chat_model.executor is original_executor
+    assert branch_b.chat_model.executor is original_executor
+    assert branch_a.chat_model.endpoint.session_id == "session-abc"
+    assert branch_b.chat_model.endpoint.session_id == "session-abc"
+
+
+async def test_forward_mcp_explicit_path_read_failure_raises(tmp_path):
+    """An explicitly configured mcp_config_path that fails to read/parse is a
+    configuration error (caller declared intent), not a silent skip.
+
+    Exercises ``_forward_mcp_to_cli_request`` directly (island 2) rather than
+    through the full ``create_agent`` flow: island 1's ``_load_mcp`` already
+    raises its own (unrelated, pre-existing) json.JSONDecodeError for the
+    same malformed file before island 2 ever runs, which would make this
+    regression test pass for the wrong reason if routed through create_agent.
+    """
+    from lionagi._errors import ConfigurationError
+    from lionagi.agent.factory import _forward_mcp_to_cli_request
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+
+    bad_path = tmp_path / "not-json.mcp.json"
+    bad_path.write_text("{not valid json")
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = str(bad_path)
+
+    branch = Branch(chat_model=iModel(provider="claude_code", model="sonnet", api_key="dummy"))
+
+    with pytest.raises(ConfigurationError):
+        _forward_mcp_to_cli_request(branch, config)
+
+
+async def test_forward_mcp_auto_discovered_path_read_failure_soft_skips(tmp_path, monkeypatch):
+    """An auto-discovered (not explicitly configured) MCP candidate that fails
+    to read/parse must soft-skip (no forwarding), not raise — only an
+    explicit spec.mcp_config_path carries enough caller intent to escalate."""
+    from lionagi.agent.factory import _forward_mcp_to_cli_request
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+
+    home = tmp_path / "home"
+    lionagi_dir = home / ".lionagi"
+    lionagi_dir.mkdir(parents=True)
+    (lionagi_dir / ".mcp.json").write_text("{not valid json")
+    monkeypatch.setenv("HOME", str(home))
+
+    config = AgentSpec.compose(
+        "reviewer", model="claude_code/sonnet", cwd=str(tmp_path / "elsewhere")
+    )
+    branch = Branch(chat_model=iModel(provider="claude_code", model="sonnet", api_key="dummy"))
+
+    _forward_mcp_to_cli_request(branch, config)  # must not raise
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+
+
+async def test_explicit_mcp_config_path_missing_file_raises_configuration_error(tmp_path):
+    """An explicitly set spec.mcp_config_path pointing at a nonexistent path
+    is a configuration error, not a silent no-op.
+
+    Before the fix, `_resolve_mcp_path` returned None for ANY unresolved
+    mcp_config_path — indistinguishable from "no path configured at all" —
+    so both `_load_mcp` and `_forward_mcp_to_cli_request` silently no-opped
+    even though the caller explicitly declared intent to load a specific
+    file. Exercised through the full create_agent() flow since either island
+    raising is sufficient evidence of the fix (island 1's _load_mcp runs
+    first and shares the same _resolve_mcp_path).
+    """
+    from lionagi._errors import ConfigurationError
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = "/nonexistent/mcp.json"
+
+    with pytest.raises(ConfigurationError):
+        await create_agent(config, load_settings=False)
+
+
+async def test_explicit_empty_string_mcp_config_path_raises_not_autodiscovers(
+    tmp_path, monkeypatch
+):
+    """An explicit empty-string mcp_config_path is a declared (malformed)
+    path, not absence: it must raise, never fall through into auto-discovery.
+
+    Presence is checked with `is not None`, not truthiness — otherwise
+    `mcp_config_path=""` silently auto-discovers whatever candidate exists
+    (e.g. ~/.lionagi/.mcp.json) and loads a config the caller never pointed
+    at.
+    """
+    from lionagi._errors import ConfigurationError
+    from lionagi.agent.factory import _resolve_mcp_path
+
+    # A discoverable home candidate that MUST NOT be returned.
+    home = tmp_path / "home"
+    (home / ".lionagi").mkdir(parents=True)
+    (home / ".lionagi" / ".mcp.json").write_text('{"mcpServers": {}}')
+    monkeypatch.setenv("HOME", str(home))
+
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+    config.mcp_config_path = ""
+
+    with pytest.raises(ConfigurationError):
+        _resolve_mcp_path(config)
 
 
 async def test_search_tool_gets_workspace_root_from_cwd(tmp_path):

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -99,6 +99,71 @@ class TestAgentSpecCoding:
         spec = AgentSpec.coding(model="anthropic/claude-sonnet-4-6")
         assert spec.model == "anthropic/claude-sonnet-4-6"
 
+    def test_coding_default_role_is_implementer(self):
+        """Regression: every existing AgentSpec.coding() caller omits role= and
+        relies on this default (grepped: no caller in lionagi/, benchmarks/,
+        examples/ passes role= explicitly)."""
+        spec = AgentSpec.coding()
+        assert spec.profile.role.name == "implementer"
+
+    def test_coding_role_param_parameterizes_preset(self):
+        spec = AgentSpec.coding(role="reviewer")
+        assert spec.profile.role.name == "reviewer"
+        assert "coding" in spec.tools
+
+
+# ---------------------------------------------------------------------------
+# Role -> Policy Binding Contract: fail-closed when a valid role has no
+# policy entry in the active pack; empty-but-present entry stays silent.
+# ---------------------------------------------------------------------------
+
+
+class TestRolePolicyBindingContract:
+    def test_missing_policy_entry_raises(self):
+        from lionagi.casts.pack import Pack
+
+        pack = Pack(name="custom", policies={}, configs={})
+        spec = AgentSpec.compose("analyst", pack=pack)
+        with pytest.raises(ValueError, match="no policy entry"):
+            spec.build_system_message()
+
+    def test_empty_but_present_policy_entry_does_not_raise(self):
+        from lionagi.casts.pack import Pack, RolePolicy
+
+        pack = Pack(name="custom", policies={"analyst": RolePolicy()}, configs={})
+        spec = AgentSpec.compose("analyst", pack=pack)
+        msg = spec.build_system_message()
+        assert "## Authority" not in msg
+        assert "## Escalation Conditions" not in msg
+
+    def test_default_pack_covers_every_shipped_role(self):
+        """Regression guard for the fail-closed raise: every role module under
+        lionagi/casts/roles/ must have a matching entry in the packaged
+        default.yaml, or this raise would break every profile using that role."""
+        import os
+
+        from lionagi.casts.catalog import _load_packaged_pack
+
+        roles_dir = os.path.join(os.path.dirname(__file__), "..", "..", "lionagi", "casts", "roles")
+        role_names = {
+            f[:-3].replace("_", "-")
+            for f in os.listdir(roles_dir)
+            if f.endswith(".py") and f != "__init__.py"
+        }
+        pack = _load_packaged_pack(raise_on_error=True)
+        missing = {name for name in role_names if pack.policy(name) is None}
+        assert missing == set(), f"roles missing a default.yaml policy entry: {missing}"
+
+    def test_pack_none_still_bypasses_policy_entirely(self):
+        """spec.pack=None is a distinct, deliberate opt-out of the whole policy
+        system — unaffected by the fail-closed raise (covered pre-existing by
+        TestAgentSpecSystemMessage.test_no_pack; asserted again here to make
+        the two escape hatches' distinction explicit)."""
+        spec = AgentSpec.compose("analyst")
+        spec2 = AgentSpec(profile=spec.profile, pack=None)
+        msg = spec2.build_system_message()  # must not raise
+        assert "## Authority" not in msg
+
 
 # ---------------------------------------------------------------------------
 # AgentSpec.build_system_message

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -1058,14 +1058,13 @@ async def test_preset_and_real_profile_nolion_no_lion_system_message(monkeypatch
     """Real profile with lion_system:false + preset=coding → implementer content present,
     profile body present, ZERO occurrences of '# Welcome to LIONAGI'.
 
-    When lion_system=False the profile's raw_body is passed; AgentSpec.lion_system
-    remains True (the implementer preset owns that flag), so the factory adds the
-    header once for the role but NOT for the profile body.
-
-    Wait — AgentSpec.lion_system is always True for AgentSpec.coding(); the
-    flag on AgentProfile.lion_system controls ONLY whether the profile body
-    gets the header prepended.  The factory always prepends once for the spec.
-    So count=1 is expected even for lion_system:false profiles.
+    The profile's explicit `lion_system: false` opt-out must propagate onto the
+    AgentSpec built for the create_agent path (--preset coding or an opted-in
+    `role:` profile): AgentSpec.coding()/compose() default lion_system=True
+    regardless of the profile's own frontmatter, so _run_agent copies
+    profile.lion_system onto the spec before calling create_agent, exactly as
+    the non-preset path already achieves by folding lion_system into
+    profile.system_prompt ahead of time. count=0 is the correct outcome.
     """
     agents_dir = _make_agents_dir(tmp_path, monkeypatch)
     profile_body = "Custom coding instructions, no lion header."
@@ -1098,10 +1097,10 @@ async def test_preset_and_real_profile_nolion_no_lion_system_message(monkeypatch
 
     rendered = tool_branch.msgs.system.rendered
     count = rendered.count("# Welcome to LIONAGI")
-    # The spec itself has lion_system=True so the factory adds it once for the
-    # role; the profile body (raw_body, no header) is appended as extra_prompt.
-    assert count == 1, (
-        f"Expected 1 '# Welcome to LIONAGI' for lion_system:false profile + preset; "
+    assert count == 0, (
+        f"Expected 0 '# Welcome to LIONAGI' for lion_system:false profile + preset "
+        f"(the profile's opt-out must propagate onto the spec); "
         f"got {count}.\nMessage start: {rendered[:600]}"
     )
+    assert profile_body in rendered
     assert profile_body in rendered, "profile body must be present"

--- a/tests/cli/test_agent_profile_role.py
+++ b/tests/cli/test_agent_profile_role.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the opt-in profile frontmatter key `role`.
+
+Covers:
+  - `role: reviewer` in a profile -> `-a reviewer` alone (no --preset coding)
+    takes the create_agent path; system message carries the reviewer policy
+    block, not the implementer's.
+  - `role: <unknown>` -> Role.load's ValueError surfaces, not swallowed into
+    a bare Branch fallback.
+  - A profile with no `role:` key keeps the plain Branch(...) path exactly
+    (regression across every existing shipped profile shape).
+  - `--preset coding` with no `-a` (no profile at all) is unaffected — the
+    default role still resolves to "implementer".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import _parse_profile
+
+# ---------------------------------------------------------------------------
+# Shared stub wiring (mirrors tests/cli/test_agent_profile_timeout.py)
+# ---------------------------------------------------------------------------
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    branches_created: list = []
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return branches_created
+
+
+def _stub_profile(monkeypatch, name: str, text: str):
+    """Wire load_agent_profile to return a real AgentProfile parsed from `text`."""
+    import lionagi.cli.agent as agent_mod
+
+    profile = _parse_profile(name, text)
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda n: profile)
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Item 1: role: reviewer -> create_agent path, reviewer policy block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_role_key_takes_create_agent_path_with_reviewer_policy(monkeypatch, tmp_path):
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "reviewer",
+        "---\nmodel: claude_code/sonnet\nrole: reviewer\n---\nExtra reviewer body.",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "review this", agent_name="reviewer")
+
+    assert branches_created
+    branch = branches_created[-1]
+    # create_agent wired CodingToolkit tools onto the branch (bare Branch()
+    # never registers any tools) — the clearest signal the create_agent path
+    # ran rather than the plain Branch(...) path.
+    assert "bash" in branch.acts.registry
+
+    rendered = branch.msgs.system.rendered
+    assert "## Authority" in rendered
+    # Reviewer's own boundary text (default.yaml), not the implementer's.
+    assert "cannot override a critic" in rendered.lower() or "approve" in rendered.lower()
+    assert "improve structure" not in rendered.lower(), (
+        "reviewer leg must not carry the implementer's policy block"
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_role_key_without_preset_flag(monkeypatch, tmp_path):
+    """The role key alone (no --preset coding) is sufficient to switch paths."""
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch, "reviewer", "---\nmodel: claude_code/sonnet\nrole: reviewer\n---\nbody"
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "go", agent_name="reviewer", preset=None)
+
+    branch = branches_created[-1]
+    assert "bash" in branch.acts.registry  # create_agent path, not bare Branch
+
+
+# ---------------------------------------------------------------------------
+# Falsy explicit `role:` values must fail closed, not silently default to
+# "implementer" (a role profile with role: "" / false / 0 must not silently
+# be granted implementer coding authority).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "yaml_role_literal",
+    ['""', "false", "0"],
+    ids=["empty-string", "false", "zero"],
+)
+async def test_profile_falsy_role_value_raises_configuration_error(
+    monkeypatch, tmp_path, yaml_role_literal
+):
+    """`role: ""`, `role: false`, `role: 0` must raise, never silently
+    resolve to the implementer default via `profile_role or "implementer"`.
+    """
+    from lionagi._errors import ConfigurationError
+
+    _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "falsy-role-profile",
+        f"---\nmodel: claude_code/sonnet\nrole: {yaml_role_literal}\n---\nbody",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ConfigurationError):
+        await _run_agent(None, "go", agent_name="falsy-role-profile")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "yaml_role_literal",
+    ['""', "false", "0"],
+    ids=["empty-string", "false", "zero"],
+)
+async def test_profile_falsy_role_value_raises_on_resume_too(
+    monkeypatch, tmp_path, yaml_role_literal
+):
+    """The falsy-role validation runs before the resume/new-branch split: a
+    malformed profile fails loudly on `--resume` / `--continue-last`
+    invocations as well, not only when a new branch is composed.
+    """
+    from lionagi._errors import ConfigurationError
+
+    _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "falsy-role-profile",
+        f"---\nmodel: claude_code/sonnet\nrole: {yaml_role_literal}\n---\nbody",
+    )
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli.agent import _run_agent
+
+    # find_branch must not be reached — validation fires first. Make it blow
+    # up loudly if the code ever gets that far, so this test cannot pass by
+    # accidentally resuming something.
+    def _boom(_id):
+        raise AssertionError("resume lookup reached before role validation")
+
+    monkeypatch.setattr(agent_mod, "find_branch", _boom)
+
+    with pytest.raises(ConfigurationError):
+        await _run_agent(None, "go", agent_name="falsy-role-profile", resume="deadbeef")
+
+
+# ---------------------------------------------------------------------------
+# Item 2: unknown role -> ValueError surfaces, not swallowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_role_unknown_raises_value_error(monkeypatch, tmp_path):
+    _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "ghost-role-profile",
+        "---\nmodel: claude_code/sonnet\nrole: nonexistent-role-xyz\n---\nbody",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ValueError, match="Unknown role"):
+        await _run_agent(None, "go", agent_name="ghost-role-profile")
+
+
+# ---------------------------------------------------------------------------
+# Item 4: profile without role: key -> byte-for-byte unchanged (bare Branch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_without_role_key_keeps_bare_branch_path(monkeypatch, tmp_path):
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "researcher", "---\nmodel: claude_code/sonnet\n---\nDo research.")
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "go", agent_name="researcher")
+
+    branch = branches_created[-1]
+    # No coding tools registered — the plain Branch(...) path never wires them.
+    assert not {"bash", "reader", "editor", "search"}.intersection(branch.acts.registry.keys())
+    assert branch.msgs.system is not None
+    assert "Do research." in branch.msgs.system.rendered
+
+
+@pytest.mark.asyncio
+async def test_profile_with_unrelated_frontmatter_keys_no_role_key(monkeypatch, tmp_path):
+    """A profile using other 'extra' frontmatter keys but no 'role' key must
+    still take the bare-Branch path (role is opt-in, never inferred)."""
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "advisor",
+        "---\nmodel: claude_code/sonnet\nsome_custom_key: whatever\n---\nAdvisor body.",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "go", agent_name="advisor")
+
+    branch = branches_created[-1]
+    assert not {"bash", "reader", "editor", "search"}.intersection(branch.acts.registry.keys())
+
+
+# ---------------------------------------------------------------------------
+# Item 7: --preset coding with no -a is unaffected (default role implementer)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# lion_system: false must propagate to the create_agent path (role: key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_role_profile_lion_system_false_suppresses_lion_preamble(monkeypatch, tmp_path):
+    """A role profile with `lion_system: false` must not carry the LION system
+    preamble even though it takes the create_agent path (AgentSpec.coding()
+    defaults lion_system=True regardless of the profile's own frontmatter)."""
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "reviewer-nolion",
+        "---\nmodel: claude_code/sonnet\nrole: reviewer\nlion_system: false\n---\nBare reviewer body.",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "review this", agent_name="reviewer-nolion")
+
+    branch = branches_created[-1]
+    assert "bash" in branch.acts.registry  # create_agent path ran
+
+    rendered = branch.msgs.system.rendered
+    assert "# Welcome to LIONAGI" not in rendered
+    assert "Bare reviewer body." in rendered
+    assert "## Authority" in rendered  # role policy block still composed
+
+
+@pytest.mark.asyncio
+async def test_role_profile_lion_system_default_true_keeps_preamble(monkeypatch, tmp_path):
+    """Sanity counterpart: a role profile with no lion_system key (default
+    True) must still carry the LION preamble on the create_agent path."""
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "reviewer-lion",
+        "---\nmodel: claude_code/sonnet\nrole: reviewer\n---\nBare reviewer body.",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "review this", agent_name="reviewer-lion")
+
+    branch = branches_created[-1]
+    rendered = branch.msgs.system.rendered
+    assert "# Welcome to LIONAGI" in rendered
+
+
+@pytest.mark.asyncio
+async def test_preset_coding_without_agent_name_unaffected(monkeypatch, tmp_path):
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("claude_code/sonnet", "go", preset="coding")
+
+    branch = branches_created[-1]
+    assert "bash" in branch.acts.registry
+    assert "implementer" in branch.msgs.system.rendered.lower()

--- a/tests/cli/test_agent_resume_role_system_message.py
+++ b/tests/cli/test_agent_resume_role_system_message.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: resuming/continuing a role-profile branch must not clobber its
+persisted system message.
+
+A brand-new role-profile branch composes its system message via
+create_agent (role header + policy block + profile body). Once that branch
+is persisted and later reopened (-r / --continue-last / the automatic
+timeout-resume leg), `took_create_agent_path` is False for the reopened leg
+(neither --preset nor a fresh profile-role branch is being created — an
+existing branch is just being loaded back). Before the fix, the
+profile-system-prompt block ran unconditionally whenever
+`not took_create_agent_path`, so it called `branch.msgs.add_message(system=...)`
+-> `set_system` -> replaced the persisted composed system message with the
+bare profile body, silently dropping the role header and policy block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import _parse_profile
+
+_REVIEWER_PROFILE_TEXT = "---\nmodel: claude_code/sonnet\nrole: reviewer\n---\nExtra reviewer body."
+
+
+def _rendered_system(branch) -> str:
+    """Return the rendered System message content.
+
+    ``branch.msgs.system`` (a plain attribute set by set_system/__init__) is
+    None after a Branch.from_dict roundtrip even though the System message is
+    still present as the first entry of the messages Pile — a from_dict gap
+    unrelated to this fix. Find it by scanning the pile so this works for
+    both freshly created and resumed/reloaded branches.
+    """
+    from lionagi.protocols.messages.system import System
+
+    if branch.msgs.system is not None:
+        return branch.msgs.system.rendered
+    for m in branch.msgs.messages:
+        if isinstance(m, System):
+            return m.rendered
+    raise AssertionError("branch has no System message")
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path, *, operate_result="done"):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    branches_created: list = []
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return operate_result
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return branches_created
+
+
+def _stub_profile(monkeypatch, name: str, text: str):
+    import lionagi.cli.agent as agent_mod
+
+    profile = _parse_profile(name, text)
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda n: profile)
+    return profile
+
+
+async def _make_persisted_role_branch(tmp_path: Path) -> tuple[str, str]:
+    """Build a real role-profile branch via create_agent (composed system
+    message with role header + policy block), snapshot it to disk, and
+    return (branch_id, rendered_system_message)."""
+    from lionagi.agent.factory import create_agent
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.coding(cwd=str(tmp_path), effort="high", role="reviewer")
+    branch = await create_agent(
+        spec,
+        chat_model="claude_code/sonnet",
+        load_settings=False,
+    )
+    rendered = branch.msgs.system.rendered
+    assert "## Authority" in rendered, (
+        "sanity: the composed system message carries the policy block"
+    )
+
+    branch_dir = tmp_path / "branches"
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    branch_id = str(branch.id)
+    (branch_dir / f"{branch_id}.json").write_text(json.dumps(branch.to_dict()))
+    return branch_id, rendered
+
+
+@pytest.mark.asyncio
+async def test_resume_flag_does_not_clobber_composed_system_message(monkeypatch, tmp_path):
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "reviewer", _REVIEWER_PROFILE_TEXT)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", resume=branch_id, agent_name="reviewer")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered, (
+        "resuming (-r) a role-profile branch must not replace its persisted "
+        "composed system message with the bare profile body"
+    )
+
+
+@pytest.mark.asyncio
+async def test_continue_last_does_not_clobber_composed_system_message(monkeypatch, tmp_path):
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "reviewer", _REVIEWER_PROFILE_TEXT)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "load_last_branch", lambda: ("run-x", branch_id))
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", continue_last=True, agent_name="reviewer")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered, (
+        "--continue-last on a role-profile branch must not replace its persisted "
+        "composed system message with the bare profile body"
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeout_auto_resume_does_not_clobber_composed_system_message(monkeypatch, tmp_path):
+    """The automatic timeout-resume leg (resume_on_timeout=True) recurses into
+    _run_agent with resume=<branch_id> — same clobber risk as an explicit -r."""
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created: list = []
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    call_count = {"n": 0}
+
+    async def fake_operate(self, instruction=None, **kw):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        if idx == 0:
+            raise TimeoutError("boom")
+        return "concluded"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": f"sess-{call_count['n']}"}
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+    _stub_profile(monkeypatch, "reviewer", _REVIEWER_PROFILE_TEXT)
+
+    from lionagi.cli.agent import _run_agent
+
+    result, _provider, _bid, status, _sid = await _run_agent(
+        None,
+        "keep going",
+        resume=branch_id,
+        agent_name="reviewer",
+        timeout=30,
+        resume_on_timeout=True,
+    )
+
+    assert call_count["n"] == 2, "expected the first leg to time out and the auto-resume leg to run"
+    assert status == "completed"
+    assert result == "concluded"
+
+    resumed_branch = branches_created[-1]
+    assert _rendered_system(resumed_branch) == original_rendered, (
+        "the automatic timeout-resume leg must not replace the persisted "
+        "composed system message with the bare profile body"
+    )

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -233,9 +233,11 @@ class TestActionManagerMCPMethodStubs:
     async def test_load_mcp_config_basic_structure(self):
         manager = ActionManager()
 
-        # Mock the MCP connection pool
+        # Mock the MCP connection pool. load_config returns the server names
+        # declared in the loaded file — load_mcp_config's default server set —
+        # so the stub must return them rather than relying on pool state.
         with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
-            mock_pool.load_config = Mock()
+            mock_pool.load_config = Mock(return_value=["test_server"])
             mock_pool._configs = {"test_server": {"command": "python"}}
 
             # Mock the register_mcp_server method

--- a/tests/providers/test_claude_code_mcp_servers_serialization.py
+++ b/tests/providers/test_claude_code_mcp_servers_serialization.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Pins the exclude=True trade-off on ClaudeCodeRequest.mcp_servers.
+
+``mcp_servers`` carries the same shape as the raw ``mcpServers`` block of a
+``.mcp.json`` file, i.e. server command lines that commonly embed secrets
+(API keys/tokens in an ``env`` dict). It is marked ``exclude=True`` so those
+values never make it into ``model_dump()``/``model_dump_json()`` output —
+notably ``APICalling.to_dict()``, which feeds persisted event logs and
+branch snapshots on disk (``~/.lionagi/runs/.../branches/{id}.json``).
+
+Investigated whether this ever erases the value from the path that
+actually matters (issuing the CLI subprocess call): it does not.
+``ClaudeCodeCLIEndpoint._call`` executes ``payload["request"]`` — the live
+``ClaudeCodeRequest`` instance built directly from kwargs each turn — never
+a re-validated/reconstructed copy from a dumped dict. The ``auto_finish``
+continuation turn uses ``request.model_copy(deep=True)`` (a field-preserving
+clone, unaffected by ``exclude``), not ``model_dump``/``model_validate``.
+There is no ``APICalling.from_dict`` construction path that replays a
+persisted record back into a live call, so the one real round-trip
+(``to_dict()`` for persistence) is one-directional: it is never validated
+back into an executable request. Given that, keeping ``exclude=True`` is the
+right trade-off (avoids leaking MCP server secrets into on-disk logs) and
+costs nothing functionally — pinned here rather than "fixed" by removing it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+from lionagi.service.imodel import iModel
+
+
+def test_mcp_servers_excluded_from_model_dump():
+    """exclude=True hides mcp_servers from model_dump(), by design."""
+    req = ClaudeCodeRequest(prompt="hi", mcp_servers={"khive": {"command": "khive-mcp"}})
+    assert req.mcp_servers == {"khive": {"command": "khive-mcp"}}
+    assert "mcp_servers" not in req.model_dump()
+    assert "mcp_servers" not in req.model_dump(mode="json")
+
+
+def test_mcp_servers_survives_auto_finish_model_copy():
+    """The auto_finish continuation turn clones via model_copy (field-
+    preserving), not model_dump/model_validate — mcp_servers must survive."""
+    req = ClaudeCodeRequest(prompt="hi", mcp_servers={"khive": {"command": "khive-mcp"}})
+    req2 = req.model_copy(deep=True)
+    assert req2.mcp_servers == {"khive": {"command": "khive-mcp"}}
+
+
+@pytest.mark.asyncio
+async def test_mcp_servers_present_on_live_request_but_absent_from_persisted_dict():
+    """The live request object used to actually issue the CLI call carries
+    mcp_servers; the persisted-record view (APICalling.to_dict(), which
+    feeds event logs / branch snapshots) intentionally does not."""
+    m = iModel(provider="claude_code", model="sonnet", api_key="dummy")
+    m.endpoint.config.kwargs["mcp_servers"] = {"khive": {"command": "khive-mcp"}}
+
+    api_call = await m.create_event(prompt="hi")
+
+    live_request = api_call.payload["request"]
+    assert isinstance(live_request, ClaudeCodeRequest)
+    assert live_request.mcp_servers == {"khive": {"command": "khive-mcp"}}
+
+    persisted = api_call.to_dict()
+    assert "mcp_servers" not in persisted["payload"]["request"]

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -238,6 +238,39 @@ class TestMCPConnectionPoolFailClosed:
 class TestLoadMcpConfigTrustedLoad:
     """load_mcp_config is a trust action: must default to allow policy and surface denials loudly."""
 
+    async def test_default_load_registers_only_the_loaded_files_servers(
+        self, tmp_path, monkeypatch
+    ):
+        """server_names=None means the servers declared in THE FILE being
+        loaded — never every config accumulated in the process-global pool.
+
+        The pool retains configs across loads, so defaulting to its keys
+        would silently re-register servers from previously loaded, unrelated
+        configs (e.g. a home-level config loaded by an earlier agent in the
+        same process) into this manager.
+        """
+        import json
+
+        from lionagi.protocols.action.manager import ActionManager
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        # Simulate an unrelated, earlier config load in the same process.
+        monkeypatch.setitem(MCPConnectionPool._configs, "earlier-server", {"command": "x"})
+
+        cfg = tmp_path / ".mcp.json"
+        cfg.write_text(json.dumps({"mcpServers": {"local": {"command": "echo", "args": ["hi"]}}}))
+
+        mgr = ActionManager()
+
+        async def fake_register(server_config, update=False, security=None):
+            return ["local_echo"]
+
+        monkeypatch.setattr(mgr, "register_mcp_server", fake_register)
+
+        result = await mgr.load_mcp_config(str(cfg))
+        assert result == {"local": ["local_echo"]}
+        assert "earlier-server" not in result
+
     async def test_default_load_sets_allow_policy_and_registers(self, tmp_path, monkeypatch):
         import json
 


### PR DESCRIPTION
Two wiring gaps closed for `li agent` legs, per the signed design note (fail-closed policy binding; claude_code MCP forwarding):

## What changes

1. **Opt-in profile `role:` key** — an explicit `role:` in a profile's frontmatter switches a plain `li agent -a <profile>` leg onto the same `create_agent` path `--preset coding` uses, parameterized with that role, so e.g. a reviewer profile gets the reviewer policy block instead of nothing. The key is never inferred from the profile name; a profile without it keeps the plain `Branch(...)` path byte-for-byte. A declared key must be a non-empty string (fails closed on `""`/`false`/`0`, validated before the resume/new-branch split); an unknown role surfaces `Role.load`'s ValueError.
2. **Fail-closed policy binding** — a role that loads but has no entry in the active pack raises instead of silently running unconstrained. An empty-but-present pack entry (`roles: {x: {}}`) is the explicit way to run a role unconstrained; a missing entry is a configuration error, not intent.
3. **claude_code MCP forwarding** — `AgentSpec` MCP fields previously reached only branch-native tools (consulted by API function-calling endpoints), never the claude CLI subprocess's own tool loop. `create_agent` now also forwards the resolved MCP servers into the CLI request (`--mcp-config`), branch-locally (the branch gets its own iModel copy sharing the caller's executor and CLI session). Allowlist semantics are fail-closed at every layer: `mcp_servers=[]` forwards an explicit empty config (never treated as "no filter", never letting the CLI fall back to its own MCP discovery, config file present or not); an explicitly set `mcp_config_path` that is missing, empty-string, or unparseable raises `ConfigurationError` (auto-discovered candidates keep the soft skip).

## Preconditions and trust decisions

- **Caller grep** (`AgentSpec.coding` / `.coding(`): the only production caller is `lionagi/cli/agent.py:_make_coding_preset`, now role-parameterized with the same `"implementer"` default; every other caller is a test using the default. No behavior change for existing callers.
- **Trust decision on MCP config resolution**: the user-home candidate `~/.lionagi/.mcp.json` is trusted by default (the user's own home directory); a project-scoped `.mcp.json` found via directory search is gated on `trust_project_settings` (untrusted checkouts must not inject MCP servers). An explicit `mcp_config_path` is caller intent and fails loudly when unreadable.
- `ClaudeCodeRequest.mcp_servers` stays excluded from serialized dumps: MCP configs commonly embed secrets and the only real dump consumer is persisted event logs; the live per-turn path never round-trips through `model_dump`. Pinned by dedicated tests.

## Review trail

Three adversarial review rounds (independent reviewer, refute mandate). Round 1 and 2 findings — resume-path system-message clobber, empty-allowlist bypass (two layers), shared-iModel endpoint contamination, `lion_system: false` drop, silent config failures, falsy-role fail-open, executor/session loss on copy — are each fixed with a regression test demonstrated to fail without its fix. Final round: APPROVE-WITH-FIXES, both remaining findings (empty-string path truthiness; role validation ordering vs resume) fixed with regressions in this diff.

`uv run pytest tests/agent/ tests/cli/ tests/providers/ -q` green (2000+ tests); ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
