### PR TITLE
test(studio): daemon API regression gate

### DIFF
--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -158,11 +158,14 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
 )
 
 
-def _live_app_routes() -> list[tuple[str, str]]:
-    """(method, path) pairs for every route on the live app, docs routes excluded."""
-    from lionagi.studio.app import app
-
-    pairs: set[tuple[str, str]] = set()
+def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str]]:
+    """Every (method, path) entry on a FastAPI app's route table, as a LIST
+    (not a set) -- a route registered twice at the same (method, path)
+    produces two entries here, one per registration. HEAD is excluded:
+    FastAPI auto-adds it for every GET, so it is never an independent
+    registration and would double every GET row for no contract value.
+    """
+    entries: list[tuple[str, str]] = []
     for route in app.routes:
         path = getattr(route, "path", None)
         methods = getattr(route, "methods", None)
@@ -170,21 +173,50 @@ def _live_app_routes() -> list[tuple[str, str]]:
             # Non-endpoint route entries (e.g. a static asset Mount when a
             # frontend dist is configured) carry no HTTP method set at all.
             continue
-        if path in _DOCS_PATHS:
-            continue
         for method in methods:
             if method == "HEAD":
-                # FastAPI auto-adds HEAD for every GET; it is not an
-                # independently-registered endpoint and would double every
-                # GET row in the golden list for no contract value.
                 continue
-            pairs.add((method, path))
-    return sorted(pairs)
+            entries.append((method, path))
+    return entries
+
+
+def _find_duplicate_routes(entries: list[tuple[str, str]]) -> dict[tuple[str, str], int]:
+    """Return {(method, path): count} for every entry registered more than once.
+
+    A duplicate (method, path) is a shadowed, unreachable handler: FastAPI's
+    router matches the first registration for a given (method, path) and
+    never even considers a later one. Collapsing entries into a set before
+    comparing against the golden list (the prior version of this gate) would
+    hide that shadowing entirely -- the golden comparison would stay green
+    while a second, dead handler sat in the route table.
+    """
+    counts: dict[tuple[str, str], int] = {}
+    for entry in entries:
+        counts[entry] = counts.get(entry, 0) + 1
+    return {pair: n for pair, n in counts.items() if n > 1}
+
+
+def _live_app_routes() -> list[tuple[str, str]]:
+    """(method, path) entries for every route on the live app, docs routes
+    excluded. Preserves duplicates -- see _find_duplicate_routes."""
+    from lionagi.studio.app import app
+
+    return [
+        (method, path) for method, path in _entries_from_fastapi_app(app) if path not in _DOCS_PATHS
+    ]
 
 
 def test_golden_route_table_matches_pinned_snapshot():
     """Any added/renamed/removed studio endpoint must be a deliberate edit here."""
-    actual = _live_app_routes()
+    actual_entries = _live_app_routes()
+
+    duplicates = _find_duplicate_routes(actual_entries)
+    assert not duplicates, (
+        "duplicate route registration(s) found -- each shadows an "
+        f"unreachable handler behind the first match: {duplicates}"
+    )
+
+    actual = sorted(set(actual_entries))
     expected = sorted(_GOLDEN_ROUTES)
     missing = set(expected) - set(actual)
     unexpected = set(actual) - set(expected)
@@ -195,6 +227,48 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 def test_golden_route_count_pinned():
     assert len(_GOLDEN_ROUTES) == 98
+
+
+def test_find_duplicate_routes_detects_a_shadowed_pair():
+    entries = [
+        ("GET", "/api/schedules/{schedule_id}"),
+        ("GET", "/api/schedules/"),
+        ("GET", "/api/schedules/{schedule_id}"),
+    ]
+    assert _find_duplicate_routes(entries) == {("GET", "/api/schedules/{schedule_id}"): 2}
+
+
+def test_find_duplicate_routes_empty_for_unique_entries():
+    entries = [("GET", "/api/schedules/"), ("POST", "/api/schedules/")]
+    assert _find_duplicate_routes(entries) == {}
+
+
+def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
+    """End-to-end proof, not just a property of the tuple-list helper: a
+    genuinely duplicated route on a real FastAPI app's route table is
+    detected by the same collection path _live_app_routes() uses.
+
+    A duplicate can't be produced through the studio_route registry itself
+    (registry.py's dedup guard raises ValueError on a second registration at
+    the same (path, method, module, qualname) -- see test_route_registry.py
+    ::test_dedup_guard_raises_on_duplicate), so this mounts two routes
+    directly on a throwaway FastAPI app the way FastAPI itself would if that
+    guard were ever bypassed or missing.
+    """
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    async def _handler() -> dict:
+        return {}
+
+    app.add_api_route("/api/schedules/{schedule_id}", _handler, methods=["GET"])
+    app.add_api_route(
+        "/api/schedules/{schedule_id}", _handler, methods=["GET"]
+    )  # shadows the first
+
+    duplicates = _find_duplicate_routes(_entries_from_fastapi_app(app))
+    assert duplicates == {("GET", "/api/schedules/{schedule_id}"): 2}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -238,6 +238,13 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     import lionagi.studio.services.schedules as schedules_mod
     import lionagi.studio.services.sessions as sessions_mod
 
