### PR TITLE
feat(studio): scheduler signal bus — typed lifecycle signals with committed-write minting

### DIFF
--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -15,9 +15,16 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from lionagi.ln.concurrency import ExceptionGroup
 from lionagi.state.reasons import RunReasons, ScheduleReasons
 from lionagi.studio.scheduler import subprocess as _subprocess
 from lionagi.studio.scheduler import threshold as _threshold
+from lionagi.studio.scheduler.signals import (
+    SchedulerSignalBus,
+    build_schedule_run_signal,
+    record_handler_failure,
+    register_default_handlers,
+)
 from lionagi.studio.services.scheduler_state import (
     SchedulerStateService,
     create_skipped_run,
@@ -230,8 +237,13 @@ async def _resolve_action_cwd(schedule: dict) -> tuple[str | None, str | None]:
 
 
 class SchedulerEngine:
-    def __init__(self, svc: SchedulerStateService | None = None) -> None:
+    def __init__(
+        self,
+        svc: SchedulerStateService | None = None,
+        signal_bus: SchedulerSignalBus | None = None,
+    ) -> None:
         self._svc = svc if svc is not None else default_scheduler_state
+        self._signal_bus = signal_bus if signal_bus is not None else SchedulerSignalBus()
         self._task: asyncio.Task | None = None
         self._running: dict[str, str] = {}  # schedule_id -> run_id
         self._stopping = False
@@ -1176,6 +1188,24 @@ class SchedulerEngine:
             )
         return written
 
