### PR TITLE
feat(service): refuse generic shell executors at MCP registration

### DIFF
--- a/docs/design/mcp-executor-admission-sufficiency.md
+++ b/docs/design/mcp-executor-admission-sufficiency.md
@@ -58,10 +58,21 @@ by spelling:
   bounded).
 - **Inert annotations** that carry no assertion and are ignored: `description`,
   `title`, `$comment`, `examples`, `default`, `format`, `pattern`, `$schema`,
-  `$id`, `$anchor`, `readOnly`, `deprecated`, `contentMediaType`, `$defs`, and
-  the `x-*` vendor-extension convention. An `x-*`/`$comment` keyword is inert
-  only when its *value* is demonstrably free of schema vocabulary — an extension
-  whose value embeds `properties` is a hidden channel, not an annotation.
+  `$id`, `$anchor`, `readOnly`, `deprecated`, `contentEncoding`,
+  `contentMediaType`, `contentSchema`, `$defs`, and the `x-*` vendor-extension
+  convention. An `x-*`/`$comment` keyword is inert only when its *value* is
+  demonstrably free of schema vocabulary — an extension whose value embeds
+  `properties` is a hidden channel, not an annotation. `contentSchema` is a
+  deliberate, argued exception to "schema-bearing means deny": its value is a
+  mapping, exactly the shape the unknown-keyword check treats as suspect, but
+  the Content vocabulary it belongs to (alongside `contentEncoding` /
+  `contentMediaType`) is annotation-only in the *default* Draft 2020-12
+  dialect this module validates against — the content-assertion vocabulary
+  that would make it actually constrain an instance is not enabled, so a
+  value under this keyword is not an admission channel today. That holds only
+  as long as the content-assertion vocabulary stays disabled; enabling it in
+  a future dialect configuration would require `contentSchema` to leave this
+  modeled-as-inert set.
 - **Unknown keywords** are tolerated only when their value cannot carry a
   subschema (a scalar, or a list/mapping built entirely of scalars). An unknown
   keyword with a mapping- or subschema-shaped value denies.
@@ -95,23 +106,72 @@ leaf path.
 
 ## Two mechanisms, kept separate
 
-Admission composes two independent checks, and keeping them separate is what
-lets a scary-named tool with a genuinely bounded schema through:
+Admission composes two independent checks with two different jobs, and
+keeping them separate is what lets a scary-named tool with a genuinely
+bounded schema through:
 
-- The **sufficiency proof** judges *shape closedness* — can an undeclared value
-  ride through? It does not inspect individual property values.
-- The **schema walker** judges *command channels by key name* — is a declared
-  property a free-form command surface? It applies the identifier exemption
-  (`service_id`, `resource_path`, `callback_url` are benign dynamic identifiers)
-  and re-taints executor targets (`executable_path`, `script_path`).
+- The **sufficiency proof** is the STRUCTURAL gate. It covers the WHOLE
+  DOCUMENT — every node, at every depth, including the interior of a
+  declared property's own value — and asks one question only: is this shape
+  provably closed against an undeclared value? It never reasons about a key's
+  *name*.
+- The **schema walker** does KEY-NAME / command classification ONLY — is a
+  declared property (by its name) a free-form command surface? It applies the
+  identifier exemption (`service_id`, `resource_path`, `callback_url` are
+  benign dynamic identifiers) and re-taints executor targets
+  (`executable_path`, `script_path`). It is NEVER load-bearing for structural
+  coverage — it does not, and must not be relied on to, prove a shape closed.
 
-A fixed-operation tool that also declares a free-form `service_id` string is
-admitted: the object is closed (sufficiency) and the identifier key is benign
-(walker). Folding value-boundedness into the sufficiency proof would erase that
-distinction and deny the legitimate case. The two checks cover disjoint
-territory — the sufficiency proof gates the shape skeleton (root, `$ref` target
-and siblings, composition branches); the walker gates property-value interiors —
-and their union is the whole document.
+The corrected boundary: the sufficiency proof's structural coverage is total:
+its allowlist gate re-runs at the root, inside every resolved `$ref` target
+and its siblings, inside every composition branch (`allOf`/`anyOf`/`oneOf`),
+and — via the property-value recursion — inside every declared property
+value that is itself object-shaped or applicator-bearing, recursively, to
+whatever depth the schema nests. The walker's classification never substitutes
+for that coverage; it only ever adds key-name evidence on top of a node the
+structural gate has already found sufficient.
+
+The prior framing — "the sufficiency proof gates the shape skeleton, the
+walker gates property-value interiors, and their union is the whole
+document" — was unsound. It assumed the walker's key-name classification
+supplied whatever structural coverage the sufficiency proof left out inside a
+property value. It does not: a keyword class the walker *does* recognize
+structurally (`patternProperties` is in the walker's own keyword whitelist)
+can still sit inside a property value in a shape the walker's key-name
+classifier cannot see — a `patternProperties` pattern keyed on a name outside
+the walker's fixed categorized-key list is never matched, so the walker never
+even inspects that pattern's subschema, and the sufficiency proof (pre-fix)
+never re-checked a property value at all. Neither mechanism's structural
+check ran on that node. The "union is the whole document" claim was false at
+exactly the composition of "walker-known keyword" × "key-name the walker's
+classifier doesn't match" × "property-value depth" — which is precisely the
+`{"patternProperties": {"^command_custom$": {"type": "string"}},
+"additionalProperties": false}` bypass this design was written to close, sitting
+one property-value level deeper than the version already fixed at the root.
+
+The fix is not "teach the walker more key names" — that repeats the
+denylist mistake this document's Approach section already rejected. It is
+"make the sufficiency proof's structural coverage recurse into every nested
+key channel", so the STRUCTURAL question ("is this shape closed") is
+answered completely by the proof alone, independent of whatever the walker's
+key-name classification separately contributes.
+
+A property value is a **key channel** — and therefore recursed into with the
+proof's full allowlist/type-gate/closedness logic — when it is itself
+object-shaped (`type` includes `"object"`) or carries an object/map
+applicator keyword (`properties`, `patternProperties`,
+`additionalProperties`, `unevaluatedProperties`, `propertyNames`,
+`dependentSchemas`) or a composition/ref applicator (`$ref`, `allOf`,
+`anyOf`, `oneOf`). A scalar-typed, array-typed, annotation-only, or bare
+free-form string property value is deliberately NOT recursed — it is a VALUE,
+not a nested key channel, and remains the walker's territory by key name.
+This is what keeps the two-mechanism separation intact: a fixed-operation
+tool that also declares a free-form `service_id` string is still admitted —
+the outer object is closed (sufficiency), `service_id`'s value is a bare
+string so it is never handed to the recursion at all, and the identifier key
+is benign (walker). Folding scalar value-boundedness into the structural gate
+would erase that distinction and deny the legitimate case; the recursion is
+scoped precisely to avoid that.
 
 ## Residuals — all fail closed
 
@@ -136,9 +196,21 @@ Every shape the proof does not model denies:
 The change is covered by the full admit/deny parametrized matrix plus: named
 cases for the `patternProperties`-custom-key, omitted-`type`, and
 `unevaluatedProperties:false` shapes; a synthetic never-modeled keyword asserted
-to deny at five positions (root, property value, `allOf` branch, `$ref` sibling,
-`anyOf` branch) with an inert-scalar control that still admits; and a
-`Draft202012Validator` differential that, for every admitted executor-signaling
-schema, asserts the schema rejects an injected free-form command instance. That
-differential includes the applicator-root admits (`$ref`-root, `anyOf`-root), so
-the delegation ordering is regression-tested, not review-checked.
+to deny at six positions (root, property value at depth 1, `allOf` branch,
+`$ref` sibling, `anyOf` branch, property value at depth 2 — the value of a
+property that is itself the value of another property) with an inert-scalar
+control that still admits; a `Draft202012Validator` differential that, for
+every admitted executor-signaling schema, asserts the schema rejects an
+injected free-form command instance (the differential includes the
+applicator-root admits — `$ref`-root, `anyOf`-root — so the delegation
+ordering is regression-tested, not review-checked); and the property-value
+recursion is separately covered by named cases with their own
+`Draft202012Validator` necessity differentials: `patternProperties` nested at
+depth 2, `dependentSchemas` nested inside a property value, and
+`unevaluatedProperties` nested inside a property value — each proven
+necessary by an oracle differential showing the raw schema, absent this
+recursion's denial, would accept the injected command. A closed nested object
+property value, a scalar identifier property value alongside a fixed
+operation, and a mapping-valued `contentSchema` annotation on an otherwise
+bounded schema are covered as admits, the last two with their own oracle
+differentials confirming injection is still rejected.

--- a/docs/design/mcp-executor-admission-sufficiency.md
+++ b/docs/design/mcp-executor-admission-sufficiency.md
@@ -1,0 +1,144 @@
+# MCP executor-admission: schema-sufficiency by known-safe allowlist
+
+## Problem
+
+`register_mcp_server` refuses to register a tool that exposes a generic
+shell/command/process/script executor surface, while still admitting
+legitimate bounded tools. A tool whose *name* looks like an executor
+(`exec`, `bash`, `spawn_process`, ...) is admitted only if its input schema is
+provably **bounded** — the caller cannot smuggle a free-form command through an
+undeclared key or an unconstrained value. This bounded-ness test is the
+*sufficiency proof*.
+
+An earlier sufficiency proof recognized dangerous schema shapes one at a time:
+an open `additionalProperties`, a non-object type, a union with a free-form
+branch, and so on. Against JSON Schema — whose vocabulary is open-ended and
+extensible — a proof built from a denylist of known-dangerous shapes cannot be
+complete. Each new applicator keyword (`patternProperties`, `propertyNames`,
+`unevaluatedProperties`, `dependentSchemas`, ...) is another way to introduce a
+value the denylist never modeled. Two concrete gaps illustrate the class:
+
+- A `patternProperties` whose pattern accepts a command-shaped key
+  (`{"patternProperties": {"^command_custom$": {"type": "string"}}, "additionalProperties": false}`)
+  looks closed but accepts `{"command_custom": "rm -rf /"}`.
+- A schema that omits `type` entirely
+  (`{"properties": {"operation": {"const": "status"}}, "additionalProperties": false}`)
+  looks like a closed object but, because an absent `type` admits every instance
+  type, also accepts a bare string.
+
+## Approach: invert the polarity to a known-safe allowlist
+
+The sufficiency proof models a **closed set of keywords it understands** and
+denies on anything else. The load-bearing rule:
+
+> Any keyword outside the understood set — present anywhere in the schema
+> skeleton the proof walks — makes the node insufficient.
+
+That single rule covers `patternProperties`, `propertyNames`,
+`unevaluatedProperties`, `dependentSchemas`, the in-place applicators
+(`if`/`then`/`else`/`not`, `contains`), `$dynamicRef`/`$recursiveRef`, and every
+future vocabulary addition, without enumerating each one. "An unmodeled
+applicator fails closed" holds *because* it is the primary rule, not as an
+incidental consequence.
+
+Membership on the understood set is decided by keyword and by value shape, not
+by spelling:
+
+- **Bounding constraints** that only ever narrow the admitted set: `type`,
+  `const`, `enum`, `required`, `additionalProperties` (only `false` or an
+  `enum`/`const`-restricted schema counts as closing), and the standardized
+  numeric/size bounds (`minLength`, `maxItems`, `minimum`, `multipleOf`, ...).
+  The numeric bounds are an explicit enumeration — never a `min*`/`max*` prefix
+  test, which would exempt an arbitrary `minCustomVocabulary` and reopen the
+  bypass.
+- **Modeled applicators** the proof recurses through: `properties` (for
+  closedness), `$ref` (local `#/...`, resolved and intersected with its
+  Draft 2020-12 siblings), `allOf` (intersection — one provably-bounded branch
+  suffices), and `anyOf`/`oneOf` (unions — every branch must independently prove
+  bounded).
+- **Inert annotations** that carry no assertion and are ignored: `description`,
+  `title`, `$comment`, `examples`, `default`, `format`, `pattern`, `$schema`,
+  `$id`, `$anchor`, `readOnly`, `deprecated`, `contentMediaType`, `$defs`, and
+  the `x-*` vendor-extension convention. An `x-*`/`$comment` keyword is inert
+  only when its *value* is demonstrably free of schema vocabulary — an extension
+  whose value embeds `properties` is a hidden channel, not an annotation.
+- **Unknown keywords** are tolerated only when their value cannot carry a
+  subschema (a scalar, or a list/mapping built entirely of scalars). An unknown
+  keyword with a mapping- or subschema-shaped value denies.
+
+## Type-gate
+
+An admittable object must constrain instances to objects. `type` must be
+present and object-admitting (`"object"`, or a type array containing `"object"`
+with no free-form alternative), **or** a top-level `const`/`enum` must pin the
+whole instance to author-declared literals. A schema that omits `type` without a
+`const`/`enum` pin is insufficient — an absent `type` admits every instance
+type, so an object-shaped closure says nothing about a scalar instance.
+
+This is a deliberate behavior change: a hand-authored executor schema that
+relies on implicit typing (`properties` + `additionalProperties: false`, no
+`type`) is now denied. The fix is to add `"type": "object"`. Denying it is the
+correct posture — the same shape without `type` accepts a bare scalar.
+
+## Ordering: applicators delegate before the type-gate
+
+The type-gate's omitted-`type` denial applies to a **leaf object node**, not to
+every node. A node that is an applicator root — `{"$ref": ...}`, `{"anyOf": ...}`,
+`{"allOf": ...}` — legitimately omits a local `type` because the type constraint
+lives in the resolved target or the branches. Applicator delegation therefore
+runs first; the proof re-applies itself (allowlist gate and type-gate included)
+inside every resolved target and branch, so delegation opens no omitted-type
+hole. The omitted-`type` denial sits at the leaf-object branch, reached only
+after no applicator has delegated. The allowlist pre-gate remains at the top of
+every node — it only ever denies, so it never pushes an applicator node down the
+leaf path.
+
+## Two mechanisms, kept separate
+
+Admission composes two independent checks, and keeping them separate is what
+lets a scary-named tool with a genuinely bounded schema through:
+
+- The **sufficiency proof** judges *shape closedness* — can an undeclared value
+  ride through? It does not inspect individual property values.
+- The **schema walker** judges *command channels by key name* — is a declared
+  property a free-form command surface? It applies the identifier exemption
+  (`service_id`, `resource_path`, `callback_url` are benign dynamic identifiers)
+  and re-taints executor targets (`executable_path`, `script_path`).
+
+A fixed-operation tool that also declares a free-form `service_id` string is
+admitted: the object is closed (sufficiency) and the identifier key is benign
+(walker). Folding value-boundedness into the sufficiency proof would erase that
+distinction and deny the legitimate case. The two checks cover disjoint
+territory — the sufficiency proof gates the shape skeleton (root, `$ref` target
+and siblings, composition branches); the walker gates property-value interiors —
+and their union is the whole document.
+
+## Residuals — all fail closed
+
+Every shape the proof does not model denies:
+
+- Remote/non-local `$ref`, `$dynamicRef`/`$recursiveRef`, and dynamic anchors
+  are not resolved → insufficient.
+- The in-place and map applicators chosen to be denied rather than modeled
+  (`unevaluatedProperties`, `dependentSchemas`, `if`/`then`/`else`, `not`,
+  `contains`, `propertyNames`, `patternProperties`) → insufficient. A
+  legitimately-bounded `unevaluatedProperties: false` object is among these; it
+  is denied in the core. Recovering that specific admit is a strictly-additive
+  follow-up, gated on real demand, and must never relax the core allowlist —
+  a bounded schema wrongly denied is a support cost; an unbounded schema
+  admitted is a security defect, so ties break to deny.
+- Cyclic `$ref` and node/depth budget exhaustion → insufficient.
+- An unknown keyword with a provably-inert scalar value is the one non-deny
+  residual, and it is safe: a scalar cannot introduce a property value.
+
+## Verification
+
+The change is covered by the full admit/deny parametrized matrix plus: named
+cases for the `patternProperties`-custom-key, omitted-`type`, and
+`unevaluatedProperties:false` shapes; a synthetic never-modeled keyword asserted
+to deny at five positions (root, property value, `allOf` branch, `$ref` sibling,
+`anyOf` branch) with an inert-scalar control that still admits; and a
+`Draft202012Validator` differential that, for every admitted executor-signaling
+schema, asserts the schema rejects an injected free-form command instance. That
+differential includes the applicator-root admits (`$ref`-root, `anyOf`-root), so
+the delegation ordering is regression-tested, not review-checked.

--- a/docs/design/mcp-executor-admission-sufficiency.md
+++ b/docs/design/mcp-executor-admission-sufficiency.md
@@ -16,93 +16,155 @@ branch, and so on. Against JSON Schema — whose vocabulary is open-ended and
 extensible — a proof built from a denylist of known-dangerous shapes cannot be
 complete. Each new applicator keyword (`patternProperties`, `propertyNames`,
 `unevaluatedProperties`, `dependentSchemas`, ...) is another way to introduce a
-value the denylist never modeled. Two concrete gaps illustrate the class:
+value the denylist never modeled.
 
-- A `patternProperties` whose pattern accepts a command-shaped key
-  (`{"patternProperties": {"^command_custom$": {"type": "string"}}, "additionalProperties": false}`)
-  looks closed but accepts `{"command_custom": "rm -rf /"}`.
-- A schema that omits `type` entirely
-  (`{"properties": {"operation": {"const": "status"}}, "additionalProperties": false}`)
-  looks like a closed object but, because an absent `type` admits every instance
-  type, also accepts a bare string.
+## Problem, round two: the discriminator moved, the defect didn't
 
-## Approach: invert the polarity to a known-safe allowlist
+A later revision inverted the polarity to a known-safe allowlist: any keyword
+outside an understood set makes the node insufficient. That closed the
+keyword-enumeration gap, but reopened the same defect class through a
+different axis. The allowlist gate only ran on nodes the recursion actually
+visited, and a separate, narrower discriminator —
+"is this declared property's *value* itself object-shaped or applicator-
+bearing" — decided which property values got recursed into at all. That
+discriminator enumerated `properties`, `patternProperties`,
+`additionalProperties`, `unevaluatedProperties`, `propertyNames`,
+`dependentSchemas`, `$ref`, `allOf`, `anyOf`, `oneOf` as the keywords that
+made a value worth recursing into. It omitted the conditional applicators
+(`if`/`then`/`else`/`not`) and the array applicators (`items`/`prefixItems`).
+A property value carrying one of those was therefore **never visited at
+all** — not walked, not allowlist-checked — regardless of what it contained:
 
-The sufficiency proof models a **closed set of keywords it understands** and
-denies on anything else. The load-bearing rule:
+- `{"if": {}}`, `{"then": {}}`, `{"else": {}}`, and `{"not": {"type": "null"}}`,
+  each sitting as a declared property's value, all admitted.
+- `service_id: {"type": "array", "items": {"not": {"type": "null"}}}` admitted,
+  even though `items`' own subschema carries an unmodeled `not`.
 
-> Any keyword outside the understood set — present anywhere in the schema
-> skeleton the proof walks — makes the node insufficient.
+Enumerating "which schema *positions* deserve the allowlist" is the same
+mistake as enumerating "which *keywords* are dangerous" — just re-entered
+through the traversal axis instead of the keyword axis. Closing it the same
+way it was closed the first time (add the missing keywords to the
+discriminator) only produces a third list to eventually miss the fourth
+keyword. The fix removes the discriminator instead.
 
-That single rule covers `patternProperties`, `propertyNames`,
-`unevaluatedProperties`, `dependentSchemas`, the in-place applicators
-(`if`/`then`/`else`/`not`, `contains`), `$dynamicRef`/`$recursiveRef`, and every
-future vocabulary addition, without enumerating each one. "An unmodeled
-applicator fails closed" holds *because* it is the primary rule, not as an
-incidental consequence.
+## Approach: one closed keyword registry, total traversal
 
-Membership on the understood set is decided by keyword and by value shape, not
-by spelling:
+Every JSON Schema Draft 2020-12 keyword is classified into **exactly one** of
+four classes, once, in a single module-level registry:
 
-- **Bounding constraints** that only ever narrow the admitted set: `type`,
-  `const`, `enum`, `required`, `additionalProperties` (only `false` or an
-  `enum`/`const`-restricted schema counts as closing), and the standardized
-  numeric/size bounds (`minLength`, `maxItems`, `minimum`, `multipleOf`, ...).
-  The numeric bounds are an explicit enumeration — never a `min*`/`max*` prefix
-  test, which would exempt an arbitrary `minCustomVocabulary` and reopen the
-  bypass.
-- **Modeled applicators** the proof recurses through: `properties` (for
-  closedness), `$ref` (local `#/...`, resolved and intersected with its
-  Draft 2020-12 siblings), `allOf` (intersection — one provably-bounded branch
-  suffices), and `anyOf`/`oneOf` (unions — every branch must independently prove
-  bounded).
-- **Inert annotations** that carry no assertion and are ignored: `description`,
-  `title`, `$comment`, `examples`, `default`, `format`, `pattern`, `$schema`,
-  `$id`, `$anchor`, `readOnly`, `deprecated`, `contentEncoding`,
-  `contentMediaType`, `contentSchema`, `$defs`, and the `x-*` vendor-extension
-  convention. An `x-*`/`$comment` keyword is inert only when its *value* is
-  demonstrably free of schema vocabulary — an extension whose value embeds
-  `properties` is a hidden channel, not an annotation. `contentSchema` is a
-  deliberate, argued exception to "schema-bearing means deny": its value is a
-  mapping, exactly the shape the unknown-keyword check treats as suspect, but
-  the Content vocabulary it belongs to (alongside `contentEncoding` /
-  `contentMediaType`) is annotation-only in the *default* Draft 2020-12
-  dialect this module validates against — the content-assertion vocabulary
-  that would make it actually constrain an instance is not enabled, so a
-  value under this keyword is not an admission channel today. That holds only
-  as long as the content-assertion vocabulary stays disabled; enabling it in
-  a future dialect configuration would require `contentSchema` to leave this
-  modeled-as-inert set.
-- **Unknown keywords** are tolerated only when their value cannot carry a
-  subschema (a scalar, or a list/mapping built entirely of scalars). An unknown
-  keyword with a mapping- or subschema-shaped value denies.
+- **Inert annotation** — carries no assertion, contributes nothing to
+  admission: `title`, `description`, `default`, `examples`, `deprecated`,
+  `readOnly`, `writeOnly`, `$comment`, `$schema`, `$id`, `$anchor`,
+  `$vocabulary`, `format`, `pattern`, `contentEncoding`, `contentMediaType`,
+  `contentSchema`.
+- **Bounding** — narrows the admitted set, carries no recursable subschema of
+  its own: `type`, `const`, `enum`, `required`, `dependentRequired`, and the
+  standardized numeric/size bounds (`multipleOf`, `maximum`, `minLength`,
+  `maxItems`, `maxContains`, `maxProperties`, ...). An explicit enumeration,
+  never a `min*`/`max*` spelling heuristic — a prefix test would exempt an
+  arbitrary `minCustomVocabulary` and reopen the bypass this registry exists
+  to close.
+- **Modeled applicator** — the proof recurses through and credits:
+  `properties`, `additionalProperties` (only when its value is a schema
+  Mapping — the `false`/bounding form is a closedness fact, not a recursion
+  target), `allOf`, `anyOf`, `oneOf`, `$ref` (local `#/...` only), `$defs`,
+  `definitions`.
+- **Denied applicator** — recognized by name, never modeled: its mere
+  *presence* denies the node outright, and the proof never recurses beneath
+  it (an ancestor denial already covers everything nested inside).
+  `patternProperties`, `propertyNames`, `unevaluatedProperties`,
+  `unevaluatedItems`, `dependentSchemas`, `if`, `then`, `else`, `not`,
+  `contains`, `items`, `prefixItems`, `$dynamicRef`, `$dynamicAnchor`,
+  `$recursiveRef`, `$recursiveAnchor`. Promoting one of these to modeled is a
+  separate, individually-argued change with its own oracle-soundness
+  argument — never a silent reclassification.
 
-## Type-gate
+A keyword outside all four classes is **unknown**, and is tolerated only when
+its value cannot itself carry a subschema (a scalar, or a list/mapping built
+entirely of scalars); a mapping- or subschema-shaped value denies.
 
-An admittable object must constrain instances to objects. `type` must be
-present and object-admitting (`"object"`, or a type array containing `"object"`
-with no free-form alternative), **or** a top-level `const`/`enum` must pin the
-whole instance to author-declared literals. A schema that omits `type` without a
-`const`/`enum` pin is insufficient — an absent `type` admits every instance
-type, so an object-shaped closure says nothing about a scalar instance.
+The traversal that consumes this registry
+(`_structural_coverage_insufficient`) visits **every** schema-bearing
+position **unconditionally** — every `properties` value, the
+`additionalProperties` schema, every composition branch, every resolved
+local `$ref` target, and every `$defs`/`definitions` entry — instead of
+deciding, node by node, whether a position is "worth" visiting. There is no
+longer a discriminator that could omit a position; the registry alone
+decides what a node's own keywords mean, and the traversal reaches every
+node regardless of its shape.
 
-This is a deliberate behavior change: a hand-authored executor schema that
-relies on implicit typing (`properties` + `additionalProperties: false`, no
-`type`) is now denied. The fix is to add `"type": "object"`. Denying it is the
-correct posture — the same shape without `type` accepts a bare scalar.
+This traversal deliberately applies **no type-gate and no closedness
+requirement**. A scalar leaf `{"type": "string"}` is sufficient on its own —
+no denied/unknown keyword is present — which is exactly what preserves a
+free-form identifier-key property (`service_id`, `resource_path`,
+`callback_url`) declared alongside a fixed `operation`: the identifier's own
+value is visited, found to carry only bounding keywords, and the walker's
+key-name policy (untouched by this change) governs it from there.
 
-## Ordering: applicators delegate before the type-gate
+### Totality argument
 
-The type-gate's omitted-`type` denial applies to a **leaf object node**, not to
-every node. A node that is an applicator root — `{"$ref": ...}`, `{"anyOf": ...}`,
-`{"allOf": ...}` — legitimately omits a local `type` because the type constraint
-lives in the resolved target or the branches. Applicator delegation therefore
-runs first; the proof re-applies itself (allowlist gate and type-gate included)
-inside every resolved target and branch, so delegation opens no omitted-type
-hole. The omitted-`type` denial sits at the leaf-object branch, reached only
-after no applicator has delegated. The allowlist pre-gate remains at the top of
-every node — it only ever denies, so it never pushes an applicator node down the
-leaf path.
+Every schema-bearing position in a document reaches the registry by exactly
+one of three routes, and no fourth route exists. (i) It sits under a chain of
+**modeled** applicators from the root — the traversal's own recursion visits
+it, because each modeled-applicator branch above it is expanded in turn. (ii)
+It sits under a **denied** applicator — the ancestor node returns insufficient
+the moment it sees that keyword, before it would ever need to look inside it,
+so the position underneath is covered by the denial rather than by a visit.
+(iii) It sits under an **unknown** keyword, which is itself checked for a
+subschema-shaped value and denied at that node if so. Because inert and
+bounding keywords never gate recursion in either direction, they cannot
+create a fourth route out of this partition. Therefore no schema-bearing
+position — at any depth, under any composition, inside any property value —
+escapes classification by the registry.
+
+### Two side obligations
+
+1. The inert-annotation class admits **no** keyword the default Draft
+   2020-12 dialect treats as an applicator or assertion — every entry in it
+   is annotation-only by specification. `contentSchema` keeps its own
+   individually-argued rationale rather than a generic "annotations are
+   safe" excuse: its value is a mapping (schema-shaped, like `$defs`), but it
+   describes the *decoded content* of a string instance and asserts nothing
+   about the instance itself, and that holds only because the
+   content-*assertion* vocabulary (as opposed to the content-*annotation*
+   vocabulary `contentSchema` belongs to) stays disabled in the default
+   dialect this module validates against. Enabling that vocabulary in a
+   future dialect configuration would require `contentSchema` to leave this
+   class.
+2. `$defs`/`definitions` entries are visited **unconditionally**, not
+   reachability-gated by whether some `$ref` in the document actually points
+   at them. This is a deliberate fail-closed choice, not an oversight: an
+   entry nobody currently references is still schema-bearing content sitting
+   in the document, and a future edit that adds a reference to it (or a
+   consumer that resolves `$defs` by convention rather than an explicit
+   `$ref`) must not inherit a channel this proof never bothered to check.
+
+## Object-boundedness: a second, orthogonal proof
+
+The registry-driven traversal answers "does any position carry a keyword this
+proof does not model" — it never asks whether the *object itself* is closed
+to undeclared keys. That question is answered by a second, independent
+function, `_object_boundedness_insufficient`, unchanged in shape from the
+prior revision: `type` must include `"object"` (or a top-level `const`/`enum`
+must pin the whole instance), applicators delegate before the omitted-type
+denial (so a `$ref`/`allOf`/`anyOf`-rooted schema that legitimately carries
+no local `type` is not false-denied), and a non-empty `properties` is only
+bounded when `additionalProperties` is `false` (or itself restricted to a
+finite `enum`/`const`). This proof also recurses into a declared property's
+value, but only when that value could itself resolve to an object instance
+(its own `type` includes `"object"`, or it carries a modeled-applicator
+keyword) — a scalar, array, or annotation-only value is left alone, which is
+what keeps the identifier-suffix exemption intact. Omitting a value here
+because it is reached only through a *denied* applicator (`if`/`then`/
+`items`, ...) is harmless: that applicator's bare presence already makes the
+whole document insufficient via the registry traversal, independent of
+whether this proof would have looked inside it.
+
+**Overall verdict**: `_schema_is_insufficient(schema)` is `True` (insufficient)
+if *either* the object-boundedness proof fails *or* the registry-driven
+structural-coverage traversal finds a denied/unknown keyword anywhere in the
+document. The two proofs run over the same document and are combined by OR;
+neither substitutes for the other.
 
 ## Two mechanisms, kept separate
 
@@ -110,68 +172,17 @@ Admission composes two independent checks with two different jobs, and
 keeping them separate is what lets a scary-named tool with a genuinely
 bounded schema through:
 
-- The **sufficiency proof** is the STRUCTURAL gate. It covers the WHOLE
-  DOCUMENT — every node, at every depth, including the interior of a
-  declared property's own value — and asks one question only: is this shape
-  provably closed against an undeclared value? It never reasons about a key's
-  *name*.
+- The **sufficiency proof** (the two functions above) is the STRUCTURAL
+  gate. It covers the WHOLE DOCUMENT — every node, at every depth, including
+  the interior of a declared property's own value — and asks only "is this
+  shape provably closed". It never reasons about a key's *name*.
 - The **schema walker** does KEY-NAME / command classification ONLY — is a
-  declared property (by its name) a free-form command surface? It applies the
-  identifier exemption (`service_id`, `resource_path`, `callback_url` are
+  declared property (by its name) a free-form command surface? It applies
+  the identifier exemption (`service_id`, `resource_path`, `callback_url` are
   benign dynamic identifiers) and re-taints executor targets
   (`executable_path`, `script_path`). It is NEVER load-bearing for structural
   coverage — it does not, and must not be relied on to, prove a shape closed.
-
-The corrected boundary: the sufficiency proof's structural coverage is total:
-its allowlist gate re-runs at the root, inside every resolved `$ref` target
-and its siblings, inside every composition branch (`allOf`/`anyOf`/`oneOf`),
-and — via the property-value recursion — inside every declared property
-value that is itself object-shaped or applicator-bearing, recursively, to
-whatever depth the schema nests. The walker's classification never substitutes
-for that coverage; it only ever adds key-name evidence on top of a node the
-structural gate has already found sufficient.
-
-The prior framing — "the sufficiency proof gates the shape skeleton, the
-walker gates property-value interiors, and their union is the whole
-document" — was unsound. It assumed the walker's key-name classification
-supplied whatever structural coverage the sufficiency proof left out inside a
-property value. It does not: a keyword class the walker *does* recognize
-structurally (`patternProperties` is in the walker's own keyword whitelist)
-can still sit inside a property value in a shape the walker's key-name
-classifier cannot see — a `patternProperties` pattern keyed on a name outside
-the walker's fixed categorized-key list is never matched, so the walker never
-even inspects that pattern's subschema, and the sufficiency proof (pre-fix)
-never re-checked a property value at all. Neither mechanism's structural
-check ran on that node. The "union is the whole document" claim was false at
-exactly the composition of "walker-known keyword" × "key-name the walker's
-classifier doesn't match" × "property-value depth" — which is precisely the
-`{"patternProperties": {"^command_custom$": {"type": "string"}},
-"additionalProperties": false}` bypass this design was written to close, sitting
-one property-value level deeper than the version already fixed at the root.
-
-The fix is not "teach the walker more key names" — that repeats the
-denylist mistake this document's Approach section already rejected. It is
-"make the sufficiency proof's structural coverage recurse into every nested
-key channel", so the STRUCTURAL question ("is this shape closed") is
-answered completely by the proof alone, independent of whatever the walker's
-key-name classification separately contributes.
-
-A property value is a **key channel** — and therefore recursed into with the
-proof's full allowlist/type-gate/closedness logic — when it is itself
-object-shaped (`type` includes `"object"`) or carries an object/map
-applicator keyword (`properties`, `patternProperties`,
-`additionalProperties`, `unevaluatedProperties`, `propertyNames`,
-`dependentSchemas`) or a composition/ref applicator (`$ref`, `allOf`,
-`anyOf`, `oneOf`). A scalar-typed, array-typed, annotation-only, or bare
-free-form string property value is deliberately NOT recursed — it is a VALUE,
-not a nested key channel, and remains the walker's territory by key name.
-This is what keeps the two-mechanism separation intact: a fixed-operation
-tool that also declares a free-form `service_id` string is still admitted —
-the outer object is closed (sufficiency), `service_id`'s value is a bare
-string so it is never handed to the recursion at all, and the identifier key
-is benign (walker). Folding scalar value-boundedness into the structural gate
-would erase that distinction and deny the legitimate case; the recursion is
-scoped precisely to avoid that.
+  This change does not touch the walker's own command-classification logic.
 
 ## Residuals — all fail closed
 
@@ -179,38 +190,76 @@ Every shape the proof does not model denies:
 
 - Remote/non-local `$ref`, `$dynamicRef`/`$recursiveRef`, and dynamic anchors
   are not resolved → insufficient.
-- The in-place and map applicators chosen to be denied rather than modeled
-  (`unevaluatedProperties`, `dependentSchemas`, `if`/`then`/`else`, `not`,
-  `contains`, `propertyNames`, `patternProperties`) → insufficient. A
-  legitimately-bounded `unevaluatedProperties: false` object is among these; it
-  is denied in the core. Recovering that specific admit is a strictly-additive
-  follow-up, gated on real demand, and must never relax the core allowlist —
-  a bounded schema wrongly denied is a support cost; an unbounded schema
-  admitted is a security defect, so ties break to deny.
+- Every denied applicator (`patternProperties`, `propertyNames`,
+  `unevaluatedProperties`, `unevaluatedItems`, `dependentSchemas`,
+  `if`/`then`/`else`/`not`, `contains`, `items`, `prefixItems`) denies at
+  sight, regardless of what its own subschema contains. Two accepted
+  over-blocks follow directly from this and are deliberate, not oversights:
+  - A legitimately-bounded `unevaluatedProperties: false` object is denied in
+    the core, even though it is a real Draft-2020-12 closing mechanism.
+    Recovering that specific admit is a strictly-additive follow-up, gated on
+    real demand, and must never relax the core allowlist.
+  - An array property whose `items`/`prefixItems` subschema is itself fully
+    bounded (e.g. `items: {"enum": ["a", "b"]}`, or a closed tuple with
+    `items: false`) is now denied too, because `items`/`prefixItems` are
+    denied applicators that deny at sight rather than being inspected for
+    boundedness. The behavior-visible consequence: a previously registerable
+    tool with a bounded-array arg on a strong name now refuses registration.
+    Recovering bounded-array admission through `items` is, like
+    `unevaluatedProperties: false`, a separate, individually-argued delta
+    with its own oracle-soundness argument — not part of this change. A
+    bounded schema wrongly denied is a support cost; an unbounded schema
+    admitted is a security defect, so ties break to deny.
 - Cyclic `$ref` and node/depth budget exhaustion → insufficient.
 - An unknown keyword with a provably-inert scalar value is the one non-deny
   residual, and it is safe: a scalar cannot introduce a property value.
 
 ## Verification
 
-The change is covered by the full admit/deny parametrized matrix plus: named
-cases for the `patternProperties`-custom-key, omitted-`type`, and
-`unevaluatedProperties:false` shapes; a synthetic never-modeled keyword asserted
-to deny at six positions (root, property value at depth 1, `allOf` branch,
-`$ref` sibling, `anyOf` branch, property value at depth 2 — the value of a
-property that is itself the value of another property) with an inert-scalar
-control that still admits; a `Draft202012Validator` differential that, for
-every admitted executor-signaling schema, asserts the schema rejects an
-injected free-form command instance (the differential includes the
-applicator-root admits — `$ref`-root, `anyOf`-root — so the delegation
-ordering is regression-tested, not review-checked); and the property-value
-recursion is separately covered by named cases with their own
-`Draft202012Validator` necessity differentials: `patternProperties` nested at
-depth 2, `dependentSchemas` nested inside a property value, and
-`unevaluatedProperties` nested inside a property value — each proven
-necessary by an oracle differential showing the raw schema, absent this
-recursion's denial, would accept the injected command. A closed nested object
-property value, a scalar identifier property value alongside a fixed
-operation, and a mapping-valued `contentSchema` annotation on an otherwise
-bounded schema are covered as admits, the last two with their own oracle
-differentials confirming injection is still rejected.
+The change is covered by:
+
+- The full pre-existing admit/deny parametrized matrix, additive apart from
+  the three array-applicator cases named above: those three moved from admit
+  to deny expectations, renamed to state the new verdict, each keeping an
+  oracle differential that now proves the opposite fact — the schema was
+  never itself capable of admitting an injected command, so the new deny is
+  an accepted over-block rather than a correction of a wrong test. Every
+  other pre-existing case, including the named `patternProperties`-custom-key,
+  omitted-`type`, and `unevaluatedProperties:false` necessity cases, the four
+  applicator-root admits, and a `Draft202012Validator` differential for every
+  admitted executor-signaling schema, is untouched.
+- A **registry-generated** regression matrix, parametrized by iterating the
+  keyword-classification registry's own frozensets directly rather than a
+  hand-listed keyword table: for every modeled applicator, a benign
+  closed/bounded payload admits (with an oracle differential) and a
+  denied/unknown payload denies, at nesting depths 1, 2, and 3; for every
+  denied applicator, denial is asserted at each of five subschema positions
+  (declared-property value, `additionalProperties` schema, a composition
+  branch, a `$ref` target, and an unreferenced `$defs` entry); a synthetic,
+  never-registered keyword denies at every position when Mapping-valued and
+  admits when its value is a provably-inert scalar. A keyword added to
+  either registry frozenset later gains coverage here automatically, with no
+  test-file edit required. A separate test asserts the four registry classes
+  partition with no keyword classified twice, and that their union covers a
+  representative Draft 2020-12 core-vocabulary keyword list.
+- The five originally-reproduced false negatives — `{"if": {}}`,
+  `{"then": {}}`, `{"else": {}}`, `{"not": {"type": "null"}}` in a declared
+  property's value, and an `items`/`prefixItems` array position carrying an
+  unmodeled `not` — now all deny.
+
+Known, accepted consequence of this change (not a regression): the three
+schemas whose only bounding mechanism was an `items`/`prefixItems`-restricted
+array (`items: {"enum": [...]}`, a closed tuple via `prefixItems` +
+`items: false`, and a nested array bounded by `enum` items at every level),
+previously admitted under the enumerated discriminator, now deny under the
+registry, because `items`/`prefixItems` are denied applicators that deny at
+sight rather than being inspected for their own boundedness. The
+behavior-visible consequence is the same one named above: a previously
+registerable tool with a bounded-array arg on a strong name now refuses
+registration. This is the same accepted-over-block shape as
+`unevaluatedProperties: false`; the regression matrix asserts the deny
+verdict directly, each case paired with an oracle differential proving the
+denied schema was never itself capable of admitting an injected command —
+the deny is a deliberate over-block, not a missed bypass. Recovering
+admission for a bounded array position is future, separately-argued work
+with its own oracle-soundness argument, not part of this change.

--- a/docs/design/mcp-executor-admission-sufficiency.md
+++ b/docs/design/mcp-executor-admission-sufficiency.md
@@ -55,12 +55,16 @@ four classes, once, in a single module-level registry:
 - **Inert annotation** — carries no assertion, contributes nothing to
   admission: `title`, `description`, `default`, `examples`, `deprecated`,
   `readOnly`, `writeOnly`, `$comment`, `$schema`, `$id`, `$anchor`,
-  `$vocabulary`, `format`, `pattern`, `contentEncoding`, `contentMediaType`,
+  `$vocabulary`, `format`, `contentEncoding`, `contentMediaType`,
   `contentSchema`.
 - **Bounding** — narrows the admitted set, carries no recursable subschema of
   its own: `type`, `const`, `enum`, `required`, `dependentRequired`, and the
   standardized numeric/size bounds (`multipleOf`, `maximum`, `minLength`,
-  `maxItems`, `maxContains`, `maxProperties`, ...). An explicit enumeration,
+  `pattern`, `maxItems`, `maxContains`, `maxProperties`, ...). `pattern` is a
+  Draft 2020-12 *assertion* that narrows the admitted set of string
+  instances to those matching a regular expression — it belongs on this
+  list, not among the inert annotations, and carries no recursable
+  subschema of its own either way. An explicit enumeration,
   never a `min*`/`max*` spelling heuristic — a prefix test would exempt an
   arbitrary `minCustomVocabulary` and reopen the bypass this registry exists
   to close.

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -247,11 +247,21 @@ class ActionManager(Manager):
             client = await MCPConnectionPool.get_client(server_config, security=security)
             tools = await client.list_tools()
 
+            # Validate every discovered descriptor BEFORE mutating the
+            # registry: a denial anywhere in the list must leave the
+            # registry exactly as it was, not partially populated with the
+            # tools that happened to be validated first.
+            for tool in tools:
+                validate_mcp_tool_admission(
+                    tool.name,
+                    getattr(tool, "inputSchema", None),
+                    getattr(tool, "description", None),
+                )
+
             for tool in tools:
                 tool_name = tool.name
                 input_schema = getattr(tool, "inputSchema", None)
                 description = getattr(tool, "description", None)
-                validate_mcp_tool_admission(tool_name, input_schema, description)
 
                 config_with_metadata = dict(server_config)
                 config_with_metadata["_original_tool_name"] = tool_name

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -57,12 +57,59 @@ class ActionManager(Manager):
         if callable(tool):
             tool = Tool(func_callable=tool)
         elif isinstance(tool, dict):
+            if len(tool) == 1:
+                (raw_tool_name,) = tool.keys()
+                if isinstance(raw_tool_name, str):
+                    from lionagi.service.connections.mcp_wrapper import (
+                        validate_mcp_tool_admission,
+                    )
+
+                    validate_mcp_tool_admission(raw_tool_name, None, None)
             tool = Tool(mcp_config=tool)
         elif not isinstance(tool, Tool):
             raise TypeError(
                 "Must provide a `Tool` object, a callable function, or an MCP config dict."
             )
+        elif tool.mcp_config is not None:
+            self._validate_prebuilt_mcp_tool_admission(tool)
+
         self.registry[tool.function] = tool
+
+    def _validate_prebuilt_mcp_tool_admission(self, tool: Tool) -> None:
+        from lionagi.service.connections.mcp_wrapper import (
+            is_synthetic_mcp_wrapper_schema,
+            validate_mcp_tool_admission,
+        )
+
+        mcp_tool_name, mcp_server_config = next(iter(tool.mcp_config.items()))
+        actual_name = mcp_server_config.get("_original_tool_name")
+        if not isinstance(actual_name, str) or not actual_name:
+            actual_name = mcp_tool_name
+
+        input_schema = None
+        description = None
+        advertised_name = None
+        if isinstance(tool.tool_schema, dict):
+            function = tool.tool_schema.get("function")
+            if isinstance(function, dict):
+                advertised_name = function.get("name")
+                input_schema = function.get("parameters")
+                description = function.get("description")
+
+        # A schema/description that is just the auto-generated `**kwargs`
+        # wrapper carries no remote-server information; treat it as absent
+        # metadata so strong identities fail closed instead of being
+        # laundered through their own synthetic schema, and so ordinary
+        # names are not falsely denied by the wrapper's generic docstring.
+        if is_synthetic_mcp_wrapper_schema(
+            mcp_tool_name, advertised_name, input_schema, description
+        ):
+            input_schema = None
+            description = None
+
+        validate_mcp_tool_admission(actual_name, input_schema, description)
+        if isinstance(advertised_name, str) and advertised_name != actual_name:
+            validate_mcp_tool_admission(advertised_name, input_schema, description)
 
     def register_tools(self, tools: list[FuncTool] | FuncTool, update: bool = False) -> None:
         tools_list = tools if isinstance(tools, list) else [tools]
@@ -166,7 +213,19 @@ class ActionManager(Manager):
                     request_options[f"{server_name}_{k}"] = request_options.pop(k)
 
         if tool_names:
+            from lionagi.service.connections.mcp_wrapper import (
+                validate_mcp_tool_admission,
+            )
+
             for tool_name in tool_names:
+                validate_mcp_tool_admission(tool_name, None, None)
+                logger.warning(
+                    f"MCP tool {tool_name!r} registered via the metadata-free "
+                    "tool_names= shortcut with no descriptor (schema/description) "
+                    "evidence; the generic-executor admission rule could not "
+                    "inspect its shape and admitted it by name alone."
+                )
+
                 config_with_metadata = dict(server_config)
                 config_with_metadata["_original_tool_name"] = tool_name
 
@@ -180,40 +239,42 @@ class ActionManager(Manager):
                 self.register_tool(tool, update=update)
                 registered_tools.append(tool_name)
         else:
-            from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+            from lionagi.service.connections.mcp_wrapper import (
+                MCPConnectionPool,
+                validate_mcp_tool_admission,
+            )
 
             client = await MCPConnectionPool.get_client(server_config, security=security)
             tools = await client.list_tools()
 
             for tool in tools:
-                config_with_metadata = dict(server_config)
-                config_with_metadata["_original_tool_name"] = tool.name
+                tool_name = tool.name
+                input_schema = getattr(tool, "inputSchema", None)
+                description = getattr(tool, "description", None)
+                validate_mcp_tool_admission(tool_name, input_schema, description)
 
-                mcp_config = {tool.name: config_with_metadata}
+                config_with_metadata = dict(server_config)
+                config_with_metadata["_original_tool_name"] = tool_name
+
+                mcp_config = {tool_name: config_with_metadata}
 
                 tool_request_options = None
-                if request_options and tool.name in request_options:
-                    tool_request_options = request_options[tool.name]
+                if request_options and tool_name in request_options:
+                    tool_request_options = request_options[tool_name]
 
                 tool_schema = None
                 try:
-                    if (
-                        hasattr(tool, "inputSchema")
-                        and tool.inputSchema is not None
-                        and isinstance(tool.inputSchema, dict)
-                    ):
+                    if isinstance(input_schema, dict):
                         tool_schema = {
                             "type": "function",
                             "function": {
-                                "name": tool.name,
-                                "description": (
-                                    tool.description if hasattr(tool, "description") else None
-                                ),
-                                "parameters": tool.inputSchema,
+                                "name": tool_name,
+                                "description": description,
+                                "parameters": input_schema,
                             },
                         }
                 except Exception as schema_error:
-                    logging.warning(f"Could not extract schema for {tool.name}: {schema_error}")
+                    logging.warning(f"Could not extract schema for {tool_name}: {schema_error}")
                     tool_schema = None
 
                 try:
@@ -223,9 +284,11 @@ class ActionManager(Manager):
                         tool_schema=tool_schema,
                     )
                     self.register_tool(tool_obj, update=update)
-                    registered_tools.append(tool.name)
+                    registered_tools.append(tool_name)
+                except PermissionError:
+                    raise
                 except Exception as e:
-                    logging.warning(f"Failed to register tool {tool.name}: {e}")
+                    logging.warning(f"Failed to register tool {tool_name}: {e}")
 
         return registered_tools
 
@@ -261,14 +324,8 @@ class ActionManager(Manager):
                 )
                 all_tools[server_name] = tools
                 logger.info("Registered %d tools from server '%s'", len(tools), server_name)
