### PR TITLE
chore: hold ADR citations in source to the exact-claim bar

### DIFF
--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -142,7 +142,7 @@ def add_dispatch_subparser(subparsers: argparse._SubParsersAction) -> None:
         "dispatch",
         help="Inspect and acknowledge durable dispatch_outbox rows.",
         description=(
-            "Read and acknowledge rows in the durable dispatch outbox (ADR-0092). "
+            "Read and acknowledge rows in the durable dispatch outbox (ADR-0059 D6). "
             "Dispatches are enqueued by schedule actions and delivered by the "
             "Studio daemon's scheduler tick; there is no `enqueue` verb here."
         ),

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -458,11 +458,12 @@ async def _build_dag(
         worker_models.append(w_model)
         role_base.setdefault(ta.assignee, w_branch)
 
-        # ADR-0064: fold this leg's OWN declared artifact contract (profile
-        # first, else the casts role's artifact_defaults — e.g. reviewer/
-        # critic) into the flow-wide contract, namespaced under this leg's
-        # own artifact subdirectory. A role that declares nothing leaves the
-        # contract untouched — this only fires for a real declaration.
+        # Fold this leg's OWN declared artifact contract (profile first, else
+        # the casts role's artifact_defaults — e.g. reviewer/critic) into the
+        # flow-wide contract, namespaced under this leg's own artifact
+        # subdirectory (ADR-0064 D3: per-leg role-default artifact
+        # expectations). A role that declares nothing leaves the contract
+        # untouched — this only fires for a real declaration.
         if ta.assignee in role_artifact_defaults:
             role_defaults = role_artifact_defaults[ta.assignee]
         else:
@@ -1000,12 +1001,12 @@ async def _execute_dag(
     n_spawned = dag_result.get("spawned_operations", 0)
 
     # Escalation backstop: a leg the executor tracked as escalated (gave up
-    # instead of producing a result — see NodeEscalated / EscalationRequest,
-    # ADR-0072/0083) reads as a normal completed op_result to the loop below.
-    # Without this, a reviewer/critic that emits EscalationRequest(route=
-    # "give_up") instead of writing its artifact is indistinguishable from a
-    # clean completion once execution finishes — this makes it loud at
-    # teardown even when no artifact_defaults declaration exists to catch it.
+    # instead of producing a result — see NodeEscalated / EscalationRequest)
+    # reads as a normal completed op_result to the loop below. Without this,
+    # a reviewer/critic that emits EscalationRequest(route="give_up") instead
+    # of writing its artifact is indistinguishable from a clean completion
+    # once execution finishes — this makes it loud at teardown even when no
+    # artifact_defaults declaration exists to catch it.
     #
     # The escalation tracker itself is plan-agnostic: it records any emitting
     # node's id whether that node was planned up front or spawned mid-run via

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -129,7 +129,7 @@ async def _resolve_session_by_branch_id(db: Any, entity_id: str) -> dict[str, An
 async def _resolve_agent_target(
     db: Any, entity_id: str | None, project: str | None
 ) -> tuple[str, dict[str, Any]] | None:
-    """`li agent status` resolution: session (any kind), ADR-0077 invocation, or
+    """`li agent status` resolution: session (any kind), invocation, or
     a branch_id (resolved to its owning session), by id; default-latest is
     scoped to agent-kind sessions for *project*.
 
@@ -154,7 +154,7 @@ async def _resolve_agent_target(
 async def _resolve_play_target(
     db: Any, entity_id: str | None, project: str | None
 ) -> tuple[str, dict[str, Any]] | None:
-    """`li play status` resolution: session, then ADR-0077 invocation, then a show
+    """`li play status` resolution: session, then invocation, then a show
     sub-play row, by id; default-latest is scoped to play/flow-kind sessions.
     """
     if entity_id:

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -82,7 +82,7 @@ def build_session_bus(
     *,
     observer: Any = None,
 ) -> HookBus:
-    """Construct a per-session HookBus with defaults merged with profile overrides (ADR-0047)."""
+    """Construct a per-session HookBus with defaults merged with agent-hook overrides (ADR-0047 D3)."""
     bus = HookBus(observer=observer)
     overrides = load_hooks_for_agent(agent_hooks)
 

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -15,10 +15,10 @@ from lionagi.libs.path_safety import GLOB_CHARS as _GLOB_CHARS
 _ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _VALIDATION_ROOT = os.path.realpath("/tmp/__contract_validate__")  # noqa: S108 — synthetic root for path-validation only, never written to
 
-# ADR-0064 D3: v1 entry fields. `kind`, `min_size`, `mime_type` are
-# reserved for v1.1 — silently accepting them now would let contract
-# files drift into looking stricter than the executor actually is.
-# Both the `li play check` pre-flight AND the real `li play` runtime
+# v1 entry fields. `kind`, `min_size`, `mime_type` are reserved for
+# v1.1 — silently accepting them now would let contract files drift
+# into looking stricter than the executor actually is. ADR-0064 D3:
+# both the `li play check` pre-flight AND the real `li play` runtime
 # path emit a warning for unknown subfields via warn_unknown_artifact_keys().
 _ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
 
@@ -82,7 +82,7 @@ def warn_unknown_artifact_keys(
     source: str = "playbook",
     emit: Any = None,
 ) -> list[str]:
-    """Warn about unrecognized subfields in expected[] entries (ADR-0064 v1.1-reserved fields); returns messages."""
+    """Warn about unrecognized subfields in expected[] entries (v1.1-reserved fields); returns messages."""
     if contract is None:
         return []
     expected = contract.get("expected") or []

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1748,7 +1748,7 @@ class StateDB:
                 f"{caller_name}({entity_id!r}, status={status_value!r}) "
                 "called without reason_code; defaulting to "
                 f"{reason_code!r}. Pass reason_code explicitly "
-                "(ADR-0028 Phase 2 deprecation).",
+                "(this fallback is deprecated).",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -1827,7 +1827,7 @@ class StateDB:
         if override and (not override_actor or not override_justification):
             raise ValueError(
                 "override=True requires both override_actor and "
-                "override_justification (ADR-0094 operational-repair trail)."
+                "override_justification (ADR-0035 D5 operational-repair trail)."
             )
         canonical_type = _validate_entity_type_for_reason(entity_type)
         _validate_reason_code(reason_code)

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -761,9 +761,9 @@ CREATE INDEX IF NOT EXISTS idx_workflow_defs_updated
 -- task in cli/orchestrate/flow.py's _execute_dag reads unapplied rows
 -- (applied_at IS NULL) and applies them
 -- against the running executor.  Apply/stamp ordering is verb-classed:
--- pause/resume/stop are idempotent (apply, then stamp), message is not
+-- pause/resume are idempotent (apply, then stamp), message is not
 -- (stamp 'applying', then apply, then finalize).  'stop' is schema-reserved
--- for later support; no CLI verb emits it yet.
+-- and rejected by the current poller as unsupported; no CLI verb emits it yet.
 
 CREATE TABLE IF NOT EXISTS session_controls (
   id          TEXT    PRIMARY KEY,         -- uuid4 hex

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -894,12 +894,12 @@ Index("idx_workflow_defs_updated", workflow_defs.c.updated_at)
 # One row per operator control verb queued against a live session. A poller task
 # in `cli/orchestrate/flow.py`'s `_execute_dag` reads unapplied rows and applies
 # them against the running executor. Apply/stamp ordering is verb-classed:
-# pause/resume/stop are
+# pause/resume are
 # idempotent (apply, then stamp — safe to re-apply on a poller crash); message
 # is not (stamp 'applying', then apply, then finalize — a crash surfaces as an
 # unapplied 'applying' row rather than risking a double injection). 'stop' is
-# schema-reserved for a later slice (the checkpoint writer); no CLI verb emits
-# it yet.
+# schema-reserved and rejected by the current poller as unsupported; no CLI
+# verb emits it yet.
 
 session_controls = Table(
     "session_controls",


### PR DESCRIPTION
## Summary

Follow-up to #2082: hold the remaining ADR citations in source comments/docstrings to the exact-claim bar — every `ADR-NNNN` reference in code must point at a decision that actually documents the specific claim being made, or be removed.

Ten corrections, comment/docstring-only (zero behavior change):

| File | Change |
|---|---|
| `lionagi/state/schema.sql` | `stop` removed from the idempotent verb grouping — it is schema-reserved and rejected by the current poller (ADR-0069 D1) |
| `lionagi/state/schema_meta.py` | same wording alignment |
| `lionagi/cli/dispatch.py` | outbox CLI cite retargeted ADR-0092 → ADR-0059 D6 (the decision that actually documents `li dispatch` against StateDB) |
| `lionagi/hooks/loader.py` | "profile overrides" → "agent-hook overrides" (ADR-0047 D3's actual term) |
| `lionagi/state/db.py` (override guard) | cite retargeted ADR-0094 → ADR-0035 D5 (override actor+justification requirement) |
| `lionagi/state/db.py` (reason_code fallback) | unsupported ADR-0028 cite dropped; deprecation prose kept |
| `lionagi/state/artifact_verifier.py` | ADR-0064 D3 cite narrowed to the warn-on-unknown behavior it documents; v1.1-reserved clause left as uncited prose |
| `lionagi/cli/status.py` | "ADR-0077 invocation" cites dropped (D1 does not document this resolution order) |
| `lionagi/cli/orchestrate/flow.py` (artifact fold) | cite narrowed to ADR-0064 D3's per-leg role-default claim only |
| `lionagi/cli/orchestrate/flow.py` (escalation backstop) | ADR-0072/0083 cites dropped (neither documents NodeEscalated/EscalationRequest) |

## Verification

- Each retained citation was checked against the named ADR's text; each dropped citation was grepped in the cited ADR and found absent.
- `uv run ruff check` on all touched files: clean.
- `uv run pytest tests/state tests/cli tests/hooks -q`: all pass (one unrelated documented skip).
- Comment-only diff; rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
