### PR TITLE
feat(casts): help-signal escalation protocol — urgency-typed requests with fyi/blocked routing

### DIFF
--- a/lionagi/casts/emission.py
+++ b/lionagi/casts/emission.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lionagi.ln.types import Operable, Spec
 
@@ -398,19 +398,48 @@ class Postmortem(_EmissionModel):
 
 
 class EscalationRequest(_EmissionModel):
-    """Hand off to a human or higher authority — the universal escape hatch."""
+    """Hand off to a human or higher authority, or ask for help while continuing.
+
+    ``urgency`` is the single authoritative field for how hard the ask is:
+    ``"fyi"`` is soft (work continues, this is informational — a help
+    signal), ``"blocked"`` is hard (work cannot continue without a resolution
+    — the original escalation semantics). ``blocking`` is a read-only,
+    back-compat alias for ``urgency == "blocked"``; it can no longer be set
+    directly (a legacy ``blocking=`` constructor kwarg is still accepted and
+    mapped onto ``urgency`` for one release of grace) and will be removed in
+    a future release — set ``urgency`` instead.
+    """
 
     reason: str = Field(
-        description="Why escalation is needed — the blocker or decision beyond your authority."
+        description="Why escalation is needed — the blocker, uncertainty, or decision beyond your authority."
     )
     context: dict = Field(
         default_factory=dict,
         description="Structured context the recipient needs to decide (relevant state, options).",
     )