-            except PermissionError:
-                logger.error(
-                    "MCP server '%s' was denied by the active MCPSecurityConfig. "
-                    "Pass mcp_security=MCPSecurityConfig(allow_commands=True, "
-                    "allow_urls=True) (or an allowlist) to load_mcp_config to "
-                    "authorize it.",
-                    server_name,
-                )
+            except PermissionError as exc:
+                logger.error("MCP server %r registration denied: %s", server_name, exc)
                 raise
             except Exception as e:
                 logger.warning("Failed to register server '%s': %s", server_name, e)
@@ -316,14 +373,8 @@ async def load_mcp_tools(
                 security=mcp_security,
             )
             logger.info("Loaded %d tools from %s", len(tools_registered), server_name)
-        except PermissionError:
-            logger.error(
-                "MCP server '%s' was denied by the active MCPSecurityConfig. "
-                "Pass mcp_security=MCPSecurityConfig(allow_commands=True, "
-                "allow_urls=True) (or an allowlist) to load_mcp_tools to "
-                "authorize it.",
-                server_name,
-            )
+        except PermissionError as exc:
+            logger.error("MCP server %r registration denied: %s", server_name, exc)
             raise
         except Exception as e:
             logger.warning("Failed to load server '%s': %s", server_name, e)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -217,8 +217,14 @@ class ActionManager(Manager):
                 validate_mcp_tool_admission,
             )
 
+            # Validate the complete tool_names list before creating or
+            # registering any tool: a denial anywhere in the list must leave
+            # the registry exactly as it was, not partially populated with
+            # the names that happened to be validated first.
             for tool_name in tool_names:
                 validate_mcp_tool_admission(tool_name, None, None)
