### PR TITLE
fix(studio): session SSE polling crashes with 'too many SQL variables' past SQLite's bind limit

### DIFF
--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -652,59 +652,38 @@ async def get_session(
 
 
 async def get_session_messages_after(session_id: str, after_ts: float) -> list[dict[str, Any]]:
+    """Poll-friendly tail read for the SSE stream/signals endpoints.
+
+    Joins each branch's progression collection via json_each rather than binding
+    every message id into an IN (...) clause — a branch with thousands of messages
+    would otherwise blow past SQLite's 999 bound-variable limit (OperationalError:
+    too many SQL variables), killing the stream on every poll tick.
+    """
     if not DEFAULT_DB_PATH.exists():
         return []
 
     async with _open_db(_DB) as db:
-        branch_cur = await db.execute(
-            "SELECT id, progression_id FROM branches WHERE session_id = ?",
-            (session_id,),
+        cur = await db.execute(
+            """
+            SELECT m.id, m.created_at, m.content, m.sender, m.role,
+                   mt.lion_class AS lion_class_str, b.id AS branch_id
+            FROM branches b
+            JOIN progressions p ON p.id = b.progression_id
+            JOIN json_each(p.collection) je ON 1=1
+            JOIN messages m ON m.id = je.value
+            LEFT JOIN message_types mt ON m.lion_class = mt.type_id
+            WHERE b.session_id = ? AND m.created_at > ?
+            ORDER BY m.created_at
+            """,
+            (session_id, after_ts),
         )
-        branch_rows = await branch_cur.fetchall()
+        rows = await cur.fetchall()
 
-        result = []
-        for br in branch_rows:
-            branch_id = br["id"]
-            prog_id = br["progression_id"]
-            if not prog_id:
-                continue
-
-            prog_cur = await db.execute(
-                "SELECT collection FROM progressions WHERE id = ?",
-                (prog_id,),
-            )
-            prog_row = await prog_cur.fetchone()
-            if not prog_row or not prog_row["collection"]:
-                continue
-
-            try:
-                msg_ids = json.loads(prog_row["collection"])
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            if not msg_ids:
-                continue
-
-            placeholders = ",".join("?" for _ in msg_ids)
-            msg_cur = await db.execute(
-                f"""
-                SELECT m.id, m.created_at, m.content, m.sender, m.role,
-                       mt.lion_class AS lion_class_str
-                FROM messages m
-                LEFT JOIN message_types mt ON m.lion_class = mt.type_id
-                WHERE m.id IN ({placeholders}) AND m.created_at > ?
-                """,  # noqa: S608
-                (*msg_ids, after_ts),
-            )
-            msg_rows = await msg_cur.fetchall()
-            by_id = {r["id"]: r for r in msg_rows}
-
-            for mid in msg_ids:
-                if mid in by_id:
-                    msg = _format_message(by_id[mid])
-                    msg["branch_id"] = branch_id
-                    result.append(msg)
-
+    result = []
+    for row in rows:
+        msg = _format_message(row)
+        msg["branch_id"] = row["branch_id"]
+        result.append(msg)
     return result
 
 

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -579,7 +579,10 @@ async def test_get_session_messages_after_filters_by_timestamp(patched_sessions_
     assert result[0]["branch_id"] == "br-ts"
 
 
-async def test_get_session_messages_after_preserves_progression_order(patched_sessions_db):
+async def test_get_session_messages_after_orders_by_created_at(patched_sessions_db):
+    """get_session_messages_after is a cursor-driven SSE tail read — it orders by
+    created_at (not raw progression order) so after_ts can advance monotonically
+    even when a branch's progression collection is not itself chronological."""
     svc, db_path = patched_sessions_db
     await seed_session(db_path, session_id="sess-order")
     # progression lists m-second before m-first (reverse of creation timestamp)
@@ -613,8 +616,8 @@ async def test_get_session_messages_after_preserves_progression_order(patched_se
     result = await svc.get_session_messages_after("sess-order", 0.0)
 
     assert len(result) == 2
-    assert result[0]["id"] == "m-second"
-    assert result[1]["id"] == "m-first"
+    assert result[0]["id"] == "m-first"
+    assert result[1]["id"] == "m-second"
 
 
 async def test_get_session_messages_after_aggregates_across_branches(patched_sessions_db):
@@ -668,6 +671,103 @@ async def test_get_session_messages_after_empty_progression_is_skipped(patched_s
 
     result = await svc.get_session_messages_after("sess-emptyprog", 0.0)
     assert result == []
+
+
+async def test_get_session_messages_after_handles_branch_over_sqlite_variable_limit(
+    patched_sessions_db,
+):
+    """Regression: a branch whose progression collection holds more message ids than
+    SQLite's bound-variable limit used to blow up get_session_messages_after with
+    sqlite3.OperationalError("too many SQL variables") on every 0.5s SSE poll, killing
+    the stream for any long-lived session (the classic SQLite default is 999; this
+    build's default, per PRAGMA compile_options MAX_VARIABLE_NUMBER, is 32766 — 33000
+    exceeds both so the test reproduces the failure regardless of build). The
+    json_each-joined query has no per-message bind variable, so it must return every
+    id without error. Only the progression collection needs to be this large — the
+    corresponding message rows are irrelevant to the bind-limit failure itself, so
+    this seeds ids without materializing 33000 message rows (keeps the test fast)."""
+    svc, db_path = patched_sessions_db
+    await seed_session(db_path, session_id="sess-huge")
+    count = 33000
+    msg_ids = [f"huge-{i}" for i in range(count)]
+    await seed_branch(db_path, branch_id="br-huge", session_id="sess-huge", msg_ids=msg_ids)
+    # A handful of real message rows (including one outside the msg_ids progression,
+    # and one before after_ts) prove the join+filter still behave correctly at scale.
+    async with StateDB(db_path) as db:
+        await db.insert_message(
+            {
+                "id": "huge-0",
+                "created_at": 50.0,
+                "content": {"text": "too old"},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "assistant",
+                "node_metadata": {},
+            }
+        )
+        await db.insert_message(
+            {
+                "id": "huge-1",
+                "created_at": 150.0,
+                "content": {"text": "in range"},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "assistant",
+                "node_metadata": {},
+            }
+        )
+
+    result = await svc.get_session_messages_after("sess-huge", 100.0)
+
+    assert result == [
+        {
+            "id": "huge-1",
+            "role": "assistant",
+            "content": {"text": "in range"},
+            "sender": "worker",
+            "timestamp": 150.0,
+            "lion_class": "__unknown__",
+            "branch_id": "br-huge",
+        }
+    ]
+
+
+async def test_get_session_messages_after_message_shape_matches_expected_fields(
+    patched_sessions_db,
+):
+    """Message shape parity: id/created_at/content/sender/role/lion_class/branch_id
+    must be present and match the pre-fix _format_message() output exactly."""
+    svc, db_path = patched_sessions_db
+    await seed_session(db_path, session_id="sess-shape")
+    await seed_branch(db_path, branch_id="br-shape", session_id="sess-shape", msg_ids=["shape-1"])
+    async with StateDB(db_path) as db:
+        await db.insert_message(
+            {
+                "id": "shape-1",
+                "created_at": 111.0,
+                "content": {"text": "hello shape"},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "assistant",
+                "node_metadata": {
+                    "lion_class": "lionagi.protocols.messages.assistant_response.AssistantResponse"
+                },
+            }
+        )
+
+    result = await svc.get_session_messages_after("sess-shape", 0.0)
+
+    assert result == [
+        {
+            "id": "shape-1",
+            "role": "assistant",
+            "content": {"text": "hello shape"},
+            "sender": "worker",
+            "timestamp": 111.0,
+            "lion_class": "lionagi.protocols.messages.assistant_response.AssistantResponse",
+            "branch_id": "br-shape",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2052 (the "Studio very slow with many live streams" report).

**Root cause (measured on the live DB):** `get_session_messages_after` bound every message id of a branch's progression into one `IN (...)` clause. Past SQLite's bound-variable limit the query raises `too many SQL variables` on every 0.5s SSE poll tick; the stream dies, the client reconnects every 2s with its cursor reset to 0, and each open long-session view becomes a permanent crash-reconnect loop saturating the daemon's single aiosqlite worker (biggest current session: 52,489 messages — instant crash).

**Fix:** one `json_each(p.collection)` join per call — two bind variables total regardless of session size, no per-tick `json.loads` of the full collection. Messages now order by `created_at` across branches (previously raw per-branch progression order); the SSE cursor already advances off max timestamp, so cursor semantics are unchanged-but-stricter. Route handlers, poll cadence, and `list_sessions` untouched.

**Regressions:** 33,000-id progression streams without error (proven to raise `OperationalError` against pre-fix code via product-hunk revert), `after_ts` cursor filtering, exact message-shape parity vs a hand-built expected dict, multi-branch aggregation. Full `tests/apps_studio_server/` + `tests/studio/` green (verified independently by the director).

Lane B: contained service fix; the only behavior delta is the documented ordering change.