### PR TITLE
fix(cli): reactive flow resume can replay reactively spawned nodes

### DIFF
--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -94,6 +94,7 @@ class CheckpointWriter:
         assignee: str | None = None,
         instruction: str | None = None,
         parent_id: str | None = None,
+        spawn_id: str | None = None,
     ) -> None:
         """Record one reactively spawned node's outcome, keyed by its own node id.
 
@@ -101,11 +102,16 @@ class CheckpointWriter:
         branch can carry a name identical to a planned agent_id's, so using
         that name as the key would silently overwrite the planned entry.
 
-        operation/assignee/instruction/parent_id (added in CHECKPOINT_VERSION 2)
-        are what resume needs to reconstruct the spawned node into a fresh
-        graph — the operation type, its routed role (if any), the instruction
-        it ran with, and the node id of whichever op's completion produced the
-        SpawnRequest (None for an independent spawn or one with no emitter). A
+        operation/assignee/instruction/parent_id/spawn_id (added in
+        CHECKPOINT_VERSION 2) are what resume needs to reconstruct the spawned
+        node into a fresh graph — the operation type, its routed role (if
+        any), the instruction it ran with, the node id of whichever op's
+        completion produced the SpawnRequest (None for an independent spawn or
+        one with no emitter), and role_node_builder's stamped spawn_id/
+        reference_id (present on every node it builds, regardless of
+        assignee — the finalize-time spawned-result scan raises if an
+        assignee-bearing node reaches it without one, so reconstruction must
+        restore this alongside assignee, never just assignee alone). A
         checkpoint written before this field set existed carries entries
         without `operation`; resume treats those as unreconstructable and
         refuses only for the affected node(s), not the whole run.
@@ -119,6 +125,7 @@ class CheckpointWriter:
                 "assignee": assignee,
                 "instruction": instruction,
                 "parent_id": parent_id,
+                "spawn_id": spawn_id,
             }
             for i, existing in enumerate(self.spawned):
                 if existing.get("node_id") == node_id:

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -24,7 +24,7 @@ __all__ = (
     "resolve_checkpoint_target",
 )
 
-CHECKPOINT_VERSION = 1
+CHECKPOINT_VERSION = 2
 
 
 class FlowResumeError(LionError):
@@ -90,15 +90,36 @@ class CheckpointWriter:
         status: str,
         response: Any,
         flow_context: dict[str, Any] | None = None,
+        operation: str | None = None,
+        assignee: str | None = None,
+        instruction: str | None = None,
+        parent_id: str | None = None,
     ) -> None:
         """Record one reactively spawned node's outcome, keyed by its own node id.
 
         Spawned nodes must never share the `ops` keyspace: a spawned child's
         branch can carry a name identical to a planned agent_id's, so using
         that name as the key would silently overwrite the planned entry.
+
+        operation/assignee/instruction/parent_id (added in CHECKPOINT_VERSION 2)
+        are what resume needs to reconstruct the spawned node into a fresh
+        graph — the operation type, its routed role (if any), the instruction
+        it ran with, and the node id of whichever op's completion produced the
+        SpawnRequest (None for an independent spawn or one with no emitter). A
+        checkpoint written before this field set existed carries entries
+        without `operation`; resume treats those as unreconstructable and
+        refuses only for the affected node(s), not the whole run.
         """
         async with self._lock:
-            entry = {"node_id": node_id, "status": status, "response": response}
+            entry = {
+                "node_id": node_id,
+                "status": status,
+                "response": response,
+                "operation": operation,
+                "assignee": assignee,
+                "instruction": instruction,
+                "parent_id": parent_id,
+            }
             for i, existing in enumerate(self.spawned):
                 if existing.get("node_id") == node_id:
                     self.spawned[i] = entry

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -879,6 +879,22 @@ async def _execute_dag(
     # cannot quietly fan out to dozens of (costly) child agents. Either way,
     # spawns already restored from a checkpoint count against it.
     max_spawn = max(0, (max_ops - len(assignments) if max_ops > 0 else 20) - restored_spawn_count)
+    # role_node_builder's spawn-id sequence is closure-scoped and rebuilt
+    # fresh below every generation — on resume it must start past whatever
+    # ordinals the restored spawns already used, or a live spawn this
+    # generation reissues the same spawn_id (and artifact directory) as a
+    # restored one. Takes the MAX existing ordinal + 1 rather than assuming
+    # count == max: a crashed run can have gaps (a spawn allocated but never
+    # completed before the crash never made it into `spawned` at all), so
+    # counting restored entries would double-allocate into that gap.
+    _spawn_seq_start = 1
+    for _entry in checkpoint_spawned_seed or []:
+        _sid = _entry.get("spawn_id")
+        if not _sid:
+            continue
+        _, _, _suffix = _sid.rpartition("-")
+        if _suffix.isdigit():
+            _spawn_seq_start = max(_spawn_seq_start, int(_suffix) + 1)
 
     heartbeat_interval = 60
     max_idle_seconds = 600
@@ -1151,7 +1167,11 @@ async def _execute_dag(
             reactive=reactive,
             spawn_type=SpawnRequest if reactive else None,
             node_builder=(
-                role_node_builder(role_base, decorate_instruction=_decorate_spawn_instruction)
+                role_node_builder(
+                    role_base,
+                    decorate_instruction=_decorate_spawn_instruction,
+                    start=_spawn_seq_start,
+                )
                 if reactive
                 else None
             ),

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -593,7 +593,9 @@ async def _build_dag(
 
 def _reconstruct_spawned_nodes(
     env: OrchestrationEnv,
+    plan_result: _PlanResult,
     dag_state: _DagState,
+    checkpoint_ops: dict[str, dict],
     checkpoint_spawned: list[dict],
 ) -> None:
     """Rebuild reactively spawned nodes from a checkpoint into the fresh graph.
@@ -604,19 +606,29 @@ def _reconstruct_spawned_nodes(
     so the executor's terminal-status short-circuit (never a live re-run)
     picks it up.
 
-    Two things must hold for a given entry, checked BEFORE any node is added
+    Three things must hold for a given entry, checked BEFORE any node is added
     to the graph so a refusal never leaves it partially mutated:
 
     1. It must carry `operation` (added in CHECKPOINT_VERSION 2, alongside
-       `assignee`/`instruction`/`parent_id`) — a checkpoint written before
-       that field set existed has nothing to rebuild an Operation node from.
+       `assignee`/`instruction`/`parent_id`/`spawn_id`) — a checkpoint written
+       before that field set existed has nothing to rebuild an Operation node
+       from.
     2. If it has a `parent_id`, that id must resolve to either a planned node
-       (already in the graph from _build_dag) or another entry in this same
-       `checkpoint_spawned` list. If it does not, the op that spawned this
-       node had not itself reached a checkpointed terminal state before the
-       crash — resuming it would either duplicate the spawn (the parent
-       re-runs and emits it again) or lose it outright (the parent never
-       re-emits it), a decision this version cannot soundly replay.
+       that is ITSELF checkpointed terminal (completed or failed in
+       `checkpoint_ops`), or another entry in this same `checkpoint_spawned`
+       list. A planned parent merely existing in the DAG is not enough — if
+       it crashed before its own checkpoint write landed, resume would
+       pre-complete this child while rerunning that parent live, and the
+       rerun can emit the same follow-up spawn again (duplicate work). If
+       the parent hasn't reached a checkpointed terminal state at all, the
+       spawn decision cannot be soundly replayed — resuming risks either
+       duplicating or silently dropping that work.
+    3. If it recorded an `assignee` (role-routed spawn), it must also carry a
+       `spawn_id` — role_node_builder stamps both together unconditionally at
+       construction time, and the finalize-time result-collection scan raises
+       a hard invariant error for any assignee-bearing node it finds without
+       one. A checkpoint entry missing `spawn_id` despite an `assignee` is
+       itself corrupt/pre-dates that field, not soundly replayable.
 
     Either failure refuses resume for only the affected node(s), named in the
     error, never the whole run merely because a spawn occurred.
