### PR TITLE
feat(scheduler): per-run coordination telemetry (measure-only)

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -567,6 +567,44 @@ async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _parse_json_field(value: Any) -> dict[str, Any] | None:
+    """Best-effort JSON-object decode for a column that may come back as a
+    Python dict (Postgres JSON auto-decode) or a raw string (SQLite text
+    storage via an ad-hoc `text()` query with no column typing)."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _format_coordination_line(telemetry: dict[str, Any]) -> str | None:
+    """One-liner rendering of an invocation's coordination telemetry
+    (`node_metadata["coordination"]`, written by the scheduler engine's
+    finalize path -- see `lionagi.studio.services.scheduler_state.
+    flush_run_telemetry`). Returns None when everything is zero: both the
+    monitor drill-in and the `li monitor run` wait-line only print this when
+    non-zero.
+    """
+    signals = telemetry.get("signals") or {}
+    emitted = signals.get("emitted") or {}
+    emitted_total = sum(emitted.values()) if isinstance(emitted, dict) else 0
+    received = signals.get("received") or 0
+    acted_on = signals.get("acted_on") or 0
+    overlap = telemetry.get("files_overlap") or {}
+    overlap_count = overlap.get("count") or 0
+    if not (emitted_total or received or acted_on or overlap_count):
+        return None
+    return (
+        f"emitted={emitted_total} received={received} "
+        f"acted_on={acted_on} files_overlap={overlap_count}"
+    )
+
+
 async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
     lines: list[str] = []
     lines.append(_bold(f"INVOCATION  {inv['id']}"))
@@ -580,6 +618,19 @@ async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
         lines.append(
             f"  started:       {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(started))}"
         )
+
+    node_metadata = _parse_json_field(inv.get("node_metadata"))
+    coordination = (node_metadata or {}).get("coordination")
+    if isinstance(coordination, dict):
+        coord_line = _format_coordination_line(coordination)
+        if coord_line:
+            lines.append("")
+            lines.append(_dim("  -- coordination --"))
+            lines.append(f"    {coord_line}")
+            top = (coordination.get("files_overlap") or {}).get("top") or []
+            for entry in top:
+                if isinstance(entry, dict) and entry.get("path"):
+                    lines.append(f"      {entry['path']}  (workers={entry.get('workers', '?')})")
 
     child_rows = await db.fetch_all(
         "SELECT id, status, model, started_at FROM sessions WHERE invocation_id = ? ORDER BY created_at",
@@ -1106,7 +1157,19 @@ async def _poll_pending_once(
         elif row["status"] not in _TERMINAL_SCHEDULE_RUN_STATUSES:
             continue
         name = await _schedule_name(db, row["schedule_id"], cache=schedule_names)
+        # Resolved before the print/append/delete trio below (not between
+        # them) so that trio stays await-free and atomic wrt cancellation.
+        coord_line = None
+        invocation_id = row.get("invocation_id")
+        if invocation_id:
+            invocation = await db.get_invocation(invocation_id)
+            node_metadata = _parse_json_field((invocation or {}).get("node_metadata"))
+            coordination = (node_metadata or {}).get("coordination")
+            if isinstance(coordination, dict):
+                coord_line = _format_coordination_line(coordination)
         print(_format_wait_line(row, name))
+        if coord_line:
+            print(f"  coordination: {coord_line}")
         done.append(row)
         del pending[run_id]
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -582,6 +582,14 @@ def _parse_json_field(value: Any) -> dict[str, Any] | None:
     return None
 
 
+def _as_number(value: Any) -> int | float:
+    """Coerce *value* to a count, treating anything non-numeric as 0 --
+    persisted telemetry is untrusted (hand-edited state.db rows, a future
+    writer with a different shape), and a malformed count must never crash
+    the monitor."""
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
+
+
 def _format_coordination_line(telemetry: dict[str, Any]) -> str | None:
     """One-liner rendering of an invocation's coordination telemetry
     (`node_metadata["coordination"]`, written by the scheduler engine's
@@ -589,14 +597,23 @@ def _format_coordination_line(telemetry: dict[str, Any]) -> str | None:
     flush_run_telemetry`). Returns None when everything is zero: both the
     monitor drill-in and the `li monitor run` wait-line only print this when
     non-zero.
+
+    Every nested field is type-checked before use: `telemetry` is read back
+    from persisted state and may not match the shape this module writes
+    (e.g. `signals` or `files_overlap` landing as a list rather than a
+    dict) -- malformed nested values are treated as zero/absent rather than
+    raising `AttributeError`.
     """
-    signals = telemetry.get("signals") or {}
-    emitted = signals.get("emitted") or {}
-    emitted_total = sum(emitted.values()) if isinstance(emitted, dict) else 0
-    received = signals.get("received") or 0
-    acted_on = signals.get("acted_on") or 0
-    overlap = telemetry.get("files_overlap") or {}
-    overlap_count = overlap.get("count") or 0
+    signals = telemetry.get("signals")
+    signals = signals if isinstance(signals, dict) else {}
+    emitted = signals.get("emitted")
+    emitted = emitted if isinstance(emitted, dict) else {}
+    emitted_total = sum(_as_number(v) for v in emitted.values())
+    received = _as_number(signals.get("received"))
+    acted_on = _as_number(signals.get("acted_on"))
+    overlap = telemetry.get("files_overlap")
+    overlap = overlap if isinstance(overlap, dict) else {}
+    overlap_count = _as_number(overlap.get("count"))
     if not (emitted_total or received or acted_on or overlap_count):
         return None
     return (
@@ -627,7 +644,9 @@ async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
             lines.append("")
             lines.append(_dim("  -- coordination --"))
             lines.append(f"    {coord_line}")
-            top = (coordination.get("files_overlap") or {}).get("top") or []
+            files_overlap = coordination.get("files_overlap")
+            top = files_overlap.get("top") if isinstance(files_overlap, dict) else None
+            top = top if isinstance(top, list) else []
             for entry in top:
                 if isinstance(entry, dict) and entry.get("path"):
                     lines.append(f"      {entry['path']}  (workers={entry.get('workers', '?')})")

--- a/lionagi/studio/scheduler/coordination.py
+++ b/lionagi/studio/scheduler/coordination.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Per-invocation files-read overlap: a cheap duplication indicator over the
+tool-call file paths a scheduled invocation's child sessions ("workers")
+touched. Measure-only, read-side aggregation over already-persisted
+messages -- never touches a live agent.
+
+Mirrors the per-session file-set union `get_session()` builds in
+lionagi/studio/services/sessions.py (`message_stats.files`), but reads
+directly off StateDB's async engine instead of that module's aiosqlite
+connection, so the scheduler's finalize path (lionagi/studio/scheduler/
+engine.py) stays on the connection it already holds rather than opening a
+second DB layer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ("compute_files_overlap",)
+
+# Legacy rows may carry the bare class name instead of the fully-qualified
+# path (see sessions.py's _ACTION_LION_CLASSES for the same accommodation).
+_ACTION_REQUEST_CLASSES = (
+    "lionagi.protocols.messages.action_request.ActionRequest",
+    "ActionRequest",
+)
+
+_DEFAULT_TOP_N = 5
+_CHUNK_SIZE = 500  # stays under SQLite's bound-variable ceiling per query
+
+
+def _parse_content(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _extract_file_path(content: dict[str, Any]) -> str | None:
+    arguments = content.get("arguments")
+    arguments = arguments if isinstance(arguments, dict) else {}
+    file_path = arguments.get("file_path") or arguments.get("path")
+    return file_path if isinstance(file_path, str) and file_path else None
+
+
+async def _worker_file_sets(db: Any, invocation_id: str) -> dict[str, set[str]]:
+    """Per-session (worker) file-path sets, unioned across all of that
+    session's branches -- one entry per child session that touched any
+    file, keyed by session id."""
+    session_rows = await db.fetch_all(
+        "SELECT id FROM sessions WHERE invocation_id = ?", (invocation_id,)
+    )
+    if not session_rows:
+        return {}
+
+    type_placeholders = ",".join("?" for _ in _ACTION_REQUEST_CLASSES)
+    type_rows = await db.fetch_all(
+        f"SELECT type_id FROM message_types WHERE lion_class IN ({type_placeholders})",  # noqa: S608
+        list(_ACTION_REQUEST_CLASSES),
+    )
+    type_ids = [r["type_id"] for r in type_rows]
+    if not type_ids:
+        return {}
+
+    file_sets: dict[str, set[str]] = {}
+    for srow in session_rows:
+        session_id = srow["id"]
+        branch_rows = await db.fetch_all(
+            "SELECT progression_id FROM branches WHERE session_id = ?", (session_id,)
+        )
+        msg_ids: list[str] = []
+        for brow in branch_rows:
+            prog_id = brow.get("progression_id")
+            if not prog_id:
+                continue
+            prog_row = await db.fetch_one(
+                "SELECT collection FROM progressions WHERE id = ?", (prog_id,)
+            )
+            collection = (prog_row or {}).get("collection")
+            if not collection:
+                continue
+            try:
+                ids = json.loads(collection) if isinstance(collection, str) else collection
+            except (ValueError, TypeError):
+                continue
+            if isinstance(ids, list):
+                msg_ids.extend(ids)
+        if not msg_ids:
+            continue
+
+        files: set[str] = set()
+        type_ph = ",".join("?" for _ in type_ids)
+        for chunk_start in range(0, len(msg_ids), _CHUNK_SIZE):
+            chunk = msg_ids[chunk_start : chunk_start + _CHUNK_SIZE]
+            id_ph = ",".join("?" for _ in chunk)
+            rows = await db.fetch_all(
+                f"SELECT content FROM messages WHERE id IN ({id_ph}) "  # noqa: S608
+                f"AND lion_class IN ({type_ph})",
+                [*chunk, *type_ids],
+            )
+            for row in rows:
+                content = _parse_content(row.get("content"))
+                file_path = _extract_file_path(content)
+                if file_path:
+                    files.add(file_path)
+        if files:
+            file_sets[session_id] = files
+    return file_sets
+
+
+def _overlap_from_file_sets(file_sets: dict[str, set[str]], *, top_n: int) -> dict[str, Any]:
+    """Files touched by >=2 distinct workers; count + top-N paths by worker
+    count (ties broken by path for deterministic output)."""
+    worker_counts: dict[str, int] = {}
+    for files in file_sets.values():
+        for path in files:
+            worker_counts[path] = worker_counts.get(path, 0) + 1
+    overlapping = {path: n for path, n in worker_counts.items() if n >= 2}
+    top = sorted(overlapping.items(), key=lambda kv: (-kv[1], kv[0]))[:top_n]
+    return {
+        "count": len(overlapping),
+        "top": [{"path": path, "workers": n} for path, n in top],
+    }
+
+
+async def compute_files_overlap(
+    db: Any, invocation_id: str, *, top_n: int = _DEFAULT_TOP_N
+) -> dict[str, Any]:
+    """``{"count": N, "top": [{"path": ..., "workers": ...}, ...]}`` for
+    *invocation_id*'s child sessions ("workers"). Zero-worker or
+    zero-overlap invocations return ``{"count": 0, "top": []}``, never an
+    error -- this runs unconditionally at invocation finalize."""
+    file_sets = await _worker_file_sets(db, invocation_id)
+    return _overlap_from_file_sets(file_sets, top_n=top_n)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -29,6 +29,7 @@ from lionagi.studio.services.scheduler_state import (
     SchedulerStateService,
     create_skipped_run,
     default_scheduler_state,
+    flush_run_telemetry,
     resolve_invocation_terminal,
 )
 
@@ -1404,7 +1405,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
             await self._svc.update_invocation(inv_id, ended_at=_end_time)
-            await self._guarded_terminal_status(
+            inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,
@@ -1415,6 +1416,10 @@ class SchedulerEngine:
                 actor=inv_id,
                 metadata=inv_meta,
             )
+            if inv_written:
+                await flush_run_telemetry(
+                    self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                )
             update_fields: dict[str, Any] = {"last_fired_at": now}
             if next_at:
                 update_fields["next_fire_at"] = next_at
@@ -1531,7 +1536,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status=status, exit_code=exit_code
             )
             await self._svc.update_invocation(inv_id, ended_at=end_time)
-            await self._guarded_terminal_status(
+            inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,
@@ -1542,6 +1547,10 @@ class SchedulerEngine:
                 actor=inv_id,
                 metadata=inv_meta,
             )
+            if inv_written:
+                await flush_run_telemetry(
+                    self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                )
             await self._check_max_runs(schedule, chain_depth)
 
             if chain_depth < _MAX_CHAIN_DEPTH:
@@ -1615,7 +1624,7 @@ class SchedulerEngine:
                     self._svc, inv_id, fallback_status="cancelled"
                 )
                 await self._svc.update_invocation(inv_id, ended_at=_end_time)
-                await self._guarded_terminal_status(
+                inv_written = await self._guarded_terminal_status(
                     "invocation",
                     inv_id,
                     new_status=inv_status,
@@ -1626,6 +1635,10 @@ class SchedulerEngine:
                     actor=inv_id,
                     metadata=inv_meta,
                 )
+                if inv_written:
+                    await flush_run_telemetry(
+                        self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                    )
                 await self._check_max_runs(schedule, chain_depth)
             except Exception:
                 _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
@@ -1666,7 +1679,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
             await self._svc.update_invocation(inv_id, ended_at=_end_time)
-            await self._guarded_terminal_status(
+            inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,
@@ -1677,6 +1690,10 @@ class SchedulerEngine:
                 actor=inv_id,
                 metadata=inv_meta,
             )
+            if inv_written:
+                await flush_run_telemetry(
+                    self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                )
             await self._check_max_runs(schedule, chain_depth)
         finally:
             if chain_depth == 0:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1420,6 +1420,14 @@ class SchedulerEngine:
                 await flush_run_telemetry(
                     self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
                 )
+            else:
+                # Another finalizer already wrote this invocation's terminal
+                # status, so no flush happens here -- but a schedule_run
+                # signal was still minted onto the bus above. Drop its
+                # counters now instead of letting them sit in the bus's
+                # per-run_id map forever (it never gets a second flush call
+                # for this run_id to consume them).
+                self._signal_bus.pop_run_counters(run_id)
             update_fields: dict[str, Any] = {"last_fired_at": now}
             if next_at:
                 update_fields["next_fire_at"] = next_at
@@ -1551,6 +1559,14 @@ class SchedulerEngine:
                 await flush_run_telemetry(
                     self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
                 )
+            else:
+                # Another finalizer already wrote this invocation's terminal
+                # status, so no flush happens here -- but a schedule_run
+                # signal was still minted onto the bus above. Drop its
+                # counters now instead of letting them sit in the bus's
+                # per-run_id map forever (it never gets a second flush call
+                # for this run_id to consume them).
+                self._signal_bus.pop_run_counters(run_id)
             await self._check_max_runs(schedule, chain_depth)
 
             if chain_depth < _MAX_CHAIN_DEPTH:
@@ -1639,6 +1655,13 @@ class SchedulerEngine:
                     await flush_run_telemetry(
                         self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
                     )
+                else:
+                    # Another finalizer already wrote this invocation's
+                    # terminal status, so no flush happens here -- but a
+                    # schedule_run signal was still minted onto the bus
+                    # above. Drop its counters now instead of letting them
+                    # sit in the bus's per-run_id map forever.
+                    self._signal_bus.pop_run_counters(run_id)
                 await self._check_max_runs(schedule, chain_depth)
             except Exception:
                 _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
@@ -1694,6 +1717,13 @@ class SchedulerEngine:
                 await flush_run_telemetry(
                     self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
                 )
+            else:
+                # Another finalizer already wrote this invocation's terminal
+                # status, so no flush happens here -- but a schedule_run
+                # signal was still minted onto the bus above. Drop its
+                # counters now instead of letting them sit in the bus's
+                # per-run_id map forever.
+                self._signal_bus.pop_run_counters(run_id)
             await self._check_max_runs(schedule, chain_depth)
         finally:
             if chain_depth == 0:

--- a/lionagi/studio/scheduler/signals.py
+++ b/lionagi/studio/scheduler/signals.py
@@ -33,6 +33,7 @@ import inspect
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from lionagi.ln.concurrency import ExceptionGroup, gather
@@ -135,6 +136,36 @@ def build_schedule_run_signal(
     return cls(**kwargs)
 
 
+@dataclass
+class _RunSignalCounters:
+    """Per-``run_id`` coordination counters, accumulated across every signal
+    :meth:`SchedulerSignalBus.emit` dispatches for that run.
+
+    ``emitted`` is a signal-type-name histogram: today's mint site fires
+    exactly one terminal ``ScheduleRun*`` signal per run (see
+    ``engine.py._fire_inner``), so in practice every value is 1, but the
+    histogram shape survives a future run minting more than one signal
+    without a counter-shape change. ``received`` counts deliveries where a
+    subscription's types AND predicates both matched (regardless of what
+    the handler returned or whether it raised); ``acted_on`` counts only
+    the subset where the handler additionally returned a truthy "acted"
+    marker — the opt-in convention that keeps this measure-only (no
+    handler is required to participate; a non-participating handler simply
+    contributes to ``received``, never to ``acted_on``).
+    """
+
+    emitted: dict[str, int] = field(default_factory=dict)
+    received: int = 0
+    acted_on: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "emitted": dict(self.emitted),
+            "received": self.received,
+            "acted_on": self.acted_on,
+        }
+
+
 class SchedulerSignalBus:
     """Stripped-down sibling of :class:`~lionagi.session.observer.SessionObserver`.
 
@@ -144,10 +175,33 @@ class SchedulerSignalBus:
     signals describe. Matching is ``isinstance``-based against any ``type``
     key, AND-composed with any callable predicate keys (e.g. filtering on
     ``reason_code``) — no topic/pattern machinery.
+
+    Also accumulates per-``run_id`` coordination counters (signals
+    emitted/received/acted-on — see :class:`_RunSignalCounters`) so a
+    caller can report them at that run's finalize via
+    :meth:`pop_run_counters`. The bus itself is the least invasive place to
+    keep them: it already sees every signal and every handler dispatch, and
+    it requires no change to the handler API (``observe``/the ``Handler``
+    signature are untouched).
     """
 
     def __init__(self) -> None:
         self._subs: list[tuple[tuple[type, ...], tuple[Predicate, ...], Handler]] = []
+        self._counters: dict[str, _RunSignalCounters] = {}
+
+    def pop_run_counters(self, run_id: str) -> dict[str, Any] | None:
+        """Remove and return *run_id*'s accumulated signal counters as a
+        plain dict, or ``None`` if no signal was ever emitted for it.
+
+        Pop, not peek: the bus is a long-lived per-daemon singleton (one
+        per :class:`SchedulerEngine`, spanning every schedule it ever
+        fires), so counters must not accumulate for the process's whole
+        lifetime past the one terminal flush each run_id gets (see
+        ``lionagi.studio.services.scheduler_state.flush_run_telemetry``,
+        the intended sole caller).
+        """
+        counters = self._counters.pop(run_id, None)
+        return counters.to_dict() if counters is not None else None
 
     def observe(self, *keys: type | Predicate, handler: Handler) -> Handler:
         """Register *handler* for signals matching all *keys* (types AND predicates)."""
@@ -183,6 +237,16 @@ class SchedulerSignalBus:
         not a handler bug to record.
         """
         candidates = [entry for entry in self._subs if not entry[0] or isinstance(signal, entry[0])]
+
+        # Emitted counts regardless of whether any handler is even
+        # listening -- it describes what the mint site dispatched, not
+        # what got delivered (that's `received`, below).
+        run_id = getattr(signal, "run_id", "") or ""
+        if run_id:
+            counters = self._counters.setdefault(run_id, _RunSignalCounters())
+            type_name = type(signal).__name__
+            counters.emitted[type_name] = counters.emitted.get(type_name, 0) + 1
+
         if not candidates:
             return []
 
@@ -192,9 +256,19 @@ class SchedulerSignalBus:
             _types, predicates, handler = entry
             if not all(pred(signal) for pred in predicates):
                 return _NO_MATCH
+            # Received: candidate matched (isinstance, above) AND every
+            # predicate passed -- counted before invocation so a handler
+            # that raises still counts as delivered, just not acted-on.
+            if run_id:
+                self._counters[run_id].received += 1
             out = handler(signal)
             if inspect.isawaitable(out):
                 out = await out
+            # Acted-on: the opt-in truthy-return convention (see
+            # _RunSignalCounters docstring) -- a non-participating handler
+            # returning None/falsy stays received-only.
+            if run_id and out:
+                self._counters[run_id].acted_on += 1
             return out
 
         raw = await gather(*(_invoke(entry) for entry in candidates), return_exceptions=True)

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -361,29 +361,48 @@ async def flush_run_telemetry(
     or the files-read pattern leaves node_metadata untouched, matching the
     "measure-only" surfacing rule (the CLI/monitor summary lines only print
     when non-zero).
+
+    Best-effort: this rides an already-committed terminal write, so a
+    failure computing overlap or persisting node_metadata must never
+    propagate back into the caller and be mistaken for (or alter) that
+    run's actual outcome. Any such failure is logged and swallowed, and the
+    counters already popped above are lost with it rather than retried --
+    telemetry is measure-only, not authoritative state. Cancellation
+    (``asyncio.CancelledError`` and any other backend's cancellation
+    exception) is a ``BaseException``, not an ``Exception``, so it is never
+    caught here and always propagates.
     """
     signals = bus.pop_run_counters(run_id)
-    overlap = await svc.compute_files_overlap(invocation_id, top_n=top_n)
-    if signals is None and not overlap.get("count"):
-        return None
+    try:
+        overlap = await svc.compute_files_overlap(invocation_id, top_n=top_n)
+        if signals is None and not overlap.get("count"):
+            return None
 
-    telemetry = {
-        "signals": signals or {"emitted": {}, "received": 0, "acted_on": 0},
-        "files_overlap": overlap,
-    }
+        telemetry = {
+            "signals": signals or {"emitted": {}, "received": 0, "acted_on": 0},
+            "files_overlap": overlap,
+        }
 
-    invocation = await svc.get_invocation(invocation_id)
-    node_metadata = (invocation or {}).get("node_metadata")
-    if isinstance(node_metadata, str):
-        try:
-            node_metadata = json.loads(node_metadata)
-        except (ValueError, TypeError):
+        invocation = await svc.get_invocation(invocation_id)
+        node_metadata = (invocation or {}).get("node_metadata")
+        if isinstance(node_metadata, str):
+            try:
+                node_metadata = json.loads(node_metadata)
+            except (ValueError, TypeError):
+                node_metadata = {}
+        if not isinstance(node_metadata, dict):
             node_metadata = {}
-    if not isinstance(node_metadata, dict):
-        node_metadata = {}
-    node_metadata["coordination"] = telemetry
-    await svc.update_invocation(invocation_id, node_metadata=node_metadata)
-    return telemetry
+        node_metadata["coordination"] = telemetry
+        await svc.update_invocation(invocation_id, node_metadata=node_metadata)
+        return telemetry
+    except Exception:
+        _log.warning(
+            "Failed to flush coordination telemetry for run %s (invocation %s)",
+            run_id,
+            invocation_id,
+            exc_info=True,
+        )
+        return None
 
 
 # Singleton for production use

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -9,11 +9,13 @@ SchedulerStateService.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Protocol
 
 from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
+from lionagi.studio.scheduler import coordination as _coordination
 
 _log = logging.getLogger(__name__)
 
@@ -40,6 +42,12 @@ class SchedulerStateService(Protocol):
     async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
 
     async def update_invocation(self, inv_id: str, **fields: Any) -> None: ...
+
+    async def get_invocation(self, invocation_id: str) -> dict[str, Any] | None: ...
+
+    async def compute_files_overlap(
+        self, invocation_id: str, *, top_n: int = 5
+    ) -> dict[str, Any]: ...
 
     async def update_status(
         self,
@@ -101,6 +109,14 @@ class _DBSchedulerStateService:
     async def update_invocation(self, inv_id: str, **fields: Any) -> None:
         async with StateDB() as db:
             await db.update_invocation(inv_id, **fields)
+
+    async def get_invocation(self, invocation_id: str) -> dict[str, Any] | None:
+        async with StateDB() as db:
+            return await db.get_invocation(invocation_id)
+
+    async def compute_files_overlap(self, invocation_id: str, *, top_n: int = 5) -> dict[str, Any]:
+        async with StateDB() as db:
+            return await _coordination.compute_files_overlap(db, invocation_id, top_n=top_n)
 
     async def update_status(
         self,
@@ -315,6 +331,59 @@ async def resolve_invocation_terminal(
         evidence_refs,
         metadata,
     )
+
+
+async def flush_run_telemetry(
+    svc: SchedulerStateService,
+    bus: Any,
+    *,
+    run_id: str,
+    invocation_id: str,
+    top_n: int = 5,
+) -> dict[str, Any] | None:
+    """Compute and persist one run's coordination telemetry exactly once,
+    riding the invocation's own terminal write (engine.py calls this only
+    after its own ``_guarded_terminal_status("invocation", ...)`` returns
+    True -- the same guard that makes that write itself land exactly once,
+    see the four `_fire_inner` terminal sites).
+
+    Pulls the bus's accumulated signal counters for *run_id* (popping them
+    -- see ``SchedulerSignalBus.pop_run_counters``) and the invocation's
+    files-read overlap across its child sessions, then merges both under a
+    ``"coordination"`` key in ``invocations.node_metadata`` (a
+    read-modify-write, since ``update_invocation`` replaces node_metadata
+    wholesale rather than merging it). *bus* is typed ``Any`` to avoid a
+    scheduler.signals import here; it only needs ``pop_run_counters``.
+
+    Returns the telemetry dict that was persisted, or ``None`` when there
+    is nothing to report at all (no signal ever emitted for this run_id AND
+    no file overlap) -- a schedule action that never touches the signal bus
+    or the files-read pattern leaves node_metadata untouched, matching the
+    "measure-only" surfacing rule (the CLI/monitor summary lines only print
+    when non-zero).
+    """
+    signals = bus.pop_run_counters(run_id)
+    overlap = await svc.compute_files_overlap(invocation_id, top_n=top_n)
+    if signals is None and not overlap.get("count"):
+        return None
+
+    telemetry = {
+        "signals": signals or {"emitted": {}, "received": 0, "acted_on": 0},
+        "files_overlap": overlap,
+    }
+
+    invocation = await svc.get_invocation(invocation_id)
+    node_metadata = (invocation or {}).get("node_metadata")
+    if isinstance(node_metadata, str):
+        try:
+            node_metadata = json.loads(node_metadata)
+        except (ValueError, TypeError):
+            node_metadata = {}
+    if not isinstance(node_metadata, dict):
+        node_metadata = {}
+    node_metadata["coordination"] = telemetry
+    await svc.update_invocation(invocation_id, node_metadata=node_metadata)
+    return telemetry
 
 
 # Singleton for production use

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -19,9 +19,11 @@ from lionagi.cli.monitor import (
     _colour_status,
     _elapsed,
     _find_entity,
+    _format_coordination_line,
     _format_table,
     _gather_table_rows,
     _invocation_to_row,
+    _parse_json_field,
     _pid_alive,
     _play_to_row,
     _render_branch_lines,
@@ -102,7 +104,13 @@ async def _make_session(
     return sid
 
 
-async def _make_invocation(db: StateDB, *, status: str = "running", skill: str = "show") -> str:
+async def _make_invocation(
+    db: StateDB,
+    *,
+    status: str = "running",
+    skill: str = "show",
+    node_metadata: dict | None = None,
+) -> str:
     inv_id = uuid.uuid4().hex[:12]
     await db.create_invocation(
         {
@@ -110,6 +118,7 @@ async def _make_invocation(db: StateDB, *, status: str = "running", skill: str =
             "skill": skill,
             "started_at": time.time(),
             "status": status,
+            "node_metadata": node_metadata,
         }
     )
     return inv_id
@@ -462,6 +471,42 @@ def test_session_to_row_current_phase_wins():
     # Before a flow leaves planning, current_phase is NULL → fall back.
     sess["current_phase"] = None
     assert _session_to_row(sess)["phase"] == "orchestrator"
+
+
+def test_parse_json_field_passes_through_dict():
+    assert _parse_json_field({"a": 1}) == {"a": 1}
+
+
+def test_parse_json_field_decodes_string():
+    assert _parse_json_field('{"a": 1}') == {"a": 1}
+
+
+def test_parse_json_field_rejects_non_object():
+    assert _parse_json_field("[1, 2]") is None
+    assert _parse_json_field("not json") is None
+    assert _parse_json_field(None) is None
+    assert _parse_json_field(42) is None
+
+
+def test_format_coordination_line_none_when_all_zero():
+    telemetry = {
+        "signals": {"emitted": {}, "received": 0, "acted_on": 0},
+        "files_overlap": {"count": 0, "top": []},
+    }
+    assert _format_coordination_line(telemetry) is None
+
+
+def test_format_coordination_line_renders_nonzero_counts():
+    telemetry = {
+        "signals": {"emitted": {"ScheduleRunSucceeded": 1}, "received": 2, "acted_on": 1},
+        "files_overlap": {"count": 3, "top": [{"path": "/a.py", "workers": 2}]},
+    }
+    line = _format_coordination_line(telemetry)
+    assert line == "emitted=1 received=2 acted_on=1 files_overlap=3"
+
+
+def test_format_coordination_line_none_when_missing_keys():
+    assert _format_coordination_line({}) is None
 
 
 def test_invocation_to_row():
@@ -1054,6 +1099,49 @@ async def test_run_detail_invocation(temp_db_path: Path) -> None:
     output = await _run_detail(inv_id)
     assert "INVOCATION" in output
     assert "codex-review" in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_invocation_shows_coordination_block(temp_db_path: Path) -> None:
+    coordination = {
+        "signals": {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1},
+        "files_overlap": {"count": 1, "top": [{"path": "/repo/shared.py", "workers": 2}]},
+    }
+    async with StateDB() as db:
+        inv_id = await _make_invocation(
+            db, skill="scheduled:flow", node_metadata={"coordination": coordination}
+        )
+    output = await _run_detail(inv_id)
+    assert "coordination" in output
+    assert "emitted=1 received=1 acted_on=1 files_overlap=1" in output
+    assert "/repo/shared.py" in output
+    assert "workers=2" in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_invocation_omits_coordination_block_when_all_zero(
+    temp_db_path: Path,
+) -> None:
+    coordination = {
+        "signals": {"emitted": {}, "received": 0, "acted_on": 0},
+        "files_overlap": {"count": 0, "top": []},
+    }
+    async with StateDB() as db:
+        inv_id = await _make_invocation(
+            db, skill="scheduled:agent", node_metadata={"coordination": coordination}
+        )
+    output = await _run_detail(inv_id)
+    assert "coordination" not in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_invocation_no_node_metadata_omits_coordination(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        inv_id = await _make_invocation(db, skill="show")
+    output = await _run_detail(inv_id)
+    assert "coordination" not in output
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -509,6 +509,31 @@ def test_format_coordination_line_none_when_missing_keys():
     assert _format_coordination_line({}) is None
 
 
+def test_format_coordination_line_malformed_signals_list_does_not_raise():
+    """`signals` persisted as a list (not a dict) must be treated as absent
+    rather than raising AttributeError on `.get()`."""
+    assert _format_coordination_line({"signals": [1]}) is None
+
+
+def test_format_coordination_line_malformed_emitted_and_overlap_do_not_raise():
+    telemetry = {
+        "signals": {"emitted": [1, 2], "received": "not-a-number", "acted_on": None},
+        "files_overlap": [{"path": "/a.py"}],
+    }
+    assert _format_coordination_line(telemetry) is None
+
+
+def test_format_coordination_line_malformed_nested_counts_ignored_alongside_valid_ones():
+    """A malformed `files_overlap` shape must not suppress a legitimate
+    nonzero signal count elsewhere in the same telemetry dict."""
+    telemetry = {
+        "signals": {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1},
+        "files_overlap": "not-a-dict",
+    }
+    line = _format_coordination_line(telemetry)
+    assert line == "emitted=1 received=1 acted_on=1 files_overlap=0"
+
+
 def test_invocation_to_row():
     inv = {
         "id": "inv001abc",
@@ -1142,6 +1167,26 @@ async def test_run_detail_invocation_no_node_metadata_omits_coordination(
         inv_id = await _make_invocation(db, skill="show")
     output = await _run_detail(inv_id)
     assert "coordination" not in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_invocation_malformed_nested_telemetry_does_not_raise(
+    temp_db_path: Path,
+) -> None:
+    """A `coordination` dict whose nested `signals`/`files_overlap` values
+    do not match the shape this module writes (e.g. hand-edited state.db,
+    or a future writer bug) must render without raising."""
+    coordination = {
+        "signals": [1],
+        "files_overlap": {"count": 1, "top": "not-a-list"},
+    }
+    async with StateDB() as db:
+        inv_id = await _make_invocation(
+            db, skill="scheduled:flow", node_metadata={"coordination": coordination}
+        )
+    output = await _run_detail(inv_id)
+    assert "INVOCATION" in output
+    assert "files_overlap=1" in output
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -73,12 +73,14 @@ async def _make_schedule_run(
     exit_code: int | None = None,
     chain_depth: int = 0,
     chain_parent_id: str | None = None,
+    invocation_id: str | None = None,
 ) -> str:
     rid = uuid.uuid4().hex[:12]
     await db.create_schedule_run(
         {
             "id": rid,
             "schedule_id": schedule_id,
+            "invocation_id": invocation_id,
             "trigger_context": {},
             "action_kind": "agent",
             "action_args": [],
@@ -193,6 +195,86 @@ async def test_poll_pending_once_reports_immediately_terminal_run(
     assert run_id in out
     assert "nightly-build" in out
     assert "status=completed" in out
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_prints_coordination_line_when_nonzero(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """The wait primitive's per-run print (`li monitor run <id>`) appends a
+    coordination one-liner sourced from the run's invocation node_metadata,
+    written by the scheduler engine's finalize path -- only when non-zero."""
+    coordination = {
+        "signals": {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1},
+        "files_overlap": {"count": 1, "top": [{"path": "/repo/shared.py", "workers": 2}]},
+    }
+    async with StateDB() as db:
+        inv_id = uuid.uuid4().hex[:12]
+        await db.create_invocation(
+            {
+                "id": inv_id,
+                "skill": "scheduled:test",
+                "started_at": time.time(),
+                "node_metadata": {"coordination": coordination},
+            }
+        )
+        sched_id = await _make_schedule(db, name="coord-sched")
+        run_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, invocation_id=inv_id
+        )
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
+
+    out = capsys.readouterr().out
+    assert "coordination: emitted=1 received=1 acted_on=1 files_overlap=1" in out
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_omits_coordination_line_when_all_zero(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    coordination = {
+        "signals": {"emitted": {}, "received": 0, "acted_on": 0},
+        "files_overlap": {"count": 0, "top": []},
+    }
+    async with StateDB() as db:
+        inv_id = uuid.uuid4().hex[:12]
+        await db.create_invocation(
+            {
+                "id": inv_id,
+                "skill": "scheduled:test",
+                "started_at": time.time(),
+                "node_metadata": {"coordination": coordination},
+            }
+        )
+        sched_id = await _make_schedule(db, name="zero-sched")
+        run_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, invocation_id=inv_id
+        )
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
+
+    out = capsys.readouterr().out
+    assert "coordination" not in out
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_no_invocation_id_omits_coordination_line(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A schedule_run with no invocation_id (or none found) must not error;
+    it simply prints no coordination line."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="no-inv-sched")
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
+
+    out = capsys.readouterr().out
+    assert "coordination" not in out
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -51,6 +51,8 @@ def _make_svc() -> AsyncMock:
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
     svc.count_schedule_runs = AsyncMock(return_value=0)
     svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 

--- a/tests/studio/test_scheduler_coordination.py
+++ b/tests/studio/test_scheduler_coordination.py
@@ -17,6 +17,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import time
 import uuid
 from unittest.mock import AsyncMock
@@ -315,3 +316,64 @@ async def test_flush_run_telemetry_writes_when_only_overlap_is_nonzero():
     assert telemetry["signals"] == {"emitted": {}, "received": 0, "acted_on": 0}
     assert telemetry["files_overlap"]["count"] == 2
     svc.update_invocation.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# flush_run_telemetry must be best-effort: I/O failures never propagate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_swallows_compute_overlap_failure():
+    """A failure computing files-overlap must not propagate -- the
+    invocation's terminal write it rides on has already committed by the
+    time flush runs."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    await bus.emit(ScheduleRunSucceeded(run_id="run-6", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(side_effect=OSError("disk error"))
+
+    result = await flush_run_telemetry(svc, bus, run_id="run-6", invocation_id="inv-6")
+
+    assert result is None
+    svc.update_invocation.assert_not_awaited()
+    # Popped regardless of the failure -- best-effort means the counters are
+    # deliberately dropped, not retried.
+    assert bus.pop_run_counters("run-6") is None
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_swallows_update_invocation_failure():
+    """A failure persisting node_metadata must not propagate either."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    await bus.emit(ScheduleRunSucceeded(run_id="run-7", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(
+        return_value={"count": 1, "top": [{"path": "/shared.py", "workers": 2}]}
+    )
+    svc.update_invocation = AsyncMock(side_effect=OSError("disk error"))
+
+    result = await flush_run_telemetry(svc, bus, run_id="run-7", invocation_id="inv-7")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_reraises_cancellation():
+    """Cancellation must never be swallowed as a mere telemetry failure."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    await bus.emit(ScheduleRunSucceeded(run_id="run-8", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await flush_run_telemetry(svc, bus, run_id="run-8", invocation_id="inv-8")

--- a/tests/studio/test_scheduler_coordination.py
+++ b/tests/studio/test_scheduler_coordination.py
@@ -1,0 +1,317 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for lionagi.studio.scheduler.coordination.compute_files_overlap()
+and lionagi.studio.services.scheduler_state.flush_run_telemetry().
+
+Covers:
+  * Overlap fixture: two workers reading one shared + N distinct files ->
+    count=1, top-1 with the correct worker count.
+  * Zero-worker / zero-overlap invocations report {"count": 0, "top": []},
+    never an error.
+  * top_n truncation and deterministic tie-breaking.
+  * Terminal flush: telemetry lands exactly once per run (pop_run_counters
+    is consumed, node_metadata["coordination"] merges rather than clobbers
+    pre-existing node_metadata, and a run with nothing to report leaves
+    node_metadata untouched).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.studio.scheduler.coordination import compute_files_overlap
+from lionagi.studio.scheduler.signals import SchedulerSignalBus, ScheduleRunSucceeded
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+async def _make_invocation(db: StateDB, invocation_id: str) -> None:
+    await db.create_invocation({"id": invocation_id, "skill": "test", "started_at": time.time()})
+
+
+async def _make_worker_session(
+    db: StateDB,
+    *,
+    invocation_id: str,
+    session_id: str,
+    branch_id: str,
+    file_paths: list[str],
+) -> None:
+    """One session ("worker") with one branch whose progression carries one
+    ActionRequest message per path in *file_paths*."""
+    session_prog = f"{session_id}-prog"
+    await db.create_progression(session_prog)
+    await db.create_session(
+        {
+            "id": session_id,
+            "progression_id": session_prog,
+            "invocation_id": invocation_id,
+            "status": "completed",
+        }
+    )
+
+    branch_prog = f"{branch_id}-prog"
+    msg_ids = [f"{branch_id}-msg-{i}" for i in range(len(file_paths))]
+    await db.create_progression(branch_prog, msg_ids)
+    await db.create_branch(
+        {
+            "id": branch_id,
+            "created_at": time.time(),
+            "name": "worker",
+            "session_id": session_id,
+            "progression_id": branch_prog,
+        }
+    )
+    for mid, path in zip(msg_ids, file_paths):
+        await db.insert_message(
+            {
+                "id": mid,
+                "created_at": time.time(),
+                "content": {"function": "Write", "arguments": {"file_path": path}},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "action",
+                "node_metadata": {"lion_class": "ActionRequest"},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# compute_files_overlap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_child_sessions_reports_zero(db: StateDB):
+    inv_id = _uid()
+    await _make_invocation(db, inv_id)
+    overlap = await compute_files_overlap(db, inv_id)
+    assert overlap == {"count": 0, "top": []}
+
+
+@pytest.mark.asyncio
+async def test_single_worker_no_overlap(db: StateDB):
+    inv_id = _uid()
+    await _make_invocation(db, inv_id)
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/repo/a.py", "/repo/b.py"],
+    )
+    overlap = await compute_files_overlap(db, inv_id)
+    assert overlap == {"count": 0, "top": []}
+
+
+@pytest.mark.asyncio
+async def test_two_workers_one_shared_file_counts_one_overlap(db: StateDB):
+    """The design's exact test-plan fixture: two workers, one shared file +
+    N distinct files each -> count=1, top-1 naming the shared path."""
+    inv_id = _uid()
+    await _make_invocation(db, inv_id)
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/repo/shared.py", "/repo/only_a.py", "/repo/only_a2.py"],
+    )
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/repo/shared.py", "/repo/only_b.py"],
+    )
+
+    overlap = await compute_files_overlap(db, inv_id)
+    assert overlap["count"] == 1
+    assert overlap["top"] == [{"path": "/repo/shared.py", "workers": 2}]
+
+
+@pytest.mark.asyncio
+async def test_overlap_top_n_truncates_and_orders_by_worker_count(db: StateDB):
+    inv_id = _uid()
+    await _make_invocation(db, inv_id)
+    # 3 workers touching a.py (most overlap), 2 touching b.py, 2 touching c.py.
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/a.py", "/b.py", "/c.py"],
+    )
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/a.py", "/b.py"],
+    )
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/a.py", "/c.py"],
+    )
+
+    overlap = await compute_files_overlap(db, inv_id, top_n=2)
+    assert overlap["count"] == 3  # a.py, b.py, c.py all overlap
+    assert len(overlap["top"]) == 2
+    assert overlap["top"][0] == {"path": "/a.py", "workers": 3}
+    # b.py and c.py tie at 2 workers -- deterministic tie-break by path.
+    assert overlap["top"][1] == {"path": "/b.py", "workers": 2}
+
+
+@pytest.mark.asyncio
+async def test_worker_with_no_file_touching_messages_excluded(db: StateDB):
+    """A worker session with branches/messages but no ActionRequest file
+    args contributes nothing to any file set."""
+    inv_id = _uid()
+    await _make_invocation(db, inv_id)
+    await _make_worker_session(
+        db, invocation_id=inv_id, session_id=_uid(), branch_id=_uid(), file_paths=[]
+    )
+    await _make_worker_session(
+        db,
+        invocation_id=inv_id,
+        session_id=_uid(),
+        branch_id=_uid(),
+        file_paths=["/x.py"],
+    )
+    overlap = await compute_files_overlap(db, inv_id)
+    assert overlap == {"count": 0, "top": []}
+
+
+# ---------------------------------------------------------------------------
+# flush_run_telemetry
+# ---------------------------------------------------------------------------
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
+    svc.update_invocation = AsyncMock()
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_writes_signals_and_overlap_once():
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: True)
+    await bus.emit(ScheduleRunSucceeded(run_id="run-1", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(
+        return_value={"count": 1, "top": [{"path": "/shared.py", "workers": 2}]}
+    )
+
+    telemetry = await flush_run_telemetry(svc, bus, run_id="run-1", invocation_id="inv-1")
+
+    assert telemetry == {
+        "signals": {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1},
+        "files_overlap": {"count": 1, "top": [{"path": "/shared.py", "workers": 2}]},
+    }
+    svc.update_invocation.assert_awaited_once_with(
+        "inv-1", node_metadata={"coordination": telemetry}
+    )
+    # Popped -- a second flush attempt for the same run_id sees no signals.
+    assert bus.pop_run_counters("run-1") is None
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_merges_into_existing_node_metadata():
+    """update_invocation replaces node_metadata wholesale, so the flush must
+    read-modify-write rather than clobber pre-existing keys."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    await bus.emit(ScheduleRunSucceeded(run_id="run-2", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.get_invocation = AsyncMock(
+        return_value={"id": "inv-2", "node_metadata": {"segments": ["existing"]}}
+    )
+
+    telemetry = await flush_run_telemetry(svc, bus, run_id="run-2", invocation_id="inv-2")
+
+    assert telemetry is not None
+    svc.update_invocation.assert_awaited_once()
+    _, kwargs = svc.update_invocation.await_args
+    assert kwargs["node_metadata"]["segments"] == ["existing"]
+    assert kwargs["node_metadata"]["coordination"] == telemetry
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_parses_string_node_metadata():
+    """A raw-text() query without column typing can return node_metadata as
+    a JSON string (SQLite) rather than an already-decoded dict."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()
+    await bus.emit(ScheduleRunSucceeded(run_id="run-3", schedule_id="s1", reason_code="ok"))
+
+    svc = _make_svc()
+    svc.get_invocation = AsyncMock(
+        return_value={"id": "inv-3", "node_metadata": '{"segments": ["existing"]}'}
+    )
+
+    await flush_run_telemetry(svc, bus, run_id="run-3", invocation_id="inv-3")
+
+    _, kwargs = svc.update_invocation.await_args
+    assert kwargs["node_metadata"]["segments"] == ["existing"]
+    assert "coordination" in kwargs["node_metadata"]
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_no_signal_and_no_overlap_writes_nothing():
+    """Measure-only: a run that never touched the signal bus and has no
+    file overlap leaves node_metadata untouched entirely."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()  # never emitted for this run_id
+    svc = _make_svc()
+
+    result = await flush_run_telemetry(svc, bus, run_id="never-emitted", invocation_id="inv-4")
+
+    assert result is None
+    svc.update_invocation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flush_run_telemetry_writes_when_only_overlap_is_nonzero():
+    """A run whose schedule_run write lost its race (so the bus never saw
+    it) can still have file overlap worth reporting."""
+    from lionagi.studio.services.scheduler_state import flush_run_telemetry
+
+    bus = SchedulerSignalBus()  # no emit for this run_id
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(
+        return_value={"count": 2, "top": [{"path": "/x.py", "workers": 2}]}
+    )
+
+    telemetry = await flush_run_telemetry(svc, bus, run_id="run-5", invocation_id="inv-5")
+
+    assert telemetry["signals"] == {"emitted": {}, "received": 0, "acted_on": 0}
+    assert telemetry["files_overlap"]["count"] == 2
+    svc.update_invocation.assert_awaited_once()

--- a/tests/studio/test_scheduler_cwd.py
+++ b/tests/studio/test_scheduler_cwd.py
@@ -393,6 +393,8 @@ def _make_svc() -> AsyncMock:
     svc.update_invocation = AsyncMock()
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -55,6 +55,8 @@ def _make_svc() -> AsyncMock:
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
     svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 
@@ -199,7 +201,10 @@ async def test_fire_happy_path_records_invocation_and_run():
     svc.update_schedule_run.assert_awaited_once()
     # update_status called for schedule_run AND invocation
     assert svc.update_status.await_count == 3  # running + completed + invocation
-    svc.update_invocation.assert_awaited_once()
+    # update_invocation is called twice: once to stamp ended_at, once more by
+    # flush_run_telemetry's read-modify-write of node_metadata["coordination"]
+    # after the invocation's terminal write lands (see scheduler_state.py).
+    assert svc.update_invocation.await_count == 2
     svc.update_schedule.assert_awaited()
 
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -744,6 +744,217 @@ async def test_fire_cancellation_schedule_run_cas_miss_does_not_skip_side_effect
 
 
 # ---------------------------------------------------------------------------
+# Coordination telemetry: terminal-write races must not leak signal counters
+# ---------------------------------------------------------------------------
+
+
+def _lose_invocation_race(entity_type, entity_id, *, new_status, **kwargs):
+    """svc.update_status side_effect: the invocation terminal write always
+    loses its race (as if a concurrent finalizer, e.g. the deadline reaper,
+    already claimed the row); every other entity_type's write succeeds."""
+    return entity_type != "invocation"
+
+
+@pytest.mark.asyncio
+async def test_fire_normal_path_discards_counters_when_invocation_write_loses_race():
+    """The normal completion path mints a ScheduleRunSucceeded signal (whose
+    counters land on the bus) before the invocation's own terminal write
+    happens. If that write loses its race, flush_run_telemetry() is never
+    called to consume the counters -- they must be explicitly discarded
+    instead of sitting in the bus's per-run_id map forever."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(side_effect=_lose_invocation_race)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.flush_run_telemetry",
+            new=AsyncMock(),
+        ) as flush_mock,
+    ):
+        await engine._fire(schedule, "run-race-normal", trigger_context={"scheduled": True})
+
+    flush_mock.assert_not_awaited()
+    assert engine._signal_bus.pop_run_counters("run-race-normal") is None
+
+
+@pytest.mark.asyncio
+async def test_fire_invalid_action_discards_counters_when_invocation_write_loses_race():
+    """Same race, on the invalid-schedule-action terminal path (build_argv
+    raising before any process spawns)."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(side_effect=_lose_invocation_race)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=RuntimeError("bad template"),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.flush_run_telemetry",
+            new=AsyncMock(),
+        ) as flush_mock,
+    ):
+        await engine._fire(schedule, "run-race-invalid", trigger_context={"scheduled": True})
+
+    flush_mock.assert_not_awaited()
+    assert engine._signal_bus.pop_run_counters("run-race-invalid") is None
+
+
+@pytest.mark.asyncio
+async def test_fire_cancellation_discards_counters_when_invocation_write_loses_race():
+    """Same race, on the CancelledError terminal path."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(side_effect=_lose_invocation_race)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.flush_run_telemetry",
+            new=AsyncMock(),
+        ) as flush_mock,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(schedule, "run-race-cancel", trigger_context={"scheduled": True})
+
+    flush_mock.assert_not_awaited()
+    assert engine._signal_bus.pop_run_counters("run-race-cancel") is None
+
+
+@pytest.mark.asyncio
+async def test_fire_exception_path_discards_counters_when_invocation_write_loses_race():
+    """Same race, on the generic-exception terminal path."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.update_status = AsyncMock(side_effect=_lose_invocation_race)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.flush_run_telemetry",
+            new=AsyncMock(),
+        ) as flush_mock,
+    ):
+        await engine._fire(schedule, "run-race-exc", trigger_context={"scheduled": True})
+
+    flush_mock.assert_not_awaited()
+    assert engine._signal_bus.pop_run_counters("run-race-exc") is None
+
+
+@pytest.mark.asyncio
+async def test_fire_telemetry_flush_failure_does_not_alter_run_outcome():
+    """flush_run_telemetry() is best-effort (see
+    scheduler_state.flush_run_telemetry): a failure computing coordination
+    telemetry after the run's own terminal write has already committed must
+    never rewrite that run's recorded outcome, and must never raise back
+    into _fire()."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.compute_files_overlap = AsyncMock(side_effect=OSError("disk error"))
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-flush-fails", trigger_context={"scheduled": True})
+
+    # Exactly the one update_schedule_run call from the normal completion
+    # path -- no second rewrite from a broad-except handler catching a
+    # telemetry failure that leaked out of flush_run_telemetry().
+    svc.update_schedule_run.assert_awaited_once()
+    _, kwargs = svc.update_schedule_run.await_args
+    assert kwargs["error_detail"] is None
+    # The invocation's own terminal write is untouched by the telemetry
+    # failure too.
+    invocation_terminal_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[0] == "invocation" and c.kwargs.get("new_status")
+    ]
+    assert len(invocation_terminal_calls) == 1
+    assert invocation_terminal_calls[0].kwargs["new_status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_fire_normal_completion_dispatches_signal_before_flush_pops_counters():
+    """The terminal ScheduleRun* signal must be minted onto the bus BEFORE
+    flush_run_telemetry() pops that run's counters, so a normal completion's
+    persisted telemetry always includes its own terminal signal's emitted
+    count -- not zero because the flush raced ahead of the mint."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-order", trigger_context={"scheduled": True})
+
+    node_metadata_calls = [
+        call.kwargs["node_metadata"]
+        for call in svc.update_invocation.await_args_list
+        if "node_metadata" in call.kwargs
+    ]
+    assert len(node_metadata_calls) == 1
+    coordination = node_metadata_calls[0]["coordination"]
+    assert coordination["signals"]["emitted"] == {"ScheduleRunSucceeded": 1}
+
+
+# ---------------------------------------------------------------------------
 # SchedulerEngine.fire_now() — delegates through service
 # ---------------------------------------------------------------------------
 

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -58,6 +58,8 @@ def _make_svc() -> AsyncMock:
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
     svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -50,6 +50,8 @@ def _make_svc() -> AsyncMock:
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
     svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -75,6 +75,8 @@ def _make_svc() -> AsyncMock:
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
     svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 
@@ -193,6 +195,168 @@ async def test_emit_with_zero_handlers_is_a_noop():
         ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
     )
     assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Per-run coordination counters (emitted/received/acted_on) + pop_run_counters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_counts_emitted_even_with_zero_handlers():
+    """Emitted describes what the mint site dispatched, not what got
+    delivered -- it counts regardless of whether anyone is listening."""
+    bus = SchedulerSignalBus()
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters == {
+        "emitted": {"ScheduleRunSucceeded": 1},
+        "received": 0,
+        "acted_on": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_emit_counts_received_for_matching_handler_with_falsy_return():
+    """A handler that matches but returns None/falsy (the default, opt-out
+    convention) counts as received-only -- never acted_on."""
+    bus = SchedulerSignalBus()
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: None)
+
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters["received"] == 1
+    assert counters["acted_on"] == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_counts_acted_on_when_handler_returns_truthy_marker():
+    """The opt-in truthy-return convention: a handler that returns a truthy
+    value counts as acted_on, on top of received."""
+    bus = SchedulerSignalBus()
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: "acted")
+
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters["received"] == 1
+    assert counters["acted_on"] == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_async_handler_acted_on_marker_is_awaited_first():
+    bus = SchedulerSignalBus()
+
+    async def _handler(sig):
+        return True
+
+    bus.observe(ScheduleRunSucceeded, handler=_handler)
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters["acted_on"] == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_predicate_reject_not_counted_as_received():
+    """A candidate whose type matched but whose predicate rejected the
+    signal must not count as received (received == "predicate passed")."""
+    bus = SchedulerSignalBus()
+    bus.observe(
+        ScheduleRunFailed,
+        lambda s: s.reason_code == RunReasons.FAILED_MISSING_CWD,
+        handler=lambda sig: True,
+    )
+
+    await bus.emit(
+        ScheduleRunFailed(run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXIT_NONZERO)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters["received"] == 0
+    assert counters["acted_on"] == 0
+    assert counters["emitted"] == {"ScheduleRunFailed": 1}
+
+
+@pytest.mark.asyncio
+async def test_emit_predicate_exception_not_counted_as_received():
+    """A predicate that raises never reaches the "passed" branch -- it must
+    not be counted as received even though emit() still surfaces the
+    failure as an ExceptionGroup."""
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    bus = SchedulerSignalBus()
+    bus.observe(
+        ScheduleRunFailed,
+        lambda s: (_ for _ in ()).throw(RuntimeError("predicate bug")),
+        handler=lambda sig: True,
+    )
+
+    with pytest.raises(ExceptionGroup):
+        await bus.emit(
+            ScheduleRunFailed(
+                run_id="r1", schedule_id="s1", reason_code=RunReasons.FAILED_EXCEPTION
+            )
+        )
+    counters = bus.pop_run_counters("r1")
+    assert counters["received"] == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_multiple_handlers_each_contribute_to_received_and_acted_on():
+    bus = SchedulerSignalBus()
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: True)
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: False)
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: None)
+
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    counters = bus.pop_run_counters("r1")
+    assert counters["received"] == 3
+    assert counters["acted_on"] == 1
+
+
+def test_pop_run_counters_returns_none_for_unknown_run():
+    bus = SchedulerSignalBus()
+    assert bus.pop_run_counters("never-emitted") is None
+
+
+@pytest.mark.asyncio
+async def test_pop_run_counters_removes_the_entry():
+    """Pop, not peek -- the bus is a long-lived per-daemon singleton, so a
+    run's counters must not linger past its one terminal flush."""
+    bus = SchedulerSignalBus()
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    first = bus.pop_run_counters("r1")
+    second = bus.pop_run_counters("r1")
+    assert first is not None
+    assert second is None
+
+
+@pytest.mark.asyncio
+async def test_counters_are_isolated_per_run_id():
+    bus = SchedulerSignalBus()
+    bus.observe(ScheduleRunSucceeded, handler=lambda sig: True)
+
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+    await bus.emit(
+        ScheduleRunSucceeded(run_id="r2", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
+    )
+
+    counters_r1 = bus.pop_run_counters("r1")
+    counters_r2 = bus.pop_run_counters("r2")
+    assert counters_r1 == {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1}
+    assert counters_r2 == {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -52,6 +52,8 @@ def _make_svc() -> AsyncMock:
     svc.count_schedule_runs = AsyncMock(return_value=0)
     svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
     svc.metric_value = AsyncMock(return_value=0.0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
 
 


### PR DESCRIPTION
## Summary

Per-run coordination telemetry for the scheduler, measure-only. This is the follow-on slice promised on #2058 ("Coordination telemetry — ... Lands as a follow-on slice consuming this bus").

- **Signal counters** on `SchedulerSignalBus`: per-run_id emitted (histogram by signal type), received (candidate matched + predicates passed, counted before invocation so a raising handler still counts as delivered), acted-on (opt-in truthy handler return — non-participating handlers contribute to received only). No handler API change.
- **Files-read overlap** (`lionagi/studio/scheduler/coordination.py`): read-side aggregation over an invocation's child sessions' persisted tool-call messages; files touched by ≥2 workers, count + top-N paths. Never touches a live agent.
- **Persistence**: `flush_run_telemetry()` merges both under `invocations.node_metadata["coordination"]` via read-modify-write (`update_invocation` replaces node_metadata wholesale). Called from all four engine terminal sites, gated on the invocation's guarded terminal write succeeding — exactly once per run, same discipline as the terminal signal mint. Bus counters are popped, not peeked, so the long-lived bus never leaks per-run state.
- **Surfacing**: `li monitor <invocation>` COORDINATION block + one-liner on the run wait path, printed only when non-zero. No Studio frontend in this slice.

No routing changes, no backpressure, no behavior gating from the overlap indicator.

## Testing

- `uv run --extra studio pytest tests/studio/ tests/cli/test_monitor.py tests/cli/test_monitor_run.py -q -n0` — 694 tests, all pass
- New `tests/studio/test_scheduler_coordination.py` (overlap fixtures: shared vs distinct files, chunking, legacy class names); counter unit tests over emit/deliver/predicate-reject/acted-marker/raising-handler paths; exactly-once flush covered at engine terminal sites; monitor rendering incl. zero-suppression
- `ruff check` + `ruff format` clean

Lane C (scheduler/W2 lane follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