+    async def _dispatch_signal(self, signal: Any) -> None:
+        """Emit *signal* on the scheduler's signal bus.
+
+        The schedule_run/invocation row this signal describes is already
+        committed by the time this runs (mint happens after
+        ``_guarded_terminal_status`` returns ``True``), so a handler
+        exception here must never be allowed to look like it undid that
+        write or to stop the tick loop from continuing on to the next
+        schedule. ``SchedulerSignalBus.emit`` fails loud (raises an
+        ``ExceptionGroup``, never swallows); this call site is where that
+        group gets caught, logged, and turned into a durable admin event.
+        """
+        try:
+            await self._signal_bus.emit(signal)
+        except ExceptionGroup as eg:
+            _log.error("Scheduler signal handler(s) failed for %s: %s", type(signal).__name__, eg)
+            await record_handler_failure(eg, signal)
+
     async def _check_max_runs(self, schedule: dict, chain_depth: int) -> None:
         """Auto-disable a schedule once its fired top-level runs hit max_runs.
 
@@ -1346,7 +1376,7 @@ class SchedulerEngine:
                     "error_detail": str(exc),
                 }
             )
-            await self._svc.update_status(
+            written = await self._svc.update_status(
                 "schedule_run",
                 run_id,
                 new_status="failed",
@@ -1357,6 +1387,19 @@ class SchedulerEngine:
                 actor=run_id,
                 metadata={"exception_class": type(exc).__name__},
             )
+            if written:
+                await self._dispatch_signal(
+                    build_schedule_run_signal(
+                        entity_id=run_id,
+                        new_status="failed",
+                        reason_code=RunReasons.FAILED_EXCEPTION,
+                        schedule_id=sid,
+                        action_kind=schedule.get("action_kind", ""),
+                        chain_depth=chain_depth,
+                        trigger_context=trigger_context,
+                        error_detail=f"{type(exc).__name__}: {exc}",
+                    )
+                )
             inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
@@ -1460,7 +1503,7 @@ class SchedulerEngine:
                 ended_at=end_time,
                 error_detail=stderr_tail if exit_code != 0 else None,
             )
-            await self._guarded_terminal_status(
+            written = await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
                 new_status=status,
@@ -1471,6 +1514,19 @@ class SchedulerEngine:
                 actor=run_id,
                 metadata={"exit_code": exit_code},
             )
+            if written:
+                await self._dispatch_signal(
+                    build_schedule_run_signal(
+                        entity_id=run_id,
+                        new_status=status,
+                        reason_code=reason_code,
+                        schedule_id=sid,
+                        action_kind=schedule.get("action_kind", ""),
+                        chain_depth=chain_depth,
+                        trigger_context=trigger_context,
+                        error_detail=stderr_tail if exit_code != 0 else "",
+                    )
+                )
             inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status=status, exit_code=exit_code
             )
@@ -1533,7 +1589,7 @@ class SchedulerEngine:
                     ended_at=_end_time,
                     error_detail="Scheduler shutdown",
                 )
-                await self._guarded_terminal_status(
+                written = await self._guarded_terminal_status(
                     "schedule_run",
                     run_id,
                     new_status="cancelled",
@@ -1543,6 +1599,18 @@ class SchedulerEngine:
                     source="executor",
                     actor=run_id,
                 )
+                if written:
+                    await self._dispatch_signal(
+                        build_schedule_run_signal(
+                            entity_id=run_id,
+                            new_status="cancelled",
+                            reason_code=RunReasons.CANCELLED_SYSTEM,
+                            schedule_id=sid,
+                            action_kind=schedule.get("action_kind", ""),
+                            chain_depth=chain_depth,
+                            trigger_context=trigger_context,
+                        )
+                    )
                 inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                     self._svc, inv_id, fallback_status="cancelled"
                 )
@@ -1570,7 +1638,7 @@ class SchedulerEngine:
                 ended_at=_end_time,
                 error_detail="Internal scheduler error",
             )
-            await self._guarded_terminal_status(
+            written = await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
                 new_status="failed",
@@ -1581,6 +1649,19 @@ class SchedulerEngine:
                 actor=run_id,
                 metadata={"exception_class": type(exc).__name__},
             )
+            if written:
+                await self._dispatch_signal(
+                    build_schedule_run_signal(
+                        entity_id=run_id,
+                        new_status="failed",
+                        reason_code=RunReasons.FAILED_EXCEPTION,
+                        schedule_id=sid,
+                        action_kind=schedule.get("action_kind", ""),
+                        chain_depth=chain_depth,
+                        trigger_context=trigger_context,
+                        error_detail=f"{type(exc).__name__}: {exc}",
+                    )
+                )
             inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
@@ -1637,3 +1718,4 @@ class SchedulerEngine:
 
 
 scheduler = SchedulerEngine()
+register_default_handlers(scheduler._signal_bus)

--- a/lionagi/studio/scheduler/signals.py
+++ b/lionagi/studio/scheduler/signals.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Typed schedule_run outcome signals and a handler registry for the scheduler daemon.
+
+Mint site: ``SchedulerEngine._fire_inner()``, immediately after each of the
+three ``_guarded_terminal_status("schedule_run", ...)`` calls returns
+``True`` — the one choke point every scheduled run's terminal write already
+passes through (in-process, synchronous with the commit, no polling
+latency). This module stays agnostic about *where* that mint happens: the
+signal classes and :class:`SchedulerSignalBus` only need the same
+status/reason_code/entity_id fields a generic post-commit hook on
+``LifecycleService.transition()`` would eventually carry, so promoting the
+mint site later is a call-site move, not a redesign of this module.
+
+``LifecycleService`` and ``StateDB`` schema are untouched by this module —
+it is scheduler-local, imitating the shape of the existing in-run DAG
+signal bus (``lionagi.session.signal`` / ``lionagi.session.observer``)
+without reusing its Flow/route/stream machinery, none of which a scheduler
+daemon process needs (``schedule_runs`` is already the durable record).
+
+Failure semantics: :meth:`SchedulerSignalBus.emit` never swallows a handler
+exception. Handlers run concurrently with ``return_exceptions=True``; any
+failures are raised together as an :class:`ExceptionGroup` after every
+handler has had a chance to run. The mint call site (``engine.py``) catches
+that group, writes a durable ``admin_events`` row describing the failure,
+and lets the tick loop continue — a broken handler must never be invisible
+and must never stop unrelated schedules from firing.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from lionagi.ln.concurrency import ExceptionGroup, gather
+from lionagi.session.signal import Signal
+
+__all__ = (
+    "ScheduleRunSucceeded",
+    "ScheduleRunFailed",
+    "ScheduleRunCancelled",
+    "SchedulerSignalBus",
+    "Handler",
+    "Predicate",
+    "build_schedule_run_signal",
+    "register_default_handlers",
+    "record_handler_failure",
+)
+
+_log = logging.getLogger(__name__)
+
+Handler = Callable[[Signal], Any]
+Predicate = Callable[[Signal], bool]
+
+_NO_MATCH = object()
+
+
+class ScheduleRunSucceeded(Signal):
+    """A scheduled run's terminal write recorded ``completed``."""
+
+    schedule_id: str = ""
+    run_id: str = ""
+    reason_code: str = ""
+    action_kind: str = ""
+    chain_depth: int = 0
+    trigger_context: dict = {}
+
+
+class ScheduleRunFailed(Signal):
+    """A scheduled run's terminal write recorded ``failed``."""
+
+    schedule_id: str = ""
+    run_id: str = ""
+    reason_code: str = ""
+    action_kind: str = ""
+    chain_depth: int = 0
+    trigger_context: dict = {}
+    error_detail: str = ""
+
+
+class ScheduleRunCancelled(Signal):
+    """A scheduled run's terminal write recorded ``cancelled``."""
+
+    schedule_id: str = ""
+    run_id: str = ""
+    reason_code: str = ""
+    action_kind: str = ""
+    chain_depth: int = 0
+    trigger_context: dict = {}
+
+
+_SIGNAL_BY_STATUS: dict[str, type[Signal]] = {
+    "completed": ScheduleRunSucceeded,
+    "failed": ScheduleRunFailed,
+    "cancelled": ScheduleRunCancelled,
+}
+
+
+def build_schedule_run_signal(
+    *,
+    entity_id: str,
+    new_status: str,
+    reason_code: str,
+    schedule_id: str = "",
+    action_kind: str = "",
+    chain_depth: int = 0,
+    trigger_context: dict | None = None,
+    error_detail: str = "",
+) -> Signal:
+    """Mint the ``ScheduleRun*`` signal matching *new_status*.
+
+    ``entity_id``, ``new_status``, and ``reason_code`` are exactly the
+    fields every ``_guarded_terminal_status()`` caller already has in hand
+    (the same fields a generic transition post-commit hook would receive);
+    ``schedule_id``/``action_kind``/``chain_depth``/``trigger_context`` are
+    scheduler-local enrichment the call site supplies today from its own
+    locals, not from the transition outcome itself.
+    """
+    cls = _SIGNAL_BY_STATUS.get(new_status)
+    if cls is None:
+        raise ValueError(f"no schedule_run signal registered for status {new_status!r}")
+    kwargs: dict[str, Any] = {
+        "run_id": entity_id,
+        "schedule_id": schedule_id,
+        "reason_code": reason_code,
+        "action_kind": action_kind,
+        "chain_depth": chain_depth,
+        "trigger_context": trigger_context or {},
+    }
+    if cls is ScheduleRunFailed:
+        kwargs["error_detail"] = error_detail
+    return cls(**kwargs)
+
+
+class SchedulerSignalBus:
+    """Stripped-down sibling of :class:`~lionagi.session.observer.SessionObserver`.
+
+    Only ``observe``/``unobserve``/``emit`` — no ``Flow``/``Progression``
+    storage, no ``route()``/``stream()``, no DB auto-persistence; the
+    ``schedule_runs`` table is already the durable record for what these
+    signals describe. Matching is ``isinstance``-based against any ``type``
+    key, AND-composed with any callable predicate keys (e.g. filtering on
+    ``reason_code``) — no topic/pattern machinery.
+    """
+
+    def __init__(self) -> None:
+        self._subs: list[tuple[tuple[type, ...], tuple[Predicate, ...], Handler]] = []
+
+    def observe(self, *keys: type | Predicate, handler: Handler) -> Handler:
+        """Register *handler* for signals matching all *keys* (types AND predicates)."""
+        types_ = tuple(k for k in keys if isinstance(k, type))
+        predicates = tuple(k for k in keys if not isinstance(k, type))
+        self._subs.append((types_, predicates, handler))
+        return handler
+
+    def unobserve(self, handler: Handler) -> int:
+        """Remove all subscriptions for *handler*; returns the count removed."""
+        before = len(self._subs)
+        self._subs = [sub for sub in self._subs if sub[2] is not handler]
+        return before - len(self._subs)
+
+    async def emit(self, signal: Signal) -> list[Any]:
+        """Dispatch *signal* to every matching handler.
+
+        Type matching (``isinstance`` against a subscription's registered
+        types) happens up front to select candidate subscriptions — it is
+        cheap and cannot raise. Predicate matching happens *inside* the same
+        protected region as handler invocation, gathered concurrently with
+        ``return_exceptions=True``: a predicate that raises becomes a
+        collected dispatch failure exactly like a handler exception, rather
+        than aborting ``emit()`` before sibling subscriptions ever run. Any
+        failures are raised together as one :class:`ExceptionGroup` once
+        every candidate has had a chance to run — never a blanket
+        ``except Exception: pass``.
+
+        ``asyncio.CancelledError`` (and any other non-``Exception``
+        ``BaseException``) is excluded from that group — the stdlib
+        ``ExceptionGroup`` cannot nest a bare ``BaseException`` — and is
+        re-raised directly instead, since cancellation must propagate and is
+        not a handler bug to record.
+        """
+        candidates = [entry for entry in self._subs if not entry[0] or isinstance(signal, entry[0])]
+        if not candidates:
+            return []
+
+        async def _invoke(
+            entry: tuple[tuple[type, ...], tuple[Predicate, ...], Handler],
+        ) -> Any:
+            _types, predicates, handler = entry
+            if not all(pred(signal) for pred in predicates):
+                return _NO_MATCH
+            out = handler(signal)
+            if inspect.isawaitable(out):
+                out = await out
+            return out
+
+        raw = await gather(*(_invoke(entry) for entry in candidates), return_exceptions=True)
+
+        cancellations = [
+            r for r in raw if isinstance(r, BaseException) and not isinstance(r, Exception)
+        ]
+        errors = [r for r in raw if isinstance(r, Exception)]
+        results = [r for r in raw if r is not _NO_MATCH and not isinstance(r, BaseException)]
+
+        if cancellations:
+            cancellation = cancellations[0]
+            if errors:
+                raise cancellation from ExceptionGroup(
+                    f"{len(errors)} scheduler signal handler(s) failed for {type(signal).__name__}",
+                    errors,
+                )
+            raise cancellation
+        if errors:
+            raise ExceptionGroup(
+                f"{len(errors)} scheduler signal handler(s) failed for {type(signal).__name__}",
+                errors,
+            )
+        return results
+
+
+def _log_schedule_run_failed(signal: ScheduleRunFailed) -> None:
+    """Worked-example default handler: log-only, proving the observe/emit contract end to end."""
+    _log.warning(
+        "Scheduled run failed: schedule=%s run=%s reason=%s",
+        signal.schedule_id,
+        signal.run_id,
+        signal.reason_code,
+    )
+
+
+def register_default_handlers(bus: SchedulerSignalBus) -> None:
+    """Register the scheduler daemon's default signal handlers on *bus*.
+
+    Production wiring calls this once at daemon startup (see the module-level
+    ``scheduler`` singleton in ``engine.py``). The one registered handler
+    today is a log-only proof of the API, not a product feature — this
+    function is the single place future default handlers get added.
+    """
+    bus.observe(ScheduleRunFailed, handler=_log_schedule_run_failed)
+
+
+async def record_handler_failure(exc_group: BaseException, signal: Signal) -> None:
+    """Write a durable ``admin_events`` row describing a handler-dispatch failure.
+
+    Called by the mint call site after :meth:`SchedulerSignalBus.emit` raises
+    an :class:`ExceptionGroup` — the schedule_run/invocation row is already
+    committed by the time this runs, so a failure here never corrupts that
+    write; it only means the diagnostic record itself couldn't be persisted,
+    which is logged and swallowed the same way ``bind_db_persistence``'s
+    best-effort persistence is (session/observer.py) — a narrow, deliberate
+    exception for exactly this one built-in recorder, not the general
+    handler-dispatch contract above.
+    """
+    from lionagi.state.db import StateDB  # noqa: PLC0415
+
+    errors = getattr(exc_group, "exceptions", (exc_group,))
+    try:
+        async with StateDB() as db:
+            await db.insert_admin_event(
+                action="scheduler_signal_handler_failed",
+                target_id=getattr(signal, "run_id", None) or None,
+                actor="scheduler",
+                details={
+                    "signal_type": type(signal).__name__,
+                    "signal_id": str(signal.id),
+                    "created_at": time.time(),
+                    "errors": [f"{type(e).__name__}: {e}" for e in errors],
+                },
+            )
+    except Exception:  # noqa: BLE001
+        _log.exception(
+            "Failed to record scheduler signal handler failure for %s (run_id=%s)",
+            type(signal).__name__,
+            getattr(signal, "run_id", ""),
+        )

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -1,0 +1,806 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the OBSERVER W2 scheduler signal bus + mint call sites.
+
+Covers:
+  * SchedulerSignalBus.observe/unobserve/emit: type matching, predicate
+    (reason_code) filtering, sync + async handler dispatch.
+  * Failure semantics: emit() raises an ExceptionGroup (never a blanket
+    swallow) while still running every matching handler; the engine's mint
+    call site catches that group, writes a durable admin_events row, and
+    the tick loop keeps going (a broken handler never stops unrelated
+    schedules).
+  * build_schedule_run_signal(): mint-site-agnostic field derivation from
+    entity_id/new_status/reason_code (the same fields any
+    _guarded_terminal_status caller already has).
+  * SchedulerEngine._fire_inner() actually mints the right signal on each
+    terminal path (succeeded, failed-nonzero-exit, failed-exception,
+    cancelled).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.state.reasons import RunReasons
+from lionagi.studio.scheduler.signals import (
+    SchedulerSignalBus,
+    ScheduleRunCancelled,
+    ScheduleRunFailed,
+    ScheduleRunSucceeded,
+    build_schedule_run_signal,
+    record_handler_failure,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/studio/test_scheduler_engine.py's fixtures)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# SchedulerSignalBus — observe/emit matching + dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bus_dispatches_to_type_matching_handler():
+    bus = SchedulerSignalBus()
+    seen: list = []
+    bus.observe(ScheduleRunSucceeded, handler=seen.append)
+
+    sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    results = await bus.emit(sig)
+
+    assert seen == [sig]
+    assert results == [None]  # list.append returns None
+
+
+@pytest.mark.asyncio
+async def test_bus_does_not_dispatch_to_non_matching_type():
+    bus = SchedulerSignalBus()
+    seen: list = []
+    bus.observe(ScheduleRunFailed, handler=seen.append)
+
+    sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    results = await bus.emit(sig)
+
+    assert seen == []
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_bus_predicate_filters_by_reason_code():
+    """Predicate-only filtering (no topic/pattern machinery): a handler
+    registered with a type + a reason_code predicate only fires for signals
+    matching both."""
+    bus = SchedulerSignalBus()
+    matched: list = []
+    bus.observe(
+        ScheduleRunFailed,
+        lambda s: s.reason_code == RunReasons.FAILED_MISSING_CWD,
+        handler=matched.append,
+    )
+
+    missing_cwd_sig = ScheduleRunFailed(
+        run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_MISSING_CWD
+    )
+    other_failure_sig = ScheduleRunFailed(
+        run_id="r2", schedule_id="s1", reason_code=RunReasons.FAILED_EXIT_NONZERO
+    )
+
+    await bus.emit(missing_cwd_sig)
+    await bus.emit(other_failure_sig)
+
+    assert matched == [missing_cwd_sig]
+
+
+@pytest.mark.asyncio
+async def test_bus_sync_and_async_handlers_both_run():
+    bus = SchedulerSignalBus()
+    sync_calls: list = []
+    async_calls: list = []
+
+    def _sync_handler(sig):
+        sync_calls.append(sig)
+
+    async def _async_handler(sig):
+        async_calls.append(sig)
+
+    bus.observe(ScheduleRunSucceeded, handler=_sync_handler)
+    bus.observe(ScheduleRunSucceeded, handler=_async_handler)
+
+    sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    await bus.emit(sig)
+
+    assert sync_calls == [sig]
+    assert async_calls == [sig]
+
+
+def test_bus_has_no_topic_or_route_stream_machinery():
+    """SchedulerSignalBus is a stripped registry: only observe/unobserve/emit
+    -- no Flow/route()/stream() (SessionObserver's DB-persistence-oriented
+    surface), and no separate topic/pattern key type beyond isinstance +
+    predicate."""
+    bus = SchedulerSignalBus()
+    assert not hasattr(bus, "route")
+    assert not hasattr(bus, "stream")
+    assert not hasattr(bus, "flow")
+
+
+@pytest.mark.asyncio
+async def test_unobserve_removes_handler_and_returns_count():
+    bus = SchedulerSignalBus()
+    seen: list = []
+
+    def handler(sig):
+        seen.append(sig)
+
+    bus.observe(ScheduleRunSucceeded, handler=handler)
+    bus.observe(ScheduleRunFailed, handler=handler)
+
+    removed = bus.unobserve(handler)
+    assert removed == 2
+
+    await bus.emit(ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code="x"))
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_emit_with_zero_handlers_is_a_noop():
+    bus = SchedulerSignalBus()
+    results = await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Failure semantics: ExceptionGroup, never a blanket swallow, siblings still run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_raises_exceptiongroup_when_a_handler_fails():
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    bus = SchedulerSignalBus()
+
+    def _boom(sig):
+        raise RuntimeError("handler bug")
+
+    bus.observe(ScheduleRunFailed, handler=_boom)
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await bus.emit(
+            ScheduleRunFailed(
+                run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION
+            )
+        )
+
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_emit_runs_every_handler_even_when_one_raises():
+    """return_exceptions=True: a broken handler must not prevent a sibling
+    handler for the SAME signal from running."""
+    bus = SchedulerSignalBus()
+    ran: list = []
+
+    def _boom(sig):
+        raise RuntimeError("handler bug")
+
+    def _good(sig):
+        ran.append(sig)
+
+    bus.observe(ScheduleRunFailed, handler=_boom)
+    bus.observe(ScheduleRunFailed, handler=_good)
+
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    sig = ScheduleRunFailed(run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION)
+    with pytest.raises(ExceptionGroup):
+        await bus.emit(sig)
+
+    assert ran == [sig]
+
+
+@pytest.mark.asyncio
+async def test_emit_collects_all_failures_into_one_group():
+    bus = SchedulerSignalBus()
+
+    def _boom1(sig):
+        raise RuntimeError("first")
+
+    def _boom2(sig):
+        raise ValueError("second")
+
+    bus.observe(ScheduleRunFailed, handler=_boom1)
+    bus.observe(ScheduleRunFailed, handler=_boom2)
+
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await bus.emit(
+            ScheduleRunFailed(
+                run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION
+            )
+        )
+
+    kinds = {type(e) for e in exc_info.value.exceptions}
+    assert kinds == {RuntimeError, ValueError}
+
+
+@pytest.mark.asyncio
+async def test_emit_predicate_exception_does_not_abort_sibling_dispatch():
+    """A raising predicate must be evaluated inside the same protected
+    region as handler invocation -- it must not abort emit() before a
+    sibling, independently-registered subscription ever gets to run."""
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    bus = SchedulerSignalBus()
+    ran: list = []
+
+    def _boom_predicate(sig):
+        raise RuntimeError("predicate bug")
+
+    def _good(sig):
+        ran.append(sig)
+
+    bus.observe(ScheduleRunFailed, _boom_predicate, handler=lambda sig: None)
+    bus.observe(ScheduleRunFailed, handler=_good)
+
+    sig = ScheduleRunFailed(run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION)
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await bus.emit(sig)
+
+    assert ran == [sig]
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_emit_reraises_cancellation_without_nesting_baseexception():
+    """gather(return_exceptions=True) can return a raw CancelledError.
+    Folding that into ExceptionGroup would raise TypeError ("cannot nest
+    BaseExceptions") -- cancellation must propagate as itself instead of
+    being wrapped or swallowed, and sibling handlers must still run."""
+    bus = SchedulerSignalBus()
+    ran: list = []
+
+    async def _cancelled(sig):
+        raise asyncio.CancelledError()
+
+    def _good(sig):
+        ran.append(sig)
+
+    bus.observe(ScheduleRunSucceeded, handler=_cancelled)
+    bus.observe(ScheduleRunSucceeded, handler=_good)
+
+    sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    with pytest.raises(asyncio.CancelledError):
+        await bus.emit(sig)
+
+    assert ran == [sig]
+
+
+@pytest.mark.asyncio
+async def test_emit_reraises_cancellation_even_with_other_handler_failures():
+    """A genuine handler bug alongside a cancellation must not turn into a
+    TypeError from ExceptionGroup nesting a BaseException -- cancellation
+    still wins and propagates, with the handler failure chained for
+    visibility rather than silently dropped."""
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    bus = SchedulerSignalBus()
+
+    async def _cancelled(sig):
+        raise asyncio.CancelledError()
+
+    def _boom(sig):
+        raise RuntimeError("handler bug")
+
+    bus.observe(ScheduleRunSucceeded, handler=_cancelled)
+    bus.observe(ScheduleRunSucceeded, handler=_boom)
+
+    sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await bus.emit(sig)
+
+    assert isinstance(exc_info.value.__cause__, ExceptionGroup)
+    assert isinstance(exc_info.value.__cause__.exceptions[0], RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# record_handler_failure — durable surfaced record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_handler_failure_writes_admin_event(tmp_path, monkeypatch):
+    import lionagi.state.db as state_db_mod
+    from lionagi.ln.concurrency import ExceptionGroup
+    from lionagi.state.db import StateDB
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+
+    sig = ScheduleRunFailed(
+        run_id="run-xyz", schedule_id="sched-xyz", reason_code=RunReasons.FAILED_EXCEPTION
+    )
+    eg = ExceptionGroup("handlers failed", [RuntimeError("boom")])
+
+    await record_handler_failure(eg, sig)
+
+    async with StateDB(fake_db) as db:
+        events = await db.list_admin_events(action="scheduler_signal_handler_failed")
+
+    assert len(events) == 1
+    assert events[0]["target_id"] == "run-xyz"
+    assert events[0]["actor"] == "scheduler"
+    details = events[0]["details"]
+    if isinstance(details, str):
+        import json
+
+        details = json.loads(details)
+    assert "RuntimeError: boom" in details["errors"][0]
+    assert details["signal_type"] == "ScheduleRunFailed"
+
+
+@pytest.mark.asyncio
+async def test_record_handler_failure_is_best_effort_and_never_raises(monkeypatch):
+    """If StateDB itself is unavailable, record_handler_failure logs and
+    swallows -- it must never become a second failure on top of the
+    already-surfaced handler exception."""
+    import lionagi.studio.scheduler.signals as signals_mod
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    class _BoomStateDB:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("lionagi.state.db.StateDB", _BoomStateDB)
+
+    sig = ScheduleRunFailed(
+        run_id="run-1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION
+    )
+    eg = ExceptionGroup("handlers failed", [RuntimeError("boom")])
+
+    # Must not raise.
+    await record_handler_failure(eg, sig)
+
+
+# ---------------------------------------------------------------------------
+# build_schedule_run_signal — mint-site-agnostic field derivation
+# ---------------------------------------------------------------------------
+
+
+def test_build_schedule_run_signal_completed_derives_succeeded():
+    sig = build_schedule_run_signal(
+        entity_id="run-1",
+        new_status="completed",
+        reason_code=RunReasons.COMPLETED_OK,
+        schedule_id="sched-1",
+        action_kind="agent",
+        chain_depth=0,
+        trigger_context={"k": "v"},
+    )
+    assert isinstance(sig, ScheduleRunSucceeded)
+    assert sig.run_id == "run-1"
+    assert sig.schedule_id == "sched-1"
+    assert sig.reason_code == RunReasons.COMPLETED_OK
+    assert sig.action_kind == "agent"
+    assert sig.chain_depth == 0
+    assert sig.trigger_context == {"k": "v"}
+
+
+def test_build_schedule_run_signal_failed_derives_failed_with_error_detail():
+    sig = build_schedule_run_signal(
+        entity_id="run-2",
+        new_status="failed",
+        reason_code=RunReasons.FAILED_EXIT_NONZERO,
+        error_detail="exit 1",
+    )
+    assert isinstance(sig, ScheduleRunFailed)
+    assert sig.error_detail == "exit 1"
+
+
+def test_build_schedule_run_signal_cancelled_derives_cancelled():
+    sig = build_schedule_run_signal(
+        entity_id="run-3",
+        new_status="cancelled",
+        reason_code=RunReasons.CANCELLED_SYSTEM,
+    )
+    assert isinstance(sig, ScheduleRunCancelled)
+
+
+def test_build_schedule_run_signal_unknown_status_raises():
+    with pytest.raises(ValueError, match="no schedule_run signal registered"):
+        build_schedule_run_signal(entity_id="run-4", new_status="running", reason_code="x")
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine._fire_inner integration — mint on each terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_happy_path_mints_schedule_run_succeeded():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunSucceeded, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
+
+    assert len(captured) == 1
+    sig = captured[0]
+    assert sig.run_id == "run-001"
+    assert sig.schedule_id == "sched-001"
+    assert sig.reason_code == RunReasons.COMPLETED_OK
+
+
+@pytest.mark.asyncio
+async def test_fire_nonzero_exit_mints_schedule_run_failed():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunFailed, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(1, "error text")),
+        ),
+    ):
+        await engine._fire(schedule, "run-002", trigger_context={"scheduled": True})
+
+    assert len(captured) == 1
+    assert captured[0].reason_code == RunReasons.FAILED_EXIT_NONZERO
+    assert captured[0].error_detail == "error text"
+
+
+@pytest.mark.asyncio
+async def test_fire_inner_exception_mints_schedule_run_failed():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunFailed, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ),
+    ):
+        await engine._fire(schedule, "run-005", trigger_context={"scheduled": True})
+
+    assert len(captured) == 1
+    assert captured[0].reason_code == RunReasons.FAILED_EXCEPTION
+    assert "RuntimeError: unexpected" in captured[0].error_detail
+
+
+@pytest.mark.asyncio
+async def test_fire_cancellation_mints_schedule_run_cancelled():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunCancelled, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(schedule, "run-004", trigger_context={"scheduled": True})
+
+    assert len(captured) == 1
+    assert captured[0].reason_code == RunReasons.CANCELLED_SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_fire_does_not_mint_when_guarded_write_loses_race():
+    """A lost race (a concurrent reaper already finalized the row) must not
+    mint a signal describing an outcome this call didn't actually commit."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(return_value=False)  # every terminal write "loses"
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunSucceeded, handler=captured.append)
+    bus.observe(ScheduleRunFailed, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-006", trigger_context={"scheduled": True})
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_fire_build_argv_exception_mints_schedule_run_failed():
+    """The pre-launch exception path (build_argv() raising, e.g. an invalid
+    action_kind or an unresolvable executable) is a fourth schedule_run
+    terminal write and must mint the same as the other three terminal
+    paths."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunFailed, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(schedule, "run-010", trigger_context={"scheduled": True})
+
+    assert len(captured) == 1
+    sig = captured[0]
+    assert sig.run_id == "run-010"
+    assert sig.schedule_id == "sched-001"
+    assert sig.reason_code == RunReasons.FAILED_EXCEPTION
+    assert "bad action_kind" in sig.error_detail
+
+
+@pytest.mark.asyncio
+async def test_fire_build_argv_exception_does_not_mint_when_write_lost_race():
+    """A lost race on the pre-launch failure write (a concurrent writer
+    already finalized the row) must not mint a signal describing an outcome
+    this call didn't actually commit."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(return_value=False)  # every terminal write "loses"
+    bus = SchedulerSignalBus()
+    captured: list = []
+    bus.observe(ScheduleRunFailed, handler=captured.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(schedule, "run-011", trigger_context={"scheduled": True})
+
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: a broken handler surfaces a durable record and the tick loop
+# continues -- it must not stop this schedule's own bookkeeping, and a
+# following, unrelated fire must still succeed normally.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broken_handler_surfaces_admin_event_and_fire_completes(tmp_path, monkeypatch):
+    import lionagi.state.db as state_db_mod
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+
+    def _boom(sig):
+        raise RuntimeError("handler bug")
+
+    bus.observe(ScheduleRunSucceeded, handler=_boom)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        # Must not raise -- the handler bug is contained at the mint call site.
+        await engine._fire(schedule, "run-007", trigger_context={"scheduled": True})
+
+    # The schedule_run's own bookkeeping (invocation/run rows, status writes,
+    # max_runs check) still ran normally despite the broken handler.
+    svc.create_invocation.assert_awaited_once()
+    svc.create_schedule_run.assert_awaited_once()
+    assert svc.update_status.await_count == 3  # running + completed + invocation
+
+    async with StateDB(fake_db) as db:
+        events = await db.list_admin_events(action="scheduler_signal_handler_failed")
+    assert len(events) == 1
+    assert events[0]["target_id"] == "run-007"
+
+
+@pytest.mark.asyncio
+async def test_broken_predicate_does_not_block_sibling_handler_and_surfaces_admin_event(
+    tmp_path, monkeypatch
+):
+    """A predicate that raises during matching must not abort dispatch
+    before a sibling, independently-registered handler ever runs -- the
+    predicate failure becomes a collected dispatch failure, surfaced as the
+    same durable admin_events record as any other handler bug."""
+    import lionagi.state.db as state_db_mod
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+    healthy: list = []
+
+    def _boom_predicate(sig):
+        raise RuntimeError("predicate bug")
+
+    bus.observe(ScheduleRunSucceeded, _boom_predicate, handler=lambda sig: None)
+    bus.observe(ScheduleRunSucceeded, handler=healthy.append)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-012", trigger_context={"scheduled": True})
+
+    assert len(healthy) == 1  # sibling handler ran despite the raising predicate
+
+    async with StateDB(fake_db) as db:
+        events = await db.list_admin_events(action="scheduler_signal_handler_failed")
+    assert len(events) == 1
+    assert events[0]["target_id"] == "run-012"
+    details = events[0]["details"]
+    if isinstance(details, str):
+        import json
+
+        details = json.loads(details)
+    assert "RuntimeError: predicate bug" in details["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_unrelated_fire_still_succeeds_after_a_prior_handler_failure(tmp_path, monkeypatch):
+    """One schedule's broken handler must not poison a subsequent, unrelated
+    fire on the same engine/bus."""
+    import lionagi.state.db as state_db_mod
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+
+    svc = _make_svc()
+    bus = SchedulerSignalBus()
+
+    def _boom(sig):
+        raise RuntimeError("handler bug")
+
+    bus.observe(ScheduleRunSucceeded, handler=_boom)
+    engine = SchedulerEngine(svc=svc, signal_bus=bus)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-008", trigger_context={"scheduled": True})
+        # Second, unrelated fire on the same engine/bus must still complete
+        # normally -- the handler exception from the first fire must not
+        # have crashed the tick loop or left the bus/engine in a bad state.
+        await engine._fire(schedule, "run-009", trigger_context={"scheduled": True})
+
+    assert svc.create_schedule_run.await_count == 2


### PR DESCRIPTION
## Summary

Adds a scheduler-scoped signal bus and wires the scheduler engine's terminal transitions to mint typed lifecycle signals.

- **`lionagi/studio/scheduler/signals.py`** (new): typed signal dataclasses for run/schedule lifecycle transitions; isinstance-matched handler registry with optional per-handler predicates. Predicates are evaluated inside the dispatch `gather(..., return_exceptions=True)` so a raising predicate is collected like a handler error and cannot starve sibling handlers. Cancellation is partitioned from ordinary failures: `CancelledError` re-raises (chaining any concurrent ordinary failures); ordinary handler failures aggregate into an `ExceptionGroup`.
- **`lionagi/studio/scheduler/engine.py`**: all four terminal transition sites mint signals only after the StateDB terminal write commits — a lost CAS race mints nothing, so a signal always reflects a committed state transition.
- **`tests/studio/test_scheduler_signals.py`** (new): test suite covering bus dispatch, predicate isolation, cancellation partitioning, and committed-write/lost-race mint pairs at the engine sites.

## Review

Independent reviewer leg, 2 rounds. Round 1: APPROVE-WITH-FIXES (3 findings: terminal-write result not gating the mint at one site; predicate evaluated during candidate selection; raw CancelledError passed to ExceptionGroup). All three fixed with regression pairs. Round 2 (narrow re-verify): all findings CLOSED, no new findings. Gates: `pytest tests/studio/test_scheduler_signals.py tests/studio/test_scheduler_engine.py -n0` → 73 passed, 14 skipped; ruff clean.

## Follow-on (same lane)

Coordination telemetry — signals emitted/received/acted-on per run plus a cheap duplication indicator (overlapping files-read), surfaced in `li monitor` / run summary. Measure-only, no agent behavior change. Lands as a follow-on slice consuming this bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
