### PR TITLE
docs(adr): ADR-0048 interoperable external hooks + ADR-0088 plugin system

### DIFF
--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -251,6 +251,21 @@ Exact semantics:
     `Branch.run()`, and `Branch.ReAct()` — and carried on the operation context as
     an explicit field threaded through the call chain (not ambient task-local
     state, which would leak across concurrently running branch operations).
+    Origination is **conditional on an explicit origin disposition** threaded on
+    the same call chain, with three states: *unset* (the default a genuine
+    outside caller produces), *forwarded token*, and *no-origin*. A public
+    ingress mints a fresh token only when the disposition is *unset*; a
+    forwarded token is carried through unchanged and never re-originated; and
+    *no-origin* means the call traverses the public method without ever holding
+    a token. This disposition — not the method being public — is the
+    deterministic rule that distinguishes a user's call to `Branch.chat()` from
+    the runtime's own call to the same public method.
+  - **Nested public ingresses forward, never re-originate.** The in-tree nested
+    path is named: `Branch.chat_and_record()` delegates to `Branch.chat()` — it
+    mints (on *unset*) before delegating and passes that same token down as the
+    *forwarded* disposition, so the delegated `chat()` mints nothing and the one
+    token is consumed at the chat boundary as usual. Any future public wrapper
+    that delegates to another public ingress inherits this forwarding rule.
   - **Consumed exactly once** at the model-submission boundary: immediately before
     provider invocation in the chat operation (which serves the chat,
     chat_and_record, communicate, and operate→communicate paths), and immediately
@@ -259,20 +274,28 @@ Exact semantics:
     `{session_id, branch_id, prompt}` — `prompt` being the rendered instruction
     text actually submitted at that boundary — and the token is cleared for the
     remainder of the turn; if absent, the boundary stays silent.
-  - **Internal turns never carry the token.** Instructions the runtime synthesizes
-    (ReAct extension and final-answer turns, parse-retry turns) are issued without
-    ingress, so their submissions find no token and emit nothing. For a multi-step
-    `ReAct()` call this means exactly one emission — at the first model submission
-    of the user's turn — and silence for every internal continuation.
+  - **Internal turns pass the explicit *no-origin* disposition.** Instructions
+    the runtime synthesizes are issued with *no-origin* at their named seams:
+    parse-repair turns, where `parse._inner_parse()` calls the public
+    `Branch.chat()` — the traversal of a public method with *no-origin* mints
+    nothing — and ReAct extension/final-answer turns, which drive `operate()`
+    directly with *no-origin*. Their submissions find no token and emit nothing.
+    For a multi-step `ReAct()` call this means exactly one emission — at the
+    first model submission of the user's turn — and silence for every internal
+    continuation.
   - Adding the enum member without the token mechanism and both consuming
     boundaries is forbidden; ADR-0047 already documents four never-wired hook
     points as exactly this trap, and this ADR does not add a fifth.
 - **Acceptance: exact-once, enumerated per path.** The implementation ships
   integration tests asserting the emission count for every ingress: direct
-  `chat()` → 1; direct `chat_and_record()` → 1; `communicate()` → 1;
+  `chat()` → 1; `chat_and_record()` delegating to `chat()` → 1 total (proving
+  the forwarded disposition does not re-originate); `communicate()` → 1;
   `operate()` delegating to communicate → 1; direct `run()` → 1; a `ReAct()`
   call with multiple internal extension turns and a final-answer turn → exactly 1
-  total; a parse-retry inside any of the above → 0 additional. A new public
+  total; and a failing-then-repaired parse inside any of the above → exactly 1
+  total, with the repair submission itself asserted as zero additional events —
+  the row names its call path, `parse._inner_parse()` → `Branch.chat()` with
+  *no-origin*. A new public
   ingress added later must add its row to this matrix — the test file carries a
   comment stating that rule.
 - A blocked `USER_PROMPT_SUBMIT` surfaces as the same `PermissionError`-family