+
+            for tool_name in tool_names:
                 logger.warning(
                     f"MCP tool {tool_name!r} registered via the metadata-free "
                     "tool_names= shortcut with no descriptor (schema/description) "

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -290,220 +290,235 @@ def _has_structural_ref_siblings(siblings: Mapping) -> bool:
     return any(key not in _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS for key in siblings)
 
 
-# Keyword allowlist for the SUFFICIENCY PROOF specifically -- a STRICT
-# SUBSET of the walker's `_KNOWN_SCHEMA_KEYWORDS` (defined further below).
-# The walker additionally understands applicators it can safely WALK for
-# command-channel evidence (`patternProperties`, `if`/`then`/`else`,
-# `items`, ...); the sufficiency proof only ever asks "is this shape
-# provably closed against an undeclared value", which only the four
-# composition applicators it actually recurses through (`$ref`/`allOf`/
-# `anyOf`/`oneOf`) and the object-closing keywords answer. Every other
-# keyword the walker walks -- `patternProperties`, `propertyNames`,
-# `unevaluatedProperties`, `dependentSchemas`, `if`/`then`/`else`, `not`,
-# `contains`, `items`, `prefixItems` -- is therefore DENIED by this gate
-# even though it is walker-known, because none of them is modeled by this
-# shape logic; the proof must not silently treat an applicator it does not
-# implement as harmless. `$defs`/`definitions` are included here as
-# MODELED (not merely inert) because their value is a mapping of
-# subschemas -- schema-bearing, so the generic value-shape inertness test
-# would otherwise flag them -- that is only ever reachable through `$ref`
-# resolution, which this function already performs.
-_SUFFICIENCY_MODELED_KEYWORDS = frozenset(
+# --- Keyword registry for the sufficiency proof --------------------------
+#
+# The sufficiency proof answers exactly one question: "is this schema
+# document provably closed against an undeclared value?" An earlier
+# iteration answered it with a per-property "is this value a key channel"
+# discriminator deciding WHICH POSITIONS deserve full scrutiny -- the same
+# defect class as enumerating "which keywords are dangerous", just re-
+# entered through the traversal axis instead of the keyword axis: that
+# discriminator omitted the conditional applicators (`if`/`then`/`else`/
+# `not`) and the array applicators (`items`/`prefixItems`), so a property
+# value carrying one of them was never visited at all, and the allowlist
+# check that would have denied it never ran there.
+#
+# The fix: classify EVERY JSON Schema Draft 2020-12 keyword into EXACTLY ONE
+# of four classes (below), then walk the ENTIRE document -- every property
+# value, every composition branch, every `$ref` target, every `$defs` entry
+# -- UNCONDITIONALLY, checking each node's OWN keywords against this
+# registry (`_structural_coverage_insufficient`, defined further below).
+# There is no longer a discriminator deciding "should this node be
+# visited"; every schema-bearing position is visited, and the registry
+# alone decides what its keywords mean. A keyword not in the registry is
+# UNKNOWN and fails closed unless its value provably cannot carry a
+# subschema.
+
+# Annotation-only: carry no assertion that admits/denies an instance value.
+_INERT_ANNOTATION_KEYWORDS = frozenset(
     {
-        # shape/bounding keywords the proof reasons over directly
-        "type",
-        "const",
-        "enum",
-        "required",
-        "additionalProperties",
-        "properties",
-        "$ref",
-        "allOf",
-        "anyOf",
-        "oneOf",
-        "$defs",
-        "definitions",
-        # pure-inert annotations: collect no assertion that admits an
-        # instance value, so their presence must never force the
-        # unmodeled-keyword branch even though most are not numeric bounds
-        "description",
         "title",
-        "$comment",
-        "examples",
+        "description",
         "default",
-        "format",
-        "pattern",
+        "examples",
+        "deprecated",
+        "readOnly",
+        "writeOnly",
+        "$comment",
         "$schema",
         "$id",
         "$anchor",
         "$vocabulary",
-        "readOnly",
-        "writeOnly",
-        "deprecated",
+        "format",
+        "pattern",
         "contentEncoding",
         "contentMediaType",
-        # `contentSchema` is a deliberate, ARGUED exception to "schema-
-        # bearing means deny", not a relaxation of the allowlist's default
-        # posture. It is a Draft 2020-12 Content-vocabulary annotation
-        # (alongside `contentEncoding`/`contentMediaType`) describing the
-        # schema of a string instance's DECODED content. Its value is a
-        # mapping (schema-bearing in shape, like `$defs`), so without this
-        # entry the generic value-shape inertness test would flag it and
-        # deny an otherwise-bounded schema that legitimately uses it. The
-        # exception holds ONLY because the Content vocabulary is
-        # ANNOTATION-ONLY in the default Draft 2020-12 dialect this module
-        # validates against: the content-assertion vocabulary that would
-        # make `contentSchema` actually constrain an instance is NOT
-        # enabled by default, so the value under this keyword is never an
-        # admission channel today. If a future dialect configuration were
-        # to enable the content-assertion vocabulary, `contentSchema` would
-        # need to leave this modeled-as-inert set.
+        # `contentSchema` KEEPS its own individually-argued caveat: its
+        # value is a mapping (schema-shaped), describing the DECODED
+        # content of a string instance, like `contentEncoding`/
+        # `contentMediaType` in the Draft 2020-12 Content vocabulary -- it
+        # asserts nothing about the instance itself. This holds ONLY while
+        # the content-assertion vocabulary stays disabled (the default
+        # dialect this module validates against); enabling that vocabulary
+        # in a future dialect configuration would require `contentSchema`
+        # to leave this class.
         "contentSchema",
     }
 )
 
-
-def _sufficiency_node_has_unmodeled_keyword(schema: Mapping, budget: list[int]) -> bool:
-    """Allowlist pre-gate for the sufficiency proof (`_schema_is_insufficient_node`
-    step 1): True when `schema` carries a keyword that the shape logic
-    downstream does not model, so the node must fail closed before any
-    type/closedness reasoning runs.
-
-    Reuses the walker's OWN inertness vocabulary as the single source of
-    truth -- `_UNRESOLVABLE_REFERENCE_KEYWORDS`, `_NUMERIC_BOUND_KEYWORDS`,
-    `_could_carry_subschema`, `_is_vendor_annotation_keyword` (all defined
-    further below in this module) -- rather than re-listing a divergent
-    keyword table. A key is allowed through when it is a
-    `_SUFFICIENCY_MODELED_KEYWORDS` shape/bounding/inert-annotation
-    keyword, a standardized numeric/size bound, a vendor extension whose
-    value is demonstrably inert, or ANY other keyword whose value cannot
-    itself carry a subschema (a plain scalar, or a scalar-only list/map --
-    e.g. `future-extension: [0, 1, 2]`). Everything else -- a walker-known
-    applicator this proof does not implement (`patternProperties`, `if`/
-    `then`/`else`, `contains`, `items`, `prefixItems`, ...) or a genuinely
-    unknown schema-bearing keyword -- makes the node insufficient. A
-    `$dynamicRef`/`$recursiveRef` anywhere on the node is denied outright by
-    keyword identity, mirroring the walker's own unresolvable-reference
-    treatment (their value is a plain string, so the schema-bearing value
-    test alone would miss them)."""
-    if any(key in schema for key in _UNRESOLVABLE_REFERENCE_KEYWORDS):
-        return True
-    for key, value in schema.items():
-        if key in _SUFFICIENCY_MODELED_KEYWORDS or key in _NUMERIC_BOUND_KEYWORDS:
-            continue
-        if _is_vendor_annotation_keyword(key, value, budget):
-            continue
-        if _could_carry_subschema(value, budget):
-            return True
-    return False
-
-
-# Object/map applicator keywords whose presence on a property's own VALUE
-# schema makes that value a nested KEY CHANNEL for the sufficiency proof's
-# property-value recursion below, rather than a scalar/array/annotation-only
-# leaf governed by the walker's key-name policy. `$ref`/`allOf`/`anyOf`/
-# `oneOf` are included because the proof's own applicator delegation resolves
-# them; the remaining object/map keywords are included because each can
-# smuggle an undeclared key past an outer "this object is closed" conclusion
-# even when the property value carries no explicit `type: object` (e.g. a
-# bare `patternProperties` node with no `type`).
-_KEY_CHANNEL_APPLICATOR_KEYWORDS = frozenset(
+# Narrows the admitted set; carries no recursable subschema of its own.
+_BOUNDING_KEYWORDS = frozenset(
     {
-        "properties",
-        "patternProperties",
-        "additionalProperties",
-        "unevaluatedProperties",
-        "propertyNames",
-        "dependentSchemas",
-        "$ref",
-        "allOf",
-        "anyOf",
-        "oneOf",
+        "type",
+        "const",
+        "enum",
+        "required",
+        "dependentRequired",
+        "multipleOf",
+        "maximum",
+        "exclusiveMaximum",
+        "minimum",
+        "exclusiveMinimum",
+        "maxLength",
+        "minLength",
+        "maxItems",
+        "minItems",
+        "uniqueItems",
+        "maxContains",
+        "minContains",
+        "maxProperties",
+        "minProperties",
     }
 )
 
+# Applicators the proof RECURSES into and credits.
+_MODELED_APPLICATOR_KEYWORDS = frozenset(
+    {
+        "properties",
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "$ref",
+        "$defs",
+        "definitions",
+    }
+)
 
-def _property_value_is_key_channel(value: object) -> bool:
-    """True when a declared property's VALUE schema is itself object-shaped
-    or applicator-bearing -- i.e. a nested key channel that the sufficiency
-    proof must recurse into with the FULL allowlist+type-gate+closedness
-    logic, rather than a scalar/array/annotation-only leaf value. A scalar-
-    typed, array-typed, annotation-only, or bare free-form string property
-    value is NOT a key channel: it is a VALUE, and the walker's key-name
-    policy (identifier-suffix exemption, categorized-key detection, ...)
-    governs it -- recursing into those here would strip the identifier-like-
-    key exemption (`service_id: {"type": "string"}`) that the two-mechanism
-    separation depends on."""
+# Applicators recognized BY NAME but not modeled: presence anywhere in the
+# document denies the node outright, and the proof never recurses beneath
+# one (an ancestor denial already covers everything nested inside it).
+# Promoting one of these to modeled is a separate, individually-argued
+# change with its own oracle-soundness argument -- never a silent
+# reclassification. (If `items`/`prefixItems` for bounded arrays is ever
+# wanted, that is such a delta -- NOT this change.)
+_DENIED_APPLICATOR_KEYWORDS = frozenset(
+    {
+        "patternProperties",
+        "propertyNames",
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "dependentSchemas",
+        "if",
+        "then",
+        "else",
+        "not",
+        "contains",
+        "items",
+        "prefixItems",
+        "$dynamicRef",
+        "$dynamicAnchor",
+        "$recursiveRef",
+        "$recursiveAnchor",
+    }
+)
+
+_KeywordClass: TypeAlias = Literal["inert", "bounding", "modeled", "denied", "unknown"]
+
+
+def _classify_keyword(name: str) -> _KeywordClass:
+    """Classify a JSON Schema keyword into exactly one of the four registry
+    classes above. A name in none of them is UNKNOWN -- the registry is a
+    closed enumeration, not a spelling heuristic, so a keyword this module
+    has never seen fails closed rather than being guessed at."""
+    if name in _INERT_ANNOTATION_KEYWORDS:
+        return "inert"
+    if name in _BOUNDING_KEYWORDS:
+        return "bounding"
+    if name in _MODELED_APPLICATOR_KEYWORDS:
+        return "modeled"
+    if name in _DENIED_APPLICATOR_KEYWORDS:
+        return "denied"
+    return "unknown"
+
+
+def _property_value_may_be_object_shaped(value: object) -> bool:
+    """True when a declared property's VALUE could itself resolve to an
+    OBJECT instance -- i.e. the object-boundedness proof's type-gate and
+    closedness reasoning must be re-run on it, rather than left to the
+    walker's key-name policy. Deliberately narrow: it only ever answers
+    "does closedness apply here", never "is a keyword modeled" -- that
+    second question is answered totally and unconditionally, for every
+    keyword at every position, by `_structural_coverage_insufficient`
+    below regardless of whether THIS gate recurses. So an omission here
+    (a value reachable only through a DENIED applicator such as `if`/
+    `then`/`items`) is harmless: the denied applicator's mere presence
+    already makes the whole document insufficient before object-
+    boundedness ever needs to look inside it. A scalar-typed, array-typed,
+    annotation-only, or bare free-form string property value returns
+    False here on purpose -- it is a VALUE, not an object-boundedness
+    position, and remains the walker's territory by key name
+    (`service_id: {"type": "string"}` stays admitted)."""
     if not isinstance(value, Mapping):
         return False
     value_type = value.get("type")
     if value_type is not None and _schema_type_includes(value_type, "object"):
         return True
-    return any(key in value for key in _KEY_CHANNEL_APPLICATOR_KEYWORDS)
+    return any(_classify_keyword(key) == "modeled" for key in value)
 
 
 def _schema_is_insufficient(input_schema: object) -> bool:
+    """Top-level sufficiency gate: insufficient (fail closed) if EITHER the
+    object-boundedness proof fails (root not provably closed to a finite
+    object shape) OR the structural-coverage proof finds a denied/unknown
+    keyword anywhere in the document. See the two functions below -- they
+    are deliberately independent, run over the same document, and combined
+    by OR."""
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
-    return _schema_is_insufficient_node(input_schema, input_schema, frozenset(), 0, [0])
+    if _object_boundedness_insufficient(input_schema, input_schema, frozenset(), 0, [0]):
+        return True
+    return _structural_coverage_insufficient(input_schema, input_schema, frozenset(), 0, [0])
 
 
-def _schema_is_insufficient_node(
+def _object_boundedness_insufficient(
     schema: Mapping,
     root_schema: Mapping,
     seen_refs: frozenset[str],
     depth: int,
     budget: list[int],
 ) -> bool:
-    """Recursive, union-aware sufficiency check for the strong-name
-    fallback gate.
+    """Recursive, union-aware TYPE-GATE + CLOSEDNESS check -- orthogonal to
+    `_structural_coverage_insufficient` below, and unaware of the keyword
+    registry: it never denies on keyword identity, only on whether the
+    instance is provably constrained to a closed, finite object shape.
 
-    Order of checks (binding -- see module design notes; applicator
-    delegation MUST run before the omitted-type denial, or an applicator-
-    root node that legitimately omits a top-level `type` because `type`
-    lives in its resolved target/branches would false-deny):
+    Order of checks (binding; applicator delegation MUST run before the
+    omitted-type denial, or an applicator-root node that legitimately omits
+    a top-level `type` because `type` lives in its resolved target/branches
+    would false-deny):
 
     1. Budget/depth cap -- fail closed.
-    2. ALLOWLIST PRE-GATE (`_sufficiency_node_has_unmodeled_keyword`): any
-       keyword this shape logic does not model makes the node insufficient,
-       before any type/closedness reasoning runs.
-    3. `type` present and excludes `"object"` -- insufficient.
-    4. `type` is a union with a free-form (non-object) alternative and no
+    2. `type` present and excludes `"object"` -- insufficient.
+    3. `type` is a union with a free-form (non-object) alternative and no
        `const`/`enum` pinning the instance -- insufficient.
-    5. APPLICATOR DELEGATION -- `$ref` (resolve local `#/...` only, and
-       intersect structural siblings); then `oneOf`/`anyOf` (UNION: an
-       instance need only satisfy one branch, so a caller-shaped tool
-       descriptor is only as bounded as its LEAST bounded alternative --
-       EVERY reachable branch must independently prove sufficient); then
-       `allOf` (INTERSECTION: an instance must satisfy every branch
-       simultaneously, so a single branch that is itself provably bounded
-       is enough by itself). Each recurses, re-applying this same
-       predicate, so the gate and every check below it re-run inside every
-       resolved target/branch.
-    6. A top-level `const`/`enum` pins the whole instance to author-declared
+    4. APPLICATOR DELEGATION -- `$ref` (resolve local `#/...` only, and
+       intersect structural siblings); then `oneOf`/`anyOf` (UNION: every
+       reachable branch must independently prove sufficient); then `allOf`
+       (INTERSECTION: one provably-bounded branch suffices). Each recurses,
+       re-applying this same predicate.
+    5. A top-level `const`/`enum` pins the whole instance to author-declared
        literal value(s) -- sufficient, regardless of `type`.
-    7. LEAF-OBJECT branch (no applicator delegated): an omitted `type`
+    6. LEAF-OBJECT branch (no applicator delegated): an omitted `type`
        (with no `const`/`enum`, already handled above) is insufficient here
        -- a bare non-object instance never reaches object keywords at all.
        Otherwise, non-empty `properties` is only bounded if the object is
        actually CLOSED (`additionalProperties: False`, or itself restricted
        to a finite `enum`/`const`); empty/absent `properties` still needs
        `additionalProperties: False` to admit only a bare `{}`. Once the
-       OUTER object is proven closed, each DECLARED property's own VALUE is
-       re-checked too (`_property_value_is_key_channel` gates which values
-       qualify): a property value that is itself object-shaped or
-       applicator-bearing is a nested key channel and must independently
-       prove sufficient by this same predicate, or the node is insufficient.
+       OUTER object is proven closed, each DECLARED property's own VALUE
+       that could itself be object-shaped
+       (`_property_value_may_be_object_shaped`) is re-checked by this same
+       predicate, or the node is insufficient. A value that cannot be
+       object-shaped is left to the walker's key-name policy; any DENIED
+       applicator such a value might carry is caught independently and
+       unconditionally by `_structural_coverage_insufficient`, so skipping
+       it here never reopens a hole.
 
     Returns True (fail closed / insufficient) for an external, cyclic,
-    unresolvable, or budget/depth-exhausted reference or composition --
-    never wider than what the walker itself would already treat as
-    unresolvable."""
+    unresolvable, or budget/depth-exhausted reference or composition."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
-        return True
-
-    if _sufficiency_node_has_unmodeled_keyword(schema, budget):
         return True
 
     top_type = schema.get("type")
@@ -530,7 +545,7 @@ def _schema_is_insufficient_node(
         resolved = _resolve_local_ref(ref, root_schema)
         if resolved is None:
             return True
-        target_insufficient = _schema_is_insufficient_node(
+        target_insufficient = _object_boundedness_insufficient(
             resolved, root_schema, seen_refs | {ref}, depth + 1, budget
         )
         if not target_insufficient:
@@ -538,14 +553,12 @@ def _schema_is_insufficient_node(
         # Draft 2020-12 evaluates `$ref` SIBLINGS -- they are not discarded.
         # A closed/bounded target does not make the overall node sufficient
         # if a sibling keyword (evaluated against the SAME instance)
-        # reopens it (e.g. a sibling `properties` entry with its own
-        # implicit-open `additionalProperties`). Pure annotation siblings
-        # (`description`, `title`, ...) contribute nothing and must not
-        # force an otherwise-open target's insufficiency onto an
-        # unrelated, harmless caller-facing property.
+        # reopens it. Pure annotation siblings (`description`, `title`, ...)
+        # contribute nothing and must not force an otherwise-open target's
+        # insufficiency onto an unrelated, harmless caller-facing property.
         siblings = {k: v for k, v in schema.items() if k != _REF_KEYWORD}
         if _has_structural_ref_siblings(siblings):
-            return _schema_is_insufficient_node(
+            return _object_boundedness_insufficient(
                 siblings, root_schema, seen_refs | {ref}, depth + 1, budget
             )
         return True
@@ -558,7 +571,9 @@ def _schema_is_insufficient_node(
             for branch in branches:
                 if not isinstance(branch, Mapping):
                     return True
-                if _schema_is_insufficient_node(branch, root_schema, seen_refs, depth + 1, budget):
+                if _object_boundedness_insufficient(
+                    branch, root_schema, seen_refs, depth + 1, budget
+                ):
                     return True
             # Every alternative independently proved sufficient.
             return False
@@ -566,7 +581,7 @@ def _schema_is_insufficient_node(
     all_of = schema.get("allOf")
     if isinstance(all_of, list) and all_of and "properties" not in schema:
         for branch in all_of:
-            if isinstance(branch, Mapping) and not _schema_is_insufficient_node(
+            if isinstance(branch, Mapping) and not _object_boundedness_insufficient(
                 branch, root_schema, seen_refs, depth + 1, budget
             ):
                 return False
@@ -605,20 +620,125 @@ def _schema_is_insufficient_node(
     if not object_closed:
         return True
     # The OUTER object being closed against undeclared keys says nothing
-    # about a DECLARED property's own VALUE: a property value that is itself
-    # object-shaped or applicator-bearing is a nested key channel and must be
-    # re-checked with this same predicate (full allowlist + type-gate +
-    # closedness, budget/depth/`$ref`-cycle guards included) -- otherwise a
-    # closed-looking outer shell can smuggle an unmodeled applicator
-    # (`patternProperties`, an open nested object, an unmodeled `$ref`
-    # target, ...) through a property's value. Scalar/array/annotation-only
-    # property values are deliberately NOT recursed here -- see
-    # `_property_value_is_key_channel`.
+    # about a DECLARED property's own VALUE: a value that could itself be
+    # object-shaped is re-checked with this same predicate (full type-gate
+    # + closedness, budget/depth/`$ref`-cycle guards included), or the node
+    # is insufficient.
     for prop_value in props.values():
-        if _property_value_is_key_channel(prop_value) and _schema_is_insufficient_node(
+        if _property_value_may_be_object_shaped(prop_value) and _object_boundedness_insufficient(
             prop_value, root_schema, seen_refs, depth + 1, budget
         ):
             return True
+    return False
+
+
+def _structural_coverage_insufficient(
+    schema: object,
+    root_schema: Mapping,
+    seen_refs: frozenset[str],
+    depth: int,
+    budget: list[int],
+) -> bool:
+    """Total, registry-driven traversal answering "does any schema-bearing
+    position in this document carry a keyword the sufficiency proof does
+    not model?" -- independent of `_object_boundedness_insufficient`'s
+    type-gate and closedness reasoning; this function applies NEITHER. A
+    scalar leaf `{"type": "string"}` is sufficient here on its own, which is
+    what preserves a free-form identifier-key property (`service_id`)
+    alongside a fixed operation: it carries no denied/unknown keyword, so
+    this traversal has nothing to say about it, and the object-boundedness
+    proof never recurses into it either (it is not object-shaped).
+
+    Every schema-bearing position is visited UNCONDITIONALLY -- not gated
+    by the shape of its own value: every `properties` value, the
+    `additionalProperties` schema (when Mapping-valued), every composition
+    branch (`allOf`/`anyOf`/`oneOf`), every resolved local `$ref` target,
+    and every `$defs`/`definitions` entry (visited even when unreferenced
+    from anywhere in the document -- the fail-closed choice). This closes
+    the traversal-axis gap a per-position discriminator could always
+    reopen: there is no discriminator left that could omit a position.
+
+    Totality argument: every schema-bearing position in the document is
+    reached by exactly one of three routes -- (i) it sits under a chain of
+    MODELED applicators from the root, in which case this function's own
+    recursion visits it; (ii) it sits under a DENIED applicator, in which
+    case the ancestor node already returned True the moment it saw that
+    keyword, before ever needing to look inside it; or (iii) it sits under
+    an UNKNOWN keyword, which is itself checked for subschema-shaped value
+    and denied at that node. No fourth route exists, so no schema-bearing
+    position escapes the registry."""
+    budget[0] += 1
+    if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
+        return True
+    if not isinstance(schema, Mapping):
+        return True
+
+    for key, value in schema.items():
+        keyword_class = _classify_keyword(key)
+        if keyword_class == "inert" or keyword_class == "bounding":
+            continue
+        if keyword_class == "denied":
+            return True
+        if keyword_class == "unknown":
+            if _is_vendor_annotation_keyword(key, value, budget):
+                continue
+            if _could_carry_subschema(value, budget):
+                return True
+            continue
+
+        # keyword_class == "modeled": recurse into every subschema slot.
+        if key == "properties":
+            if not isinstance(value, Mapping):
+                return True
+            for prop_value in value.values():
+                if _structural_coverage_insufficient(
+                    prop_value, root_schema, seen_refs, depth + 1, budget
+                ):
+                    return True
+        elif key == "additionalProperties":
+            # A boolean value is closedness, not a recursable subschema --
+            # that question belongs to `_object_boundedness_insufficient`.
+            if isinstance(value, Mapping):
+                if _structural_coverage_insufficient(
+                    value, root_schema, seen_refs, depth + 1, budget
+                ):
+                    return True
+        elif key in ("allOf", "anyOf", "oneOf"):
+            if not isinstance(value, list) or not value:
+                return True
+            for branch in value:
+                if not isinstance(branch, Mapping):
+                    return True
+                if _structural_coverage_insufficient(
+                    branch, root_schema, seen_refs, depth + 1, budget
+                ):
+                    return True
+        elif key == _REF_KEYWORD:
+            if not isinstance(value, str) or not value.startswith("#/") or value in seen_refs:
+                return True
+            resolved = _resolve_local_ref(value, root_schema)
+            if resolved is None:
+                return True
+            if _structural_coverage_insufficient(
+                resolved, root_schema, seen_refs | {value}, depth + 1, budget
+            ):
+                return True
+        elif key in ("$defs", "definitions"):
+            if not isinstance(value, Mapping):
+                return True
+            # Visited UNCONDITIONALLY, not reachability-gated: an entry
+            # never referenced by any `$ref` in the document is still
+            # covered, so a future reference (or a caller relying on
+            # tooling that resolves `$defs` by convention rather than an
+            # explicit `$ref`) cannot smuggle an unmodeled keyword through
+            # an entry this proof never bothered to look at.
+            for sub_schema in value.values():
+                if not isinstance(sub_schema, Mapping):
+                    return True
+                if _structural_coverage_insufficient(
+                    sub_schema, root_schema, seen_refs, depth + 1, budget
+                ):
+                    return True
     return False
 
 
@@ -828,7 +948,7 @@ _MAX_SCHEMA_WALK_NODES = 5000
 # so it is never itself a command-channel destination worth walking into.
 # This holds ONLY while the content-assertion vocabulary stays disabled (the
 # default dialect this module validates against) -- see the matching caveat
-# on `_SUFFICIENCY_MODELED_KEYWORDS` above.
+# on `_INERT_ANNOTATION_KEYWORDS` above.
 _SCALAR_ONLY_SCHEMA_KEYWORDS = frozenset(
     {
         "type",

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -290,6 +290,97 @@ def _has_structural_ref_siblings(siblings: Mapping) -> bool:
     return any(key not in _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS for key in siblings)
 
 
+# Keyword allowlist for the SUFFICIENCY PROOF specifically -- a STRICT
+# SUBSET of the walker's `_KNOWN_SCHEMA_KEYWORDS` (defined further below).
+# The walker additionally understands applicators it can safely WALK for
+# command-channel evidence (`patternProperties`, `if`/`then`/`else`,
+# `items`, ...); the sufficiency proof only ever asks "is this shape
+# provably closed against an undeclared value", which only the four
+# composition applicators it actually recurses through (`$ref`/`allOf`/
+# `anyOf`/`oneOf`) and the object-closing keywords answer. Every other
+# keyword the walker walks -- `patternProperties`, `propertyNames`,
+# `unevaluatedProperties`, `dependentSchemas`, `if`/`then`/`else`, `not`,
+# `contains`, `items`, `prefixItems` -- is therefore DENIED by this gate
+# even though it is walker-known, because none of them is modeled by this
+# shape logic; the proof must not silently treat an applicator it does not
+# implement as harmless. `$defs`/`definitions` are included here as
+# MODELED (not merely inert) because their value is a mapping of
+# subschemas -- schema-bearing, so the generic value-shape inertness test
+# would otherwise flag them -- that is only ever reachable through `$ref`
+# resolution, which this function already performs.
+_SUFFICIENCY_MODELED_KEYWORDS = frozenset(
+    {
+        # shape/bounding keywords the proof reasons over directly
+        "type",
+        "const",
+        "enum",
+        "required",
+        "additionalProperties",
+        "properties",
+        "$ref",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "$defs",
+        "definitions",
+        # pure-inert annotations: collect no assertion that admits an
+        # instance value, so their presence must never force the
+        # unmodeled-keyword branch even though most are not numeric bounds
+        "description",
+        "title",
+        "$comment",
+        "examples",
+        "default",
+        "format",
+        "pattern",
+        "$schema",
+        "$id",
+        "$anchor",
+        "$vocabulary",
+        "readOnly",
+        "writeOnly",
+        "deprecated",
+        "contentEncoding",
+        "contentMediaType",
+    }
+)
+
+
+def _sufficiency_node_has_unmodeled_keyword(schema: Mapping, budget: list[int]) -> bool:
+    """Allowlist pre-gate for the sufficiency proof (`_schema_is_insufficient_node`
+    step 1): True when `schema` carries a keyword that the shape logic
+    downstream does not model, so the node must fail closed before any
+    type/closedness reasoning runs.
+
+    Reuses the walker's OWN inertness vocabulary as the single source of
+    truth -- `_UNRESOLVABLE_REFERENCE_KEYWORDS`, `_NUMERIC_BOUND_KEYWORDS`,
+    `_could_carry_subschema`, `_is_vendor_annotation_keyword` (all defined
+    further below in this module) -- rather than re-listing a divergent
+    keyword table. A key is allowed through when it is a
+    `_SUFFICIENCY_MODELED_KEYWORDS` shape/bounding/inert-annotation
+    keyword, a standardized numeric/size bound, a vendor extension whose
+    value is demonstrably inert, or ANY other keyword whose value cannot
+    itself carry a subschema (a plain scalar, or a scalar-only list/map --
+    e.g. `future-extension: [0, 1, 2]`). Everything else -- a walker-known
+    applicator this proof does not implement (`patternProperties`, `if`/
+    `then`/`else`, `contains`, `items`, `prefixItems`, ...) or a genuinely
+    unknown schema-bearing keyword -- makes the node insufficient. A
+    `$dynamicRef`/`$recursiveRef` anywhere on the node is denied outright by
+    keyword identity, mirroring the walker's own unresolvable-reference
+    treatment (their value is a plain string, so the schema-bearing value
+    test alone would miss them)."""
+    if any(key in schema for key in _UNRESOLVABLE_REFERENCE_KEYWORDS):
+        return True
+    for key, value in schema.items():
+        if key in _SUFFICIENCY_MODELED_KEYWORDS or key in _NUMERIC_BOUND_KEYWORDS:
+            continue
+        if _is_vendor_annotation_keyword(key, value, budget):
+            continue
+        if _could_carry_subschema(value, budget):
+            return True
+    return False
+
+
 def _schema_is_insufficient(input_schema: object) -> bool:
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
@@ -306,22 +397,47 @@ def _schema_is_insufficient_node(
     """Recursive, union-aware sufficiency check for the strong-name
     fallback gate.
 
-    A schema is sufficient (not insufficient) only when it is itself
-    affirmatively bounded (has its own non-empty `properties`, or is a
-    closed `additionalProperties: False` object), or resolves to such a
-    schema through `$ref`/composition. `oneOf`/`anyOf` are UNIONS: an
-    instance need only satisfy one branch, so a caller-shaped tool descriptor
-    is only as bounded as its LEAST bounded alternative -- EVERY reachable
-    branch must independently prove sufficient, or the whole union is
-    insufficient. `allOf` is an INTERSECTION: an instance must satisfy every
-    branch simultaneously, so a single branch that is itself provably
-    bounded is enough by itself -- the remaining branches can only add
-    constraints on top of it, never relax it. Returns True (fail closed /
-    insufficient) for an external, cyclic, unresolvable, or budget/depth-
-    exhausted reference or composition -- never wider than what the walker
-    itself would already treat as unresolvable."""
+    Order of checks (binding -- see module design notes; applicator
+    delegation MUST run before the omitted-type denial, or an applicator-
+    root node that legitimately omits a top-level `type` because `type`
+    lives in its resolved target/branches would false-deny):
+
+    1. Budget/depth cap -- fail closed.
+    2. ALLOWLIST PRE-GATE (`_sufficiency_node_has_unmodeled_keyword`): any
+       keyword this shape logic does not model makes the node insufficient,
+       before any type/closedness reasoning runs.
+    3. `type` present and excludes `"object"` -- insufficient.
+    4. `type` is a union with a free-form (non-object) alternative and no
+       `const`/`enum` pinning the instance -- insufficient.
+    5. APPLICATOR DELEGATION -- `$ref` (resolve local `#/...` only, and
+       intersect structural siblings); then `oneOf`/`anyOf` (UNION: an
+       instance need only satisfy one branch, so a caller-shaped tool
+       descriptor is only as bounded as its LEAST bounded alternative --
+       EVERY reachable branch must independently prove sufficient); then
+       `allOf` (INTERSECTION: an instance must satisfy every branch
+       simultaneously, so a single branch that is itself provably bounded
+       is enough by itself). Each recurses, re-applying this same
+       predicate, so the gate and every check below it re-run inside every
+       resolved target/branch.
+    6. A top-level `const`/`enum` pins the whole instance to author-declared
+       literal value(s) -- sufficient, regardless of `type`.
+    7. LEAF-OBJECT branch (no applicator delegated): an omitted `type`
+       (with no `const`/`enum`, already handled above) is insufficient here
+       -- a bare non-object instance never reaches object keywords at all.
+       Otherwise, non-empty `properties` is only bounded if the object is
+       actually CLOSED (`additionalProperties: False`, or itself restricted
+       to a finite `enum`/`const`); empty/absent `properties` still needs
+       `additionalProperties: False` to admit only a bare `{}`.
+
+    Returns True (fail closed / insufficient) for an external, cyclic,
+    unresolvable, or budget/depth-exhausted reference or composition --
+    never wider than what the walker itself would already treat as
+    unresolvable."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
+        return True
+
+    if _sufficiency_node_has_unmodeled_keyword(schema, budget):
         return True
 
     top_type = schema.get("type")
@@ -388,6 +504,19 @@ def _schema_is_insufficient_node(
                 branch, root_schema, seen_refs, depth + 1, budget
             ):
                 return False
+        return True
+
+    # A top-level `const`/`enum` pins the entire instance to author-declared
+    # literal value(s) -- the caller cannot inject beyond the enumerated
+    # set, so this alone satisfies the type-gate regardless of `type`.
+    if "const" in schema or "enum" in schema:
+        return False
+
+    # LEAF-OBJECT branch: no applicator delegated above, so `type` is
+    # evaluated node-locally. An omitted `type` (no `const`/`enum`, already
+    # handled) means a bare non-object instance never reaches the
+    # `properties`/`additionalProperties` keywords below at all.
+    if top_type is None:
         return True
 
     if "properties" in schema and not isinstance(schema["properties"], Mapping):

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -260,60 +260,41 @@ def _is_exec_tainted_key(norm_key: str) -> bool:
     return any(token in _EXEC_TAINTED_KEY_TOKENS for token in norm_key.split("_"))
 
 
-def _resolve_effective_schema_for_sufficiency(
+def _schema_is_insufficient(input_schema: object) -> bool:
+    if input_schema is None or not isinstance(input_schema, Mapping):
+        return True
+    return _schema_is_insufficient_node(input_schema, input_schema, frozenset(), 0, [0])
+
+
+def _schema_is_insufficient_node(
     schema: Mapping,
     root_schema: Mapping,
     seen_refs: frozenset[str],
     depth: int,
-) -> Mapping | None:
-    """Resolve `schema` to the node whose own `properties`/
-    `additionalProperties` should be inspected for the strong-name
-    sufficiency gate.
+    budget: list[int],
+) -> bool:
+    """Recursive, union-aware sufficiency check for the strong-name
+    fallback gate.
 
-    A schema expressed purely via a top-level local `$ref` (or via
-    `oneOf`/`anyOf`/`allOf` composition with no properties of its own) is
-    not automatically "schema-less": the walker can resolve it exactly as
-    `_walk_schema` does, so the sufficiency gate should judge the RESOLVED
-    schema rather than demanding the caller-provided root carry `properties`
-    directly. Returns None (fail closed / insufficient) for an external,
-    cyclic, or otherwise unresolvable reference -- never widens what the
-    walker itself would already treat as unresolvable. Returns `schema`
-    unchanged when there is no `$ref`/composition to resolve, or when
-    composition branches exist but none of them resolve to a schema with its
-    own `properties` (the original conservative default: fall through to the
-    caller's own empty-properties/`additionalProperties` check)."""
-    if depth > _MAX_SCHEMA_WALK_DEPTH:
-        return None
-    ref = schema.get(_REF_KEYWORD)
-    if ref is not None:
-        if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
-            return None
-        resolved = _resolve_local_ref(ref, root_schema)
-        if resolved is None:
-            return None
-        return _resolve_effective_schema_for_sufficiency(
-            resolved, root_schema, seen_refs | {ref}, depth + 1
-        )
-    if "properties" in schema:
-        return schema
-    for comp_key in ("oneOf", "anyOf", "allOf"):
-        branches = schema.get(comp_key)
-        if isinstance(branches, list):
-            for branch in branches:
-                if not isinstance(branch, Mapping):
-                    continue
-                resolved_branch = _resolve_effective_schema_for_sufficiency(
-                    branch, root_schema, seen_refs, depth + 1
-                )
-                if resolved_branch is not None and "properties" in resolved_branch:
-                    return resolved_branch
-    return schema
-
-
-def _schema_is_insufficient(input_schema: object) -> bool:
-    if input_schema is None or not isinstance(input_schema, Mapping):
+    A schema is sufficient (not insufficient) only when it is itself
+    affirmatively bounded (has its own non-empty `properties`, or is a
+    closed `additionalProperties: False` object), or resolves to such a
+    schema through `$ref`/composition. `oneOf`/`anyOf` are UNIONS: an
+    instance need only satisfy one branch, so a caller-shaped tool descriptor
+    is only as bounded as its LEAST bounded alternative -- EVERY reachable
+    branch must independently prove sufficient, or the whole union is
+    insufficient. `allOf` is an INTERSECTION: an instance must satisfy every
+    branch simultaneously, so a single branch that is itself provably
+    bounded is enough by itself -- the remaining branches can only add
+    constraints on top of it, never relax it. Returns True (fail closed /
+    insufficient) for an external, cyclic, unresolvable, or budget/depth-
+    exhausted reference or composition -- never wider than what the walker
+    itself would already treat as unresolvable."""
+    budget[0] += 1
+    if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return True
-    top_type = input_schema.get("type")
+
+    top_type = schema.get("type")
     # `type` may be a Draft 2020-12 type array (e.g. `["object", "null"]`);
     # such a schema is an object schema whenever "object" is one of its
     # allowed types, and its properties must still be inspected. Only a
@@ -322,23 +303,45 @@ def _schema_is_insufficient(input_schema: object) -> bool:
     if top_type is not None and not _schema_type_includes(top_type, "object"):
         return True
 
-    resolved = input_schema
-    if "properties" not in input_schema and any(
-        k in input_schema for k in ("$ref", "oneOf", "anyOf", "allOf")
-    ):
-        candidate = _resolve_effective_schema_for_sufficiency(
-            input_schema, input_schema, frozenset(), 0
-        )
-        if candidate is None:
+    ref = schema.get(_REF_KEYWORD)
+    if ref is not None:
+        if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
             return True
-        resolved = candidate
+        resolved = _resolve_local_ref(ref, root_schema)
+        if resolved is None:
+            return True
+        return _schema_is_insufficient_node(
+            resolved, root_schema, seen_refs | {ref}, depth + 1, budget
+        )
 
-    if "properties" in resolved and not isinstance(resolved["properties"], Mapping):
+    for comp_key in ("oneOf", "anyOf"):
+        branches = schema.get(comp_key)
+        if branches is not None:
+            if not isinstance(branches, list) or not branches:
+                return True
+            for branch in branches:
+                if not isinstance(branch, Mapping):
+                    return True
+                if _schema_is_insufficient_node(branch, root_schema, seen_refs, depth + 1, budget):
+                    return True
+            # Every alternative independently proved sufficient.
+            return False
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list) and all_of and "properties" not in schema:
+        for branch in all_of:
+            if isinstance(branch, Mapping) and not _schema_is_insufficient_node(
+                branch, root_schema, seen_refs, depth + 1, budget
+            ):
+                return False
         return True
-    properties = resolved.get("properties")
+
+    if "properties" in schema and not isinstance(schema["properties"], Mapping):
+        return True
+    properties = schema.get("properties")
     props = properties if isinstance(properties, Mapping) else {}
     if not props:
-        return resolved.get("additionalProperties") is not False
+        return schema.get("additionalProperties") is not False
     return False
 
 
@@ -381,7 +384,13 @@ def _item_schema_reaches_free_form_string(
     `if`/`then`/`else`/`not` composition are resolved/recursed so an item
     schema that only reaches a string through one layer of indirection
     (`{"anyOf": [{"type": "string"}]}`, a `$ref` to a string schema, ...) is
-    still caught.
+    still caught. A nested array item (`items: {type: array, items: ...}`,
+    or `prefixItems` at that position) is itself recursed into with the
+    same depth cap / `$ref`-cycle guard / node budget: an immediate
+    `type: "array"` item is NOT non-string-and-therefore-bounded on its
+    own -- it is only bounded if its OWN item schema is bounded (e.g.
+    `enum`/`const`-restricted), otherwise a caller can smuggle a free-form
+    argv-shaped channel one array level deeper (`args: [["sh", "-c", ...]]`).
     """
     if item_schema is True:
         return True
@@ -400,7 +409,24 @@ def _item_schema_reaches_free_form_string(
         return False
     item_type = item_schema.get("type")
     if item_type is not None:
-        return _schema_type_includes(item_type, "string")
+        if _schema_type_includes(item_type, "string"):
+            return True
+        if _schema_type_includes(item_type, "array"):
+            nested_items = item_schema.get("items")
+            if nested_items is not None and _item_schema_reaches_free_form_string(
+                nested_items, root_schema, depth + 1, seen_refs, result
+            ):
+                return True
+            nested_prefix_items = item_schema.get("prefixItems")
+            if isinstance(nested_prefix_items, list):
+                return any(
+                    _item_schema_reaches_free_form_string(
+                        nested_item, root_schema, depth + 1, seen_refs, result
+                    )
+                    for nested_item in nested_prefix_items
+                )
+            return False
+        return False
 
     ref = item_schema.get(_REF_KEYWORD)
     branches: list[object] = []
@@ -570,18 +596,47 @@ def _could_carry_subschema(value: object) -> bool:
     return False
 
 
-def _is_vendor_annotation_keyword(key: str) -> bool:
+def _is_inert_annotation_value(value: object, depth: int = 0) -> bool:
+    """True when `value` cannot itself carry a subschema: recursively, a
+    scalar (string/number/bool/None), or a list/mapping built entirely from
+    such values with no JSON-Schema-vocabulary key appearing anywhere inside
+    it. A vendor annotation whose value is genuinely just descriptive
+    UI/ordering metadata (`{"widget": "select", "order": 1}`) is inert; one
+    that embeds real schema vocabulary (`x-input-schema: {"properties":
+    {...}}`) is not, regardless of the `x-`/`$comment` key it hangs off --
+    the value's SHAPE decides inertness, not the key's spelling."""
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        return False
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, list):
+        return all(_is_inert_annotation_value(item, depth + 1) for item in value)
+    if isinstance(value, Mapping):
+        if any(key in _KNOWN_SCHEMA_KEYWORDS for key in value):
+            return False
+        return all(_is_inert_annotation_value(v, depth + 1) for v in value.values())
+    return False
+
+
+def _is_vendor_annotation_keyword(key: str, value: object) -> bool:
     """True for a keyword that is metadata/annotation-only, never an
-    applicator or reference -- exempt from the unknown-subschema-bearing
-    check even though its value may be a Mapping. Deliberately narrow: only
-    the `x-` vendor-extension convention (the OpenAPI/JSON-Schema community
-    convention for non-standard annotations, e.g. `x-ui`, `x-order`) and
-    JSON Schema's own `$comment` (annotation-only by spec). NEVER exempt
-    `$`-prefixed keywords in general -- that prefix is exactly where real
-    reference/applicator keywords live (`$ref`, `$dynamicRef`,
-    `$recursiveRef`, ...), so a blanket `$*` exemption would reopen the
-    reference-bypass class this walker closes."""
-    return key.startswith("x-") or key == "$comment"
+    applicator or reference, AND whose value carries no schema-bearing
+    content -- exempt from the unknown-subschema-bearing check. Narrow on
+    two axes: (1) only the `x-` vendor-extension convention (the
+    OpenAPI/JSON-Schema community convention for non-standard annotations,
+    e.g. `x-ui`, `x-order`) and JSON Schema's own `$comment` (annotation-only
+    by spec) are even considered; (2) even for those keys, the VALUE must be
+    demonstrably inert (`_is_inert_annotation_value`) -- a vendor extension
+    whose value is itself schema-shaped (`x-input-schema: {"properties":
+    {"command": {"type": "string"}}}`) is exactly the kind of hidden channel
+    this walker exists to catch, so it is NOT exempted just because its key
+    starts with `x-`. NEVER exempt `$`-prefixed keywords in general -- that
+    prefix is exactly where real reference/applicator keywords live (`$ref`,
+    `$dynamicRef`, `$recursiveRef`, ...), so a blanket `$*` exemption would
+    reopen the reference-bypass class this walker closes."""
+    if key != "$comment" and not key.startswith("x-"):
+        return False
+    return _is_inert_annotation_value(value)
 
 
 def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) -> None:
@@ -606,7 +661,7 @@ def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) ->
     for key, value in schema.items():
         if key in _KNOWN_SCHEMA_KEYWORDS or _is_known_scalar_only_keyword(key):
             continue
-        if _is_vendor_annotation_keyword(key):
+        if _is_vendor_annotation_keyword(key, value):
             continue
         if _could_carry_subschema(value):
             result.unresolvable = True

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -229,6 +229,20 @@ def _has_executor_description_signal(description: object) -> bool:
     return any(f" {phrase} " in padded for phrase in _EXECUTOR_DESCRIPTION_PHRASES)
 
 
+_IDENTIFIER_LIKE_KEY_PATTERN = re.compile(
+    r"^(?:[a-z0-9]+_)*(?:id|ids|path|paths|uri|url|uuid|slug)$"
+)
+
+
+def _is_identifier_like_key(norm_key: str) -> bool:
+    """True for dynamic-but-benign resource identifiers (`service_id`,
+    `resource_path`, `request_id`, ...). These are excluded from the
+    strong-name "must be affirmatively bounded" fallback: a fixed-operation
+    tool with a free-form identifier field is not executor-shaped, even
+    though the identifier itself is an unbounded string."""
+    return bool(_IDENTIFIER_LIKE_KEY_PATTERN.match(norm_key))
+
+
 def _schema_is_insufficient(input_schema: object) -> bool:
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
@@ -292,6 +306,239 @@ def _property_is_free_form(prop_schema: object, is_categorized_key: bool) -> boo
     return False
 
 
+_MAX_SCHEMA_WALK_DEPTH = 12
+
+
+class _SchemaWalkResult:
+    """Accumulates classifier evidence discovered while traversing a
+    (possibly nested/composed) JSON Schema input descriptor."""
+
+    __slots__ = (
+        "free_form_command_keys",
+        "free_form_program_keys",
+        "free_form_argument_keys",
+        "free_form_payload_keys",
+        "non_auxiliary_free_form_keys",
+        "non_identifier_free_form_keys",
+        "selector_key_present",
+        "unresolvable",
+    )
+
+    def __init__(self) -> None:
+        self.free_form_command_keys: set[str] = set()
+        self.free_form_program_keys: set[str] = set()
+        self.free_form_argument_keys: set[str] = set()
+        self.free_form_payload_keys: set[str] = set()
+        self.non_auxiliary_free_form_keys: set[str] = set()
+        self.non_identifier_free_form_keys: set[str] = set()
+        self.selector_key_present = False
+        # True when a channel could not be proven bounded: an external/
+        # unresolvable `$ref`, a `$ref` cycle, a depth-cap trip, or a
+        # malformed `properties`/composition shape. Fed into fail-closed
+        # handling for descriptor-bearing tools whose name or description
+        # signals an executor; otherwise it is just insufficient evidence.
+        self.unresolvable = False
+
+
+def _resolve_local_ref(ref: str, root_schema: Mapping) -> Mapping | None:
+    """Resolve a same-document `$ref` (e.g. `#/$defs/Foo`) against
+    `root_schema`. Returns None if the pointer cannot be resolved locally."""
+    node: Any = root_schema
+    for raw_part in ref[2:].split("/"):
+        if raw_part == "":
+            continue
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(node, Mapping) or part not in node:
+            return None
+        node = node[part]
+    return node if isinstance(node, Mapping) else None
+
+
+def _pattern_matches_categorized_key(pattern: object) -> str | None:
+    """If a `patternProperties` regex would match one of the recognized
+    command/process/argument/payload/selector key names, return that key."""
+    if not isinstance(pattern, str):
+        return None
+    try:
+        compiled = re.compile(pattern)
+    except re.error:
+        return None
+    for key in _CATEGORIZED_KEYS:
+        if compiled.search(key):
+            return key
+    return None
+
+
+def _record_free_form_key(norm_key: str, result: _SchemaWalkResult) -> None:
+    if norm_key in _COMMAND_KEYS:
+        result.free_form_command_keys.add(norm_key)
+    elif norm_key in _PROGRAM_KEYS:
+        result.free_form_program_keys.add(norm_key)
+    elif norm_key in _ARGUMENT_KEYS:
+        result.free_form_argument_keys.add(norm_key)
+    elif norm_key in _PAYLOAD_KEYS:
+        result.free_form_payload_keys.add(norm_key)
+    if norm_key not in _AUXILIARY_KEYS:
+        result.non_auxiliary_free_form_keys.add(norm_key)
+        if not _is_identifier_like_key(norm_key):
+            result.non_identifier_free_form_keys.add(norm_key)
+
+
+def _consider_property(
+    raw_key: object,
+    prop_schema: object,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    is_strong_name: bool,
+    is_executor_description: bool,
+    result: _SchemaWalkResult,
+) -> None:
+    norm_key = _normalize_mcp_identifier(raw_key)
+    if norm_key in _SELECTOR_KEYS:
+        result.selector_key_present = True
+
+    if isinstance(prop_schema, Mapping):
+        has_nested_shape = any(
+            k in prop_schema
+            for k in (
+                "properties",
+                "$ref",
+                "allOf",
+                "anyOf",
+                "oneOf",
+                "additionalProperties",
+                "patternProperties",
+            )
+        )
+        prop_type = prop_schema.get("type")
+        type_excludes_object = prop_type is not None and not _schema_type_includes(
+            prop_type, "object"
+        )
+        if has_nested_shape and not type_excludes_object:
+            # A container (e.g. a nested `options` object) is not itself a
+            # command/process/script value; walk its own reachable
+            # properties instead of classifying the container's key.
+            _walk_schema(
+                prop_schema,
+                root_schema,
+                depth + 1,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
+            return
+
+    if not _property_is_free_form(prop_schema, norm_key in _CATEGORIZED_KEYS):
+        return
+
+    _record_free_form_key(norm_key, result)
+
+
+def _walk_schema(
+    schema: object,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    is_strong_name: bool,
+    is_executor_description: bool,
+    result: _SchemaWalkResult,
+) -> None:
+    """Bounded, cycle-safe traversal collecting classifier evidence from
+    `properties` (including nested objects), `allOf`/`anyOf`/`oneOf`
+    branches, local `$ref` resolution, `patternProperties`, and
+    `additionalProperties`."""
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        result.unresolvable = True
+        return
+    if not isinstance(schema, Mapping):
+        return
+
+    ref = schema.get("$ref")
+    if ref is not None:
+        if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
+            # External/non-local or cyclic reference: cannot be proven
+            # bounded from this document alone.
+            result.unresolvable = True
+            return
+        resolved = _resolve_local_ref(ref, root_schema)
+        if resolved is None:
+            result.unresolvable = True
+            return
+        _walk_schema(
+            resolved,
+            root_schema,
+            depth + 1,
+            seen_refs | {ref},
+            is_strong_name,
+            is_executor_description,
+            result,
+        )
+        return
+
+    for comp_key in ("allOf", "anyOf", "oneOf"):
+        branches = schema.get(comp_key)
+        if branches is None:
+            continue
+        if not isinstance(branches, list):
+            result.unresolvable = True
+            continue
+        for branch in branches:
+            _walk_schema(
+                branch,
+                root_schema,
+                depth + 1,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
+
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, Mapping):
+            result.unresolvable = True
+        else:
+            for raw_key, prop_schema in properties.items():
+                _consider_property(
+                    raw_key,
+                    prop_schema,
+                    root_schema,
+                    depth,
+                    seen_refs,
+                    is_strong_name,
+                    is_executor_description,
+                    result,
+                )
+
+    pattern_properties = schema.get("patternProperties")
+    if isinstance(pattern_properties, Mapping):
+        for pattern, pattern_schema in pattern_properties.items():
+            matched_key = _pattern_matches_categorized_key(pattern)
+            if matched_key is not None:
+                _consider_property(
+                    matched_key,
+                    pattern_schema,
+                    root_schema,
+                    depth,
+                    seen_refs,
+                    is_strong_name,
+                    is_executor_description,
+                    result,
+                )
+
+    additional_properties = schema.get("additionalProperties")
+    if additional_properties is not None and additional_properties is not False:
+        if _property_is_free_form(additional_properties, True):
+            # No fixed key name is available for a free-form map channel; it
+            # only counts as executor-shaped evidence when corroborated by
+            # the tool's own name or description (the same corroboration
+            # `unbounded-script-payload` already requires of payload keys).
+            if is_strong_name or is_executor_description:
+                _record_free_form_key("<additionalProperties>", result)
+
+
 def _classify_generic_executor(
     tool_name: str,
     input_schema: object | None,
@@ -301,44 +548,26 @@ def _classify_generic_executor(
     is_executor_description = _has_executor_description_signal(description)
     schema_insufficient = _schema_is_insufficient(input_schema)
 
-    properties: Mapping[str, Any] = {}
-    if not schema_insufficient and isinstance(input_schema, Mapping):
-        raw_properties = input_schema.get("properties")
-        if isinstance(raw_properties, Mapping):
-            properties = raw_properties
+    result = _SchemaWalkResult()
+    if isinstance(input_schema, Mapping):
+        top_type = input_schema.get("type")
+        if top_type is None or _schema_type_includes(top_type, "object"):
+            _walk_schema(
+                input_schema,
+                input_schema,
+                0,
+                frozenset(),
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
 
-    free_form_command_keys: set[str] = set()
-    free_form_program_keys: set[str] = set()
-    free_form_argument_keys: set[str] = set()
-    free_form_payload_keys: set[str] = set()
-    non_auxiliary_free_form_keys: set[str] = set()
-    selector_key_present = False
-
-    for raw_key, prop_schema in properties.items():
-        norm_key = _normalize_mcp_identifier(raw_key)
-        if norm_key in _SELECTOR_KEYS:
-            selector_key_present = True
-
-        if not _property_is_free_form(prop_schema, norm_key in _CATEGORIZED_KEYS):
-            continue
-
-        if norm_key in _COMMAND_KEYS:
-            free_form_command_keys.add(norm_key)
-        elif norm_key in _PROGRAM_KEYS:
-            free_form_program_keys.add(norm_key)
-        elif norm_key in _ARGUMENT_KEYS:
-            free_form_argument_keys.add(norm_key)
-        elif norm_key in _PAYLOAD_KEYS:
-            free_form_payload_keys.add(norm_key)
-        if norm_key not in _AUXILIARY_KEYS:
-            non_auxiliary_free_form_keys.add(norm_key)
-
-    has_free_form_command = bool(free_form_command_keys)
-    s_process = bool(free_form_program_keys) and bool(free_form_argument_keys)
-    s_payload = bool(free_form_payload_keys) and (
-        selector_key_present or is_strong_name or is_executor_description
+    has_free_form_command = bool(result.free_form_command_keys)
+    s_process = bool(result.free_form_program_keys) and bool(result.free_form_argument_keys)
+    s_payload = bool(result.free_form_payload_keys) and (
+        result.selector_key_present or is_strong_name or is_executor_description
     )
-    s_broad = bool(non_auxiliary_free_form_keys)
+    s_broad = bool(result.non_auxiliary_free_form_keys)
 
     # An unbounded command-shaped field is dangerous on its own; unrelated
     # extra properties (benign or not) do not make it safe, and no name or
@@ -349,13 +578,16 @@ def _classify_generic_executor(
         return "unbounded-process-input"
     if s_payload:
         return "unbounded-script-payload"
-    if is_executor_description and s_broad:
+    if is_executor_description and (s_broad or result.unresolvable):
         return "executor-description-with-broad-input"
     # A strong executor identity must be affirmatively demonstrated safe
-    # (empty/no schema, or every property bounded via enum/const); any
-    # remaining free-form property -- even one not in a recognized
-    # command/process/payload key set -- leaves the identity uncorroborated.
-    if is_strong_name and (schema_insufficient or non_auxiliary_free_form_keys):
+    # (empty/no schema, or every property bounded via enum/const, or only
+    # auxiliary/identifier-like free-form fields); an unresolvable channel
+    # or a remaining executor-shaped free-form property leaves the identity
+    # uncorroborated.
+    if is_strong_name and (
+        schema_insufficient or result.unresolvable or result.non_identifier_free_form_keys
+    ):
         return "executor-identity-with-insufficient-schema"
     return None
 

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -330,7 +330,6 @@ _INERT_ANNOTATION_KEYWORDS = frozenset(
         "$anchor",
         "$vocabulary",
         "format",
-        "pattern",
         "contentEncoding",
         "contentMediaType",
         # `contentSchema` KEEPS its own individually-argued caveat: its
@@ -361,6 +360,7 @@ _BOUNDING_KEYWORDS = frozenset(
         "exclusiveMinimum",
         "maxLength",
         "minLength",
+        "pattern",
         "maxItems",
         "minItems",
         "uniqueItems",

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, TypeAlias
 from urllib.parse import urlparse
 
 from lionagi.ln._hash import compute_hash
@@ -50,6 +52,8 @@ __all__ = (
     "MCPSecurityConfig",
     "MCPConnectionPool",
     "create_mcp_tool",
+    "is_synthetic_mcp_wrapper_schema",
+    "validate_mcp_tool_admission",
 )
 
 
@@ -64,6 +68,352 @@ class MCPSecurityConfig:
     env_denylist_patterns: frozenset[str] = field(default_factory=lambda: _SENSITIVE_ENV_PATTERNS)
     filter_sensitive_env: bool = True
     max_connections_per_server: int = 5
+
+
+# --- Generic-executor admission rule -----------------------------------
+#
+# Registration-time admission control for MCP tool descriptors. This is
+# independent of MCPSecurityConfig (transport authorization) and of
+# PermissionPolicy (invocation-time, keyed by tool name): it rejects a
+# caller-shaped generic command/process/script executor before it ever
+# reaches the tool registry, regardless of transport settings.
+
+AdmissionReason: TypeAlias = Literal[
+    "unbounded-command-input",
+    "unbounded-process-input",
+    "unbounded-script-payload",
+    "executor-description-with-broad-input",
+    "executor-identity-with-insufficient-schema",
+]
+
+_STRONG_EXECUTOR_NAMES = frozenset(
+    {
+        "bash",
+        "sh",
+        "zsh",
+        "shell",
+        "cmd",
+        "powershell",
+        "pwsh",
+        "terminal",
+        "exec",
+        "exec_command",
+        "execute_command",
+        "run_command",
+        "run_shell",
+        "shell_exec",
+        "command_exec",
+        "spawn_process",
+        "run_process",
+    }
+)
+
+_EXECUTOR_DESCRIPTION_PHRASES = (
+    "arbitrary command",
+    "arbitrary commands",
+    "arbitrary shell",
+    "execute command",
+    "execute commands",
+    "executes command",
+    "executes commands",
+    "execute a command",
+    "execute os command",
+    "execute os commands",
+    "executes os commands",
+    "execute an os command",
+    "execute system command",
+    "execute system commands",
+    "executes system commands",
+    "execute a system command",
+    "execute shell command",
+    "execute shell commands",
+    "executes shell commands",
+    "execute a shell command",
+    "execute terminal command",
+    "execute terminal commands",
+    "executes terminal commands",
+    "execute a terminal command",
+    "run command",
+    "run commands",
+    "runs command",
+    "runs commands",
+    "run a command",
+    "run os command",
+    "run os commands",
+    "runs os commands",
+    "run an os command",
+    "run system command",
+    "run system commands",
+    "runs system commands",
+    "run a system command",
+    "run shell command",
+    "run shell commands",
+    "runs shell commands",
+    "run a shell command",
+    "run terminal command",
+    "run terminal commands",
+    "runs terminal commands",
+    "run a terminal command",
+    "run shell",
+    "run a shell",
+    "execute script",
+    "execute scripts",
+    "executes scripts",
+    "execute a script",
+    "spawn process",
+    "spawn processes",
+    "spawns processes",
+    "spawn a process",
+    "shell command executor",
+    "shell command runner",
+    "command line executor",
+    "command line runner",
+)
+
+_COMMAND_KEYS = frozenset({"command", "cmd", "command_line", "shell_command"})
+_PROGRAM_KEYS = frozenset({"program", "executable", "binary"})
+_ARGUMENT_KEYS = frozenset({"args", "argv"})
+_PAYLOAD_KEYS = frozenset({"script", "code", "input", "text"})
+_SELECTOR_KEYS = frozenset({"shell", "interpreter"})
+_AUXILIARY_KEYS = frozenset(
+    {
+        "cwd",
+        "working_directory",
+        "working_dir",
+        "env",
+        "environment",
+        "stdin",
+        "timeout",
+        "timeout_seconds",
+        "shell",
+        "interpreter",
+        "user",
+    }
+)
+_CATEGORIZED_KEYS = _COMMAND_KEYS | _PROGRAM_KEYS | _ARGUMENT_KEYS | _PAYLOAD_KEYS | _SELECTOR_KEYS
+
+_CAMEL_BOUNDARY_LOWER_UPPER = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_CAMEL_BOUNDARY_UPPER_RUN = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_NON_ALNUM_RUN = re.compile(r"[^a-zA-Z0-9]+")
+_REPEATED_UNDERSCORE = re.compile(r"_+")
+_NON_ALPHANUM_RUN = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_mcp_identifier(name: object) -> str:
+    """Case-fold a tool/property name to `_`-joined tokens, splitting camelCase first."""
+    if not isinstance(name, str):
+        return ""
+    split = _CAMEL_BOUNDARY_UPPER_RUN.sub("_", _CAMEL_BOUNDARY_LOWER_UPPER.sub("_", name))
+    folded = split.casefold()
+    replaced = _NON_ALNUM_RUN.sub("_", folded)
+    return _REPEATED_UNDERSCORE.sub("_", replaced).strip("_")
+
+
+def _normalize_mcp_description(description: object) -> str:
+    """Case-fold a description to single-space-joined tokens for phrase matching."""
+    if not isinstance(description, str):
+        return ""
+    folded = description.casefold()
+    return _NON_ALPHANUM_RUN.sub(" ", folded).strip()
+
+
+def _has_strong_executor_name(tool_name: object) -> bool:
+    return _normalize_mcp_identifier(tool_name) in _STRONG_EXECUTOR_NAMES
+
+
+def _has_executor_description_signal(description: object) -> bool:
+    normalized = _normalize_mcp_description(description)
+    if not normalized:
+        return False
+    padded = f" {normalized} "
+    return any(f" {phrase} " in padded for phrase in _EXECUTOR_DESCRIPTION_PHRASES)
+
+
+def _schema_is_insufficient(input_schema: object) -> bool:
+    if input_schema is None or not isinstance(input_schema, Mapping):
+        return True
+    top_type = input_schema.get("type")
+    # `type` may be a Draft 2020-12 type array (e.g. `["object", "null"]`);
+    # such a schema is an object schema whenever "object" is one of its
+    # allowed types, and its properties must still be inspected. Only a
+    # top-level type that excludes "object" entirely makes the schema
+    # insufficient.
+    if top_type is not None and not _schema_type_includes(top_type, "object"):
+        return True
+    if "properties" in input_schema and not isinstance(input_schema["properties"], Mapping):
+        return True
+    if "properties" not in input_schema and any(
+        k in input_schema for k in ("$ref", "oneOf", "anyOf", "allOf")
+    ):
+        return True
+    properties = input_schema.get("properties")
+    props = properties if isinstance(properties, Mapping) else {}
+    if not props:
+        return input_schema.get("additionalProperties") is not False
+    return False
+
+
+def _property_is_bounded(prop_schema: object) -> bool:
+    if not isinstance(prop_schema, Mapping):
+        return False
+    if "enum" in prop_schema or "const" in prop_schema:
+        return True
+    if _schema_type_includes(prop_schema.get("type"), "array"):
+        items = prop_schema.get("items")
+        if isinstance(items, Mapping) and ("enum" in items or "const" in items):
+            return True
+    return False
+
+
+def _schema_type_includes(type_value: object, target: str) -> bool:
+    """True when a JSON Schema `type` (string or Draft 2020-12 type array) allows `target`."""
+    if isinstance(type_value, list):
+        return target in type_value
+    return type_value == target
+
+
+def _property_is_free_form(prop_schema: object, is_categorized_key: bool) -> bool:
+    # JSON Schema boolean `true` matches any value, so it is at least as
+    # permissive as an untyped free-form string; `false` matches nothing.
+    if prop_schema is True:
+        return True
+    if prop_schema is False or not isinstance(prop_schema, Mapping):
+        return False
+    if _property_is_bounded(prop_schema):
+        return False
+    prop_type = prop_schema.get("type")
+    if _schema_type_includes(prop_type, "string"):
+        return True
+    if _schema_type_includes(prop_type, "array"):
+        items = prop_schema.get("items")
+        return isinstance(items, Mapping) and _schema_type_includes(items.get("type"), "string")
+    if prop_type is None and is_categorized_key:
+        return True
+    return False
+
+
+def _classify_generic_executor(
+    tool_name: str,
+    input_schema: object | None,
+    description: str | None,
+) -> AdmissionReason | None:
+    is_strong_name = _has_strong_executor_name(tool_name)
+    is_executor_description = _has_executor_description_signal(description)
+    schema_insufficient = _schema_is_insufficient(input_schema)
+
+    properties: Mapping[str, Any] = {}
+    if not schema_insufficient and isinstance(input_schema, Mapping):
+        raw_properties = input_schema.get("properties")
+        if isinstance(raw_properties, Mapping):
+            properties = raw_properties
+
+    free_form_command_keys: set[str] = set()
+    free_form_program_keys: set[str] = set()
+    free_form_argument_keys: set[str] = set()
+    free_form_payload_keys: set[str] = set()
+    non_auxiliary_free_form_keys: set[str] = set()
+    selector_key_present = False
+
+    for raw_key, prop_schema in properties.items():
+        norm_key = _normalize_mcp_identifier(raw_key)
+        if norm_key in _SELECTOR_KEYS:
+            selector_key_present = True
+
+        if not _property_is_free_form(prop_schema, norm_key in _CATEGORIZED_KEYS):
+            continue
+
+        if norm_key in _COMMAND_KEYS:
+            free_form_command_keys.add(norm_key)
+        elif norm_key in _PROGRAM_KEYS:
+            free_form_program_keys.add(norm_key)
+        elif norm_key in _ARGUMENT_KEYS:
+            free_form_argument_keys.add(norm_key)
+        elif norm_key in _PAYLOAD_KEYS:
+            free_form_payload_keys.add(norm_key)
+        if norm_key not in _AUXILIARY_KEYS:
+            non_auxiliary_free_form_keys.add(norm_key)
+
+    has_free_form_command = bool(free_form_command_keys)
+    s_process = bool(free_form_program_keys) and bool(free_form_argument_keys)
+    s_payload = bool(free_form_payload_keys) and (
+        selector_key_present or is_strong_name or is_executor_description
+    )
+    s_broad = bool(non_auxiliary_free_form_keys)
+
+    # An unbounded command-shaped field is dangerous on its own; unrelated
+    # extra properties (benign or not) do not make it safe, and no name or
+    # description corroboration is required to deny it.
+    if has_free_form_command:
+        return "unbounded-command-input"
+    if s_process:
+        return "unbounded-process-input"
+    if s_payload:
+        return "unbounded-script-payload"
+    if is_executor_description and s_broad:
+        return "executor-description-with-broad-input"
+    # A strong executor identity must be affirmatively demonstrated safe
+    # (empty/no schema, or every property bounded via enum/const); any
+    # remaining free-form property -- even one not in a recognized
+    # command/process/payload key set -- leaves the identity uncorroborated.
+    if is_strong_name and (schema_insufficient or non_auxiliary_free_form_keys):
+        return "executor-identity-with-insufficient-schema"
+    return None
+
+
+# `create_mcp_tool()` wraps every MCP tool in `async def mcp_callable(**kwargs)`.
+# When a `Tool` is built without an explicit `tool_schema` (e.g. a caller
+# constructs `Tool(mcp_config={"exec": {...}})` directly rather than going
+# through server discovery), `function_to_schema()` reflects that wrapper
+# into this exact deterministic shape. It carries no information from the
+# remote server -- it is a fixed artifact of the wrapper's own signature and
+# docstring -- and must not be treated as remote descriptor metadata by the
+# admission rule.
+_SYNTHETIC_MCP_WRAPPER_PARAMETERS = {
+    "type": "object",
+    "properties": {"kwargs": {"type": "string", "description": None}},
+    "required": ["kwargs"],
+}
+
+
+def is_synthetic_mcp_wrapper_schema(
+    mcp_tool_name: str,
+    advertised_name: object,
+    input_schema: object,
+    description: object,
+) -> bool:
+    """True when a prebuilt `Tool`'s schema is the auto-generated `**kwargs` wrapper.
+
+    `mcp_tool_name` is the key under which the tool was registered in
+    `Tool.mcp_config` -- the identity `create_mcp_tool()` used to name and
+    document the wrapper callable.
+    """
+    return (
+        advertised_name == mcp_tool_name
+        and description == f"MCP tool: {mcp_tool_name}"
+        and input_schema == _SYNTHETIC_MCP_WRAPPER_PARAMETERS
+    )
+
+
+def validate_mcp_tool_admission(
+    tool_name: str,
+    input_schema: object | None,
+    description: str | None,
+) -> None:
+    """Raise PermissionError when an MCP descriptor exposes a generic executor.
+
+    Pure and synchronous: does not read MCPSecurityConfig, environment
+    variables, files, pool state, or acquire a client. Registration-time
+    admission control only; it does not change transport authorization or
+    invocation-time permissions.
+    """
+    reason = _classify_generic_executor(tool_name, input_schema, description)
+    if reason is None:
+        return
+    raise PermissionError(
+        f"MCP tool {tool_name!r} was not registered: generic executor surface "
+        f"detected [{reason}]. Expose a structured, bounded operation instead; "
+        "this admission rule has no configuration opt-out."
+    )
 
 
 def _filter_env(env: dict[str, str], config: MCPSecurityConfig) -> dict[str, str]:

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -342,6 +342,23 @@ _SUFFICIENCY_MODELED_KEYWORDS = frozenset(
         "deprecated",
         "contentEncoding",
         "contentMediaType",
+        # `contentSchema` is a deliberate, ARGUED exception to "schema-
+        # bearing means deny", not a relaxation of the allowlist's default
+        # posture. It is a Draft 2020-12 Content-vocabulary annotation
+        # (alongside `contentEncoding`/`contentMediaType`) describing the
+        # schema of a string instance's DECODED content. Its value is a
+        # mapping (schema-bearing in shape, like `$defs`), so without this
+        # entry the generic value-shape inertness test would flag it and
+        # deny an otherwise-bounded schema that legitimately uses it. The
+        # exception holds ONLY because the Content vocabulary is
+        # ANNOTATION-ONLY in the default Draft 2020-12 dialect this module
+        # validates against: the content-assertion vocabulary that would
+        # make `contentSchema` actually constrain an instance is NOT
+        # enabled by default, so the value under this keyword is never an
+        # admission channel today. If a future dialect configuration were
+        # to enable the content-assertion vocabulary, `contentSchema` would
+        # need to leave this modeled-as-inert set.
+        "contentSchema",
     }
 )
 
@@ -379,6 +396,50 @@ def _sufficiency_node_has_unmodeled_keyword(schema: Mapping, budget: list[int]) 
         if _could_carry_subschema(value, budget):
             return True
     return False
+
+
+# Object/map applicator keywords whose presence on a property's own VALUE
+# schema makes that value a nested KEY CHANNEL for the sufficiency proof's
+# property-value recursion below, rather than a scalar/array/annotation-only
+# leaf governed by the walker's key-name policy. `$ref`/`allOf`/`anyOf`/
+# `oneOf` are included because the proof's own applicator delegation resolves
+# them; the remaining object/map keywords are included because each can
+# smuggle an undeclared key past an outer "this object is closed" conclusion
+# even when the property value carries no explicit `type: object` (e.g. a
+# bare `patternProperties` node with no `type`).
+_KEY_CHANNEL_APPLICATOR_KEYWORDS = frozenset(
+    {
+        "properties",
+        "patternProperties",
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "dependentSchemas",
+        "$ref",
+        "allOf",
+        "anyOf",
+        "oneOf",
+    }
+)
+
+
+def _property_value_is_key_channel(value: object) -> bool:
+    """True when a declared property's VALUE schema is itself object-shaped
+    or applicator-bearing -- i.e. a nested key channel that the sufficiency
+    proof must recurse into with the FULL allowlist+type-gate+closedness
+    logic, rather than a scalar/array/annotation-only leaf value. A scalar-
+    typed, array-typed, annotation-only, or bare free-form string property
+    value is NOT a key channel: it is a VALUE, and the walker's key-name
+    policy (identifier-suffix exemption, categorized-key detection, ...)
+    governs it -- recursing into those here would strip the identifier-like-
+    key exemption (`service_id: {"type": "string"}`) that the two-mechanism
+    separation depends on."""
+    if not isinstance(value, Mapping):
+        return False
+    value_type = value.get("type")
+    if value_type is not None and _schema_type_includes(value_type, "object"):
+        return True
+    return any(key in value for key in _KEY_CHANNEL_APPLICATOR_KEYWORDS)
 
 
 def _schema_is_insufficient(input_schema: object) -> bool:
@@ -427,7 +488,12 @@ def _schema_is_insufficient_node(
        Otherwise, non-empty `properties` is only bounded if the object is
        actually CLOSED (`additionalProperties: False`, or itself restricted
        to a finite `enum`/`const`); empty/absent `properties` still needs
-       `additionalProperties: False` to admit only a bare `{}`.
+       `additionalProperties: False` to admit only a bare `{}`. Once the
+       OUTER object is proven closed, each DECLARED property's own VALUE is
+       re-checked too (`_property_value_is_key_channel` gates which values
+       qualify): a property value that is itself object-shaped or
+       applicator-bearing is a nested key channel and must independently
+       prove sufficient by this same predicate, or the node is insufficient.
 
     Returns True (fail closed / insufficient) for an external, cyclic,
     unresolvable, or budget/depth-exhausted reference or composition --
@@ -533,11 +599,27 @@ def _schema_is_insufficient_node(
     # `command` property from riding alongside it unless
     # `additionalProperties` is `false` (or itself restricted to a finite
     # enum/const of values).
-    if additional is False:
-        return False
-    if isinstance(additional, Mapping) and ("enum" in additional or "const" in additional):
-        return False
-    return True
+    object_closed = additional is False or (
+        isinstance(additional, Mapping) and ("enum" in additional or "const" in additional)
+    )
+    if not object_closed:
+        return True
+    # The OUTER object being closed against undeclared keys says nothing
+    # about a DECLARED property's own VALUE: a property value that is itself
+    # object-shaped or applicator-bearing is a nested key channel and must be
+    # re-checked with this same predicate (full allowlist + type-gate +
+    # closedness, budget/depth/`$ref`-cycle guards included) -- otherwise a
+    # closed-looking outer shell can smuggle an unmodeled applicator
+    # (`patternProperties`, an open nested object, an unmodeled `$ref`
+    # target, ...) through a property's value. Scalar/array/annotation-only
+    # property values are deliberately NOT recursed here -- see
+    # `_property_value_is_key_channel`.
+    for prop_value in props.values():
+        if _property_value_is_key_channel(prop_value) and _schema_is_insufficient_node(
+            prop_value, root_schema, seen_refs, depth + 1, budget
+        ):
+            return True
+    return False
 
 
 def _property_is_bounded(prop_schema: object) -> bool:
@@ -738,6 +820,15 @@ _MAX_SCHEMA_WALK_NODES = 5000
 # Keywords whose value never itself carries a subschema (or, for `$defs`/
 # `definitions`, is only reachable indirectly via `$ref` resolution, which
 # `_resolve_local_ref` already handles without needing to pre-walk them).
+# `contentSchema` is included on the same footing, as a deliberate, argued
+# exception rather than a relaxation: its value IS a mapping (schema-shaped),
+# but -- like `contentEncoding`/`contentMediaType` in the Draft 2020-12
+# Content vocabulary -- it describes the DECODED content of a string
+# instance and asserts nothing about the instance the walker is classifying,
+# so it is never itself a command-channel destination worth walking into.
+# This holds ONLY while the content-assertion vocabulary stays disabled (the
+# default dialect this module validates against) -- see the matching caveat
+# on `_SUFFICIENCY_MODELED_KEYWORDS` above.
 _SCALAR_ONLY_SCHEMA_KEYWORDS = frozenset(
     {
         "type",
@@ -752,6 +843,7 @@ _SCALAR_ONLY_SCHEMA_KEYWORDS = frozenset(
         "examples",
         "$defs",
         "definitions",
+        "contentSchema",
     }
 )
 

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -662,15 +662,35 @@ _KNOWN_SCHEMA_KEYWORDS = (
 )
 
 
+# The standardized numeric/size-bound keywords, all scalar-valued by spec.
+# An explicit enumeration, NOT a `min*`/`max*` spelling heuristic: a prefix
+# test would exempt an arbitrary unknown vocabulary key (`minCustomThing`)
+# from the could-carry-subschema check and reopen the whitelist bypass this
+# walker exists to close.
+_NUMERIC_BOUND_KEYWORDS = frozenset(
+    {
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "minProperties",
+        "maxProperties",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "minContains",
+        "maxContains",
+        "multipleOf",
+    }
+)
+
+
 def _is_known_scalar_only_keyword(key: str) -> bool:
-    if key in _SCALAR_ONLY_SCHEMA_KEYWORDS:
-        return True
-    # Numeric/size bounds (`minLength`, `maxItems`, `minimum`, `maxProperties`,
-    # `exclusiveMinimum`, `multipleOf`'s siblings, ...) are always scalar.
-    return key.startswith("min") or key.startswith("max")
+    return key in _SCALAR_ONLY_SCHEMA_KEYWORDS or key in _NUMERIC_BOUND_KEYWORDS
 
 
-def _could_carry_subschema(value: object, depth: int = 0) -> bool:
+def _could_carry_subschema(value: object, budget: list[int], depth: int = 0) -> bool:
     """True when an unrecognized keyword's value is shaped like it could
     itself hold a schema (a mapping, or a list -- at any nesting depth --
     containing a mapping) -- the signal that makes an unknown keyword
@@ -678,17 +698,21 @@ def _could_carry_subschema(value: object, depth: int = 0) -> bool:
     lists of ... of mappings) under the same depth cap as the walker,
     instead of only inspecting one level, so a schema-bearing value cannot
     be laundered past the whitelist by wrapping it in extra list nesting.
-    Fails closed (treated as could-carry) once the depth cap is hit."""
-    if depth > _MAX_SCHEMA_WALK_DEPTH:
+    Charges every visited element against the shared node budget and fails
+    closed (treated as could-carry) when either the depth cap or the node
+    budget is exhausted, so a pathologically wide value cannot force
+    unbounded traversal work."""
+    budget[0] += 1
+    if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return True
     if isinstance(value, Mapping):
         return True
     if isinstance(value, list):
-        return any(_could_carry_subschema(item, depth + 1) for item in value)
+        return any(_could_carry_subschema(item, budget, depth + 1) for item in value)
     return False
 
 
-def _is_inert_annotation_value(value: object, depth: int = 0) -> bool:
+def _is_inert_annotation_value(value: object, budget: list[int], depth: int = 0) -> bool:
     """True when `value` cannot itself carry a subschema: recursively, a
     scalar (string/number/bool/None), or a list/mapping built entirely from
     such values with no JSON-Schema-vocabulary key appearing anywhere inside
@@ -696,21 +720,24 @@ def _is_inert_annotation_value(value: object, depth: int = 0) -> bool:
     UI/ordering metadata (`{"widget": "select", "order": 1}`) is inert; one
     that embeds real schema vocabulary (`x-input-schema: {"properties":
     {...}}`) is not, regardless of the `x-`/`$comment` key it hangs off --
-    the value's SHAPE decides inertness, not the key's spelling."""
-    if depth > _MAX_SCHEMA_WALK_DEPTH:
+    the value's SHAPE decides inertness, not the key's spelling. Charges
+    every visited element against the shared node budget and fails closed
+    (not inert) on exhaustion, mirroring `_could_carry_subschema`."""
+    budget[0] += 1
+    if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return False
     if value is None or isinstance(value, (str, int, float, bool)):
         return True
     if isinstance(value, list):
-        return all(_is_inert_annotation_value(item, depth + 1) for item in value)
+        return all(_is_inert_annotation_value(item, budget, depth + 1) for item in value)
     if isinstance(value, Mapping):
         if any(key in _KNOWN_SCHEMA_KEYWORDS for key in value):
             return False
-        return all(_is_inert_annotation_value(v, depth + 1) for v in value.values())
+        return all(_is_inert_annotation_value(v, budget, depth + 1) for v in value.values())
     return False
 
 
-def _is_vendor_annotation_keyword(key: str, value: object) -> bool:
+def _is_vendor_annotation_keyword(key: str, value: object, budget: list[int]) -> bool:
     """True for a keyword that is metadata/annotation-only, never an
     applicator or reference, AND whose value carries no schema-bearing
     content -- exempt from the unknown-subschema-bearing check. Narrow on
@@ -728,7 +755,7 @@ def _is_vendor_annotation_keyword(key: str, value: object) -> bool:
     reopen the reference-bypass class this walker closes."""
     if key != "$comment" and not key.startswith("x-"):
         return False
-    return _is_inert_annotation_value(value)
+    return _is_inert_annotation_value(value, budget)
 
 
 def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) -> None:
@@ -750,14 +777,19 @@ def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) ->
     if any(key in schema for key in _UNRESOLVABLE_REFERENCE_KEYWORDS):
         result.unresolvable = True
         return
+    # Value inspection shares the walker's node budget: work spent deciding
+    # whether an unknown/annotation value is inert counts against the same
+    # cap as schema traversal, and exhaustion fails closed via the helpers.
+    budget = [result.nodes_visited]
     for key, value in schema.items():
         if key in _KNOWN_SCHEMA_KEYWORDS or _is_known_scalar_only_keyword(key):
             continue
-        if _is_vendor_annotation_keyword(key, value):
+        if _is_vendor_annotation_keyword(key, value, budget):
             continue
-        if _could_carry_subschema(value):
+        if _could_carry_subschema(value, budget):
             result.unresolvable = True
             break
+    result.nodes_visited = max(result.nodes_visited, budget[0])
 
 
 # Object-applicator keywords: presence of any of these on a property's own

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -233,6 +233,14 @@ _IDENTIFIER_LIKE_KEY_PATTERN = re.compile(
     r"^(?:[a-z0-9]+_)*(?:id|ids|path|paths|uri|url|uuid|slug)$"
 )
 
+# Tokens that make an otherwise identifier-shaped key (`*_path`, `*_id`, ...)
+# still executor-shaped: an `executable_path`/`script_path`/`command_path` is
+# a caller-controlled executor target, not a benign resource locator, even
+# though it lexically matches the identifier-like suffix pattern.
+_EXEC_TAINTED_KEY_TOKENS = frozenset(
+    {"command", "cmd", "shell", "script", "program", "binary", "executable", "argv", "args"}
+)
+
 
 def _is_identifier_like_key(norm_key: str) -> bool:
     """True for dynamic-but-benign resource identifiers (`service_id`,
@@ -241,6 +249,15 @@ def _is_identifier_like_key(norm_key: str) -> bool:
     tool with a free-form identifier field is not executor-shaped, even
     though the identifier itself is an unbounded string."""
     return bool(_IDENTIFIER_LIKE_KEY_PATTERN.match(norm_key))
+
+
+def _is_exec_tainted_key(norm_key: str) -> bool:
+    """True when a key's own tokens name an executor channel (`executable_path`,
+    `script_path`, `command_path`, `binary_path`, `program_path`, ...), even
+    though the key otherwise lexically matches the identifier-like suffix
+    exemption. Such a key must NOT be exempted from the strong-name fallback:
+    an arbitrary executable/script/command target is itself executor input."""
+    return any(token in _EXEC_TAINTED_KEY_TOKENS for token in norm_key.split("_"))
 
 
 def _schema_is_insufficient(input_schema: object) -> bool:
@@ -300,13 +317,142 @@ def _property_is_free_form(prop_schema: object, is_categorized_key: bool) -> boo
         return True
     if _schema_type_includes(prop_type, "array"):
         items = prop_schema.get("items")
-        return isinstance(items, Mapping) and _schema_type_includes(items.get("type"), "string")
+        if isinstance(items, Mapping) and _schema_type_includes(items.get("type"), "string"):
+            return True
+        # Positional/tuple validation is an argv-shaped channel too: an
+        # array whose prefixItems admit strings carries caller-controlled
+        # string elements exactly like items-of-strings.
+        prefix_items = prop_schema.get("prefixItems")
+        return isinstance(prefix_items, list) and any(
+            isinstance(item, Mapping) and _schema_type_includes(item.get("type"), "string")
+            for item in prefix_items
+        )
     if prop_type is None and is_categorized_key:
         return True
     return False
 
 
 _MAX_SCHEMA_WALK_DEPTH = 12
+_MAX_SCHEMA_WALK_NODES = 5000
+
+# --- Walker keyword whitelist -------------------------------------------
+#
+# The walker is a WHITELIST, not a blacklist of applicator keywords: earlier
+# rounds each closed specific evasions (nested `properties`, `anyOf`, `$ref`,
+# `additionalProperties`, `patternProperties`; then `if`/`then`/`else`,
+# `not`, `items`, `prefixItems`) only to have the next JSON Schema keyword
+# reopen the same class of bypass. Enumerating "keywords we deny" loses that
+# arms race by construction. Instead we enumerate keywords we affirmatively
+# understand (and walk or treat as inert scalars); ANY OTHER key whose value
+# could itself carry a subschema (a `dict`, or a `list` containing a `dict`)
+# is unresolvable -- future/unsupported schema-bearing keywords (e.g.
+# `unevaluatedProperties`, `dependentSchemas`, `contains`, `propertyNames`)
+# deny by default for executor-signaling tools instead of admitting by
+# default.
+
+# Keywords whose value never itself carries a subschema (or, for `$defs`/
+# `definitions`, is only reachable indirectly via `$ref` resolution, which
+# `_resolve_local_ref` already handles without needing to pre-walk them).
+_SCALAR_ONLY_SCHEMA_KEYWORDS = frozenset(
+    {
+        "type",
+        "enum",
+        "const",
+        "description",
+        "title",
+        "format",
+        "pattern",
+        "required",
+        "default",
+        "examples",
+        "$defs",
+        "definitions",
+    }
+)
+
+# Applicator/structural keywords the walker knows how to traverse.
+_SINGLE_SUBSCHEMA_KEYWORDS = frozenset({"if", "then", "else", "not"})
+_LIST_OF_SUBSCHEMAS_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+# `items` is Draft 2020-12 single-schema ("the rest of the array") or
+# Draft-07-style list-of-schemas (positional/tuple validation); both walked.
+_ITEMS_KEYWORD = "items"
+_PROPERTIES_KEYWORD = "properties"
+_PATTERN_PROPERTIES_KEYWORD = "patternProperties"
+_ADDITIONAL_PROPERTIES_KEYWORD = "additionalProperties"
+_REF_KEYWORD = "$ref"
+
+_KNOWN_SCHEMA_KEYWORDS = (
+    _SCALAR_ONLY_SCHEMA_KEYWORDS
+    | _SINGLE_SUBSCHEMA_KEYWORDS
+    | _LIST_OF_SUBSCHEMAS_KEYWORDS
+    | {
+        _ITEMS_KEYWORD,
+        _PROPERTIES_KEYWORD,
+        _PATTERN_PROPERTIES_KEYWORD,
+        _ADDITIONAL_PROPERTIES_KEYWORD,
+        _REF_KEYWORD,
+    }
+)
+
+
+def _is_known_scalar_only_keyword(key: str) -> bool:
+    if key in _SCALAR_ONLY_SCHEMA_KEYWORDS:
+        return True
+    # Numeric/size bounds (`minLength`, `maxItems`, `minimum`, `maxProperties`,
+    # `exclusiveMinimum`, `multipleOf`'s siblings, ...) are always scalar.
+    return key.startswith("min") or key.startswith("max")
+
+
+def _could_carry_subschema(value: object) -> bool:
+    """True when an unrecognized keyword's value is shaped like it could
+    itself hold a schema (a mapping, or a list containing a mapping) -- the
+    signal that makes an unknown keyword unresolvable rather than inert."""
+    if isinstance(value, Mapping):
+        return True
+    if isinstance(value, list):
+        return any(isinstance(item, Mapping) for item in value)
+    return False
+
+
+def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) -> None:
+    """Whitelist enforcement: any keyword this walker does not explicitly
+    understand, whose value is shaped like it could itself carry a subschema,
+    is unresolvable. This is what makes an unsupported or future JSON Schema
+    keyword (`unevaluatedProperties`, `dependentSchemas`, `contains`,
+    `propertyNames`, ...) deny-by-default for executor-signaling tools
+    instead of admit-by-default -- applied to every schema node the
+    classifier inspects, including property schemas that are otherwise
+    treated as leaves."""
+    for key, value in schema.items():
+        if key in _KNOWN_SCHEMA_KEYWORDS or _is_known_scalar_only_keyword(key):
+            continue
+        if _could_carry_subschema(value):
+            result.unresolvable = True
+            break
+
+
+# Object-applicator keywords: presence of any of these on a property's own
+# schema means the property IS itself a restated/composed schema, not a leaf
+# value -- classify by recursing into it instead of treating it as a scalar.
+_OBJECT_CONTAINER_KEYWORDS = (
+    _PROPERTIES_KEYWORD,
+    _PATTERN_PROPERTIES_KEYWORD,
+    _ADDITIONAL_PROPERTIES_KEYWORD,
+    _REF_KEYWORD,
+    "allOf",
+    "anyOf",
+    "oneOf",
+    "if",
+    "then",
+    "else",
+    "not",
+)
+# Array-shape keywords: an array property can be BOTH a free-form leaf
+# channel in its own right (e.g. `argv: array-of-strings`, matched by
+# `_property_is_free_form`) AND hide a command channel inside an
+# object-shaped item (`items`/`prefixItems`); both must be checked, so these
+# do not short-circuit leaf classification the way object applicators do.
+_ARRAY_ITEM_KEYWORDS = (_ITEMS_KEYWORD, "prefixItems")
 
 
 class _SchemaWalkResult:
@@ -322,6 +468,7 @@ class _SchemaWalkResult:
         "non_identifier_free_form_keys",
         "selector_key_present",
         "unresolvable",
+        "nodes_visited",
     )
 
     def __init__(self) -> None:
@@ -333,11 +480,29 @@ class _SchemaWalkResult:
         self.non_identifier_free_form_keys: set[str] = set()
         self.selector_key_present = False
         # True when a channel could not be proven bounded: an external/
-        # unresolvable `$ref`, a `$ref` cycle, a depth-cap trip, or a
-        # malformed `properties`/composition shape. Fed into fail-closed
-        # handling for descriptor-bearing tools whose name or description
-        # signals an executor; otherwise it is just insufficient evidence.
+        # unresolvable `$ref`, a `$ref` cycle, a depth-cap or node-budget
+        # trip, a malformed `properties`/composition/`patternProperties`
+        # shape, or an unrecognized schema-bearing keyword. Fed into
+        # fail-closed handling for descriptor-bearing tools whose name or
+        # description signals an executor; otherwise it is just
+        # insufficient evidence.
         self.unresolvable = False
+        # Total-work budget companion to the depth cap: bounds runtime
+        # against a schema with harmless but extremely wide fan-out (e.g.
+        # tens of thousands of `anyOf` branches).
+        self.nodes_visited = 0
+
+
+def _consume_node_budget(result: _SchemaWalkResult) -> bool:
+    """Count one unit of walker work; returns False (and marks the result
+    unresolvable) once the total-node budget is exceeded, so callers can stop
+    iterating further branches/properties instead of finishing a huge fan-out
+    node by node."""
+    result.nodes_visited += 1
+    if result.nodes_visited > _MAX_SCHEMA_WALK_NODES:
+        result.unresolvable = True
+        return False
+    return True
 
 
 def _resolve_local_ref(ref: str, root_schema: Mapping) -> Mapping | None:
@@ -354,19 +519,20 @@ def _resolve_local_ref(ref: str, root_schema: Mapping) -> Mapping | None:
     return node if isinstance(node, Mapping) else None
 
 
-def _pattern_matches_categorized_key(pattern: object) -> str | None:
-    """If a `patternProperties` regex would match one of the recognized
-    command/process/argument/payload/selector key names, return that key."""
+def _compile_pattern_or_mark_unresolvable(
+    pattern: object, result: _SchemaWalkResult
+) -> re.Pattern | None:
+    """Compile a `patternProperties` regex key; a non-string key or an
+    invalid regex cannot be inspected and must fail closed rather than be
+    silently skipped."""
     if not isinstance(pattern, str):
+        result.unresolvable = True
         return None
     try:
-        compiled = re.compile(pattern)
+        return re.compile(pattern)
     except re.error:
+        result.unresolvable = True
         return None
-    for key in _CATEGORIZED_KEYS:
-        if compiled.search(key):
-            return key
-    return None
 
 
 def _record_free_form_key(norm_key: str, result: _SchemaWalkResult) -> None:
@@ -380,8 +546,55 @@ def _record_free_form_key(norm_key: str, result: _SchemaWalkResult) -> None:
         result.free_form_payload_keys.add(norm_key)
     if norm_key not in _AUXILIARY_KEYS:
         result.non_auxiliary_free_form_keys.add(norm_key)
-        if not _is_identifier_like_key(norm_key):
+        if _is_exec_tainted_key(norm_key) or not _is_identifier_like_key(norm_key):
             result.non_identifier_free_form_keys.add(norm_key)
+
+
+def _composition_branch_reaches_free_form(
+    prop_schema: object,
+    root_schema: Mapping,
+    is_categorized_key: bool,
+    depth: int,
+    seen_refs: frozenset[str],
+    result: _SchemaWalkResult,
+) -> bool:
+    """True when any composition/conditional/`$ref` branch of a keyed
+    property resolves to a free-form leaf. A property like
+    `{"anyOf": [{"type": "string"}]}` or `{"if": ..., "then": {"type":
+    "string"}}` constrains the SAME instance the key names, so the key is an
+    unbounded channel even though the leaf type is expressed indirectly --
+    without this, wrapping a plain string schema in one applicator layer
+    would strip the key association the classifier relies on."""
+    if not isinstance(prop_schema, Mapping):
+        return False
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        result.unresolvable = True
+        return False
+    branches: list[object] = []
+    ref = prop_schema.get(_REF_KEYWORD)
+    if isinstance(ref, str) and ref.startswith("#/") and ref not in seen_refs:
+        resolved = _resolve_local_ref(ref, root_schema)
+        if resolved is not None:
+            seen_refs = seen_refs | {ref}
+            branches.append(resolved)
+    for comp_key in ("allOf", "anyOf", "oneOf"):
+        comp = prop_schema.get(comp_key)
+        if isinstance(comp, list):
+            branches.extend(comp)
+    for single_key in _SINGLE_SUBSCHEMA_KEYWORDS:
+        branch = prop_schema.get(single_key)
+        if branch is not None:
+            branches.append(branch)
+    for branch in branches:
+        if not _consume_node_budget(result):
+            return False
+        if _property_is_free_form(branch, is_categorized_key):
+            return True
+        if _composition_branch_reaches_free_form(
+            branch, root_schema, is_categorized_key, depth + 1, seen_refs, result
+        ):
+            return True
+    return False
 
 
 def _consider_property(
@@ -399,26 +612,26 @@ def _consider_property(
         result.selector_key_present = True
 
     if isinstance(prop_schema, Mapping):
-        has_nested_shape = any(
-            k in prop_schema
-            for k in (
-                "properties",
-                "$ref",
-                "allOf",
-                "anyOf",
-                "oneOf",
-                "additionalProperties",
-                "patternProperties",
-            )
-        )
-        prop_type = prop_schema.get("type")
-        type_excludes_object = prop_type is not None and not _schema_type_includes(
-            prop_type, "object"
-        )
-        if has_nested_shape and not type_excludes_object:
+        # A leaf-shaped property schema is never handed to _walk_schema, so
+        # enforce the unknown-keyword whitelist here as well; redundant for
+        # container-shaped properties (which are walked) but harmless.
+        _mark_unknown_schema_keywords(prop_schema, result)
+        if any(k in prop_schema for k in _OBJECT_CONTAINER_KEYWORDS):
             # A container (e.g. a nested `options` object) is not itself a
             # command/process/script value; walk its own reachable
-            # properties instead of classifying the container's key.
+            # properties instead of classifying the container's key -- but
+            # first attribute to the key any free-form leaf reachable purely
+            # through composition/conditional branches, which constrain the
+            # key's own value.
+            if _composition_branch_reaches_free_form(
+                prop_schema,
+                root_schema,
+                norm_key in _CATEGORIZED_KEYS,
+                depth,
+                seen_refs,
+                result,
+            ):
+                _record_free_form_key(norm_key, result)
             _walk_schema(
                 prop_schema,
                 root_schema,
@@ -429,11 +642,51 @@ def _consider_property(
                 result,
             )
             return
+        if any(k in prop_schema for k in _ARRAY_ITEM_KEYWORDS):
+            # Walk `items`/`prefixItems` for a hidden object-shaped command
+            # channel, but still fall through to the leaf check below: the
+            # array property itself may also be a free-form channel (e.g.
+            # `argv: array-of-strings`).
+            _walk_schema(
+                prop_schema,
+                root_schema,
+                depth + 1,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
 
     if not _property_is_free_form(prop_schema, norm_key in _CATEGORIZED_KEYS):
         return
 
     _record_free_form_key(norm_key, result)
+
+
+def _walk_subschema_list(
+    branches: object,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    is_strong_name: bool,
+    is_executor_description: bool,
+    result: _SchemaWalkResult,
+) -> None:
+    if not isinstance(branches, list):
+        result.unresolvable = True
+        return
+    for branch in branches:
+        if not _consume_node_budget(result):
+            return
+        _walk_schema(
+            branch,
+            root_schema,
+            depth + 1,
+            seen_refs,
+            is_strong_name,
+            is_executor_description,
+            result,
+        )
 
 
 def _walk_schema(
@@ -445,17 +698,23 @@ def _walk_schema(
     is_executor_description: bool,
     result: _SchemaWalkResult,
 ) -> None:
-    """Bounded, cycle-safe traversal collecting classifier evidence from
-    `properties` (including nested objects), `allOf`/`anyOf`/`oneOf`
-    branches, local `$ref` resolution, `patternProperties`, and
-    `additionalProperties`."""
+    """Bounded, cycle-safe, budgeted traversal collecting classifier
+    evidence. Recognizes `properties` (including nested objects),
+    `allOf`/`anyOf`/`oneOf`, `if`/`then`/`else`/`not`, `items`/`prefixItems`,
+    local `$ref` resolution, `patternProperties`, and `additionalProperties`
+    (both as a scalar free-form map channel and, when object-valued, as a
+    nested subschema to recurse into). Any other keyword whose value could
+    itself carry a subschema is unresolvable -- see the whitelist rationale
+    above `_KNOWN_SCHEMA_KEYWORDS`."""
     if depth > _MAX_SCHEMA_WALK_DEPTH:
         result.unresolvable = True
+        return
+    if not _consume_node_budget(result):
         return
     if not isinstance(schema, Mapping):
         return
 
-    ref = schema.get("$ref")
+    ref = schema.get(_REF_KEYWORD)
     if ref is not None:
         if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
             # External/non-local or cyclic reference: cannot be proven
@@ -477,16 +736,26 @@ def _walk_schema(
         )
         return
 
-    for comp_key in ("allOf", "anyOf", "oneOf"):
+    for comp_key in ("allOf", "anyOf", "oneOf", "prefixItems"):
         branches = schema.get(comp_key)
-        if branches is None:
-            continue
-        if not isinstance(branches, list):
-            result.unresolvable = True
-            continue
-        for branch in branches:
+        if branches is not None:
+            _walk_subschema_list(
+                branches,
+                root_schema,
+                depth,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
+
+    for single_key in _SINGLE_SUBSCHEMA_KEYWORDS:
+        branch_schema = schema.get(single_key)
+        if branch_schema is not None:
+            if not _consume_node_budget(result):
+                return
             _walk_schema(
-                branch,
+                branch_schema,
                 root_schema,
                 depth + 1,
                 seen_refs,
@@ -495,12 +764,44 @@ def _walk_schema(
                 result,
             )
 
-    properties = schema.get("properties")
+    items_schema = schema.get(_ITEMS_KEYWORD)
+    if items_schema is not None:
+        if isinstance(items_schema, list):
+            _walk_subschema_list(
+                items_schema,
+                root_schema,
+                depth,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
+        elif isinstance(items_schema, Mapping):
+            if _consume_node_budget(result):
+                _walk_schema(
+                    items_schema,
+                    root_schema,
+                    depth + 1,
+                    seen_refs,
+                    is_strong_name,
+                    is_executor_description,
+                    result,
+                )
+        elif items_schema is True or items_schema is False:
+            # Boolean item schemas ("any item"/"no items") carry no nested
+            # subschema to walk.
+            pass
+        else:
+            result.unresolvable = True
+
+    properties = schema.get(_PROPERTIES_KEYWORD)
     if properties is not None:
         if not isinstance(properties, Mapping):
             result.unresolvable = True
         else:
             for raw_key, prop_schema in properties.items():
+                if not _consume_node_budget(result):
+                    break
                 _consider_property(
                     raw_key,
                     prop_schema,
@@ -512,24 +813,46 @@ def _walk_schema(
                     result,
                 )
 
-    pattern_properties = schema.get("patternProperties")
-    if isinstance(pattern_properties, Mapping):
-        for pattern, pattern_schema in pattern_properties.items():
-            matched_key = _pattern_matches_categorized_key(pattern)
-            if matched_key is not None:
-                _consider_property(
-                    matched_key,
-                    pattern_schema,
-                    root_schema,
-                    depth,
-                    seen_refs,
-                    is_strong_name,
-                    is_executor_description,
-                    result,
-                )
+    pattern_properties = schema.get(_PATTERN_PROPERTIES_KEYWORD)
+    if pattern_properties is not None:
+        if not isinstance(pattern_properties, Mapping):
+            result.unresolvable = True
+        else:
+            for pattern, pattern_schema in pattern_properties.items():
+                if not _consume_node_budget(result):
+                    break
+                compiled = _compile_pattern_or_mark_unresolvable(pattern, result)
+                if compiled is None:
+                    continue
+                matched_key = next((key for key in _CATEGORIZED_KEYS if compiled.search(key)), None)
+                if matched_key is not None:
+                    _consider_property(
+                        matched_key,
+                        pattern_schema,
+                        root_schema,
+                        depth,
+                        seen_refs,
+                        is_strong_name,
+                        is_executor_description,
+                        result,
+                    )
 
-    additional_properties = schema.get("additionalProperties")
+    additional_properties = schema.get(_ADDITIONAL_PROPERTIES_KEYWORD)
     if additional_properties is not None and additional_properties is not False:
+        if isinstance(additional_properties, Mapping) and _consume_node_budget(result):
+            # An object-valued map entry schema (e.g. every value under the
+            # map is itself `{"properties": {"command": ...}}`) is a reachable
+            # subschema in its own right; walk it so a command channel hidden
+            # behind a dynamic map key is not silently admitted.
+            _walk_schema(
+                additional_properties,
+                root_schema,
+                depth + 1,
+                seen_refs,
+                is_strong_name,
+                is_executor_description,
+                result,
+            )
         if _property_is_free_form(additional_properties, True):
             # No fixed key name is available for a free-form map channel; it
             # only counts as executor-shaped evidence when corroborated by
@@ -537,6 +860,8 @@ def _walk_schema(
             # `unbounded-script-payload` already requires of payload keys).
             if is_strong_name or is_executor_description:
                 _record_free_form_key("<additionalProperties>", result)
+
+    _mark_unknown_schema_keywords(schema, result)
 
 
 def _classify_generic_executor(

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -260,6 +260,36 @@ def _is_exec_tainted_key(norm_key: str) -> bool:
     return any(token in _EXEC_TAINTED_KEY_TOKENS for token in norm_key.split("_"))
 
 
+# Non-object JSON Schema types whose instances are not intrinsically
+# finite: a root `type` UNION that includes one of these (without a
+# top-level `enum`/`const` collapsing the whole instance to a fixed set) has
+# a branch that can carry an arbitrary value, bypassing every object-shaped
+# constraint (`properties`, `additionalProperties`, ...) entirely.
+_UNBOUNDED_NON_OBJECT_TYPES = frozenset({"string", "number", "integer", "array"})
+
+
+def _type_union_has_free_form_alternative(top_type: list, schema: Mapping) -> bool:
+    if "enum" in schema or "const" in schema:
+        return False
+    return any(t in _UNBOUNDED_NON_OBJECT_TYPES for t in top_type)
+
+
+# Keywords on a node carrying a `$ref` that are annotation-only and never
+# themselves constrain the instance -- present alongside `$ref`, they add no
+# sibling obligation the sufficiency check needs to evaluate.
+_ANNOTATION_ONLY_REF_SIBLING_KEYWORDS = frozenset(
+    {"description", "title", "$comment", "examples", "default", "$defs", "definitions"}
+)
+
+
+def _has_structural_ref_siblings(siblings: Mapping) -> bool:
+    """True when a `$ref` node's sibling keywords (the node minus `$ref`
+    itself) include anything beyond pure annotation -- i.e. something that,
+    per Draft 2020-12, constrains the same instance as the reference target
+    and must be evaluated in its own right rather than discarded."""
+    return any(key not in _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS for key in siblings)
+
+
 def _schema_is_insufficient(input_schema: object) -> bool:
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
@@ -302,6 +332,14 @@ def _schema_is_insufficient_node(
     # insufficient.
     if top_type is not None and not _schema_type_includes(top_type, "object"):
         return True
+    # A type UNION that includes "object" alongside a type that can itself
+    # carry a free-form value (`string`/`number`/`integer`/`array`, absent a
+    # top-level `enum`/`const` pinning the whole instance) is only as
+    # bounded as its least-bounded alternative: an instance satisfying the
+    # non-object branch never even reaches the object-specific
+    # `properties`/`additionalProperties` keywords below.
+    if isinstance(top_type, list) and _type_union_has_free_form_alternative(top_type, schema):
+        return True
 
     ref = schema.get(_REF_KEYWORD)
     if ref is not None:
@@ -310,9 +348,25 @@ def _schema_is_insufficient_node(
         resolved = _resolve_local_ref(ref, root_schema)
         if resolved is None:
             return True
-        return _schema_is_insufficient_node(
+        target_insufficient = _schema_is_insufficient_node(
             resolved, root_schema, seen_refs | {ref}, depth + 1, budget
         )
+        if not target_insufficient:
+            return False
+        # Draft 2020-12 evaluates `$ref` SIBLINGS -- they are not discarded.
+        # A closed/bounded target does not make the overall node sufficient
+        # if a sibling keyword (evaluated against the SAME instance)
+        # reopens it (e.g. a sibling `properties` entry with its own
+        # implicit-open `additionalProperties`). Pure annotation siblings
+        # (`description`, `title`, ...) contribute nothing and must not
+        # force an otherwise-open target's insufficiency onto an
+        # unrelated, harmless caller-facing property.
+        siblings = {k: v for k, v in schema.items() if k != _REF_KEYWORD}
+        if _has_structural_ref_siblings(siblings):
+            return _schema_is_insufficient_node(
+                siblings, root_schema, seen_refs | {ref}, depth + 1, budget
+            )
+        return True
 
     for comp_key in ("oneOf", "anyOf"):
         branches = schema.get(comp_key)
@@ -340,9 +394,21 @@ def _schema_is_insufficient_node(
         return True
     properties = schema.get("properties")
     props = properties if isinstance(properties, Mapping) else {}
+    additional = schema.get("additionalProperties")
     if not props:
-        return schema.get("additionalProperties") is not False
-    return False
+        return additional is not False
+    # A non-empty `properties` mapping only proves the schema bounded if the
+    # object is actually CLOSED: JSON Schema's `additionalProperties`
+    # defaults to permissive (implicit `true`), so a caller can always add
+    # an undeclared key -- a fixed `operation` enum/const does not stop a
+    # `command` property from riding alongside it unless
+    # `additionalProperties` is `false` (or itself restricted to a finite
+    # enum/const of values).
+    if additional is False:
+        return False
+    if isinstance(additional, Mapping) and ("enum" in additional or "const" in additional):
+        return False
+    return True
 
 
 def _property_is_bounded(prop_schema: object) -> bool:
@@ -350,10 +416,12 @@ def _property_is_bounded(prop_schema: object) -> bool:
         return False
     if "enum" in prop_schema or "const" in prop_schema:
         return True
-    if _schema_type_includes(prop_schema.get("type"), "array"):
-        items = prop_schema.get("items")
-        if isinstance(items, Mapping) and ("enum" in items or "const" in items):
-            return True
+    # Deliberately no array carve-out here: an array's boundedness depends on
+    # BOTH its `prefixItems` members and its `items` (rest-of-array) schema
+    # together (see `_array_reaches_free_form`) -- a bounded `items` alone
+    # (e.g. `items: {"enum": [...]}`) says nothing about an unbounded
+    # `prefixItems` member sitting alongside it, so this shortcut must not
+    # short-circuit before the full array check runs.
     return False
 
 
@@ -412,20 +480,7 @@ def _item_schema_reaches_free_form_string(
         if _schema_type_includes(item_type, "string"):
             return True
         if _schema_type_includes(item_type, "array"):
-            nested_items = item_schema.get("items")
-            if nested_items is not None and _item_schema_reaches_free_form_string(
-                nested_items, root_schema, depth + 1, seen_refs, result
-            ):
-                return True
-            nested_prefix_items = item_schema.get("prefixItems")
-            if isinstance(nested_prefix_items, list):
-                return any(
-                    _item_schema_reaches_free_form_string(
-                        nested_item, root_schema, depth + 1, seen_refs, result
-                    )
-                    for nested_item in nested_prefix_items
-                )
-            return False
+            return _array_reaches_free_form(item_schema, root_schema, depth + 1, seen_refs, result)
         return False
 
     ref = item_schema.get(_REF_KEYWORD)
@@ -461,6 +516,52 @@ def _item_schema_reaches_free_form_string(
     return True
 
 
+def _array_reaches_free_form(
+    array_schema: Mapping,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    result: _SchemaWalkResult,
+) -> bool:
+    """True when an array-shaped schema node (property-level or nested
+    item-level) admits a free-form element -- i.e. is an argv-shaped
+    channel.
+
+    Draft 2020-12 `prefixItems`/`items` semantics: `prefixItems` validates
+    only the array's PREFIX positions; `items` validates every position AT
+    OR AFTER that prefix (the "rest" of the array). Critically, a MISSING
+    `items` keyword defaults to `true` -- an entirely unconstrained rest --
+    so an array whose `prefixItems` are all enum/const-bounded is still a
+    free-form channel unless `items` is explicitly present and itself
+    bounded (or `false`, closing the tuple to exactly its prefix). Every
+    `prefixItems` member is checked too: a bounded `items` schema says
+    nothing about an unbounded value sitting in the fixed prefix.
+    """
+    prefix_items = array_schema.get("prefixItems")
+    if isinstance(prefix_items, list):
+        for item in prefix_items:
+            if _item_schema_reaches_free_form_string(
+                item, root_schema, depth + 1, seen_refs, result
+            ):
+                return True
+
+    if "items" not in array_schema:
+        # No `items` keyword: per Draft 2020-12 this defaults to `true`,
+        # leaving every position beyond `prefixItems` totally unconstrained.
+        return True
+
+    items_val = array_schema.get("items")
+    if items_val is False:
+        # Explicitly closed: no elements beyond `prefixItems` are permitted
+        # at all, so the array's shape is exactly its (already-checked)
+        # prefix.
+        return False
+
+    return _item_schema_reaches_free_form_string(
+        items_val, root_schema, depth + 1, seen_refs, result
+    )
+
+
 def _property_is_free_form(
     prop_schema: object,
     is_categorized_key: bool,
@@ -481,23 +582,7 @@ def _property_is_free_form(
     if _schema_type_includes(prop_type, "string"):
         return True
     if _schema_type_includes(prop_type, "array"):
-        items = prop_schema.get("items")
-        if items is not None and _item_schema_reaches_free_form_string(
-            items, root_schema, depth + 1, seen_refs, result
-        ):
-            return True
-        # Positional/tuple validation is an argv-shaped channel too: an
-        # array whose prefixItems admit strings carries caller-controlled
-        # string elements exactly like items-of-strings.
-        prefix_items = prop_schema.get("prefixItems")
-        if isinstance(prefix_items, list):
-            return any(
-                _item_schema_reaches_free_form_string(
-                    item, root_schema, depth + 1, seen_refs, result
-                )
-                for item in prefix_items
-            )
-        return False
+        return _array_reaches_free_form(prop_schema, root_schema, depth, seen_refs, result)
     if prop_type is None and is_categorized_key:
         return True
     return False
@@ -585,14 +670,21 @@ def _is_known_scalar_only_keyword(key: str) -> bool:
     return key.startswith("min") or key.startswith("max")
 
 
-def _could_carry_subschema(value: object) -> bool:
+def _could_carry_subschema(value: object, depth: int = 0) -> bool:
     """True when an unrecognized keyword's value is shaped like it could
