### PR TITLE
fix(studio): fleet run-detail execution graph — edgeless-graph fall-through + compact MiniMap

### DIFF
--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -10,7 +10,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { computeEdgeSourceCompleted } from "./WorkerCanvas";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { computeEdgeSourceCompleted, shouldShowMiniMap } from "./WorkerCanvas";
 
 describe("computeEdgeSourceCompleted", () => {
   it("uses the legacy completedMap when nodeStatuses is undefined", () => {
@@ -42,5 +44,49 @@ describe("computeEdgeSourceCompleted", () => {
 
   it("node with no coverage anywhere and no legacy record is not completed", () => {
     expect(computeEdgeSourceCompleted("z", {}, new Map())).toBe(false);
+  });
+});
+
+// ─── MiniMap suppressed in compact embeds ─────────────────────────────────────
+// RunDetail's run-dag panel is a fixed 280px-tall container — at that size a
+// MiniMap reads as a floating cluster of gray micro-nodes rather than a
+// useful overview, so `compact` embeds must never show it, no matter how
+// many nodes the graph has. Non-compact usage (the full-page graph editor)
+// keeps the existing >10-nodes threshold.
+
+describe("shouldShowMiniMap", () => {
+  it("compact embed never shows the minimap, even with many nodes", () => {
+    expect(shouldShowMiniMap(true, 50)).toBe(false);
+  });
+
+  it("compact embed hides the minimap when under the node threshold too", () => {
+    expect(shouldShowMiniMap(true, 3)).toBe(false);
+  });
+
+  it("non-compact usage shows the minimap once nodes exceed the threshold", () => {
+    expect(shouldShowMiniMap(false, 11)).toBe(true);
+  });
+
+  it("non-compact usage hides the minimap at or under the threshold", () => {
+    expect(shouldShowMiniMap(false, 10)).toBe(false);
+  });
+});
+
+describe("WorkerCanvas.tsx — source contract for the compact MiniMap fix", () => {
+  const CANVAS_DIR = path.resolve(__dirname);
+  const src = fs.readFileSync(path.join(CANVAS_DIR, "WorkerCanvas.tsx"), "utf-8");
+
+  it("declares a compact prop, defaulting to false", () => {
+    expect(src).toMatch(/compact\?: boolean/);
+    expect(src).toMatch(/compact = false/);
+  });
+
+  it("gates the MiniMap through shouldShowMiniMap, not a raw node-count check", () => {
+    expect(src).toMatch(/shouldShowMiniMap\(compact, nodes\.length\)/);
+  });
+
+  it("docks the minimap bottom-right and sizes it down", () => {
+    expect(src).toMatch(/position="bottom-right"/);
+    expect(src).toMatch(/style=\{\{ width: \d+, height: \d+ \}\}/);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -50,6 +50,10 @@ interface WorkerCanvasProps {
   nodeStatuses?: Record<string, NodeExecStatus>;
   currentStep?: string | null;
   onChange?: (nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => void;
+  /** Read-only embed in a small container (e.g. RunDetail's 280px run-dag
+   * panel). Suppresses the MiniMap — at that size it reads as a floating
+   * cluster of gray nodes rather than a useful overview. */
+  compact?: boolean;
 }
 
 // ─── Conversion helpers ─────────────────────────────────
@@ -63,6 +67,16 @@ const edgeTypes = { condition: ConditionEdgeComponent };
 // the legacy case). An edge's source node absent from that map must fall
 // back to the legacy execSteps-derived completedMap rather than being
 // treated as "not completed" just because *some* nodeStatuses object exists.
+// A MiniMap only earns its keep once the canvas is large enough for an
+// overview to mean something. In a `compact` embed (RunDetail's 280px
+// run-dag panel) it instead reads as a floating cluster of gray micro-nodes
+// overlapping the real graph, so suppress it outright there regardless of
+// node count.
+export function shouldShowMiniMap(compact: boolean, nodeCount: number): boolean {
+  if (compact) return false;
+  return nodeCount > 10;
+}
+
 export function computeEdgeSourceCompleted(
   source: string,
   nodeStatuses: Record<string, NodeExecStatus> | undefined,
@@ -143,6 +157,7 @@ export default function WorkerCanvas({
   nodeStatuses,
   currentStep = null,
   onChange,
+  compact = false,
 }: WorkerCanvasProps) {
   const initialised = useRef(false);
 
@@ -352,11 +367,15 @@ export default function WorkerCanvas({
             showInteractive={false}
             className="!bg-surface-raised !border-edge !shadow-none [&>button]:!bg-surface-raised [&>button]:!border-edge [&>button]:!text-content-secondary [&>button:hover]:!bg-surface-overlay [&>button:hover]:!text-content-primary"
           />
-          {nodes.length > 10 ? (
+          {shouldShowMiniMap(compact, nodes.length) ? (
             <MiniMap
+              position="bottom-right"
+              pannable={false}
+              zoomable={false}
               nodeColor={() => "var(--edge-strong)"}
               maskColor="rgba(0, 0, 0, 0.5)"
               className="!bg-surface-raised !border-edge"
+              style={{ width: 120, height: 80 }}
             />
           ) : null}
 

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -121,6 +121,81 @@ describe("transitiveReduce (lib/operationGraph) — why RunDetail must not apply
   });
 });
 
+// ─── Edgeless authored graph falls through to the runtime opGraph ────────────
+// Reactive runs persist an early `graph` snapshot (nodes only, no edges yet)
+// that is never refreshed. Laid out with zero edges, dagre puts every node
+// in the same rank — a meaningless vertical column. When that snapshot has
+// ≥2 nodes and 0 edges, and the runtime opGraph (built from Node* signal
+// depends_on/parent_id/cause_op_id) has real edges, the authored graph must
+// not be rendered as the DAG — render opGraph instead. An authored graph
+// that already carries edges keeps priority exactly as before.
+
+describe("history/RunDetail.tsx — shouldRenderAuthoredGraph", () => {
+  it("exports shouldRenderAuthoredGraph and wires it into the run-dag render branch", () => {
+    const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+    expect(src).toMatch(/export function shouldRenderAuthoredGraph/);
+    expect(src).toMatch(/runGraph && shouldRenderAuthoredGraph\(runGraph, opGraph\)/);
+  });
+
+  it("passes compact to the authored-graph WorkerCanvas embed", () => {
+    const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+    // The <WorkerCanvas ... compact /> block sits between the authored-graph
+    // ternary head and the opGraph fallback branch.
+    const start = src.indexOf("shouldRenderAuthoredGraph(runGraph, opGraph)");
+    const end = src.indexOf("</Suspense>", start);
+    expect(src.slice(start, end)).toMatch(/\bcompact\b/);
+  });
+
+  it("edgeless authored graph + runtime edges → opGraph path chosen", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const authoredNoEdges = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [],
+    };
+    const opGraphWithEdges = { edges: [{ source: "op-a", target: "op-b" }] };
+    expect(shouldRenderAuthoredGraph(authoredNoEdges, opGraphWithEdges)).toBe(false);
+  });
+
+  it("edgeless authored graph but opGraph ALSO has no edges → still renders authored (nothing better to fall through to)", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const authoredNoEdges = { nodes: [{ id: "a" }, { id: "b" }], edges: [] };
+    expect(shouldRenderAuthoredGraph(authoredNoEdges, { edges: [] })).toBe(true);
+  });
+
+  it("authored graph WITH edges is still preferred over opGraph, regardless of opGraph edges", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const authoredWithEdges = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [{ id: "e1", source: "a", target: "b" }],
+    };
+    const opGraphWithEdges = { edges: [{ source: "op-a", target: "op-b" }] };
+    expect(shouldRenderAuthoredGraph(authoredWithEdges, opGraphWithEdges)).toBe(true);
+    expect(shouldRenderAuthoredGraph(authoredWithEdges, { edges: [] })).toBe(true);
+  });
+
+  it("missing graph.edges (backend omitted the field) is treated as edgeless", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const authoredMissingEdges = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: undefined as unknown as unknown[],
+    };
+    const opGraphWithEdges = { edges: [{ source: "op-a", target: "op-b" }] };
+    expect(shouldRenderAuthoredGraph(authoredMissingEdges, opGraphWithEdges)).toBe(false);
+  });
+
+  it("a single-node authored graph is never considered edgeless (nothing to draw an edge between)", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const singleNode = { nodes: [{ id: "a" }], edges: [] };
+    const opGraphWithEdges = { edges: [{ source: "op-a", target: "op-b" }] };
+    expect(shouldRenderAuthoredGraph(singleNode, opGraphWithEdges)).toBe(true);
+  });
+
+  it("null graph never renders as the authored DAG", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    expect(shouldRenderAuthoredGraph(null, { edges: [] })).toBe(false);
+  });
+});
+
 describe("stale-write guard predicate (mirrors the done handler's merge condition)", () => {
   function mergeIfSameSession(
     prev: { id: string; status: string } | null,

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -194,6 +194,28 @@ describe("history/RunDetail.tsx — shouldRenderAuthoredGraph", () => {
     const { shouldRenderAuthoredGraph } = await import("./RunDetail");
     expect(shouldRenderAuthoredGraph(null, { edges: [] })).toBe(false);
   });
+
+  // A persisted graph may omit `edges` entirely. shouldRenderAuthoredGraph
+  // treats that as edgeless, but when the runtime opGraph ALSO has no edges
+  // the authored graph still renders — and WorkerCanvas maps over `edges`,
+  // so the decode site must normalize an omitted field to [] or that valid
+  // combination crashes the run-detail graph instead of rendering it.
+  it("decode site normalizes omitted graph.edges to [] before setRunGraph", () => {
+    const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+    expect(src).toMatch(/edges:\s*graph\.edges\s*\?\?\s*\[\]/);
+  });
+
+  it("omitted edges + no runtime edges renders the authored graph, and normalized edges survive a WorkerCanvas-style map", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const persisted = { nodes: [{ id: "a" }, { id: "b" }] } as {
+      nodes: unknown[];
+      edges?: unknown[] | null;
+    };
+    // Mirrors the decode-site normalization under test above.
+    const runGraph = { nodes: persisted.nodes, edges: persisted.edges ?? [] };
+    expect(shouldRenderAuthoredGraph(runGraph, { edges: [] })).toBe(true);
+    expect(() => runGraph.edges.map((e) => e)).not.toThrow();
+  });
 });
 
 describe("stale-write guard predicate (mirrors the done handler's merge condition)", () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -54,6 +54,25 @@ function classifyLC(lc: string): string {
   return "unknown";
 }
 
+// The persisted/authored graph (Studio's early_graph) is only meaningful as
+// the rendered DAG when it actually carries the designer's edges. Reactive
+// runs persist an early snapshot with nodes but zero edges (they're added
+// later, and the snapshot is never refreshed) — laid out with no edges, every
+// node lands in a single dagre rank, rendering as a meaningless vertical
+// column. When that happens and the runtime opGraph has real edges (derived
+// from Node* depends_on/parent_id/cause_op_id), prefer opGraph instead. An
+// authored graph that already has edges keeps priority, unreduced — see the
+// note above nodeStatuses.
+export function shouldRenderAuthoredGraph(
+  graph: { nodes: unknown[]; edges: unknown[] | null | undefined } | null,
+  opGraph: { edges: unknown[] },
+): boolean {
+  if (!graph) return false;
+  const edgeCount = graph.edges?.length ?? 0;
+  const isEdgeless = graph.nodes.length >= 2 && edgeCount === 0;
+  return !(isEdgeless && opGraph.edges.length > 0);
+}
+
 function branchToRunStep(branch: SessionBranch, status: string): RunStep {
   const msgs = branch.messages;
   const runMessages: RunMessage[] = [];
@@ -689,7 +708,9 @@ export default function RunDetail({ id }: RunDetailProps) {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] } | null | undefined;
+          | { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] }
+          | null
+          | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
           setRunGraph({
             name: s.name || id,
@@ -1034,11 +1055,17 @@ export default function RunDetail({ id }: RunDetailProps) {
     errorCount: errors.length,
     partialWindow,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     playbookName: (session as unknown as Record<string, unknown>).playbook_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
   };
 
   const content = (
@@ -1068,7 +1095,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         contract={session.artifact_contract_json}
         verification={session.artifact_verification_json}
       />
-      {runGraph ? (
+      {runGraph && shouldRenderAuthoredGraph(runGraph, opGraph) ? (
         <div id="run-dag" className="scroll-mt-4">
           <SectionHeader label={t("sectionExecutionGraph")} count={runGraph.nodes.length} />
           <div className="h-[280px] rounded border border-edge bg-surface-raised shadow-card overflow-hidden">
@@ -1078,6 +1105,7 @@ export default function RunDetail({ id }: RunDetailProps) {
                 editable={false}
                 execSteps={execSteps}
                 nodeStatuses={nodeStatuses}
+                compact
               />
             </Suspense>
           </div>

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -708,7 +708,7 @@ export default function RunDetail({ id }: RunDetailProps) {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          | { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] }
+          | { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null }
           | null
           | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
@@ -716,7 +716,9 @@ export default function RunDetail({ id }: RunDetailProps) {
             name: s.name || id,
             description: "",
             nodes: graph.nodes,
-            edges: graph.edges,
+            // A persisted graph may omit edges entirely; WorkerCanvas maps
+            // over the array, so an absent field must normalize to empty.
+            edges: graph.edges ?? [],
           });
         }
       })


### PR DESCRIPTION
## Defects

Two rendering defects in the Studio Fleet run-detail execution graph (the surface Ocean watched live):

**1. Edgeless authored graph preferred over runtime graph with real edges.** `RunDetail.tsx` set `runGraph` from the session's persisted graph whenever it had nodes, ignoring edges. Reactive runs persist an early snapshot with nodes but zero edges (never refreshed), so dagre ranked every node into a single column with no edges drawn — while the runtime `opGraph` (real dependency edges reconstructed from `depends_on`/`parent_id`/`cause_op_id` signal payloads) sat unused. New `shouldRenderAuthoredGraph(graph, opGraph)` falls through to the opGraph render branch only when the authored graph has ≥2 nodes and 0 edges AND the opGraph has edges. Authored graphs with edges keep priority, unreduced; edgeless-with-nothing-better still renders as before.

**2. MiniMap ghost cluster.** `WorkerCanvas` rendered a default-sized MiniMap whenever `nodes.length > 10` — inside RunDetail's 280px letterbox it read as a floating cluster of gray micro-nodes. New `compact` prop (RunDetail passes it) suppresses the MiniMap in small embeds via `shouldShowMiniMap(compact, nodeCount)`; when shown, it's now explicitly docked bottom-right at 120×80, non-interactive. The full-page graph editor is unchanged (default `compact=false`).

## Verification

- 15 new/updated assertions in `RunDetail.test.tsx` + 7 in `WorkerCanvas.test.ts`, each proven to fail with the product hunks reverted (`git apply -R`) and pass restored.
- `npm run test` — 821 passed (36 files). `npm run typecheck` and `npm run lint` clean.

Scope: these two defects only. The state-first/drawer redesign (design note approved through the SPEC gate) is a separate follow-up PR that rebases on this.