+    # An environment with LIONAGI_STUDIO_AUTH_TOKEN set (a dev machine, CI)
+    # would make every unauthenticated request in this file 401 before it
+    # ever reaches the handler being pinned -- neutralize it, matching the
+    # delenv pattern the rest of this suite uses (test_security_batch1.py,
+    # test_audit_remediation.py, test_launches_api.py, test_startup_warnings.py).
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+
     # StateDB's path cascade consults settings.LIONAGI_STATE_DB_URL BEFORE
     # DEFAULT_DB_PATH, so an environment with that set (dev machine, CI)
     # would route these tests at the real configured DB — neutralize it.
@@ -656,6 +663,95 @@ def test_schedules_unknown_id_404_shape_across_mutation_routes(
     r = getattr(client, method)(f"/api/schedules/does-not-exist{path_suffix}", **kwargs)
     assert r.status_code == 404
     assert sorted(r.json().keys()) == ["detail"]
+
+
+# Success-path contracts for the same five mutation routes above. The 404
+# parametrization only proves "unknown id is rejected"; it says nothing
+# about what a successful call returns, so a handler's success shape could
+# regress (e.g. PATCH's {"ok": True} silently becoming {}) without failing
+# anything in this file. Each test creates its own schedule through the
+# same temp-DB path the rest of the family uses, then pins the real response.
+
+
+def test_schedules_patch_success_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.patch(f"/api/schedules/{schedule_id}", json={"description": "gate patch"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    # The write actually landed, not just an accepted-and-dropped no-op.
+    detail = client.get(f"/api/schedules/{schedule_id}")
+    assert detail.json()["description"] == "gate patch"
+
+
+def test_schedules_delete_success_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.delete(f"/api/schedules/{schedule_id}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    # The schedule is actually gone, not just acknowledged.
+    assert client.get(f"/api/schedules/{schedule_id}").status_code == 404
+
+
+def test_schedules_enable_success_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.post(f"/api/schedules/{schedule_id}/enable")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "enabled": True}
+
+
+def test_schedules_disable_success_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.post(f"/api/schedules/{schedule_id}/disable")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "enabled": False}
+
+    # The write actually landed: a disabled schedule reads back falsy.
+    # SQLite has no native boolean -- the column round-trips as the
+    # integer 0/1, not Python False/True.
+    detail = client.get(f"/api/schedules/{schedule_id}")
+    assert not detail.json()["enabled"]
+
+
+def test_schedules_trigger_success_response_shape(tmp_path, monkeypatch):
+    """scheduler.fire_now() is mocked out: a real fire spawns a background
+    asyncio task that launches a subprocess (engine.py::_tracked_fire), which
+    has no place in a response-shape pin. This isolates the route handler's
+    own success contract -- {"ok": True, "run_id": <the value fire_now
+    returned>} -- from the scheduler engine's fire machinery, which has its
+    own coverage elsewhere."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    from lionagi.studio.scheduler.engine import scheduler
+
+    async def _fake_fire_now(_schedule_id: str) -> str:
+        return "gate-fake-run-id"
+
+    monkeypatch.setattr(scheduler, "fire_now", _fake_fire_now)
+
+    r = client.post(f"/api/schedules/{schedule_id}/trigger")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "run_id": "gate-fake-run-id"}
 
 
 def test_schedule_runs_list_response_shape(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -237,6 +237,15 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     import lionagi.studio.services.schedules as schedules_mod
     import lionagi.studio.services.sessions as sessions_mod
 
+    # StateDB's path cascade consults settings.LIONAGI_STATE_DB_URL BEFORE
+    # DEFAULT_DB_PATH, so an environment with that set (dev machine, CI)
+    # would route these tests at the real configured DB — neutralize it.
+    # AppSettings is frozen, so swap the module's reference for a copy.
+    monkeypatch.setattr(
+        state_db_mod,
+        "settings",
+        state_db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": None}),
+    )
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -32,6 +32,7 @@ test_admin.py, test_schedule_runs_route.py) -- never against ~/.lionagi.
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from pathlib import Path
@@ -158,14 +159,40 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
 )
 
 
-def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str]]:
-    """Every (method, path) entry on a FastAPI app's route table, as a LIST
-    (not a set) -- a route registered twice at the same (method, path)
-    produces two entries here, one per registration. HEAD is excluded:
-    FastAPI auto-adds it for every GET, so it is never an independent
-    registration and would double every GET row for no contract value.
+_PARAM_NAME_RE = re.compile(r"\(\?P<\w+>")
+
+
+def _normalize_route_match_shape(path_regex_pattern: str) -> str:
+    """Erase parameter NAMES from a compiled Starlette path_regex pattern,
+    keeping converter/regex semantics.
+
+    Starlette compiles "/x/{id}" and "/x/{schedule_id}" to the same regex
+    BODY under different named groups (`(?P<id>[^/]+)` vs
+    `(?P<schedule_id>[^/]+)`) -- the router dispatches purely on the
+    compiled match, never on the param spelling, so two routes differing
+    only in param name shadow each other exactly like an identical literal
+    path would. A typed converter changes the body itself
+    (`(?P<id>[0-9]+)` for `{id:int}`), so it stays a genuinely distinct
+    shape from the untyped `{id}` -- only the group NAME is erased here,
+    not the pattern inside it.
     """
-    entries: list[tuple[str, str]] = []
+    return _PARAM_NAME_RE.sub("(?P<_>", path_regex_pattern)
+
+
+def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str, str]]:
+    """(method, path, match_shape) for every route on a FastAPI app's route
+    table, as a LIST (not a set) -- a route registered twice at the same
+    match shape produces two entries here, one per registration.
+
+    match_shape is the route's compiled path_regex with parameter names
+    erased (see _normalize_route_match_shape); it is what FastAPI's router
+    actually dispatches on, kept alongside the original `path` so a
+    duplicate report can show a developer both source spellings. HEAD is
+    excluded: FastAPI auto-adds it for every GET, so it is never an
+    independent registration and would double every GET row for no
+    contract value.
+    """
+    entries: list[tuple[str, str, str]] = []
     for route in app.routes:
         path = getattr(route, "path", None)
         methods = getattr(route, "methods", None)
