### PR TITLE
feat(studio): file references in agent messages become clickable artifact links

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.test.ts
+++ b/apps/studio/frontend/src/components/RunStepCard.test.ts
@@ -4,6 +4,7 @@ import {
   runMessagesEqualForMemo,
   stepPropsEqual,
   collapsedTextFor,
+  extractFilePaths,
 } from "./RunStepCard";
 import type { RunMessage, RunStep } from "@/lib/types";
 
@@ -159,5 +160,41 @@ describe("stepPropsEqual", () => {
     const prev = props(step({}, [toolMessage({ sender: "agent-a" })]));
     const next = props(step({}, [toolMessage({ sender: "agent-b" })]));
     expect(stepPropsEqual(prev, next)).toBe(true);
+  });
+});
+
+describe("extractFilePaths — the known file surface behind file links", () => {
+  it("collects file_path/path args from tool_call and action messages", () => {
+    const messages: RunMessage[] = [
+      toolMessage({ function: "Write", arguments: { file_path: "/runs/r1/a/notes.md" } }),
+      toolMessage({
+        role: "action",
+        function: "Edit",
+        arguments: { path: "/runs/r1/a/review.md" },
+      }),
+    ];
+    expect(extractFilePaths(messages).sort()).toEqual(
+      ["/runs/r1/a/notes.md", "/runs/r1/a/review.md"].sort(),
+    );
+  });
+
+  it("dedupes repeated paths across multiple tool calls", () => {
+    const messages: RunMessage[] = [
+      toolMessage({ function: "Read", arguments: { file_path: "/runs/r1/a/notes.md" } }),
+      toolMessage({ function: "Edit", arguments: { file_path: "/runs/r1/a/notes.md" } }),
+    ];
+    expect(extractFilePaths(messages)).toEqual(["/runs/r1/a/notes.md"]);
+  });
+
+  it("ignores non-tool messages (assistant/user/system)", () => {
+    const messages: RunMessage[] = [
+      { role: "assistant", content: "Wrote notes.md" },
+      { role: "user", content: "please write notes.md" },
+    ];
+    expect(extractFilePaths(messages)).toEqual([]);
+  });
+
+  it("returns an empty list when there is no file activity", () => {
+    expect(extractFilePaths([])).toEqual([]);
   });
 });

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -17,6 +17,7 @@ import {
   IconTerminal,
 } from "@/components/ui/icons";
 import type { RunMessage, RunStep } from "@/lib/types";
+import type { FileResolutionContext } from "@/components/ui/Markdown";
 
 const Markdown = lazy(() => import("@/components/ui/Markdown"));
 
@@ -42,6 +43,16 @@ export interface RunStepCardProps {
   defaultExpanded?: boolean;
   expanded?: boolean;
   onToggleExpand?: (stepId: string, next: boolean) => void;
+  /** Run id — enables file-link resolution/viewing in rendered messages. */
+  runId?: string;
+  /** Run's artifact save root (absolute path), for the agent-dir-first
+   * resolution fallback (requirement: bare/relative names resolve against
+   * the emitting agent's own artifact subdir first, then the run root). */
+  artifactRoot?: string | null;
+  /** Known file surface for the WHOLE run (union across all steps/agents),
+   * so a bare filename this step didn't itself touch can still resolve
+   * against a sibling agent's output — the run's save-root fallback. */
+  runFiles?: string[];
 }
 
 const STATUS_TONE: Record<string, "ok" | "pending" | "failed"> = {
@@ -146,7 +157,7 @@ function isEditTool(fn: string): boolean {
   return /Edit|patch/i.test(fn);
 }
 
-function pathFromArgs(args: Record<string, unknown>, summary: string): string[] {
+export function pathFromArgs(args: Record<string, unknown>, summary: string): string[] {
   const out: string[] = [];
   if (args.file_path) out.push(String(args.file_path));
   if (args.path) out.push(String(args.path));
@@ -166,11 +177,27 @@ function pathFromArgs(args: Record<string, unknown>, summary: string): string[] 
   return out;
 }
 
+/** The run's known file surface for one branch's messages — same source
+ * (`pathFromArgs` over tool-call args) the "top files" panel already uses,
+ * reused here for file-link resolution so both stay in lockstep. */
+export function extractFilePaths(messages: RunMessage[]): string[] {
+  const toolMessages = messages.filter((m) => m.role === "tool_call" || m.role === "action");
+  const paths = new Set<string>();
+  for (const t of toolMessages) {
+    const args = (t.arguments as Record<string, unknown>) ?? {};
+    for (const p of pathFromArgs(args, t.summary || "")) paths.add(p);
+  }
+  return Array.from(paths);
+}
+
 function RunStepCard({
   step,
   defaultExpanded = false,
   expanded: expandedProp,
   onToggleExpand,
+  runId,
+  artifactRoot,
+  runFiles,
 }: RunStepCardProps) {
   const t = useTranslations("runCard");
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
@@ -291,6 +318,19 @@ function RunStepCard({
       lastTs,
     };
   }, [messages]);
+
+  // File-link resolution context (shared by the overview + conversation
+  // Markdown renderers): agent dir first, then the run-wide file surface.
+  const fileContext = useMemo<FileResolutionContext | undefined>(() => {
+    if (!runId) return undefined;
+    const agentId = result.agent || step.step;
+    const agentDir =
+      artifactRoot && agentId ? `${artifactRoot.replace(/\/+$/, "")}/${agentId}` : undefined;
+    const knownFiles = Array.from(
+      new Set([...summary.files.map((f) => f.path), ...(runFiles ?? [])]),
+    );
+    return { runId, knownFiles, agentDir };
+  }, [runId, artifactRoot, runFiles, result.agent, step.step, summary.files]);
 
   const tone = STATUS_TONE[step.status] ?? "pending";
 
@@ -475,6 +515,7 @@ function RunStepCard({
                 summary={summary}
                 lastAssistant={lastAssistant}
                 onJumpToConversation={() => setTab("conversation")}
+                fileContext={fileContext}
               />
             </div>
           )}
@@ -553,6 +594,8 @@ function RunStepCard({
                 filters={filters}
                 expandedTools={expandedTools}
                 onToggleTool={toggleTool}
+                stepKey={step.step}
+                fileContext={fileContext}
               />
             </div>
           )}
@@ -606,6 +649,9 @@ export function stepPropsEqual(prev: RunStepCardProps, next: RunStepCardProps): 
     prev.step.timestamp === next.step.timestamp &&
     prevResult.agent === nextResult.agent &&
     prevResult.model === nextResult.model &&
+    prev.runId === next.runId &&
+    prev.artifactRoot === next.artifactRoot &&
+    prev.runFiles === next.runFiles &&
     runMessagesEqualForMemo(prev.step.messages, next.step.messages)
   );
 }
