### PR TITLE
fix(cli): fail fast on nonexistent --cwd before spawning an agent

### DIFF
--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 EXIT_CODE_BY_STATUS: dict[str, int] = {
@@ -19,6 +20,28 @@ EXIT_CODE_BY_STATUS: dict[str, int] = {
     "aborted": 130,
     "cancelled": 143,
 }
+
+
+def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> None:
+    """Fail fast when a user-supplied working directory doesn't exist.
+
+    Every CLI surface that forwards a ``cwd``/``repo`` value to a CLI-backed
+    agent spawn (claude/codex/gemini-code) must call this BEFORE allocating a
+    run or starting the spawn, so a typo'd path produces a clear, immediate
+    error instead of the provider layer silently creating the directory (or
+    the spawn failing deep inside an opaque subprocess). Raises
+    ``ConfigurationError`` (a ``ValueError`` subclass) naming both the path
+    and the flag; a caller with no cwd override (``cwd`` falsy) is a no-op.
+    """
+    if not cwd:
+        return
+    from lionagi._errors import ConfigurationError
+
+    path = Path(cwd).expanduser()
+    if not path.exists():
+        raise ConfigurationError(f"{flag} path does not exist: {cwd!r}")
+    if not path.is_dir():
+        raise ConfigurationError(f"{flag} path is not a directory: {cwd!r}")
 
 
 def classify_exception(exc: BaseException) -> str:

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -22,7 +22,7 @@ EXIT_CODE_BY_STATUS: dict[str, int] = {
 }
 
 
-def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> None:
+def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> str | None:
     """Fail fast when a user-supplied working directory doesn't exist.
 
     Every CLI surface that forwards a ``cwd``/``repo`` value to a CLI-backed
@@ -31,10 +31,15 @@ def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> None:
     error instead of the provider layer silently creating the directory (or
     the spawn failing deep inside an opaque subprocess). Raises
     ``ConfigurationError`` (a ``ValueError`` subclass) naming both the path
-    and the flag; a caller with no cwd override (``cwd`` falsy) is a no-op.
+    and the flag; a caller with no cwd override (``cwd`` falsy) gets it back
+    unchanged.
+
+    Returns the tilde-expanded path string, and callers must forward THAT:
+    validating ``~/proj`` expanded while forwarding the literal would pass
+    here and then fail deep in the provider layer, which never expands.
     """
     if not cwd:
-        return
+        return cwd
     from lionagi._errors import ConfigurationError
 
     path = Path(cwd).expanduser()
@@ -42,6 +47,7 @@ def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> None:
         raise ConfigurationError(f"{flag} path does not exist: {cwd!r}")
     if not path.is_dir():
         raise ConfigurationError(f"{flag} path is not a directory: {cwd!r}")
+    return str(path)
 
 
 def classify_exception(exc: BaseException) -> str:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -224,7 +224,8 @@ async def _run_agent(
     # Fail fast: a nonexistent --cwd must never silently spawn into a
     # provider-created directory (or a deep, opaque subprocess failure) —
     # validate before any run is allocated or persistence is set up.
-    validate_cwd_exists(cwd)
+    # Forward the returned tilde-expanded path; providers never expand `~`.
+    cwd = validate_cwd_exists(cwd)
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
     if preset and (resume or continue_last):

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -51,7 +51,7 @@ from ._runs import (
     setup_agent_persist,
     teardown_agent_persist,
 )
-from ._util import EXIT_CODE_BY_STATUS, classify_exception
+from ._util import EXIT_CODE_BY_STATUS, classify_exception, validate_cwd_exists
 
 # ---------------------------------------------------------------------------
 # Preset names supported by --preset
@@ -221,6 +221,10 @@ async def _run_agent(
     called, or setup itself failed and disabled persistence for this run).
     """
     effort = normalize_effort(effort)
+    # Fail fast: a nonexistent --cwd must never silently spawn into a
+    # provider-created directory (or a deep, opaque subprocess failure) —
+    # validate before any run is allocated or persistence is set up.
+    validate_cwd_exists(cwd)
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
     if preset and (resume or continue_last):

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -367,7 +367,8 @@ async def setup_orchestration(
 
     # Fail fast: a nonexistent --cwd must never silently spawn into a
     # provider-created directory — validate before any run is allocated.
-    validate_cwd_exists(cwd)
+    # Forward the returned tilde-expanded path; providers never expand `~`.
+    cwd = validate_cwd_exists(cwd)
 
     cache_cancelled_exc_class()
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -45,6 +45,7 @@ from .._runs import (
     save_last_branch_pointer,
     teardown_persist,
 )
+from .._util import validate_cwd_exists
 
 __all__ = (
     "OrchestrationEnv",
@@ -363,6 +364,10 @@ async def setup_orchestration(
 ) -> OrchestrationEnv:
     """Resolve orchestrator config, allocate run, build branch+session."""
     from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+    # Fail fast: a nonexistent --cwd must never silently spawn into a
+    # provider-created directory — validate before any run is allocated.
+    validate_cwd_exists(cwd)
 
     cache_cancelled_exc_class()
 

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -148,6 +148,12 @@ async def ndjson_from_cli(
 def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
     if repo is None:
         repo = Path.cwd()
+    # A user-supplied repo/cwd that doesn't exist must fail here, before any
+    # caller can spawn a subprocess into it (or, worse, silently mkdir it —
+    # every CLI-backed provider's spawn path shares this helper, so this is
+    # the single point that catches a nonexistent cwd regardless of surface).
+    if not repo.is_dir():
+        raise ValueError(f"cwd does not exist or is not a directory: {repo}")
     if not workspace:
         return repo
 

--- a/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
+++ b/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o flow` / `li o fanout` (and `li play`, which expands into `li o flow`)
+share `setup_orchestration()` as their one setup helper. A nonexistent --cwd
+must fail fast there, before any imodel/branch/run is built, instead of
+silently reaching a provider spawn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi._errors import ConfigurationError
+from lionagi.cli.orchestrate._orchestration import setup_orchestration
+
+
+@pytest.mark.asyncio
+async def test_setup_orchestration_rejects_nonexistent_cwd_before_any_setup(monkeypatch, tmp_path):
+    """A nonexistent --cwd must raise before build_imodel_from_spec/allocate_run
+    ever run — i.e. before any provider is spawned or run record created."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _boom_build_imodel(*a, **kw):
+        raise AssertionError(
+            "build_imodel_from_spec must not be reached — cwd validation must fire first"
+        )
+
+    def _boom_allocate_run(*a, **kw):
+        raise AssertionError("allocate_run must not be reached — cwd validation must fire first")
+
+    monkeypatch.setattr(orch_mod, "build_imodel_from_spec", _boom_build_imodel)
+    monkeypatch.setattr(orch_mod, "allocate_run", _boom_allocate_run)
+
+    bad_cwd = str(tmp_path / "nonexistent-workspace")
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await setup_orchestration(
+            pattern_name="Fanout",
+            model_spec="claude",
+            agent_name=None,
+            save_dir=None,
+            cwd=bad_cwd,
+            yolo=False,
+            verbose=False,
+            effort=None,
+            theme=None,
+        )
+
+    msg = str(exc_info.value)
+    assert bad_cwd in msg
+    assert "--cwd" in msg
+
+
+@pytest.mark.asyncio
+async def test_setup_orchestration_rejects_cwd_that_is_a_file(monkeypatch, tmp_path):
+    f = tmp_path / "im-a-file.txt"
+    f.write_text("x")
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await setup_orchestration(
+            pattern_name="Flow",
+            model_spec="claude",
+            agent_name=None,
+            save_dir=None,
+            cwd=str(f),
+            yolo=False,
+            verbose=False,
+            effort=None,
+            theme=None,
+        )
+    assert "not a directory" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_setup_orchestration_none_cwd_is_unaffected(monkeypatch):
+    """cwd=None (no --cwd given) must not be rejected by the new check —
+    it must reach the existing 'model spec required' validation instead."""
+    with pytest.raises(ConfigurationError) as exc_info:
+        await setup_orchestration(
+            pattern_name="Flow",
+            model_spec="",
+            agent_name=None,
+            save_dir=None,
+            cwd=None,
+            yolo=False,
+            verbose=False,
+            effort=None,
+            theme=None,
+        )
+    # Falls through to the pre-existing "model spec required" error, proving
+    # the cwd check did not short-circuit a legitimate cwd=None call.
+    assert "model spec" in str(exc_info.value).lower()

--- a/tests/cli/test_agent_cwd_failfast.py
+++ b/tests/cli/test_agent_cwd_failfast.py
@@ -27,13 +27,27 @@ from lionagi.cli._util import validate_cwd_exists
 
 class TestValidateCwdExists:
     def test_none_is_a_noop(self):
-        validate_cwd_exists(None)  # must not raise
+        assert validate_cwd_exists(None) is None  # must not raise
 
     def test_empty_string_is_a_noop(self):
-        validate_cwd_exists("")  # must not raise
+        assert validate_cwd_exists("") == ""  # must not raise
 
     def test_existing_directory_passes(self, tmp_path):
-        validate_cwd_exists(str(tmp_path))  # must not raise
+        assert validate_cwd_exists(str(tmp_path)) == str(tmp_path)  # must not raise
+
+    def test_tilde_path_to_existing_dir_returns_expanded(self, tmp_path, monkeypatch):
+        """A `--cwd=~/...` value must come back tilde-expanded: validating the
+        expanded path while forwarding the literal would pass validation and
+        then fail deep in the provider layer, which never expands `~`."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "proj").mkdir()
+        assert validate_cwd_exists("~/proj") == str(tmp_path / "proj")
+
+    def test_tilde_path_to_nonexistent_dir_still_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_cwd_exists("~/does-not-exist-xyz")
+        assert "~/does-not-exist-xyz" in str(exc_info.value)
 
     def test_nonexistent_path_raises_naming_path_and_flag(self, tmp_path):
         bad = str(tmp_path / "does-not-exist-xyz")
@@ -95,10 +109,9 @@ async def test_run_agent_rejects_nonexistent_cwd_before_any_spawn(monkeypatch, t
     assert "--cwd" in msg
 
 
-@pytest.mark.asyncio
-async def test_run_agent_accepts_existing_cwd_and_reaches_spawn(monkeypatch, tmp_path):
-    """Regression guard: a *valid* --cwd must not be rejected — validation
-    only fires for a genuinely missing/non-directory path."""
+def _patch_agent_happy_path(monkeypatch, tmp_path) -> dict:
+    """Stub out everything around _run_agent's spawn so a test can observe
+    exactly what `repo` (the forwarded cwd) reaches Branch.operate."""
     import lionagi.cli.agent as agent_mod
     from lionagi import Branch
     from lionagi.service.manager import iModelManager
@@ -144,6 +157,16 @@ async def test_run_agent_accepts_existing_cwd_and_reaches_spawn(monkeypatch, tmp
         return "ok"
 
     monkeypatch.setattr(Branch, "operate", fake_operate)
+    return spawned
+
+
+@pytest.mark.asyncio
+async def test_run_agent_accepts_existing_cwd_and_reaches_spawn(monkeypatch, tmp_path):
+    """Regression guard: a *valid* --cwd must not be rejected — validation
+    only fires for a genuinely missing/non-directory path."""
+    import lionagi.cli.agent as agent_mod
+
+    spawned = _patch_agent_happy_path(monkeypatch, tmp_path)
 
     _result, _provider, _bid, terminal_status, _sid = await agent_mod._run_agent(
         "codex/model", "do the thing", cwd=str(tmp_path)
@@ -152,6 +175,25 @@ async def test_run_agent_accepts_existing_cwd_and_reaches_spawn(monkeypatch, tmp
     assert terminal_status == "completed"
     assert spawned.get("called") is True
     assert spawned.get("repo") == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_forwards_tilde_expanded_cwd_to_spawn(monkeypatch, tmp_path):
+    """A `--cwd=~/...` value must reach the spawn tilde-expanded — the
+    provider layer never expands `~`, so forwarding the literal would fail
+    deep in the subprocess despite passing validation."""
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "ws").mkdir()
+    spawned = _patch_agent_happy_path(monkeypatch, tmp_path)
+
+    _result, _provider, _bid, terminal_status, _sid = await agent_mod._run_agent(
+        "codex/model", "do the thing", cwd="~/ws"
+    )
+
+    assert terminal_status == "completed"
+    assert spawned.get("repo") == str(tmp_path / "ws")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_agent_cwd_failfast.py
+++ b/tests/cli/test_agent_cwd_failfast.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li agent --cwd <nonexistent>` must fail fast, before any run is allocated
+or any agent is spawned, instead of the provider layer silently creating the
+directory (or a deep, opaque subprocess failure reported as a clean success).
+
+Covers the shared validator (`lionagi.cli._util.validate_cwd_exists`) and its
+wiring into both the async engine (`_run_agent`) and the sync CLI entry point
+(`run_agent`).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi._errors import ConfigurationError
+from lionagi.cli._util import validate_cwd_exists
+
+# ---------------------------------------------------------------------------
+# validate_cwd_exists — the shared validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCwdExists:
+    def test_none_is_a_noop(self):
+        validate_cwd_exists(None)  # must not raise
+
+    def test_empty_string_is_a_noop(self):
+        validate_cwd_exists("")  # must not raise
+
+    def test_existing_directory_passes(self, tmp_path):
+        validate_cwd_exists(str(tmp_path))  # must not raise
+
+    def test_nonexistent_path_raises_naming_path_and_flag(self, tmp_path):
+        bad = str(tmp_path / "does-not-exist-xyz")
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_cwd_exists(bad)
+        msg = str(exc_info.value)
+        assert bad in msg
+        assert "--cwd" in msg
+
+    def test_path_that_is_a_file_raises_not_a_directory(self, tmp_path):
+        f = tmp_path / "im-a-file.txt"
+        f.write_text("x")
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_cwd_exists(str(f))
+        msg = str(exc_info.value)
+        assert str(f) in msg
+        assert "not a directory" in msg
+
+    def test_custom_flag_name_is_reflected_in_message(self, tmp_path):
+        bad = str(tmp_path / "nope")
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_cwd_exists(bad, flag="--workspace")
+        assert "--workspace" in str(exc_info.value)
+        assert "--cwd" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_agent: fails before any spawn / run allocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_rejects_nonexistent_cwd_before_any_spawn(monkeypatch, tmp_path):
+    """A nonexistent --cwd must raise before allocate_run/build_chat_model/
+    branch.operate ever run — i.e. before any run record could be created and
+    before any provider CLI could be spawned."""
+    import lionagi.cli.agent as agent_mod
+
+    def _boom_allocate_run():
+        raise AssertionError("allocate_run must not be reached — cwd validation must fire first")
+
+    def _boom_build_chat_model(*a, **kw):
+        raise AssertionError(
+            "build_chat_model must not be reached — cwd validation must fire first"
+        )
+
+    monkeypatch.setattr(agent_mod, "allocate_run", _boom_allocate_run)
+    monkeypatch.setattr(agent_mod, "build_chat_model", _boom_build_chat_model)
+
+    bad_cwd = str(tmp_path / "nonexistent-workspace")
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await _run_agent("claude", "do the thing", cwd=bad_cwd)
+
+    msg = str(exc_info.value)
+    assert bad_cwd in msg
+    assert "--cwd" in msg
+
+
+@pytest.mark.asyncio
+async def test_run_agent_accepts_existing_cwd_and_reaches_spawn(monkeypatch, tmp_path):
+    """Regression guard: a *valid* --cwd must not be rejected — validation
+    only fires for a genuinely missing/non-directory path."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/model")
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, *, status="completed", **kw):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    spawned = {}
+
+    async def fake_operate(self, instruction=None, **kw):
+        spawned["called"] = True
+        spawned["repo"] = kw.get("repo")
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+
+    _result, _provider, _bid, terminal_status, _sid = await agent_mod._run_agent(
+        "codex/model", "do the thing", cwd=str(tmp_path)
+    )
+
+    assert terminal_status == "completed"
+    assert spawned.get("called") is True
+    assert spawned.get("repo") == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# run_agent (sync CLI entry point): clean diagnostic before re-raising
+# ---------------------------------------------------------------------------
+
+
+def _agent_args(**overrides) -> SimpleNamespace:
+    base = dict(
+        query=["claude", "do the thing"],
+        prompt_flag=None,
+        prompt_file=None,
+        yolo=False,
+        verbose=False,
+        theme=None,
+        resume=None,
+        continue_last=False,
+        effort=None,
+        agent=None,
+        cwd=None,
+        timeout=None,
+        fast=False,
+        invocation=None,
+        project=None,
+        bypass=False,
+        preset=None,
+        form=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_run_agent_cli_nonzero_and_diagnostic_for_nonexistent_cwd(monkeypatch, tmp_path):
+    """The full sync CLI entry point (`run_agent`) must surface a clear,
+    one-line diagnostic naming the path and --cwd before the exception
+    propagates (which the console-script wrapper turns into a nonzero
+    process exit — see classify_exception -> EXIT_CODE_BY_STATUS['failed'])."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli._util import EXIT_CODE_BY_STATUS, classify_exception
+
+    errors_emitted: list[str] = []
+    monkeypatch.setattr(agent_mod, "log_error", lambda msg: errors_emitted.append(msg))
+
+    bad_cwd = str(tmp_path / "nonexistent-workspace")
+
+    from lionagi.cli.agent import run_agent
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        run_agent(_agent_args(cwd=bad_cwd))
+
+    # classify_exception must route this to the "failed" (nonzero exit) bucket.
+    assert classify_exception(exc_info.value) == "failed"
+    assert EXIT_CODE_BY_STATUS["failed"] != 0
+
+    assert errors_emitted, "log_error must be called with a clear diagnostic"
+    combined = " ".join(errors_emitted)
+    assert bad_cwd in combined
+    assert "--cwd" in combined
+
+
+def test_run_agent_cli_no_run_allocated_for_nonexistent_cwd(monkeypatch, tmp_path):
+    """No run record may be created at all when --cwd fails validation —
+    stronger than merely 'not completed.ok'."""
+    import lionagi.cli.agent as agent_mod
+
+    def _boom_allocate_run():
+        raise AssertionError("allocate_run must not be reached")
+
+    monkeypatch.setattr(agent_mod, "allocate_run", _boom_allocate_run)
+    monkeypatch.setattr(agent_mod, "log_error", lambda msg: None)
+
+    bad_cwd = str(tmp_path / "nonexistent-workspace")
+
+    from lionagi.cli.agent import run_agent
+
+    with pytest.raises(ConfigurationError):
+        run_agent(_agent_args(cwd=bad_cwd))

--- a/tests/providers/test_cli_subprocess_cwd.py
+++ b/tests/providers/test_cli_subprocess_cwd.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`resolve_cli_workspace` is the one helper shared by every CLI-backed
+provider (claude_code, codex, gemini_code) to resolve the subprocess working
+directory before spawning. A nonexistent `repo` (the resolved value of a
+user-supplied --cwd) must raise here — the single point that previously let
+`li agent --cwd <bad path>` silently mkdir the directory (claude_code) or
+spawn into a directory that was never validated (codex/gemini_code), instead
+of failing fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lionagi.providers._cli_subprocess import resolve_cli_workspace
+
+
+class TestResolveCliWorkspaceCwdValidation:
+    def test_nonexistent_repo_raises(self, tmp_path):
+        bad = tmp_path / "does-not-exist"
+        with pytest.raises(ValueError) as exc_info:
+            resolve_cli_workspace(bad, None)
+        assert str(bad) in str(exc_info.value)
+
+    def test_repo_that_is_a_file_raises(self, tmp_path):
+        f = tmp_path / "im-a-file.txt"
+        f.write_text("x")
+        with pytest.raises(ValueError):
+            resolve_cli_workspace(f, None)
+
+    def test_existing_repo_no_workspace_returns_repo_unchanged(self, tmp_path):
+        assert resolve_cli_workspace(tmp_path, None) == tmp_path
+
+    def test_existing_repo_with_new_workspace_subdir_still_resolves(self, tmp_path):
+        """Regression guard: a --ws sub-workspace that doesn't exist YET under
+        an existing repo is a legitimate "create a fresh workspace" flow (the
+        caller mkdir's it after resolution) — only the base repo must exist,
+        not the final joined workspace path."""
+        result = resolve_cli_workspace(tmp_path, "fresh-subdir")
+        assert result == (tmp_path / "fresh-subdir").resolve()
+        assert not result.exists()  # not created by resolve_cli_workspace itself
+
+    def test_repo_none_defaults_to_process_cwd(self):
+        # Path.cwd() always exists for a live process — sanity check that the
+        # None-repo default path doesn't regress under the new validation.
+        assert resolve_cli_workspace(None, None) == Path.cwd()
+
+    def test_absolute_workspace_still_rejected(self, tmp_path):
+        """Pre-existing validation (unrelated to this fix) must still work."""
+        with pytest.raises(ValueError, match="must be relative"):
+            resolve_cli_workspace(tmp_path, "/absolute/path")
+
+    def test_workspace_traversal_still_rejected(self, tmp_path):
+        """Pre-existing validation (unrelated to this fix) must still work."""
+        with pytest.raises(ValueError, match="traversal"):
+            resolve_cli_workspace(tmp_path, "../escape")
+
+
+class TestProviderRequestsRejectNonexistentRepo:
+    """End-to-end (still no subprocess spawn): each CLI-backed request's own
+    .cwd() must surface the same fail-fast validation, since all three route
+    through resolve_cli_workspace."""
+
+    def test_claude_code_request_cwd_rejects_nonexistent_repo(self, tmp_path):
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+        bad = tmp_path / "nonexistent-repo"
+        req = ClaudeCodeRequest(prompt="hi", repo=bad)
+        with pytest.raises(ValueError):
+            req.cwd()
+
+    def test_codex_request_cwd_rejects_nonexistent_repo(self, tmp_path):
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        bad = tmp_path / "nonexistent-repo"
+        req = CodexCodeRequest(prompt="hi", repo=bad)
+        with pytest.raises(ValueError):
+            req.cwd()
+
+    def test_gemini_code_request_cwd_rejects_nonexistent_repo(self, tmp_path):
+        from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+        bad = tmp_path / "nonexistent-repo"
+        req = GeminiCodeRequest(prompt="hi", repo=bad)
+        with pytest.raises(ValueError):
+            req.cwd()

--- a/tests/service/connections/providers/test_cli_behavior_parity.py
+++ b/tests/service/connections/providers/test_cli_behavior_parity.py
@@ -126,7 +126,7 @@ async def test_claude_ndjson_uses_repair_callback():
 
 
 @pytest.mark.asyncio
-async def test_codex_ndjson_does_not_pass_cwd():
+async def test_codex_ndjson_does_not_pass_cwd(tmp_path):
     """Codex _ndjson_from_cli must NOT pass cwd= to ndjson_from_cli.
 
     The Codex CLI already receives the workspace via '-C <repo>' in as_cmd_args().
@@ -145,7 +145,11 @@ async def test_codex_ndjson_does_not_pass_cwd():
         patch.object(codex_models, "CODEX_CLI", "/fake/codex"),
         patch.object(codex_models, "ndjson_from_cli", _fake_ndjson),
     ):
-        req = codex_models.CodexCodeRequest(prompt="p", repo=Path("relative_repo"))
+        # repo must exist on disk: resolve_cli_workspace() now validates it
+        # (a nonexistent --cwd must fail fast, not spawn) — the fictional
+        # relative path this test previously used only worked because that
+        # validation didn't exist yet.
+        req = codex_models.CodexCodeRequest(prompt="p", repo=tmp_path)
         async for _ in codex_models._ndjson_from_cli(req):
             pass
 
@@ -156,16 +160,17 @@ async def test_codex_ndjson_does_not_pass_cwd():
     )
 
 
