### PR TITLE
docs(adr): correct ADR-0090 Amendment 1 still-open list against shipped code

### DIFF
--- a/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
+++ b/docs/adr/ADR-0090-local-sandbox-and-measured-cell-backend-seams.md
@@ -606,17 +606,26 @@ the following statements in it no longer describe current behavior:
   the caller passes the keyword-only `allow_protected=True`. `CodingToolkit` exposes
   that override only as a constructor parameter (`sandbox_allow_protected`), never in
   the model-visible tool schema.
-- **Cleanup is truthful.** `sandbox_discard` marks a session inactive only when both
-  the worktree removal and the branch deletion succeeded, and the `CodingToolkit`
-  discard action retains the session and reports failure on partial cleanup.
+- **Cleanup is truthful and retryable.** `sandbox_discard` marks a session inactive
+  only when both the worktree removal and the branch deletion succeeded, and the
+  `CodingToolkit` discard action retains the session and reports failure on partial
+  cleanup. Cleanup checks are state-aware: a removal step whose target is already
+  absent (worktree no longer registered, branch no longer existing) counts as
+  succeeded, so retrying a partially-completed discard converges instead of failing
+  forever. `sandbox_diff` raises and `sandbox_commit` returns an error when the
+  worktree directory is missing, rather than reporting an empty diff or a silent
+  success.
 - **The base commit is recorded.** `create_sandbox` resolves and stores the base
   branch's commit SHA on `SandboxSession.base_sha` at creation time.
 
 Delta 1 in "Current-vs-ideal delta" is substantially closed: base-commit recording,
-non-staging diff, unverified-target refusal, and truthful partial-cleanup reporting
-are implemented and tested. Still open from its acceptance list: behavior when the
-base branch has advanced since creation, merge-conflict handling, repeated-teardown
-idempotence, and the patch truncation noted above.
+non-staging diff, unverified-target refusal, truthful partial-cleanup reporting, and
+repeated-teardown idempotence (state-aware retry convergence, above) are implemented
+and tested. Still open from its acceptance list: behavior when the base branch has
+advanced since creation (`base_sha` is recorded but merge neither detects nor
+reports drift from it), merge-conflict handling (a conflicted merge is reported as
+a failure but the repository root is left in the in-progress merge state), and the
+patch truncation noted above.
 
 ## Notes
 


### PR DESCRIPTION
Correction to the Amendment 1 text merged in #2045, which was written before #2044's final contract landed and now contradicts shipped code.

- **Removed from still-open**: repeated-teardown idempotence — closed by #2044's state-aware cleanup retries (absence-aware checks make retry converge; diff raises / commit errors on a missing worktree; all covered by fail-without-fix regressions).
- **Re-verified the other three items against the shipped code** (not memory): base-branch-advanced behavior is still open (`base_sha` is recorded at creation but merge neither detects nor reports drift); merge-conflict handling is still open (a conflicted merge returns a failure dict but leaves the repository root in the in-progress merge state — no abort); the 10,000-character patch truncation is unchanged and still open.
- Expanded the 'Cleanup is truthful' bullet to state the retry-convergence and loud-failure semantics the code now has.

Lane C: ADR content, full read requested.