-    itself hold a schema (a mapping, or a list containing a mapping) -- the
-    signal that makes an unknown keyword unresolvable rather than inert."""
+    itself hold a schema (a mapping, or a list -- at any nesting depth --
+    containing a mapping) -- the signal that makes an unknown keyword
+    unresolvable rather than inert. Recurses through nested lists (a list of
+    lists of ... of mappings) under the same depth cap as the walker,
+    instead of only inspecting one level, so a schema-bearing value cannot
+    be laundered past the whitelist by wrapping it in extra list nesting.
+    Fails closed (treated as could-carry) once the depth cap is hit."""
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        return True
     if isinstance(value, Mapping):
         return True
     if isinstance(value, list):
-        return any(isinstance(item, Mapping) for item in value)
+        return any(_could_carry_subschema(item, depth + 1) for item in value)
     return False
 
 
@@ -975,7 +1067,11 @@ def _walk_schema(
             is_executor_description,
             result,
         )
-        return
+        # Draft 2020-12 evaluates `$ref` SIBLINGS -- they are not discarded.
+        # Fall through (no early `return`) so every other keyword on THIS
+        # node (`properties`, `additionalProperties`, `allOf`/`anyOf`, ...)
+        # is still walked for a free-form channel reachable alongside the
+        # reference, instead of being silently skipped.
 
     for comp_key in ("allOf", "anyOf", "oneOf", "prefixItems"):
         branches = schema.get(comp_key)

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -260,6 +260,56 @@ def _is_exec_tainted_key(norm_key: str) -> bool:
     return any(token in _EXEC_TAINTED_KEY_TOKENS for token in norm_key.split("_"))
 
 
