### PR TITLE
fix(studio): truncated run-file reads tolerate a multibyte character split at the cap

### DIFF
--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -850,10 +850,16 @@ async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
         os.close(fd)
 
     truncated = len(raw) > _MAX_FILE_READ_BYTES
-    try:
-        content = raw[:_MAX_FILE_READ_BYTES].decode("utf-8")
-    except UnicodeDecodeError:
-        raise HTTPException(status_code=415, detail="File is not text/UTF-8") from None
+    if truncated:
+        # The cap can split a multibyte UTF-8 sequence at the boundary of an
+        # otherwise-valid file; that must read as truncation, not as a binary
+        # file. Only genuinely non-text files (untruncated branch) get a 415.
+        content = raw[:_MAX_FILE_READ_BYTES].decode("utf-8", errors="replace")
+    else:
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            raise HTTPException(status_code=415, detail="File is not text/UTF-8") from None
 
     return {
         "path": str(resolved),

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -165,6 +165,42 @@ async def test_large_file_is_truncated(patched_runs_svc, tmp_path, monkeypatch):
     assert result["size"] == 100
 
 
+async def test_multibyte_char_split_at_cap_is_truncation_not_415(
+    patched_runs_svc, tmp_path, monkeypatch
+):
+    """A valid UTF-8 file whose multibyte character straddles the read cap must
+    come back as truncated text with a replacement character, not a 415."""
+    svc, db_path = patched_runs_svc
+    monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 10)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "unicode.txt"
+    # 9 ASCII bytes then a 3-byte character: bytes 10-12 hold the sequence, so
+    # the 10-byte cap slices it mid-character while the file itself is valid.
+    target.write_text("a" * 9 + "€" * 10, encoding="utf-8")
+    await seed_session(db_path, session_id="run-12", artifacts_path=str(artifact_root))
+
+    result = await svc.get_run_file("run-12", str(target))
+    assert result["truncated"] is True
+    assert result["content"].startswith("a" * 9)
+    assert "�" in result["content"]
+
+
+async def test_untruncated_binary_file_still_returns_415(patched_runs_svc, tmp_path, monkeypatch):
+    """The lenient decode applies only to the truncated branch — a small
+    genuinely non-text file keeps the strict 415 contract."""
+    svc, db_path = patched_runs_svc
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "blob.bin"
+    target.write_bytes(b"\xff\xfe\x00\x01binary")
+    await seed_session(db_path, session_id="run-13", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-13", str(target))
+    assert exc_info.value.status_code == 415
+
+
 # ---------------------------------------------------------------------------
 # Bounded read: the cap must be enforced by the read itself, not by slicing
 # an already-materialized full read (Path.read_bytes() then [:cap] would


### PR DESCRIPTION
## Summary

The run-file endpoint's read cap can slice a valid UTF-8 file mid-character; the strict decode then misreported the file as non-text (415). The truncated branch now decodes with `errors="replace"` so a capped read renders as truncated text with a replacement character. Untruncated files keep the strict decode and the 415 contract for genuinely binary content.

Two regressions: a valid file whose 3-byte character straddles the cap returns 200/truncated with a replacement character; a small binary file still 415s.

Lane A shape: ~8-line behavior fix on the truncated-decode branch only, no API change, plus tests. Gates: `test_run_file.py` 25 passed; full `tests/apps_studio_server/` suite green; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