@@ -647,15 +659,32 @@ def _reconstruct_spawned_nodes(
             "'completed' nor 'failed', so it cannot be safely replayed."
         )
 
+    unstamped = [
+        e["node_id"] for e in checkpoint_spawned if e.get("assignee") and not e.get("spawn_id")
+    ]
+    if unstamped:
+        raise FlowResumeError(
+            "Resume refused for reactively spawned node(s) "
+            f"[{', '.join(unstamped)}]: recorded a role assignee but no "
+            "spawn_id — role_node_builder stamps both together, so this "
+            "checkpoint predates spawn_id capture (or is otherwise corrupt) "
+            "and cannot be soundly rebuilt. Re-run the flow from scratch."
+        )
+
     known_ids = {str(n) for n in dag_state.node_ids}
     candidate_ids = {e["node_id"] for e in checkpoint_spawned}
+    terminal_planned_ids = {
+        str(node_id)
+        for agent_id, node_id in zip(plan_result.agent_ids, dag_state.node_ids, strict=True)
+        if (checkpoint_ops.get(agent_id) or {}).get("status") in ("completed", "failed")
+    }
 
     unsound = [
         f"{e['node_id']} (parent {e['parent_id']})"
         for e in checkpoint_spawned
         if e.get("parent_id")
-        and e["parent_id"] not in known_ids
         and e["parent_id"] not in candidate_ids
+        and not (e["parent_id"] in known_ids and e["parent_id"] in terminal_planned_ids)
     ]
     if unsound:
         raise FlowResumeError(
@@ -671,11 +700,18 @@ def _reconstruct_spawned_nodes(
     for entry in checkpoint_spawned:
         node_id = entry["node_id"]
         assignee = entry.get("assignee")
+        spawn_id = entry.get("spawn_id")
+        metadata: dict[str, Any] = {}
+        if assignee:
+            metadata["assignee"] = assignee
+        if spawn_id:
+            metadata["spawn_id"] = spawn_id
+            metadata["reference_id"] = spawn_id
         node = create_operation(
             entry["operation"],
             parameters={"instruction": entry.get("instruction") or ""},
             id=_UUID(node_id),
-            metadata={"assignee": assignee} if assignee else {},
+            metadata=metadata,
         )
         node.execution.status = (
             EventStatus.COMPLETED if entry["status"] == "completed" else EventStatus.FAILED
@@ -721,7 +757,7 @@ def _apply_checkpoint_precompletion(
     from lionagi.protocols.types import EventStatus
 
     if checkpoint_spawned:
-        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+        _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     graph = env.builder.get_graph()
     degraded: list[str] = []
@@ -765,6 +801,7 @@ async def _execute_dag(
     checkpoint_config: dict | None = None,
     checkpoint_ops_seed: dict[str, dict] | None = None,
     checkpoint_flow_context: dict | None = None,
+    checkpoint_spawned_seed: list[dict] | None = None,
 ) -> _ExecResult:
     """Drive the planning engine over the DAG and collect per-agent results.
 
@@ -773,6 +810,13 @@ async def _execute_dag(
     completion/failure observers. checkpoint_flow_context seeds the
     executor's shared context workspace on resume with what was accumulated
     before the crash, so pending ops see the same workspace they would live.
+    checkpoint_spawned_seed carries forward any reactively spawned entries a
+    prior checkpoint already recorded (reconstructed into the graph by
+    _apply_checkpoint_precompletion before this call) — without it, this
+    generation's first flush would overwrite `spawned` with `[]`, and since
+    pre-completed nodes never re-emit a completion signal to re-record
+    themselves, a second crash before any NEW spawn occurs would silently
+    lose all the previously reconstructed work.
     """
     assignments = plan_result.assignments
     agent_ids = plan_result.agent_ids
@@ -810,6 +854,7 @@ async def _execute_dag(
             # lose it despite nothing having gone wrong with restoration.
             flow_context=dict(checkpoint_flow_context or {}),
             ops=dict(checkpoint_ops_seed or {}),
+            spawned=list(checkpoint_spawned_seed or []),
         )
         with contextlib.suppress(Exception):
             await _checkpoint_writer.flush()
@@ -942,6 +987,13 @@ async def _execute_dag(
                         if isinstance(params, dict)
                         else getattr(params, "instruction", None)
                     )
+                    # role_node_builder stamps spawn_id unconditionally
+                    # (lionagi/orchestration/patterns.py), independent of
+                    # whether the request carried an assignee — captured the
+                    # same way regardless so reconstruction can restore it
+                    # and the finalize-time assignee-without-spawn_id
+                    # invariant check never trips for a resumed node.
+                    spawn_fields["spawn_id"] = spawned_node.metadata.get("spawn_id")
             _checkpoint_tasks.append(
                 _asyncio.ensure_future(
                     _checkpoint_writer.record_spawned(
@@ -1936,6 +1988,9 @@ async def _run_flow_inner(
         checkpoint_ops_seed=resume_checkpoint.get("ops") if resume_checkpoint is not None else None,
         checkpoint_flow_context=(
             resume_checkpoint.get("flow_context") if resume_checkpoint is not None else None
+        ),
+        checkpoint_spawned_seed=(
+            resume_checkpoint.get("spawned") if resume_checkpoint is not None else None
         ),
     )
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -866,10 +866,19 @@ async def _execute_dag(
     else:
         progress(f"Executing DAG (reactive off): {len(assignments)} assignments...")
     conc = max_concurrent if max_concurrent > 0 else max(len(assignments), 1)
+    # Restored spawns (from a prior checkpoint's `spawned` list, reconstructed
+    # into the graph before this call) already consumed part of the run's
+    # spawn budget and already exist as completed/failed work — both the
+    # live budget below and this generation's spawn accounting must count
+    # them, or a resumed --max-ops run could accept spawns beyond what was
+    # ever allowed, and restored-only spawned work would look like zero
+    # spawns happened at all.
+    restored_spawn_count = len(checkpoint_spawned_seed or [])
     # Spawn budget: when --max-ops is set, the initial plan + spawns share it.
     # Otherwise fall back to a conservative default so an un-capped reactive run
-    # cannot quietly fan out to dozens of (costly) child agents.
-    max_spawn = max(0, max_ops - len(assignments)) if max_ops > 0 else 20
+    # cannot quietly fan out to dozens of (costly) child agents. Either way,
+    # spawns already restored from a checkpoint count against it.
+    max_spawn = max(0, (max_ops - len(assignments) if max_ops > 0 else 20) - restored_spawn_count)
 
     heartbeat_interval = 60
     max_idle_seconds = 600
@@ -1177,7 +1186,13 @@ async def _execute_dag(
             await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
 
     op_results = dag_result.get("operation_results", {})
-    n_spawned = dag_result.get("spawned_operations", 0)
+    # Total spawn count for this run includes restored spawns from a prior
+    # checkpoint generation, not just what this generation's live executor
+    # spawned — otherwise a resume that reconstructs every spawned node as
+    # already-terminal (zero NEW spawns this generation) would report
+    # n_spawned=0 and silently skip the automatic synthesis path that gates
+    # on it (see the with_synthesis-or-n_spawned check in _run_flow_inner).
+    n_spawned = restored_spawn_count + dag_result.get("spawned_operations", 0)
 
     # Escalation backstop: a leg the executor tracked as escalated (gave up
     # instead of producing a result — see NodeEscalated / EscalationRequest)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -591,6 +591,111 @@ async def _build_dag(
 # ── Resume: pre-mark checkpoint-completed nodes ───────────────────────────────
 
 
+def _reconstruct_spawned_nodes(
+    env: OrchestrationEnv,
+    dag_state: _DagState,
+    checkpoint_spawned: list[dict],
+) -> None:
+    """Rebuild reactively spawned nodes from a checkpoint into the fresh graph.
+
+    A reactively spawned node has no entry in the persisted plan (only
+    planned legs do) — it must be reconstructed from what its own `spawned`
+    checkpoint entry recorded, then pre-completed exactly like a planned node
+    so the executor's terminal-status short-circuit (never a live re-run)
+    picks it up.
+
+    Two things must hold for a given entry, checked BEFORE any node is added
+    to the graph so a refusal never leaves it partially mutated:
+
+    1. It must carry `operation` (added in CHECKPOINT_VERSION 2, alongside
+       `assignee`/`instruction`/`parent_id`) — a checkpoint written before
+       that field set existed has nothing to rebuild an Operation node from.
+    2. If it has a `parent_id`, that id must resolve to either a planned node
+       (already in the graph from _build_dag) or another entry in this same
+       `checkpoint_spawned` list. If it does not, the op that spawned this
+       node had not itself reached a checkpointed terminal state before the
+       crash — resuming it would either duplicate the spawn (the parent
+       re-runs and emits it again) or lose it outright (the parent never
+       re-emits it), a decision this version cannot soundly replay.
+
+    Either failure refuses resume for only the affected node(s), named in the
+    error, never the whole run merely because a spawn occurred.
+    """
+    from uuid import UUID as _UUID
+
+    from lionagi.operations.node import create_operation
+    from lionagi.protocols.graph.edge import Edge
+    from lionagi.protocols.types import EventStatus
+
+    legacy = [e for e in checkpoint_spawned if not e.get("operation")]
+    if legacy:
+        ids = ", ".join(str(e.get("node_id", "?")) for e in legacy)
+        raise FlowResumeError(
+            f"Resume refused for reactively spawned node(s) [{ids}]: this "
+            "checkpoint predates spawn-reconstruction support (no operation "
+            "type recorded for them), so they cannot be rebuilt. Re-run the "
+            "flow from scratch."
+        )
+
+    unrecognized = [
+        e["node_id"] for e in checkpoint_spawned if e.get("status") not in ("completed", "failed")
+    ]
+    if unrecognized:
+        raise FlowResumeError(
+            "Resume refused for reactively spawned node(s) "
+            f"[{', '.join(unrecognized)}]: checkpoint status is neither "
+            "'completed' nor 'failed', so it cannot be safely replayed."
+        )
+
+    known_ids = {str(n) for n in dag_state.node_ids}
+    candidate_ids = {e["node_id"] for e in checkpoint_spawned}
+
+    unsound = [
+        f"{e['node_id']} (parent {e['parent_id']})"
+        for e in checkpoint_spawned
+        if e.get("parent_id")
+        and e["parent_id"] not in known_ids
+        and e["parent_id"] not in candidate_ids
+    ]
+    if unsound:
+        raise FlowResumeError(
+            f"Resume refused for reactively spawned node(s) [{'; '.join(unsound)}]: "
+            "the op that spawned them had not itself reached a checkpointed "
+            "terminal state, so the spawn decision cannot be soundly replayed "
+            "— resuming risks either duplicating or silently dropping that "
+            "work. Re-run the flow from scratch."
+        )
+
+    graph = env.builder.get_graph()
+    built: dict[str, Any] = {}
+    for entry in checkpoint_spawned:
+        node_id = entry["node_id"]
+        assignee = entry.get("assignee")
+        node = create_operation(
+            entry["operation"],
+            parameters={"instruction": entry.get("instruction") or ""},
+            id=_UUID(node_id),
+            metadata={"assignee": assignee} if assignee else {},
+        )
+        node.execution.status = (
+            EventStatus.COMPLETED if entry["status"] == "completed" else EventStatus.FAILED
+        )
+        node.execution.response = entry.get("response")
+        role_branch = dag_state.role_base.get(assignee) if assignee else None
+        if role_branch is not None:
+            node.branch_id = role_branch.id
+        built[node_id] = node
+
+    for node in built.values():
+        graph.add_node(node)
+    for entry in checkpoint_spawned:
+        parent_id = entry.get("parent_id")
+        if not parent_id:
+            continue
+        parent_uuid = _UUID(parent_id) if parent_id in known_ids else built[parent_id].id
+        graph.add_edge(Edge(head=parent_uuid, tail=built[entry["node_id"]].id, label=["spawn"]))
+
+
 def _apply_checkpoint_precompletion(
     env: OrchestrationEnv,
     plan_result: _PlanResult,
@@ -607,21 +712,16 @@ def _apply_checkpoint_precompletion(
     FAILED rather than silently re-run (they may have had side effects before
     the process died). A pending op with inherit_context is refused unless the
     caller passes allow_degraded_context — resume restores results-context
-    only, not conversation history (v1). checkpoint_spawned refuses resume
-    outright when non-empty: reactively spawned nodes aren't replayable from
-    the persisted plan, and silently proceeding would drop completed work.
+    only, not conversation history (v1). checkpoint_spawned entries are
+    rebuilt into the graph and pre-completed the same way (see
+    _reconstruct_spawned_nodes) — resume refuses only the specific spawned
+    node(s) it genuinely cannot replay soundly, never the whole run just
+    because a spawn occurred.
     """
     from lionagi.protocols.types import EventStatus
 
     if checkpoint_spawned:
-        spawned_ids = ", ".join(str(e.get("node_id", "?")) for e in checkpoint_spawned)
-        raise FlowResumeError(
-            "Resume refused: this checkpoint recorded reactively spawned "
-            f"node(s) [{spawned_ids}] that this version cannot replay. "
-            "Resuming would silently drop that completed work. Re-run the "
-            "flow from scratch, or resume only checkpoints without spawned "
-            "entries."
-        )
+        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
 
     graph = env.builder.get_graph()
     degraded: list[str] = []
@@ -819,10 +919,37 @@ async def _execute_dag(
                 )
             )
         else:
+            # Capture what resume needs to rebuild this node into a fresh
+            # graph: the operation type, its routed role (if any), and the
+            # instruction it ran with, read back off the still-live graph
+            # node (never removed once _accept_node adds it). parent_id
+            # comes straight off the signal — flow_progress_signals already
+            # resolves it (including through reactive spawns) via its own
+            # NodeSpawned observer. A lookup failure (should not normally
+            # happen) leaves operation/assignee/instruction unset, which
+            # resume treats as unreconstructable for this node alone.
+            spawn_fields: dict[str, Any] = {"parent_id": sig.parent_id}
+            with contextlib.suppress(Exception):
+                from uuid import UUID as _UUID
+
+                spawned_node = env.builder.get_graph().internal_nodes.get(_UUID(sig.op_id))
+                if spawned_node is not None:
+                    params = spawned_node.parameters
+                    spawn_fields["operation"] = spawned_node.operation
+                    spawn_fields["assignee"] = spawned_node.metadata.get("assignee")
+                    spawn_fields["instruction"] = (
+                        params.get("instruction")
+                        if isinstance(params, dict)
+                        else getattr(params, "instruction", None)
+                    )
             _checkpoint_tasks.append(
                 _asyncio.ensure_future(
                     _checkpoint_writer.record_spawned(
-                        sig.op_id, status=status, response=response, flow_context=flow_ctx
+                        sig.op_id,
+                        status=status,
+                        response=response,
+                        flow_context=flow_ctx,
+                        **spawn_fields,
                     )
                 )
             )

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -63,6 +63,7 @@ def role_node_builder(
     roles: dict[str, Branch],
     *,
     decorate_instruction: Callable[[SpawnRequest, str], str] | None = None,
+    start: int = 1,
 ):
     """Return a node_builder closure that routes SpawnRequests to role branches.
 
@@ -72,6 +73,14 @@ def role_node_builder(
     same artifact-directory + REQUIRED-file text a planned leg gets (see
     ``lionagi.cli.orchestrate.flow``); library/engine callers that pass
     nothing keep the plain no-artifact instruction.
+
+    *start* seeds the closure's spawn-id sequence past whatever ordinals a
+    caller already handed out in a prior generation (e.g. a CLI resume that
+    reconstructed completed spawns from a checkpoint) — this closure is
+    rebuilt fresh every generation, so without it a brand new sequence
+    starting back at 1 would reissue an id already used by a restored node,
+    and any live spawn this generation would collide with it (same
+    spawn_id, same artifact directory).
     """
     # Closure-scoped monotonic sequence: the ONLY correct source of a spawned
     # node's stable id. It must be allocated here, at construction time,
@@ -82,7 +91,7 @@ def role_node_builder(
     # spawn". Minting the id at completion-time let an unrelated node "steal"
     # spawn-1 depending on which sibling happened to finish first — that is
     # the bug this closure exists to fix.
-    _next_spawn_seq = itertools.count(1)
+    _next_spawn_seq = itertools.count(start)
 
     def build(req: SpawnRequest, emitter: Operation) -> Operation:
         # Defense-in-depth: validate the operation at the routing boundary even

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -291,9 +291,9 @@ async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedu
     its one entry rather than appending a duplicate.
 
     Also pins the CHECKPOINT_VERSION 2 reconstruction fields (operation,
-    assignee, instruction, parent_id) round-tripping through the same entry,
-    and defaulting to None when the caller (an old-format write path, or one
-    that couldn't resolve the live graph node) omits them.
+    assignee, instruction, parent_id, spawn_id) round-tripping through the
+    same entry, and defaulting to None when the caller (an old-format write
+    path, or one that couldn't resolve the live graph node) omits them.
     """
     path = tmp_path / "checkpoint.json"
     writer = CheckpointWriter(path=path, session_id="s", prompt="p", plan=[], config={})
@@ -308,6 +308,7 @@ async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedu
         assignee="critic",
         instruction="critique the draft",
         parent_id="node-0",
+        spawn_id="spawn-3",
     )
 
     data = load_checkpoint(path)
@@ -323,6 +324,7 @@ async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedu
             "assignee": "critic",
             "instruction": "critique the draft",
             "parent_id": "node-0",
+            "spawn_id": "spawn-3",
         }
     ]
 
@@ -523,13 +525,29 @@ def _real_planned_node(assignee: str = "worker") -> tuple[OperationGraphBuilder,
     return builder, node_id, branch
 
 
+def _terminal_plan_and_ops(agent_id: str, node_id, status: str = "completed") -> tuple:
+    """A minimal _PlanResult + checkpoint_ops pair recording *agent_id*'s
+    planned node as checkpointed terminal -- what the soundness gate
+    requires of a spawn's planned parent before accepting it."""
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee=agent_id)],
+        agent_ids=[agent_id],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    checkpoint_ops = {agent_id: {"agent_id": agent_id, "status": status, "response": "done"}}
+    return plan_result, checkpoint_ops
+
+
 def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_branch():
     """The core sound-replay case: a reactively spawned node whose own
     checkpoint entry recorded operation/assignee/instruction/parent_id (the
     CHECKPOINT_VERSION 2 fields) is rebuilt into the graph, wired to its
     parent by a 'spawn' edge, routed to the same role branch a live spawn
     would have used, and pre-completed -- so the executor's terminal-status
-    short-circuit picks it up instead of re-running it.
+    short-circuit picks it up instead of re-running it. The planned parent
+    is checkpointed completed, satisfying the soundness gate.
     """
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = SimpleNamespace(builder=builder)
@@ -542,6 +560,7 @@ def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_br
         role_base={"worker": worker_branch},
         worker_models=[],
     )
+    plan_result, checkpoint_ops = _terminal_plan_and_ops("worker", parent_id)
     child_id = str(uuid4())
     checkpoint_spawned = [
         {
@@ -552,16 +571,19 @@ def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_br
             "assignee": "worker",
             "instruction": "follow-up task",
             "parent_id": str(parent_id),
+            "spawn_id": "spawn-1",
         }
     ]
 
-    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+    _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     graph = builder.get_graph()
     child = graph.internal_nodes[UUID(child_id)]
     assert child.execution.status == EventStatus.COMPLETED
     assert child.execution.response == "child result"
     assert child.branch_id == worker_branch.id
+    assert child.metadata["spawn_id"] == "spawn-1"
+    assert child.metadata["reference_id"] == "spawn-1"
     incoming_heads = list(graph.node_edge_mapping[UUID(child_id)]["in"].values())
     assert parent_id in incoming_heads
 
@@ -578,6 +600,7 @@ def test_reconstruct_spawned_nodes_marks_failed_child_terminal_not_rerun():
         role_base={"worker": worker_branch},
         worker_models=[],
     )
+    plan_result, checkpoint_ops = _terminal_plan_and_ops("worker", parent_id)
     child_id = str(uuid4())
     checkpoint_spawned = [
         {
@@ -588,10 +611,11 @@ def test_reconstruct_spawned_nodes_marks_failed_child_terminal_not_rerun():
             "assignee": "worker",
             "instruction": "follow-up task",
             "parent_id": str(parent_id),
+            "spawn_id": "spawn-2",
         }
     ]
 
-    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+    _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     child = builder.get_graph().internal_nodes[UUID(child_id)]
     assert child.execution.status == EventStatus.FAILED
@@ -614,6 +638,10 @@ def test_reconstruct_spawned_nodes_chains_through_another_reconstructed_spawn():
         role_base={},
         worker_models=[],
     )
+    plan_result = _PlanResult(
+        assignments=[], agent_ids=[], dep_indices=[], pool=[], budget_preambles={}
+    )
+    checkpoint_ops: dict[str, dict] = {}
     grandparent_id = str(uuid4())
     child_id = str(uuid4())
     checkpoint_spawned = [
@@ -637,7 +665,7 @@ def test_reconstruct_spawned_nodes_chains_through_another_reconstructed_spawn():
         },
     ]
 
-    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+    _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     graph = builder.get_graph()
     assert len(graph.internal_nodes) == 2
@@ -664,6 +692,10 @@ def test_reconstruct_spawned_nodes_refuses_when_parent_not_checkpointed_terminal
         role_base={},
         worker_models=[],
     )
+    plan_result = _PlanResult(
+        assignments=[], agent_ids=[], dep_indices=[], pool=[], budget_preambles={}
+    )
+    checkpoint_ops: dict[str, dict] = {}
     checkpoint_spawned = [
         {
             "node_id": "spawn-a",
@@ -677,9 +709,58 @@ def test_reconstruct_spawned_nodes_refuses_when_parent_not_checkpointed_terminal
     ]
 
     with pytest.raises(FlowResumeError, match="spawn-a"):
-        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+        _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     assert len(builder.get_graph().internal_nodes) == 0
+
+
+def test_reconstruct_spawned_nodes_refuses_when_planned_parent_exists_but_is_still_pending():
+    """Tighter parent-soundness case: a spawned child's parent_id names a REAL planned DAG node -- not a
+    stray string -- but that planned node has no terminal entry in
+    checkpoint_ops (still pending at crash time). Accepting this on the old
+    "parent_id is any known planned node" rule would pre-complete the child
+    while the parent reruns live, and the parent can then emit the same
+    follow-up spawn again -- exactly the duplicate-work case the design
+    calls out. Tightening the gate to require the planned parent be
+    checkpointed terminal (same rule already applied to spawn-chain parents)
+    must refuse this the same way.
+    """
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    # "worker" has no entry at all in checkpoint_ops -- still pending.
+    checkpoint_ops: dict[str, dict] = {}
+    checkpoint_spawned = [
+        {
+            "node_id": "spawn-a",
+            "status": "completed",
+            "response": "x",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "do it",
+            "parent_id": str(parent_id),
+        }
+    ]
+
+    with pytest.raises(FlowResumeError, match="spawn-a"):
+        _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
+
+    assert len(builder.get_graph().internal_nodes) == 1  # only the pre-existing planned node
 
 
 def test_reconstruct_spawned_nodes_refuses_unrecognized_status():
@@ -694,6 +775,10 @@ def test_reconstruct_spawned_nodes_refuses_unrecognized_status():
         role_base={},
         worker_models=[],
     )
+    plan_result = _PlanResult(
+        assignments=[], agent_ids=[], dep_indices=[], pool=[], budget_preambles={}
+    )
+    checkpoint_ops: dict[str, dict] = {}
     checkpoint_spawned = [
         {
             "node_id": "spawn-x",
@@ -707,9 +792,51 @@ def test_reconstruct_spawned_nodes_refuses_unrecognized_status():
     ]
 
     with pytest.raises(FlowResumeError, match="spawn-x"):
-        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+        _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
 
     assert len(builder.get_graph().internal_nodes) == 0
+
+
+def test_reconstruct_spawned_nodes_refuses_assignee_without_spawn_id():
+    """The defensive counterpart to spawn_id reconstruction: role_node_builder
+    stamps spawn_id and assignee together, unconditionally, at construction
+    time -- so a
+    checkpoint entry recording an assignee but no spawn_id cannot have come
+    from a sound live spawn. Reconstructing it anyway would hand the
+    finalize-time result-collection scan an assignee-bearing node with no
+    spawn_id, which is precisely the RuntimeError invariant violation this
+    fix exists to prevent; refusing resume for the node is the safe
+    alternative to smuggling that broken state through.
+    """
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    plan_result, checkpoint_ops = _terminal_plan_and_ops("worker", parent_id)
+    checkpoint_spawned = [
+        {
+            "node_id": str(uuid4()),
+            "status": "completed",
+            "response": "x",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up",
+            "parent_id": str(parent_id),
+            "spawn_id": None,
+        }
+    ]
+
+    with pytest.raises(FlowResumeError, match="spawn_id"):
+        _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
+
+    assert len(builder.get_graph().internal_nodes) == 1  # only the pre-existing planned node
 
 
 def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without_refusing():
@@ -750,6 +877,7 @@ def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without
             "assignee": "worker",
             "instruction": "follow-up",
             "parent_id": str(parent_id),
+            "spawn_id": "spawn-9",
         }
     ]
 
@@ -770,6 +898,8 @@ def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without
     assert child_node.execution.status == EventStatus.COMPLETED
     assert child_node.execution.response == "child done"
     assert child_node.branch_id == worker_branch.id
+    assert child_node.metadata["spawn_id"] == "spawn-9"
+    assert child_node.metadata["reference_id"] == "spawn-9"
 
 
 # ── _execute_dag: checkpoint write correctness ───────────────────────────────
@@ -936,8 +1066,184 @@ async def test_checkpoint_spawned_node_name_collision_does_not_overwrite_planned
             "assignee": None,
             "instruction": None,
             "parent_id": "node-critic",
+            "spawn_id": None,
         }
     ]