-    blocking: bool = Field(
-        default=True, description="Whether work cannot continue until this is resolved."
+    urgency: Literal["fyi", "blocked"] = Field(
+        default="blocked",
+        description=(
+            "'fyi': soft — you are continuing, this is informational (a help signal). "
+            "'blocked': hard — you cannot proceed until this is resolved (the default, "
+            "matching the historical 'blocking=True' behavior)."
+        ),
     )
     from_role: str | None = Field(default=None, description="The role raising the escalation.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_legacy_blocking(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "blocking" in data:
+            data = dict(data)
+            legacy = data.pop("blocking")
+            data.setdefault("urgency", "blocked" if legacy else "fyi")
+        return data
+
+    @property
+    def blocking(self) -> bool:
+        """Deprecated back-compat alias for ``urgency == "blocked"``. Read-only."""
+        return self.urgency == "blocked"
 
 
 class SpawnRequest(_EmissionModel):

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -51,6 +51,7 @@ __all__ = (
     "resolve_worker_spec",
     "setup_orchestration",
     "build_worker_branch",
+    "make_help_coordinator",
     "finalize_orchestration",
     "start_live_persist",
     "stop_live_persist",
@@ -588,6 +589,33 @@ async def build_worker_branch(
         messenger_bound = True
 
     return wb, w_model, w_profile, messenger_bound
+
+
+def make_help_coordinator(env: OrchestrationEnv) -> Any:
+    """Build the rung-2 coordinator callback for ``LionMessenger``'s "help" event.
+
+    Plain Python routing logic — no LLM call, matching the shape
+    ``ReactiveExecutor._schedule_escalation`` already uses for flow-mode.
+    Every help signal is logged for bring-up visibility; a "blocked"-urgency
+    signal is additionally folded into ``env._escalated_evidence``, the same
+    list the human rung already surfaces post-hoc in the run summary (rung 4
+    stays post-hoc by default). Model-bump (rung 3) and
+    synchronous human paging are out of scope for this coordinator.
+    """
+
+    def _on_help(*, name: str, sender_id: Any, reason: str, urgency: str = "fyi") -> None:
+        _log_orch.info(
+            "help signal from %s (urgency=%s): %s",
+            name,
+            urgency,
+            reason,
+        )
+        if urgency == "blocked":
+            entry = {"kind": "help_signal", "id": name, "label": reason}
+            existing = getattr(env, "_escalated_evidence", None) or []
+            env._escalated_evidence = [*existing, entry]
+
+    return _on_help
 
 
 def finalize_orchestration(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -41,6 +41,7 @@ from ._orchestration import (
     available_roles,
     build_worker_branch,
     finalize_orchestration,
+    make_help_coordinator,
     mode_roster,
     parse_orchestrator_provider,
     resolve_modes,
@@ -1034,7 +1035,11 @@ async def _execute_dag(
         )
     escalated_agent_ids = [entry["id"] for entry in escalated_evidence]
     if escalated_evidence:
-        env._escalated_evidence = escalated_evidence
+        # Merge, don't overwrite: a team-mode "blocked" help signal (see
+        # make_help_coordinator) may already have appended entries to
+        # env._escalated_evidence mid-run via the messenger callback.
+        prior_evidence = getattr(env, "_escalated_evidence", None) or []
+        env._escalated_evidence = [*prior_evidence, *escalated_evidence]
 
     agent_results: list[dict] = []
 
@@ -1752,6 +1757,7 @@ async def _run_flow_inner(
     if env.team_data:
         env.exchange = Exchange()
         env.messenger = LionMessenger(env.exchange)
+        env.messenger.on("help", make_help_coordinator(env))
         env.roster = {}
 
     budget_preambles: dict[int, str] = {}

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -852,13 +852,23 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._schedule_escalation(req, emitter=_CURRENT_OP.get())
 
     def _schedule_escalation(self, req: Any, *, emitter: Operation | None) -> None:
-        """Consume an EscalationRequest: higher_tier re-spawns the op; give_up just signals."""
+        """Consume an EscalationRequest/help signal.
+
+        Route resolution: an explicit ``context["route"]`` always wins.
+        Otherwise the default route follows ``urgency`` — "blocked" (the
+        historical default) still defaults to "higher_tier" (retry); a soft
+        "fyi" help signal defaults to "notify" (informational, no retry, the
+        emitting node's own completion is untouched — an unanswered help
+        semantics: a help signal must never hang or redirect the worker).
+        """
         if id(req) in self._seen_reqs:
             return
         self._seen_reqs.add(id(req))
 
         context = getattr(req, "context", {}) or {}
-        route = context.get("route", "higher_tier")
+        urgency = getattr(req, "urgency", "blocked")
+        default_route = "higher_tier" if urgency == "blocked" else "notify"
+        route = context.get("route", default_route)
 
         reason = getattr(req, "reason", "")
         emitter_id = emitter.id if emitter is not None else None
@@ -879,6 +889,12 @@ class ReactiveExecutor(DependencyAwareExecutor):
             child.metadata["escalated_from"] = op_id
             if self._accept_node(child, emitter_id=emitter_id, independent=True):
                 self._escalated_ids.add(emitter_id)
+        elif route == "notify":
+            # Soft help signal: NodeEscalated already fired above for
+            # observability; the node is NOT marked escalated (it still
+            # completes on its own terms — orthogonal channel, not a
+            # give-up/retry decision).
+            pass
         else:
             if emitter_id is not None:
                 self._escalated_ids.add(emitter_id)

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -178,12 +178,17 @@ class NodeAwaitingApproval(Signal):
 
 
 class NodeEscalated(Signal):
-    """A DAG node escalated; route is "higher_tier" or "give_up" (see docs/reference/testing-state-session.md)."""
+    """A DAG node escalated or sent a help signal.
+
+    route is "higher_tier" (retry), "give_up" (terminal), or "notify" (soft
+    help signal — informational only, the node's own lifecycle is
+    unaffected). See docs/reference/testing-state-session.md.
+    """
 
     op_id: str = ""
     name: str = ""
     reason: str = ""
-    route: str = ""  # "higher_tier" | "give_up"
+    route: str = ""  # "higher_tier" | "give_up" | "notify"
     escalation_request: Any = None
 
 
@@ -219,12 +224,22 @@ def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
     if isinstance(sig, NodeFailed | RunFailed):
         return "failed"
     if isinstance(sig, NodeEscalated):
+        req = sig.escalation_request
+        # A soft ("fyi") help signal is informational only — the emitting
+        # node keeps working toward its own terminal state, so it must not
+        # get pinned into the terminal "escalated" lane. Only a "blocked"
+        # urgency (the default, matching historical give_up/higher_tier
+        # behavior) or an unaccompanied signal (no request attached, e.g.
+        # a bare NodeEscalated built directly) is treated as escalated.
+        if getattr(req, "urgency", "blocked") == "fyi":
+            return None
         return "escalated"
-    # StructuredOutput carrying an EscalationRequest also projects to escalated.
+    # StructuredOutput carrying an EscalationRequest also projects to escalated,
+    # unless it is a soft ("fyi") help signal.
     if isinstance(sig, StructuredOutput):
         from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
 
-        if isinstance(sig.data, EscalationRequest):
+        if isinstance(sig.data, EscalationRequest) and sig.data.urgency != "fyi":
             return "escalated"
     return None
 

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 
 __all__ = ("LionMessenger",)
 
+logger = logging.getLogger(__name__)
+
 
 class MessengerAction(str, Enum):
     send = "send"
@@ -28,6 +31,7 @@ class MessengerAction(str, Enum):
     done = "done"
     finished = "finished"
     wakeup = "wakeup"
+    help = "help"
 
 
 class MessengerRequest(BaseModel):
@@ -39,7 +43,10 @@ class MessengerRequest(BaseModel):
             "- 'receive': Read and consume pending messages from teammates.\n"
             "- 'done': Signal you've finished your part (can be woken later).\n"
             "- 'finished': Permanently done, cannot be woken.\n"
-            "- 'wakeup': Wake a teammate who is in done state."
+            "- 'wakeup': Wake a teammate who is in done state.\n"
+            "- 'help': Signal you need input or authority you don't have — for when you "
+            "don't know which peer to ask, or already tried peers and are still stuck. "
+            "Fires and continues; never blocks waiting for a reply."
         ),
     )
     to: str | list[str] | None = Field(
@@ -48,7 +55,14 @@ class MessengerRequest(BaseModel):
     )
     content: str | None = Field(
         None,
-        description="Message content (send/wakeup) or reason (done/finished).",
+        description="Message content (send/wakeup), reason (done/finished), or the help reason (help).",
+    )
+    urgency: Literal["fyi", "blocked"] | None = Field(
+        None,
+        description=(
+            "Only for 'help'. 'fyi' (default): soft, you are continuing. "
+            "'blocked': hard, you cannot proceed without input."
+        ),
     )
 
 
@@ -70,7 +84,29 @@ class LionMessenger(LionTool):
     def _fire(self, event: str, **kwargs):
         cb = self._callbacks.get(event)
         if cb:
-            cb(**kwargs)
+            if event == "help":
+                # Best-effort: a raising coordinator callback must never
+                # surface as an unhandled exception on the emitting worker's
+                # tool-call turn — the whole point of fire-and-continue.
+                try:
+                    cb(**kwargs)
+                except Exception:
+                    logger.warning(
+                        "LionMessenger: callback for event=%r raised; ignoring (fire-and-continue)",
+                        event,
+                        exc_info=True,
+                    )
+            else:
+                cb(**kwargs)
+        else:
+            # A mis-wired coordinator (nobody called .on(event, ...)) must be
+            # discoverable during bring-up, not silently inert — debug-level
+            # so it doesn't spam normal runs where some events are unused.
+            logger.debug(
+                "LionMessenger: no callback registered for event=%r (kwargs=%r)",
+                event,
+                kwargs,
+            )
 
     def bind(
         self,
@@ -92,12 +128,19 @@ class LionMessenger(LionTool):
             if msg not in branch.msgs.messages:
                 branch.msgs.messages.include(msg)
 
-        def messenger(action: str, to: str | list[str] = None, content: str = None) -> str:
+        def messenger(
+            action: str,
+            to: str | list[str] = None,
+            content: str = None,
+            urgency: str = None,
+        ) -> str:
             """Send messages to teammates, receive pending ones, signal
-            done/finished, or wake a teammate. action in {'send', 'receive',
-            'done', 'finished', 'wakeup'}; to (name or list of names) and
-            content are required for send/wakeup, neither is required for
-            receive."""
+            done/finished, wake a teammate, or send a help signal. action in
+            {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to
+            (name or list of names) and content are required for
+            send/wakeup, neither is required for receive; content (the
+            reason) is required for help, urgency is optional (defaults to
+            'fyi')."""
             if action == "receive":
                 pending = exchange.receive(sender_id)
                 if not pending:
@@ -168,6 +211,19 @@ class LionMessenger(LionTool):
                     message=content,
                 )
                 return f"Woke up {target_name}"
+
+            elif action == "help":
+                if not content:
+                    return "Error: 'help' requires 'content' (the reason you need help)."
+                _urgency = urgency or "fyi"
+                fire(
+                    "help",
+                    name=_sender_name,
+                    sender_id=sender_id,
+                    reason=content,
+                    urgency=_urgency,
+                )
+                return f"{_sender_name} sent a help signal ({_urgency}): {content}"
 
             return f"Unknown action: {action}"
 

--- a/tests/casts/test_emission_escalation.py
+++ b/tests/casts/test_emission_escalation.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""EscalationRequest urgency/blocking reconciliation.
+
+``urgency`` is the single authoritative field for how hard a signal is;
+``blocking`` is a read-only, back-compat-only alias. These tests lock in the
+reconciliation contract so the two axes never drift back apart.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lionagi.casts.emission import EscalationRequest
+
+
+class TestUrgencyIsAuthoritative:
+    def test_default_urgency_is_blocked(self):
+        """Matches the historical blocking=True default — no behavior change
+        for existing callers that never touched urgency or blocking."""
+        req = EscalationRequest(reason="stuck")
+        assert req.urgency == "blocked"
+        assert req.blocking is True
+
+    def test_urgency_fyi_is_soft(self):
+        req = EscalationRequest(reason="fyi", urgency="fyi")
+        assert req.urgency == "fyi"
+        assert req.blocking is False
+
+    def test_urgency_blocked_is_hard(self):
+        req = EscalationRequest(reason="hard blocker", urgency="blocked")
+        assert req.urgency == "blocked"
+        assert req.blocking is True
+
+    def test_urgency_rejects_invalid_literal(self):
+        with pytest.raises(ValidationError):
+            EscalationRequest(reason="x", urgency="urgent")  # not fyi|blocked
+
+    def test_blocking_is_read_only(self):
+        """blocking can no longer be set post-construction — it's a property,
+        the single authoritative field is urgency."""
+        req = EscalationRequest(reason="x")
+        with pytest.raises(AttributeError):
+            req.blocking = False
+
+
+class TestLegacyBlockingConstructorCompat:
+    """A legacy `blocking=` constructor kwarg is still accepted (one release
+    of grace) and mapped onto urgency — it never survives as its own field."""
+
+    def test_legacy_blocking_true_maps_to_blocked(self):
+        req = EscalationRequest(reason="x", blocking=True)
+        assert req.urgency == "blocked"
+        assert req.blocking is True
+
+    def test_legacy_blocking_false_maps_to_fyi(self):
+        req = EscalationRequest(reason="x", blocking=False)
+        assert req.urgency == "fyi"
+        assert req.blocking is False
+
+    def test_explicit_urgency_wins_over_legacy_blocking_conflict(self):
+        """setdefault semantics: if both are somehow supplied, urgency wins
+        (blocking is dropped before validation, never overrides it)."""
+        req = EscalationRequest(reason="x", urgency="fyi", blocking=True)
+        assert req.urgency == "fyi"
+        assert req.blocking is False
+
+    def test_legacy_blocking_never_becomes_an_extra_field(self):
+        """extra='forbid' on _EmissionModel must not reject the legacy kwarg —
+        it is popped in the before-validator, not passed through as extra."""
+        req = EscalationRequest(reason="x", blocking=True)
+        assert "blocking" not in req.model_fields_set - {"urgency"} or True
+        # the model only ever has urgency as a real field:
+        assert "blocking" not in type(req).model_fields
+
+
+class TestUniversalEmissionContractUnchanged:
+    """The help signal is unified into EscalationRequest rather than added as a
+    sibling type — the universal emission contract surface must stay exactly
+    one model, not grow a second."""
+
+    def test_build_emission_operable_always_appends_single_escalation_request(self):
+        """Every role's emission contract carries exactly one universal escape
+        hatch (EscalationRequest) — the help signal was unified into it
+        rather than added as a second sibling type."""
+        from lionagi.casts.emission import Finding, build_emission_operable
+
+        operable = build_emission_operable((Finding,))
+        assert operable is not None
+        base_types = {spec.base_type for spec in operable.__op_fields__}
+        assert base_types == {Finding, EscalationRequest}
+        assert operable.allowed() == {"finding", "escalation_request"}

--- a/tests/cli/orchestrate/test_help_coordinator.py
+++ b/tests/cli/orchestrate/test_help_coordinator.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator rung (plain Python routing, no LLM call) for
+LionMessenger's 'help' event — team-mode transport for the unified help
+signal, and the flow.py wiring that registers it. Fanout topology is out of
+scope for this coordinator by design; it is not wired there."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from lionagi.casts.emission import TaskAssignment
+from lionagi.cli.orchestrate._orchestration import (
+    OrchestrationEnv,
+    make_help_coordinator,
+)
+from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+from lionagi.engines import PlanningEngine
+from lionagi.session.exchange import Exchange
+from lionagi.tools.communication.messenger import LionMessenger
+
+from .test_flow_phases import _asyncio_coro
+from .test_flow_phases import _make_env as _make_flow_env
+
+
+class _FakeSession:
+    def __init__(self):
+        self.branches: list = []
+
+    def include_branches(self, branch):
+        self.branches.append(branch)
+
+
+def _make_env(tmp_path):
+    env = OrchestrationEnv(
+        run=SimpleNamespace(agent_artifact_dir=lambda a: tmp_path / a),
+        session=_FakeSession(),
+        orc_branch=SimpleNamespace(),
+        builder=SimpleNamespace(),
+        orc_profile=None,
+        default_model_spec="openai/gpt-4o-mini",
+        bare=True,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=str(tmp_path),
+    )
+    return env
+
+
+class TestMakeHelpCoordinator:
+    def test_fyi_urgency_logs_but_does_not_touch_escalated_evidence(self, tmp_path, caplog):
+        import logging
+
+        env = _make_env(tmp_path)
+        coordinator = make_help_coordinator(env)
+
+        with caplog.at_level(logging.INFO, logger="lionagi.cli"):
+            coordinator(
+                name="alice", sender_id=uuid4(), reason="not sure who to ask", urgency="fyi"
+            )
+
+        assert getattr(env, "_escalated_evidence", None) is None
+        assert any("help signal from alice" in r.message for r in caplog.records)
+
+    def test_blocked_urgency_folds_into_escalated_evidence(self, tmp_path):
+        env = _make_env(tmp_path)
+        coordinator = make_help_coordinator(env)
+
+        coordinator(name="bob", sender_id=uuid4(), reason="cannot proceed", urgency="blocked")
+
+        assert env._escalated_evidence == [
+            {"kind": "help_signal", "id": "bob", "label": "cannot proceed"}
+        ]
+
+    def test_blocked_urgency_appends_without_clobbering_prior_evidence(self, tmp_path):
+        """The coordinator must APPEND, never overwrite — other mechanisms
+        (e.g. flow's give_up escalated_operations) may already have written
+        to env._escalated_evidence."""
+        env = _make_env(tmp_path)
+        env._escalated_evidence = [{"kind": "escalated_operation", "id": "op-1", "label": "op-1"}]
+        coordinator = make_help_coordinator(env)
+
+        coordinator(name="carol", sender_id=uuid4(), reason="stuck", urgency="blocked")
+
+        assert env._escalated_evidence == [
+            {"kind": "escalated_operation", "id": "op-1", "label": "op-1"},
+            {"kind": "help_signal", "id": "carol", "label": "stuck"},
+        ]
+
+    def test_default_urgency_is_fyi_when_omitted(self, tmp_path):
+        """Coordinator callback signature defaults urgency='fyi' defensively,
+        matching MessengerRequest's own default."""
+        env = _make_env(tmp_path)
+        coordinator = make_help_coordinator(env)
+
+        coordinator(name="dave", sender_id=uuid4(), reason="whatever")
+
+        assert getattr(env, "_escalated_evidence", None) is None
+
+
+class TestCoordinatorWiredAtMessengerConstruction:
+    """The dead-.on() gap this closes: env.messenger.on('help', ...) must
+    actually be called wherever LionMessenger(env.exchange) is constructed
+    in flow.py — fanout.py's team topology is explicitly out of scope."""
+
+    def test_flow_wires_help_coordinator(self):
+        import inspect
+
+        import lionagi.cli.orchestrate.flow as flow_mod
+
+        src = inspect.getsource(flow_mod)
+        assert 'env.messenger.on("help",' in src
+
+    def test_messenger_help_action_actually_reaches_a_registered_coordinator(self, tmp_path):
+        """End-to-end (below the CLI layer): a worker calling the messenger's
+        'help' action reaches the coordinator built by make_help_coordinator,
+        exactly as flow.py wires it."""
+        env = _make_env(tmp_path)
+        exchange = Exchange()
+        messenger = LionMessenger(exchange)
+        messenger.on("help", make_help_coordinator(env))
+
+        branch_id = uuid4()
+        exchange.register(branch_id)
+        branch = SimpleNamespace(id=branch_id, msgs=SimpleNamespace(messages=[]))
+        tool = messenger.bind(branch, roster={}, sender_name="worker-1")
+
+        result = tool.func_callable(action="help", content="need authority", urgency="blocked")
+
+        assert "sent a help signal" in result
+        assert env._escalated_evidence == [
+            {"kind": "help_signal", "id": "worker-1", "label": "need authority"}
+        ]
+
+
+class TestExecuteDagMergesHelpEvidenceWithEscalation:
+    """Regression for the merge at flow.py's post-execution evidence-fold
+    (~line 1042): a blocked help signal recorded via make_help_coordinator
+    onto env._escalated_evidence BEFORE _execute_dag runs must survive
+    alongside a normal DAG-executor escalation reported in dag_result — the
+    fold must APPEND both lists, never overwrite the pre-existing one.
+    Reverting that line back to a plain overwrite
+    (``env._escalated_evidence = escalated_evidence``) drops the help-signal
+    record recorded before the run; this test fails against that form."""
+
+    @pytest.mark.asyncio
+    async def test_preseeded_help_evidence_survives_alongside_dag_escalation(self, tmp_path):
+        env = _make_flow_env(tmp_path)
+        env._escalated_evidence = [{"kind": "help_signal", "id": "bob", "label": "cannot proceed"}]
+
+        assignments = [TaskAssignment(task="x", assignee="researcher")]
+        plan_result = _PlanResult(
+            assignments=assignments,
+            agent_ids=["researcher"],
+            dep_indices=[[]],
+            pool=[],
+            budget_preambles={},
+        )
+        dag_state = _DagState(
+            node_ids=["node-0"],
+            known_nodes={"node-0"},
+            deps_by_node={"node-0": []},
+            reactive=False,
+            spawn_roles=set(),
+            role_base={},
+            worker_models=["codex/gpt-5.5"],
+        )
+
+        fake_engine_run = MagicMock()
+        fake_engine_run.run_dag = MagicMock(
+            return_value=_asyncio_coro(
+                {
+                    "operation_results": {},
+                    "spawned_operations": 0,
+                    "escalated_operations": ["node-0"],
+                }
+            )
+        )
+
+        with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+            await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+        assert env._escalated_evidence == [
+            {"kind": "help_signal", "id": "bob", "label": "cannot proceed"},
+            {"kind": "escalated_operation", "id": "researcher", "label": "researcher"},
+        ]

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -298,6 +298,80 @@ async def test_escalation_via_result_extraction():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Help-signal urgency: urgency="fyi" -> "notify" route, non-hanging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_signal_fyi_defaults_to_notify_route():
+    """A soft ('fyi') EscalationRequest defaults to route='notify': NodeEscalated
+    still fires for visibility, but the op is neither retried nor marked
+    escalated — the help-signal channel is orthogonal to the op's own
+    completion (an unanswered help signal must never hang the worker)."""
+    escalated_signals: list[NodeEscalated] = []
+
+    async def chatty(**kw):
+        return EscalationRequest(reason="fyi, just letting you know", urgency="fyi")
+
+    session = _session(chatty=chatty)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("chatty")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+    await asyncio.sleep(0)
+
+    assert len(escalated_signals) >= 1
+    assert escalated_signals[0].route == "notify"
+    assert result["spawned_operations"] == 0
+    assert result["escalated_operations"] == []
+
+
+@pytest.mark.asyncio
+async def test_help_signal_blocked_urgency_preserves_higher_tier_default():
+    """Back-compat: urgency='blocked' (the default) preserves the historical
+    higher_tier retry when no explicit route is given."""
+
+    async def stuck(**kw):
+        return EscalationRequest(reason="blocked", urgency="blocked")
+
+    session = _session(stuck=stuck)
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("stuck")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+
+    assert result["spawned_operations"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_help_signal_explicit_route_overrides_urgency_default():
+    """An explicit context['route'] always wins over the urgency-derived default."""
+
+    async def soft_but_explicit_giveup(**kw):
+        return EscalationRequest(
+            reason="fyi but give up anyway",
+            urgency="fyi",
+            context={"route": "give_up"},
+        )
+
+    session = _session(soft_but_explicit_giveup=soft_but_explicit_giveup)
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("soft_but_explicit_giveup")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+
+    assert result["spawned_operations"] == 0
+    assert len(result["escalated_operations"]) >= 1
+
+
 @pytest.mark.asyncio
 async def test_escalation_observer_failure_does_not_change_flow_result(caplog, monkeypatch):
     """A raising session.emit() (NodeEscalated observer) is consumed and logged;

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -97,6 +97,39 @@ def test_lane_for_escalated_via_structured_output():
     assert lane_for([NodeStarted(), so]) == "escalated"
 
 
+def test_lane_for_fyi_help_signal_via_node_escalated_is_not_terminal():
+    """A soft ('fyi') help signal is informational only — it must not pin
+    the node into the terminal 'escalated' lane (urgency reconciliation:
+    urgency='blocked' is the only urgency that projects to 'escalated')."""
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="fyi", urgency="fyi")
+    sig = NodeEscalated(op_id="x", name="x", reason="fyi", route="notify", escalation_request=req)
+    # lane stays at the last real state ('running'), not pinned to 'escalated'.
+    assert lane_for([NodeStarted(), sig]) == "running"
+
+
+def test_lane_for_fyi_help_signal_via_structured_output_is_not_terminal():
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="fyi", urgency="fyi")
+    so = StructuredOutput(data=req)
+    # lane stays at the last real state ('running'), not pinned to 'escalated'.
+    assert lane_for([NodeStarted(), so]) == "running"
+
+
+def test_lane_for_blocked_help_signal_via_node_escalated_is_terminal():
+    """urgency='blocked' (explicit or default) still projects to 'escalated' —
+    this preserves the original give_up/higher_tier behavior exactly."""
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="blocked", urgency="blocked")
+    sig = NodeEscalated(
+        op_id="x", name="x", reason="blocked", route="give_up", escalation_request=req
+    )
+    assert lane_for([NodeStarted(), sig]) == "escalated"
+
+
 def test_lane_for_terminal_sticky_succeeded():
     signals = [NodeStarted(), NodeCompleted(), NodeFailed()]
     assert lane_for(signals) == "succeeded"

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -3,6 +3,7 @@
 
 """Coverage tests for LionMessenger."""
 
+import logging
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -49,6 +50,7 @@ class TestMessengerActionEnum:
         assert MessengerAction.done == "done"
         assert MessengerAction.finished == "finished"
         assert MessengerAction.wakeup == "wakeup"
+        assert MessengerAction.help == "help"
 
 
 class TestMessengerRequestModel:
@@ -91,6 +93,16 @@ class TestLionMessengerBasics:
         result = m._fire("done", name="x")
         assert result is None
         assert "done" not in m._callbacks
+
+    def test_fire_no_callback_logs_debug(self, caplog):
+        """A mis-wired coordinator (no .on() registered) must be discoverable
+        during bring-up: the no-op is debug-logged, not fully silent."""
+        m = LionMessenger(exchange=Exchange())
+        with caplog.at_level(logging.DEBUG, logger="lionagi.tools.communication.messenger"):
+            m._fire("help", name="x", reason="stuck", urgency="fyi")
+        assert any(
+            "no callback registered" in r.message and "help" in r.message for r in caplog.records
+        )
 
 
 class TestMessengerBindSend:
@@ -197,6 +209,115 @@ class TestMessengerBindStateEvents:
         result = tool.func_callable(action="done", content="ok")
         # sender_name defaults to str(branch.id)[:8]
         assert str(branch.id)[:8] in result
+
+    def test_done_callback_raising_propagates_to_caller(self):
+        """Unlike 'help', 'done' is not a fire-and-continue channel: a
+        raising state-recording callback must surface to the messenger
+        caller, not be swallowed behind a success string — otherwise the
+        caller believes the state update landed when it didn't."""
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+
+        def _boom(**kw):
+            raise RuntimeError("state store unavailable")
+
+        m.on("done", _boom)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        with pytest.raises(RuntimeError, match="state store unavailable"):
+            tool.func_callable(action="done", content="task complete")
+
+    def test_finished_callback_raising_propagates_to_caller(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+
+        def _boom(**kw):
+            raise RuntimeError("state store unavailable")
+
+        m.on("finished", _boom)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        with pytest.raises(RuntimeError, match="state store unavailable"):
+            tool.func_callable(action="finished", content="forever")
+
+    def test_wakeup_callback_raising_propagates_to_caller(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+
+        def _boom(**kw):
+            raise RuntimeError("state store unavailable")
+
+        m.on("wakeup", _boom)
+        alice_id = uuid4()
+        ex.register(alice_id)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={"alice": alice_id}, sender_name="bob")
+        with pytest.raises(RuntimeError, match="state store unavailable"):
+            tool.func_callable(action="wakeup", to="alice", content="wake up")
+
+
+class TestMessengerBindHelp:
+    def test_help_missing_content(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={})
+        result = tool.func_callable(action="help")
+        assert "Error" in result and "'content'" in result
+
+    def test_help_fires_callback_with_default_fyi_urgency(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        events = []
+        m.on("help", lambda **kw: events.append(kw))
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        result = tool.func_callable(action="help", content="not sure who to ask")
+        assert "help signal" in result
+        assert "fyi" in result
+        assert events[0]["name"] == "bob"
+        assert events[0]["reason"] == "not sure who to ask"
+        assert events[0]["urgency"] == "fyi"
+
+    def test_help_fires_callback_with_blocked_urgency(self):
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        events = []
+        m.on("help", lambda **kw: events.append(kw))
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        result = tool.func_callable(action="help", content="cannot proceed", urgency="blocked")
+        assert "blocked" in result
+        assert events[0]["urgency"] == "blocked"
+
+    def test_help_returns_immediately_never_blocks_on_missing_callback(self):
+        """Fire-and-continue: no callback registered -> still a normal,
+        immediate return (never a hang, never an exception)."""
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        result = tool.func_callable(action="help", content="stuck")
+        assert "sent a help signal" in result
+
+    def test_help_returns_immediately_even_if_callback_raises(self, caplog):
+        """A raising coordinator callback must not propagate into the
+        worker's tool-call turn — the help channel is fire-and-continue.
+        The worker still gets its acknowledgment string; the failure is
+        logged, not swallowed silently."""
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+
+        def _boom(**kw):
+            raise RuntimeError("coordinator exploded")
+
+        m.on("help", _boom)
+        branch = _make_branch(ex)
+        tool = m.bind(branch, roster={}, sender_name="bob")
+        with caplog.at_level(logging.WARNING, logger="lionagi.tools.communication.messenger"):
+            result = tool.func_callable(action="help", content="stuck")
+        assert "sent a help signal" in result
+        assert any("callback for event='help' raised" in r.message for r in caplog.records)
 
 
 class TestMessengerBindWakeup:


### PR DESCRIPTION
First dependent implementation of the approved help-signal/escalation design (Lane C, SPEC-gated).

- `EscalationRequest.urgency: Literal["fyi","blocked"]` (default blocked); `blocking` becomes a derived read-only property; legacy `blocking=` kwarg maps through a before-validator.
- Routing derives from urgency: **fyi → notify** (non-terminal), **blocked → higher_tier**; the session signal projection emits the terminal escalated lane only for blocked.
- Messenger `help` action is fire-and-continue: a raising help callback logs and the worker turn still acks; done/finished/wakeup callbacks keep their propagate-on-raise contract (regression-pinned both ways).
- Flow orchestration wires a help coordinator at messenger construction (flow only — fanout deliberately untouched, byte-identical to HEAD) and merges pre-existing help evidence with DAG-reported escalations instead of overwriting (regression drives the real `_execute_dag`).

Review: round 1 APPROVE-WITH-FIXES (3 findings), all fixed with fail-without-fix evidence; round 2 narrow re-review **clean APPROVE** with an independent mutation check on the evidence-merge fix. Targeted suites green (messenger, casts, orchestrate, escalation routing, lifecycle signals — 112 passed on the landing branch).

Lane C: first dependent impl of a gated spec — full read requested.