### PR TITLE
chore(state): remove dead can_transition helper

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -291,13 +291,6 @@ VALID_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
 }
 
 
-def can_transition(current: str | None, target: str) -> bool:
-    """Return True iff a session may move from *current* to *target*."""
-    if current != "running":
-        return False
-    return target in SESSION_TERMINAL_STATUSES
-
-
 # Re-exported (not redefined) so `from lionagi.state.db import
 # TransitionRejectedError` is unchanged for existing callers — the lifecycle
 # adapter module raises this same class object; see

--- a/tests/state/test_session_status_vocabulary.py
+++ b/tests/state/test_session_status_vocabulary.py
@@ -18,7 +18,6 @@ from lionagi.state.db import (
     SESSION_TERMINAL_STATUSES,
     VALID_SESSION_STATUSES,
     StateDB,
-    can_transition,
 )
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -76,31 +75,6 @@ def test_admin_targets_exclude_completed_and_timed_out():
     assert "completed" not in ADMIN_TRANSITION_TARGETS
     assert "timed_out" not in ADMIN_TRANSITION_TARGETS
     assert ADMIN_TRANSITION_TARGETS == frozenset({"failed", "aborted", "cancelled"})
-
-
-# ── can_transition ────────────────────────────────────────────────────────────
-
-
-def test_can_transition_only_from_running():
-    for target in SESSION_TERMINAL_STATUSES:
-        assert can_transition("running", target)
-
-
-def test_can_transition_rejects_terminal_origin():
-    for current in SESSION_TERMINAL_STATUSES:
-        for target in SESSION_TERMINAL_STATUSES:
-            assert not can_transition(current, target), (
-                f"transition {current!r} → {target!r} should be rejected"
-            )
-
-
-def test_can_transition_rejects_unknown_target():
-    assert not can_transition("running", "in_progress")
-    assert not can_transition("running", "stale")  # stale = health, not status
-
-
-def test_can_transition_rejects_none_origin():
-    assert not can_transition(None, "completed")
 
 
 # ── DB-level validation ───────────────────────────────────────────────────────


### PR DESCRIPTION
Removes `can_transition()` from `lionagi/state/db.py` and its four dedicated unit tests. The helper has zero production callers (verified: only its own definition and its own tests reference it) and is fully superseded by the PolicyRegistry-driven `_transition()` edge graph in `lionagi/state/lifecycle/service.py`. The vocabulary-pinning tests in the same file are kept — they test the status vocabulary itself, not the dead function.

Follow-up from the consolidation audit in #2103.

## Verification
- `grep -rn can_transition lionagi/ tests/` → zero references remain
- `uv run pytest tests/state/ -q` → 500 passed (postgres-extra excluded, pre-existing env gap)
- `ruff check` + pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)