@@ -173,50 +200,64 @@ def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str]]:
             # Non-endpoint route entries (e.g. a static asset Mount when a
             # frontend dist is configured) carry no HTTP method set at all.
             continue
+        path_regex = getattr(route, "path_regex", None)
+        match_shape = _normalize_route_match_shape(path_regex.pattern) if path_regex else path
         for method in methods:
             if method == "HEAD":
                 continue
-            entries.append((method, path))
+            entries.append((method, path, match_shape))
     return entries
 
 
-def _find_duplicate_routes(entries: list[tuple[str, str]]) -> dict[tuple[str, str], int]:
-    """Return {(method, path): count} for every entry registered more than once.
+def _find_duplicate_routes(
+    entries: list[tuple[str, str, str]],
+) -> dict[tuple[str, str], list[str]]:
+    """Return {(method, match_shape): [path, path, ...]} for every match
+    shape registered more than once.
 
-    A duplicate (method, path) is a shadowed, unreachable handler: FastAPI's
-    router matches the first registration for a given (method, path) and
-    never even considers a later one. Collapsing entries into a set before
-    comparing against the golden list (the prior version of this gate) would
-    hide that shadowing entirely -- the golden comparison would stay green
-    while a second, dead handler sat in the route table.
+    Keying on match_shape (not the raw path) is what catches two routes
+    that read as different source -- "/x/{schedule_id}" vs "/x/{id}" --
+    but compile to the identical dispatch target: FastAPI's router matches
+    the first registration for a given compiled shape and never even
+    considers a later one, so the second is dead code regardless of what
+    its param happens to be named. The path list preserves both original
+    spellings for the failure message.
     """
-    counts: dict[tuple[str, str], int] = {}
-    for entry in entries:
-        counts[entry] = counts.get(entry, 0) + 1
-    return {pair: n for pair, n in counts.items() if n > 1}
+    by_shape: dict[tuple[str, str], list[str]] = {}
+    for method, path, match_shape in entries:
+        by_shape.setdefault((method, match_shape), []).append(path)
+    return {key: paths for key, paths in by_shape.items() if len(paths) > 1}
 
 
-def _live_app_routes() -> list[tuple[str, str]]:
-    """(method, path) entries for every route on the live app, docs routes
-    excluded. Preserves duplicates -- see _find_duplicate_routes."""
+def _live_app_route_entries() -> list[tuple[str, str, str]]:
+    """(method, path, match_shape) entries for every route on the live app,
+    docs routes excluded. Preserves duplicates -- see _find_duplicate_routes."""
     from lionagi.studio.app import app
 
     return [
-        (method, path) for method, path in _entries_from_fastapi_app(app) if path not in _DOCS_PATHS
+        (method, path, match_shape)
+        for method, path, match_shape in _entries_from_fastapi_app(app)
+        if path not in _DOCS_PATHS
     ]
+
+
+def _live_app_routes() -> list[tuple[str, str]]:
+    """(method, path) entries only, for callers that don't need match_shape."""
+    return [(method, path) for method, path, _match_shape in _live_app_route_entries()]
 
 
 def test_golden_route_table_matches_pinned_snapshot():
     """Any added/renamed/removed studio endpoint must be a deliberate edit here."""
-    actual_entries = _live_app_routes()
+    entries = _live_app_route_entries()
 
-    duplicates = _find_duplicate_routes(actual_entries)
+    duplicates = _find_duplicate_routes(entries)
     assert not duplicates, (
-        "duplicate route registration(s) found -- each shadows an "
-        f"unreachable handler behind the first match: {duplicates}"
+        "duplicate route registration(s) found -- distinct path spellings "
+        "that FastAPI's router matches identically, each shadowing a "
+        f"handler behind the first match: {duplicates}"
     )
 
-    actual = sorted(set(actual_entries))
+    actual = sorted({(method, path) for method, path, _match_shape in entries})
     expected = sorted(_GOLDEN_ROUTES)
     missing = set(expected) - set(actual)
     unexpected = set(actual) - set(expected)
@@ -229,24 +270,59 @@ def test_golden_route_count_pinned():
     assert len(_GOLDEN_ROUTES) == 98
 
 