--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -1,0 +1,428 @@
+# ADR-0048: Interoperable external hooks (Claude Code / Codex hook contract)
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: hooks
+- **Date**: 2026-07-12
+- **Relations**: extends ADR-0047 (hook mechanism scopes — this ADR adds an external,
+  cross-harness contract on top of the mechanisms ADR-0047 ratified; it does not move
+  their ownership boundaries); builds on ADR-0095 (its D3 no-shell executable-adapter
+  posture is adopted verbatim for hook commands)
+
+## Context
+
+LionAGI has three in-process hook mechanisms with distinct scopes, ratified by
+ADR-0047: the session-scoped `HookBus` (`lionagi/hooks/`, observe/audit plane with one
+hard-wired blocking point at `TOOL_PRE`), the tool-scoped preprocessor/postprocessor
+chain (`lionagi/agent/spec.py` `HooksMixin`, full-payload mutation), and the
+service-scoped `HookRegistry` on `iModel` events. All three register in-process Python
+callables. The only way to run an *external program* as a hook today is
+`lionagi/agent/settings.py`'s `_make_shell_hook`: argv-only subprocess, stdin JSON,
+fixed 10-second timeout, and — critically — no stdout read-back. An external hook can
+veto (nonzero exit becomes `PermissionError` on the pre phase) but cannot rewrite
+arguments, attach context, or return a structured decision.
+
+Meanwhile the two dominant agent harnesses have converged on one external-hook wire
+contract. Claude Code and Codex CLI both ship: a JSON envelope on stdin carrying
+`session_id`, `cwd`, `hook_event_name`, and per-event fields (`tool_name`,
+`tool_input`, `tool_response`); an exit-code protocol (0 = success and stdout is
+parsed as JSON, 2 = block with stderr as the reason, other = non-blocking failure);
+and a stdout decision shape (`hookSpecificOutput.permissionDecision` ∈
+`allow|deny|ask` with `permissionDecisionReason` and optional `updatedInput` for
+`PreToolUse`; top-level `decision: "block"` + `reason` for most other events). Both
+use the same nested config shape (`hooks.<EventName>` → `[{matcher, hooks: [{type,
+command, timeout}]}]`) and largely the same event names. Codex additionally ships a
+hash-pinned trust gate: a non-managed hook's exact command must be explicitly trusted
+before it runs.
+
+This convergence is an opportunity with a deadline attached. Users who already
+maintain a hardened hook suite for Claude Code or Codex (guards, formatters, audit
+loggers, notification bridges) should be able to point LionAGI at it and have it
+work; hooks written for LionAGI should run unmodified under either harness. If
+LionAGI invents a third wire contract, every hook gets written twice and the
+ecosystem's existing hook tooling is unusable here.
+
+Named problems:
+
+- **P1 — no structured decision channel.** `_make_shell_hook` inspects only
+  `returncode`/stderr. An external guard cannot say "allow but rewrite the argument,"
+  "deny with this machine-readable reason," or "attach this context to the turn."
+  Every richer behavior currently requires an in-process Python hook, which
+  cross-harness users cannot share.
+- **P2 — no cross-harness config portability.** LionAGI's `hooks:` settings shape
+  (`{pre,post,on_error}: {tool_name: [spec]}`) is structurally unrelated to the
+  CC/Codex shape (`hooks.<EventName>` → matcher groups). A team running both harnesses
+  maintains two disjoint configurations for the same guard commands.
+- **P3 — event-vocabulary gap.** CC/Codex hooks fire on `UserPromptSubmit`; LionAGI
+  has no hook point that models "an instruction is about to be submitted to the
+  model." A prompt-hygiene or context-injection hook has no seam to attach to.
+- **P4 — seam mismatch on tool events.** The blocking point LionAGI exposes on
+  `HookBus` (`TOOL_PRE`) carries a 200-character argument summary; honoring
+  `updatedInput` requires the full-payload tool preprocessor chain. Those tool hooks
+  in turn do not fire for MCP-discovered tools at all today — the chain is wired per
+  registered `Tool` at agent-factory time, and MCP server tools registered through
+  `ActionManager.register_mcp_server` bypass it. An external `PreToolUse` hook that
+  silently skips MCP tools is a security hole, not a feature.
+- **P5 — no trust boundary for command hooks.** `settings.py` gates Python
+  import-path hooks behind `trusted_hook_modules`, but shell-command hooks from any
+  merged settings file run unconditionally. Once configs can be *imported* from
+  `.claude/settings.json` or plugin bundles (ADR-0088), "whatever the file says,
+  execute it" is not a defensible posture.
+
+| Concern | Decision |
+|---------|----------|
+| External wire contract | D1: adopt the converged CC/Codex stdin/exit-code/stdout-JSON contract |
+| Event vocabulary and mapping | D2: fixed mapping table; `USER_PROMPT_SUBMIT` added with its emit site; unmapped events fail loud at load |
+| Which internal seam serves tool events | D3: tool pre/post events route to the tool-hook chain, relocated to the `ActionManager` invoke chokepoint so MCP tools are covered |
+| Executor | D4: one exec adapter extending `_make_shell_hook` — argv-only, stdout parse-back, per-hook timeout |
+| Decision semantics | D5: `allow`/`defer` continue, `deny` raises, `ask` fails closed; `updatedInput` honored only at the preprocessor seam |
+| Config surface | D6: CC-shaped `hooks:` block in `.lionagi/settings.yaml`, plus explicit import of CC/Codex hook configs |
+| Trust | D7: hash-pinned trust for command hooks that are not project-committed |
+
+Out of scope for this ADR:
+
+- **HTTP / MCP-tool / prompt / agent hook handler types** (CC's `type: http|mcp_tool|
+  prompt|agent`) — deferred; the D6 config schema reserves the `type` field so they
+  can be added without a shape break, but v1 executes only `type: command`.
+- **`Stop` / `PreCompact` / `PostCompact` events** — LionAGI's runtime has no
+  turn-stop arbitration loop or context-compaction phase to attach them to. Mapping
+  them before the runtime concept exists would violate the rule that a hook point
+  ships with its emit site (see D2). They become mappable when the corresponding
+  runtime surfaces exist.
+- **Making `HookBus` blocking behavior per-config.** Blocking stays a closed,
+  code-reviewed property of specific hook points, per ADR-0047's rationale that
+  ordinary hooks are intentionally failure-isolated. This ADR adds one new blocking
+  point (D2) through code review, not a configuration switch.
+- **The plugin bundle format that can carry hook configs** — ADR-0088.
+
+## Decision
+
+### D1 — Adopt the converged external-hook wire contract
+
+LionAGI's contract for external hook processes is the CC/Codex contract, not a new
+one.
+
+**Stdin envelope** (one JSON object, UTF-8, single line or pretty — the hook must
+parse, not line-split):
+
+```json
+{
+  "session_id": "s-…",
+  "cwd": "/abs/path",
+  "hook_event_name": "PreToolUse",
+  "harness": "lionagi",
+  "tool_name": "bash",
+  "tool_input": {"command": ["git", "status"]},
+  "tool_response": null
+}
+```
+
+Common fields (`session_id`, `cwd`, `hook_event_name`) are always present. Per-event
+fields follow the CC/Codex field names exactly (`tool_name`, `tool_input`,
+`tool_response`, `prompt`). One LionAGI addition: `harness: "lionagi"` — a hook that
+must behave differently per harness keys off this; CC and Codex omit it, so its
+absence means "not lionagi." Fields LionAGI cannot populate (for example
+`transcript_path` when no transcript file exists for the surface) are omitted, never
+sent as fabricated values.
+
+**Exit-code protocol**, exactly as the harnesses define it:
+
+- exit 0 — success; stdout is parsed as JSON if non-empty (parse failure of non-empty
+  stdout is logged and treated as "no structured output," not as a block).
+- exit 2 — block; stderr (trimmed) is the human-readable reason; stdout is ignored.
+- any other exit — hook failure; logged with stderr; execution continues (a broken
+  observer must not take down the run — same failure-isolation stance as
+  `HookBus.emit`).
+- timeout — the process group is terminated (`aterminate_process_group`, the existing
+  teardown) and treated as the "other exit" case on advisory events, and as `deny`
+  (fail closed) on blocking events. A guard that hangs must not admit the action it
+  was guarding.
+
+**Stdout decision shape** on exit 0: `hookSpecificOutput.permissionDecision` +
+`permissionDecisionReason` + `updatedInput` for `PreToolUse`-mapped events;
+`decision: "block"` + `reason` for other events; unknown fields ignored (forward
+compatibility with harness spec evolution).
+
+Why this way: the alternative — a LionAGI-native contract with an adapter shim per
+harness — was rejected because the two harnesses have *already* converged on one
+contract between themselves; a third dialect creates permanent translation liability
+for zero expressive gain. Adopting the contract verbatim means the same guard binary
+serves three harnesses, and the existing ecosystem of published CC/Codex hooks runs
+on LionAGI unmodified. The contract is external-facing and versioned by the harness
+docs; where CC and Codex diverge in the future, LionAGI follows the intersection and
+documents the divergence in this ADR's Notes.
+
+### D2 — Event vocabulary: fixed mapping, fail-loud on the unmappable
+
+The external event names LionAGI accepts in hook configuration, and the internal seam
+each drives:
+
+| External event | Internal seam | Capability |
+|---|---|---|
+| `SessionStart` | `HookPoint.SESSION_START` (HookBus) | observe; `additionalContext` ignored in v1 |
+| `SessionEnd` | `HookPoint.SESSION_END` (HookBus) | observe |
+| `UserPromptSubmit` | `HookPoint.USER_PROMPT_SUBMIT` (HookBus, **new, blocking**) | observe or block (exit 2 / `decision: "block"`) |
+| `PreToolUse` | tool preprocessor chain at the invoke chokepoint (D3) | block, rewrite via `updatedInput` |
+| `PostToolUse` | tool postprocessor chain at the invoke chokepoint (D3) | observe, annotate |
+| `PostToolUseFailure` | `HookPoint.TOOL_ERROR` (HookBus) | observe (exception stringified into `tool_response.error`) |
+
+Exact semantics:
+
+- `USER_PROMPT_SUBMIT` is a new `HookPoint` enum member **shipped in the same change
+  as its emit site** — a `blocking_emit` immediately before instruction submission in
+  the operations layer, covering both the API path (`communicate`) and the CLI/stream
+  path (`run`), with payload `{session_id, branch_id, prompt}` where `prompt` is the
+  rendered instruction text. Adding the enum member without the emit site is
+  forbidden; ADR-0047 already documents four never-wired hook points as exactly this
+  trap, and this ADR does not add a fifth.
+- `USER_PROMPT_SUBMIT` becomes the second blocking point in `HookBus` (after
+  `TOOL_PRE`). The blocking set remains hardcoded in `bus.py` — extending it is a
+  code change with review, not configuration (see out-of-scope).
+- A config that names any other external event (`Stop`, `PreCompact`,
+  `SubagentStart`, `Notification`, …) **fails at config load** with a diagnostic
+  naming the event and stating that LionAGI has no seam for it — never a silent
+  drop. Rationale: a user who installs a stop-guard and gets no error believes they
+  are protected; silent no-op on a guard is the worst failure mode available.
+- Matchers follow the harness semantics: omitted/`""`/`"*"` matches all;
+  alphanumeric/`_`/`-`/space/`,`/`|` strings are exact-or-list matches; anything else
+  is an unanchored regex. The matched field is `tool_name` for tool events and the
+  event's primary subject otherwise. Matching is evaluated by the adapter layer
+  before spawning the process — a non-matching hook costs zero subprocesses.
+- LionAGI-native hook points with no external counterpart (`BRANCH_CREATE`,
+  `MESSAGE_ADD`, the service-scope `HookRegistry` events) are **not** exposed to
+  external hook configs in v1. Exposing them would invent event names no other
+  harness recognizes, recreating the portability problem this ADR exists to remove.
+  They remain reachable by in-process hooks exactly as today.
+
+### D3 — Tool events route through the invoke chokepoint
+
+`PreToolUse`/`PostToolUse` adapters register into the tool preprocessor/postprocessor
+chain, not `HookBus` — and that chain moves to the one place every tool call passes
+through: `ActionManager.invoke`.
+
+The contract:
+
+- `ActionManager` gains an optional pre/post processor pair applied inside `invoke`,
+  around the `Tool` call, for **every** tool — plain function tools, `Tool` objects,
+  and MCP-discovered tools alike. The existing per-`Tool` `preprocessor`/
+  `postprocessor` attributes remain and run innermost (closest to the tool), so
+  current `AgentSpec`/`HooksMixin` wiring keeps its behavior and ordering
+  (`security -> user -> security recheck` is preserved within the existing layer).
+- The external-hook adapter attaches at the `ActionManager` layer, outermost. Order
+  on a call: external `PreToolUse` hooks (config order) → spec-level pre chain →
+  tool → spec-level post chain → external `PostToolUse` hooks.
+- The preprocessor receives and may replace the full argument dict (`updatedInput`);
+  the postprocessor receives the full result. The postprocessor applies regardless of
+  result type — the current dict-only restriction on the spec-level post chain is a
+  known gap and is not inherited by the new layer.
+- `HookBus.TOOL_PRE`/`TOOL_POST`/`TOOL_ERROR` continue to fire exactly as today
+  (summary payloads, audit plane). D3 adds a mutation-capable layer; it does not
+  repurpose the audit layer. A config-driven external hook therefore produces both
+  its own effect and the ordinary `HookSignal` audit trail.
+
+Why this way: the alternative — wiring external tool hooks into `HookBus.TOOL_PRE` —
+was rejected because that point's payload is a truncated summary by design (the audit
+plane must not hold full arguments), so `updatedInput` is unimplementable there, and
+because MCP tools would remain uncovered. Moving enforcement to `ActionManager.invoke`
+resolves the MCP gap for the external layer without touching the ADR-0047 ownership
+boundaries: the bus stays the observe/audit plane, the tool chain stays the mutation
+plane, and the chokepoint is simply where the mutation plane is anchored so coverage
+is total.
+
+### D4 — One exec adapter, extending the existing executor
+
+A single adapter turns a hook config entry into an async callable conforming to the
+target seam:
+
+```python
+def external_hook_adapter(
+    *,
+    event: str,                    # external event name, e.g. "PreToolUse"
+    command: list[str],            # argv vector — never a shell string
+    timeout: float = 60.0,
+    matcher: str | None = None,
+) -> HookHandler | ToolProcessor:  # shape depends on the mapped seam (D2/D3)
+```
+
+- The executor extends `_make_shell_hook`'s existing subprocess model —
+  `asyncio.create_subprocess_exec`, stdin JSON write, bounded wait,
+  `aterminate_process_group` on timeout — and adds what P1 requires: capture and
+  parse stdout on exit 0, honor the D1/D5 decision semantics, distinguish exit 2 from
+  other nonzero exits (the current executor collapses all nonzero to
+  `PermissionError` on pre hooks; the new one reserves that meaning for exit 2 and
+  the `deny` decision).
+- **Argv-only, no shell — ever.** A string-form `command` is a config error with a
+  diagnostic, not something to `shlex.split` heuristically. This is ADR-0095 D3's
+  posture applied to hooks: the config shape is the argv vector, so there is nothing
+  for a shell to interpret and no injection surface. (CC supports a shell-string
+  form; LionAGI deliberately does not import that part of the contract — a portable
+  hook config that must also run on LionAGI uses the argv form, which both harnesses
+  accept.)
+- Timeout is per-hook-configurable with a 60s default (CC defaults to 600s;
+  LionAGI's runtime is frequently a synchronous step inside an orchestration DAG
+  where a ten-minute stall is a run-killer; 60s is generous for a guard and loud for
+  a hang). The existing fixed 10s in `_make_shell_hook` remains for the legacy
+  `{pre,post,on_error}` shape until that shape is migrated.
+- Concurrency: hooks for one event fire sequentially in config order (a rewrite
+  must see the previous rewrite's output; parallel rewriters have no defined merge).
+
+### D5 — Decision semantics, enumerated
+
+For a blocking-capable seam (`PreToolUse` via D3, `USER_PROMPT_SUBMIT` via D2):
+
+- `permissionDecision: "allow"` (or exit 0 with no decision) — continue; if
+  `updatedInput` is present at the preprocessor seam, the argument dict is replaced
+  with it and the chain continues on the new value. `updatedInput` anywhere else is
+  logged and ignored (there is nothing to rewrite).
+- `"deny"` — raise `PermissionError(permissionDecisionReason or stderr)`; the tool
+  call or prompt submission does not happen; the error travels the existing per-seam
+  error path (same as today's guard-hook denial).
+- exit 2 — equivalent to `"deny"` with stderr as the reason.
+- `"ask"` — **fail closed**: treated as `deny` with reason
+  `"hook requested interactive approval ('ask'); no interactive approval surface
+  exists in this runtime — failing closed"`. LionAGI's hook execution context is
+  headless (CLI runs, scheduled runs, orchestration DAG nodes); inventing a blocking
+  interactive prompt inside those is a separate product decision. Fail-open
+  (`ask`→`allow`) was rejected outright: a hook author who wrote `ask` expressed
+  doubt, and doubt must not admit the action unattended.
+- `"defer"` — continue (defer means "let the normal permission flow decide"; LionAGI's
+  normal flow at that point is the remaining chain, so deferral is continuation).
+- `decision: "block"` on advisory events (`PostToolUse`, `UserPromptSubmit` via the
+  top-level shape) — on `USER_PROMPT_SUBMIT` it blocks (that point is blocking); on
+  `PostToolUse` the action already happened, so `block` cannot un-run it: the reason
+  is logged and surfaced into the branch as a system-visible note, matching the
+  harnesses' own "feed it back to the model" behavior as closely as the seam allows.
+
+### D6 — Config surface and import
+
+`.lionagi/settings.yaml` (global + project merge, existing loader) accepts a new
+`hooks_external:` block in the harness shape:
+
+```yaml
+hooks_external:
+  PreToolUse:
+    - matcher: "bash|shell"
+      hooks:
+        - type: command
+          command: ["uv", "run", "guards/check_cmd.py"]
+          timeout: 30
+  UserPromptSubmit:
+    - hooks:
+        - type: command
+          command: ["./hooks/prompt_hygiene"]
+```
+
+- The block name is `hooks_external`, not `hooks`, because the existing `hooks:` key
+  already means the `{pre,post,on_error}` tool-name shape; overloading one key with
+  two schemas discriminated by structure is a parse-ambiguity trap. The legacy shape
+  keeps working unchanged; both may coexist in one file.
+- `type` is required and must be `command` in v1 (reserved: `http`, `mcp_tool`,
+  `prompt` — see out-of-scope). Unknown `type` is a load-time error naming the value.
+- **Import, not live-read, of foreign configs.** `li hooks import claude|codex
+  [path]` translates a `.claude/settings.json` `hooks` block or a Codex `hooks.json`
+  into `hooks_external` entries in the project `.lionagi/settings.yaml`, reporting
+  per-event: imported, or rejected-with-reason (unmappable event per D2, shell-string
+  command per D4, unsupported handler type). Live-reading `.claude/settings.json` at
+  session start was rejected: it creates an invisible cross-product coupling where
+  editing Claude Code's config silently changes LionAGI runtime behavior, and the
+  fail-loud rule of D2 would make LionAGI refuse to start on a CC config that uses
+  CC-only events — hostile when the file was written for CC, informative when the
+  user explicitly ran an import.
+- Merge semantics across global → project: entries concatenate (project entries run
+  after global entries for the same event); project may not silently delete a global
+  entry — removal is done where the entry is defined. This matches Codex's
+  merge-not-override layering, which is the safer semantic for guards (an org-level
+  guard should not vanish because a project defined its own list).
+
+### D7 — Trust: hash-pinned approval for non-project command hooks
+
+Command hooks are arbitrary code execution. The trust rule, by config source:
+
+- **Project-committed** (`.lionagi/settings.yaml` inside the repo): trusted as code —
+  it is versioned, reviewed, and diffable exactly like the code it sits next to.
+- **User-global** (`~/.lionagi/settings.yaml`): trusted — the user wrote it on their
+  own machine.
+- **Imported or plugin-bundled** (output of `li hooks import`, or a plugin's hook
+  block per ADR-0088): requires an explicit trust record before first execution. The
+  record pins `sha256(json.dumps(argv))` per hook command; `li hooks trust` lists
+  pending commands and records approval into `~/.lionagi/settings.yaml`
+  (`trusted_hook_commands: [<hash>, …]`). An untrusted command hook does not run:
+  blocking events fail closed (`deny` with a diagnostic naming the untrusted
+  command), advisory events skip with a warning. A changed argv changes the hash and
+  re-enters pending state — an update to a plugin's hook is a new approval, which is
+  the point.
+- No bypass flag in v1. Codex ships `--dangerously-bypass-hook-trust`; LionAGI's
+  hook execution frequently happens in unattended scheduled runs where a bypass flag
+  in a wrapper script would become permanent invisible policy. If operational
+  pressure demands a bypass, it arrives as a follow-up decision with its own
+  audit trail, not as a v1 convenience.
+- The existing `trusted_hook_modules` gate for Python import-path hooks is unchanged
+  and orthogonal (it governs in-process code loading; this governs subprocess
+  execution).
+
+## Consequences
+
+- A hook binary written against the CC/Codex contract runs on LionAGI unmodified
+  (argv form), and hooks written for LionAGI run under CC and Codex. Guard suites
+  become write-once.
+- `ActionManager.invoke` becomes the single tool-call chokepoint with an
+  external-enforcement layer; MCP-discovered tools stop being exempt from tool
+  hooks. Contributors must know that tool-hook ordering is now two-layered
+  (manager-level external, spec-level internal) and that the manager layer sees
+  every tool.
+- Two new failure modes exist and are deliberate: a hanging blocking hook denies its
+  action after timeout (fail closed), and an unmappable event name refuses to load.
+  Both trade convenience for the property that a configured guard is either running
+  or loudly absent — never silently absent.
+- The `hooks_external` name means LionAGI carries two hook-config shapes
+  indefinitely. Cost accepted: the legacy shape has production users and collapsing
+  the two would couple this ADR to a migration it does not need.
+- Reversal cost: D1/D5/D6 are additive and could be removed by deleting the adapter
+  and loader (no core surface bends around them). D3's chokepoint relocation is the
+  structural commitment — reverting it would re-open the MCP coverage gap and
+  reorder the chain; treat D3 as the decision to review hardest.
+- `USER_PROMPT_SUBMIT` enlarges the blocking surface: a misbehaving prompt hook can
+  now stall or veto every turn. Mitigated by the 60s timeout, fail-closed-on-timeout
+  semantics, and the trust gate; accepted because a prompt-hygiene gate that cannot
+  block is an observer, not a gate.
+
+## Alternatives considered
+
+- **LionAGI-native wire contract + per-harness shims** — maximum expressive freedom
+  (could expose `BRANCH_CREATE` etc. natively). Lost: every existing CC/Codex hook
+  needs a shim, every LionAGI hook needs two shims to travel, and the shims are
+  permanent maintenance. The converged contract's expressiveness is sufficient for
+  every P1–P5 need identified.
+- **Route `PreToolUse` through `HookBus.TOOL_PRE`** — smallest diff, reuses the
+  existing blocking point. Lost on two hard requirements: the summary-only payload
+  cannot honor `updatedInput`, and MCP tools stay invisible. Keeping the audit plane
+  summary-only is an ADR-0047 property worth preserving, which forces the mutation
+  work onto the tool chain.
+- **Extend the per-`Tool` preprocessor attributes instead of adding a manager layer**
+  — preserves a single chain. Lost: MCP tools materialize as `Tool` objects at
+  discovery time in a path that never passes through `AgentSpec` wiring, so per-Tool
+  attributes systematically miss them; patching every discovery path is strictly more
+  invasive than one chokepoint.
+- **Live-read `.claude/settings.json`** — zero-step interop. Rejected for the
+  coupling and fail-loud conflicts described in D6; import-with-report keeps the
+  interop win and the explicitness.
+- **`ask` → interactive prompt via a new approval surface** — the faithful semantic.
+  Rejected for v1: it requires a UI/TTY arbitration design (headless runs, DAG
+  nodes, scheduled fires) that is its own ADR-sized decision; fail-closed preserves
+  safety meanwhile and is the conservative reading of `ask`.
+- **Trust nothing / trust everything for command hooks** — trusting everything is
+  indefensible once configs arrive via import and plugins (P5); trusting nothing
+  (hash-pin even project-committed hooks) punishes the common case where the hook
+  sits in the same reviewed repo as the code and adds an approval step with no
+  security delta. The source-tiered rule (D7) takes each where it is defensible.
+
+## Notes
+
+- Naming: the existing `StopHook` exception (chain-control: "stop remaining handlers")
+  is unrelated to the harnesses' `Stop` event (turn-stop arbitration). This ADR maps
+  no `Stop` event, and any future ADR that does must not reuse the `StopHook` name for
+  it.
+- The CC and Codex hook specs are actively evolving surfaces. This ADR pins the
+  intersection contract as of 2026-07-12 (envelope fields, exit codes, decision
+  shapes listed in D1); divergences discovered later are recorded here with the
+  chosen side.

--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -22,25 +22,36 @@ fixed 10-second timeout, and — critically — no stdout read-back. An external
 veto (nonzero exit becomes `PermissionError` on the pre phase) but cannot rewrite
 arguments, attach context, or return a structured decision.
 
-Meanwhile the two dominant agent harnesses have converged on one external-hook wire
-contract. Claude Code and Codex CLI both ship: a JSON envelope on stdin carrying
-`session_id`, `cwd`, `hook_event_name`, and per-event fields (`tool_name`,
-`tool_input`, `tool_response`); an exit-code protocol (0 = success and stdout is
-parsed as JSON, 2 = block with stderr as the reason, other = non-blocking failure);
-and a stdout decision shape (`hookSpecificOutput.permissionDecision` ∈
-`allow|deny|ask` with `permissionDecisionReason` and optional `updatedInput` for
-`PreToolUse`; top-level `decision: "block"` + `reason` for most other events). Both
-use the same nested config shape (`hooks.<EventName>` → `[{matcher, hooks: [{type,
-command, timeout}]}]`) and largely the same event names. Codex additionally ships a
-hash-pinned trust gate: a non-managed hook's exact command must be explicitly trusted
-before it runs.
+Meanwhile the two dominant agent harnesses ship external-hook contracts of the same
+*family*: a JSON envelope on stdin carrying `session_id`, `cwd`, `hook_event_name`,
+and per-event fields (`tool_name`, `tool_input`, `tool_response`); an exit-code
+protocol (0 = success and stdout is parsed as JSON, 2 = block with stderr as the
+reason, other = non-blocking failure); a stdout decision shape
+(`hookSpecificOutput.permissionDecision` with `permissionDecisionReason` and optional
+`updatedInput` for `PreToolUse`; top-level `decision: "block"` + `reason` for most
+other events); and a nested config shape (`hooks.<EventName>` → `[{matcher, hooks:
+[{type, command, timeout}]}]`) with largely shared event names. The family
+resemblance is real, but they are **not one contract**, and this ADR must not
+pretend otherwise. Divergences that matter here: Claude Code configures `command`
+as a shell string (with a separate args-array form for no-shell execution) while
+Codex executes the configured command as shell text; Codex's `UserPromptSubmit`
+input schema *requires* fields (`model`, `permission_mode`, `transcript_path`,
+`turn_id`) that Claude Code does not; Codex's `PreToolUse` decision vocabulary
+admits only `allow|deny|ask`; and Claude Code cancels a timed-out
+`UserPromptSubmit` hook and lets the prompt proceed, i.e. fails open. Codex
+additionally ships a hash-pinned trust gate: a non-managed hook's exact command
+must be explicitly trusted before it runs.
 
-This convergence is an opportunity with a deadline attached. Users who already
-maintain a hardened hook suite for Claude Code or Codex (guards, formatters, audit
-loggers, notification bridges) should be able to point LionAGI at it and have it
-work; hooks written for LionAGI should run unmodified under either harness. If
-LionAGI invents a third wire contract, every hook gets written twice and the
-ecosystem's existing hook tooling is unusable here.
+The shared family is still an opportunity with a deadline attached. Users who
+already maintain a hardened hook suite for Claude Code or Codex (guards,
+formatters, audit loggers, notification bridges) should be able to bring most of it
+to LionAGI, and hooks written against the common subset should travel the other
+way. If LionAGI invents an unrelated third dialect, every hook gets written twice
+and the ecosystem's existing hook tooling is unusable here. But because the two
+harnesses genuinely differ, the deliverable is a **stated, versioned compatibility
+profile** — exactly which events, fields, decisions, and config forms LionAGI
+guarantees, and where it knowingly diverges from each harness — not a claim of
+equivalence the upstream systems themselves do not have.
 
 Named problems:
 
@@ -71,13 +82,13 @@ Named problems:
 
 | Concern | Decision |
 |---------|----------|
-| External wire contract | D1: adopt the converged CC/Codex stdin/exit-code/stdout-JSON contract |
-| Event vocabulary and mapping | D2: fixed mapping table; `USER_PROMPT_SUBMIT` added with its emit site; unmapped events fail loud at load |
-| Which internal seam serves tool events | D3: tool pre/post events route to the tool-hook chain, relocated to the `ActionManager` invoke chokepoint so MCP tools are covered |
-| Executor | D4: one exec adapter extending `_make_shell_hook` — argv-only, stdout parse-back, per-hook timeout |
-| Decision semantics | D5: `allow`/`defer` continue, `deny` raises, `ask` fails closed; `updatedInput` honored only at the preprocessor seam |
-| Config surface | D6: CC-shaped `hooks:` block in `.lionagi/settings.yaml`, plus explicit import of CC/Codex hook configs |
-| Trust | D7: hash-pinned trust for command hooks that are not project-committed |
+| External wire contract | D1: a versioned LionAGI compatibility profile over the CC/Codex family — exact field guarantees and named divergences, no equivalence claim |
+| Event vocabulary and mapping | D2: fixed mapping table; `USER_PROMPT_SUBMIT` added with a turn-origin token consumed exactly once; unmapped events fail loud at load |
+| Which internal seam serves tool events | D3: tool pre/post events route to the tool-hook chain, relocated to the `ActionManager` invoke chokepoint (Branch-mediated coverage incl. MCP; direct `FunctionCalling` construction is a documented, tested bypass) |
+| Executor | D4: one exec adapter extending `_make_shell_hook` — non-empty argv only, stdout parse-back, per-hook timeout |
+| Decision semantics | D5: `allow` continues, `deny` raises, `ask` fails closed, unrecognized decisions fail closed; `updatedInput` honored only at the preprocessor seam |
+| Config surface | D6: CC-shaped `hooks_external:` block in `.lionagi/settings.yaml`, plus explicit import of CC/Codex hook configs with per-entry source provenance |
+| Trust | D7: hash-pinned trust for command hooks that are not project-authored; provenance markers survive import |
 
 Out of scope for this ADR:
 
@@ -97,10 +108,16 @@ Out of scope for this ADR:
 
 ## Decision
 
-### D1 — Adopt the converged external-hook wire contract
+### D1 — A versioned compatibility profile, not an equivalence claim
 
-LionAGI's contract for external hook processes is the CC/Codex contract, not a new
-one.
+LionAGI defines **external-hook compatibility profile v1**: an explicit, versioned
+statement of the envelope LionAGI emits, the decisions it accepts, and how foreign
+configurations translate. The profile follows the CC/Codex family shape wherever the
+two harnesses agree, and **names every divergence** where they do not (or where
+LionAGI deliberately departs). Nothing in this ADR claims the contract is verbatim,
+converged, or that arbitrary foreign hooks run unmodified — those are properties the
+conformance matrix (below) must demonstrate per event, not properties asserted by
+adoption.
 
 **Stdin envelope** (one JSON object, UTF-8, single line or pretty — the hook must
 parse, not line-split):
@@ -117,20 +134,50 @@ parse, not line-split):
 }
 ```
 
-Common fields (`session_id`, `cwd`, `hook_event_name`) are always present. Per-event
-fields follow the CC/Codex field names exactly (`tool_name`, `tool_input`,
-`tool_response`, `prompt`). The translation is mechanical and total: LionAGI's tool
-argument dict (the `arguments` mapping a `FunctionCalling` invocation carries) is
-placed under `tool_input` verbatim — it is already an arbitrary JSON-serializable
-dict, so no reshaping occurs; a returned `updatedInput` replaces that same dict
-whole (no per-key merge — partial rewrites are the hook's job to construct from the
-`tool_input` it was sent). `tool_name` is the registered tool name string
-(`Tool.function`), and `tool_response` is the tool's result as JSON where
-serializable, else its string form. One LionAGI addition: `harness: "lionagi"` — a
-hook that must behave differently per harness keys off this; CC and Codex omit it,
-so its absence means "not lionagi." Fields LionAGI cannot populate (for example
-`transcript_path` when no transcript file exists for the surface) are omitted, never
-sent as fabricated values.
+**Per-event field guarantees.** Common fields (`session_id`, `cwd`,
+`hook_event_name`, `harness`) are always present. Per-event fields use the CC/Codex
+field names, with an explicit presence guarantee each:
+
+| Event | Field | Guarantee |
+|---|---|---|
+| `PreToolUse` | `tool_name` | always; the LionAGI registered name (`Tool.function`) — see the tool-naming divergence below |
+| `PreToolUse` | `tool_input` | always; the LionAGI argument dict verbatim (already an arbitrary JSON-serializable mapping, no reshaping); a returned `updatedInput` replaces this dict whole — no per-key merge |
+| `PostToolUse` | `tool_name`, `tool_input` | as above |
+| `PostToolUse` | `tool_response` | always; the tool result as JSON where serializable, else its string form |
+| `UserPromptSubmit` | `prompt` | always; the rendered instruction text actually being submitted |
+| `UserPromptSubmit` | `model` | always; the branch's active model identifier |
+| `UserPromptSubmit` | `permission_mode` | always; the attached `PermissionPolicy` mode, else `"default"` |
+| all | `harness` | always `"lionagi"` — a hook that must behave differently per harness keys off this; CC and Codex omit it, so its absence means "not lionagi" |
+
+**Named divergence Dv1-1 (envelope):** Codex's `UserPromptSubmit` input schema
+additionally requires `transcript_path` and `turn_id`. LionAGI has no transcript
+file or turn identifier on every surface and does not fabricate values: the fields
+are present when the surface has them (a persisted run's branch-snapshot path; a
+flow node id) and **omitted** otherwise. A Codex hook that hard-requires them does
+not run unmodified on LionAGI; it must tolerate their absence when
+`harness == "lionagi"`. The import command (D6) warns when it cannot prove an
+imported hook tolerates this.
+
+**Named divergence Dv1-2 (tool naming):** matchers and `tool_name` carry LionAGI
+registered tool names, not CC/Codex built-in names (`Bash`, `Read`, …). No automatic
+name mapping exists in v1 — a matcher written as `"Bash"` matches a LionAGI tool
+only if a tool is registered under that exact name. `li hooks import` (D6) reports
+every matcher that references a name with no registered LionAGI tool so the user
+can re-target it; an alias table is future work that belongs to the tool registry,
+not to this profile.
+
+**Named divergence Dv1-3 (command form):** LionAGI executes argv vectors only —
+never a shell (D4). CC configures `command` as a shell string (argv is a separate
+form); Codex executes command text via a shell. Import translation (D6) tokenizes a
+foreign command string only when it contains no shell metacharacters; anything else
+is rejected-with-reason, never reinterpreted.
+
+**Named divergence Dv1-4 (blocking timeout):** Claude Code cancels a timed-out
+`UserPromptSubmit` hook and lets the prompt proceed — fail open. LionAGI fails
+closed on every blocking point (D1 timeout rule below, D5). This is a deliberate
+policy divergence: an unattended runtime must not admit an action its guard never
+cleared. Hook authors porting from CC must know their timeout now blocks instead of
+waving through.
 
 **Exit-code protocol**, exactly as the harnesses define it:
 
@@ -147,17 +194,33 @@ sent as fabricated values.
 
 **Stdout decision shape** on exit 0: `hookSpecificOutput.permissionDecision` +
 `permissionDecisionReason` + `updatedInput` for `PreToolUse`-mapped events;
-`decision: "block"` + `reason` for other events; unknown fields ignored (forward
-compatibility with harness spec evolution).
+`decision: "block"` + `reason` for other events. The accepted
+`permissionDecision` vocabulary is the genuine cross-harness intersection —
+`allow | deny | ask` (Codex's schemas admit nothing else) — with the exact
+semantics in D5. Unknown *fields* are ignored (forward compatibility with harness
+spec evolution); an unrecognized *decision value* fails closed as `deny` with a
+diagnostic naming the value — a guard channel does not guess at verbs it does not
+know.
+
+**Conformance matrix (acceptance artifact).** The implementation ships a
+conformance test matrix: for each profile event, fixture hooks authored against the
+current CC documentation and the current Codex schemas run under LionAGI, asserting
+each field-guarantee row and each named divergence above. Until that matrix exists
+and passes, neither documentation nor `li hooks import` output may describe a
+foreign hook as running "unmodified" — the import report says "imported; verify
+against profile v1" and lists the divergences that apply to that entry.
 
 Why this way: the alternative — a LionAGI-native contract with an adapter shim per
-harness — was rejected because the two harnesses have *already* converged on one
-contract between themselves; a third dialect creates permanent translation liability
-for zero expressive gain. Adopting the contract verbatim means the same guard binary
-serves three harnesses, and the existing ecosystem of published CC/Codex hooks runs
-on LionAGI unmodified. The contract is external-facing and versioned by the harness
-docs; where CC and Codex diverge in the future, LionAGI follows the intersection and
-documents the divergence in this ADR's Notes.
+harness — was rejected because the CC/Codex family shape is expressive enough for
+every P1–P5 need, and a third unrelated dialect creates permanent translation
+liability for zero expressive gain. But the opposite temptation — declaring the
+family a single converged contract and adopting it "verbatim" — fails on the facts:
+the harnesses differ in command form, required input fields, decision vocabulary,
+and timeout semantics, so an equivalence claim would leave every implementer to
+rediscover the exceptions. A versioned profile with named divergences keeps the
+portability of the shared shape and makes the residual differences a checkable
+contract. The profile is LionAGI-owned and versioned here; when CC or Codex moves,
+the profile revs with a new version entry in Notes, never silently.
 
 ### D2 — Event vocabulary: fixed mapping, fail-loud on the unmappable
 
@@ -176,26 +239,42 @@ each drives:
 Exact semantics:
 
 - `USER_PROMPT_SUBMIT` is a new `HookPoint` enum member **shipped in the same change
-  as its emit sites** — plural, because the API path and the CLI/stream path are
-  architecturally disjoint and share no single "instruction submission" function:
-  one `blocking_emit` in the `communicate` middle before its chat call, and one in
-  the `run` middle before streaming begins. Payload: `{session_id, branch_id,
-  prompt}` where `prompt` is the rendered instruction text. Adding the enum member
-  without both emit sites is forbidden; ADR-0047 already documents four never-wired
-  hook points as exactly this trap, and this ADR does not add a fifth.
-- **Fires exactly once per user-originated turn.** `operate()` delegates to
-  `communicate` through the `Middle` protocol, so a naive emit at both layers would
-  double-fire on one turn; a turn-scoped emitted-flag on the operation context
-  guards this — the outermost entry emits, the delegated inner call sees the flag
-  and stays silent. The point fires **only for a user-originated instruction**:
-  internal instructions the runtime synthesizes (ReAct sub-steps, parse-retry
-  turns) never emit it. The discriminator is placement — the emits live in the
-  top-level middle entries named above, never in `a_add_message` or any shared
-  message-construction primitive, because internal turns traverse those shared
-  primitives too and a prompt guard firing on the model's own reasoning steps
-  would block the run from inside. Implementation acceptance: an integration test
-  asserting exactly one emission for an `operate→communicate` turn and zero
-  emissions for a ReAct internal step.
+  as its emit mechanism**. Placement alone cannot express "user-originated": the
+  public ingress APIs are plural (`Branch.chat()` and `Branch.chat_and_record()`
+  call the low-level chat operation directly, never entering `communicate`), and
+  the internal callers of the same middles are also plural (ReAct drives repeated
+  synthetic `operate()` calls through the very `communicate`/`run_and_collect`
+  middles a middle-level emit would live in). Any fixed emit site is therefore
+  either incomplete or over-broad. The mechanism is a **turn-origin token**:
+  - **Created** at each public user-ingress API — `Branch.chat()`,
+    `Branch.chat_and_record()`, `Branch.communicate()`, `Branch.operate()`,
+    `Branch.run()`, and `Branch.ReAct()` — and carried on the operation context as
+    an explicit field threaded through the call chain (not ambient task-local
+    state, which would leak across concurrently running branch operations).
+  - **Consumed exactly once** at the model-submission boundary: immediately before
+    provider invocation in the chat operation (which serves the chat,
+    chat_and_record, communicate, and operate→communicate paths), and immediately
+    before streaming begins in the `run` middle. Consumption is
+    check-and-clear: if the token is present, `blocking_emit` fires with payload
+    `{session_id, branch_id, prompt}` — `prompt` being the rendered instruction
+    text actually submitted at that boundary — and the token is cleared for the
+    remainder of the turn; if absent, the boundary stays silent.
+  - **Internal turns never carry the token.** Instructions the runtime synthesizes
+    (ReAct extension and final-answer turns, parse-retry turns) are issued without
+    ingress, so their submissions find no token and emit nothing. For a multi-step
+    `ReAct()` call this means exactly one emission — at the first model submission
+    of the user's turn — and silence for every internal continuation.
+  - Adding the enum member without the token mechanism and both consuming
+    boundaries is forbidden; ADR-0047 already documents four never-wired hook
+    points as exactly this trap, and this ADR does not add a fifth.
+- **Acceptance: exact-once, enumerated per path.** The implementation ships
+  integration tests asserting the emission count for every ingress: direct
+  `chat()` → 1; direct `chat_and_record()` → 1; `communicate()` → 1;
+  `operate()` delegating to communicate → 1; direct `run()` → 1; a `ReAct()`
+  call with multiple internal extension turns and a final-answer turn → exactly 1
+  total; a parse-retry inside any of the above → 0 additional. A new public
+  ingress added later must add its row to this matrix — the test file carries a
+  comment stating that rule.
 - A blocked `USER_PROMPT_SUBMIT` surfaces as the same `PermissionError`-family
   failure the blocking convention already defines, at the operation boundary: an
   interactive session fails the turn with the hook's reason; a headless DAG node
@@ -223,14 +302,32 @@ Exact semantics:
 ### D3 — Tool events route through the invoke chokepoint
 
 `PreToolUse`/`PostToolUse` adapters register into the tool preprocessor/postprocessor
-chain, not `HookBus` — and that chain moves to the one place every tool call passes
-through: `ActionManager.invoke`.
+chain, not `HookBus` — and that chain moves to `ActionManager.invoke`, the point
+every **Branch-mediated** tool call passes through.
+
+**Coverage, stated precisely.** The guarantee of this decision is scoped to tool
+calls that flow through `ActionManager.invoke()`: the Branch action path
+(`act`/`operate`/`ReAct` action requests) and every tool registered on the manager,
+including MCP-discovered tools. That is the entire product surface LionAGI ships
+today. It is **not** a universal interception point: `FunctionCalling` is itself an
+executable event that runs `Tool.preprocessor`, the callable, and
+`Tool.postprocessor` directly — code that constructs a `FunctionCalling` and
+invokes it bypasses the manager layer, and always has. v1 does not internalize that
+constructor (privatizing a long-public API is a breaking change with its own blast
+radius, recorded below as deferred hardening); instead the bypass is a **named,
+documented, tested limit**: an acceptance test constructs a `FunctionCalling`
+directly and asserts external hooks do *not* fire, so the boundary is a pinned
+contract rather than an accident, and code review owns keeping product paths on the
+manager. Deferred hardening decision, recorded for a future ADR: make
+`ActionManager` the sole constructor/invoker of `FunctionCalling` (or gate direct
+construction behind an internal token), at which point the guarantee upgrades from
+"Branch-mediated" to universal.
 
 The contract:
 
 - `ActionManager` gains an optional pre/post processor pair applied inside `invoke`,
-  around the `Tool` call, for **every** tool — plain function tools, `Tool` objects,
-  and MCP-discovered tools alike. The existing per-`Tool` `preprocessor`/
+  around the `Tool` call, for **every** tool invoked through it — plain function
+  tools, `Tool` objects, and MCP-discovered tools alike. The existing per-`Tool` `preprocessor`/
   `postprocessor` attributes remain and run innermost (closest to the tool), so
   current `AgentSpec`/`HooksMixin` wiring keeps its behavior and ordering
   (`security -> user -> security recheck` is preserved within the existing layer).
@@ -300,13 +397,22 @@ def external_hook_adapter(
   other nonzero exits (the current executor collapses all nonzero to
   `PermissionError` on pre hooks; the new one reserves that meaning for exit 2 and
   the `deny` decision).
-- **Argv-only, no shell — ever.** A string-form `command` is a config error with a
-  diagnostic, not something to `shlex.split` heuristically. This is ADR-0095 D3's
-  posture applied to hooks: the config shape is the argv vector, so there is nothing
-  for a shell to interpret and no injection surface. (CC supports a shell-string
-  form; LionAGI deliberately does not import that part of the contract — a portable
-  hook config that must also run on LionAGI uses the argv form, which both harnesses
-  accept.)
+- **Argv-only, no shell — ever, and never empty.** A string-form `command` is a
+  config error with a diagnostic, not something to `shlex.split` heuristically.
+  This is ADR-0095 D3's posture applied to hooks: the config shape is the argv
+  vector, so there is nothing for a shell to interpret and no injection surface.
+  (CC supports a shell-string form and Codex executes shell text; LionAGI
+  deliberately does not import that behavior — divergence Dv1-3. Import
+  translation is D6's job.) `command` must additionally be a **non-empty list of
+  non-empty, non-whitespace strings** — the same invalid-argv classification
+  ADR-0095 applies to callback argv from every source. The rule is enforced at
+  three gates: config load, `li hooks import`, and trust recording (D7). A
+  violating entry **fails config load** with a diagnostic naming the file, event,
+  and entry (`hooks_external: command must be a non-empty argv list`) — load
+  failure rather than ADR-0095's disable-before-launch, because a hook config is
+  durable declared policy, and a declared-but-undefined guard is the silent-absence
+  failure mode D2 already refuses. Consequently no trust record can ever pin the
+  hash of an empty argv.
 - Timeout is per-hook-configurable with a 60s default (CC defaults to 600s;
   LionAGI's runtime is frequently a synchronous step inside an orchestration DAG
   where a ten-minute stall is a run-killer; 60s is generous for a guard and loud for
@@ -342,8 +448,13 @@ For a blocking-capable seam (`PreToolUse` via D3, `USER_PROMPT_SUBMIT` via D2):
   strict relaxation (more permissive, and only for `ask`; headless contexts keep
   fail-closed unchanged), so no carve-out is needed now to avoid a breaking
   semantic change later.
-- `"defer"` — continue (defer means "let the normal permission flow decide"; LionAGI's
-  normal flow at that point is the remaining chain, so deferral is continuation).
+- Any other `permissionDecision` value — **fail closed**: treated as `deny` with a
+  diagnostic naming the unrecognized value. The accepted vocabulary is the
+  cross-harness intersection `allow | deny | ask` (D1); Codex's schemas admit
+  nothing else, and a decision channel that guesses at unknown verbs is a guard
+  that can be talked past. If a harness later standardizes a new value (a `defer`,
+  a `warn`), supporting it is a profile revision recorded in Notes, not a silent
+  acceptance.
 - `decision: "block"` on advisory events (`PostToolUse`, `UserPromptSubmit` via the
   top-level shape) — on `USER_PROMPT_SUBMIT` it blocks (that point is blocking); on
   `PostToolUse` the action already happened, so `block` cannot un-run it: the reason
@@ -378,13 +489,24 @@ hooks_external:
 - **Import, not live-read, of foreign configs.** `li hooks import claude|codex
   [path]` translates a `.claude/settings.json` `hooks` block or a Codex `hooks.json`
   into `hooks_external` entries in the project `.lionagi/settings.yaml`, reporting
-  per-event: imported, or rejected-with-reason (unmappable event per D2, shell-string
-  command per D4, unsupported handler type). Live-reading `.claude/settings.json` at
-  session start was rejected: it creates an invisible cross-product coupling where
-  editing Claude Code's config silently changes LionAGI runtime behavior, and the
-  fail-loud rule of D2 would make LionAGI refuse to start on a CC config that uses
-  CC-only events — hostile when the file was written for CC, informative when the
-  user explicitly ran an import.
+  per-event: imported, or rejected-with-reason (unmappable event per D2,
+  untranslatable shell command per Dv1-3, empty argv per D4, unsupported handler
+  type), plus the Dv1-1/Dv1-2 warnings that apply to each imported entry.
+  Live-reading `.claude/settings.json` at session start was rejected: it creates an
+  invisible cross-product coupling where editing Claude Code's config silently
+  changes LionAGI runtime behavior, and the fail-loud rule of D2 would make LionAGI
+  refuse to start on a CC config that uses CC-only events — hostile when the file
+  was written for CC, informative when the user explicitly ran an import.
+- **Imported entries carry provenance in the data.** Every entry `li hooks import`
+  writes includes `source: imported:claude` or `source: imported:codex` as a field
+  of the hook entry itself, so the trust class survives the write, file merges, and
+  later commits. An entry authored in place has no `source` field and belongs to
+  the tier of the file it lives in. The loader's execution rule is D7's, driven by
+  this field — *where the entry sits* never upgrades *what the entry is*.
+  Promotion to project-authored status is an explicit edit: deleting the `source`
+  field in the project settings file, which is a reviewed, git-diffable change —
+  that visible diff is the transition mechanism, and no separate promote command
+  exists in v1.
 - Merge semantics across global → project: entries concatenate (project entries run
   after global entries for the same event); project may not silently delete a global
   entry — removal is done where the entry is defined. This matches Codex's
@@ -393,21 +515,33 @@ hooks_external:
 
 ### D7 — Trust: hash-pinned approval for non-project command hooks
 
-Command hooks are arbitrary code execution. The trust rule, by config source:
+Command hooks are arbitrary code execution. Trust attaches to the **entry's
+provenance** (the D6 `source` field plus load location), never to the file it
+happens to sit in — an imported entry inside the project settings file is still an
+imported entry. The tiers:
 
-- **Project-committed** (`.lionagi/settings.yaml` inside the repo): trusted as code —
-  it is versioned, reviewed, and diffable exactly like the code it sits next to.
-- **User-global** (`~/.lionagi/settings.yaml`): trusted — the user wrote it on their
-  own machine.
-- **Imported or plugin-bundled** (output of `li hooks import`, or a plugin's hook
-  block per ADR-0088): requires an explicit trust record before first execution. The
-  record pins `sha256(json.dumps(argv))` per hook command; `li hooks trust` lists
-  pending commands and records approval into `~/.lionagi/settings.yaml`
-  (`trusted_hook_commands: [<hash>, …]`). An untrusted command hook does not run:
-  blocking events fail closed (`deny` with a diagnostic naming the untrusted
-  command), advisory events skip with a warning. A changed argv changes the hash and
-  re-enters pending state — an update to a plugin's hook is a new approval, which is
-  the point.
+- **Project-authored** (entry with no `source` field in the repo's
+  `.lionagi/settings.yaml`): trusted as code — it is versioned, reviewed, and
+  diffable exactly like the code it sits next to.
+- **User-authored** (entry with no `source` field in `~/.lionagi/settings.yaml`):
+  trusted — the user wrote it on their own machine.
+- **Imported or plugin-bundled** (entry carrying `source: imported:*` wherever it
+  sits, or any hook loaded from a plugin bundle per ADR-0088): requires an explicit
+  trust record before first execution. The record pins `sha256(json.dumps(argv))`
+  per hook command — argv is validated non-empty first (D4), so no record ever pins
+  an empty command; `li hooks trust` lists pending commands and records approval
+  into `~/.lionagi/settings.yaml` (`trusted_hook_commands: [<hash>, …]`). An
+  untrusted command hook does not run: blocking events fail closed (`deny` with a
+  diagnostic naming the untrusted command), advisory events skip with a warning. A
+  changed argv changes the hash and re-enters pending state — an update to a
+  plugin's hook is a new approval, which is the point.
+- **Loader rule, exact.** Before executing any external hook command the loader
+  resolves: entry from a plugin bundle → tier `plugin`; else entry has `source:
+  imported:*` → tier `imported`; else → the tier of the defining file (project /
+  user). Tiers `project` and `user` execute; tiers `imported` and `plugin` execute
+  only when the argv hash is in `trusted_hook_commands`. There is no path by which
+  location, merging, or committing a file changes an entry's tier — only the
+  explicit promotion edit defined in D6.
 - No bypass flag in v1. Codex ships `--dangerously-bypass-hook-trust`; LionAGI's
   hook execution frequently happens in unattended scheduled runs where a bypass flag
   in a wrapper script would become permanent invisible policy. If operational
@@ -419,14 +553,17 @@ Command hooks are arbitrary code execution. The trust rule, by config source:
 
 ## Consequences
 
-- A hook binary written against the CC/Codex contract runs on LionAGI unmodified
-  (argv form), and hooks written for LionAGI run under CC and Codex. Guard suites
-  become write-once.
-- `ActionManager.invoke` becomes the single tool-call chokepoint with an
-  external-enforcement layer; MCP-discovered tools stop being exempt from tool
-  hooks. Contributors must know that tool-hook ordering is now two-layered
-  (manager-level external, spec-level internal) and that the manager layer sees
-  every tool.
+- A hook binary written against compatibility profile v1 (the CC/Codex common
+  subset plus the named divergences) runs under all three harnesses; a foreign hook
+  ports with the Dv1-1…Dv1-4 checklist rather than a rewrite. Guard suites become
+  write-mostly-once; the conformance matrix is what turns that from a hope into a
+  tested property.
+- `ActionManager.invoke` becomes the enforcement chokepoint for Branch-mediated
+  tool calls with an external layer; MCP-discovered tools stop being exempt from
+  tool hooks. Contributors must know that tool-hook ordering is now two-layered
+  (manager-level external, spec-level internal), that the manager layer sees every
+  tool invoked through it, and that direct `FunctionCalling` construction is a
+  documented, tested bypass that code review keeps out of product paths.
 - Two new failure modes exist and are deliberate: a hanging blocking hook denies its
   action after timeout (fail closed), and an unmappable event name refuses to load.
   Both trade convenience for the property that a configured guard is either running
@@ -448,8 +585,9 @@ Command hooks are arbitrary code execution. The trust rule, by config source:
 - **LionAGI-native wire contract + per-harness shims** — maximum expressive freedom
   (could expose `BRANCH_CREATE` etc. natively). Lost: every existing CC/Codex hook
   needs a shim, every LionAGI hook needs two shims to travel, and the shims are
-  permanent maintenance. The converged contract's expressiveness is sufficient for
-  every P1–P5 need identified.
+  permanent maintenance. The CC/Codex family shape's expressiveness is sufficient
+  for every P1–P5 need identified, and the compatibility profile handles the
+  residual divergence at far lower cost than a full dialect.
 - **Route `PreToolUse` through `HookBus.TOOL_PRE`** — smallest diff, reuses the
   existing blocking point. Lost on two hard requirements: the summary-only payload
   cannot honor `updatedInput`, and MCP tools stay invisible. Keeping the audit plane
@@ -479,7 +617,10 @@ Command hooks are arbitrary code execution. The trust rule, by config source:
   is unrelated to the harnesses' `Stop` event (turn-stop arbitration). This ADR maps
   no `Stop` event, and any future ADR that does must not reuse the `StopHook` name for
   it.
-- The CC and Codex hook specs are actively evolving surfaces. This ADR pins the
-  intersection contract as of 2026-07-12 (envelope fields, exit codes, decision
-  shapes listed in D1); divergences discovered later are recorded here with the
-  chosen side.
+- The CC and Codex hook specs are actively evolving surfaces. Compatibility profile
+  v1 is pinned as of 2026-07-12: the field-guarantee table, exit-code protocol,
+  decision vocabulary `allow|deny|ask`, and named divergences Dv1-1 through Dv1-4
+  in D1. When either harness moves, the profile revs — a new version entry is
+  appended here naming what changed and which side LionAGI takes; the loader and
+  import command reference the profile version they implement. No revision happens
+  silently.

--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -119,9 +119,16 @@ parse, not line-split):
 
 Common fields (`session_id`, `cwd`, `hook_event_name`) are always present. Per-event
 fields follow the CC/Codex field names exactly (`tool_name`, `tool_input`,
-`tool_response`, `prompt`). One LionAGI addition: `harness: "lionagi"` — a hook that
-must behave differently per harness keys off this; CC and Codex omit it, so its
-absence means "not lionagi." Fields LionAGI cannot populate (for example
+`tool_response`, `prompt`). The translation is mechanical and total: LionAGI's tool
+argument dict (the `arguments` mapping a `FunctionCalling` invocation carries) is
+placed under `tool_input` verbatim — it is already an arbitrary JSON-serializable
+dict, so no reshaping occurs; a returned `updatedInput` replaces that same dict
+whole (no per-key merge — partial rewrites are the hook's job to construct from the
+`tool_input` it was sent). `tool_name` is the registered tool name string
+(`Tool.function`), and `tool_response` is the tool's result as JSON where
+serializable, else its string form. One LionAGI addition: `harness: "lionagi"` — a
+hook that must behave differently per harness keys off this; CC and Codex omit it,
+so its absence means "not lionagi." Fields LionAGI cannot populate (for example
 `transcript_path` when no transcript file exists for the surface) are omitted, never
 sent as fabricated values.
 
@@ -169,12 +176,31 @@ each drives:
 Exact semantics:
 
 - `USER_PROMPT_SUBMIT` is a new `HookPoint` enum member **shipped in the same change
-  as its emit site** — a `blocking_emit` immediately before instruction submission in
-  the operations layer, covering both the API path (`communicate`) and the CLI/stream
-  path (`run`), with payload `{session_id, branch_id, prompt}` where `prompt` is the
-  rendered instruction text. Adding the enum member without the emit site is
-  forbidden; ADR-0047 already documents four never-wired hook points as exactly this
-  trap, and this ADR does not add a fifth.
+  as its emit sites** — plural, because the API path and the CLI/stream path are
+  architecturally disjoint and share no single "instruction submission" function:
+  one `blocking_emit` in the `communicate` middle before its chat call, and one in
+  the `run` middle before streaming begins. Payload: `{session_id, branch_id,
+  prompt}` where `prompt` is the rendered instruction text. Adding the enum member
+  without both emit sites is forbidden; ADR-0047 already documents four never-wired
+  hook points as exactly this trap, and this ADR does not add a fifth.
+- **Fires exactly once per user-originated turn.** `operate()` delegates to
+  `communicate` through the `Middle` protocol, so a naive emit at both layers would
+  double-fire on one turn; a turn-scoped emitted-flag on the operation context
+  guards this — the outermost entry emits, the delegated inner call sees the flag
+  and stays silent. The point fires **only for a user-originated instruction**:
+  internal instructions the runtime synthesizes (ReAct sub-steps, parse-retry
+  turns) never emit it. The discriminator is placement — the emits live in the
+  top-level middle entries named above, never in `a_add_message` or any shared
+  message-construction primitive, because internal turns traverse those shared
+  primitives too and a prompt guard firing on the model's own reasoning steps
+  would block the run from inside. Implementation acceptance: an integration test
+  asserting exactly one emission for an `operate→communicate` turn and zero
+  emissions for a ReAct internal step.
+- A blocked `USER_PROMPT_SUBMIT` surfaces as the same `PermissionError`-family
+  failure the blocking convention already defines, at the operation boundary: an
+  interactive session fails the turn with the hook's reason; a headless DAG node
+  fails that node through the node's normal error path — never a silent skip,
+  never a process abort.
 - `USER_PROMPT_SUBMIT` becomes the second blocking point in `HookBus` (after
   `TOOL_PRE`). The blocking set remains hardcoded in `bus.py` — extending it is a
   code change with review, not configuration (see out-of-scope).
@@ -215,10 +241,33 @@ The contract:
   the postprocessor receives the full result. The postprocessor applies regardless of
   result type — the current dict-only restriction on the spec-level post chain is a
   known gap and is not inherited by the new layer.
+- **Rewritten arguments are revalidated before the tool runs.** The current
+  `FunctionCalling` path does not re-run request-model validation after a
+  preprocessor replaces arguments (a gap ADR-0047 records). This ADR does not ship
+  arg-rewrite on top of that gap: after the external hooks and the spec-level chain
+  have both run, the final argument dict is validated against the tool's
+  `request_options` (when the tool declares one) before the callable executes; a
+  validation failure is a `deny`-equivalent block carrying the validation error.
+  A tool without `request_options` runs on the rewritten dict as-is — that tool
+  never had schema enforcement, and the external layer does not weaken or invent
+  one.
+- **`security_pre` stays the last pre-stage validator.** External hooks are
+  strictly outside the spec-level chain, so any `updatedInput` rewrite happens
+  before `security_pre` sees the arguments; the guard therefore always validates
+  the post-rewrite values that will actually reach the tool. This holds in the
+  no-user-hook case too (external rewrite, no spec-level user pre-hook: the single
+  `security_pre` run still sees final args, because external ran first). The
+  ordering is a load-bearing invariant of this design, not an accident — an
+  implementation must not move external hooks inside or after the security stage.
 - `HookBus.TOOL_PRE`/`TOOL_POST`/`TOOL_ERROR` continue to fire exactly as today
   (summary payloads, audit plane). D3 adds a mutation-capable layer; it does not
   repurpose the audit layer. A config-driven external hook therefore produces both
-  its own effect and the ordinary `HookSignal` audit trail.
+  its own effect and the ordinary `HookSignal` audit trail. One consequence to
+  know: the bus's `TOOL_PRE` emit happens in the act layer before
+  `ActionManager.invoke`, so its argument summary reflects the **pre-rewrite**
+  arguments by construction. The faithful post-rewrite record lives in the tool
+  event itself; if the audit plane ever needs the final args, that is a follow-up
+  emit-site move, decided there, not silently here.
 
 Why this way: the alternative — wiring external tool hooks into `HookBus.TOOL_PRE` —
 was rejected because that point's payload is a truncated summary by design (the audit
@@ -265,6 +314,10 @@ def external_hook_adapter(
   `{pre,post,on_error}` shape until that shape is migrated.
 - Concurrency: hooks for one event fire sequentially in config order (a rewrite
   must see the previous rewrite's output; parallel rewriters have no defined merge).
+  Across tool calls, hook concurrency mirrors the tool-call strategy: concurrent
+  tool invocations run their hook chains concurrently, so a hook touching shared
+  external state (a file-backed rate limiter, a counter) owns its own mutual
+  exclusion — the harness serializes within a call's chain, not across calls.
 
 ### D5 — Decision semantics, enumerated
 
@@ -284,7 +337,11 @@ For a blocking-capable seam (`PreToolUse` via D3, `USER_PROMPT_SUBMIT` via D2):
   headless (CLI runs, scheduled runs, orchestration DAG nodes); inventing a blocking
   interactive prompt inside those is a separate product decision. Fail-open
   (`ask`→`allow`) was rejected outright: a hook author who wrote `ask` expressed
-  doubt, and doubt must not admit the action unattended.
+  doubt, and doubt must not admit the action unattended. Deferring the interactive
+  path is also forward-safe: moving `ask` from deny to a TTY prompt later is a
+  strict relaxation (more permissive, and only for `ask`; headless contexts keep
+  fail-closed unchanged), so no carve-out is needed now to avoid a breaking
+  semantic change later.
 - `"defer"` — continue (defer means "let the normal permission flow decide"; LionAGI's
   normal flow at that point is the remaining chain, so deferral is continuation).
 - `decision: "block"` on advisory events (`PostToolUse`, `UserPromptSubmit` via the

--- a/docs/adr/ADR-0088-plugin-system.md
+++ b/docs/adr/ADR-0088-plugin-system.md
@@ -69,7 +69,7 @@ run at `import lionagi` at all.
 | Manifest schema | D2: declarative capability manifest; pure data, no code references executed at parse |
 | Activation timing | D3: manifest-only discovery on first registry miss; code import deferred to capability first-use |
 | Pluggable surfaces (v1) | D4: tools, external hooks, agent profiles, playbooks, providers |
-| Trust | D5: manifest-hash trust record required before any plugin code or command runs |
+| Trust | D5: content-pinned trust record (manifest + every declared capability file) required before any plugin code, command, profile, or playbook is used |
 | Collisions | D6: built-ins always win; plugin-vs-plugin same-name is a hard load error |
 | Lifecycle | D7: `li plugin list/info/trust/enable/disable`; uninstall is directory removal |
 | Python-package plugins | D8 (DEFERRED): `lionagi.plugins` entry-points group resolving to the same manifest |
@@ -249,21 +249,33 @@ do not exist), and roles by recorded design decision — see out-of-scope.
   cannot bury one in an elided display. User-level, not project-level: a repo must
   not be able to self-trust the plugin it carries by committing a settings line —
   the human on the machine approves.
-- The trust record pins **content, not just declaration**: `sha256` of the
-  canonical-JSON manifest plus `sha256` of every file the manifest declares as
-  executable capability — tool `target` files, provider `module` files, hook
-  binaries. Any change to the manifest or to a declared file reverts the plugin to
-  `changed — re-trust required` and it stops loading. Pinning only the manifest
-  was considered and rejected as incoherent: it would argv-pin the *subprocess*
-  hooks (the lower-privilege surface) while letting the in-process Python behind
-  fixed `target` strings — which runs with the host's full privileges on the
-  shared event loop — swap freely without re-approval. The set of hashed files is
-  exactly the declared set, so the cost is O(declared capabilities) at trust time
-  and at each load-time verification. Files inside the bundle that the manifest
-  does not declare (prompts, data, docs a declared module might read) are **not**
-  hashed — that is the honest, bounded limitation of this design, stated rather
-  than hidden: the boundary pins what may execute, not every byte a trusted
-  execution may consume.
+- The trust record pins **content, not just declaration**, for **every declared
+  capability file** — executable *and* consumed-as-instructions alike: `sha256` of
+  the canonical-JSON manifest, plus `sha256` of every tool `target` file, provider
+  `module` file, hook binary, **agent profile file, playbook file, and pack data
+  file** the manifest declares. Any change to the manifest or to any declared file
+  reverts the plugin to `changed — re-trust required` and it stops loading —
+  the changed capability is not exposed again before re-approval. Two narrower
+  scopes were considered and rejected:
+  - *Manifest-only pinning* is incoherent: it would argv-pin the subprocess hooks
+    (the lower-privilege surface) while letting the in-process Python behind fixed
+    `target` strings — which runs with the host's full privileges on the shared
+    event loop — swap freely without re-approval.
+  - *Executables-only pinning* repeats the same mistake one layer up: this ADR
+    itself classifies a poisoned profile prompt as an attack (first bullet), and a
+    profile or playbook is injected into a session's instruction stream — content
+    the model acts on. Leaving those files unhashed means a bundle can pass trust
+    with a benign `agents/researcher.md`, then swap in attacker instructions
+    without touching any pinned hash. The displayed-then-mutable gap is exactly
+    the attack the display contract exists to prevent, so everything the display
+    contract shows, the trust record pins.
+  The set of hashed files is exactly the declared set, so the cost is O(declared
+  capabilities) at trust time and at each load-time verification. The one remaining
+  unpinned category is bundle files the manifest does **not** declare (auxiliary
+  data or docs a declared module might read at runtime) — that is the honest,
+  bounded limitation of this design, stated rather than hidden: the boundary pins
+  every capability LionAGI itself loads into a session or execution path, not every
+  byte a trusted execution may choose to consume.
 - Plugin hook commands additionally pass through ADR-0048 D7 (they are the
   "plugin-bundled" tier there); trusting a plugin records their argv hashes in the
   same step — defensible precisely because the display contract above already put
@@ -357,10 +369,11 @@ The design, recorded in full for the follow-up:
 - Failure surface moves earlier and louder: manifest typos, collisions, and
   incompatible ranges all surface at discovery with plugin-named diagnostics,
   instead of as deep-stack ImportErrors at call time.
-- The trust boundary pins declared executable content (manifest + target files +
-  hook binaries), so a bundle edit behind a trusted manifest stops the plugin
-  loading until re-approved. Undeclared bundle files remain unpinned — stated in
-  D5 as the design's honest limit.
+- The trust boundary pins every declared capability file (manifest, target files,
+  hook binaries, profiles, playbooks, packs), so a bundle edit behind a trusted
+  manifest stops the plugin loading until re-approved — including a swap of
+  instruction-bearing prompt files. Undeclared bundle files remain unpinned —
+  stated in D5 as the design's honest limit.
 - Built-in-collision detection for the code surfaces (providers, tools) happens at
   activation, not discovery — deferred by construction, because knowing the
   built-in set requires the loads D3 forbids at discovery. A colliding plugin

--- a/docs/adr/ADR-0088-plugin-system.md
+++ b/docs/adr/ADR-0088-plugin-system.md
@@ -2,7 +2,7 @@
 
 - **Status**: Proposed
 - **Kind**: Aspirational
-- **Area**: governance
+- **Area**: substrates
 - **Date**: 2026-07-12
 - **Relations**: builds on ADR-0047 (hook mechanism scopes) and ADR-0048 (external
   hook contract — a plugin's hook block is delivered through it, including its D7
@@ -18,7 +18,10 @@ discovery timing, and trust model:
    `find_lionagi_dirs()`, first match wins. Data-only, no install step. The most
    mature "drop a file, it works" seam.
 2. **Playbooks** — `~/.lionagi/playbooks/*.playbook.yaml`, discovered by glob at
-   `li play` time. Same drop-a-file shape.
+   `li play` time. Same drop-a-file shape, but **global-only** (no project-local
+   `.lionagi/playbooks/`, no `find_lionagi_dirs()` cascade), and the discovery is
+   split across two sites: a pre-argparse CLI branch resolves the playbook name
+   and rewrites argv, and the downstream flow subcommand resolves the file again.
 3. **Tools** — imperative runtime registration (`branch.register_tools`,
    `ActionManager.register_mcp_server`). No declarative form, no discovery.
 4. **Hooks** — a name→callable registry (`lionagi/hooks/loader.py:_REGISTRY`,
@@ -179,12 +182,26 @@ Two-stage laziness, mirroring the endpoint registry's `_ensure_loaded` pattern:
   trigger points:
   - `ActionManager` tool-name miss → "does a trusted, enabled plugin declare this
     tool?"
-  - `match_endpoint` registry miss → import declared provider modules (which
-    self-register via the existing decorator), then re-match once.
+  - provider resolution: **`EndpointRegistry.match()` never misses today** — on no
+    registered match it silently falls through to a generic OpenAI-compatible
+    endpoint, so there is no existing miss event to hook. This decision therefore
+    requires a small, named refactor of the registry: an interception point after
+    "no registered entry matched" and **before** the generic fallback, which
+    consults the plugin registry, imports any declared provider module for that
+    provider name (the module self-registers at import time via the existing
+    decorator, so importing before the fallback is sufficient — no registry
+    reload), re-runs the match once, and only then falls back. Without this
+    interception a plugin provider would silently receive the generic endpoint
+    instead of its own — a wrong-answer failure, not an error.
   - agent-profile resolution miss → plugin `agents/` entries join the search list
     after project and global profiles.
-  - `li play` name resolution and playbook listing → plugin playbooks join the
-    scan, namespaced (D6).
+  - playbooks: discovery today is global-only and split across a pre-argparse CLI
+    branch (name resolution + argv rewrite) and the downstream flow resolver.
+    Plugin-playbook support therefore lands **with** a unification of playbook
+    discovery onto `find_lionagi_dirs()` (project, global, then plugin dirs), and
+    both resolution sites consult the unified scan. A `<plugin>/<name>` token (D6)
+    is passed through the argv rewrite as an opaque playbook identifier — the
+    rewrite branch must not split on `/` — and resolved only at the unified scan.
   - session-bus construction (`build_session_bus`) and agent-factory hook wiring →
     plugin `hooks_external` blocks join the ADR-0048 loader input.
   - `li plugin *` commands → full scan, eagerly.
@@ -198,7 +215,11 @@ Two-stage laziness, mirroring the endpoint registry's `_ensure_loaded` pattern:
 - Failure cases: a `target` whose file is missing or whose callable name is absent
   raises at first use with a diagnostic carrying plugin name + manifest path (not
   an ImportError three frames deep); a provider module that raises on import is
-  reported once, cached as failed, and does not retry per call.
+  reported once, cached as failed, and does not retry per call. The failed-import
+  cache is **new infrastructure** — the built-in provider auto-loader swallows
+  ImportError per module with no memory of the failure, so the plugin loader
+  builds its own (a per-plugin `{target: error}` map held by the plugin registry),
+  it does not extend an existing one.
 
 ### D4 — v1 pluggable surfaces
 
@@ -219,33 +240,59 @@ do not exist), and roles by recorded design decision — see out-of-scope.
   list`/`info` (rendered from manifest data only), and completely inert — no code
   import, no command execution, no profile/playbook exposure (a poisoned system
   prompt is an attack, not just code).
-- `li plugin trust <name>` shows what the plugin declares (capability inventory,
-  argv of every hook command, module list) and records
-  `sha256(canonical-json(manifest))` into `~/.lionagi/settings.yaml` under
-  `trusted_plugins: {<name>: <hash>}`. User-level, not project-level: a repo must
+- `li plugin trust <name>` shows what the plugin declares and records trust into
+  `~/.lionagi/settings.yaml` under `trusted_plugins: {<name>: {manifest: <hash>,
+  targets: {<path>: <hash>, …}}}`. The display contract is **complete and
+  non-skippable**: every hook command's full argv (no truncation, no counts-only
+  summary), every `target`/`module` path, and every profile/playbook file are
+  rendered before the approval prompt — a bundle carrying many hook commands
+  cannot bury one in an elided display. User-level, not project-level: a repo must
   not be able to self-trust the plugin it carries by committing a settings line —
   the human on the machine approves.
-- Any manifest change invalidates the hash; the plugin reverts to untrusted and
-  `list` shows `changed — re-trust required`. Contents referenced by the manifest
-  (tool modules, hook binaries) are *not* content-hashed in v1: the manifest hash
-  pins *what may run* (targets, argv, capability set), not every byte of it. A
-  bundle whose code you cannot trust to stay benign at fixed argv/targets should
-  not be trusted at all. This is recorded as an accepted, revisitable limitation —
-  content pinning is a straightforward hardening if evidence demands it.
+- The trust record pins **content, not just declaration**: `sha256` of the
+  canonical-JSON manifest plus `sha256` of every file the manifest declares as
+  executable capability — tool `target` files, provider `module` files, hook
+  binaries. Any change to the manifest or to a declared file reverts the plugin to
+  `changed — re-trust required` and it stops loading. Pinning only the manifest
+  was considered and rejected as incoherent: it would argv-pin the *subprocess*
+  hooks (the lower-privilege surface) while letting the in-process Python behind
+  fixed `target` strings — which runs with the host's full privileges on the
+  shared event loop — swap freely without re-approval. The set of hashed files is
+  exactly the declared set, so the cost is O(declared capabilities) at trust time
+  and at each load-time verification. Files inside the bundle that the manifest
+  does not declare (prompts, data, docs a declared module might read) are **not**
+  hashed — that is the honest, bounded limitation of this design, stated rather
+  than hidden: the boundary pins what may execute, not every byte a trusted
+  execution may consume.
 - Plugin hook commands additionally pass through ADR-0048 D7 (they are the
   "plugin-bundled" tier there); trusting a plugin records their argv hashes in the
-  same step, so one approval covers the bundle without weakening the hook-level
-  gate (an edited hook argv still re-pends on its own).
+  same step — defensible precisely because the display contract above already put
+  every argv in front of the approver — and an edited hook argv still re-pends on
+  its own through the hook-level gate.
 - Trusted plugin code runs in-process with the host's privileges. The ADR says so
   plainly; see out-of-scope for why no sandbox is claimed.
 
 ### D6 — Collisions: built-ins win; peers hard-fail
 
-- A plugin capability whose name collides with a **built-in** (a lionagi-shipped
-  tool name, provider match, or playbook) is rejected at discovery with a
-  diagnostic; the built-in stays authoritative. A plugin must never silently
-  change what a stock name does — that is a supply-chain attack shape, not a
-  customization feature.
+- A plugin capability must never silently change what a stock name does — that is
+  a supply-chain attack shape, not a customization feature. The built-in stays
+  authoritative and the plugin capability is rejected with a diagnostic. **When**
+  that check runs is surface-dependent, because for the code surfaces the set of
+  built-in names is itself only knowable by loading code, which D3 forbids at
+  discovery:
+  - **Data-only surfaces** (agent profiles, playbooks, packs): checked at
+    discovery — the built-in/shipped set is enumerable from data.
+  - **Providers**: checked at the activation trigger (the D3 match
+    interception), where the built-in registry has necessarily been loaded
+    anyway. A plugin provider name shadowing a built-in provider match is
+    rejected there, first use, with the diagnostic.
+  - **Tools**: there is no global built-in tool set today — tool registries are
+    per-`ActionManager`, populated imperatively. "Built-in" for tools therefore
+    means: a plugin tool may never replace a name already present in the
+    consuming manager's registry (whatever put it there — factory wiring, user
+    code, another plugin), checked at the point the plugin tool would be
+    registered/matched. No abstract shipped-tool list is claimed, because none
+    exists.
 - Two **enabled plugins** declaring the same capability name is a hard error at
   discovery, naming both plugins and the surface (the Studio route-registry
   precedent: duplicates are `ValueError`, not last-writer-wins). Resolution is
@@ -310,9 +357,16 @@ The design, recorded in full for the follow-up:
 - Failure surface moves earlier and louder: manifest typos, collisions, and
   incompatible ranges all surface at discovery with plugin-named diagnostics,
   instead of as deep-stack ImportErrors at call time.
-- The trust model is honest but coarse (manifest-hash, not content-hash): a trusted
-  plugin's author can change code behind fixed targets. Accepted and documented in
-  D5; revisit with content pinning if real-world evidence demands.
+- The trust boundary pins declared executable content (manifest + target files +
+  hook binaries), so a bundle edit behind a trusted manifest stops the plugin
+  loading until re-approved. Undeclared bundle files remain unpinned — stated in
+  D5 as the design's honest limit.
+- Built-in-collision detection for the code surfaces (providers, tools) happens at
+  activation, not discovery — deferred by construction, because knowing the
+  built-in set requires the loads D3 forbids at discovery. A colliding plugin
+  provider therefore surfaces its rejection diagnostic at first use of that
+  provider name, not at `li plugin trust` time; maintainers should expect the
+  later timing when triaging reports.
 - Studio's CC-bundle viewer and this system stay separate concepts sharing a
   directory idiom. A repository may ship one directory that is both (a
   `.claude-plugin/plugin.json` for CC and a `plugin.yaml` for LionAGI, side by
@@ -358,6 +412,11 @@ The design, recorded in full for the follow-up:
 
 ## Notes
 
+- Numbering: this record's area is `substrates`, whose number block (0090-0095) is
+  exhausted; the number is allocated from the adjacent free gap. The `Area` header
+  is authoritative for classification — the block ranges are an allocation
+  convenience, and recent records have already outgrown strict block-area
+  correspondence.
 - Naming: "plugin" here always means a LionAGI runtime extension bundle.
   Studio's existing plugin routes render *Claude Code* bundles; the two appear
   together only in the marketplace directory of this repository, which may carry

--- a/docs/adr/ADR-0088-plugin-system.md
+++ b/docs/adr/ADR-0088-plugin-system.md
@@ -1,0 +1,366 @@
+# ADR-0088: Plugin system (directory-bundle manifest with lazy activation)
+
+- **Status**: Proposed
+- **Kind**: Aspirational
+- **Area**: governance
+- **Date**: 2026-07-12
+- **Relations**: builds on ADR-0047 (hook mechanism scopes) and ADR-0048 (external
+  hook contract — a plugin's hook block is delivered through it, including its D7
+  trust gate); none superseded
+
+## Context
+
+LionAGI already has six independent extension seams, each with a different shape,
+discovery timing, and trust model:
+
+1. **Agent profiles** — markdown + YAML frontmatter under `.lionagi/agents/`
+   (project) and `~/.lionagi/agents/` (global), discovered by directory scan via
+   `find_lionagi_dirs()`, first match wins. Data-only, no install step. The most
+   mature "drop a file, it works" seam.
+2. **Playbooks** — `~/.lionagi/playbooks/*.playbook.yaml`, discovered by glob at
+   `li play` time. Same drop-a-file shape.
+3. **Tools** — imperative runtime registration (`branch.register_tools`,
+   `ActionManager.register_mcp_server`). No declarative form, no discovery.
+4. **Hooks** — a name→callable registry (`lionagi/hooks/loader.py:_REGISTRY`,
+   last-writer-wins), plus the settings-driven tool-hook shape, plus (with ADR-0048)
+   external command hooks.
+5. **Providers/endpoints** — `@register_endpoint` self-registration at import time,
+   with a hardcoded built-in module list (`_import_all_providers`) walked once on
+   first `match_endpoint`. The decorator already works for any module that gets
+   imported; what is missing is only *who imports third-party modules*.
+6. **Casts roles/modes** — an explicitly closed built-in set; packs overlay behavior
+   on existing roles but cannot add roles.
+
+There is no unit that groups these into one installable, listable, versionable,
+trustable thing. The practical consequences:
+
+- **P1 — no distribution unit.** Sharing "my agent profile + its guard hook + the
+  playbook that drives it + the provider it needs" means a README with four manual
+  copy steps into three directories plus an import-side-effect arrangement for the
+  provider. There is nothing to hand a user.
+- **P2 — no discovery for code capabilities.** A third-party provider endpoint
+  works if and only if something imports its module before first
+  `match_endpoint()`. Nothing owns that import today; users get "provider not
+  found" with a working package installed.
+- **P3 — no inventory or lifecycle.** Nothing answers "what extensions are active
+  in this project?" — extensions are invisible until they fire. There is no
+  disable-without-delete, no version-compatibility check, and no uninstall other
+  than hunting files.
+- **P4 — no trust boundary.** Every existing seam either runs nothing external
+  (data-only seams) or runs whatever is present (import-side-effect providers,
+  last-writer-wins hook registry). A bundle of third-party capability needs an
+  explicit approval step before its code executes in-process.
+- **P5 — a plugin concept already half-exists, for the wrong system.** Studio ships
+  a read-only viewer for *Claude Code* plugin bundles (directory + manifest +
+  `skills/`/`agents/` subdirectories), and the repo ships one such bundle. The
+  directory-bundle shape is proven in this codebase; what does not exist is a
+  bundle that extends *LionAGI's own runtime*.
+
+Hard constraint from the architecture: **import-time O(1)**. `lionagi/__init__.py`
+is lazy by design; plugin discovery must not import plugin code, and must not even
+run at `import lionagi` at all.
+
+| Concern | Decision |
+|---------|----------|
+| What a plugin is | D1: a directory bundle with a `plugin.yaml` manifest under `.lionagi/plugins/` |
+| Manifest schema | D2: declarative capability manifest; pure data, no code references executed at parse |
+| Activation timing | D3: manifest-only discovery on first registry miss; code import deferred to capability first-use |
+| Pluggable surfaces (v1) | D4: tools, external hooks, agent profiles, playbooks, providers |
+| Trust | D5: manifest-hash trust record required before any plugin code or command runs |
+| Collisions | D6: built-ins always win; plugin-vs-plugin same-name is a hard load error |
+| Lifecycle | D7: `li plugin list/info/trust/enable/disable`; uninstall is directory removal |
+| Python-package plugins | D8 (DEFERRED): `lionagi.plugins` entry-points group resolving to the same manifest |
+
+Out of scope, each deliberately:
+
+- **CLI subcommands as plugin capability** — the argparse tree is statically built
+  with pre-parse interception branches; a lazy subcommand registry is real
+  architectural work on `cli/main.py` that should not ride a plugin ADR. Revisit
+  once the manifest shape has proven itself.
+- **Casts roles/modes** — closed by an explicit recorded design decision
+  (`casts/pattern.py`); packs remain the extension surface for cast behavior. A
+  plugin may ship a pack file; it may not add roles.
+- **Schedule `action_kind` values** — dispatch is string-compared across several
+  studio/scheduler sites with no registry; making that pluggable requires the
+  registry to exist first (its own change, in scheduling-control-plane).
+- **Sandboxed execution of plugin code** — `SandboxSession` provides git-worktree
+  *filesystem* isolation, not process or capability isolation; advertising it as a
+  plugin security boundary would be false. Trust (D5) is the boundary in this
+  design; process-level isolation is a possible future hardening with its own ADR.
+- **A remote marketplace/index** — distribution beyond "a directory you obtained"
+  is a product decision, not runtime architecture.
+
+## Decision
+
+### D1 — A plugin is a directory bundle with a manifest
+
+```text
+.lionagi/plugins/<name>/
+  plugin.yaml            # the manifest (D2) — required
+  tools/                 # python modules for declared tools
+  hooks/                 # hook commands (executables) referenced by the manifest
+  agents/<n>.md          # agent profiles, same format as .lionagi/agents/
+  playbooks/*.playbook.yaml
+  providers/             # python modules using @register_endpoint
+  packs/*.yaml           # casts pack overlays
+```
+
+- Discovery scans `<dir>/plugins/*/plugin.yaml` for each directory yielded by
+  `find_lionagi_dirs()` — project `.lionagi/` first, then `~/.lionagi/`, the exact
+  precedence agent profiles already use. No new path convention.
+- A directory without `plugin.yaml` is ignored (not an error — it may be a work in
+  progress). A `plugin.yaml` that fails schema validation is a load-time diagnostic
+  naming the file and field, and the plugin is excluded (never partially loaded:
+  half a plugin is harder to reason about than none).
+- The bundle is self-contained: manifest references are relative paths inside the
+  bundle; a manifest entry that points outside its own directory
+  (path-traversal-checked with the existing `has_traversal` helper) is a validation
+  error. This is what makes "uninstall = delete the directory" true (D7).
+- Why directory-bundle first: it matches the two proven discovery seams in this
+  codebase (agent profiles, playbooks) and the Studio-side CC-bundle reader; it
+  needs no packaging knowledge from plugin authors; and it can carry data-only
+  bundles (profiles + playbooks + packs) that have no importable Python at all —
+  the case a pip-package-only design cannot express cleanly.
+
+### D2 — Manifest schema: declarative, pure data
+
+```yaml
+# plugin.yaml
+name: web-research            # ^[a-z0-9][a-z0-9-]{0,31}$ — doubles as namespace
+version: "0.3.0"              # plugin's own version, informational
+description: Web research toolkit
+lionagi: ">=0.30,<1.0"        # PEP 440 specifier set — compatibility gate
+
+capabilities:
+  tools:
+    - name: web_search        # registered tool name
+      target: tools/search.py:web_search    # module-path:callable inside the bundle
+    - name: fetch_page
+      target: tools/fetch.py:fetch_page
+  hooks_external:             # ADR-0048 D6 shape, verbatim
+    PreToolUse:
+      - matcher: "web_search|fetch_page"
+        hooks:
+          - type: command
+            command: ["hooks/rate_guard"]   # relative to bundle root
+  agents: [agents/researcher.md]
+  playbooks: [playbooks/deep-research.playbook.yaml]
+  providers:
+    - module: providers/searchapi.py        # imported lazily; self-registers
+  packs: [packs/research.yaml]
+```
+
+Exact semantics:
+
+- Parsing the manifest imports nothing and executes nothing: `target` and `module`
+  are strings, resolved only per D3. This is the same deferred-reference idea as the
+  provider config layer's `LazyType` (`"module:Class"` strings resolved on demand),
+  extended to bundle-relative paths.
+- `lionagi:` is checked at discovery against the installed version; out-of-range
+  plugins are listed by `li plugin list` as `incompatible` with the failing
+  specifier, and none of their capabilities load. Skip-with-visible-reason rather
+  than hard error: an incompatible plugin must not break the session that merely
+  walked past it.
+- `name` is the namespace for everything the plugin registers (see D6). Version
+  ranges between *plugins* are not resolved — there is no inter-plugin dependency
+  field in v1; a plugin that needs Python packages states them in its own docs or
+  ships as D8 later. Building a dependency resolver for directory bundles
+  duplicates pip badly; declining it keeps the loader honest about what it is.
+- Unknown top-level or capability keys are load-time errors (catch typos like
+  `playbook:` early), except keys prefixed `x-` which are reserved for
+  user/vendor annotation and ignored.
+
+### D3 — Lazy activation: manifests at first need, code at first use
+
+Two-stage laziness, mirroring the endpoint registry's `_ensure_loaded` pattern:
+
+- **Stage 1 — discovery (cheap, data-only).** The plugin registry scans and parses
+  manifests the first time any consumer asks it anything. Consumers and their
+  trigger points:
+  - `ActionManager` tool-name miss → "does a trusted, enabled plugin declare this
+    tool?"
+  - `match_endpoint` registry miss → import declared provider modules (which
+    self-register via the existing decorator), then re-match once.
+  - agent-profile resolution miss → plugin `agents/` entries join the search list
+    after project and global profiles.
+  - `li play` name resolution and playbook listing → plugin playbooks join the
+    scan, namespaced (D6).
+  - session-bus construction (`build_session_bus`) and agent-factory hook wiring →
+    plugin `hooks_external` blocks join the ADR-0048 loader input.
+  - `li plugin *` commands → full scan, eagerly.
+- **Stage 2 — activation (code, per capability).** A declared `target`/`module` is
+  imported only when that specific capability is actually invoked or matched —
+  never as a side effect of discovery, listing, or an unrelated capability of the
+  same plugin firing.
+- `import lionagi` alone triggers neither stage. Nothing at module import time
+  touches the plugin registry; the import-time O(1) invariant holds by
+  construction, not by discipline.
+- Failure cases: a `target` whose file is missing or whose callable name is absent
+  raises at first use with a diagnostic carrying plugin name + manifest path (not
+  an ImportError three frames deep); a provider module that raises on import is
+  reported once, cached as failed, and does not retry per call.
+
+### D4 — v1 pluggable surfaces
+
+Exactly five: **tools, external hooks, agent profiles, playbooks, providers** —
+plus pack files as data. The selection rule is: every v1 surface extends a seam
+that already exists (registration call, directory scan, or registration decorator);
+no v1 surface requires building a new registry inside a subsystem that lacks one.
+Tools/profiles/playbooks/packs are the low-lift group (existing dynamic seams);
+providers are included despite being medium-lift because they are the single
+highest-value plugin case (a new LLM backend without a lionagi PR) and the missing
+piece is precisely what a manifest supplies: the name of the module to import.
+CLI subcommands and schedule kinds are excluded by that same rule (their registries
+do not exist), and roles by recorded design decision — see out-of-scope.
+
+### D5 — Trust: nothing executes before an explicit trust record
+
+- A plugin arrives untrusted. Untrusted means: fully visible in `li plugin
+  list`/`info` (rendered from manifest data only), and completely inert — no code
+  import, no command execution, no profile/playbook exposure (a poisoned system
+  prompt is an attack, not just code).
+- `li plugin trust <name>` shows what the plugin declares (capability inventory,
+  argv of every hook command, module list) and records
+  `sha256(canonical-json(manifest))` into `~/.lionagi/settings.yaml` under
+  `trusted_plugins: {<name>: <hash>}`. User-level, not project-level: a repo must
+  not be able to self-trust the plugin it carries by committing a settings line —
+  the human on the machine approves.
+- Any manifest change invalidates the hash; the plugin reverts to untrusted and
+  `list` shows `changed — re-trust required`. Contents referenced by the manifest
+  (tool modules, hook binaries) are *not* content-hashed in v1: the manifest hash
+  pins *what may run* (targets, argv, capability set), not every byte of it. A
+  bundle whose code you cannot trust to stay benign at fixed argv/targets should
+  not be trusted at all. This is recorded as an accepted, revisitable limitation —
+  content pinning is a straightforward hardening if evidence demands it.
+- Plugin hook commands additionally pass through ADR-0048 D7 (they are the
+  "plugin-bundled" tier there); trusting a plugin records their argv hashes in the
+  same step, so one approval covers the bundle without weakening the hook-level
+  gate (an edited hook argv still re-pends on its own).
+- Trusted plugin code runs in-process with the host's privileges. The ADR says so
+  plainly; see out-of-scope for why no sandbox is claimed.
+
+### D6 — Collisions: built-ins win; peers hard-fail
+
+- A plugin capability whose name collides with a **built-in** (a lionagi-shipped
+  tool name, provider match, or playbook) is rejected at discovery with a
+  diagnostic; the built-in stays authoritative. A plugin must never silently
+  change what a stock name does — that is a supply-chain attack shape, not a
+  customization feature.
+- Two **enabled plugins** declaring the same capability name is a hard error at
+  discovery, naming both plugins and the surface (the Studio route-registry
+  precedent: duplicates are `ValueError`, not last-writer-wins). Resolution is
+  human: disable one. Silent shadowing by scan order (the agent-profile precedent)
+  was rejected for cross-plugin conflicts because scan order is not something a
+  user meaningfully chose.
+- A plugin colliding with a **user's own local file** (project agent profile with
+  the same name, e.g.) resolves to the user's file, with a logged shadow warning —
+  the user's explicit local file is the nearest intent.
+- Namespacing keeps collisions rare: playbooks and agent profiles from plugins are
+  addressable as `<plugin>/<name>` (`li play web-research/deep-research`); bare
+  names resolve only when unambiguous. Tool names are global by necessity (the
+  model calls them by bare name), which is exactly why the two rules above are
+  strict.
+
+### D7 — Lifecycle and CLI
+
+```text
+li plugin list                 # name, version, state: active|disabled|untrusted|changed|incompatible
+li plugin info <name>          # manifest render: capabilities, trust state, paths
+li plugin trust <name>         # inventory display + hash record (D5)
+li plugin enable|disable <name>  # flips enabled: false in ~/.lionagi/settings.yaml plugins block
+```
+
+- Disable is a settings flag, not a file mutation inside the bundle — the bundle
+  stays pristine and diffable against its source.
+- Uninstall is `rm -r` of the bundle directory (or removing the package, under D8).
+  Trust records for absent plugins are inert and garbage-collected by `li plugin
+  list` when noticed.
+- No `li plugin install <url>` in v1 — acquisition is out of scope (see
+  out-of-scope: marketplace); the loader consumes directories however they arrived
+  (git clone, copy, checkout of a monorepo path).
+
+### D8 — DEFERRED: Python-package plugins via entry points
+
+The design, recorded in full for the follow-up:
+
+- A pip-installable package declares
+  `[project.entry-points."lionagi.plugins"] <name> = "pkg.module:get_manifest"`;
+  the callable returns the D2 manifest as a dict, with `target`/`module` references
+  resolved as import paths instead of bundle-relative files.
+- Discovery adds `importlib.metadata.entry_points(group="lionagi.plugins")` to
+  Stage 1 — names only; the entry point is **loaded** (which imports the package)
+  only on trust + first use, keeping Stage 1 data-only for the common path.
+- Trust (D5) applies identically — installation via pip is not approval.
+- Deferred because it adds a second resolution path (import-path vs bundle-relative)
+  to every capability loader before the first path has users; the manifest schema
+  is designed now so nothing about D2 changes when this lands.
+
+## Consequences
+
+- "Install" becomes: obtain a directory, `li plugin trust <name>`. One approval
+  step, full inventory shown, everything listable afterward — P1/P3/P4 close.
+- Providers gain their missing discovery half: the manifest names the module,
+  `match_endpoint` miss triggers the import, the existing decorator does the rest —
+  P2 closes with no change to the registration mechanism itself.
+- Contributors must know the two-stage laziness rule when adding any new
+  registry/consumer: ask the plugin registry on miss, never import plugin code in
+  discovery. A consumer that eagerly imports plugin modules re-breaks the
+  import-time invariant in a way no test on `import lionagi` alone will catch
+  unless the invariant test asserts zero plugin imports too (it must).
+- Failure surface moves earlier and louder: manifest typos, collisions, and
+  incompatible ranges all surface at discovery with plugin-named diagnostics,
+  instead of as deep-stack ImportErrors at call time.
+- The trust model is honest but coarse (manifest-hash, not content-hash): a trusted
+  plugin's author can change code behind fixed targets. Accepted and documented in
+  D5; revisit with content pinning if real-world evidence demands.
+- Studio's CC-bundle viewer and this system stay separate concepts sharing a
+  directory idiom. A repository may ship one directory that is both (a
+  `.claude-plugin/plugin.json` for CC and a `plugin.yaml` for LionAGI, side by
+  side); neither reader consumes the other's manifest, so neither product's format
+  evolution can break the other — at the cost that dual-target bundles maintain two
+  small manifests, which is the cheaper side of the trade.
+- Reversal cost: D1–D4 are additive (delete the loader and the miss-hooks; no core
+  path bends around them). D6's namespacing (`<plugin>/<name>`) is the piece users
+  will have embedded in playbook references and scripts — the hardest to walk back;
+  it is also the piece least likely to need reversal.
+
+## Alternatives considered
+
+- **Python entry-points as the primary (or only) mechanism** — pip handles
+  versioning, dependency resolution, uninstall. Lost as primary: it cannot express
+  data-only bundles without forcing a Python package around three YAML files; it
+  puts a packaging toolchain between a user and "share my agent setup"; and
+  discovery-by-installation means `pip install` alone injects capability — a worse
+  trust posture than an inert directory. Retained as D8 because code-heavy plugins
+  (providers with dependencies) genuinely want pip underneath.
+- **Adopt Claude Code's plugin format as LionAGI's own** (one `plugin.json` read by
+  both products) — one manifest, and Studio's reader half-exists. Rejected: the
+  format is owned and versioned by another product for a different host (its
+  capability sections — skills, LSP servers, monitors — map to Claude Code
+  concepts, not to `Branch`/`ActionManager`/`match_endpoint`), so LionAGI's runtime
+  needs would either bend to a foreign schema's evolution or fork it silently —
+  worse than two explicit manifests side by side.
+- **No plugin concept — document the six seams and let users script them** — zero
+  new code. Rejected: leaves P2 (nobody owns provider imports) and P4 (no trust
+  step) genuinely unsolved; those are not documentation problems.
+- **Last-writer-wins or scan-order shadowing for all collisions** (the existing
+  hook-registry and agent-profile precedents) — simplest loader. Rejected for
+  plugin-vs-plugin and plugin-vs-built-in because both are exactly the silent
+  capability-substitution shape a plugin system must not import; retained only for
+  user-local-file-wins, where the shadowed thing is the user's own explicit intent.
+- **Per-plugin process isolation / sandboxing for tool execution** — a real
+  security boundary instead of trust. Deferred, not rejected: LionAGI tools are
+  in-process async callables sharing the event loop; pushing plugin tools out of
+  process changes the `Tool` execution contract (serialization, latency, streaming)
+  for all callers and deserves its own ADR with measurements. Trust-then-in-process
+  matches the risk profile of the v1 audience (users installing bundles they
+  obtained deliberately).
+
+## Notes
+
+- Naming: "plugin" here always means a LionAGI runtime extension bundle.
+  Studio's existing plugin routes render *Claude Code* bundles; the two appear
+  together only in the marketplace directory of this repository, which may carry
+  dual manifests per the Consequences note.
+- The `x-` manifest-key escape hatch exists so downstream tooling can annotate
+  bundles (provenance stamps, registry metadata) without schema violations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -207,9 +207,7 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 - [ADR-0086](ADR-0086-local-tool-controls-and-session-authorization.md) — Local tool controls and
   session authorization observation
 - [ADR-0087](ADR-0087-evidence-backed-governed-execution.md) — Evidence-backed governed execution
-- [ADR-0088](ADR-0088-plugin-system.md) — Plugin system (directory-bundle manifest with
-  lazy activation)
-- 0089 — unused (intentional gap)
+- 0088-0089 — unused (0088 allocated to a substrates record from this gap; see below)
 
 ### substrates (0090-0095)
 
@@ -225,6 +223,8 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
   github-poll schedules
 - [ADR-0095](ADR-0095-run-terminal-callbacks-and-orphan-recovery.md) — Run-terminal
   callbacks and orphan recovery (supersedes ADR-0060)
+- [ADR-0088](ADR-0088-plugin-system.md) — Plugin system (directory-bundle manifest with
+  lazy activation; number from the adjacent free gap — the substrates block is exhausted)
 
 Remaining areas land here as their records are accepted.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -132,7 +132,9 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 
 - [ADR-0047](ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md) — Hook mechanism scopes
   and canonical ownership
-- 0048-0049 — unused (intentional gaps)
+- [ADR-0048](ADR-0048-interoperable-external-hooks.md) — Interoperable external hooks
+  (Claude Code / Codex hook contract)
+- 0049 — unused (intentional gap)
 
 ### utilities (0050-0054)
 
@@ -205,7 +207,9 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 - [ADR-0086](ADR-0086-local-tool-controls-and-session-authorization.md) — Local tool controls and
   session authorization observation
 - [ADR-0087](ADR-0087-evidence-backed-governed-execution.md) — Evidence-backed governed execution
-- 0088-0089 — unused (intentional gaps)
+- [ADR-0088](ADR-0088-plugin-system.md) — Plugin system (directory-bundle manifest with
+  lazy activation)
+- 0089 — unused (intentional gap)
 
 ### substrates (0090-0095)
 


### PR DESCRIPTION
## Summary

Two new decision-ADRs answering the directives to make lionagi hooks interoperable with Claude Code / Codex hooks, and to introduce a plugin system:

- **ADR-0048 — Interoperable external hooks (Claude Code / Codex hook contract)** (Area: hooks, extends ADR-0047). Adopts the converged CC/Codex external-hook wire contract verbatim (stdin JSON envelope, exit-code protocol, `permissionDecision`/`updatedInput` stdout shape); fixed event mapping with fail-loud on unmappable events; new `USER_PROMPT_SUBMIT` blocking point shipped with both emit sites and a fire-once-per-user-turn guard; tool events route through a mutation layer at the `ActionManager.invoke` chokepoint (closing the MCP-tool coverage gap) with post-rewrite revalidation against `request_options` and `security_pre` as the last pre-stage validator; argv-only executor per ADR-0095's no-shell posture; `ask` fails closed; separate `hooks_external:` settings block + explicit `li hooks import claude|codex`; source-tiered trust with hash-pinning for imported/plugin-bundled command hooks.
- **ADR-0088 — Plugin system (directory-bundle manifest with lazy activation)** (Area: substrates; number allocated from the adjacent free gap, substrates block exhausted). Directory bundles under `.lionagi/plugins/<name>/` with a pure-data `plugin.yaml`; two-stage laziness (manifest-only discovery on first registry need, code import at capability first-use) preserving the import-time O(1) invariant by construction; v1 surfaces = tools, external hooks (via ADR-0048), agent profiles, playbooks, providers; trust content-pins the manifest plus every declared target file and hook binary behind a complete non-skippable inventory display; built-ins win with surface-appropriate collision timing; plugin-vs-plugin same-name is a hard error; `li plugin list/info/trust/enable/disable`; entry-points path recorded in full as DEFERRED.

Both drafts went through an adversarial hardening pass before this PR; the corrections it produced (two-site emit with de-dup, provider match-interception refactor named as new work, collision timing split by surface, content-pinned trust) are folded in.

## Verification

- `scripts/check_adr_status_sets.py` passes.
- README index updated (hooks block gains 0048; 0088 listed under substrates with the numbering note).
- Docs-only; no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