+def _resolve_effective_schema_for_sufficiency(
+    schema: Mapping,
+    root_schema: Mapping,
+    seen_refs: frozenset[str],
+    depth: int,
+) -> Mapping | None:
+    """Resolve `schema` to the node whose own `properties`/
+    `additionalProperties` should be inspected for the strong-name
+    sufficiency gate.
+
+    A schema expressed purely via a top-level local `$ref` (or via
+    `oneOf`/`anyOf`/`allOf` composition with no properties of its own) is
+    not automatically "schema-less": the walker can resolve it exactly as
+    `_walk_schema` does, so the sufficiency gate should judge the RESOLVED
+    schema rather than demanding the caller-provided root carry `properties`
+    directly. Returns None (fail closed / insufficient) for an external,
+    cyclic, or otherwise unresolvable reference -- never widens what the
+    walker itself would already treat as unresolvable. Returns `schema`
+    unchanged when there is no `$ref`/composition to resolve, or when
+    composition branches exist but none of them resolve to a schema with its
+    own `properties` (the original conservative default: fall through to the
+    caller's own empty-properties/`additionalProperties` check)."""
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        return None
+    ref = schema.get(_REF_KEYWORD)
+    if ref is not None:
+        if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:
+            return None
+        resolved = _resolve_local_ref(ref, root_schema)
+        if resolved is None:
+            return None
+        return _resolve_effective_schema_for_sufficiency(
+            resolved, root_schema, seen_refs | {ref}, depth + 1
+        )
+    if "properties" in schema:
+        return schema
+    for comp_key in ("oneOf", "anyOf", "allOf"):
+        branches = schema.get(comp_key)
+        if isinstance(branches, list):
+            for branch in branches:
+                if not isinstance(branch, Mapping):
+                    continue
+                resolved_branch = _resolve_effective_schema_for_sufficiency(
+                    branch, root_schema, seen_refs, depth + 1
+                )
+                if resolved_branch is not None and "properties" in resolved_branch:
+                    return resolved_branch
+    return schema
+
+
 def _schema_is_insufficient(input_schema: object) -> bool:
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
@@ -271,16 +321,24 @@ def _schema_is_insufficient(input_schema: object) -> bool:
     # insufficient.
     if top_type is not None and not _schema_type_includes(top_type, "object"):
         return True
-    if "properties" in input_schema and not isinstance(input_schema["properties"], Mapping):
-        return True
+
+    resolved = input_schema
     if "properties" not in input_schema and any(
         k in input_schema for k in ("$ref", "oneOf", "anyOf", "allOf")
     ):
+        candidate = _resolve_effective_schema_for_sufficiency(
+            input_schema, input_schema, frozenset(), 0
+        )
+        if candidate is None:
+            return True
+        resolved = candidate
+
+    if "properties" in resolved and not isinstance(resolved["properties"], Mapping):
         return True
-    properties = input_schema.get("properties")
+    properties = resolved.get("properties")
     props = properties if isinstance(properties, Mapping) else {}
     if not props:
-        return input_schema.get("additionalProperties") is not False
+        return resolved.get("additionalProperties") is not False
     return False
 
 
@@ -303,7 +361,88 @@ def _schema_type_includes(type_value: object, target: str) -> bool:
     return type_value == target
 
 
-def _property_is_free_form(prop_schema: object, is_categorized_key: bool) -> bool:
+def _item_schema_reaches_free_form_string(
+    item_schema: object,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    result: _SchemaWalkResult,
+) -> bool:
+    """True when an array's `items`/`prefixItems` member schema may itself
+    admit an arbitrary string value -- i.e. the array is a free-form,
+    argv-shaped channel at that position.
+
+    Item schemas are always treated conservatively: unlike a keyed object
+    property (which gets the identifier-suffix exemption), an array element
+    has no name of its own, so an opaque/unsupported/unconstrained item
+    shape -- `true`, `{}` (no constraints), an untyped schema, an external
+    or cyclic `$ref`, a malformed items entry -- is presumed free-form
+    rather than benign. Local `$ref` and `allOf`/`anyOf`/`oneOf`/
+    `if`/`then`/`else`/`not` composition are resolved/recursed so an item
+    schema that only reaches a string through one layer of indirection
+    (`{"anyOf": [{"type": "string"}]}`, a `$ref` to a string schema, ...) is
+    still caught.
+    """
+    if item_schema is True:
+        return True
+    if item_schema is False:
+        return False
+    if not isinstance(item_schema, Mapping):
+        # Malformed item schema (not a boolean, not a mapping): cannot be
+        # proven bounded -- fail closed.
+        return True
+    if depth > _MAX_SCHEMA_WALK_DEPTH:
+        result.unresolvable = True
+        return True
+    if not _consume_node_budget(result):
+        return True
+    if _property_is_bounded(item_schema):
+        return False
+    item_type = item_schema.get("type")
+    if item_type is not None:
+        return _schema_type_includes(item_type, "string")
+
+    ref = item_schema.get(_REF_KEYWORD)
+    branches: list[object] = []
+    if isinstance(ref, str):
+        if ref.startswith("#/") and ref not in seen_refs:
+            resolved = _resolve_local_ref(ref, root_schema)
+            if resolved is None:
+                return True
+            seen_refs = seen_refs | {ref}
+            branches.append(resolved)
+        else:
+            # External or cyclic $ref: cannot be proven bounded.
+            return True
+
+    for comp_key in ("allOf", "anyOf", "oneOf"):
+        comp = item_schema.get(comp_key)
+        if isinstance(comp, list):
+            branches.extend(comp)
+    for single_key in _SINGLE_SUBSCHEMA_KEYWORDS:
+        branch = item_schema.get(single_key)
+        if branch is not None:
+            branches.append(branch)
+
+    if branches:
+        return any(
+            _item_schema_reaches_free_form_string(branch, root_schema, depth + 1, seen_refs, result)
+            for branch in branches
+        )
+
+    # No type, no $ref, no composition: a genuinely empty/opaque schema
+    # (`{}`) constrains nothing -- conservatively free-form.
+    return True
+
+
+def _property_is_free_form(
+    prop_schema: object,
+    is_categorized_key: bool,
+    root_schema: Mapping,
+    depth: int,
+    seen_refs: frozenset[str],
+    result: _SchemaWalkResult,
+) -> bool:
     # JSON Schema boolean `true` matches any value, so it is at least as
     # permissive as an untyped free-form string; `false` matches nothing.
     if prop_schema is True:
@@ -317,16 +456,22 @@ def _property_is_free_form(prop_schema: object, is_categorized_key: bool) -> boo
         return True
     if _schema_type_includes(prop_type, "array"):
         items = prop_schema.get("items")
-        if isinstance(items, Mapping) and _schema_type_includes(items.get("type"), "string"):
+        if items is not None and _item_schema_reaches_free_form_string(
+            items, root_schema, depth + 1, seen_refs, result
+        ):
             return True
         # Positional/tuple validation is an argv-shaped channel too: an
         # array whose prefixItems admit strings carries caller-controlled
         # string elements exactly like items-of-strings.
         prefix_items = prop_schema.get("prefixItems")
-        return isinstance(prefix_items, list) and any(
-            isinstance(item, Mapping) and _schema_type_includes(item.get("type"), "string")
-            for item in prefix_items
-        )
+        if isinstance(prefix_items, list):
+            return any(
+                _item_schema_reaches_free_form_string(
+                    item, root_schema, depth + 1, seen_refs, result
+                )
+                for item in prefix_items
+            )
+        return False
     if prop_type is None and is_categorized_key:
         return True
     return False