+def _compiled_match_shape(path_template: str) -> str:
+    """Real Starlette-compiled match shape for a path template.
+
+    Goes through an actual Route object (the same path_regex Starlette
+    itself computes), rather than a hand-typed regex string, so the test
+    fixtures below can't drift from Starlette's real compile_path() output.
+    """
+    from starlette.routing import Route
+
+    async def _noop() -> None:
+        return None
+
+    return _normalize_route_match_shape(Route(path_template, endpoint=_noop).path_regex.pattern)
+
+
 def test_find_duplicate_routes_detects_a_shadowed_pair():
+    shape_param = _compiled_match_shape("/api/schedules/{schedule_id}")
+    shape_literal = _compiled_match_shape("/api/schedules/")
+    assert shape_param != shape_literal
+
     entries = [
-        ("GET", "/api/schedules/{schedule_id}"),
-        ("GET", "/api/schedules/"),
-        ("GET", "/api/schedules/{schedule_id}"),
+        ("GET", "/api/schedules/{schedule_id}", shape_param),
+        ("GET", "/api/schedules/", shape_literal),
+        ("GET", "/api/schedules/{schedule_id}", shape_param),
     ]
-    assert _find_duplicate_routes(entries) == {("GET", "/api/schedules/{schedule_id}"): 2}
+    assert _find_duplicate_routes(entries) == {
+        ("GET", shape_param): ["/api/schedules/{schedule_id}", "/api/schedules/{schedule_id}"]
+    }
 
 
 def test_find_duplicate_routes_empty_for_unique_entries():
-    entries = [("GET", "/api/schedules/"), ("POST", "/api/schedules/")]
+    shape = _compiled_match_shape("/api/schedules/")
+    entries = [("GET", "/api/schedules/", shape), ("POST", "/api/schedules/", shape)]
     assert _find_duplicate_routes(entries) == {}