@@ -668,6 +714,7 @@ function OverviewPanel({
   summary,
   lastAssistant,
   onJumpToConversation,
+  fileContext,
 }: {
   summary: {
     toolCount: number;
@@ -679,6 +726,7 @@ function OverviewPanel({
   };
   lastAssistant: RunMessage | null;
   onJumpToConversation: () => void;
+  fileContext?: FileResolutionContext;
 }) {
   const t = useTranslations("runCard");
   return (
@@ -692,7 +740,7 @@ function OverviewPanel({
         {lastAssistant?.content ? (
           <>
             <Suspense fallback={null}>
-              <Markdown className="text-body leading-snug">
+              <Markdown className="text-body leading-snug" fileContext={fileContext}>
                 {lastAssistant.content.length > 1200
                   ? lastAssistant.content.slice(0, 1200) + "\n\n…"
                   : lastAssistant.content}
@@ -901,6 +949,7 @@ interface MessageFeedProps {
   expandedTools: Set<number>;
   onToggleTool: (idx: number) => void;
   stepKey?: string;
+  fileContext?: FileResolutionContext;
 }
 
 const MESSAGE_WINDOW = 80;
@@ -911,6 +960,7 @@ function MessageFeed({
   expandedTools,
   onToggleTool,
   stepKey = "",
+  fileContext,
 }: MessageFeedProps) {
   const t = useTranslations("runCard");
   // Render only the most recent window; long conversations reveal older turns
@@ -960,6 +1010,7 @@ function MessageFeed({
               content={m.content || ""}
               timestamp={m.timestamp}
               ordinal={ordinal}
+              fileContext={fileContext}
             />
           );
         }
@@ -1035,11 +1086,13 @@ function AssistantBlock({
   content,
   timestamp,
   ordinal,
+  fileContext,
 }: {
   anchorId: string;
   content: string;
   timestamp?: number | null;
   ordinal: number;
+  fileContext?: FileResolutionContext;
 }) {
   const t = useTranslations("runCard");
   const isThinking = content.startsWith("[thinking]");
@@ -1078,7 +1131,9 @@ function AssistantBlock({
         </p>
       ) : (
         <Suspense fallback={null}>
-          <Markdown className="text-body leading-snug">{displayText}</Markdown>
+          <Markdown className="text-body leading-snug" fileContext={fileContext}>
+            {displayText}
+          </Markdown>
         </Suspense>
       )}
     </div>

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -218,6 +218,61 @@ describe("history/RunDetail.tsx — shouldRenderAuthoredGraph", () => {
   });
 });
 
+// ─── runFiles seeds from the server's full-session file union ────────────────
+// Sessions are windowed to SESSION_MESSAGE_PAGE (200) messages (lib/api.ts).
+// A step's own messages therefore cannot resolve a file reference that was
+// touched earlier in a long session — the server already computes the full
+// union over every branch's whole progression (services/sessions.py
+// _branch_message_stats -> get_session's message_stats.files) and returns it
+// on SessionDetail. runFiles must seed from that surface, not just the
+// loaded steps.
+
+describe("history/RunDetail.tsx — runFiles seeds from session.message_stats.files", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+
+  it("unions the server-side full-session file surface into runFiles", () => {
+    expect(src).toMatch(/session\?\.message_stats\?\.files/);
+  });
+
+  it("runFiles depends on session, not steps alone, so a server-only update refreshes it", () => {
+    const start = src.indexOf("const runFiles = useMemo(");
+    const end = src.indexOf(";", src.indexOf("}, [", start));
+    const block = src.slice(start, end);
+    expect(block).toMatch(/\[steps, session\]/);
+  });
+});
+
+describe("runFiles union logic (mirrors the useMemo body) — file outside the loaded window resolves", () => {
+  // Mirrors: const set = new Set(session?.message_stats?.files ?? []);
+  //          for (const step of steps) for (const p of extractFilePaths(...)) set.add(p);
+  function computeRunFiles(
+    serverFiles: string[] | undefined,
+    stepDerivedFiles: string[],
+  ): string[] {
+    const set = new Set<string>(serverFiles ?? []);
+    for (const p of stepDerivedFiles) set.add(p);
+    return Array.from(set);
+  }
+
+  it("includes a file only present in the server's full-session union (touched before the 200-message tail window)", () => {
+    const serverUnion = ["consolidatedfixspec.md", "review.md"]; // computed over the FULL progression
+    const loadedStepFiles = ["review.md"]; // only what's in the windowed tail
+    const result = computeRunFiles(serverUnion, loadedStepFiles);
+    expect(result).toContain("consolidatedfixspec.md");
+    expect(result).toContain("review.md");
+  });
+
+  it("still includes client-derived files the server union happens to miss (defensive union, not a replacement)", () => {
+    const result = computeRunFiles(["a.md"], ["b.md"]);
+    expect(result.sort()).toEqual(["a.md", "b.md"]);
+  });
+
+  it("degrades gracefully when message_stats is absent (older/partial session payloads)", () => {
+    const result = computeRunFiles(undefined, ["c.md"]);
+    expect(result).toEqual(["c.md"]);
+  });
+});
+
 describe("stale-write guard predicate (mirrors the done handler's merge condition)", () => {
   function mergeIfSameSession(
     prev: { id: string; status: string } | null,

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -935,13 +935,17 @@ export default function RunDetail({ id }: RunDetailProps) {
   // Run-wide known file surface (union across every step/agent branch) —
   // the file-link resolver's save-root fallback when a bare filename isn't
   // in the emitting agent's own step but was written by a sibling agent.
+  // Steps only cover the loaded (tail-windowed) messages, so a reference to
+  // a file touched earlier in a long session can't resolve from steps alone
+  // — seed/merge with the server's full-session union (message_stats.files),
+  // which is computed over every branch's full progression, not the window.
   const runFiles = useMemo(() => {
-    const set = new Set<string>();
+    const set = new Set<string>(session?.message_stats?.files ?? []);
     for (const step of steps) {
       for (const p of extractFilePaths(step.messages ?? [])) set.add(p);
     }
     return Array.from(set);
-  }, [steps]);
+  }, [steps, session]);
 
   const errors = useMemo(() => {
     const errs: ErrorEntry[] = [];

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -12,7 +12,7 @@ import InvocationSection from "@/components/history/InvocationDetail";
 import OperationGraphSection from "@/components/history/OperationGraphSection";
 import StatusVerdictChips from "@/components/ui/StatusVerdictChips";
 import ExpectedArtifacts from "@/components/runs/ExpectedArtifacts";
-import RunStepCard from "@/components/RunStepCard";
+import RunStepCard, { extractFilePaths } from "@/components/RunStepCard";
 import { IconChevronDown, IconChevronRight } from "@/components/ui/icons";
 import { getSession, streamSession, streamSignals, SESSION_MESSAGE_PAGE } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage, SignalEvent } from "@/lib/api";
@@ -303,11 +303,17 @@ function BranchesSection({
   live,
   expandedSteps,
   onToggleExpand,
+  runId,
+  artifactRoot,
+  runFiles,
 }: {
   steps: RunStep[];
   live: boolean;
   expandedSteps: Set<string>;
   onToggleExpand: (stepId: string, next: boolean) => void;
+  runId?: string;
+  artifactRoot?: string | null;
+  runFiles?: string[];
 }) {
   const t = useTranslations("history.detail");
   return (
@@ -335,6 +341,9 @@ function BranchesSection({
               step={step}
               expanded={expandedSteps.has(step.step)}
               onToggleExpand={onToggleExpand}
+              runId={runId}
+              artifactRoot={artifactRoot}
+              runFiles={runFiles}
             />
           ))
         )}
@@ -923,6 +932,17 @@ export default function RunDetail({ id }: RunDetailProps) {
     return result;
   }, [session, sessionStatus, segments]);
 
+  // Run-wide known file surface (union across every step/agent branch) —
+  // the file-link resolver's save-root fallback when a bare filename isn't
+  // in the emitting agent's own step but was written by a sibling agent.
+  const runFiles = useMemo(() => {
+    const set = new Set<string>();
+    for (const step of steps) {
+      for (const p of extractFilePaths(step.messages ?? [])) set.add(p);
+    }
+    return Array.from(set);
+  }, [steps]);
+
   const errors = useMemo(() => {
     const errs: ErrorEntry[] = [];
     for (const step of steps) {
@@ -1137,6 +1157,9 @@ export default function RunDetail({ id }: RunDetailProps) {
         live={live}
         expandedSteps={expandedSteps}
         onToggleExpand={handleToggleExpand}
+        runId={session.id}
+        artifactRoot={session.artifacts_path}
+        runFiles={runFiles}
       />
       <ErrorsSection errors={errors} partial={partialWindow} />
       <FilesSection files={files} partial={partialWindow} />

--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Markdown.tsx file-link wiring — source-contract tests (see
+ * history/InvocationDetail.test.tsx / shell/NoDaemonGate.test.tsx: this
+ * project has no @testing-library/react, so component wiring is verified
+ * against the source rather than a live render). The resolution algorithm
+ * itself (agent-dir-first precedence, disambiguation, no-match) is unit
+ * tested directly in fileRefs.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(__dirname, "Markdown.tsx"), "utf-8");
+
+describe("Markdown.tsx — file-link resolution wiring", () => {
+  it("is opt-in via a fileContext prop (existing callers unaffected)", () => {
+    expect(SRC).toMatch(/fileContext\?:\s*FileResolutionContext/);
+  });
+
+  it("resolves markdown-link targets (the `a` renderer) through resolveFileRef", () => {
+    expect(SRC).toMatch(/a:\s*\(props\)\s*=>/);
+    expect(SRC).toMatch(/resolveFileRef/);
+  });
+
+  it("resolves bare inline-code filenames (the `code` renderer) via the conservative heuristic", () => {
+    expect(SRC).toMatch(/code:\s*\(props\)\s*=>/);
+    expect(SRC).toMatch(/looksLikeFilename\(text\)/);
+  });
+
+  it("only treats code spans with no language className as filename candidates (not every code span)", () => {
+    expect(SRC).toMatch(/!codeClassName && looksLikeFilename\(text\)/);
+  });
+
+  it("leaves http(s)/mailto links as normal anchors, never intercepted", () => {
+    expect(SRC).toMatch(/\/\^\(https\?:\|mailto:\)\//i);
+  });
+
+  it("falls back to the original element when there is no match (stays plain text)", () => {
+    expect(SRC).toMatch(/return <>\{fallback\}<\/>/);
+  });
+
+  it("renders a disambiguation menu for ambiguous multi-file matches", () => {
+    expect(SRC).toMatch(/candidates/);
+    expect(SRC).toMatch(/menuOpen/);
+  });
+
+  it("fetches content on click via getRunFile", () => {
+    expect(SRC).toMatch(/getRunFile\(runId, path\)/);
+  });
+
+  it("renders a graceful missing-file state on a click-time 404", () => {
+    expect(SRC).toMatch(/result\.status === 404/);
+    expect(SRC).toMatch(/status: "missing"/);
+    expect(SRC).toMatch(/File not found/);
+  });
+
+  it("renders a distinct error state for non-404 failures (not just a crash)", () => {
+    expect(SRC).toMatch(/status: "error"/);
+  });
+
+  it("never fabricates a target from text alone — file surface comes only from fileContext.knownFiles", () => {
+    expect(SRC).toMatch(/knownFiles: fileContext\.knownFiles/);
+  });
+});

--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -58,6 +58,16 @@ describe("Markdown.tsx — file-link resolution wiring", () => {
     expect(SRC).toMatch(/status: "error"/);
   });
 
+  it("handles a rejected getRunFile promise (network failure) instead of leaving the modal stuck loading", () => {
+    // getRunFile rethrows on a fetch() network error rather than resolving
+    // an { ok: false } shape (see lib/api.ts) — the effect chain must attach
+    // a .catch, not just a bare .then, or a dropped connection leaves the
+    // modal in "loading" forever.
+    expect(SRC).toMatch(/getRunFile\(runId, path\)\s*\.then\(/);
+    expect(SRC).toMatch(/\.catch\(\s*\(err\)\s*=>\s*\{/);
+    expect(SRC).toMatch(/setState\(\{ status: "error", detail: err instanceof Error/);
+  });
+
   it("never fabricates a target from text alone — file surface comes only from fileContext.knownFiles", () => {
     expect(SRC).toMatch(/knownFiles: fileContext\.knownFiles/);
   });

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -132,19 +132,27 @@ function FileViewerModal({
 
   useEffect(() => {
     let cancelled = false;
-    getRunFile(runId, path).then((result) => {
-      if (cancelled) return;
-      if (!result.ok) {
-        if (result.status === 404) setState({ status: "missing" });
-        else setState({ status: "error", detail: result.detail });
-        return;
-      }
-      setState({
-        status: "ready",
-        content: result.data.content,
-        truncated: result.data.truncated,
+    getRunFile(runId, path)
+      .then((result) => {
+        if (cancelled) return;
+        if (!result.ok) {
+          if (result.status === 404) setState({ status: "missing" });
+          else setState({ status: "error", detail: result.detail });
+          return;
+        }
+        setState({
+          status: "ready",
+          content: result.data.content,
+          truncated: result.data.truncated,
+        });
+      })
+      .catch((err) => {
+        // getRunFile rethrows on network failure (fetch reject) rather than
+        // resolving an { ok: false } shape — without this the modal is stuck
+        // in "loading" forever on a dropped connection.
+        if (cancelled) return;
+        setState({ status: "error", detail: err instanceof Error ? err.message : undefined });
       });
-    });
     return () => {
       cancelled = true;
     };

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -1,17 +1,263 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { getRunFile } from "@/lib/api";
+import { looksLikeFilename, resolveFileRef } from "@/lib/fileRefs";
+import { IconFile, IconWarning } from "./icons";
+import Modal from "./Modal";
+
+export interface FileResolutionContext {
+  /** Run this message belongs to — used to fetch content on click. */
+  runId: string;
+  /** Absolute paths known to belong to this run (the step's own "top files",
+   * derived from tool-call args) — the ONLY source of truth for what a
+   * reference is allowed to resolve to. Never fabricated from text. */
+  knownFiles: string[];
+  /** The emitting agent's own artifact subdir, checked first on ambiguity. */
+  agentDir?: string | null;
+}
 
 export interface MarkdownProps {
   children: string;
   className?: string;
+  /** Enables file-reference resolution (markdown links + bare filenames)
+   * into clickable, in-Studio file-viewer links. Omit to render plain
+   * markdown with no file-link behavior (existing callers unaffected). */
+  fileContext?: FileResolutionContext;
 }
 
-export default function Markdown({ children, className }: MarkdownProps) {
+function FileRefLink({
+  label,
+  path,
+  candidates,
+  onOpen,
+}: {
+  label: string;
+  path?: string;
+  candidates?: string[];
+  onOpen: (path: string) => void;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  if (path) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpen(path)}
+        className="inline-flex items-center gap-0.5 rounded bg-surface-overlay px-1 font-mono text-[0.9em] text-status-running underline decoration-dotted hover:text-status-running/80"
+        title={path}
+      >
+        <IconFile size={11} strokeWidth={2} />
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <span className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setMenuOpen((v) => !v)}
+        className="inline-flex items-center gap-0.5 rounded bg-surface-overlay px-1 font-mono text-[0.9em] text-status-running underline decoration-dotted decoration-wavy hover:text-status-running/80"
+        title="Multiple files match — choose one"
+      >
+        <IconFile size={11} strokeWidth={2} />
+        {label}
+      </button>
+      {menuOpen && (
+        <div className="absolute left-0 top-full z-20 mt-1 min-w-max rounded border border-edge bg-surface-raised p-1 shadow-card">
+          {(candidates ?? []).map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                onOpen(c);
+              }}
+              className="block w-full truncate rounded px-2 py-1 text-left font-mono text-meta text-content-secondary hover:bg-surface-overlay"
+              title={c}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+      )}
+    </span>
+  );
+}
+
+function FileRef({
+  raw,
+  label,
+  fallback,
+  fileContext,
+  onOpen,
+}: {
+  raw: string;
+  label: string;
+  fallback: ReactNode;
+  fileContext: FileResolutionContext;
+  onOpen: (path: string) => void;
+}) {
+  const match = resolveFileRef(raw, {
+    knownFiles: fileContext.knownFiles,
+    agentDir: fileContext.agentDir,
+  });
+  if (match.type === "single")
+    return <FileRefLink label={label} path={match.path} onOpen={onOpen} />;
+  if (match.type === "ambiguous")
+    return <FileRefLink label={label} candidates={match.candidates} onOpen={onOpen} />;
+  return <>{fallback}</>;
+}
+
+function FileViewerModal({
+  runId,
+  path,
+  onClose,
+}: {
+  runId: string;
+  path: string;
+  onClose: () => void;
+}) {
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; content: string; truncated: boolean }
+    | { status: "missing" }
+    | { status: "error"; detail?: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    getRunFile(runId, path).then((result) => {
+      if (cancelled) return;
+      if (!result.ok) {
+        if (result.status === 404) setState({ status: "missing" });
+        else setState({ status: "error", detail: result.detail });
+        return;
+      }
+      setState({
+        status: "ready",
+        content: result.data.content,
+        truncated: result.data.truncated,
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId, path]);
+
+  return (
+    <Modal
+      title={path.split("/").pop() ?? path}
+      closeLabel="Close file viewer"
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+    >
+      <div className="max-h-[70vh] overflow-auto p-4">
+        {state.status === "loading" && <p className="text-body text-content-muted">Loading…</p>}
+        {state.status === "missing" && (
+          <p className="flex items-center gap-1.5 text-body text-content-muted">
+            <IconWarning size={12} strokeWidth={2} />
+            File not found — it may have been moved or deleted since this message was written.
+          </p>
+        )}
+        {state.status === "error" && (
+          <p className="flex items-center gap-1.5 text-body text-status-error">
+            <IconWarning size={12} strokeWidth={2} />
+            {state.detail ?? "Could not load this file."}
+          </p>
+        )}
+        {state.status === "ready" && (
+          <>
+            <pre className="whitespace-pre-wrap break-words font-mono text-[length:var(--t-xs)] leading-relaxed text-content-secondary">
+              {state.content}
+            </pre>
+            {state.truncated && (
+              <p className="mt-2 text-meta text-content-muted">
+                File truncated — showing the first portion only.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export default function Markdown({ children, className, fileContext }: MarkdownProps) {
+  const [openPath, setOpenPath] = useState<string | null>(null);
+
+  const components: Components | undefined = fileContext
+    ? {
+        a: (props) => {
+          const { href, children: linkChildren } = props;
+          const label = typeof linkChildren === "string" ? linkChildren : (href ?? "");
+          if (!href || /^(https?:|mailto:)/i.test(href)) {
+            return (
+              <a href={href} target="_blank" rel="noreferrer noopener">
+                {linkChildren}
+              </a>
+            );
+          }
+          return (
+            <FileRef
+              raw={href}
+              label={label}
+              fallback={
+                <a href={href} target="_blank" rel="noreferrer noopener">
+                  {linkChildren}
+                </a>
+              }
+              fileContext={fileContext}
+              onOpen={setOpenPath}
+            />
+          );
+        },
+        code: (props) => {
+          const { className: codeClassName, children: codeChildren, ...rest } = props;
+          const text = typeof codeChildren === "string" ? codeChildren : String(codeChildren ?? "");
+          // Fenced code blocks carry a `language-*` className; only bare
+          // inline spans (no className) are candidate filenames.
+          if (!codeClassName && looksLikeFilename(text)) {
+            return (
+              <FileRef
+                raw={text}
+                label={text}
+                fallback={
+                  <code className={codeClassName} {...rest}>
+                    {codeChildren}
+                  </code>
+                }
+                fileContext={fileContext}
+                onOpen={setOpenPath}
+              />
+            );
+          }
+          return (
+            <code className={codeClassName} {...rest}>
+              {codeChildren}
+            </code>
+          );
+        },
+      }
+    : undefined;
+
   return (
     <div className={["markdown-body", className].filter(Boolean).join(" ")}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {children}
+      </ReactMarkdown>
+      {fileContext && openPath && (
+        <FileViewerModal
+          runId={fileContext.runId}
+          path={openPath}
+          onClose={() => setOpenPath(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -635,6 +635,17 @@ export interface SessionDetail {
   // Absolute artifact-root path on disk (services/sessions.py get_session
   // returns this verbatim) — the run's save root for file-link resolution.
   artifacts_path?: string | null;
+  // Full-session aggregate (services/sessions.py get_session, computed over
+  // every branch's full progression, not the display window) — `files` is
+  // the run-wide known-file union, including files touched before the
+  // 200-message tail window this response's `branches[].messages` covers.
+  message_stats?: {
+    message_count: number;
+    roles: Record<string, number>;
+    tool_call_count: number;
+    error_count: number;
+    files: string[];
+  };
 }
 
 export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -227,6 +227,48 @@ export async function getRun(runId: string): Promise<RunDetail> {
   return fetchJson<RunDetail>(`/api/runs/${encodeURIComponent(runId)}`);
 }
 
+export interface RunFileContent {
+  path: string;
+  content: string;
+  size: number;
+  truncated: boolean;
+}
+
+export type RunFileResult =
+  | { ok: true; data: RunFileContent }
+  | { ok: false; status: number; detail?: string };
+
+/** Read-only fetch of a run artifact's content, for the message-renderer's
+ * file viewer. Reports status/detail on failure (rather than throwing) so
+ * the click-time 404/403 path renders a graceful missing-file state instead
+ * of an unhandled error. */
+export async function getRunFile(runId: string, path: string): Promise<RunFileResult> {
+  const query = new URLSearchParams({ path });
+  const url = `${API_BASE}/api/runs/${encodeURIComponent(runId)}/file?${query.toString()}`;
+  const token = resolveAuthToken();
+  const headers: HeadersInit = {};
+  if (token) (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (err) {
+    reportConnectivityFailure();
+    throw err;
+  }
+  if (!response.ok) {
+    let detail: string | undefined;
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (typeof body?.detail === "string") detail = body.detail;
+    } catch {
+      // not JSON — ignore
+    }
+    return { ok: false, status: response.status, detail };
+  }
+  return { ok: true, data: (await response.json()) as RunFileContent };
+}
+
 // ─── Workers (playbooks) ──────────────────────────────────────────────────────
 
 interface PlaybookDetail {
@@ -590,6 +632,9 @@ export interface SessionDetail {
   // ADR-0029: artifact contract and verification result.
   artifact_contract_json?: ArtifactContract | null;
   artifact_verification_json?: ArtifactVerification | null;
+  // Absolute artifact-root path on disk (services/sessions.py get_session
+  // returns this verbatim) — the run's save root for file-link resolution.
+  artifacts_path?: string | null;
 }
 
 export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/apps/studio/frontend/src/lib/fileRefs.test.ts
+++ b/apps/studio/frontend/src/lib/fileRefs.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeFilename, resolveFileRef, stripTrailingPunctuation } from "./fileRefs";
+
+describe("looksLikeFilename", () => {
+  it("accepts common source/doc extensions", () => {
+    expect(looksLikeFilename("review_findings.md")).toBe(true);
+    expect(looksLikeFilename("main.py")).toBe(true);
+    expect(looksLikeFilename("config.json")).toBe(true);
+    expect(looksLikeFilename("path/to/file.ts")).toBe(true);
+  });
+
+  it("rejects prose and non-filename tokens", () => {
+    expect(looksLikeFilename("e.g.")).toBe(false);
+    expect(looksLikeFilename("v1.2.3")).toBe(false);
+    expect(looksLikeFilename("hello world.md")).toBe(false); // whitespace
+    expect(looksLikeFilename("")).toBe(false);
+    expect(looksLikeFilename("just some code")).toBe(false);
+  });
+
+  it("rejects overly long tokens", () => {
+    expect(looksLikeFilename(`${"a".repeat(300)}.md`)).toBe(false);
+  });
+});
+
+describe("stripTrailingPunctuation", () => {
+  it("strips trailing sentence punctuation", () => {
+    expect(stripTrailingPunctuation("review.md.")).toBe("review.md");
+    expect(stripTrailingPunctuation("notes.txt,")).toBe("notes.txt");
+    expect(stripTrailingPunctuation("(spec.md)")).toBe("(spec.md");
+  });
+});
+
+describe("resolveFileRef", () => {
+  const knownFiles = [
+    "/runs/r1/agentA/review_findings.md",
+    "/runs/r1/agentA/review.md",
+    "/runs/r1/agentB/review.md",
+    "/runs/r1/synthesis.md",
+  ];
+
+  it("resolves an absolute markdown-link path shape via exact match", () => {
+    const result = resolveFileRef("/runs/r1/synthesis.md", { knownFiles });
+    expect(result).toEqual({ type: "single", path: "/runs/r1/synthesis.md" });
+  });
+
+  it("returns none for an absolute path not on the known surface (never fabricates)", () => {
+    const result = resolveFileRef("/etc/passwd", { knownFiles });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("resolves a bare filename shape by basename when unique", () => {
+    const result = resolveFileRef("review_findings.md", { knownFiles });
+    expect(result).toEqual({ type: "single", path: "/runs/r1/agentA/review_findings.md" });
+  });
+
+  it("prefers the emitting agent's own dir first on ambiguous basename", () => {
+    const result = resolveFileRef("review.md", {
+      knownFiles,
+      agentDir: "/runs/r1/agentB",
+    });
+    expect(result).toEqual({ type: "single", path: "/runs/r1/agentB/review.md" });
+  });
+
+  it("falls back to ambiguous disambiguation when agent dir doesn't resolve it", () => {
+    const result = resolveFileRef("review.md", { knownFiles });
+    expect(result.type).toBe("ambiguous");
+    if (result.type === "ambiguous") {
+      expect(result.candidates.sort()).toEqual(
+        ["/runs/r1/agentA/review.md", "/runs/r1/agentB/review.md"].sort(),
+      );
+    }
+  });
+
+  it("stays 'none' (plain text) when there is no match at all", () => {
+    const result = resolveFileRef("nonexistent.md", { knownFiles });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("strips trailing sentence punctuation before matching", () => {
+    const result = resolveFileRef("synthesis.md.", { knownFiles });
+    expect(result).toEqual({ type: "single", path: "/runs/r1/synthesis.md" });
+  });
+
+  it("handles file:// URL shape", () => {
+    const result = resolveFileRef("file:///runs/r1/synthesis.md", { knownFiles });
+    expect(result).toEqual({ type: "single", path: "/runs/r1/synthesis.md" });
+  });
+});

--- a/apps/studio/frontend/src/lib/fileRefs.ts
+++ b/apps/studio/frontend/src/lib/fileRefs.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolve file references found in rendered agent messages (markdown links
+ * and bare inline-code filenames) against the run's KNOWN file surface —
+ * never fabricates a target from text alone.
+ */
+
+const FILENAME_EXTENSIONS =
+  "md|markdown|py|pyi|js|jsx|mjs|cjs|ts|tsx|json|jsonl|txt|ya?ml|toml|rs|go|java|kt|" +
+  "c|cc|cpp|h|hpp|sh|bash|zsh|css|scss|less|html?|csv|tsv|log|xml|ini|cfg|conf|sql|" +
+  "proto|graphql|lock|env|patch|diff|rst|svg";
+
+const FILENAME_RE = new RegExp(`^[A-Za-z0-9_][\\w./-]*\\.(${FILENAME_EXTENSIONS})$`, "i");
+
+/** Conservative heuristic for "this inline-code span looks like a filename" —
+ * requires a recognized extension, no whitespace, and a reasonable length. */
+export function looksLikeFilename(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > 200) return false;
+  if (/\s/.test(trimmed)) return false;
+  return FILENAME_RE.test(trimmed);
+}
+
+/** Strip trailing sentence punctuation a model might glue onto a path
+ * ("Wrote review.md." / "see notes.txt,"). */
+export function stripTrailingPunctuation(text: string): string {
+  return text.replace(/[.,;:!?)\]}'"]+$/, "");
+}
+
+export type FileMatch =
+  | { type: "none" }
+  | { type: "single"; path: string }
+  | { type: "ambiguous"; candidates: string[] };
+
+function basename(p: string): string {
+  const parts = p.split("/");
+  return parts[parts.length - 1] ?? p;
+}
+
+export interface ResolveFileRefOptions {
+  /** Absolute paths known to belong to this run (files touched by tool calls). */
+  knownFiles: string[];
+  /** The emitting agent's own artifact subdir, absolute path, checked first. */
+  agentDir?: string | null;
+}
+
+/**
+ * Resolve a raw reference (markdown link target, or a bare filename token)
+ * against the known file surface. Absolute refs must match a known file
+ * exactly. Bare/relative refs match by basename, preferring candidates
+ * under agentDir; multiple remaining matches come back "ambiguous" rather
+ * than guessing.
+ */
+export function resolveFileRef(rawRef: string, opts: ResolveFileRefOptions): FileMatch {
+  const ref = stripTrailingPunctuation(rawRef.trim());
+  if (!ref) return { type: "none" };
+
+  const knownFiles = opts.knownFiles ?? [];
+  const isAbsolute = ref.startsWith("/");
+
+  if (isAbsolute) {
+    return knownFiles.includes(ref) ? { type: "single", path: ref } : { type: "none" };
+  }
+
+  // file:// URLs — normalize to a bare absolute path before matching.
+  if (ref.startsWith("file://")) {
+    const stripped = ref.slice("file://".length);
+    return knownFiles.includes(stripped) ? { type: "single", path: stripped } : { type: "none" };
+  }
+
+  const refBase = basename(ref);
+  const candidates = knownFiles.filter((f) => {
+    if (f === ref) return true;
+    if (f.endsWith(`/${ref}`)) return true;
+    return basename(f) === refBase;
+  });
+
+  if (candidates.length === 0) return { type: "none" };
+  if (candidates.length === 1) return { type: "single", path: candidates[0] };
+
+  if (opts.agentDir) {
+    const agentDir = opts.agentDir.endsWith("/") ? opts.agentDir : `${opts.agentDir}/`;
+    const inAgentDir = candidates.filter((c) => c.startsWith(agentDir));
+    if (inAgentDir.length === 1) return { type: "single", path: inAgentDir[0] };
+    if (inAgentDir.length > 1) return { type: "ambiguous", candidates: inAgentDir };
+  }
+
+  return { type: "ambiguous", candidates };
+}

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import os
+import stat
 import time
 from pathlib import Path
 from typing import Any
@@ -761,6 +763,40 @@ async def get_run_route(
     return run
 
 
+def _open_regular_file_no_follow(root: Path, resolved: Path) -> int:
+    """Open `resolved` (already containment-checked under `root`) through a
+    root-anchored, no-follow descriptor walk and return the open fd.
+
+    `resolve_workspace_path` only validates the path at check time — nothing
+    stops the target from being replaced with a symlink before a later
+    `open()`-by-path follows it out of the artifact root (CWE-367/59). This
+    walks each path component with `os.open(..., dir_fd=parent_fd)` instead:
+    every component is resolved relative to a directory descriptor obtained
+    *before* it, never by re-walking a path string, and `O_NOFOLLOW` refuses
+    a symlink at any position (including an intermediate directory). The
+    caller owns closing the returned fd.
+    """
+    parts = resolved.relative_to(root).parts
+    if not parts:
+        raise PermissionError(f"no path components under root: {resolved!r}")
+    dir_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        for i, part in enumerate(parts):
+            is_last = i == len(parts) - 1
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            if not is_last:
+                flags |= os.O_DIRECTORY
+            fd = os.open(part, flags, dir_fd=dir_fd)
+            os.close(dir_fd)
+            dir_fd = fd
+        if not stat.S_ISREG(os.fstat(dir_fd).st_mode):
+            raise PermissionError(f"not a regular file: {resolved!r}")
+        return dir_fd
+    except BaseException:
+        os.close(dir_fd)
+        raise
+
+
 async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
     """Read-only content fetch for a file inside a run's artifact root.
 
@@ -779,19 +815,32 @@ async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
     artifact_root = Path(artifacts_path)
     if not artifact_root.exists():
         raise HTTPException(status_code=404, detail="Run artifact root no longer exists")
+    root = artifact_root.resolve()
 
     try:
-        resolved = resolve_workspace_path(path, artifact_root.resolve())
+        resolved = resolve_workspace_path(path, root)
     except PermissionError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
 
-    if not resolved.exists() or not resolved.is_file():
-        raise HTTPException(status_code=404, detail=f"File '{path}' not found")
-
-    size = resolved.stat().st_size
-    raw = resolved.read_bytes()[:_MAX_FILE_READ_BYTES]
     try:
-        content = raw.decode("utf-8")
+        fd = _open_regular_file_no_follow(root, resolved)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"File '{path}' not found") from exc
+    except (OSError, PermissionError) as exc:
+        raise HTTPException(status_code=403, detail=f"File '{path}' is not accessible") from exc
+
+    try:
+        size = os.fstat(fd).st_size
+        # Read at most cap+1 bytes in a single syscall — the extra byte only
+        # decides `truncated`, never a full-file materialization regardless
+        # of actual file size.
+        raw = os.read(fd, _MAX_FILE_READ_BYTES + 1)
+    finally:
+        os.close(fd)
+
+    truncated = len(raw) > _MAX_FILE_READ_BYTES
+    try:
+        content = raw[:_MAX_FILE_READ_BYTES].decode("utf-8")
     except UnicodeDecodeError:
         raise HTTPException(status_code=415, detail="File is not text/UTF-8") from None
 
@@ -799,7 +848,7 @@ async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
         "path": str(resolved),
         "content": content,
         "size": size,
-        "truncated": size > _MAX_FILE_READ_BYTES,
+        "truncated": truncated,
     }
 
 

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -7,9 +7,15 @@ from typing import Any
 
 from fastapi import HTTPException, Query
 
+from lionagi.libs.path_safety import resolve_workspace_path
+
 from ..registry import studio_route
 from . import sessions as _sessions_svc
 from ._path_safety import public_path
+
+# Read-only file viewer cap (ADR file-links feature): large artifacts are
+# truncated rather than rejected outright, so a giant log still previews.
+_MAX_FILE_READ_BYTES = 2_000_000
 
 _STATUS_ALIASES: dict[str, set[str]] = {
     "done": {"done", "completed", "success", "finished"},
@@ -753,6 +759,53 @@ async def get_run_route(
     if run is None:
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
     return run
+
+
+async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
+    """Read-only content fetch for a file inside a run's artifact root.
+
+    Backs the message-renderer's clickable file links: a link is only ever
+    rendered when the frontend already believes the path is part of the
+    run's known file surface (message_stats.files / tool-call args), but a
+    file can still vanish between render and click — this always re-validates
+    against the live artifact root rather than trusting the caller.
+    """
+    session = await _sessions_svc.get_session(run_id, message_limit=1)
+    if session is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+    artifacts_path = session.get("artifacts_path")
+    if not artifacts_path:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' has no artifact root")
+    artifact_root = Path(artifacts_path)
+    if not artifact_root.exists():
+        raise HTTPException(status_code=404, detail="Run artifact root no longer exists")
+
+    try:
+        resolved = resolve_workspace_path(path, artifact_root.resolve())
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    if not resolved.exists() or not resolved.is_file():
+        raise HTTPException(status_code=404, detail=f"File '{path}' not found")
+
+    size = resolved.stat().st_size
+    raw = resolved.read_bytes()[:_MAX_FILE_READ_BYTES]
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=415, detail="File is not text/UTF-8") from None
+
+    return {
+        "path": str(resolved),
+        "content": content,
+        "size": size,
+        "truncated": size > _MAX_FILE_READ_BYTES,
+    }
+
+
+@studio_route("/runs/{run_id}/file", method="GET", area="runs", name="get_run_file")
+async def get_run_file_route(run_id: str, path: str = Query(...)) -> dict[str, Any]:
+    return await get_run_file(run_id, path)
 
 
 # ADR-0008: /api/runs/{id}/events SSE (read stream/*.buffer.jsonl, forbidden

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -831,10 +831,21 @@ async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
 
     try:
         size = os.fstat(fd).st_size
-        # Read at most cap+1 bytes in a single syscall — the extra byte only
-        # decides `truncated`, never a full-file materialization regardless
-        # of actual file size.
-        raw = os.read(fd, _MAX_FILE_READ_BYTES + 1)
+        # Read at most cap+1 bytes total — the extra byte only decides
+        # `truncated`, never a full-file materialization regardless of actual
+        # file size. os.read may legally return fewer bytes than requested
+        # without signaling EOF, so accumulate until EOF or the allowance is
+        # exhausted; a single short read must not mislabel an oversized file
+        # as complete.
+        chunks: list[bytes] = []
+        remaining = _MAX_FILE_READ_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
     finally:
         os.close(fd)
 

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the read-only run-artifact file endpoint (get_run_file)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from fastapi import HTTPException  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+
+async def seed_session(db_path: Path, *, session_id: str, artifacts_path: str) -> None:
+    prog_id = f"{session_id}-prog"
+    async with StateDB(db_path) as db:
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": prog_id,
+                "name": f"run-{session_id}",
+                "status": "completed",
+                "artifacts_path": artifacts_path,
+                "source_kind": "live",
+            }
+        )
+
+
+@pytest.fixture
+def patched_runs_svc(tmp_path: Path, monkeypatch: Any):
+    import lionagi.studio.services.sessions as sessions_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+
+    import lionagi.studio.services.runs as runs_svc
+
+    return runs_svc, db_path
+
+
+async def test_happy_path_reads_file_content(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "review.md"
+    target.write_text("# Review\n\nLooks good.")
+
+    await seed_session(db_path, session_id="run-1", artifacts_path=str(artifact_root))
+
+    result = await svc.get_run_file("run-1", str(target))
+    assert result["content"] == "# Review\n\nLooks good."
+    assert result["truncated"] is False
+    assert result["size"] == len("# Review\n\nLooks good.")
+
+
+async def test_relative_path_resolves_under_artifact_root(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    (artifact_root / "sub").mkdir(parents=True)
+    (artifact_root / "sub" / "notes.txt").write_text("hello")
+
+    await seed_session(db_path, session_id="run-2", artifacts_path=str(artifact_root))
+
+    result = await svc.get_run_file("run-2", "sub/notes.txt")
+    assert result["content"] == "hello"
+
+
+async def test_missing_file_returns_404(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    await seed_session(db_path, session_id="run-3", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-3", str(artifact_root / "nope.md"))
+    assert exc_info.value.status_code == 404
+
+
+async def test_unknown_run_returns_404(patched_runs_svc):
+    svc, _db_path = patched_runs_svc
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("no-such-run", "/tmp/anything.md")
+    assert exc_info.value.status_code == 404
+
+
+async def test_traversal_outside_artifact_root_rejected(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    await seed_session(db_path, session_id="run-4", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-4", "../secret.txt")
+    assert exc_info.value.status_code == 403
+
+
+async def test_absolute_path_outside_artifact_root_rejected(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    await seed_session(db_path, session_id="run-5", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-5", str(secret))
+    assert exc_info.value.status_code == 403
+
+
+async def test_symlink_escape_rejected(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope")
+    link = artifact_root / "escape.txt"
+    link.symlink_to(outside)
+    await seed_session(db_path, session_id="run-6", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-6", str(link))
+    assert exc_info.value.status_code == 403
+
+
+async def test_symlinked_directory_escape_rejected(patched_runs_svc, tmp_path):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir()
+    (outside_dir / "leak.txt").write_text("leaked")
+    (artifact_root / "linked_dir").symlink_to(outside_dir)
+    await seed_session(db_path, session_id="run-7", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-7", "linked_dir/leak.txt")
+    assert exc_info.value.status_code == 403
+
+
+async def test_large_file_is_truncated(patched_runs_svc, tmp_path, monkeypatch):
+    svc, db_path = patched_runs_svc
+    monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 10)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    big = artifact_root / "big.log"
+    big.write_text("x" * 100)
+    await seed_session(db_path, session_id="run-8", artifacts_path=str(artifact_root))
+
+    result = await svc.get_run_file("run-8", str(big))
+    assert result["truncated"] is True
+    assert len(result["content"]) == 10
+    assert result["size"] == 100

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +14,9 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi import HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
+from lionagi.libs.path_safety import resolve_workspace_path  # noqa: E402
 from lionagi.state.db import StateDB  # noqa: E402
 
 
@@ -160,3 +163,283 @@ async def test_large_file_is_truncated(patched_runs_svc, tmp_path, monkeypatch):
     assert result["truncated"] is True
     assert len(result["content"]) == 10
     assert result["size"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Bounded read: the cap must be enforced by the read itself, not by slicing
+# an already-materialized full read (Path.read_bytes() then [:cap] would
+# allocate the whole file before the cap applies).
+# ---------------------------------------------------------------------------
+
+
+async def test_content_read_never_calls_path_read_bytes(patched_runs_svc, tmp_path, monkeypatch):
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "small.txt"
+    target.write_text("hello world")
+    await seed_session(db_path, session_id="run-9", artifacts_path=str(artifact_root))
+
+    def _boom(self, *a, **k):
+        raise AssertionError("Path.read_bytes must not be used for run-file content reads")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+
+    result = await svc.get_run_file("run-9", str(target))
+    assert result["content"] == "hello world"
+
+
+async def test_bounded_read_requests_at_most_cap_plus_one_byte(
+    patched_runs_svc, tmp_path, monkeypatch
+):
+    """A large file must never be fully read — only cap+1 bytes are requested,
+    via a single os.read() call on the no-follow descriptor."""
+    svc, db_path = patched_runs_svc
+    monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 1024)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    huge = artifact_root / "huge.log"
+    # Real file well over the cap — proves the cap is enforced by the read
+    # size, not by slicing a full read after the fact.
+    huge.write_bytes(b"y" * (5 * 1024 * 1024))
+    await seed_session(db_path, session_id="run-10", artifacts_path=str(artifact_root))
+
+    real_read = os.read
+    requested_sizes: list[int] = []
+
+    def _tracking_read(fd, n):
+        requested_sizes.append(n)
+        return real_read(fd, n)
+
+    monkeypatch.setattr(os, "read", _tracking_read)
+
+    result = await svc.get_run_file("run-10", str(huge))
+
+    assert requested_sizes == [1025]  # cap + 1, exactly one call
+    assert result["truncated"] is True
+    assert len(result["content"]) == 1024
+    assert result["size"] == 5 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Symlink swap after validation (TOCTOU): resolve_workspace_path validates a
+# path that was a regular file at check time; a later open-by-path would
+# follow whatever occupies that name at open time. The no-follow descriptor
+# walk must refuse the swapped target instead.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_helper_refuses_target_swapped_to_symlink_after_validation(tmp_path):
+    import lionagi.studio.services.runs as runs_svc
+
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("top secret")
+    target = artifact_root / "review.md"
+    target.write_text("looks good")
+
+    root = artifact_root.resolve()
+    # Validate while `target` is still a regular file inside root.
+    resolved = resolve_workspace_path(str(target), root)
+
+    # Simulate the race: swap the validated path for a symlink pointing
+    # outside root before the read-side open happens.
+    target.unlink()
+    target.symlink_to(outside)
+
+    with pytest.raises((OSError, PermissionError)):
+        runs_svc._open_regular_file_no_follow(root, resolved)
+
+
+async def test_open_helper_refuses_intermediate_dir_swapped_to_symlink(tmp_path):
+    import lionagi.studio.services.runs as runs_svc
+
+    artifact_root = tmp_path / "artifacts"
+    (artifact_root / "sub").mkdir(parents=True)
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir()
+    (outside_dir / "leak.txt").write_text("leaked")
+    target = artifact_root / "sub" / "notes.txt"
+    target.write_text("hello")
+
+    root = artifact_root.resolve()
+    resolved = resolve_workspace_path("sub/notes.txt", root)
+
+    # Swap the intermediate directory for a symlink after validation.
+    import shutil
+
+    shutil.rmtree(artifact_root / "sub")
+    (artifact_root / "sub").symlink_to(outside_dir)
+
+    with pytest.raises((OSError, PermissionError)):
+        runs_svc._open_regular_file_no_follow(root, resolved)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level coverage: exercise GET /api/runs/{run_id}/file through the
+# actual FastAPI route (TestClient), not just the service function directly.
+# ---------------------------------------------------------------------------
+
+
+def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+async def _seed(db_path: Path, *, session_id: str, artifacts_path: str) -> None:
+    await seed_session(db_path, session_id=session_id, artifacts_path=artifacts_path)
+
+
+def test_route_happy_path(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "review.md"
+    target.write_text("# Review\n\nLooks good.")
+    _run_async(_seed(db_path, session_id="route-1", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-1/file", params={"path": str(target)})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == "# Review\n\nLooks good."
+    assert body["truncated"] is False
+
+
+def test_route_traversal_rejected_without_leaking_resolved_path(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    _run_async(_seed(db_path, session_id="route-2", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-2/file", params={"path": "../secret.txt"})
+    assert resp.status_code == 403
+    assert str(secret.resolve()) not in resp.text
+    assert "top secret" not in resp.text
+
+
+def test_route_absolute_escape_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    _run_async(_seed(db_path, session_id="route-3", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-3/file", params={"path": str(secret)})
+    assert resp.status_code == 403
+    assert "top secret" not in resp.text
+
+
+def test_route_final_symlink_escape_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope")
+    link = artifact_root / "escape.txt"
+    link.symlink_to(outside)
+    _run_async(_seed(db_path, session_id="route-4", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-4/file", params={"path": str(link)})
+    assert resp.status_code == 403
+    assert "nope" not in resp.text
+
+
+def test_route_intermediate_symlink_dir_escape_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir()
+    (outside_dir / "leak.txt").write_text("leaked")
+    (artifact_root / "linked_dir").symlink_to(outside_dir)
+    _run_async(_seed(db_path, session_id="route-5", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-5/file", params={"path": "linked_dir/leak.txt"})
+    assert resp.status_code == 403
+    assert "leaked" not in resp.text
+
+
+def test_route_protected_basename_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    dotenv = artifact_root / ".env"
+    dotenv.write_text("SECRET=abc123")
+    _run_async(_seed(db_path, session_id="route-6", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-6/file", params={"path": str(dotenv)})
+    assert resp.status_code == 403
+    assert "abc123" not in resp.text
+
+
+def test_route_non_utf8_returns_415(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    binary = artifact_root / "data.bin"
+    binary.write_bytes(b"\xff\xfe\x00\x01binary")
+    _run_async(_seed(db_path, session_id="route-7", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-7/file", params={"path": str(binary)})
+    assert resp.status_code == 415
+
+
+def test_route_bounded_read_and_truncation(tmp_path, monkeypatch):
+    import lionagi.studio.services.runs as runs_svc
+
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    monkeypatch.setattr(runs_svc, "_MAX_FILE_READ_BYTES", 16)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    big = artifact_root / "big.log"
+    big.write_text("z" * 1000)
+    _run_async(_seed(db_path, session_id="route-8", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-8/file", params={"path": str(big)})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["truncated"] is True
+    assert len(body["content"]) == 16
+    assert body["size"] == 1000
+
+
+def test_route_missing_file_returns_404_without_leaking_resolved_path(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    _run_async(_seed(db_path, session_id="route-9", artifacts_path=str(artifact_root)))
+
+    # Relative, caller-supplied path — the server-resolved absolute path
+    # must not appear in the 404 body even though it never existed.
+    resp = client.get("/api/runs/route-9/file", params={"path": "nope.md"})
+    assert resp.status_code == 404
+    assert str(artifact_root.resolve()) not in resp.text
+
+
+def _run_async(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -192,8 +192,8 @@ async def test_content_read_never_calls_path_read_bytes(patched_runs_svc, tmp_pa
 async def test_bounded_read_requests_at_most_cap_plus_one_byte(
     patched_runs_svc, tmp_path, monkeypatch
 ):
-    """A large file must never be fully read — only cap+1 bytes are requested,
-    via a single os.read() call on the no-follow descriptor."""
+    """A large file must never be fully read — at most cap+1 bytes total are
+    requested across os.read() calls on the no-follow descriptor."""
     svc, db_path = patched_runs_svc
     monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 1024)
     artifact_root = tmp_path / "artifacts"
@@ -215,10 +215,45 @@ async def test_bounded_read_requests_at_most_cap_plus_one_byte(
 
     result = await svc.get_run_file("run-10", str(huge))
 
-    assert requested_sizes == [1025]  # cap + 1, exactly one call
+    assert sum(requested_sizes) <= 1025 * 2  # allowance never exceeded per call
+    assert max(requested_sizes) <= 1025  # no single request beyond cap + 1
     assert result["truncated"] is True
     assert len(result["content"]) == 1024
     assert result["size"] == 5 * 1024 * 1024
+
+
+async def test_short_reads_still_mark_oversized_file_truncated(
+    patched_runs_svc, tmp_path, monkeypatch
+):
+    """os.read may return fewer bytes than requested without signaling EOF; a
+    short first read must not mislabel an over-cap file as complete, and the
+    total bytes obtained must never exceed cap+1."""
+    svc, db_path = patched_runs_svc
+    monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 16)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "chunky.txt"
+    target.write_bytes(b"a" * 100)
+    await seed_session(db_path, session_id="run-11", artifacts_path=str(artifact_root))
+
+    real_read = os.read
+    total_returned = 0
+
+    def _short_read(fd, n):
+        nonlocal total_returned
+        # Return at most 5 bytes per call regardless of the request size.
+        chunk = real_read(fd, min(n, 5))
+        total_returned += len(chunk)
+        return chunk
+
+    monkeypatch.setattr(os, "read", _short_read)
+
+    result = await svc.get_run_file("run-11", str(target))
+
+    assert result["truncated"] is True
+    assert len(result["content"]) == 16
+    assert result["size"] == 100
+    assert total_returned <= 17  # cap + 1 total, even across many short reads
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the message-panel file-link directive: file references in rendered agent messages — markdown links with filesystem-path targets and bare inline-code filenames — become clickable links opening an in-Studio file viewer.

**Resolution (never fabricated from text):** references resolve only against the run's known file surface — the tool-call-derived paths the TOP FILES panel already shows, unioned run-wide. Absolute refs need an exact known-file match; bare names resolve agent-artifact-dir-first, then run save root; multi-match basenames get a disambiguation popover; unmatched refs render unchanged. Built once in the shared `Markdown` renderer (a `fileContext` prop), so the fleet split-pane LATEST MESSAGE panel and run-detail conversation view both get it — and the upcoming drawer inspector inherits it for free.

**Backend (flagging explicitly as new surface):** no existing artifact-content endpoint existed, so this adds a minimal read-only `GET /api/runs/{run_id}/file?path=…` — validated against the run's artifact root via the pre-existing `resolve_workspace_path` primitive (traversal + symlink-escape rejected including symlinked intermediate dirs, protected filenames blocked), 2MB read cap, non-UTF-8 refused, click-time 404 for vanished files. 9 endpoint tests including traversal/symlink-escape rejection.

**Tests:** resolver unit tests (12), renderer wiring source-contracts (11), extractFilePaths units (4), backend endpoint (9). Full frontend suite 833 passed; `tests/apps_studio_server/` green; typecheck/lint clean (verified independently by the director). Rebased onto main over the merged run-detail graph fix; conflict was one type annotation, kept the merged optional form.

Lane B per prior classification; the new read-only endpoint is called out above in case it warrants a bump.