@@ -381,6 +526,17 @@ _PATTERN_PROPERTIES_KEYWORD = "patternProperties"
 _ADDITIONAL_PROPERTIES_KEYWORD = "additionalProperties"
 _REF_KEYWORD = "$ref"
 
+# Reference-bearing keywords the walker does NOT resolve: Draft 2020-12
+# `$dynamicRef` and Draft-2019-09 `$recursiveRef` are schema-bearing exactly
+# like `$ref`, but their VALUE is a plain string (a URI fragment / dynamic
+# anchor lookup), not a Mapping -- so `_could_carry_subschema`'s value-type
+# test (Mapping, or list-of-Mapping) never flags them, and a command channel
+# reachable only behind one of these keywords would otherwise be silently
+# admitted. Recognized by KEYWORD IDENTITY, always treated as unresolvable
+# (conservative: dynamic-scope `$dynamicAnchor` resolution is not something
+# this walker can safely reproduce).
+_UNRESOLVABLE_REFERENCE_KEYWORDS = frozenset({"$dynamicRef", "$recursiveRef"})
+
 _KNOWN_SCHEMA_KEYWORDS = (
     _SCALAR_ONLY_SCHEMA_KEYWORDS
     | _SINGLE_SUBSCHEMA_KEYWORDS
@@ -414,6 +570,20 @@ def _could_carry_subschema(value: object) -> bool:
     return False
 
 
+def _is_vendor_annotation_keyword(key: str) -> bool:
+    """True for a keyword that is metadata/annotation-only, never an
+    applicator or reference -- exempt from the unknown-subschema-bearing
+    check even though its value may be a Mapping. Deliberately narrow: only
+    the `x-` vendor-extension convention (the OpenAPI/JSON-Schema community
+    convention for non-standard annotations, e.g. `x-ui`, `x-order`) and
+    JSON Schema's own `$comment` (annotation-only by spec). NEVER exempt
+    `$`-prefixed keywords in general -- that prefix is exactly where real
+    reference/applicator keywords live (`$ref`, `$dynamicRef`,
+    `$recursiveRef`, ...), so a blanket `$*` exemption would reopen the
+    reference-bypass class this walker closes."""
+    return key.startswith("x-") or key == "$comment"
+
+
 def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) -> None:
     """Whitelist enforcement: any keyword this walker does not explicitly
     understand, whose value is shaped like it could itself carry a subschema,
@@ -422,9 +592,21 @@ def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) ->
     `propertyNames`, ...) deny-by-default for executor-signaling tools
     instead of admit-by-default -- applied to every schema node the
     classifier inspects, including property schemas that are otherwise
-    treated as leaves."""
+    treated as leaves.
+
+    Two carve-outs on top of the base whitelist test: (1) a `$dynamicRef`/
+    `$recursiveRef` anywhere on this node makes it unresolvable outright,
+    regardless of the (string-shaped) value's container type -- see
+    `_UNRESOLVABLE_REFERENCE_KEYWORDS`; (2) a vendor-extension/annotation
+    keyword (`_is_vendor_annotation_keyword`) is exempt even when
+    Mapping-valued, since it is never an applicator."""
+    if any(key in schema for key in _UNRESOLVABLE_REFERENCE_KEYWORDS):
+        result.unresolvable = True
+        return
     for key, value in schema.items():
         if key in _KNOWN_SCHEMA_KEYWORDS or _is_known_scalar_only_keyword(key):
+            continue
+        if _is_vendor_annotation_keyword(key):
             continue
         if _could_carry_subschema(value):
             result.unresolvable = True
@@ -588,7 +770,9 @@ def _composition_branch_reaches_free_form(
     for branch in branches:
         if not _consume_node_budget(result):
             return False
-        if _property_is_free_form(branch, is_categorized_key):
+        if _property_is_free_form(
+            branch, is_categorized_key, root_schema, depth, seen_refs, result
+        ):
             return True
         if _composition_branch_reaches_free_form(
             branch, root_schema, is_categorized_key, depth + 1, seen_refs, result
@@ -657,7 +841,9 @@ def _consider_property(
                 result,
             )
 
-    if not _property_is_free_form(prop_schema, norm_key in _CATEGORIZED_KEYS):
+    if not _property_is_free_form(
+        prop_schema, norm_key in _CATEGORIZED_KEYS, root_schema, depth, seen_refs, result
+    ):
         return
 
     _record_free_form_key(norm_key, result)
@@ -853,7 +1039,9 @@ def _walk_schema(
                 is_executor_description,
                 result,
             )
-        if _property_is_free_form(additional_properties, True):
+        if _property_is_free_form(
+            additional_properties, True, root_schema, depth, seen_refs, result
+        ):
             # No fixed key name is available for a free-form map channel; it
             # only counts as executor-shaped evidence when corroborated by
             # the tool's own name or description (the same corroboration

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -396,6 +396,12 @@ class TestActionManagerMCPAdmission:
                                 "enum": ["status", "restart"],
                             }
                         },
+                        # `additionalProperties: False` closes the object so
+                        # the strong-name sufficiency gate can prove it
+                        # bounded (an implicit-open object never proves
+                        # sufficient no matter how bounded its declared
+                        # properties are).
+                        "additionalProperties": False,
                     },
                 },
             },
@@ -548,6 +554,7 @@ class TestActionManagerMCPAdmission:
                         "operation": {"type": "string", "enum": ["status", "restart"]},
                         "service_id": {"type": "string"},
                     },
+                    "additionalProperties": False,
                 },
             }
         )
@@ -739,6 +746,91 @@ class TestActionManagerMCPAdmission:
             }
         )
         assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_nested_array_item_defaulting_open(self):
+        """A missing `items` keyword on a nested array item
+        defaults to `true` (an unconstrained rest) in Draft 2020-12 -- an
+        inner `{"type": "array"}` with no `items`/`prefixItems` of its own
+        is a free-form argv channel one level deeper, not bounded."""
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"const": "status"},
+                        "args": {"type": "array", "items": {"type": "array"}},
+                    },
+                },
+            }
+        )
+        assert "exec" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_prefixitems_only_array_open_rest(self):
+        """`prefixItems` only constrains the array's prefix; an
+        absent `items` leaves every position after it entirely open."""
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"const": "status"},
+                        "args": {
+                            "type": "array",
+                            "prefixItems": [{"enum": ["fixed"]}],
+                        },
+                    },
+                },
+            }
+        )
+        assert "exec" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_bounded_items_with_unbounded_prefixitems(self):
+        """A bounded `items` schema (enum-restricted) does not
+        launder an unbounded `prefixItems` member sitting in the array's
+        fixed prefix."""
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"const": "status"},
+                        "args": {
+                            "type": "array",
+                            "items": {"enum": ["fixed"]},
+                            "prefixItems": [{"type": "string"}],
+                        },
+                    },
+                },
+            }
+        )
+        assert "exec" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_open_object_with_only_bounded_properties(self):
+        """A strong-executor-name schema with non-empty
+        `properties` is only actually bounded when the object is closed
+        (`additionalProperties: False`); the implicit-open default still
+        admits an undeclared key riding alongside a bounded `operation`."""
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"operation": {"const": "status"}},
+                },
+            }
+        )
+        assert "exec" not in manager.registry
 
     @pytest.mark.asyncio
     async def test_register_mcp_server_tool_names_mixed_list_leaves_registry_untouched(self):

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -422,6 +422,201 @@ class TestActionManagerMCPAdmission:
         assert result == ["format_run_command"]
         assert "format_run_command" in manager.registry
 
+    async def _discover_and_register(self, descriptor):
+        """Helper: register a server whose discovery returns a single mock
+        tool built from `descriptor` (name/description/inputSchema)."""
+        manager = ActionManager()
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = descriptor["name"]
+            mock_tool.description = descriptor.get("description")
+            mock_tool.inputSchema = descriptor.get("inputSchema")
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+            return manager, await manager.register_mcp_server(
+                {"command": "python", "args": ["-m", "srv"]}
+            )
+
+    async def _discover_and_expect_denial(self, descriptor):
+        manager = ActionManager()
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = descriptor["name"]
+            mock_tool.description = descriptor.get("description")
+            mock_tool.inputSchema = descriptor.get("inputSchema")
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+            with pytest.raises(PermissionError):
+                await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_nested_object_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "options": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        }
+                    },
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_anyof_branch_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "anyOf": [
+                        {"properties": {"target": {"type": "string", "enum": ["a", "b"]}}},
+                        {"properties": {"command": {"type": "string"}}},
+                    ],
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_local_ref_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"config": {"$ref": "#/$defs/CommandConfig"}},
+                    "$defs": {
+                        "CommandConfig": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        }
+                    },
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_freeform_additional_properties_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_pattern_properties_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "patternProperties": {"^command$": {"type": "string"}},
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_admits_strong_name_with_dynamic_resource_id(self):
+        manager, result = await self._discover_and_register(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"type": "string", "enum": ["status", "restart"]},
+                        "service_id": {"type": "string"},
+                    },
+                },
+            }
+        )
+        assert result == ["exec"]
+        assert "exec" in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_admits_nested_config_without_command_fields(self):
+        manager, result = await self._discover_and_register(
+            {
+                "name": "maintenance",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "options": {
+                            "type": "object",
+                            "properties": {
+                                "verbosity": {"type": "string", "enum": ["low", "high"]},
+                                "label": {"type": "string"},
+                            },
+                        }
+                    },
+                },
+            }
+        )
+        assert result == ["maintenance"]
+        assert "maintenance" in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denied_tool_leaves_registry_untouched_with_earlier_allowed(
+        self,
+    ):
+        """A denied descriptor anywhere in the discovered list must not leave
+        an earlier, already-processed tool registered: the whole descriptor
+        list is validated before any registry mutation."""
+        manager = ActionManager()
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+
+            allowed_tool = Mock()
+            allowed_tool.name = "run_tests"
+            allowed_tool.description = "Runs the project test suite"
+            allowed_tool.inputSchema = {
+                "type": "object",
+                "properties": {
+                    "suite": {"type": "string", "enum": ["unit", "integration"]},
+                },
+            }
+
+            denied_tool = Mock()
+            denied_tool.name = "bash"
+            denied_tool.description = None
+            denied_tool.inputSchema = {
+                "type": "object",
+                "properties": {"script": {"type": "string"}},
+            }
+
+            mock_client.list_tools = AsyncMock(return_value=[allowed_tool, denied_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+
+            with pytest.raises(PermissionError):
+                await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+
+        assert "run_tests" not in manager.registry
+        assert "bash" not in manager.registry
+        assert len(manager.registry) == 0
+
 
 class TestLoadMCPToolsFunction:
     @pytest.mark.asyncio

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -251,6 +251,178 @@ class TestActionManagerMCPMethodStubs:
             assert result["test_server"] == ["tool1", "tool2"]
 
 
+class TestActionManagerMCPAdmission:
+    """Registration-boundary coverage for the generic-executor admission rule:
+    discovered descriptors, the metadata-free `tool_names=` shortcut, raw MCP
+    config dicts, and prebuilt `Tool` objects must all be checked before a
+    tool enters the registry."""
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_discovered_shell_executor(self):
+        manager = ActionManager()
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = "bash"
+            mock_tool.description = None
+            mock_tool.inputSchema = {
+                "type": "object",
+                "properties": {"script": {"type": "string"}},
+            }
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+
+            with pytest.raises(PermissionError):
+                await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+
+        assert "bash" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_admits_structured_run_tests(self):
+        manager = ActionManager()
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = "run_tests"
+            mock_tool.description = "Runs the project test suite"
+            mock_tool.inputSchema = {
+                "type": "object",
+                "properties": {
+                    "suite": {"type": "string", "enum": ["unit", "integration"]},
+                    "test_path": {"type": "string"},
+                    "markers": {"type": "array", "items": {"type": "string"}},
+                    "coverage": {"type": "boolean"},
+                },
+            }
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+
+            result = await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+
+        assert result == ["run_tests"]
+        assert "run_tests" in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denial_error_is_actionable(self):
+        manager = ActionManager()
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = "spawn_process"
+            mock_tool.description = None
+            mock_tool.inputSchema = {
+                "type": "object",
+                "properties": {
+                    "program": {"type": "string"},
+                    "argv": {"type": "array", "items": {"type": "string"}},
+                },
+            }
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+
+            with pytest.raises(PermissionError) as exc_info:
+                await manager.register_mcp_server({"command": "python"})
+
+        message = str(exc_info.value)
+        assert "spawn_process" in message
+        assert "opt-out" in message
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_tool_names_denies_executor_name(self):
+        manager = ActionManager()
+
+        with pytest.raises(PermissionError):
+            await manager.register_mcp_server(
+                {"command": "python", "args": ["-m", "srv"]},
+                tool_names=["run_command"],
+            )
+
+        assert "run_command" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_tool_names_admits_non_executor_name(self):
+        manager = ActionManager()
+
+        result = await manager.register_mcp_server(
+            {"command": "python", "args": ["-m", "srv"]},
+            tool_names=["run_tests"],
+        )
+
+        assert result == ["run_tests"]
+        assert "run_tests" in manager.registry
+
+    def test_register_tool_denies_raw_dict_shell_executor(self):
+        manager = ActionManager()
+        mcp_config = {"run_command": {"command": "python", "args": ["-m", "test_server"]}}
+
+        with pytest.raises(PermissionError):
+            manager.register_tool(mcp_config)
+
+        assert "run_command" not in manager.registry
+
+    @pytest.mark.parametrize("tool_name", ["exec", "bash"])
+    def test_register_tool_denies_prebuilt_tool_shell_executor(self, tool_name):
+        """A directly constructed `Tool` gets an auto-generated `**kwargs`
+        wrapper schema with no real remote metadata; that synthetic schema
+        must not launder a strong executor identity past admission."""
+        manager = ActionManager()
+        tool = Tool(mcp_config={tool_name: {"command": "python"}})
+
+        with pytest.raises(PermissionError) as exc_info:
+            manager.register_tool(tool)
+
+        assert tool_name in str(exc_info.value)
+        assert tool_name not in manager.registry
+
+    def test_register_tool_admits_prebuilt_tool_with_rich_bounded_descriptor(self):
+        """A prebuilt `Tool` carrying a genuine, bounded remote descriptor
+        (not the synthetic wrapper shape) remains admitted."""
+        manager = ActionManager()
+        tool = Tool(
+            mcp_config={"exec": {"command": "python"}},
+            tool_schema={
+                "type": "function",
+                "function": {
+                    "name": "exec",
+                    "description": "Restart or check status of a managed process",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "operation": {
+                                "type": "string",
+                                "enum": ["status", "restart"],
+                            }
+                        },
+                    },
+                },
+            },
+        )
+
+        manager.register_tool(tool)
+
+        assert "exec" in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_tool_names_admits_ordinary_name_containing_strong_phrase(
+        self,
+    ):
+        """`tool_names=["format_run_command"]` must not be falsely denied by
+        the auto-generated wrapper's docstring ('MCP tool: format_run_command')
+        colliding with the 'run command' description phrase."""
+        manager = ActionManager()
+
+        result = await manager.register_mcp_server(
+            {"command": "python", "args": ["-m", "srv"]},
+            tool_names=["format_run_command"],
+        )
+
+        assert result == ["format_run_command"]
+        assert "format_run_command" in manager.registry
+
+
 class TestLoadMCPToolsFunction:
     @pytest.mark.asyncio
     async def test_load_mcp_tools_no_servers_error(self):

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -331,6 +331,33 @@ class TestActionManagerMCPAdmission:
         assert "opt-out" in message
 
     @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_min_prefixed_unknown_keyword_channel(self):
+        """A min*-spelled unknown vocabulary key hiding a subschema must fail
+        closed at the live registration boundary, not slip past as a
+        scalar-only numeric bound."""
+        manager = ActionManager()
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_client = AsyncMock()
+            mock_tool = Mock()
+            mock_tool.name = "exec"
+            mock_tool.description = None
+            mock_tool.inputSchema = {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "minCustomVocabulary": {"properties": {"command": {"type": "string"}}},
+            }
+            mock_client.list_tools = AsyncMock(return_value=[mock_tool])
+            mock_pool.get_client = AsyncMock(return_value=mock_client)
+
+            with pytest.raises(PermissionError):
+                await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+
+        assert "exec" not in manager.registry
+
+    @pytest.mark.asyncio
     async def test_register_mcp_server_tool_names_denies_executor_name(self):
         manager = ActionManager()
 

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -617,6 +617,146 @@ class TestActionManagerMCPAdmission:
         assert "bash" not in manager.registry
         assert len(manager.registry) == 0
 
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_if_then_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "if": {"properties": {"mode": {"const": "advanced"}}},
+                    "then": {"properties": {"command": {"type": "string"}}},
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_array_items_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "cmds": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"command": {"type": "string"}},
+                            },
+                        }
+                    },
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_prefix_items_command_channel(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "cmds": {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "type": "object",
+                                    "properties": {"command": {"type": "string"}},
+                                }
+                            ],
+                        }
+                    },
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_object_valued_additional_properties_map(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    },
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_executable_path_under_strong_name(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "exec",
+                "description": None,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"type": "string", "enum": ["run"]},
+                        "executable_path": {"type": "string"},
+                    },
+                },
+            }
+        )
+        assert "exec" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_non_mapping_pattern_properties(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "patternProperties": ["not-a-mapping"],
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_denies_invalid_pattern_regex(self):
+        manager = await self._discover_and_expect_denial(
+            {
+                "name": "maintenance",
+                "description": "runs shell commands",
+                "inputSchema": {
+                    "type": "object",
+                    "patternProperties": {"(": {"type": "string"}},
+                },
+            }
+        )
+        assert "maintenance" not in manager.registry
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_tool_names_mixed_list_leaves_registry_untouched(self):
+        """The metadata-free `tool_names=` shortcut must be atomic on its own
+        input path too: a denied name anywhere in the list must not leave an
+        earlier, already-processed name registered."""
+        manager = ActionManager()
+
+        with pytest.raises(PermissionError):
+            await manager.register_mcp_server(
+                {"command": "python", "args": ["-m", "srv"]},
+                tool_names=["run_tests", "bash"],
+            )
+
+        assert "run_tests" not in manager.registry
+        assert "bash" not in manager.registry
+        assert len(manager.registry) == 0
+
 
 class TestLoadMCPToolsFunction:
     @pytest.mark.asyncio

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -7,9 +7,22 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 import pytest
 from jsonschema import Draft202012Validator
 
+# Private sufficiency-proof internals -- imported directly so the
+# registry-generated regression matrix below can assert the STRUCTURAL
+# coverage claim in isolation, independent of the (separately tested)
+# key-name walker layer. `_schema_is_insufficient` is the same function
+# `validate_mcp_tool_admission` calls; testing it directly avoids a
+# confound where the walker's own command-key detection would raise a
+# DENY for a reason unrelated to the sufficiency proof's own coverage.
 from lionagi.service.connections.mcp_wrapper import (
+    _BOUNDING_KEYWORDS,
+    _DENIED_APPLICATOR_KEYWORDS,
+    _INERT_ANNOTATION_KEYWORDS,
+    _MODELED_APPLICATOR_KEYWORDS,
     MCPConnectionPool,
     MCPSecurityConfig,
+    _classify_keyword,
+    _schema_is_insufficient,
     create_mcp_tool,
     validate_mcp_tool_admission,
 )
@@ -1447,6 +1460,74 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="unevaluatedproperties-nested-in-property-value-denies",
         ),
+        # --- Array-applicator over-block: `items`/`prefixItems` are DENIED
+        # applicators -- their mere presence denies regardless of what their
+        # own subschema contains, including a fully bounded one. These three
+        # schemas are provably safe on their own (see the oracle
+        # differentials in `ARRAY_APPLICATOR_OVER_BLOCK_CASES` below, which
+        # confirm the validator itself still bounds them): a caller cannot
+        # inject a free-form value through any of them. The denial is a
+        # deliberate, accepted over-block, not evidence the schema is
+        # unsafe -- recovering admission for a bounded array position is a
+        # separate, individually-argued delta with its own oracle-soundness
+        # argument, not folded into this change. A nested array bounded by
+        # `enum`/`const` items at every level. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
+                    },
+                },
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-array-bounded-by-enum-items-denies-under-array-applicator-rule",
+        ),
+        # A closed tuple (`prefixItems` all enum/const-bounded AND
+        # `items: false`, so no elements beyond the prefix are permitted at
+        # all) denies too -- `prefixItems` is a denied applicator regardless
+        # of the closing `items: false` sitting alongside it.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
+                        "items": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="closed-tuple-prefixitems-bounded-denies-under-array-applicator-rule",
+        ),
+        # `items` alone (bounded, no `prefixItems`) denies too -- every
+        # position being governed by the same enum-restricted schema does
+        # not matter; `items`' mere presence is what denies.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
+                },
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="items-enum-with-no-prefixitems-denies-under-array-applicator-rule",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1765,25 +1846,6 @@ class TestValidateMcpToolAdmission:
             None,
             id="strong-name-spawn-process-root-ref-to-bounded-closed-schema",
         ),
-        # --- Anti-over-block: a nested array bounded by enum/const
-        # items at every level must remain admitted -- only a nested array
-        # that itself REACHES a free-form string is denied. ---
-        pytest.param(
-            "exec",
-            {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {
-                        "type": "array",
-                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
-                    },
-                },
-                "additionalProperties": False,
-            },
-            None,
-            id="nested-array-bounded-by-enum-items-remains-admitted",
-        ),
         # --- Anti-over-block: `anyOf` where EVERY alternative is
         # independently closed-bounded must still admit -- the union check
         # only denies when at least one alternative is unbounded. ---
@@ -1807,42 +1869,6 @@ class TestValidateMcpToolAdmission:
             },
             None,
             id="anyof-with-every-alternative-closed-bounded-remains-admitted",
-        ),
-        # --- Anti-over-block: a closed tuple (`prefixItems` all
-        # enum/const-bounded AND `items: false`, so no elements beyond the
-        # prefix are permitted at all) must remain admitted. ---
-        pytest.param(
-            "exec",
-            {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {
-                        "type": "array",
-                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
-                        "items": False,
-                    },
-                },
-                "additionalProperties": False,
-            },
-            None,
-            id="closed-tuple-prefixitems-bounded-with-items-false-remains-admitted",
-        ),
-        # --- Anti-over-block: `items` alone (bounded, no
-        # `prefixItems`) must remain admitted -- every position is governed
-        # by the same enum-restricted schema. ---
-        pytest.param(
-            "exec",
-            {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
-                },
-                "additionalProperties": False,
-            },
-            None,
-            id="items-enum-with-no-prefixitems-remains-admitted",
         ),
         # --- Anti-over-block: the exact open-object shape that
         # must now DENY (see "open-object-with-only-bounded-properties-is-
@@ -1917,15 +1943,19 @@ class TestValidateMcpToolAdmission:
             None,
             id="nested-closed-object-property-value-remains-admitted",
         ),
-        # --- LOAD-BEARING anti-over-block: the recursion must NOT fold
-        # value-boundedness into the structural gate. A scalar free-form
-        # identifier property (`service_id`) alongside a fixed operation is
-        # NOT a key channel -- it carries no object/applicator keyword and
-        # is not `type: object` -- so `_property_value_is_key_channel`
-        # excludes it from the recursion entirely; the walker's
+        # --- LOAD-BEARING anti-over-block: the object-boundedness proof's
+        # recursion must NOT fold value-boundedness into the structural
+        # gate. A scalar free-form identifier property (`service_id`)
+        # alongside a fixed operation carries no object/applicator keyword
+        # and is not `type: object` -- so
+        # `_property_value_may_be_object_shaped` excludes it from the
+        # boundedness recursion entirely, and the registry-driven
+        # structural-coverage traversal finds nothing but bounding
+        # keywords (`type`) on its own value; the walker's
         # identifier-suffix exemption alone governs it, exactly as before
-        # this fix. If the recursion were to also apply to scalar leaf
-        # values, this case would flip to a false DENY. ---
+        # this fix. If either proof recursed into scalar leaf values as if
+        # they needed object-closedness, this case would flip to a false
+        # DENY. ---
         pytest.param(
             "exec",
             {
@@ -2156,6 +2186,92 @@ class TestValidateMcpToolAdmission:
         assert validator.is_valid(
             {"operation": "status", "options": {"mode": "a", "command": "rm -rf /"}}
         )
+
+    # --- Array-applicator over-block: `items`/`prefixItems` are DENIED
+    # applicators under the sufficiency proof's keyword registry -- their
+    # mere presence denies a node regardless of what their own subschema
+    # contains, including a subschema that is itself fully bounded
+    # (`enum`/`const`-restricted items, or a closed tuple via `prefixItems`
+    # + `items: false`). Unlike the other named necessity cases above
+    # (F1-F6), the oracle differential here goes the OTHER way: the raw
+    # validator does NOT accept an injected command through any of these
+    # schemas -- they were already closed on their own -- so denying them is
+    # a deliberate, accepted over-block, not a missed bypass. Behavior-
+    # visible consequence: a strong-executor-named tool that declares a
+    # bounded array argument (e.g. `args: {"type": "array", "items":
+    # {"enum": [...]}}`) alongside a fixed operation, and that was
+    # previously admitted, now refuses registration. Recovering admission
+    # for a bounded array position is a separate, individually-argued delta
+    # with its own oracle-soundness argument -- not part of this change; a
+    # bounded schema wrongly denied is a support cost, an unbounded schema
+    # admitted is a security defect, so ties break to deny.
+    ARRAY_APPLICATOR_OVER_BLOCK_DENY_CASES = [
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
+                    },
+                },
+                "additionalProperties": False,
+            },
+            {"operation": "status"},
+            id="nested-array-bounded-by-enum-items",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
+                        "items": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            {"operation": "status"},
+            id="closed-tuple-prefixitems-bounded-with-items-false",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
+                },
+                "additionalProperties": False,
+            },
+            {"operation": "status"},
+            id="items-enum-with-no-prefixitems",
+        ),
+    ]
+
+    @pytest.mark.parametrize("schema, minimal_instance", ARRAY_APPLICATOR_OVER_BLOCK_DENY_CASES)
+    def test_array_applicator_over_block_denies_despite_oracle_confirming_schema_is_bounded(
+        self, schema, minimal_instance
+    ):
+        """`items`/`prefixItems` deny at sight under the sufficiency proof's
+        keyword registry even when their own subschema is fully bounded.
+        The inverted oracle differential proves this is an over-block, not
+        a bypass: the raw validator accepts the minimal, honest instance,
+        and rejects both a bare command string and a command riding
+        alongside the fixed operation -- the schema was never actually
+        unsafe on its own."""
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid(minimal_instance)
+        assert not validator.is_valid("rm -rf /")
+        assert not validator.is_valid({**minimal_instance, "command": "rm -rf /"})
 
     SYNTHETIC_UNKNOWN_KEYWORD_DENY_CASES = [
         pytest.param(
@@ -2467,22 +2583,6 @@ class TestValidateMcpToolAdmission:
         pytest.param(
             "exec",
             {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {
-                        "type": "array",
-                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
-                    },
-                },
-                "additionalProperties": False,
-            },
-            {},
-            id="nested-array-bounded-by-enum-items-remains-admitted",
-        ),
-        pytest.param(
-            "exec",
-            {
                 "anyOf": [
                     {
                         "type": "object",
@@ -2500,36 +2600,6 @@ class TestValidateMcpToolAdmission:
             },
             {"operation": "status"},
             id="anyof-with-every-alternative-closed-bounded-remains-admitted",
-        ),
-        pytest.param(
-            "exec",
-            {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {
-                        "type": "array",
-                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
-                        "items": False,
-                    },
-                },
-                "additionalProperties": False,
-            },
-            {},
-            id="closed-tuple-prefixitems-bounded-with-items-false-remains-admitted",
-        ),
-        pytest.param(
-            "exec",
-            {
-                "type": "object",
-                "properties": {
-                    "operation": {"const": "status"},
-                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
-                },
-                "additionalProperties": False,
-            },
-            {},
-            id="items-enum-with-no-prefixitems-remains-admitted",
         ),
         pytest.param(
             "exec",
@@ -2707,3 +2777,420 @@ class TestValidateMcpToolAdmission:
         }
 
         assert validate_mcp_tool_admission("search_config", huge_schema, None) is None
+
+
+class TestSufficiencyProofKeywordRegistry:
+    """Registry-GENERATED regression matrix for the total structural-
+    coverage traversal (`_structural_coverage_insufficient`, invoked
+    through `_schema_is_insufficient`).
+
+    Every case below is parametrized by ITERATING THE REGISTRY FROZENSETS
+    directly (`_MODELED_APPLICATOR_KEYWORDS`, `_DENIED_APPLICATOR_KEYWORDS`)
+    -- never a hand-listed keyword table. This is the anti-hand-enumeration
+    mechanism the design requires: enumerating "which keywords need a test"
+    by hand is the exact defect class (enumerate positions/keywords one at a
+    time, miss the next one) the registry-driven proof exists to close. A
+    keyword added to either frozenset later gains matrix coverage here
+    automatically, with no test-file edit required.
+
+    Tests exercise `_schema_is_insufficient` directly (rather than the full
+    `validate_mcp_tool_admission` pipeline) so the assertions are about the
+    sufficiency proof's own coverage, isolated from the separately-tested
+    key-name walker (which would otherwise sometimes deny for an unrelated
+    reason -- e.g. a literal `command` key -- and mask what this matrix is
+    actually proving)."""
+
+    # ---- schema-construction helpers ----------------------------------
+
+    # Object-shaped (not a bare scalar): a composition applicator
+    # (`allOf`/`anyOf`/`oneOf`/`$ref`) can resolve to ANY instance type, and
+    # the object-boundedness proof's own gate for recursing into a property
+    # value (`_property_value_may_be_object_shaped`) triggers on the
+    # PRESENCE of a modeled-applicator keyword, not on what it resolves to
+    # -- so a composition wrapping a bare scalar would independently fail
+    # the (orthogonal, unchanged) object-boundedness type-gate, which is
+    # not what this matrix is testing. An object-shaped benign leaf keeps
+    # object-boundedness satisfied at every wrapper while still exercising
+    # structural-coverage's recursion through each modeled applicator.
+    BENIGN_LEAF = {
+        "type": "object",
+        "properties": {"x": {"const": 1}},
+        "additionalProperties": False,
+    }
+    # Carries a DENIED-applicator keyword (`not`) -- any value works, since
+    # a denied applicator's mere PRESENCE denies, regardless of content.
+    DENIED_LEAF = {"not": {"type": "null"}}
+    # A keyword the registry has never seen, Mapping-valued (schema-bearing
+    # in shape) -- must be denied as UNKNOWN, not silently admitted.
+    UNKNOWN_LEAF = {"quorumProperties": {"minMembers": 2}}
+    # Same synthetic keyword, but with a scalar value: cannot itself carry
+    # a subschema, so it is the one tolerated UNKNOWN residual.
+    UNKNOWN_LEAF_SCALAR_VALUE = 3
+
+    @staticmethod
+    def _nest_property(inner, depth):
+        """Wrap `inner` `depth - 1` levels deep inside closed nested-object
+        property values (`{"nested": ...}`), so the recursion under test is
+        exercised at nesting depths 1 (direct), 2, and 3."""
+        node = inner
+        for _ in range(depth - 1):
+            node = {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"nested": node},
+            }
+        return node
+
+    @staticmethod
+    def _root_with_target(target_value):
+        """A closed, bounded root object with a fixed `operation` and one
+        additional declared property (`target`) holding the position under
+        test."""
+        return {
+            "type": "object",
+            "required": ["operation"],
+            "additionalProperties": False,
+            "properties": {"operation": {"const": "status"}, "target": target_value},
+        }
+
+    @staticmethod
+    def _inject_at_depth(depth):
+        """A `command`-shaped injection payload buried `depth` levels deep
+        under the SAME `{"nested": ...}` chain `_nest_property` builds --
+        for the oracle differential proving an ADMIT verdict is not a
+        security hole."""
+        node = {"command": "rm -rf /"}
+        for _ in range(depth - 1):
+            node = {"nested": node}
+        return node
+
+    @classmethod
+    def _build_modeled(cls, keyword, payload):
+        """A minimal schema in which `keyword` (a MODELED applicator) is
+        the applicator the sufficiency proof must recurse THROUGH to reach
+        `payload`."""
+        if keyword == "properties":
+            return {
+                "type": "object",
+                "properties": {"inner": payload},
+                "additionalProperties": False,
+            }
+        if keyword == "additionalProperties":
+            # `additionalProperties` recursion is only reachable through a
+            # Mapping value. Give the merged value an `enum` so the
+            # (unrelated) object-boundedness closedness check for this
+            # node doesn't independently deny regardless of payload --
+            # this matrix is about structural-coverage recursion, not
+            # closedness, and the two proofs are deliberately orthogonal.
+            merged = {"enum": ["x"], **payload}
+            return {
+                "type": "object",
+                "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                "additionalProperties": merged,
+            }
+        if keyword == "allOf":
+            return {"allOf": [payload]}
+        if keyword in ("anyOf", "oneOf"):
+            # UNION semantics: pair with one other independently-bounded
+            # branch so a benign payload's admit isn't accidental.
+            bounded_branch = {
+                "type": "object",
+                "properties": {"x": {"const": 1}},
+                "additionalProperties": False,
+            }
+            return {keyword: [payload, bounded_branch]}
+        raise AssertionError(f"unhandled modeled keyword in test helper: {keyword!r}")
+
+    @classmethod
+    def _build_schema(cls, keyword, payload, depth):
+        """Build the FULL schema under test for the MODELED-applicator
+        matrix. `$ref`/`$defs`/`definitions` need special handling here: a
+        JSON Pointer `$ref` always resolves against the schema's DOCUMENT
+        ROOT (`_resolve_local_ref` is called with the true root passed to
+        `_schema_is_insufficient`, never with whichever local node the
+        `$ref` happens to sit inside) -- so their `$defs`/`definitions`
+        companion must live at the true root, not nested inside the
+        `target` property alongside the `$ref` itself, or resolution fails
+        closed regardless of payload. Every other modeled keyword is
+        self-contained and uses the generic `properties`-nested wrapper."""
+        if keyword in ("$ref", "$defs", "definitions"):
+            defs_key = "$defs" if keyword != "definitions" else "definitions"
+            schema = cls._root_with_target({"$ref": f"#/{defs_key}/Target"})
+            schema[defs_key] = {"Target": cls._nest_property(payload, depth)}
+            return schema
+        return cls._root_with_target(
+            cls._nest_property(cls._build_modeled(keyword, payload), depth)
+        )
+
+    @staticmethod
+    def _keyword_only_schema(keyword):
+        """A minimal schema carrying `keyword` (a DENIED applicator or a
+        synthetic unknown keyword) with an arbitrary Mapping value -- the
+        keyword's mere presence is what the assertion is about, not its
+        content."""
+        return {keyword: {"type": "null"}}
+
+    # ---- (1) every MODELED applicator: benign payload admits ----------
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    @pytest.mark.parametrize("keyword", sorted(_MODELED_APPLICATOR_KEYWORDS))
+    def test_modeled_applicator_benign_payload_admits(self, keyword, depth):
+        schema = self._build_schema(keyword, self.BENIGN_LEAF, depth)
+        assert not _schema_is_insufficient(schema)
+
+        # Oracle differential: the admitted schema must still reject an
+        # injected command-shaped instance buried at the matching depth.
+        validator = Draft202012Validator(schema)
+        instance = {"operation": "status", "target": self._inject_at_depth(depth)}
+        assert not validator.is_valid(instance)
+
+    # ---- (1) every MODELED applicator: denied/unknown payload denies --
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    @pytest.mark.parametrize("bad_payload_name", ["denied", "unknown"])
+    @pytest.mark.parametrize("keyword", sorted(_MODELED_APPLICATOR_KEYWORDS))
+    def test_modeled_applicator_bad_payload_denies(self, keyword, bad_payload_name, depth):
+        bad_payload = self.DENIED_LEAF if bad_payload_name == "denied" else self.UNKNOWN_LEAF
+        schema = self._build_schema(keyword, bad_payload, depth)
+        assert _schema_is_insufficient(schema)
+
+    # ---- (2) every DENIED applicator: denies at every subschema position ---
+
+    @staticmethod
+    def _denied_at_property_value(keyword, depth):
+        return TestSufficiencyProofKeywordRegistry._root_with_target(
+            TestSufficiencyProofKeywordRegistry._nest_property(
+                TestSufficiencyProofKeywordRegistry._keyword_only_schema(keyword), depth
+            )
+        )
+
+    @staticmethod
+    def _denied_at_additional_properties(keyword):
+        return {
+            "type": "object",
+            "properties": {"operation": {"const": "status"}},
+            "additionalProperties": TestSufficiencyProofKeywordRegistry._keyword_only_schema(
+                keyword
+            ),
+        }
+
+    @staticmethod
+    def _denied_at_composition_branch(keyword):
+        return {
+            "type": "object",
+            "allOf": [TestSufficiencyProofKeywordRegistry._keyword_only_schema(keyword)],
+        }
+
+    @staticmethod
+    def _denied_at_ref_target(keyword):
+        return {
+            "$ref": "#/$defs/Target",
+            "$defs": {"Target": TestSufficiencyProofKeywordRegistry._keyword_only_schema(keyword)},
+        }
+
+    @staticmethod
+    def _denied_at_defs_entry_unreferenced(keyword):
+        return {
+            "type": "object",
+            "required": ["operation"],
+            "additionalProperties": False,
+            "properties": {"operation": {"const": "status"}},
+            "$defs": {"Unused": TestSufficiencyProofKeywordRegistry._keyword_only_schema(keyword)},
+        }
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    @pytest.mark.parametrize("keyword", sorted(_DENIED_APPLICATOR_KEYWORDS))
+    def test_denied_applicator_denies_at_property_value(self, keyword, depth):
+        assert _schema_is_insufficient(self._denied_at_property_value(keyword, depth))
+
+    @pytest.mark.parametrize("keyword", sorted(_DENIED_APPLICATOR_KEYWORDS))
+    def test_denied_applicator_denies_at_additional_properties(self, keyword):
+        assert _schema_is_insufficient(self._denied_at_additional_properties(keyword))
+
+    @pytest.mark.parametrize("keyword", sorted(_DENIED_APPLICATOR_KEYWORDS))
+    def test_denied_applicator_denies_at_composition_branch(self, keyword):
+        assert _schema_is_insufficient(self._denied_at_composition_branch(keyword))
+
+    @pytest.mark.parametrize("keyword", sorted(_DENIED_APPLICATOR_KEYWORDS))
+    def test_denied_applicator_denies_at_ref_target(self, keyword):
+        assert _schema_is_insufficient(self._denied_at_ref_target(keyword))
+
+    @pytest.mark.parametrize("keyword", sorted(_DENIED_APPLICATOR_KEYWORDS))
+    def test_denied_applicator_denies_at_unreferenced_defs_entry(self, keyword):
+        """`$defs` entries are visited UNCONDITIONALLY, not reachability-
+        gated -- an entry never reached by any `$ref` in the document must
+        still deny when it carries a denied applicator."""
+        assert _schema_is_insufficient(self._denied_at_defs_entry_unreferenced(keyword))
+
+    def test_denied_applicator_property_value_necessity_oracle_differential(self):
+        """Documents necessity for a representative denied applicator
+        (`patternProperties`, the F1/F4 case already covered by name
+        elsewhere): the identical schema validates against a raw
+        Draft2020-12 validator and ACCEPTS the injected key, proving the
+        schema was never actually closed."""
+        schema = self._denied_at_property_value("patternProperties", depth=2)
+        assert _schema_is_insufficient(schema)
+        # `patternProperties` here has no fixed key pattern matching a real
+        # instance key, so the necessity differential uses the sibling
+        # keyword form directly to keep the injected instance constructible.
+        raw = {
+            "type": "object",
+            "required": ["operation"],
+            "additionalProperties": False,
+            "properties": {
+                "operation": {"const": "status"},
+                "target": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "nested": {
+                            "type": "object",
+                            "patternProperties": {"^injected$": {"type": "string"}},
+                        }
+                    },
+                },
+            },
+        }
+        validator = Draft202012Validator(raw)
+        assert validator.is_valid(
+            {"operation": "status", "target": {"nested": {"injected": "rm -rf /"}}}
+        )
+
+    # ---- (3) synthetic never-registered keyword at every position -----
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_synthetic_unknown_keyword_mapping_value_denies_at_property_value(self, depth):
+        schema = self._root_with_target(self._nest_property(self.UNKNOWN_LEAF, depth))
+        assert _schema_is_insufficient(schema)
+
+    def test_synthetic_unknown_keyword_mapping_value_denies_at_additional_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {"operation": {"const": "status"}},
+            "additionalProperties": {"enum": ["x"], **self.UNKNOWN_LEAF},
+        }
+        assert _schema_is_insufficient(schema)
+
+    def test_synthetic_unknown_keyword_mapping_value_denies_at_composition_branch(self):
+        schema = {"type": "object", "allOf": [self.UNKNOWN_LEAF]}
+        assert _schema_is_insufficient(schema)
+
+    def test_synthetic_unknown_keyword_mapping_value_denies_at_ref_target(self):
+        schema = {"$ref": "#/$defs/Target", "$defs": {"Target": self.UNKNOWN_LEAF}}
+        assert _schema_is_insufficient(schema)
+
+    def test_synthetic_unknown_keyword_mapping_value_denies_at_unreferenced_defs_entry(self):
+        schema = {
+            "type": "object",
+            "required": ["operation"],
+            "additionalProperties": False,
+            "properties": {"operation": {"const": "status"}},
+            "$defs": {"Unused": self.UNKNOWN_LEAF},
+        }
+        assert _schema_is_insufficient(schema)
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_synthetic_unknown_keyword_scalar_value_control_admits_at_property_value(self, depth):
+        """Control: the SAME never-registered keyword spelling with a
+        provably-inert SCALAR value stays admitted at every depth -- the
+        gate keys off VALUE SHAPE, not keyword spelling."""
+        node = self._nest_property({"quorumProperties": 3}, depth)
+        schema = self._root_with_target(node)
+        assert not _schema_is_insufficient(schema)
+
+    # ---- registry completeness/partition proof -------------------------
+
+    def test_registry_partitions_with_no_keyword_in_two_classes(self):
+        classes = (
+            _INERT_ANNOTATION_KEYWORDS,
+            _BOUNDING_KEYWORDS,
+            _MODELED_APPLICATOR_KEYWORDS,
+            _DENIED_APPLICATOR_KEYWORDS,
+        )
+        seen: set[str] = set()
+        overlaps: set[str] = set()
+        for keyword_set in classes:
+            overlaps |= seen & keyword_set
+            seen |= keyword_set
+        assert not overlaps, f"keyword(s) classified in more than one registry class: {overlaps}"
+
+    def test_registry_covers_representative_draft202012_keyword_list(self):
+        """A representative Draft 2020-12 core-vocabulary keyword list must
+        be fully covered by the union of the four registry classes -- no
+        keyword this module is expected to understand falls through to the
+        UNKNOWN default silently."""
+        representative_keywords = {
+            "type",
+            "const",
+            "enum",
+            "required",
+            "dependentRequired",
+            "multipleOf",
+            "maximum",
+            "exclusiveMaximum",
+            "minimum",
+            "exclusiveMinimum",
+            "maxLength",
+            "minLength",
+            "maxItems",
+            "minItems",
+            "uniqueItems",
+            "maxContains",
+            "minContains",
+            "maxProperties",
+            "minProperties",
+            "properties",
+            "patternProperties",
+            "additionalProperties",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+            "propertyNames",
+            "dependentSchemas",
+            "allOf",
+            "anyOf",
+            "oneOf",
+            "not",
+            "if",
+            "then",
+            "else",
+            "items",
+            "prefixItems",
+            "contains",
+            "$ref",
+            "$dynamicRef",
+            "$recursiveRef",
+            "$dynamicAnchor",
+            "$recursiveAnchor",
+            "$defs",
+            "definitions",
+            "$schema",
+            "$id",
+            "$anchor",
+            "$vocabulary",
+            "$comment",
+            "title",
+            "description",
+            "default",
+            "examples",
+            "deprecated",
+            "readOnly",
+            "writeOnly",
+            "format",
+            "pattern",
+            "contentEncoding",
+            "contentMediaType",
+            "contentSchema",
+        }
+        covered = (
+            _INERT_ANNOTATION_KEYWORDS
+            | _BOUNDING_KEYWORDS
+            | _MODELED_APPLICATOR_KEYWORDS
+            | _DENIED_APPLICATOR_KEYWORDS
+        )
+        missing = representative_keywords - covered
+        assert not missing, f"registry does not classify: {sorted(missing)}"
+        for keyword in representative_keywords:
+            assert _classify_keyword(keyword) != "unknown"
+
+    def test_classify_keyword_defaults_unknown_for_unregistered_name(self):
+        assert _classify_keyword("this-spelling-was-never-registered") == "unknown"

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -1291,6 +1291,162 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="omitted-type-closed-object-denied-by-type-gate",
         ),
+        # --- Sufficiency-proof property-value recursion: the OUTER object
+        # being closed (`additionalProperties: False`) says nothing about a
+        # DECLARED property's own value -- a nested object-shaped property
+        # value that is itself open, or carries an unmodeled applicator, is a
+        # hidden key channel the proof must independently re-check. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "required": ["operation"],
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "patternProperties": {"^command_custom$": {"type": "string"}},
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-patternproperties-custom-key-property-value-denies",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {"type": "object"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-open-object-property-value-denies",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {"$ref": "#/$defs/Open"},
+                },
+                "$defs": {"Open": {"type": "object"}},
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-ref-to-open-object-property-value-denies",
+        ),
+        # --- A synthetic never-modeled applicator keyword
+        # (`quorumProperties`-style, mapping-valued) nested one level deep
+        # inside a closed property value's own schema must still deny -- the
+        # property-value recursion re-runs the FULL sufficiency proof
+        # (including its own allowlist gate) on the nested node, not merely
+        # its type/closedness reasoning. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                        "additionalProperties": False,
+                        "quorumProperties": {"minMembers": 2},
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-unmodeled-applicator-keyword-in-property-value-denies",
+        ),
+        # --- The recursive structural scan reaches known-but-denied
+        # applicators at DEPTH -- not only directly inside the first-level
+        # property value. `patternProperties` here sits inside a property
+        # value that is itself the value of another property (depth 2 from
+        # the root), so only a recursion that re-applies itself at every
+        # nested key channel -- not a single extra check bolted onto depth
+        # 1 -- catches it. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "required": ["operation"],
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "suboptions": {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "patternProperties": {"^command_custom$": {"type": "string"}},
+                            }
+                        },
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="depth-2-nested-patternproperties-custom-key-denies",
+        ),
+        # --- `dependentSchemas` is a walker-known-to-be-unmodeled applicator
+        # (it is not in the walker's own keyword whitelist either): nested
+        # inside a property value with no closing `additionalProperties`,
+        # the object remains genuinely open, and `dependentSchemas` adds a
+        # conditional branch on top without narrowing it. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string"}},
+                        "dependentSchemas": {"mode": {"type": "object"}},
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="dependentschemas-nested-in-property-value-denies",
+        ),
+        # --- `unevaluatedProperties` nested inside a property value: an
+        # explicit `unevaluatedProperties: true` alongside no
+        # `additionalProperties` leaves every property not otherwise
+        # evaluated open, exactly like the implicit-open default -- the
+        # recursion must still deny it. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string"}},
+                        "unevaluatedProperties": True,
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="unevaluatedproperties-nested-in-property-value-denies",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1739,6 +1895,77 @@ class TestValidateMcpToolAdmission:
             None,
             id="root-enum-pins-instance-without-type",
         ),
+        # --- Sufficiency-proof property-value recursion: a nested object
+        # property value that is itself provably CLOSED (own `properties` +
+        # `additionalProperties: False`, every member bounded) must remain
+        # admitted -- the recursion denies only an unbounded/unmodeled
+        # nested channel, never a genuinely closed one. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                        "additionalProperties": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            None,
+            id="nested-closed-object-property-value-remains-admitted",
+        ),
+        # --- LOAD-BEARING anti-over-block: the recursion must NOT fold
+        # value-boundedness into the structural gate. A scalar free-form
+        # identifier property (`service_id`) alongside a fixed operation is
+        # NOT a key channel -- it carries no object/applicator keyword and
+        # is not `type: object` -- so `_property_value_is_key_channel`
+        # excludes it from the recursion entirely; the walker's
+        # identifier-suffix exemption alone governs it, exactly as before
+        # this fix. If the recursion were to also apply to scalar leaf
+        # values, this case would flip to a false DENY. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "service_id": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            None,
+            id="scalar-identifier-property-value-not-recursed-remains-admitted",
+        ),
+        # --- `contentSchema` MAJOR fix: a mapping-valued Content-vocabulary
+        # annotation on an otherwise-bounded, closed schema must not be
+        # treated as an unmodeled schema-bearing keyword. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+                "contentSchema": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                },
+            },
+            None,
+            id="content-schema-annotation-on-bounded-schema-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+            },
+            None,
+            id="content-schema-annotation-removed-still-remains-admitted",
+        ),
     ]
 
     @pytest.mark.parametrize("tool_name, input_schema, description, reason", DENY_CASES)
@@ -1831,6 +2058,105 @@ class TestValidateMcpToolAdmission:
         validator = Draft202012Validator(schema)
         assert not validator.is_valid({"operation": "status", "command": "rm -rf /"})
 
+    def test_f4_depth_2_nested_patternproperties_denies(self):
+        """The CRITICAL bypass at depth 2: `patternProperties` sits inside
+        a property value that is itself the value of another property
+        (`options.suboptions`, two levels below the root), keyed on a
+        pattern the walker's fixed categorized-key list never matches. Only
+        a recursion that re-applies the FULL sufficiency proof at every
+        nested key channel -- not a single depth-1 check -- reaches it.
+        Documents necessity: the identical schema validates against a raw
+        JSON Schema validator and ACCEPTS the injected key at that depth."""
+        schema = {
+            "type": "object",
+            "required": ["operation"],
+            "additionalProperties": False,
+            "properties": {
+                "operation": {"const": "status"},
+                "options": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "suboptions": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "patternProperties": {"^command_custom$": {"type": "string"}},
+                        }
+                    },
+                },
+            },
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid(
+            {"operation": "status", "options": {"suboptions": {"command_custom": "rm -rf /"}}}
+        )
+
+    def test_f5_dependentschemas_nested_in_property_value_denies(self):
+        """`dependentSchemas` nested inside a property value, with no
+        closing `additionalProperties` at that level, leaves the nested
+        object genuinely open -- the conditional branch it adds narrows
+        nothing. Documents necessity: the identical schema validates
+        against a raw JSON Schema validator and ACCEPTS an injected
+        `command` key riding alongside the `dependentSchemas` trigger."""
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "operation": {"const": "status"},
+                "options": {
+                    "type": "object",
+                    "properties": {"mode": {"type": "string"}},
+                    "dependentSchemas": {"mode": {"type": "object"}},
+                },
+            },
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid(
+            {"operation": "status", "options": {"mode": "a", "command": "rm -rf /"}}
+        )
+
+    def test_f6_unevaluatedproperties_nested_in_property_value_denies(self):
+        """`unevaluatedProperties: true` nested inside a property value is
+        an explicit-open declaration, functionally identical to the
+        implicit-open default for anything the object's own `properties`
+        does not cover. Documents necessity: the identical schema validates
+        against a raw JSON Schema validator and ACCEPTS an injected
+        `command` key at that nesting level."""
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "operation": {"const": "status"},
+                "options": {
+                    "type": "object",
+                    "properties": {"mode": {"type": "string"}},
+                    "unevaluatedProperties": True,
+                },
+            },
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid(
+            {"operation": "status", "options": {"mode": "a", "command": "rm -rf /"}}
+        )
+
     SYNTHETIC_UNKNOWN_KEYWORD_DENY_CASES = [
         pytest.param(
             {
@@ -1904,6 +2230,28 @@ class TestValidateMcpToolAdmission:
             },
             id="inside-anyof-branch",
         ),
+        pytest.param(
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "suboptions": {
+                                "type": "object",
+                                "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                                "additionalProperties": False,
+                                "quorumProperties": {"minMembers": 2},
+                            }
+                        },
+                    },
+                },
+            },
+            id="nested-in-property-value-depth-2",
+        ),
     ]
 
     @pytest.mark.parametrize("input_schema", SYNTHETIC_UNKNOWN_KEYWORD_DENY_CASES)
@@ -1911,12 +2259,16 @@ class TestValidateMcpToolAdmission:
         """`quorumProperties` is a spelling the classifier has never
         modeled (deliberately NOT a vendor `x-`/`$comment` prefix, which
         would be exempt) and its value is schema-bearing (a mapping) at