+
+
+async def test_checkpoint_record_captures_spawn_id_from_live_role_routed_graph_node(
+    tmp_path: Path,
+):
+    """The write-side counterpart: role_node_builder stamps spawn_id/
+    reference_id on a spawned node's metadata unconditionally, whether or
+    not the request
+    carried an assignee (lionagi/orchestration/patterns.py). _checkpoint_record
+    must capture spawn_id off the live graph node the same way it already
+    captures assignee, so a role-routed spawn's checkpoint entry carries
+    what reconstruction later needs to satisfy the finalize-time
+    assignee-without-spawn_id invariant check.
+    """
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = _make_resume_env(tmp_path)
+    env.builder = builder
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={parent_id: []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=["claude"],
+    )
+
+    from lionagi.operations.node import create_operation
+
+    spawned_node = create_operation("operate", parameters={"instruction": "follow-up"})
+    spawned_node.metadata["assignee"] = "worker"
+    spawned_node.metadata["spawn_id"] = "spawn-7"
+    spawned_node.metadata["reference_id"] = "spawn-7"
+    builder.get_graph().add_node(spawned_node)
+    spawned_id_str = str(spawned_node.id)
+
+    async def _run_dag_result(*args, executor_ref=None, **_kw):
+        executor_ref["executor"] = SimpleNamespace(
+            context=SimpleNamespace(content={}),
+            results={spawned_node.id: "spawned-result"},
+        )
+        await env.session.emit(
+            NodeCompleted(
+                op_id=spawned_id_str,
+                name="worker-clone",
+                elapsed=0.1,
+                parent_id=str(parent_id),
+                depends_on=[str(parent_id)],
+            )
+        )
+        return {
+            "operation_results": {spawned_id_str: "spawned-result"},
+            "spawned_operations": 1,
+            "escalated_operations": [],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = _run_dag_result
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+        )
+
+    data = load_checkpoint(env.run.checkpoint_path)
+    assert data["spawned"] == [
+        {
+            "node_id": spawned_id_str,
+            "status": "completed",
+            "response": "spawned-result",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up",
+            "parent_id": str(parent_id),
+            "spawn_id": "spawn-7",
+        }
+    ]
+
+
+async def test_execute_dag_seeds_fresh_checkpoint_with_already_reconstructed_spawned_entries(
+    tmp_path: Path,
+):
+    """Double-crash/double-resume: a first resume reconstructs a
+    completed reactively-spawned node from a prior checkpoint's `spawned`
+    list into the graph and pre-completes it (never re-run, so it never
+    emits a fresh completion signal to re-record itself). The NEXT
+    _execute_dag call for this generation constructs a brand new
+    CheckpointWriter; without seeding it with the already-reconstructed
+    entries, its very first flush would overwrite `spawned` back to `[]` --
+    so if this resumed run crashes AGAIN before anything new completes, the
+    second resume would find nothing to reconstruct from and silently lose
+    that already-completed spawned work.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+
+    seeded_spawned_entry = {
+        "node_id": str(uuid4()),
+        "status": "completed",
+        "response": "child done",
+        "operation": "operate",
+        "assignee": None,
+        "instruction": "follow-up",
+        "parent_id": "node-0",
+        "spawn_id": None,
+    }
+
+    async def _run_dag_result(*args, executor_ref=None, **_kw):
+        executor_ref["executor"] = SimpleNamespace(context=SimpleNamespace(content={}), results={})
+        # This generation crashes again before ANYTHING new completes -- the
+        # already-reconstructed spawned node never re-emits a signal either.
+        return {"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = _run_dag_result
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_ops_seed={
+                "worker": {"agent_id": "worker", "status": "completed", "response": "already done"}
+            },
+            checkpoint_spawned_seed=[seeded_spawned_entry],
+        )
+
+    data = load_checkpoint(env.run.checkpoint_path)
+    assert data["spawned"] == [seeded_spawned_entry]
 
 
 # ── Resume sequencing: planner skipped, finalization tail still runs ────────

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -1246,6 +1246,233 @@ async def test_execute_dag_seeds_fresh_checkpoint_with_already_reconstructed_spa
     assert data["spawned"] == [seeded_spawned_entry]
 
 
+async def test_execute_dag_max_spawn_budget_accounts_for_restored_spawns(tmp_path: Path):
+    """--max-ops is a TOTAL budget for the whole logical run, including
+    resumes -- _resume_flow replays the checkpoint's persisted config
+    verbatim rather than re-deriving max_ops, and the CLI's own progress
+    text calls it "at most {max_ops} ops total, INCLUDING any reactively
+    spawned" ones. Recomputing the live spawn budget on resume as
+    max_ops - len(assignments), with no adjustment for spawns already
+    restored from a prior checkpoint generation, would silently re-grant
+    the SAME budget every resume -- a run that had already exhausted its
+    spawn budget before a crash could accept spawns beyond what --max-ops
+    ever allowed.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+
+    # max_ops=10 total; 1 planned assignment; 8 spawns already restored from
+    # the checkpoint -- only 1 more spawn slot should remain this generation
+    # (10 - 1 - 8 == 1), not the naive 9 (10 - 1) a resume without this fix
+    # would recompute every time.
+    seeded_spawned = [
+        {
+            "node_id": str(uuid4()),
+            "status": "completed",
+            "response": f"child-{i}",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "follow-up",
+            "parent_id": "node-0",
+            "spawn_id": None,
+        }
+        for i in range(8)
+    ]
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = AsyncMock(
+        return_value={"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=10,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_spawned_seed=seeded_spawned,
+        )
+
+    assert fake_engine_run.run_dag.call_args.kwargs["max_spawn"] == 1
+
+
+async def test_execute_dag_n_spawned_counts_restored_spawns_alongside_new_ones(tmp_path: Path):
+    """The synthesis gate in _run_flow_inner is `with_synthesis or
+    exec_result.n_spawned`. A resume where every reactively spawned node was
+    already completed before the crash -- so THIS generation's live run_dag
+    produces zero new spawns -- must still report the restored count as
+    n_spawned, or a fully-restored, spawn-having run would silently skip
+    synthesis solely because nothing NEW happened to spawn this generation.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+    seeded_spawned = [
+        {
+            "node_id": str(uuid4()),
+            "status": "completed",
+            "response": "child done",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "follow-up",
+            "parent_id": "node-0",
+            "spawn_id": None,
+        }
+    ]
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = AsyncMock(
+        return_value={"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        exec_result = await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_spawned_seed=seeded_spawned,
+        )
+
+    assert exec_result.n_spawned == 1
+
+
+async def test_resumed_run_with_only_restored_spawns_triggers_synthesis(tmp_path: Path):
+    """End-to-end through _run_flow_inner: the synthesis gate must fire even
+    when every reactively spawned node was already completed before the
+    crash and this generation's live run_dag produces zero new spawns --
+    proving the n_spawned accounting fix actually reaches the gate check,
+    not just the _execute_dag return value in isolation. Reconstruction
+    itself (_apply_checkpoint_precompletion) is stubbed here since its
+    correctness is covered elsewhere; this isolates the downstream
+    accounting/gating consequence of a checkpoint carrying `spawned` entries
+    into a resume.
+    """
+    env = _make_resume_env(tmp_path)
+    checkpoint = {
+        "version": 2,
+        "session_id": "prior-session",
+        "prompt": "write the brief",
+        "plan": [
+            {
+                "task": "write the brief",
+                "assignee": "worker",
+                "inputs": [],
+                "exit_criteria": None,
+                "depends_on": [],
+                "modes": [],
+                "agent_id": "worker",
+                "dep_indices": [],
+            }
+        ],
+        "config": {},
+        "flow_context": {},
+        "ops": {
+            "worker": {"agent_id": "worker", "status": "completed", "response": "already done"}
+        },
+        "spawned": [
+            {
+                "node_id": str(uuid4()),
+                "status": "completed",
+                "response": "child done",
+                "operation": "operate",
+                "assignee": None,
+                "instruction": "follow-up",
+                "parent_id": "node-0",
+                "spawn_id": None,
+            }
+        ],
+    }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(
+        return_value=_asyncio_coro(
+            {
+                "operation_results": {"node-0": "already done"},
+                "spawned_operations": 0,
+                "escalated_operations": [],
+            }
+        )
+    )
+
+    synthesize_mock = AsyncMock(return_value="synthesized")
+
+    from lionagi.engines import PlanningEngine
+
+    with (
+        patch(
+            "lionagi.cli.orchestrate.flow.build_worker_branch",
+            return_value=(_FakeBranch("worker"), "codex/gpt-5.5", None, False),
+        ),
+        patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
+        patch("lionagi.cli.orchestrate.flow.plan") as plan_mock,
+        patch("lionagi.cli.orchestrate.flow._apply_checkpoint_precompletion"),
+        patch("lionagi.cli.orchestrate.flow._synthesize", synthesize_mock),
+        patch("lionagi.cli.orchestrate.flow._finalize_flow", return_value="ok"),
+    ):
+        await _run_flow_inner(
+            "codex/gpt-5.5",
+            "write the brief",
+            env=env,
+            resume_checkpoint=checkpoint,
+            allow_degraded_context=False,
+            checkpoint_config=None,
+            reactive_spec="on",
+        )
+
+    plan_mock.assert_not_called()
+    synthesize_mock.assert_called_once()
+
+
 # ── Resume sequencing: planner skipped, finalization tail still runs ────────
 
 

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -1473,6 +1473,163 @@ async def test_resumed_run_with_only_restored_spawns_triggers_synthesis(tmp_path
     synthesize_mock.assert_called_once()
 
 
+# ── Spawn-id sequence: resume must not reissue a restored spawn's id ────────
+
+
+def test_role_node_builder_start_seeds_first_spawn_id_past_restored_ordinal():
+    """Direct proof of the resume-facing knob: role_node_builder(..., start=2)
+    must issue spawn-2 for the first live spawn built through it, not
+    spawn-1 -- the exact collision (same spawn_id, same artifact directory,
+    since the CLI derives one from the other) a resumed run's fresh closure
+    would otherwise reissue against an already-restored spawn-1.
+    """
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.orchestration.patterns import role_node_builder
+
+    build = role_node_builder({}, start=2)
+    node = build(SpawnRequest(instruction="follow-up"), None)
+
+    assert node.metadata["spawn_id"] == "spawn-2"
+    assert node.metadata["reference_id"] == "spawn-2"
+
+
+async def test_execute_dag_seeds_spawn_sequence_past_restored_ordinal(tmp_path: Path):
+    """When resuming a checkpoint that already restored spawn-1, the fresh
+    role_node_builder(...) this _execute_dag call constructs must start its
+    sequence at 2, not 1 -- otherwise any pending op that emits a new spawn
+    after the resume reuses spawn-1's id (and artifact directory) instead of
+    representing a distinct spawned operation.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+    seeded_spawned = [
+        {
+            "node_id": str(uuid4()),
+            "status": "completed",
+            "response": "child done",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "follow-up",
+            "parent_id": "node-0",
+            "spawn_id": "spawn-1",
+        }
+    ]
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = AsyncMock(
+        return_value={"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    with (
+        patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
+        patch("lionagi.cli.orchestrate.flow.role_node_builder") as role_node_builder_mock,
+    ):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_spawned_seed=seeded_spawned,
+        )
+
+    assert role_node_builder_mock.call_args.kwargs["start"] == 2
+
+
+async def test_execute_dag_seeds_spawn_sequence_past_gap_in_restored_ordinals(tmp_path: Path):
+    """A crashed run may have gaps -- a spawn allocated (consuming an
+    ordinal from role_node_builder's sequence) but never reaching a
+    checkpointed terminal state before the crash never appears in a
+    checkpoint's `spawned` list at all. The next-ordinal seed must take the
+    MAX existing restored ordinal + 1, not len(restored) + 1, or it would
+    double-allocate into the gap and still collide. Restoring only
+    "spawn-3" (as if spawn-1/spawn-2 existed but crashed before completing)
+    must still seed the next sequence at 4, not 2.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+    seeded_spawned = [
+        {
+            "node_id": str(uuid4()),
+            "status": "completed",
+            "response": "child done",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "follow-up",
+            "parent_id": "node-0",
+            "spawn_id": "spawn-3",
+        }
+    ]
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = AsyncMock(
+        return_value={"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    with (
+        patch.object(PlanningEngine, "new_run", return_value=fake_engine_run),
+        patch("lionagi.cli.orchestrate.flow.role_node_builder") as role_node_builder_mock,
+    ):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_spawned_seed=seeded_spawned,
+        )
+
+    assert role_node_builder_mock.call_args.kwargs["start"] == 4
+
+
 # ── Resume sequencing: planner skipped, finalization tail still runs ────────
 
 

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -33,8 +33,10 @@ from lionagi.cli.orchestrate.flow import (
     _DagState,
     _execute_dag,
     _PlanResult,
+    _reconstruct_spawned_nodes,
     _run_flow_inner,
 )
+from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.types import EventStatus
 from lionagi.session.signal import NodeCompleted, NodeFailed
 from lionagi.state.db import StateDB
@@ -207,7 +209,7 @@ async def test_checkpoint_writer_record_writes_valid_schema_no_leftover_tmp(tmp_
     assert not list(tmp_path.glob("checkpoint.*.tmp"))
 
     data = load_checkpoint(path)
-    assert data["version"] == 1
+    assert data["version"] == 2
     assert data["session_id"] == "sess-1"
     assert data["prompt"] == "do the thing"
     assert data["ops"]["worker"] == {
@@ -287,20 +289,41 @@ async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedu
     (clones inherit the source branch's name), so `ops` and `spawned` are kept
     as two distinct groves, and re-recording the same spawned node id updates
     its one entry rather than appending a duplicate.
+
+    Also pins the CHECKPOINT_VERSION 2 reconstruction fields (operation,
+    assignee, instruction, parent_id) round-tripping through the same entry,
+    and defaulting to None when the caller (an old-format write path, or one
+    that couldn't resolve the live graph node) omits them.
     """
     path = tmp_path / "checkpoint.json"
     writer = CheckpointWriter(path=path, session_id="s", prompt="p", plan=[], config={})
 
     await writer.record("critic", status="completed", response="planned-result")
     await writer.record_spawned("spawned-1", status="completed", response="child-result-v1")
-    await writer.record_spawned("spawned-1", status="completed", response="child-result-v2")
+    await writer.record_spawned(
+        "spawned-1",
+        status="completed",
+        response="child-result-v2",
+        operation="operate",
+        assignee="critic",
+        instruction="critique the draft",
+        parent_id="node-0",
+    )
 
     data = load_checkpoint(path)
     assert data["ops"] == {
         "critic": {"agent_id": "critic", "status": "completed", "response": "planned-result"}
     }
     assert data["spawned"] == [
-        {"node_id": "spawned-1", "status": "completed", "response": "child-result-v2"}
+        {
+            "node_id": "spawned-1",
+            "status": "completed",
+            "response": "child-result-v2",
+            "operation": "operate",
+            "assignee": "critic",
+            "instruction": "critique the draft",
+            "parent_id": "node-0",
+        }
     ]
 
 
@@ -432,11 +455,14 @@ def test_apply_checkpoint_precompletion_preserves_failed_ops_as_terminal_not_rer
 
 
 def test_apply_checkpoint_precompletion_refuses_when_spawned_entries_present():
-    """Replaying reactively spawned work on resume isn't implemented, so a
-    checkpoint that recorded any must refuse resume outright rather than
-    silently drop that completed work. Refusal is unconditional -- it is not
-    something --allow-degraded-context (a different concern) can bypass -- and
-    happens before any node is mutated.
+    """A checkpoint's `spawned` entries in the pre-CHECKPOINT_VERSION-2 shape
+    (no `operation` recorded) carry nothing resume can rebuild an Operation
+    node from, so they must refuse resume outright rather than silently drop
+    that completed work. Refusal is unconditional -- it is not something
+    --allow-degraded-context (a different concern) can bypass -- and happens
+    before any node is mutated. Contrast with
+    test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without_refusing
+    below, where a CHECKPOINT_VERSION-2-shaped entry resumes cleanly.
     """
     nodes = {"n-worker": _FakeNode("n-worker")}
     env = SimpleNamespace(
@@ -481,6 +507,269 @@ def test_apply_checkpoint_precompletion_refuses_when_spawned_entries_present():
             checkpoint_spawned=checkpoint_spawned,
         )
     assert nodes["n-worker"].execution.status is None
+
+
+# ── _reconstruct_spawned_nodes: sound resume-after-partial-reactive-run ─────
+#
+# These use a REAL OperationGraphBuilder/Graph (not the dict-backed _FakeNode
+# fixtures above) because reconstruction adds real Operation nodes and Edge
+# objects into the graph -- something a plain dict can't stand in for.
+
+
+def _real_planned_node(assignee: str = "worker") -> tuple[OperationGraphBuilder, UUID, Branch]:
+    builder = OperationGraphBuilder()
+    branch = Branch(name=assignee)
+    node_id = builder.add_operation("operate", branch=branch, instruction="do it")
+    return builder, node_id, branch
+
+
+def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_branch():
+    """The core sound-replay case: a reactively spawned node whose own
+    checkpoint entry recorded operation/assignee/instruction/parent_id (the
+    CHECKPOINT_VERSION 2 fields) is rebuilt into the graph, wired to its
+    parent by a 'spawn' edge, routed to the same role branch a live spawn
+    would have used, and pre-completed -- so the executor's terminal-status
+    short-circuit picks it up instead of re-running it.
+    """
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    child_id = str(uuid4())
+    checkpoint_spawned = [
+        {
+            "node_id": child_id,
+            "status": "completed",
+            "response": "child result",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up task",
+            "parent_id": str(parent_id),
+        }
+    ]
+
+    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+
+    graph = builder.get_graph()
+    child = graph.internal_nodes[UUID(child_id)]
+    assert child.execution.status == EventStatus.COMPLETED
+    assert child.execution.response == "child result"
+    assert child.branch_id == worker_branch.id
+    incoming_heads = list(graph.node_edge_mapping[UUID(child_id)]["in"].values())
+    assert parent_id in incoming_heads
+
+
+def test_reconstruct_spawned_nodes_marks_failed_child_terminal_not_rerun():
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    child_id = str(uuid4())
+    checkpoint_spawned = [
+        {
+            "node_id": child_id,
+            "status": "failed",
+            "response": {"error": "boom"},
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up task",
+            "parent_id": str(parent_id),
+        }
+    ]
+
+    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+
+    child = builder.get_graph().internal_nodes[UUID(child_id)]
+    assert child.execution.status == EventStatus.FAILED
+    assert child.execution.response == {"error": "boom"}
+
+
+def test_reconstruct_spawned_nodes_chains_through_another_reconstructed_spawn():
+    """A grandchild spawn (spawned by a node that was itself reactively
+    spawned) resolves its parent against the other entries in the SAME
+    checkpoint_spawned batch, not just the statically planned nodes.
+    """
+    builder = OperationGraphBuilder()
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[],
+        known_nodes=set(),
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=[],
+    )
+    grandparent_id = str(uuid4())
+    child_id = str(uuid4())
+    checkpoint_spawned = [
+        {
+            "node_id": grandparent_id,
+            "status": "completed",
+            "response": "a",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "a",
+            "parent_id": None,
+        },
+        {
+            "node_id": child_id,
+            "status": "completed",
+            "response": "b",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "b",
+            "parent_id": grandparent_id,
+        },
+    ]
+
+    _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+
+    graph = builder.get_graph()
+    assert len(graph.internal_nodes) == 2
+    incoming_heads = list(graph.node_edge_mapping[UUID(child_id)]["in"].values())
+    assert UUID(grandparent_id) in incoming_heads
+
+
+def test_reconstruct_spawned_nodes_refuses_when_parent_not_checkpointed_terminal():
+    """The genuinely unsound subcase named in the design: a spawned node
+    whose parent op had NOT itself reached a checkpointed terminal state
+    before the crash. Resuming would either duplicate the spawn (the parent
+    re-runs and emits it again) or lose it outright (the parent never
+    re-emits it) -- a decision this version cannot soundly replay. Refusal
+    names only the affected node, and mutates nothing first.
+    """
+    builder = OperationGraphBuilder()
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[],
+        known_nodes=set(),
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=[],
+    )
+    checkpoint_spawned = [
+        {
+            "node_id": "spawn-a",
+            "status": "completed",
+            "response": "x",
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "do it",
+            "parent_id": "some-op-that-never-reached-a-checkpointed-terminal-state",
+        }
+    ]
+
+    with pytest.raises(FlowResumeError, match="spawn-a"):
+        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+
+    assert len(builder.get_graph().internal_nodes) == 0
+
+
+def test_reconstruct_spawned_nodes_refuses_unrecognized_status():
+    builder = OperationGraphBuilder()
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[],
+        known_nodes=set(),
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=[],
+    )
+    checkpoint_spawned = [
+        {
+            "node_id": "spawn-x",
+            "status": "running",
+            "response": None,
+            "operation": "operate",
+            "assignee": None,
+            "instruction": "x",
+            "parent_id": None,
+        }
+    ]
+
+    with pytest.raises(FlowResumeError, match="spawn-x"):
+        _reconstruct_spawned_nodes(env, dag_state, checkpoint_spawned)
+
+    assert len(builder.get_graph().internal_nodes) == 0
+
+
+def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without_refusing():
+    """End-to-end through the actual entry point _run_flow_inner calls: a
+    CHECKPOINT_VERSION-2-shaped spawned entry resumes cleanly alongside the
+    normal planned-op precompletion -- no refusal just because a spawn
+    occurred, matching the design's core fix (contrast with the legacy-format
+    refusal test above).
+    """
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+
+    assignments = [TaskAssignment(task="do it", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    checkpoint_ops = {"worker": {"agent_id": "worker", "status": "completed", "response": "done"}}
+    child_id = str(uuid4())
+    checkpoint_spawned = [
+        {
+            "node_id": child_id,
+            "status": "completed",
+            "response": "child done",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up",
+            "parent_id": str(parent_id),
+        }
+    ]
+
+    _apply_checkpoint_precompletion(
+        env,
+        plan_result,
+        dag_state,
+        checkpoint_ops,
+        allow_degraded_context=False,
+        checkpoint_spawned=checkpoint_spawned,
+    )
+
+    graph = builder.get_graph()
+    parent_node = graph.internal_nodes[parent_id]
+    child_node = graph.internal_nodes[UUID(child_id)]
+    assert parent_node.execution.status == EventStatus.COMPLETED
+    assert parent_node.execution.response == "done"
+    assert child_node.execution.status == EventStatus.COMPLETED
+    assert child_node.execution.response == "child done"
+    assert child_node.branch_id == worker_branch.id
 
 
 # ── _execute_dag: checkpoint write correctness ───────────────────────────────
@@ -634,8 +923,20 @@ async def test_checkpoint_spawned_node_name_collision_does_not_overwrite_planned
     assert data["ops"] == {
         "critic": {"agent_id": "critic", "status": "completed", "response": None}
     }
+    # op_id "spawned-node-xyz" isn't a real UUID (test shorthand), so the
+    # live-graph-node lookup in _checkpoint_record can't resolve it and
+    # operation/assignee/instruction stay unset -- only parent_id, which
+    # comes straight off the NodeFailed signal, is captured.
     assert data["spawned"] == [
-        {"node_id": "spawned-node-xyz", "status": "failed", "response": None}
+        {
+            "node_id": "spawned-node-xyz",
+            "status": "failed",
+            "response": None,
+            "operation": None,
+            "assignee": None,
+            "instruction": None,
+            "parent_id": "node-critic",
+        }
     ]
 
 


### PR DESCRIPTION
## What

`li o flow` resume refused any checkpoint containing reactively spawned nodes with a blanket `FlowResumeError`, even when the spawned node had cleanly completed before the crash. Root cause: `CheckpointWriter.record_spawned` only persisted `{node_id, status, response}` — no operation type, role, instruction, or parent linkage — so resume had nothing to rebuild an `Operation` from.

- `record_spawned` now captures `operation` / `assignee` / `instruction` / `parent_id` (read off the live graph node, which is never removed once accepted; `parent_id` rides the existing `NodeCompleted`/`NodeFailed` signals — no new bus wiring).
- New `_reconstruct_spawned_nodes` in `flow.py`: a spawned node that reached `completed`/`failed` before the crash is rebuilt into the fresh graph, wired with a `spawn` edge to its resolved parent (chains work), routed to the correct role branch, and pre-completed so the executor's terminal-status short-circuit skips re-running it.
- Refusal is now narrow and per-node-id: (1) pre-upgrade checkpoints with no `operation` field recorded, and (2) a spawn whose parent op had not itself reached a checkpointed terminal state — the spawn decision depended on in-memory state that is gone, so replay would duplicate or lose it.
- `CHECKPOINT_VERSION` 1 → 2; detection is by field presence, degrading gracefully for old checkpoints.

## Verification

- `tests/cli/orchestrate/test_flow_checkpoint_resume.py`: 31 passed (8 added — sound reconstruction for completed/failed, spawn chains, both narrowed-refusal subcases, full `_apply_checkpoint_precompletion` entry point), re-run independently by the reviewer seat after rebase onto main
- `tests/operations/ tests/cli/` green apart from pre-existing fastapi-extra gaps and the known control-poller timing flake (verified pre-existing on base)
- `ruff check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)