### PR TITLE
perf(messages): revision-keyed per-message render cache for prepared history

### DIFF
--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from pydantic import JsonValue
@@ -14,11 +15,50 @@ from lionagi.protocols.messages import (
 )
 from lionagi.protocols.messages.assistant_response import AssistantResponseContent
 from lionagi.protocols.messages.instruction import InstructionContent
+from lionagi.protocols.messages.message import Message, MessageContent
 
 from ..types import ChatParam, RunParam
 
 if TYPE_CHECKING:
     from lionagi.session.branch import Branch
+
+
+@dataclass
+class _PreparedContent:
+    """A prepared content item and, when safe, its reusable source rendering."""
+
+    source: Message | None = None
+    cache_variant: str | None = None
+    content: MessageContent | None = None
+
+    @property
+    def base_content(self) -> MessageContent:
+        if self.content is not None:
+            return self.content
+        if self.source is not None:
+            return self.source.content
+        raise RuntimeError("Prepared content has neither source nor content.")
+
+    @property
+    def role(self) -> MessageRole:
+        return self.base_content.role
+
+    def materialize(self) -> MessageContent:
+        """Build a mutable overlay only for a transformation boundary."""
+        if self.content is None:
+            if self.source is None:
+                raise RuntimeError("Prepared content has neither source nor content.")
+            if self.cache_variant == "prepared_instruction":
+                self.content = self.source.content.with_updates(
+                    tool_schemas=[], response_format=None
+                )
+            elif self.cache_variant == "prepared_assistant":
+                self.content = self.source.content.with_updates()
+            else:
+                self.content = self.source.content
+            self.source = None
+            self.cache_variant = None
+        return self.content
 
 
 def _build_instruction(
@@ -46,12 +86,13 @@ def _prepare_run_kwargs(
     param: ChatParam,
     *,
     ins: Instruction | None = None,
+    _use_render_cache: bool = True,
 ) -> tuple[Instruction, dict]:
     if ins is None:
         ins = _build_instruction(branch, instruction, param)
 
     _use_ins_content = None
-    _contents = []
+    _contents: list[_PreparedContent] = []
     _act_res = []
     progression = param.progression or branch.progression
 
@@ -60,10 +101,16 @@ def _prepare_run_kwargs(
             _act_res.append(msg)
 
         elif isinstance(msg, AssistantResponse):
-            _contents.append(msg.content.with_updates())
+            _contents.append(
+                _PreparedContent(
+                    source=msg,
+                    cache_variant="prepared_assistant",
+                )
+            )
 
         elif isinstance(msg, Instruction):
             updates = {"tool_schemas": [], "response_format": None}
+            has_action_context = bool(_act_res)
 
             if _act_res:
                 d_ = _collect_action_dicts(_act_res)
@@ -72,7 +119,13 @@ def _prepare_run_kwargs(
                 updates["prompt_context"] = extended_ctx
                 _act_res = []
 
-            _contents.append(msg.content.with_updates(**updates))
+            _contents.append(
+                _PreparedContent(
+                    source=msg if not has_action_context else None,
+                    cache_variant="prepared_instruction" if not has_action_context else None,
+                    content=(msg.content.with_updates(**updates) if has_action_context else None),
+                )
+            )
 
     if _act_res:
         d_ = _collect_action_dicts(_act_res)
@@ -80,24 +133,25 @@ def _prepare_run_kwargs(
         extended_ctx.extend(z for z in d_ if z not in extended_ctx)
         _use_ins_content = ins.content.with_updates(prompt_context=extended_ctx)
 
-    _contents = [c for c in _contents if c.role != MessageRole.UNSET]
+    _contents = [entry for entry in _contents if entry.role != MessageRole.UNSET]
 
     # Merge consecutive assistant responses
     if len(_contents) > 1:
         merged = [_contents[0]]
-        for c in _contents[1:]:
-            if isinstance(c, AssistantResponseContent):
-                if isinstance(merged[-1], AssistantResponseContent):
-                    merged[
-                        -1
-                    ].assistant_response = (
-                        f"{merged[-1].assistant_response}\n\n{c.assistant_response}"
+        for entry in _contents[1:]:
+            content = entry.base_content
+            if isinstance(content, AssistantResponseContent):
+                if isinstance(merged[-1].base_content, AssistantResponseContent):
+                    previous = merged[-1]
+                    previous_content = previous.materialize()
+                    previous_content.assistant_response = (
+                        f"{previous_content.assistant_response}\n\n{content.assistant_response}"
                     )
                 else:
-                    merged.append(c)
+                    merged.append(entry)
             else:
-                if isinstance(merged[-1], AssistantResponseContent):
-                    merged.append(c)
+                if isinstance(merged[-1].base_content, AssistantResponseContent):
+                    merged.append(entry)
         _contents = merged
 
     if branch.msgs.system:
@@ -113,30 +167,45 @@ def _prepare_run_kwargs(
             return branch.msgs.system.rendered + injected + g
 
         if len(_contents) == 0:
-            _contents.append(ins.content.with_updates(guidance=f(ins.content)))
+            _contents.append(
+                _PreparedContent(content=ins.content.with_updates(guidance=f(ins.content)))
+            )
         elif len(_contents) >= 1:
-            first = _contents[0]
+            first = _contents[0].materialize()
             if not isinstance(first, InstructionContent):
                 raise ValueError("First message in progression must be an Instruction or System")
-            _contents[0] = first.with_updates(guidance=f(first))
+            _contents[0] = _PreparedContent(content=first.with_updates(guidance=f(first)))
             content_to_append = _use_ins_content or ins.content
             if content_to_append is not None:
-                _contents.append(content_to_append)
+                _contents.append(_PreparedContent(content=content_to_append))
     else:
         content_to_append = _use_ins_content or ins.content
         if content_to_append is not None:
-            _contents.append(content_to_append)
+            _contents.append(_PreparedContent(content=content_to_append))
 
     kw = (param.imodel_kw or {}).copy()
 
     chat_msgs = []
-    for c in _contents:
-        if c is None:
-            continue
-        rendered = c.rendered
+    for entry in _contents:
+        if _use_render_cache and entry.source is not None and entry.cache_variant is not None:
+            source = entry.source
+            if entry.cache_variant == "prepared_instruction":
+                rendered = source._render_cached(
+                    entry.cache_variant,
+                    lambda source=source: (
+                        source.content.with_updates(tool_schemas=[], response_format=None).rendered
+                    ),
+                )
+            else:
+                rendered = source._render_cached(
+                    entry.cache_variant, lambda source=source: source.content.rendered
+                )
+        else:
+            rendered = entry.materialize().rendered
         if not rendered:
             continue
-        role_str = c.role.value if isinstance(c.role, MessageRole) else str(c.role)
+        role = entry.role
+        role_str = role.value if isinstance(role, MessageRole) else str(role)
         chat_msgs.append({"role": role_str, "content": rendered})
 
     kw["messages"] = chat_msgs

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -77,6 +77,22 @@ class InstructionContent(MessageContent):
             self, "_structure_instance", _build_structure(self.response_format, structure_cls)
         )
 
+    def __getstate__(self) -> tuple[Any, Any]:
+        # The private structure may cache a dynamically created request-model
+        # class that cannot be serialized; it is disposable state, excluded
+        # here and rebuilt from the restored public fields in __setstate__.
+        import dataclasses
+
+        slots: dict[str, Any] = {}
+        for f in dataclasses.fields(self):
+            if f.name == "_structure_instance":
+                continue
+            try:
+                slots[f.name] = getattr(self, f.name)
+            except AttributeError:
+                continue
+        return (None, slots)
+
     def __setstate__(self, state: tuple[Any, Any]) -> None:
         # Restore copied/unpickled state through __setattr__ so mutable render
         # inputs are re-wrapped, then rebuild the private structure from the

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -77,6 +77,23 @@ class InstructionContent(MessageContent):
             self, "_structure_instance", _build_structure(self.response_format, structure_cls)
         )
 
+    def __setstate__(self, state: tuple[Any, Any]) -> None:
+        # Restore copied/unpickled state through __setattr__ so mutable render
+        # inputs are re-wrapped, then rebuild the private structure from the
+        # restored response_format: keeping the copied structure would leave
+        # the renderer reading a dict detached from the restored public field.
+        dict_state, slots_state = state
+        for source in (dict_state, slots_state):
+            if not source:
+                continue
+            for name, value in source.items():
+                setattr(self, name, value)
+        object.__setattr__(
+            self,
+            "_structure_instance",
+            _build_structure(self.response_format, _resolve_structure_cls(self.structure)),
+        )
+
     def to_dict(self, exclude: set[str] | frozenset[str] | None = None) -> dict[str, Any]:
         # Conditionally include response_format when its value is a plain dict
         # (JSON-serializable); keep excluding it for type/BaseModel references

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -56,7 +56,6 @@ class InstructionContent(MessageContent):
         structure: type | str | None = None,
     ):
         structure_cls = _resolve_structure_cls(structure)
-        structure_inst = _build_structure(response_format, structure_cls)
 
         object.__setattr__(self, "instruction", instruction)
         object.__setattr__(self, "guidance", guidance)
@@ -67,10 +66,16 @@ class InstructionContent(MessageContent):
         object.__setattr__(self, "tool_schemas", tool_schemas if tool_schemas is not None else [])
         object.__setattr__(self, "response_format", response_format)
         object.__setattr__(self, "structure", structure_cls)
-        object.__setattr__(self, "_structure_instance", structure_inst)
+        object.__setattr__(self, "_structure_instance", None)
         object.__setattr__(self, "images", images if images is not None else [])
         object.__setattr__(self, "image_detail", image_detail)
         MessageContent.__post_init__(self)
+        # Build the structure from the tracked copy, not the caller's dict: a
+        # structure holding the caller's alias would let external mutation
+        # change the rendering without advancing the content revision.
+        object.__setattr__(
+            self, "_structure_instance", _build_structure(self.response_format, structure_cls)
+        )
 
     def to_dict(self, exclude: set[str] | frozenset[str] | None = None) -> dict[str, Any]:
         # Conditionally include response_format when its value is a plain dict
@@ -159,10 +164,9 @@ class InstructionContent(MessageContent):
             )
             if valid:
                 structure_cls = _resolve_structure_cls(structure)
-                structure_inst = _build_structure(response_format, structure_cls)
                 inst.response_format = response_format
                 inst.structure = structure_cls
-                inst._structure_instance = structure_inst
+                inst._structure_instance = _build_structure(inst.response_format, structure_cls)
 
         return inst
 

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -70,6 +70,7 @@ class InstructionContent(MessageContent):
         object.__setattr__(self, "_structure_instance", structure_inst)
         object.__setattr__(self, "images", images if images is not None else [])
         object.__setattr__(self, "image_detail", image_detail)
+        MessageContent.__post_init__(self)
 
     def to_dict(self, exclude: set[str] | frozenset[str] | None = None) -> dict[str, Any]:
         # Conditionally include response_format when its value is a plain dict
@@ -159,9 +160,9 @@ class InstructionContent(MessageContent):
             if valid:
                 structure_cls = _resolve_structure_cls(structure)
                 structure_inst = _build_structure(response_format, structure_cls)
-                object.__setattr__(inst, "response_format", response_format)
-                object.__setattr__(inst, "structure", structure_cls)
-                object.__setattr__(inst, "_structure_instance", structure_inst)
+                inst.response_format = response_format
+                inst.structure = structure_cls
+                inst._structure_instance = structure_inst
 
         return inst
 

--- a/lionagi/protocols/messages/manager.py
+++ b/lionagi/protocols/messages/manager.py
@@ -500,11 +500,14 @@ class MessageManager(Manager):
             else:
                 break
 
-    def to_chat_msgs(self, progression=None) -> list[dict]:
+    def to_chat_msgs(self, progression=None, *, _use_render_cache: bool = True) -> list[dict]:
         if progression == []:
             return []
         try:
-            return [self.messages[mid].chat_msg for mid in (progression or self.progression)]
+            return [
+                self.messages[mid]._chat_msg(use_render_cache=_use_render_cache)
+                for mid in (progression or self.progression)
+            ]
         except Exception as e:
             raise ValueError(
                 "One or more messages in the requested progression are invalid."

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
-from pydantic import Field, field_serializer, field_validator
+from pydantic import Field, PrivateAttr, field_serializer, field_validator
 
 from lionagi.ln.types import DataClass, ModelConfig
 
@@ -18,11 +20,180 @@ from .base import (
 )
 
 
+class _TrackedList(list):
+    """List that bumps its owning content revision after mutation."""
+
+    __slots__ = ("_touch",)
+
+    def __init__(self, values=(), touch: Callable[[], None] | None = None):
+        self._touch = touch
+        super().__init__(_track_mutable(value, touch) for value in values)
+
+    def _changed(self) -> None:
+        if self._touch is not None:
+            self._touch()
+
+    def append(self, value) -> None:
+        super().append(_track_mutable(value, self._touch))
+        self._changed()
+
+    def extend(self, values) -> None:
+        super().extend(_track_mutable(value, self._touch) for value in values)
+        self._changed()
+
+    def insert(self, index, value) -> None:
+        super().insert(index, _track_mutable(value, self._touch))
+        self._changed()
+
+    def __setitem__(self, index, value) -> None:
+        if isinstance(index, slice):
+            value = [_track_mutable(item, self._touch) for item in value]
+        else:
+            value = _track_mutable(value, self._touch)
+        super().__setitem__(index, value)
+        self._changed()
+
+    def __delitem__(self, index) -> None:
+        super().__delitem__(index)
+        self._changed()
+
+    def clear(self) -> None:
+        super().clear()
+        self._changed()
+
+    def pop(self, index=-1):
+        value = super().pop(index)
+        self._changed()
+        return value
+
+    def remove(self, value) -> None:
+        super().remove(value)
+        self._changed()
+
+    def reverse(self) -> None:
+        super().reverse()
+        self._changed()
+
+    def sort(self, *args, **kwargs) -> None:
+        super().sort(*args, **kwargs)
+        self._changed()
+
+    def __iadd__(self, values):
+        self.extend(values)
+        return self
+
+    def __imul__(self, value):
+        super().__imul__(value)
+        self._changed()
+        return self
+
+
+class _TrackedDict(dict):
+    """Dict that bumps its owning content revision after mutation."""
+
+    __slots__ = ("_touch",)
+
+    def __init__(self, values=(), touch: Callable[[], None] | None = None, **kwargs):
+        self._touch = touch
+        super().__init__()
+        self.update(values, **kwargs)
+
+    def _changed(self) -> None:
+        if self._touch is not None:
+            self._touch()
+
+    def __setitem__(self, key, value) -> None:
+        super().__setitem__(key, _track_mutable(value, self._touch))
+        self._changed()
+
+    def __delitem__(self, key) -> None:
+        super().__delitem__(key)
+        self._changed()
+
+    def clear(self) -> None:
+        super().clear()
+        self._changed()
+
+    def pop(self, key, *args):
+        value = super().pop(key, *args)
+        self._changed()
+        return value
+
+    def popitem(self):
+        value = super().popitem()
+        self._changed()
+        return value
+
+    def setdefault(self, key, default=None):
+        if key in self:
+            return super().setdefault(key, default)
+        value = _track_mutable(default, self._touch)
+        super().__setitem__(key, value)
+        self._changed()
+        return value
+
+    def update(self, *args, **kwargs) -> None:
+        values = dict(*args, **kwargs)
+        for key, value in values.items():
+            dict.__setitem__(self, key, _track_mutable(value, self._touch))
+        if values:
+            self._changed()
+
+    def __ior__(self, values):
+        self.update(values)
+        return self
+
+
+def _track_mutable(value: Any, touch: Callable[[], None] | None) -> Any:
+    """Copy mutable render inputs into revision-aware containers."""
+    if isinstance(value, _TrackedList):
+        value = list(value)
+    elif isinstance(value, _TrackedDict):
+        value = dict(value)
+
+    if isinstance(value, list):
+        return _TrackedList(value, touch)
+    if isinstance(value, dict):
+        return _TrackedDict(value, touch)
+    return value
+
+
 @dataclass(slots=True)
 class MessageContent(DataClass):
     """A base class for message content structures."""
 
     _config: ClassVar[ModelConfig] = ModelConfig(none_as_sentinel=True)
+    _revision: int = field(default=0, init=False, repr=False, compare=False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        track_mutation = not name.startswith("_") and hasattr(self, "_revision")
+        if not name.startswith("_"):
+            value = _track_mutable(value, self._touch_revision)
+        object.__setattr__(self, name, value)
+        if track_mutation:
+            self._touch_revision()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_revision", 0)
+        DataClass.__post_init__(self)
+        self._track_render_inputs()
+        object.__setattr__(self, "_revision", 0)
+
+    def _track_render_inputs(self) -> None:
+        for name in self.allowed():
+            object.__setattr__(
+                self,
+                name,
+                _track_mutable(getattr(self, name), self._touch_revision),
+            )
+
+    def _touch_revision(self) -> None:
+        object.__setattr__(self, "_revision", self._revision + 1)
+
+    @property
+    def _render_revision(self) -> int:
+        """Internal revision used to invalidate rendered-message cache entries."""
+        return self._revision
 
     @property
     def rendered(self) -> str:
@@ -45,6 +216,7 @@ class Message(Node, Sendable):
     _content_type: ClassVar[type] = MessageContent
 
     content: Any = None
+    _render_cache: dict[str, tuple[Any, int, Any]] = PrivateAttr(default_factory=dict)
 
     @field_validator("content", mode="before")
     @classmethod
@@ -108,11 +280,38 @@ class Message(Node, Sendable):
     @property
     def chat_msg(self) -> dict[str, Any] | None:
         """A dictionary representation typically used in chat-based contexts."""
+        return self._chat_msg()
+
+    def _chat_msg(self, *, use_render_cache: bool = True) -> dict[str, Any] | None:
+        """Build a provider chat message, reusing the stable content rendering when safe."""
         try:
             role_str = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
-            return {"role": role_str, "content": self.rendered}
+            return {
+                "role": role_str,
+                "content": self._render_cached("chat", lambda: self.rendered)
+                if use_render_cache
+                else self.rendered,
+            }
         except Exception:
             return None
+
+    def _render_cached(self, variant: str, render: Callable[[], Any]) -> Any:
+        """Return a rendering cached by content identity and revision.
+
+        The entry retains the content object itself and is served only when
+        the stored content IS the current content: an id()-based key could
+        cross-wire two content objects whose lifetimes never overlap but
+        happen to reuse the same address.
+        """
+        content = self.content
+        revision = getattr(content, "_render_revision", 0)
+        cached = self._render_cache.get(variant)
+        if cached is not None and cached[0] is content and cached[1] == revision:
+            return _copy_rendered(cached[2])
+
+        rendered = render()
+        self._render_cache[variant] = (content, revision, _copy_rendered(rendered))
+        return rendered
 
     @property
     def rendered(self) -> str:
@@ -150,6 +349,13 @@ class Message(Node, Sendable):
         if isinstance(msg_, dict) and isinstance(msg_["content"], list):
             return [i for i in msg_["content"] if i["type"] == "image_url"]
         return None
+
+
+def _copy_rendered(rendered: Any) -> Any:
+    """Keep cached structured content isolated from provider-side mutation."""
+    if isinstance(rendered, list | dict):
+        return deepcopy(rendered)
+    return rendered
 
 
 RoledMessage = Message

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -33,6 +33,12 @@ class _TrackedList(list):
         if self._touch is not None:
             self._touch()
 
+    def __reduce__(self):
+        # Copy/pickle as a plain list: the revision callback is bound to the
+        # owning content and must not survive reconstruction. The owning
+        # content re-wraps its fields when its own state is restored.
+        return (list, (list(self),))
+
     def append(self, value) -> None:
         super().append(_track_mutable(value, self._touch))
         self._changed()
@@ -101,6 +107,10 @@ class _TrackedDict(dict):
     def _changed(self) -> None:
         if self._touch is not None:
             self._touch()
+
+    def __reduce__(self):
+        # Copy/pickle as a plain dict; see _TrackedList.__reduce__.
+        return (dict, (dict(self),))
 
     def __setitem__(self, key, value) -> None:
         super().__setitem__(key, _track_mutable(value, self._touch))

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -228,6 +228,24 @@ class Message(Node, Sendable):
     content: Any = None
     _render_cache: dict[str, tuple[Any, int, Any]] = PrivateAttr(default_factory=dict)
 
+    def __getstate__(self) -> dict[str, Any]:
+        # A clone must start uncached: the copied entry would hold the source
+        # content/revision pair and never be servable.
+        state = super().__getstate__()
+        private = state.get("__pydantic_private__")
+        if private and private.get("_render_cache"):
+            private = dict(private)
+            private["_render_cache"] = {}
+            state = {**state, "__pydantic_private__": private}
+        return state
+
+    def __deepcopy__(self, memo: dict | None = None) -> "Message":
+        clone = super().__deepcopy__(memo)
+        private = getattr(clone, "__pydantic_private__", None)
+        if private is not None and private.get("_render_cache"):
+            private["_render_cache"] = {}
+        return clone
+
     @field_validator("content", mode="before")
     @classmethod
     def _validate_content(cls, v: Any) -> Any:

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -162,3 +162,40 @@ def test_message_deepcopy_pickle_and_prepare_roundtrip():
     duplicate.content.prompt_context.append({"more": [2]})
     assert duplicate.content._render_revision > revision
     assert "more" not in str(message.content.prompt_context)
+
+
+@pytest.mark.parametrize("via", ["deepcopy", "pickle"])
+def test_copied_dict_response_format_stays_wired_to_structure(via: str):
+    import copy
+    import pickle
+
+    from lionagi.protocols.messages.instruction import Instruction, InstructionContent
+
+    message = Instruction(
+        content=InstructionContent(
+            instruction="copy",
+            response_format={"answer": {"description": "before"}},
+        )
+    )
+    if via == "deepcopy":
+        clone = copy.deepcopy(message)
+    else:
+        clone = pickle.loads(pickle.dumps(message))
+
+    # The restored private structure must read the restored public field, so a
+    # public mutation on the copy changes the rendered schema.
+    assert clone.content._structure_instance.base_dict is clone.content.response_format
+    revision = clone.content._render_revision
+    clone.content.response_format["answer"]["description"] = "after"
+    assert clone.content._render_revision > revision
+    assert "after" in clone.rendered
+    assert "before" not in clone.rendered
+    assert "before" in message.rendered
+
+    from lionagi.protocols.messages.manager import MessageManager
+
+    manager = MessageManager(messages=[clone])
+    cached = manager.to_chat_msgs()
+    uncached = manager.to_chat_msgs(_use_render_cache=False)
+    assert orjson.dumps(cached) == orjson.dumps(uncached)
+    assert "after" in orjson.dumps(cached).decode()

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Equivalence and invalidation coverage for the per-message render cache."""
+
+import orjson
+import pytest
+
+from lionagi.operations.chat._prepare import _prepare_run_kwargs
+from lionagi.operations.types import ChatParam
+from lionagi.session.branch import Branch
+
+
+def _build_history(size: int) -> Branch:
+    branch = Branch(system="Follow the system policy.")
+    branch.msgs.add_message(
+        instruction="Describe the first artifact.",
+        context=[{"source": "fixture", "values": [1, 2]}],
+        images=["data:image/png;base64,aGVsbG8="],
+    )
+    branch.msgs.add_message(assistant_response="The first artifact is recorded.")
+    request = branch.msgs.add_message(
+        action_function="lookup", action_arguments={"record_id": "r-1"}
+    )
+    branch.msgs.add_message(action_request=request, action_output={"status": "found"})
+
+    for index in range(size - len(branch.msgs.messages)):
+        if index % 2 == 0:
+            branch.msgs.add_message(instruction=f"Historic instruction {index}.")
+        else:
+            branch.msgs.add_message(assistant_response=f"Historic answer {index}.")
+
+    assert len(branch.msgs.messages) == size
+    return branch
+
+
+def _chat_param(branch: Branch) -> ChatParam:
+    return ChatParam(sender="user", recipient=branch.id, imodel=branch.chat_model, imodel_kw={})
+
+
+@pytest.mark.parametrize("size", [10, 100])
+def test_cached_preparation_is_byte_identical_to_uncached_history(size: int):
+    branch = _build_history(size)
+    param = _chat_param(branch)
+
+    _, uncached = _prepare_run_kwargs(
+        branch, "Current instruction.", param, _use_render_cache=False
+    )
+    _, cached = _prepare_run_kwargs(branch, "Current instruction.", param)
+    _, warm_cached = _prepare_run_kwargs(branch, "Current instruction.", param)
+
+    assert orjson.dumps(cached) == orjson.dumps(uncached)
+    assert orjson.dumps(warm_cached) == orjson.dumps(uncached)
+
+    uncached_messages = branch.msgs.to_chat_msgs(_use_render_cache=False)
+    cached_messages = branch.msgs.to_chat_msgs()
+    assert orjson.dumps(cached_messages) == orjson.dumps(uncached_messages)
+
+
+def test_historic_in_place_mutation_invalidates_only_that_message_rendering():
+    branch = _build_history(10)
+    param = _chat_param(branch)
+    historic_instructions = list(branch.msgs.instructions)
+    changed = historic_instructions[2]
+    unchanged = historic_instructions[3]
+
+    _prepare_run_kwargs(branch, "Current instruction.", param)
+    changed_before = changed._render_cache["prepared_instruction"]
+    unchanged_before = unchanged._render_cache["prepared_instruction"]
+
+    changed.content.instruction = "Edited historic instruction."
+    _, prepared = _prepare_run_kwargs(branch, "Current instruction.", param)
+
+    assert "Edited historic instruction." in orjson.dumps(prepared).decode()
+    assert changed._render_cache["prepared_instruction"] is not changed_before
+    assert unchanged._render_cache["prepared_instruction"] is unchanged_before
+
+
+def test_content_object_replacement_invalidates_rendering():
+    branch = Branch()
+    message = branch.msgs.add_message(instruction="Original text.")
+
+    assert "Original text." in branch.msgs.to_chat_msgs()[0]["content"]
+
+    # update() swaps in a brand-new content object at revision zero; the
+    # cache must key on the content object itself, not its address, so the
+    # replacement can never be confused with a prior same-address content.
+    message.update(instruction="Replaced text.")
+    entry = message._render_cache["chat"]
+    assert entry[0] is not message.content
+
+    rendered = branch.msgs.to_chat_msgs()[0]["content"]
+    assert "Replaced text." in rendered
+    assert "Original text." not in rendered
+    assert message._render_cache["chat"][0] is message.content
+
+
+def test_render_cache_is_message_identity_scoped_across_branches():
+    first = Branch()
+    second = Branch()
+    first_message = first.msgs.add_message(instruction="Same text.")
+    second_message = second.msgs.add_message(instruction="Same text.")
+
+    assert first.msgs.to_chat_msgs() == second.msgs.to_chat_msgs()
+    second_before = second_message._render_cache["chat"]
+
+    first_message.content.instruction = "First branch changed."
+    assert "First branch changed." in first.msgs.to_chat_msgs()[0]["content"]
+    assert second.msgs.to_chat_msgs()[0]["content"] != first.msgs.to_chat_msgs()[0]["content"]
+    assert second_message._render_cache["chat"] is second_before

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -108,3 +108,57 @@ def test_render_cache_is_message_identity_scoped_across_branches():
     assert "First branch changed." in first.msgs.to_chat_msgs()[0]["content"]
     assert second.msgs.to_chat_msgs()[0]["content"] != first.msgs.to_chat_msgs()[0]["content"]
     assert second_message._render_cache["chat"] is second_before
+
+
+def test_response_format_structure_derives_from_tracked_copy():
+    schema = {"answer": {"type": "string", "description": "before"}}
+    branch = Branch()
+    message = branch.msgs.add_message(instruction="historic", response_format=schema)
+    branch.msgs.to_chat_msgs()
+
+    # Mutating the caller's original dict is invisible: the structure was
+    # built from the tracked copy, so cached and uncached renderings agree.
+    schema["answer"]["description"] = "external-alias-edit"
+    cached = branch.msgs.to_chat_msgs()
+    uncached = branch.msgs.to_chat_msgs(_use_render_cache=False)
+    assert orjson.dumps(cached) == orjson.dumps(uncached)
+    assert "external-alias-edit" not in cached[0]["content"]
+
+    # Mutating the tracked field advances the revision and stays in parity.
+    revision = message.content._render_revision
+    message.content.response_format["answer"]["description"] = "tracked-edit"
+    assert message.content._render_revision > revision
+    assert orjson.dumps(branch.msgs.to_chat_msgs()) == orjson.dumps(
+        branch.msgs.to_chat_msgs(_use_render_cache=False)
+    )
+
+
+def test_message_deepcopy_pickle_and_prepare_roundtrip():
+    import copy
+    import pickle
+
+    from lionagi.protocols.generic.pile import Pile
+    from lionagi.protocols.messages.instruction import Instruction, InstructionContent
+    from lionagi.protocols.messages.prepare import prepare_messages_for_chat
+
+    content = InstructionContent(
+        instruction="copy me",
+        prompt_context=[{"nested": [1]}],
+        tool_schemas=[{"name": "lookup"}],
+        images=["data:image/png;base64,aGVsbG8="],
+    )
+    message = Instruction(content=content)
+
+    duplicate = copy.deepcopy(message)
+    assert duplicate.rendered == message.rendered
+
+    restored = pickle.loads(pickle.dumps(message))
+    assert restored.rendered == message.rendered
+
+    assert prepare_messages_for_chat(Pile(), new_instruction=message) is not None
+
+    # The copy tracks revisions independently of the original.
+    revision = duplicate.content._render_revision
+    duplicate.content.prompt_context.append({"more": [2]})
+    assert duplicate.content._render_revision > revision
+    assert "more" not in str(message.content.prompt_context)

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -199,3 +199,43 @@ def test_copied_dict_response_format_stays_wired_to_structure(via: str):
     uncached = manager.to_chat_msgs(_use_render_cache=False)
     assert orjson.dumps(cached) == orjson.dumps(uncached)
     assert "after" in orjson.dumps(cached).decode()
+
+
+def test_model_response_format_message_pickles_after_render():
+    import copy
+    import pickle
+
+    from lionagi.operations.select.utils import SelectionModel
+    from lionagi.protocols.messages.instruction import Instruction, InstructionContent
+
+    for response_format in (SelectionModel, SelectionModel(selected=["x"])):
+        message = Instruction(
+            content=InstructionContent(instruction="model", response_format=response_format)
+        )
+        rendered = message.rendered  # caches the dynamic request-model class
+        for protocol in (2, pickle.HIGHEST_PROTOCOL):
+            restored = pickle.loads(pickle.dumps(message, protocol=protocol))
+            assert restored.rendered == rendered
+        assert copy.deepcopy(message).rendered == rendered
+
+
+def test_warmed_message_clone_starts_uncached():
+    import copy
+    import pickle
+
+    from lionagi.protocols.messages.instruction import Instruction, InstructionContent
+    from lionagi.protocols.messages.manager import MessageManager
+
+    source = Instruction(
+        content=InstructionContent(instruction="warm", response_format={"answer": "before"})
+    )
+    source.content.response_format["answer"] = "changed"
+    MessageManager(messages=[source]).to_chat_msgs()
+    assert source._render_cache
+
+    for op in (copy.deepcopy, lambda x: pickle.loads(pickle.dumps(x, pickle.HIGHEST_PROTOCOL))):
+        clone = op(source)
+        assert clone._render_cache == {}
+        MessageManager(messages=[clone]).to_chat_msgs()
+        assert clone._render_cache
+    assert source._render_cache


### PR DESCRIPTION
## What

Per-turn message preparation re-rendered every retained historic message on every turn. This adds a private render cache on each `Message`, keyed on the content object identity (held strongly, compared with `is`) plus a content revision counter that advances on direct field replacement and on mutations to tracked list/dict render inputs (including nested lists/dicts). The response-format structure derives from the tracked copy, so no external alias can change a rendering without advancing the revision.

**Cached**: raw per-message renderings in `to_chat_msgs()`; historic assistant renderings not merged with another assistant; historic instruction renderings after tool-schema/response-format stripping.

**Always fresh**: the current instruction; instructions receiving folded action results; assistant-merge runs; the first retained instruction when system/guidance/context injection folds into it.

## Correctness

- Cached vs uncached pipelines pinned **byte-identical** (orjson) for 10- and 100-message histories covering system message, structured context, images, and action request/response turns.
- In-place edit at stable history length invalidates exactly the edited message (revision-keyed, not length-keyed) — pinned by test.
- Content object replacement via `update()` cannot be served a prior object's rendering: the entry retains the content object and serves only on an `is` match — pinned by test.
- External response-format alias mutation and tracked-field mutation both stay in cached/uncached parity — pinned by test.
- deepcopy, pickle, and `prepare_messages_for_chat` roundtrip with context/tool-schemas/images; copies track revisions independently — pinned by test.
- Identical text in another message or branch cannot share an entry — pinned by test.
- Tracked containers serialize identically under json/orjson and roundtrip `to_dict`/`from_dict`.

## Benchmarks

Config: provider-free prepare pipeline, macOS arm64, CPython 3.10.15, medians of 7 fixed-size batches after 2 warm-ups; all values below quoted directly from the retained `bench_results.json`.

| Retained messages | Before prepare median | After prepare median | Improvement | After CV |
| ---: | ---: | ---: | ---: | ---: |
| 10 | 1.075 ms | 0.623 ms | 1.73x | 16.5% |
| 100 | 6.236 ms | 1.882 ms | 3.31x | 36.8% |
| 1,000 | 55.313 ms | 5.955 ms | 9.29x | 8.9% |

`MessageManager.to_chat_msgs()` at 1,000 messages: 175.677 ms → 2.795 ms. Rows with CV above 20% carried host scheduling outliers; medians are stable but re-measure on a quiet host before quoting fleet-wide.

## Gates

- `uv run ruff check lionagi/` — pass
- `uv run pytest tests/operations/ tests/protocols/ tests/session/` — pass (1 skip, 2 xfail pre-existing; one pre-existing stream-cancel timing flake passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)