-        every one of the five positions parametrized here (top-level
-        root; nested inside a property value; inside an `allOf` branch;
-        as a `$ref` sibling; inside an `anyOf` branch). The union of the
+        every one of the six positions parametrized here (top-level root;
+        nested inside a property value at depth 1; inside an `allOf`
+        branch; as a `$ref` sibling; inside an `anyOf` branch; nested
+        inside a property value at depth 2, i.e. the value of a property
+        that is itself the value of another property). The union of the
         walker (property-value interiors) and the sufficiency proof's
-        allowlist gate (root, `allOf`/`anyOf` branches, `$ref` siblings)
-        must deny it regardless of WHERE in the shape skeleton it
+        allowlist gate (root, `allOf`/`anyOf` branches, `$ref` siblings,
+        and -- after the property-value recursion -- every nested key
+        channel at any depth) must deny it regardless of WHERE in the
+        shape skeleton it
         appears, proving the invariant holds independent of keyword
         spelling or position."""
         with pytest.raises(PermissionError) as exc_info:
@@ -2217,6 +2569,37 @@ class TestValidateMcpToolAdmission:
             {"enum": [{"operation": "status"}]},
             {"operation": "status"},
             id="root-enum-pins-instance-without-type",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "options": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                        "additionalProperties": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            {"operation": "status"},
+            id="nested-closed-object-property-value-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+                "contentSchema": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                },
+            },
+            {"operation": "status"},
+            id="content-schema-annotation-on-bounded-schema-remains-admitted",
         ),
     ]
 

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -3194,3 +3194,96 @@ class TestSufficiencyProofKeywordRegistry:
 
     def test_classify_keyword_defaults_unknown_for_unregistered_name(self):
         assert _classify_keyword("this-spelling-was-never-registered") == "unknown"
+
+    def test_classify_keyword_exact_class_per_registered_keyword(self):
+        """A literal keyword -> expected-class mapping for the full union of
+        all four registry sets, checked one keyword at a time against
+        `_classify_keyword`. Stronger than the partition/coverage tests
+        above: those prove no keyword is double-classified or silently
+        unknown, but neither pins any SPECIFIC keyword to a SPECIFIC class --
+        a keyword could be moved between the two non-applicator classes
+        (inert annotation <-> bounding assertion) without either test
+        noticing. This dict is a literal, so any future reclassification is
+        a conscious, reviewed edit to this test, never a silent pass-through."""
+        expected_class = {
+            # inert annotation -- carries no assertion
+            "title": "inert",
+            "description": "inert",
+            "default": "inert",
+            "examples": "inert",
+            "deprecated": "inert",
+            "readOnly": "inert",
+            "writeOnly": "inert",
+            "$comment": "inert",
+            "$schema": "inert",
+            "$id": "inert",
+            "$anchor": "inert",
+            "$vocabulary": "inert",
+            "format": "inert",
+            "contentEncoding": "inert",
+            "contentMediaType": "inert",
+            "contentSchema": "inert",
+            # bounding -- narrows the admitted set, no recursable subschema
+            "type": "bounding",
+            "const": "bounding",
+            "enum": "bounding",
+            "required": "bounding",
+            "dependentRequired": "bounding",
+            "multipleOf": "bounding",
+            "maximum": "bounding",
+            "exclusiveMaximum": "bounding",
+            "minimum": "bounding",
+            "exclusiveMinimum": "bounding",
+            "maxLength": "bounding",
+            "minLength": "bounding",
+            "pattern": "bounding",
+            "maxItems": "bounding",
+            "minItems": "bounding",
+            "uniqueItems": "bounding",
+            "maxContains": "bounding",
+            "minContains": "bounding",
+            "maxProperties": "bounding",
+            "minProperties": "bounding",
+            # modeled applicator -- recursed into and credited
+            "properties": "modeled",
+            "additionalProperties": "modeled",
+            "allOf": "modeled",
+            "anyOf": "modeled",
+            "oneOf": "modeled",
+            "$ref": "modeled",
+            "$defs": "modeled",
+            "definitions": "modeled",
+            # denied applicator -- presence alone denies
+            "patternProperties": "denied",
+            "propertyNames": "denied",
+            "unevaluatedProperties": "denied",
+            "unevaluatedItems": "denied",
+            "dependentSchemas": "denied",
+            "if": "denied",
+            "then": "denied",
+            "else": "denied",
+            "not": "denied",
+            "contains": "denied",
+            "items": "denied",
+            "prefixItems": "denied",
+            "$dynamicRef": "denied",
+            "$dynamicAnchor": "denied",
+            "$recursiveRef": "denied",
+            "$recursiveAnchor": "denied",
+        }
+        all_registered = (
+            _INERT_ANNOTATION_KEYWORDS
+            | _BOUNDING_KEYWORDS
+            | _MODELED_APPLICATOR_KEYWORDS
+            | _DENIED_APPLICATOR_KEYWORDS
+        )
+        assert set(expected_class) == all_registered, (
+            "expected-class mapping in this test is out of sync with the "
+            "registry's own union -- update the mapping alongside any "
+            "registry change"
+        )
+        for keyword, expected in expected_class.items():
+            actual = _classify_keyword(keyword)
+            assert actual == expected, (
+                f"{keyword!r} classified as {actual!r}, expected {expected!r}"
+            )

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -976,6 +976,98 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="array-items-local-ref-reaches-string-is-free-form-argv-channel",
         ),
+        # --- Nested-array items: an array item is not "non-string, therefore
+        # bounded" on its own -- the walker must recurse into ITS OWN
+        # items/prefixItems, or a caller can smuggle a free-form argv
+        # channel one array level deeper (`args: [["sh", "-c", ...]]`). ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-array-items-reaches-free-form-string-is-argv-channel",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "prefixItems": [{"type": "string"}],
+                        },
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-prefixitems-reaches-free-form-string-is-argv-channel",
+        ),
+        # --- Union-composition sufficiency: `_schema_is_insufficient` must judge `anyOf`/`oneOf`
+        # as UNIONS -- every branch must independently prove bounded, or a
+        # caller can register under the least-bounded alternative. ---
+        pytest.param(
+            "exec",
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                    {"type": "object"},
+                ]
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="anyof-with-fully-open-object-alternative-is-insufficient",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                    {},
+                ]
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="anyof-with-empty-schema-alternative-is-insufficient",
+        ),
+        # --- Vendor-annotation exemption must be VALUE-based,
+        # not just key-based -- an `x-*` extension whose value embeds real
+        # schema vocabulary is a hidden channel, not inert metadata. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "x-input-schema": {"properties": {"command": {"type": "string"}}},
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="schema-bearing-vendor-extension-is-not-exempted",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1234,6 +1326,48 @@ class TestValidateMcpToolAdmission:
             },
             None,
             id="strong-name-spawn-process-root-ref-to-bounded-closed-schema",
+        ),
+        # --- Anti-over-block: a nested array bounded by enum/const
+        # items at every level must remain admitted -- only a nested array
+        # that itself REACHES a free-form string is denied. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
+                    },
+                },
+            },
+            None,
+            id="nested-array-bounded-by-enum-items-remains-admitted",
+        ),
+        # --- Anti-over-block: `anyOf` where EVERY alternative is
+        # independently closed-bounded must still admit -- the union check
+        # only denies when at least one alternative is unbounded. ---
+        pytest.param(
+            "exec",
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "restart"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                ]
+            },
+            None,
+            id="anyof-with-every-alternative-closed-bounded-remains-admitted",
         ),
     ]
 

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -631,7 +631,7 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="external-ref-fails-closed-for-strong-name",
         ),
-        # --- Round-2 evasions: conditional/array/object-map command channels ---
+        # Conditional/array/object-map command channels must fail closed.
         pytest.param(
             "maintenance",
             {
@@ -694,7 +694,7 @@ class TestValidateMcpToolAdmission:
             "unbounded-command-input",
             id="object-valued-additionalproperties-map-command-channel",
         ),
-        # --- Round-2: identifier-suffix exemption must not launder exec targets ---
+        # Identifier-suffix exemption must not launder exec targets.
         pytest.param(
             "exec",
             {
@@ -760,7 +760,7 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="program-path-not-exempted-under-strong-name",
         ),
-        # --- Round-2: malformed patternProperties must fail closed, not open ---
+        # Malformed patternProperties must fail closed, not open.
         pytest.param(
             "maintenance",
             {"type": "object", "patternProperties": ["not-a-mapping"]},
@@ -775,7 +775,7 @@ class TestValidateMcpToolAdmission:
             "executor-description-with-broad-input",
             id="invalid-pattern-regex-fails-closed",
         ),
-        # --- Round-2: unresolvable node-work budget denies fast for
+        # Unresolvable node-work budget denies fast for
         # executor-signaling descriptors with harmless-looking wide fan-out. ---
         pytest.param(
             "maintenance",
@@ -1068,6 +1068,133 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="schema-bearing-vendor-extension-is-not-exempted",
         ),
+        # --- A missing `items` keyword defaults to `true` in
+        # Draft 2020-12 -- an entirely unconstrained "rest of the array" --
+        # and every `prefixItems` member must itself be checked, not just
+        # whatever `items` says. An inner `{"type": "array"}` item with no
+        # `items`/`prefixItems` of its own is free-form one level deeper,
+        # not "non-string and therefore bounded". ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {"type": "array"}},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-array-item-with-no-items-defaults-open",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "prefixItems": [{"enum": ["fixed"]}],
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="prefixitems-only-array-with-no-items-rest-is-open",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"enum": ["fixed"]},
+                        "prefixItems": [{"type": "string"}],
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="bounded-items-does-not-launder-an-unbounded-prefixitems-member",
+        ),
+        # --- A strong-executor-name schema with non-empty
+        # `properties` is only actually bounded when the object is CLOSED
+        # (`additionalProperties: False`, or an additionalProperties schema
+        # itself restricted to a finite enum/const) -- JSON Schema's
+        # implicit-open default otherwise still admits an undeclared
+        # "command"-shaped key riding alongside a perfectly bounded
+        # `operation`. ---
+        pytest.param(
+            "exec",
+            {"type": "object", "properties": {"operation": {"const": "status"}}},
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="open-object-with-only-bounded-properties-is-still-insufficient",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": ["object", "string"],
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="root-type-union-with-free-form-string-alternative-is-insufficient",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "allOf": [
+                    {"type": "object", "properties": {"operation": {"const": "status"}}},
+                    {"type": "object"},
+                ]
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="allof-open-object-branch-does-not-narrow-to-sufficient",
+        ),
+        # --- `$ref` SIBLINGS are evaluated in Draft 2020-12, not
+        # discarded -- a free-form property declared alongside a `$ref` must
+        # still be walked and caught, even though the ref target itself is
+        # (partially) bounded. ---
+        pytest.param(
+            "exec",
+            {
+                "$ref": "#/$defs/open",
+                "properties": {"command": {"type": "string"}},
+                "$defs": {
+                    "open": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                    }
+                },
+            },
+            None,
+            "unbounded-command-input",
+            id="ref-sibling-command-property-is-not-discarded",
+        ),
+        # --- The unknown-keyword whitelist's could-carry-a-
+        # subschema test must recurse through nested lists (a list of lists
+        # of mappings), not just one level -- otherwise wrapping a hidden
+        # command channel in extra list nesting under an unrecognized
+        # keyword bypasses deny-by-default entirely. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "future-extension": [[{"properties": {"command": {"type": "string"}}}]],
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="nested-list-of-list-of-mapping-unknown-keyword-is-unresolvable",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1138,6 +1265,14 @@ class TestValidateMcpToolAdmission:
             {
                 "type": "object",
                 "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
+                # `additionalProperties: False` is required for the strong-name
+                # sufficiency gate to treat this object as closed:
+                # an object schema whose `properties` are all bounded is only
+                # actually bounded if the object cannot also carry an
+                # undeclared key (JSON Schema's implicit-open default would
+                # otherwise still admit an arbitrary extra "command"-shaped
+                # property alongside "operation").
+                "additionalProperties": False,
             },
             None,
             id="strong-name-with-rich-bounded-schema-overrides-heuristic",
@@ -1167,6 +1302,11 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "service_id": {"type": "string"},
                 },
+                # See "strong-name-with-rich-bounded-schema-overrides-heuristic"
+                # above: closedness is required for the strong-name
+                # sufficiency gate; this test's own concern (the identifier-
+                # suffix exemption for "service_id") is orthogonal.
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-service-id",
@@ -1179,6 +1319,7 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "resource_path": {"type": "string"},
                 },
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-resource-path",
@@ -1191,6 +1332,7 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "request_id": {"type": "string"},
                 },
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-request-id",
@@ -1226,7 +1368,7 @@ class TestValidateMcpToolAdmission:
             None,
             id="nested-config-object-without-command-like-fields",
         ),
-        # --- Round-2: benign identifier-suffix fields remain admitted. ---
+        # Benign identifier-suffix fields remain admitted.
         pytest.param(
             "exec",
             {
@@ -1235,6 +1377,7 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "tenant_uuid": {"type": "string"},
                 },
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-tenant-uuid",
@@ -1247,6 +1390,7 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "callback_url": {"type": "string"},
                 },
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-callback-url",
@@ -1259,11 +1403,12 @@ class TestValidateMcpToolAdmission:
                     "operation": {"type": "string", "enum": ["status", "restart"]},
                     "page_slug": {"type": "string"},
                 },
+                "additionalProperties": False,
             },
             None,
             id="strong-name-fixed-operation-with-dynamic-page-slug",
         ),
-        # --- Round-1 regression: array-of-strings free-form leaf channel
+        # Regression: array-of-strings free-form leaf channel
         # (argv) must still be caught even though the walker now also
         # recurses into `items` for hidden object-shaped command channels. ---
         pytest.param(
@@ -1307,6 +1452,7 @@ class TestValidateMcpToolAdmission:
                 "type": "object",
                 "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
                 "x-ui": {"widget": "select", "order": 1},
+                "additionalProperties": False,
             },
             None,
             id="strong-name-bounded-schema-with-vendor-extension-annotation",
@@ -1341,6 +1487,7 @@ class TestValidateMcpToolAdmission:
                         "items": {"type": "array", "items": {"enum": ["a", "b"]}},
                     },
                 },
+                "additionalProperties": False,
             },
             None,
             id="nested-array-bounded-by-enum-items-remains-admitted",
@@ -1368,6 +1515,77 @@ class TestValidateMcpToolAdmission:
             },
             None,
             id="anyof-with-every-alternative-closed-bounded-remains-admitted",
+        ),
+        # --- Anti-over-block: a closed tuple (`prefixItems` all
+        # enum/const-bounded AND `items: false`, so no elements beyond the
+        # prefix are permitted at all) must remain admitted. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
+                        "items": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            None,
+            id="closed-tuple-prefixitems-bounded-with-items-false-remains-admitted",
+        ),
+        # --- Anti-over-block: `items` alone (bounded, no
+        # `prefixItems`) must remain admitted -- every position is governed
+        # by the same enum-restricted schema. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
+                },
+                "additionalProperties": False,
+            },
+            None,
+            id="items-enum-with-no-prefixitems-remains-admitted",
+        ),
+        # --- Anti-over-block: the exact open-object shape that
+        # must now DENY (see "open-object-with-only-bounded-properties-is-
+        # still-insufficient" in DENY_CASES), but with an explicit
+        # `additionalProperties: False` closing it, must still ADMIT. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+            },
+            None,
+            id="closed-object-with-only-bounded-properties-remains-admitted",
+        ),
+        # --- Anti-over-block: a `$ref` whose only siblings are
+        # pure annotations (`description`) must still admit -- annotation
+        # siblings constrain nothing and must not be treated as reopening an
+        # otherwise-closed reference target. ---
+        pytest.param(
+            "exec",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "description": "Restart or check status of a managed process",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            None,
+            id="ref-with-only-annotation-siblings-remains-admitted",
         ),
     ]
 

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -542,6 +542,95 @@ class TestValidateMcpToolAdmission:
             "unbounded-command-input",
             id="nullable-object-top-level-type-array-still-inspected",
         ),
+        # --- Descriptor-indirection evasion shapes (traversal coverage) ---
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "options": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    }
+                },
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="nested-object-property-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "anyOf": [
+                    {"properties": {"target": {"type": "string", "enum": ["a", "b"]}}},
+                    {"properties": {"command": {"type": "string"}}},
+                ],
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="anyof-branch-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {"config": {"$ref": "#/$defs/CommandConfig"}},
+                "$defs": {
+                    "CommandConfig": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    }
+                },
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="local-ref-resolves-to-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="freeform-additionalproperties-channel-with-executor-description",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "patternProperties": {"^command$": {"type": "string"}},
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="patternproperties-command-channel",
+        ),
+        pytest.param(
+            "exec",
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="strong-name-freeform-additionalproperties-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {"config": {"$ref": "https://example.com/schemas/x.json"}},
+            },
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="external-ref-fails-closed-for-executor-description",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"config": {"$ref": "https://example.com/schemas/x.json"}},
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="external-ref-fails-closed-for-strong-name",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -631,6 +720,75 @@ class TestValidateMcpToolAdmission:
             None,
             id="nullable-object-type-array-with-harmless-property-still-admitted",
         ),
+        # --- False-positive fix: strong name + fixed operation + dynamic
+        # identifier/path/request-id fields is not executor-shaped. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "service_id": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-service-id",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "resource_path": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-resource-path",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "request_id": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-request-id",
+        ),
+        # --- Traversal coverage: harmless nested/composed schemas remain
+        # admitted (no command-like free-form channel reachable). ---
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "anyOf": [
+                    {"properties": {"mode": {"type": "string", "enum": ["fast", "slow"]}}},
+                    {"properties": {"level": {"type": "string", "enum": ["low", "high"]}}},
+                ],
+            },
+            None,
+            id="anyof-of-two-bounded-shapes",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "options": {
+                        "type": "object",
+                        "properties": {
+                            "verbosity": {"type": "string", "enum": ["low", "high"]},
+                            "label": {"type": "string"},
+                        },
+                    }
+                },
+            },
+            None,
+            id="nested-config-object-without-command-like-fields",
+        ),
     ]
 
     @pytest.mark.parametrize("tool_name, input_schema, description, reason", DENY_CASES)
@@ -646,3 +804,34 @@ class TestValidateMcpToolAdmission:
     @pytest.mark.parametrize("tool_name, input_schema, description", ADMIT_CASES)
     def test_admits_ordinary_or_bounded_tool(self, tool_name, input_schema, description):
         assert validate_mcp_tool_admission(tool_name, input_schema, description) is None
+
+    def test_nested_channel_denial_does_not_echo_schema_or_description_content(self):
+        """Traversal reaches deep into nested/composed schemas to find the
+        command channel, but the denial message must still carry only the
+        tool name and stable reason code -- never schema values, the
+        offending key path, or the description text."""
+        sentinel_command_value_marker = "sentinel-should-never-appear-CmdSecretXYZ"
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission(
+                "maintenance",
+                {
+                    "type": "object",
+                    "properties": {
+                        "options": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "string",
+                                    "default": sentinel_command_value_marker,
+                                }
+                            },
+                        }
+                    },
+                },
+                f"runs shell commands with {sentinel_command_value_marker}",
+            )
+
+        message = str(exc_info.value)
+        assert sentinel_command_value_marker not in message
+        assert "maintenance" in message
+        assert "unbounded-command-input" in message

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -865,6 +865,117 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="unknown-subschema-keyword-on-property-is-unresolvable",
         ),
+        # --- $dynamicRef / $recursiveRef are schema-bearing REFERENCE
+        # keywords whose value is a plain string, not a Mapping -- they must
+        # be recognized by keyword identity (not the generic value-type
+        # test) and treated as unresolvable, so a command channel reachable
+        # only behind one is not silently admitted. ---
+        pytest.param(
+            "exec",
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {"options": {"$dynamicRef": "#command_object"}},
+                "$defs": {
+                    "command_object": {
+                        "$dynamicAnchor": "command_object",
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    }
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="dynamic-ref-string-valued-reference-is-unresolvable",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {"options": {"$recursiveRef": "#"}},
+            },
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="recursive-ref-string-valued-reference-is-unresolvable",
+        ),
+        # --- Array-leaf free-form detection must be a recursive,
+        # key-preserving predicate over `items`/`prefixItems`: `true`, `{}`
+        # (an empty/unconstrained item schema), item-level `anyOf` reaching
+        # a string, and a `prefixItems` member of `true` are all just as
+        # free-form as `items: {"type": "string"}`. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": True},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="array-items-boolean-true-is-free-form-argv-channel",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {}},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="array-items-empty-schema-is-free-form-argv-channel",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"anyOf": [{"type": "string"}]},
+                    },
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="array-items-anyof-reaches-string-is-free-form-argv-channel",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "argv": {"type": "array", "prefixItems": [True]},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="prefixitems-boolean-true-member-is-free-form-argv-channel",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/StringArg"},
+                    },
+                },
+                "$defs": {"StringArg": {"type": "string"}},
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="array-items-local-ref-reaches-string-is-free-form-argv-channel",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1074,6 +1185,55 @@ class TestValidateMcpToolAdmission:
             },
             None,
             id="array-of-strings-leaf-remains-benign-when-not-corroborated",
+        ),
+        # --- False-positive fix: a bounded, closed schema expressed via a
+        # top-level local `$ref` is not "schema-less" -- the sufficiency
+        # gate must resolve it (as the walker itself already does) instead
+        # of demanding the caller-provided root carry `properties` directly.
+        pytest.param(
+            "exec",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            None,
+            id="strong-name-root-ref-to-bounded-closed-schema",
+        ),
+        # --- False-positive fix: a vendor-extension/annotation keyword
+        # (`x-ui`) on an otherwise bounded schema is metadata, not an
+        # applicator, and must not trip the unknown-subschema-bearing check.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
+                "x-ui": {"widget": "select", "order": 1},
+            },
+            None,
+            id="strong-name-bounded-schema-with-vendor-extension-annotation",
+        ),
+        pytest.param(
+            "spawn_process",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            None,
+            id="strong-name-spawn-process-root-ref-to-bounded-closed-schema",
         ),
     ]
 

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from lionagi.service.connections.mcp_wrapper import (
     MCPConnectionPool,
@@ -1255,6 +1256,41 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="annotation-scalar-list-exceeding-node-budget-fails-closed",
         ),
+        # --- Sufficiency-proof allowlist gate: a `patternProperties`
+        # entry whose PATTERN does not match any of the walker's fixed
+        # categorized key names (so the walker never even considers the
+        # pattern's own subschema) is a caller-chosen-key command channel
+        # the walker's key-name classifier structurally cannot see. The
+        # sufficiency proof's allowlist gate denies it directly: a
+        # `patternProperties` value is a mapping (schema-bearing) and the
+        # keyword itself is not in the proof's modeled-keyword set. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "patternProperties": {"^command_custom$": {"type": "string"}},
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="patternproperties-non-categorized-key-denied-by-sufficiency-gate",
+        ),
+        # --- Sufficiency-proof type-gate: an object descriptor that omits
+        # `type` entirely (a common hand-authored shape:
+        # `properties`+`additionalProperties: false` with no explicit
+        # `type`) never actually constrains the instance to an object --
+        # a caller can submit a bare scalar and never reach the
+        # `properties`/`additionalProperties` keywords at all. ---
+        pytest.param(
+            "exec",
+            {
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="omitted-type-closed-object-denied-by-type-gate",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1687,6 +1723,22 @@ class TestValidateMcpToolAdmission:
             None,
             id="ref-with-only-annotation-siblings-remains-admitted",
         ),
+        # --- Type-gate literal-pin path: a top-level `const`/`enum`
+        # pins the whole instance to author-declared literal value(s), so
+        # it satisfies the type-gate on its own -- the caller cannot
+        # inject beyond the enumerated set even with no `type` present. ---
+        pytest.param(
+            "exec",
+            {"const": {"operation": "status"}},
+            None,
+            id="root-const-pins-instance-without-type",
+        ),
+        pytest.param(
+            "exec",
+            {"enum": [{"operation": "status"}]},
+            None,
+            id="root-enum-pins-instance-without-type",
+        ),
     ]
 
     @pytest.mark.parametrize("tool_name, input_schema, description, reason", DENY_CASES)
@@ -1702,6 +1754,508 @@ class TestValidateMcpToolAdmission:
     @pytest.mark.parametrize("tool_name, input_schema, description", ADMIT_CASES)
     def test_admits_ordinary_or_bounded_tool(self, tool_name, input_schema, description):
         assert validate_mcp_tool_admission(tool_name, input_schema, description) is None
+
+    def test_f1_patternproperties_custom_key_denies(self):
+        """`patternProperties` keyed on a pattern the walker's fixed
+        categorized-key list never matches is a caller-chosen-key command
+        channel: `_consider_property` (the walker's command-detection path)
+        is only reached for a pattern that matches one of the fixed
+        `_CATEGORIZED_KEYS`, so a pattern like `^command_custom$` (never
+        equal to the literal key "command") slips past the walker
+        entirely. The sufficiency proof's allowlist gate denies it
+        directly instead: `patternProperties` is not a modeled keyword and
+        its value is a mapping. Documents necessity: the identical schema
+        validates against a raw JSON Schema validator and ACCEPTS the
+        injected key, proving the schema itself was never actually
+        closed."""
+        schema = {
+            "type": "object",
+            "patternProperties": {"^command_custom$": {"type": "string"}},
+            "additionalProperties": False,
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid({"command_custom": "rm -rf /"})
+
+    def test_f2_omitted_type_denies(self):
+        """An object descriptor with no `type` keyword never actually
+        constrains the instance shape -- `properties`/`additionalProperties`
+        are only evaluated against object instances, so a bare scalar
+        satisfies the schema untouched, bypassing every object-shaped
+        constraint. Documents necessity: the identical schema validates a
+        malicious bare string."""
+        schema = {
+            "properties": {"operation": {"const": "status"}},
+            "additionalProperties": False,
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert validator.is_valid("rm -rf /")
+
+    def test_f3_unevaluated_properties_false_denies_in_core(self):
+        """`unevaluatedProperties: false` is a legitimate Draft-2020-12
+        closing mechanism -- the raw validator below REJECTS the injected
+        `command` key -- but the sufficiency proof does not model
+        `unevaluatedProperties` as a closing keyword: only
+        `additionalProperties: false` (or an enum/const-restricted
+        `additionalProperties`) closes an object here. This is an
+        ACCEPTED over-block (a real bounded schema authored with
+        `unevaluatedProperties` instead of `additionalProperties` is
+        denied today). A strictly-additive recovery rule -- treat
+        `unevaluatedProperties: false` as closing iff the node carries no
+        `patternProperties`/`allOf`/`anyOf`/`oneOf`/`$ref`/`if` -- is a
+        documented follow-up that must never relax the core allowlist;
+        deferred until the support cost of this over-block proves real."""
+        schema = {
+            "type": "object",
+            "properties": {"operation": {"const": "status"}},
+            "required": ["operation"],
+            "unevaluatedProperties": False,
+        }
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", schema, None)
+        message = str(exc_info.value)
+        assert "exec" in message
+        assert "executor-identity-with-insufficient-schema" in message
+
+        validator = Draft202012Validator(schema)
+        assert not validator.is_valid({"operation": "status", "command": "rm -rf /"})
+
+    SYNTHETIC_UNKNOWN_KEYWORD_DENY_CASES = [
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+                "quorumProperties": {"minMembers": 2},
+            },
+            id="top-level-root",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "opts": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string", "enum": ["a", "b"]}},
+                        "additionalProperties": False,
+                        "quorumProperties": {"minMembers": 2},
+                    }
+                },
+                "additionalProperties": False,
+            },
+            id="nested-in-property-value",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "additionalProperties": False,
+                        "quorumProperties": {"minMembers": 2},
+                    }
+                ],
+            },
+            id="inside-allof-branch",
+        ),
+        pytest.param(
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "quorumProperties": {"minMembers": 2},
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            id="ref-sibling",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "additionalProperties": False,
+                        "quorumProperties": {"minMembers": 2},
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "restart"}},
+                        "additionalProperties": False,
+                    },
+                ],
+            },
+            id="inside-anyof-branch",
+        ),
+    ]
+
+    @pytest.mark.parametrize("input_schema", SYNTHETIC_UNKNOWN_KEYWORD_DENY_CASES)
+    def test_synthetic_unknown_keyword_denies_at_every_position(self, input_schema):
+        """`quorumProperties` is a spelling the classifier has never
+        modeled (deliberately NOT a vendor `x-`/`$comment` prefix, which
+        would be exempt) and its value is schema-bearing (a mapping) at
+        every one of the five positions parametrized here (top-level
+        root; nested inside a property value; inside an `allOf` branch;
+        as a `$ref` sibling; inside an `anyOf` branch). The union of the
+        walker (property-value interiors) and the sufficiency proof's
+        allowlist gate (root, `allOf`/`anyOf` branches, `$ref` siblings)
+        must deny it regardless of WHERE in the shape skeleton it
+        appears, proving the invariant holds independent of keyword
+        spelling or position."""
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("exec", input_schema, None)
+        assert "executor-identity-with-insufficient-schema" in str(exc_info.value)
+
+    def test_synthetic_unknown_keyword_with_inert_scalar_value_remains_admitted(self):
+        """Control for the case above: the SAME unmodeled keyword spelling
+        with a provably-inert SCALAR value (not a mapping/list-of-mapping)
+        on an otherwise-closed schema must still admit -- the gate keys
+        off VALUE SHAPE, not keyword spelling, so this does not regress
+        the existing `future-extension`-style admit."""
+        schema = {
+            "type": "object",
+            "properties": {"operation": {"const": "status"}},
+            "required": ["operation"],
+            "additionalProperties": False,
+            "quorumProperties": 3,
+        }
+        assert validate_mcp_tool_admission("exec", schema, None) is None
+
+    # jsonschema-oracle differential harness (§Fork 4): every ADMIT case
+    # whose tool name is a strong executor name compiles to a schema that
+    # must still REJECT a battery of command-injection attempts -- proof,
+    # independent of `validate_mcp_tool_admission` admitting the
+    # descriptor, that the admitted shape is actually closed. Includes the
+    # four §8 applicator-root ADMITs (`$ref`-only-root ×2, `anyOf`-only-
+    # root, `$ref`-with-annotation-siblings) so the binding ordering
+    # correction (applicator delegation before the omitted-type denial)
+    # is caught by test, not just by review.
+    ADMIT_ORACLE_CASES = [
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-with-rich-bounded-schema-overrides-heuristic",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "service_id": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-service-id",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "resource_path": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-resource-path",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "request_id": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-request-id",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "tenant_uuid": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-tenant-uuid",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "callback_url": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-callback-url",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "page_slug": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-fixed-operation-with-dynamic-page-slug",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            {"operation": "status"},
+            id="strong-name-root-ref-to-bounded-closed-schema",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
+                "x-ui": {"widget": "select", "order": 1},
+                "additionalProperties": False,
+            },
+            {},
+            id="strong-name-bounded-schema-with-vendor-extension-annotation",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 10,
+                        "multipleOf": 2,
+                    },
+                },
+                "required": ["operation"],
+                "additionalProperties": False,
+                "minProperties": 1,
+                "maxProperties": 3,
+            },
+            {"operation": "status"},
+            id="strong-name-standard-numeric-bounds-remain-scalar-only",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "future-extension": [0, 1, 2],
+            },
+            {"operation": "status"},
+            id="strong-name-small-scalar-unknown-keyword-remains-admitted",
+        ),
+        pytest.param(
+            "spawn_process",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            {"operation": "status"},
+            id="strong-name-spawn-process-root-ref-to-bounded-closed-schema",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"enum": ["a", "b"]}},
+                    },
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="nested-array-bounded-by-enum-items-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"operation": {"const": "restart"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    },
+                ]
+            },
+            {"operation": "status"},
+            id="anyof-with-every-alternative-closed-bounded-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {
+                        "type": "array",
+                        "prefixItems": [{"enum": ["a"]}, {"const": "b"}],
+                        "items": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="closed-tuple-prefixitems-bounded-with-items-false-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "args": {"type": "array", "items": {"enum": ["a", "b"]}},
+                },
+                "additionalProperties": False,
+            },
+            {},
+            id="items-enum-with-no-prefixitems-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "additionalProperties": False,
+            },
+            {},
+            id="closed-object-with-only-bounded-properties-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "$ref": "#/$defs/BoundedOperation",
+                "description": "Restart or check status of a managed process",
+                "$defs": {
+                    "BoundedOperation": {
+                        "type": "object",
+                        "properties": {"operation": {"const": "status"}},
+                        "required": ["operation"],
+                        "additionalProperties": False,
+                    }
+                },
+            },
+            {"operation": "status"},
+            id="ref-with-only-annotation-siblings-remains-admitted",
+        ),
+        pytest.param(
+            "exec",
+            {"const": {"operation": "status"}},
+            {"operation": "status"},
+            id="root-const-pins-instance-without-type",
+        ),
+        pytest.param(
+            "exec",
+            {"enum": [{"operation": "status"}]},
+            {"operation": "status"},
+            id="root-enum-pins-instance-without-type",
+        ),
+    ]
+
+    # The four §8 applicator-root ADMITs that a naive "omitted type ==
+    # insufficient" gate placed BEFORE applicator delegation would
+    # false-deny -- must be present in the oracle differential above.
+    _APPLICATOR_ROOT_ORACLE_IDS = frozenset(
+        {
+            "strong-name-root-ref-to-bounded-closed-schema",
+            "strong-name-spawn-process-root-ref-to-bounded-closed-schema",
+            "anyof-with-every-alternative-closed-bounded-remains-admitted",
+            "ref-with-only-annotation-siblings-remains-admitted",
+        }
+    )
+
+    def test_applicator_root_admits_are_covered_by_oracle_differential(self):
+        """Confirms the four §8 applicator-root ADMITs are actually
+        present in `ADMIT_ORACLE_CASES` below -- the exact ordering
+        regression (applicator delegation must run before the
+        omitted-type denial) is caught by test, not just by review."""
+        covered_ids = {case.id for case in self.ADMIT_ORACLE_CASES}
+        assert self._APPLICATOR_ROOT_ORACLE_IDS <= covered_ids
+
+    @pytest.mark.parametrize("tool_name, input_schema, minimal_instance", ADMIT_ORACLE_CASES)
+    def test_admit_schemas_reject_command_injection(
+        self, tool_name, input_schema, minimal_instance
+    ):
+        """jsonschema-oracle differential harness (test-only; the
+        `jsonschema` import lives in this test module only, never on the
+        core admission path). Any ADMIT case whose oracle ACCEPTS a
+        command-injection attempt is a design failure surfaced here as a
+        red test rather than a production incident."""
+        assert validate_mcp_tool_admission(tool_name, input_schema, None) is None
+
+        validator = Draft202012Validator(input_schema)
+        assert not validator.is_valid("rm -rf /")
+        assert not validator.is_valid({**minimal_instance, "command": "rm -rf /"})
+        assert not validator.is_valid({"cmd": "rm -rf /"})
+        assert not validator.is_valid({"command_custom": "rm -rf /"})
 
     def test_nested_channel_denial_does_not_echo_schema_or_description_content(self):
         """Traversal reaches deep into nested/composed schemas to find the

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -10,6 +10,7 @@ from lionagi.service.connections.mcp_wrapper import (
     MCPConnectionPool,
     MCPSecurityConfig,
     create_mcp_tool,
+    validate_mcp_tool_admission,
 )
 
 
@@ -399,3 +400,249 @@ class TestCreateMCPTool:
             result = await tool()
 
             assert result == {"custom": "data"}
+
+
+class TestValidateMcpToolAdmission:
+    """Pure classifier cases: representative tool name / schema / description
+    combinations that must be denied or admitted by the generic-executor
+    admission rule."""
+
+    DENY_CASES = [
+        pytest.param(
+            "run_tests",
+            {"type": "object", "properties": {"command": {"type": "string"}}},
+            None,
+            "unbounded-command-input",
+            id="command-only-field-benign-name",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "cwd": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                },
+            },
+            None,
+            "unbounded-command-input",
+            id="command-field-with-auxiliary-modifiers",
+        ),
+        pytest.param(
+            "spawn_process",
+            {
+                "type": "object",
+                "properties": {
+                    "program": {"type": "string"},
+                    "argv": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            None,
+            "unbounded-process-input",
+            id="program-plus-argv",
+        ),
+        pytest.param(
+            "bash",
+            {"type": "object", "properties": {"script": {"type": "string"}}},
+            None,
+            "unbounded-script-payload",
+            id="strong-name-with-script-payload",
+        ),
+        pytest.param(
+            "maintenance",
+            {"type": "object", "properties": {"input": {"type": "string"}}},
+            "executes arbitrary shell commands",
+            "unbounded-script-payload",
+            id="payload-field-corroborated-by-description",
+        ),
+        pytest.param(
+            "maintenance",
+            {"type": "object", "properties": {"payload": {"type": "string"}}},
+            "run a command",
+            "executor-description-with-broad-input",
+            id="broad-field-corroborated-by-description",
+        ),
+        pytest.param(
+            "run_command",
+            None,
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="strong-name-metadata-free",
+        ),
+        pytest.param(
+            "exec",
+            None,
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="strong-name-explicit-registration-no-descriptor",
+        ),
+        pytest.param(
+            "run-command",
+            None,
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="hyphen-normalizes-to-strong-name",
+        ),
+        pytest.param(
+            "runCommand",
+            None,
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="camel-case-normalizes-to-strong-name",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+            },
+            "Runs a maintenance task",
+            "unbounded-command-input",
+            id="unrelated-extra-field-does-not-neutralize-command-key",
+        ),
+        pytest.param(
+            "exec",
+            {"type": "object", "properties": {"payload": {"type": "string"}}},
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="strong-name-with-uncategorized-free-form-property",
+        ),
+        pytest.param(
+            "run_command",
+            {"type": "object", "properties": {"command": True}},
+            None,
+            "unbounded-command-input",
+            id="boolean-true-schema-accepts-any-value",
+        ),
+        pytest.param(
+            "run_command",
+            {"type": "object", "properties": {"command": {"type": ["string", "null"]}}},
+            None,
+            "unbounded-command-input",
+            id="nullable-type-union-still-accepts-string",
+        ),
+        pytest.param(
+            "maintenance",
+            {"type": "object", "properties": {"payload": {"type": "string"}}},
+            "Runs OS commands supplied by the caller",
+            "executor-description-with-broad-input",
+            id="plural-inflection-of-description-phrase",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": ["object", "null"],
+                "properties": {"command": {"type": "string"}},
+            },
+            None,
+            "unbounded-command-input",
+            id="nullable-object-top-level-type-array-still-inspected",
+        ),
+    ]
+
+    ADMIT_CASES = [
+        pytest.param(
+            "run_tests",
+            {
+                "type": "object",
+                "properties": {
+                    "suite": {"type": "string", "enum": ["unit", "integration"]},
+                    "test_path": {"type": "string"},
+                    "markers": {"type": "array", "items": {"type": "string"}},
+                    "coverage": {"type": "boolean"},
+                },
+            },
+            None,
+            id="structured-run-tests-is-not-a-shell-executor",
+        ),
+        pytest.param(
+            "search",
+            {"type": "object", "properties": {"query": {"type": "string"}}},
+            None,
+            id="ordinary-single-string-search",
+        ),
+        pytest.param(
+            "execute_query",
+            {
+                "type": "object",
+                "properties": {
+                    "database_id": {"type": "string"},
+                    "query": {"type": "string"},
+                },
+            },
+            None,
+            id="execute-query-name-is-not-strong-name",
+        ),
+        pytest.param(
+            "command_status",
+            {"type": "object", "properties": {"job_id": {"type": "string"}}},
+            None,
+            id="command-status-is-observation-not-executor",
+        ),
+        pytest.param(
+            "shellfish_lookup",
+            {"type": "object", "properties": {"query": {"type": "string"}}},
+            None,
+            id="substring-shell-does-not-match",
+        ),
+        pytest.param(
+            "format_command",
+            {
+                "type": "object",
+                "properties": {"parts": {"type": "array", "items": {"type": "string"}}},
+            },
+            "formats a shell command",
+            id="formatter-phrase-is-not-a-description-signal",
+        ),
+        pytest.param(
+            "build_target",
+            {
+                "type": "object",
+                "properties": {"command": {"type": "string", "enum": ["build", "clean", "test"]}},
+            },
+            None,
+            id="enum-bounded-command-field",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"type": "string", "enum": ["status", "restart"]}},
+            },
+            None,
+            id="strong-name-with-rich-bounded-schema-overrides-heuristic",
+        ),
+        pytest.param(
+            "mocked_tool",
+            None,
+            None,
+            id="metadata-free-non-strong-name-compatibility",
+        ),
+        pytest.param(
+            "search",
+            {
+                "type": ["object", "null"],
+                "properties": {"query": {"type": "string"}},
+            },
+            None,
+            id="nullable-object-type-array-with-harmless-property-still-admitted",
+        ),
+    ]
+
+    @pytest.mark.parametrize("tool_name, input_schema, description, reason", DENY_CASES)
+    def test_denies_generic_executor_shape(self, tool_name, input_schema, description, reason):
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission(tool_name, input_schema, description)
+
+        message = str(exc_info.value)
+        assert tool_name in message
+        assert reason in message
+        assert "opt-out" in message
+
+    @pytest.mark.parametrize("tool_name, input_schema, description", ADMIT_CASES)
+    def test_admits_ordinary_or_bounded_tool(self, tool_name, input_schema, description):
+        assert validate_mcp_tool_admission(tool_name, input_schema, description) is None

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -1195,6 +1195,66 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="nested-list-of-list-of-mapping-unknown-keyword-is-unresolvable",
         ),