+
+
+def test_normalize_route_match_shape_erases_param_names_but_keeps_converters():
+    """The reviewer's exact distinction: two untyped params with different
+    names collapse to one shape; a typed converter stays distinct from the
+    untyped param even when the name matches."""
+    shape_schedule_id = _compiled_match_shape("/api/schedules/{schedule_id}")
+    shape_id = _compiled_match_shape("/api/schedules/{id}")
+    shape_id_int = _compiled_match_shape("/api/schedules/{id:int}")
+
+    assert shape_schedule_id == shape_id
+    assert shape_id_int != shape_id
 
 
 def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
     """End-to-end proof, not just a property of the tuple-list helper: a
-    genuinely duplicated route on a real FastAPI app's route table is
-    detected by the same collection path _live_app_routes() uses.
+    genuinely duplicated route (identical path spelling) on a real FastAPI
+    app's route table is detected by the same collection path
+    _live_app_routes() uses.
 
     A duplicate can't be produced through the studio_route registry itself
     (registry.py's dedup guard raises ValueError on a second registration at
@@ -268,7 +344,45 @@ def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
     )  # shadows the first
 
     duplicates = _find_duplicate_routes(_entries_from_fastapi_app(app))
-    assert duplicates == {("GET", "/api/schedules/{schedule_id}"): 2}
+    assert len(duplicates) == 1
+    (method, _match_shape), paths = next(iter(duplicates.items()))
+    assert method == "GET"
+    assert paths == ["/api/schedules/{schedule_id}", "/api/schedules/{schedule_id}"]
+
+
+def test_duplicate_route_registration_with_different_param_names_is_caught():
+    """The reviewer's exact regression: /api/schedules/{schedule_id} and
+    /api/schedules/{id} read as different source but compile to the same
+    dispatch target, so the second shadows the first exactly like an
+    identical-path duplicate would -- the gate must name them as duplicates
+    even though no two path strings in the pair are equal.
+
+    One route is registered through an APIRouter + include_router (with a
+    path prefix, the way every real studio area router mounts), and the
+    other directly on the app, proving match-shape normalization survives
+    prefix compilation rather than only working on a hand-built path string.
+    """
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    async def _direct_handler() -> dict:
+        return {}
+
+    router = APIRouter(prefix="/api")
+
+    @router.get("/schedules/{id}")
+    async def _router_handler() -> dict:
+        return {}
+
+    app.include_router(router)
+    app.add_api_route("/api/schedules/{schedule_id}", _direct_handler, methods=["GET"])
+
+    duplicates = _find_duplicate_routes(_entries_from_fastapi_app(app))
+    assert len(duplicates) == 1
+    (method, _match_shape), paths = next(iter(duplicates.items()))
+    assert method == "GET"
+    assert sorted(paths) == ["/api/schedules/{id}", "/api/schedules/{schedule_id}"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Studio daemon API contract gate.
+
+Regression class this guards, in plain terms: CLI/daemon contract drift that
+was discovered live rather than caught by CI. Two known instances of this
+class: a URL-prefix bug where a client (mis-)configured base URL caused every
+request to double up the "/api" prefix (".../api/api/..."), and a CWD bug
+where a spawned subprocess inherited the daemon's working directory instead
+of resolving one explicitly, so behavior depended on how the daemon itself
+happened to be launched. Neither was caught by a test; both were found by an
+operator hitting a broken request in practice.
+
+This suite pins the daemon's actual, observed contract:
+
+  1. The full sorted (method, path) route table (excluding FastAPI's
+     auto-generated docs/schema routes) as a golden list. Adding, renaming,
+     or removing an endpoint forces a deliberate edit here instead of
+     silently drifting.
+  2. The `/api` prefix contract: it appears exactly once in every mounted
+     API route path (the shape of the double-prefix regression class).
+  3. Per-endpoint success/404/422/400 response shape (status code + sorted
+     top-level JSON object keys, not full payloads) for the admin, session,
+     and schedule endpoint families -- the areas gate 5 was scoped to.
+
+Everything here is read empirically from the routers themselves
+(lionagi/studio/services/admin.py, sessions.py, schedules.py) and from
+running the live app against a temp SQLite DB, per the existing suite's
+`_patch_db` / `monkeypatch.setattr(..., DEFAULT_DB_PATH, ...)` pattern (see
+test_admin.py, test_schedule_runs_route.py) -- never against ~/.lionagi.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+from ._helpers import run_async  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# 1. Golden route table -- excludes FastAPI's auto-generated docs/schema routes.
+# ---------------------------------------------------------------------------
+
+_DOCS_PATHS = frozenset({"/openapi.json", "/docs", "/redoc", "/docs/oauth2-redirect"})
+
+# Sorted (method, path) pairs for every non-docs route mounted on the live
+# app, pinned 2026-07-12 against the actual route table (see
+# lionagi/studio/registry.py::_STUDIO_ROUTE_MODULES for the area modules that
+# populate it, and app.py::_mount_studio_routes for the "/api" + route.path
+# mounting rule).
+_GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
+    ("DELETE", "/api/agents/{name}"),
+    ("DELETE", "/api/engine-defs/{def_id}"),
+    ("DELETE", "/api/playbooks/{name}"),
+    ("DELETE", "/api/projects/{name}"),
+    ("DELETE", "/api/schedules/{schedule_id}"),
+    ("DELETE", "/api/sessions/{session_id}/tags/{tag:path}"),
+    ("DELETE", "/api/workflow-defs/{def_id}"),
+    ("GET", "/api/admin/doctor"),
+    ("GET", "/api/admin/events"),
+    ("GET", "/api/admin/health"),
+    ("GET", "/api/agents/"),
+    ("GET", "/api/agents/{name}"),
+    ("GET", "/api/approvals/evidence/verify"),
+    ("GET", "/api/approvals/{approval_id}"),
+    ("GET", "/api/artifacts/by-session/{session_id}"),
+    ("GET", "/api/artifacts/{artifact_id}"),
+    ("GET", "/api/casts/"),
+    ("GET", "/api/definitions/"),
+    ("GET", "/api/definitions/{kind}/{name}"),
+    ("GET", "/api/definitions/{kind}/{name}/versions/{version}"),
+    ("GET", "/api/engine-defs/"),
+    ("GET", "/api/engine-defs/{def_id}"),
+    ("GET", "/api/engine-runs/"),
+    ("GET", "/api/engine-runs/{run_id}"),
+    ("GET", "/api/invocations/"),
+    ("GET", "/api/invocations/{invocation_id}"),
+    ("GET", "/api/playbook-templates/"),
+    ("GET", "/api/playbook-templates/{name}"),
+    ("GET", "/api/playbooks/"),
+    ("GET", "/api/playbooks/{name}"),
+    ("GET", "/api/plugins"),
+    ("GET", "/api/plugins/{name}"),
+    ("GET", "/api/plugins/{plugin_name}/agents/{agent_name}"),
+    ("GET", "/api/plugins/{plugin_name}/skills/{skill_name}"),
+    ("GET", "/api/projects/"),
+    ("GET", "/api/projects/{name}"),
+    ("GET", "/api/runs/"),
+    ("GET", "/api/runs/projects"),
+    ("GET", "/api/runs/{run_id}"),
+    ("GET", "/api/runs/{run_id}/file"),
+    ("GET", "/api/schedules/"),
+    ("GET", "/api/schedules/limits"),
+    ("GET", "/api/schedules/runs/{run_id}"),
+    ("GET", "/api/schedules/{schedule_id}"),
+    ("GET", "/api/schedules/{schedule_id}/runs"),
+    ("GET", "/api/sessions/"),
+    ("GET", "/api/sessions/{session_id}"),
+    ("GET", "/api/sessions/{session_id}/signals"),
+    ("GET", "/api/sessions/{session_id}/stream"),
+    ("GET", "/api/shows/"),
+    ("GET", "/api/shows/{topic}"),
+    ("GET", "/api/shows/{topic}/stream"),
+    ("GET", "/api/skills/"),
+    ("GET", "/api/skills/{name}"),
+    ("GET", "/api/stats"),
+    ("GET", "/api/stats/activity"),
+    ("GET", "/api/teams/"),
+    ("GET", "/api/teams/{team_id}"),
+    ("GET", "/api/workflow-defs/"),
+    ("GET", "/api/workflow-defs/{def_id}"),
+    ("GET", "/health"),
+    ("PATCH", "/api/schedules/{schedule_id}"),
+    ("POST", "/api/admin/maintenance"),
+    ("POST", "/api/admin/prune"),
+    ("POST", "/api/admin/prune-old-data"),
+    ("POST", "/api/admin/transition"),
+    ("POST", "/api/agents/{name}"),
+    ("POST", "/api/agents/{name}/validate"),
+    ("POST", "/api/approvals/"),
+    ("POST", "/api/approvals/{approval_id}/deny"),
+    ("POST", "/api/approvals/{approval_id}/grant"),
+    ("POST", "/api/definitions/snapshot"),
+    ("POST", "/api/definitions/{kind}/{name}"),
+    ("POST", "/api/definitions/{kind}/{name}/rollback"),
+    ("POST", "/api/engine-defs/"),
+    ("POST", "/api/invocations/{invocation_id}/cancel"),
+    ("POST", "/api/launches/"),
+    ("POST", "/api/leo/sessions"),
+    ("POST", "/api/leo/sessions/{session_id}/messages"),
+    ("POST", "/api/playbook-templates/{name}/install"),
+    ("POST", "/api/playbooks/{name}"),
+    ("POST", "/api/playbooks/{name}/run"),
+    ("POST", "/api/playbooks/{name}/validate"),
+    ("POST", "/api/projects/"),
+    ("POST", "/api/projects/{name}/assign"),
+    ("POST", "/api/schedules/"),
+    ("POST", "/api/schedules/{schedule_id}/disable"),
+    ("POST", "/api/schedules/{schedule_id}/enable"),
+    ("POST", "/api/schedules/{schedule_id}/trigger"),
+    ("POST", "/api/sessions/{session_id}/tags"),
+    ("POST", "/api/shows/import"),
+    ("POST", "/api/workflow-defs/"),
+    ("POST", "/api/workflow-defs/{def_id}/run"),
+    ("PUT", "/api/agents/{name}"),
+    ("PUT", "/api/engine-defs/{def_id}"),
+    ("PUT", "/api/playbooks/{name}"),
+    ("PUT", "/api/projects/{name}"),
+    ("PUT", "/api/workflow-defs/{def_id}"),
+)
+
+
+def _live_app_routes() -> list[tuple[str, str]]:
+    """(method, path) pairs for every route on the live app, docs routes excluded."""
+    from lionagi.studio.app import app
+
+    pairs: set[tuple[str, str]] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path is None or methods is None:
+            # Non-endpoint route entries (e.g. a static asset Mount when a
+            # frontend dist is configured) carry no HTTP method set at all.
+            continue
+        if path in _DOCS_PATHS:
+            continue
+        for method in methods:
+            if method == "HEAD":
+                # FastAPI auto-adds HEAD for every GET; it is not an
+                # independently-registered endpoint and would double every
+                # GET row in the golden list for no contract value.
+                continue
+            pairs.add((method, path))
+    return sorted(pairs)
+
+
+def test_golden_route_table_matches_pinned_snapshot():
+    """Any added/renamed/removed studio endpoint must be a deliberate edit here."""
+    actual = _live_app_routes()
+    expected = sorted(_GOLDEN_ROUTES)
+    missing = set(expected) - set(actual)
+    unexpected = set(actual) - set(expected)
+    assert not missing, f"routes removed/renamed since golden was pinned: {sorted(missing)}"
+    assert not unexpected, f"routes added since golden was pinned: {sorted(unexpected)}"
+    assert actual == expected
+
+
+def test_golden_route_count_pinned():
+    assert len(_GOLDEN_ROUTES) == 98
+
+
+# ---------------------------------------------------------------------------
+# 2. The /api prefix contract -- the double-prefix regression class.
+# ---------------------------------------------------------------------------
+
+
+def test_api_prefix_appears_exactly_once_in_every_route_path():
+    """Every mounted studio API route path carries exactly one "/api" segment.
+
+    Guards the double-prefix regression class directly: a client (or a
+    future route-registration change) that prepends "/api" a second time
+    would produce paths like "/api/api/sessions/", which this test catches
+    by counting occurrences of the literal "/api" substring rather than
+    just checking the leading prefix.
+    """
+    for _method, path in _live_app_routes():
+        if path == "/health":
+            assert "/api" not in path
+            continue
+        assert path.startswith("/api/"), f"non-/health route missing /api prefix: {path!r}"
+        assert path.count("/api") == 1, f"route path repeats the /api prefix: {path!r}"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures/helpers for the per-family response-shape pins below.
+# ---------------------------------------------------------------------------
+
+
+def _patch_db(monkeypatch, db_path: Path) -> None:
+    """Point every service module's DB reference at a fresh temp path.
+
+    Must run before any seeding call -- StateDB() reads
+    lionagi.state.db.DEFAULT_DB_PATH fresh at each instantiation (see
+    StateDB.__init__), and admin.py/sessions.py additionally cache the path
+    as a plain string in their own module-level `_DB` for aiosqlite.connect.
+    """
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.schedules as schedules_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _make_client() -> TestClient:
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+async def _seed_completed_session(db_path: Path, session_id: str) -> None:
+    prog_id = f"{session_id}-prog"
+    async with StateDB(db_path) as db:
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": prog_id,
+                "name": "gate-test-session",
+                "status": "completed",
+                "started_at": time.time() - 10,
+                "ended_at": time.time(),
+            }
+        )
+
+
+async def _seed_running_session(db_path: Path, session_id: str) -> None:
+    prog_id = f"{session_id}-prog"
+    async with StateDB(db_path) as db:
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": prog_id,
+                "name": "gate-test-running-session",
+                "status": "running",
+                "started_at": time.time(),
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3a. Admin endpoint family.
+# ---------------------------------------------------------------------------
+
+
+def test_admin_doctor_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/admin/doctor")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["db_health", "diagnostic_run_at", "phantom_sessions"]
+
+
+def test_admin_health_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/admin/health")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["db", "diagnostic_run_at", "sessions"]
+
+
+def test_admin_events_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/admin/events")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["events"]
+
+
+def test_admin_transition_success_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    sid = str(uuid.uuid4())
+    run_async(_seed_running_session(db_path, sid))
+    client = _make_client()
+
+    r = client.post(
+        "/api/admin/transition",
+        json={"session_ids": [sid], "target_status": "failed", "reason": "gate pin"},
+    )
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["event_id", "skipped", "transitioned"]
+
+
+def test_admin_transition_missing_reason_400_shape(tmp_path, monkeypatch):
+    """Body validates fine (session_ids + target_status present) but the
+    handler's own reason_code-required check fails -- a 400, not 422."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post(
+        "/api/admin/transition",
+        json={"session_ids": ["x"], "target_status": "failed"},
+    )
+    assert r.status_code == 400
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_admin_transition_malformed_body_422_shape(tmp_path, monkeypatch):
+    """Missing required fields (session_ids, target_status) fails pydantic
+    validation before the handler ever runs."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post("/api/admin/transition", json={})
+    assert r.status_code == 422
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_admin_maintenance_checkpoint_response_shape(tmp_path, monkeypatch):
+    """No DB on disk yet -- checkpoint_state_db's no-op shape."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["action", "busy", "checkpointed", "log_pages", "mode"]
+
+
+def test_admin_maintenance_malformed_action_422_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post("/api/admin/maintenance", json={"action": "not-a-real-action"})
+    assert r.status_code == 422
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_admin_prune_old_data_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post("/api/admin/prune-old-data", json={})
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["dispatch_purged", "runs_pruned", "sessions_pruned"]
+
+
+# ---------------------------------------------------------------------------
+# 3b. Sessions endpoint family.
+# ---------------------------------------------------------------------------
+
+_SESSION_DETAIL_KEYS = sorted(
+    [
+        "agent_hash",
+        "agent_name",
+        "artifact_contract_json",
+        "artifact_verification_json",
+        "artifacts_path",
+        "branches",
+        "created_at",
+        "duration_ms",
+        "effort",
+        "ended_at",
+        "graph",
+        "id",
+        "invocation_id",
+        "invocation_kind",
+        "last_message_at",
+        "message_cursor",
+        "message_limit",
+        "message_next_cursor",
+        "message_stats",
+        "model",
+        "name",
+        "node_metadata",
+        "playbook_name",
+        "project",
+        "project_source",
+        "provider",
+        "segments",
+        "show_play_name",
+        "show_topic",
+        "source_kind",
+        "source_show",
+        "started_at",
+        "status",
+        "status_evidence_refs",
+        "status_reason_code",
+        "status_reason_summary",
+        "updated_at",
+    ]
+)
+
+
+def test_sessions_list_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/sessions/")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["sessions"]
+
+
+def test_sessions_detail_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    sid = str(uuid.uuid4())
+    run_async(_seed_completed_session(db_path, sid))
+    client = _make_client()
+
+    r = client.get(f"/api/sessions/{sid}")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == _SESSION_DETAIL_KEYS
+
+
+def test_sessions_detail_404_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get(f"/api/sessions/{uuid.uuid4()}")
+    assert r.status_code == 404
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_sessions_detail_malformed_cursor_400_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    sid = str(uuid.uuid4())
+    run_async(_seed_completed_session(db_path, sid))
+    client = _make_client()
+
+    r = client.get(f"/api/sessions/{sid}", params={"message_cursor": "not-valid-base64-json!!"})
+    assert r.status_code == 400
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 3c. Schedules endpoint family.
+# ---------------------------------------------------------------------------
+
+_SCHEDULE_DETAIL_KEYS = sorted(
+    [
+        "action_agent",
+        "action_command",
+        "action_command_args",
+        "action_cwd",
+        "action_extra_args",
+        "action_flow_yaml",
+        "action_kind",
+        "action_model",
+        "action_playbook",
+        "action_project",
+        "action_prompt",
+        "budget_tokens",
+        "budget_usd",
+        "consecutive_failures",
+        "created_at",
+        "cron_expr",
+        "description",
+        "enabled",
+        "github_cursor",
+        "github_filter",
+        "github_repo",
+        "id",
+        "interval_sec",
+        "last_alert_at",
+        "last_fired_at",
+        "last_healthy_poll_at",
+        "last_status",
+        "max_runs",
+        "missed_fire_policy",
+        "name",
+        "next_fire_at",
+        "on_fail",
+        "on_success",
+        "overlap_policy",
+        "poll_interval_sec",
+        "poller_consecutive_401",
+        "project",
+        "recent_runs",
+        "threshold_config",
+        "trigger_type",
+        "updated_at",
+    ]
+)
+
+
+def _create_gate_schedule(db_path: Path) -> str:
+    async def _create() -> str:
+        import lionagi.studio.services.schedules as schedules_mod
+
+        created = await schedules_mod.create_schedule(
+            {
+                "name": f"gate-test-{uuid.uuid4().hex[:8]}",
+                "trigger_type": "cron",
+                "cron_expr": "0 18 * * *",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+            }
+        )
+        return created["id"]
+
+    return run_async(_create())
+
+
+def test_schedules_list_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/schedules/")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["schedules"]
+
+
+def test_schedules_limits_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/schedules/limits")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["current_inflight", "max_scheduled_concurrent"]
+
+
+def test_schedules_create_response_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post(
+        "/api/schedules/",
+        json={
+            "name": f"gate-create-{uuid.uuid4().hex[:8]}",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        },
+    )
+    assert r.status_code == 201
+    assert sorted(r.json().keys()) == ["created_at", "id", "name"]
+
+
+def test_schedules_create_malformed_body_422_shape(tmp_path, monkeypatch):
+    """action_kind is a required pydantic field; omitting it never reaches the handler."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post(
+        "/api/schedules/",
+        json={"name": "missing-action-kind", "trigger_type": "cron"},
+    )
+    assert r.status_code == 422
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_schedules_create_domain_validation_400_shape(tmp_path, monkeypatch):
+    """Body is pydantic-valid but violates a domain rule (cron trigger with
+    no cron_expr) -- create_schedule() raises ValueError, mapped to 400."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.post(
+        "/api/schedules/",
+        json={"name": "no-cron-expr", "trigger_type": "cron", "action_kind": "agent"},
+    )
+    assert r.status_code == 400
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_schedules_detail_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.get(f"/api/schedules/{schedule_id}")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == _SCHEDULE_DETAIL_KEYS
+
+
+def test_schedules_detail_404_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/schedules/does-not-exist")
+    assert r.status_code == 404
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+@pytest.mark.parametrize(
+    "method,path_suffix",
+    [
+        ("patch", ""),
+        ("delete", ""),
+        ("post", "/enable"),
+        ("post", "/disable"),
+        ("post", "/trigger"),
+    ],
+)
+def test_schedules_unknown_id_404_shape_across_mutation_routes(
+    tmp_path, monkeypatch, method, path_suffix
+):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    kwargs = {"json": {"name": "x"}} if method == "patch" else {}
+    r = getattr(client, method)(f"/api/schedules/does-not-exist{path_suffix}", **kwargs)
+    assert r.status_code == 404
+    assert sorted(r.json().keys()) == ["detail"]
+
+
+def test_schedule_runs_list_response_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.get(f"/api/schedules/{schedule_id}/runs")
+    assert r.status_code == 200
+    assert sorted(r.json().keys()) == ["has_next", "limit", "offset", "runs"]
+
+
+def test_schedule_run_detail_404_shape(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    r = client.get("/api/schedules/runs/does-not-exist")
+    assert r.status_code == 404
+    assert sorted(r.json().keys()) == ["detail"]

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -234,6 +234,7 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     """
     import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.db_maintenance as db_maintenance_mod
     import lionagi.studio.services.schedules as schedules_mod
     import lionagi.studio.services.sessions as sessions_mod
 
@@ -252,6 +253,9 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
     monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+    # db_maintenance imports DEFAULT_DB_PATH by value, so the state_db_mod
+    # patch above never reaches its own module-level binding.
+    monkeypatch.setattr(db_maintenance_mod, "DEFAULT_DB_PATH", db_path)
 
 
 def _make_client() -> TestClient:


### PR DESCRIPTION
Gate 5 from #2102 (daemon API regression suite).

## What

Adds `tests/apps_studio_server/test_daemon_api_gate.py` (30 tests):

- **Route-table golden**: all 98 (method, path) pairs of the Studio daemon app pinned (docs/schema routes excluded) — a new, renamed, or deleted endpoint forces a deliberate test edit
- **URL-prefix contract**: `/api` appears exactly once in every route path (the double-prefix regression class, previously found live)
- **Per-endpoint pins** for the admin (doctor, health, events, transition, maintenance, prune-old-data), sessions (list/detail/404/malformed-cursor 400), and schedules (full CRUD + enable/disable/trigger 404s, runs) families: success status codes + top-level response-shape keys, against a temp SQLite DB via the existing suite's DB-patching pattern — never ~/.lionagi

Two debatable-but-not-buggy behaviors pinned as observed: `POST /api/admin/transition` returns 400 (not 422) for a missing reason since the check lives in the handler, and the three service modules resolve their DB path inconsistently (admin/sessions cache a separate attr; schedules doesn't).

## Regression class

CLI/daemon contract drift — the URL-prefix and CWD-inheritance breakages were both found live, not by CI.

## Verification

- `uv run pytest tests/apps_studio_server/test_daemon_api_gate.py -v` → 30 passed (re-run by the reviewer seat post-rebase)
- Full `tests/apps_studio_server/` green except one pre-existing xdist timing flake (`test_leo_concurrent_turn_second_gets_409`), which passes in isolation
- `ruff check` clean

Part of #2102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)