-def test_codex_as_cmd_args_contains_dash_c_flag():
+def test_codex_as_cmd_args_contains_dash_c_flag(tmp_path):
     """Codex as_cmd_args() emits '-C <repo>' so the CLI handles the workspace itself."""
     from lionagi.providers.openai.codex import CodexCodeRequest
 
-    req = CodexCodeRequest(prompt="hello", repo=Path("my_repo"))
+    # repo must exist on disk (see comment in test_codex_ndjson_does_not_pass_cwd).
+    req = CodexCodeRequest(prompt="hello", repo=tmp_path)
     args = req.as_cmd_args()
 
     assert "-C" in args
     c_idx = args.index("-C")
-    assert args[c_idx + 1] == "my_repo"
+    assert args[c_idx + 1] == str(tmp_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2099.

## What

`li agent --cwd <nonexistent>` silently created the missing directory (`mkdir(parents=True)` deep in the CLI-provider workspace resolution), ran the agent inside it, and reported `status: completed`, exit 0. Confirmed live before fixing.

Fail-fast now happens at every spawn surface, before `allocate_run()`:

- `lionagi/cli/_util.py` — new shared `validate_cwd_exists(cwd, *, flag="--cwd")` raising `ConfigurationError` naming the path and flag
- `lionagi/cli/agent.py` — validated at the top of `_run_agent()`
- `lionagi/cli/orchestrate/_orchestration.py` — validated in `setup_orchestration()`, covering `li o flow`, `li o fanout`, and `li play` (pure sugar over `li o flow`)
- `lionagi/providers/_cli_subprocess.py` — `resolve_cli_workspace()` now rejects a nonexistent base `repo` as defense-in-depth for non-CLI callers, while preserving the legitimate create-a-fresh-sub-workspace flow (only the base must exist)

The scheduler engine already validates its execution root and attributes failure properly — verified, no change needed there.

## Verification

- New tests: `tests/cli/test_agent_cwd_failfast.py`, `tests/cli/orchestrate/test_orchestration_cwd_failfast.py`, `tests/providers/test_cli_subprocess_cwd.py` — the error path raises before `allocate_run`/`build_chat_model` are touched; happy path unchanged
- Two pre-existing tests constructed requests with fictional repo paths; updated to `tmp_path` since the new validation correctly rejects them
- `uv run pytest tests/cli/ -q` → 2400+ passed; providers + studio + all suites importing touched modules green; `ruff check` clean
- Live-verified post-fix: `li agent` and `li o fanout` with a bad `--cwd` exit 1 with a one-line diagnostic and never create the directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