+        # Scalar-only keyword recognition is an explicit enumeration of the
+        # standardized numeric/size bounds, never a min*/max* spelling
+        # heuristic -- an unknown vocabulary key that merely STARTS with
+        # min/max must still reach the could-carry-subschema check.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "minCustomVocabulary": {"properties": {"command": {"type": "string"}}},
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="min-prefixed-unknown-keyword-hiding-a-subschema-is-unresolvable",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "maxFuture": [[{"properties": {"command": {"type": "string"}}}]],
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="max-prefixed-unknown-keyword-nested-list-is-unresolvable",
+        ),
+        # Unknown-keyword and annotation value inspection consumes the same
+        # node budget as schema traversal and fails closed on exhaustion --
+        # a pathologically wide scalar list cannot force unbounded work and
+        # cannot be admitted unexamined.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "future-extension": [0] * 100_000,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="unknown-keyword-scalar-list-exceeding-node-budget-fails-closed",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "x-huge": [0] * 100_000,
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="annotation-scalar-list-exceeding-node-budget-fails-closed",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -1456,6 +1516,46 @@ class TestValidateMcpToolAdmission:
             },
             None,
             id="strong-name-bounded-schema-with-vendor-extension-annotation",
+        ),
+        # The standardized numeric/size-bound keywords stay recognized as
+        # scalar-only after the explicit enumeration replaced the min*/max*
+        # spelling heuristic -- a bounded executor descriptor using them must
+        # not be denied.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"const": "status"},
+                    "count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 10,
+                        "multipleOf": 2,
+                    },
+                },
+                "required": ["operation"],
+                "additionalProperties": False,
+                "minProperties": 1,
+                "maxProperties": 3,
+            },
+            None,
+            id="strong-name-standard-numeric-bounds-remain-scalar-only",
+        ),
+        # A small unknown-keyword value made purely of scalars carries no
+        # subschema and stays admitted -- the node-budget fail-closed rule
+        # applies to pathological width, not ordinary inert extensions.
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"operation": {"const": "status"}},
+                "required": ["operation"],
+                "additionalProperties": False,
+                "future-extension": [0, 1, 2],
+            },
+            None,
+            id="strong-name-small-scalar-unknown-keyword-remains-admitted",
         ),
         pytest.param(
             "spawn_process",

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -631,6 +631,240 @@ class TestValidateMcpToolAdmission:
             "executor-identity-with-insufficient-schema",
             id="external-ref-fails-closed-for-strong-name",
         ),
+        # --- Round-2 evasions: conditional/array/object-map command channels ---
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "if": {"properties": {"mode": {"const": "advanced"}}},
+                "then": {"properties": {"command": {"type": "string"}}},
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="if-then-branch-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "cmds": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        },
+                    }
+                },
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="array-items-object-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "properties": {
+                    "cmds": {
+                        "type": "array",
+                        "prefixItems": [
+                            {
+                                "type": "object",
+                                "properties": {"command": {"type": "string"}},
+                            }
+                        ],
+                    }
+                },
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="prefix-items-object-command-channel",
+        ),
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                },
+            },
+            "runs shell commands",
+            "unbounded-command-input",
+            id="object-valued-additionalproperties-map-command-channel",
+        ),
+        # --- Round-2: identifier-suffix exemption must not launder exec targets ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["run"]},
+                    "executable_path": {"type": "string"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="executable-path-not-exempted-under-strong-name",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["run"]},
+                    "script_path": {"type": "string"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="script-path-not-exempted-under-strong-name",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["run"]},
+                    "command_path": {"type": "string"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="command-path-not-exempted-under-strong-name",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["run"]},
+                    "binary_path": {"type": "string"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="binary-path-not-exempted-under-strong-name",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["run"]},
+                    "program_path": {"type": "string"},
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="program-path-not-exempted-under-strong-name",
+        ),
+        # --- Round-2: malformed patternProperties must fail closed, not open ---
+        pytest.param(
+            "maintenance",
+            {"type": "object", "patternProperties": ["not-a-mapping"]},
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="non-mapping-pattern-properties-fails-closed",
+        ),
+        pytest.param(
+            "maintenance",
+            {"type": "object", "patternProperties": {"(": {"type": "string"}}},
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="invalid-pattern-regex-fails-closed",
+        ),
+        # --- Round-2: unresolvable node-work budget denies fast for
+        # executor-signaling descriptors with harmless-looking wide fan-out. ---
+        pytest.param(
+            "maintenance",
+            {
+                "type": "object",
+                "anyOf": [
+                    {"properties": {f"field_{i}": {"type": "string", "enum": ["a", "b"]}}}
+                    for i in range(10_000)
+                ],
+            },
+            "runs shell commands",
+            "executor-description-with-broad-input",
+            id="wide-anyof-fanout-exceeds-node-budget",
+        ),
+        # --- Composition on the keyed property itself must not strip the
+        # key association: these wrap a plain free-form string leaf in one
+        # applicator layer (anyOf / if-then / allOf), which constrains the
+        # SAME instance the key names. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {"input": {"anyOf": [{"type": "string"}]}},
+            },
+            None,
+            "unbounded-script-payload",
+            id="anyof-wrapped-free-form-property-still-attributed-to-key",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "if": {"minLength": 1},
+                        "then": {"type": "string"},
+                    }
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="conditional-wrapped-free-form-property-still-attributed-to-key",
+        ),
+        pytest.param(
+            "spawn_process",
+            {
+                "type": "object",
+                "properties": {
+                    "command": {"allOf": [{"type": "string"}]},
+                },
+            },
+            None,
+            "unbounded-command-input",
+            id="allof-wrapped-command-key-is-still-a-command-channel",
+        ),
+        # --- prefixItems tuple validation is an argv-shaped channel exactly
+        # like items-of-strings. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "argv": {
+                        "type": "array",
+                        "prefixItems": [{"type": "string"}],
+                    }
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="prefixitems-array-of-strings-is-a-free-form-leaf",
+        ),
+        # --- The unknown-keyword whitelist applies to leaf-shaped property
+        # schemas too, not only to schema nodes reached via _walk_schema. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "options": {
+                        "type": "object",
+                        "unevaluatedProperties": {"type": "string"},
+                    }
+                },
+            },
+            None,
+            "executor-identity-with-insufficient-schema",
+            id="unknown-subschema-keyword-on-property-is-unresolvable",
+        ),
     ]
 
     ADMIT_CASES = [
@@ -789,6 +1023,58 @@ class TestValidateMcpToolAdmission:
             None,
             id="nested-config-object-without-command-like-fields",
         ),
+        # --- Round-2: benign identifier-suffix fields remain admitted. ---
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "tenant_uuid": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-tenant-uuid",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "callback_url": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-callback-url",
+        ),
+        pytest.param(
+            "exec",
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": ["status", "restart"]},
+                    "page_slug": {"type": "string"},
+                },
+            },
+            None,
+            id="strong-name-fixed-operation-with-dynamic-page-slug",
+        ),
+        # --- Round-1 regression: array-of-strings free-form leaf channel
+        # (argv) must still be caught even though the walker now also
+        # recurses into `items` for hidden object-shaped command channels. ---
+        pytest.param(
+            "run_tests",
+            {
+                "type": "object",
+                "properties": {
+                    "suite": {"type": "string", "enum": ["unit", "integration"]},
+                    "markers": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            None,
+            id="array-of-strings-leaf-remains-benign-when-not-corroborated",
+        ),
     ]
 
     @pytest.mark.parametrize("tool_name, input_schema, description, reason", DENY_CASES)
@@ -835,3 +1121,40 @@ class TestValidateMcpToolAdmission:
         assert sentinel_command_value_marker not in message
         assert "maintenance" in message
         assert "unbounded-command-input" in message
+
+    def test_wide_anyof_fanout_stays_bounded_and_denies(self):
+        """A 10,000-branch `anyOf` fan-out (all harmless enum-bounded
+        properties) must not be fully walked node-by-node: the node-work
+        budget trips, and for an executor-signaling tool that unresolvable
+        result denies fail-closed -- in well under a second, not the
+        multi-second cost of walking every branch."""
+        import time
+
+        huge_schema = {
+            "type": "object",
+            "anyOf": [
+                {"properties": {f"field_{i}": {"type": "string", "enum": ["a", "b"]}}}
+                for i in range(10_000)
+            ],
+        }
+
+        start = time.perf_counter()
+        with pytest.raises(PermissionError) as exc_info:
+            validate_mcp_tool_admission("maintenance", huge_schema, "runs shell commands")
+        elapsed = time.perf_counter() - start
+
+        assert "executor-description-with-broad-input" in str(exc_info.value)
+        assert elapsed < 2.0
+
+    def test_wide_anyof_fanout_admits_when_not_executor_signaling(self):
+        """The same wide fan-out schema, with no strong name or executor
+        description, is still just insufficient evidence -- not a denial."""
+        huge_schema = {
+            "type": "object",
+            "anyOf": [
+                {"properties": {f"field_{i}": {"type": "string", "enum": ["a", "b"]}}}
+                for i in range(10_000)
+            ],
+        }
+
+        assert validate_mcp_tool_admission("search_config", huge_schema, None) is None


### PR DESCRIPTION
## Summary
Implements #2066. MCP tools whose name, description, and input schema expose a caller-controlled command/process/script executor are refused at registration time with `PermissionError`, across all native registration paths (discovery descriptors, raw config dicts, prebuilt Tool objects, and strong executor names on the metadata-free `tool_names=` shortcut). Ordered deny rules fix a stable reason per denial; denials name the tool and recommend a bounded structured operation; no configuration opt-out. List-typed JSON Schema `type` values that include `object` are inspected like plain object schemas, so nullable-object shapes cannot dodge property checks.

Deliberately out of scope (per the issue): transport authentication / server allowlisting. Name-only registrations carry no shape evidence to check — they log a warning on admission, and their containment belongs to the transport-auth design tracked separately (#2069).

## Testing
- Admission matrix: executor shapes denied (command/process/script/description-signal variants, including the nullable-object case), structured tools admitted (`run_tests` with bounded args, search/query/status shapes, command enums).
- `uv run --all-extras pytest tests/protocols/ tests/service/ tests/agent/ -n0` → 3095 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
