### PR TITLE
fix(telemetry): wire token/cost capture for claude_code, codex, and API paths

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -370,6 +370,13 @@ async def run(
                 metadata["thinking"] = "\n".join(thinking_parts)
             if result_meta:
                 metadata["model_response"] = dict(result_meta)
+                # Clear after stamping so a later flush within the same run()
+                # call (e.g. a provider that reports usage per internal turn,
+                # with tool calls in between) doesn't restamp already-recorded
+                # usage onto a second AssistantResponse -- _collect_branch_usage
+                # sums across every message on the branch, so a stale/repeated
+                # result_meta here would double-count tokens/cost.
+                result_meta.clear()
             res = AssistantResponse(
                 content=AssistantResponseContent(assistant_response=text),
                 sender=branch.id,

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -722,6 +722,23 @@ async def stream_claude_code_cli(  # noqa: C901
                 session.duration_api_ms = obj.get("duration_api_ms")
                 session.is_error = obj.get("is_error", False)
 
+                # Terminal usage/cost/turns/duration -- the only channel run.py
+                # reads provider-reported usage from (persisted onto
+                # model_response, see run.py's "result" chunk handling).
+                result_meta: dict[str, Any] = {}
+                if session.usage:
+                    result_meta["usage"] = session.usage
+                if session.total_cost_usd is not None:
+                    result_meta["total_cost_usd"] = session.total_cost_usd
+                if session.num_turns is not None:
+                    result_meta["num_turns"] = session.num_turns
+                if session.duration_ms is not None:
+                    result_meta["duration_ms"] = session.duration_ms
+                if result_meta:
+                    rsc = StreamChunk(type="result", metadata=result_meta)
+                    session.chunks.append(rsc)
+                    yield rsc
+
             # ------------------------ DONE -------------------------------------
             elif typ == "done":
                 break

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -630,6 +630,27 @@ async def stream_codex_cli(
                 session.total_cost_usd = obj.get("total_cost_usd", obj.get("cost"))
                 session.num_turns = (session.num_turns or 0) + 1
 
+                # Terminal usage/cost/turns -- the only channel run.py reads
+                # provider-reported usage from (persisted onto model_response,
+                # see run.py's "result" chunk handling; mirrors claude_code's
+                # "result" event). turn.completed can fire more than once per
+                # run() call for multi-turn codex sessions; each event's
+                # usage/cost are assumed cumulative-to-date (codex reports a
+                # running total, not a per-turn delta -- num_turns is the only
+                # field this code increments locally), so re-emitting on every
+                # occurrence just keeps the latest (highest) snapshot.
+                result_meta: dict[str, Any] = {}
+                if session.usage:
+                    result_meta["usage"] = session.usage
+                if session.total_cost_usd is not None:
+                    result_meta["total_cost_usd"] = session.total_cost_usd
+                if session.num_turns is not None:
+                    result_meta["num_turns"] = session.num_turns
+                if result_meta:
+                    rsc = StreamChunk(type="result", metadata=result_meta)
+                    session.chunks.append(rsc)
+                    yield rsc
+
             # -- turn.failed / error --
             elif typ in ("turn.failed", "error"):
                 session.is_error = True
@@ -741,6 +762,22 @@ async def stream_codex_cli(
                 session.num_turns = obj.get("num_turns", obj.get("turns"))
                 session.duration_ms = obj.get("duration_ms", obj.get("duration"))
                 session.is_error = obj.get("is_error", obj.get("error") is not None)
+
+                # Legacy terminal event (older CLI versions) -- same seam as
+                # turn.completed above.
+                result_meta: dict[str, Any] = {}
+                if session.usage:
+                    result_meta["usage"] = session.usage
+                if session.total_cost_usd is not None:
+                    result_meta["total_cost_usd"] = session.total_cost_usd
+                if session.num_turns is not None:
+                    result_meta["num_turns"] = session.num_turns
+                if session.duration_ms is not None:
+                    result_meta["duration_ms"] = session.duration_ms
+                if result_meta:
+                    rsc = StreamChunk(type="result", metadata=result_meta)
+                    session.chunks.append(rsc)
+                    yield rsc
 
             elif typ == "done":
                 break

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -451,6 +451,19 @@ async def stream_codex_cli(
     theme = request.cli_display_theme or "light"
     _start_monotonic = asyncio.get_running_loop().time()
 
+    # turn.completed reports usage/cost as a running total-to-date, not a
+    # per-turn delta. run.py stamps each "result" chunk's metadata onto
+    # whichever AssistantResponse it next flushes, and _collect_branch_usage
+    # SUMS that metadata across every message on the branch -- if a tool call
+    # flushes a message between two turn.completed events, each cumulative
+    # snapshot lands on a different message and earlier turns get counted
+    # again. Track the last-seen cumulative values here so only the marginal
+    # (this-turn-only) delta is ever exposed per event.
+    _prev_input_tokens = 0
+    _prev_output_tokens = 0
+    _prev_cost: float = 0.0
+    _seen_cost = False
+
     stream = stream_codex_cli_events(request)
     try:
         async for obj in stream:
@@ -626,30 +639,53 @@ async def stream_codex_cli(
 
             # -- turn.completed (usage stats) --
             elif typ == "turn.completed":
-                session.usage = obj.get("usage", {})
-                session.total_cost_usd = obj.get("total_cost_usd", obj.get("cost"))
+                turn_usage = obj.get("usage", {}) or {}
+                session.usage = turn_usage
+                turn_cost = obj.get("total_cost_usd", obj.get("cost"))
+                session.total_cost_usd = turn_cost
                 session.num_turns = (session.num_turns or 0) + 1
 
                 # Terminal usage/cost/turns -- the only channel run.py reads
                 # provider-reported usage from (persisted onto model_response,
                 # see run.py's "result" chunk handling; mirrors claude_code's
                 # "result" event). turn.completed can fire more than once per
-                # run() call for multi-turn codex sessions; each event's
-                # usage/cost are assumed cumulative-to-date (codex reports a
-                # running total, not a per-turn delta -- num_turns is the only
-                # field this code increments locally), so re-emitting on every
-                # occurrence just keeps the latest (highest) snapshot.
+                # run() call for multi-turn codex sessions, and each event's
+                # usage/cost is cumulative-to-date, not a per-turn delta --
+                # emit only the marginal contribution since the previous
+                # event (clamped at 0 in case a provider quirk ever reports a
+                # lower running total) so summing across every flushed
+                # message reconstructs the true total exactly once, not N
+                # times over.
+                cur_input = int(
+                    turn_usage.get("input_tokens", turn_usage.get("prompt_tokens", 0)) or 0
+                )
+                cur_output = int(
+                    turn_usage.get("output_tokens", turn_usage.get("completion_tokens", 0)) or 0
+                )
+                delta_input = max(cur_input - _prev_input_tokens, 0)
+                delta_output = max(cur_output - _prev_output_tokens, 0)
+                _prev_input_tokens = cur_input
+                _prev_output_tokens = cur_output
+
                 result_meta: dict[str, Any] = {}
-                if session.usage:
-                    result_meta["usage"] = session.usage
-                if session.total_cost_usd is not None:
-                    result_meta["total_cost_usd"] = session.total_cost_usd
-                if session.num_turns is not None:
-                    result_meta["num_turns"] = session.num_turns
-                if result_meta:
-                    rsc = StreamChunk(type="result", metadata=result_meta)
-                    session.chunks.append(rsc)
-                    yield rsc
+                if delta_input or delta_output:
+                    result_meta["usage"] = {
+                        "input_tokens": delta_input,
+                        "output_tokens": delta_output,
+                    }
+                if isinstance(turn_cost, (int, float)):
+                    delta_cost = float(turn_cost) - (_prev_cost if _seen_cost else 0.0)
+                    _prev_cost = float(turn_cost)
+                    _seen_cost = True
+                    result_meta["total_cost_usd"] = max(delta_cost, 0.0)
+                # Each turn.completed occurrence is exactly one new turn --
+                # unlike usage/cost this is already a delta, never a running
+                # total (num_turns is incremented locally above, not read off
+                # the event), so it is always safe to emit as 1.
+                result_meta["num_turns"] = 1
+                rsc = StreamChunk(type="result", metadata=result_meta)
+                session.chunks.append(rsc)
+                yield rsc
 
             # -- turn.failed / error --
             elif typ in ("turn.failed", "error"):

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -77,11 +77,16 @@ class RunStart(Signal):
 
 
 class RunEnd(Signal):
-    """Run lifecycle: completed. Usage fields are populated when available."""
+    """Run lifecycle: completed. Usage fields are populated when available.
+
+    total_cost_usd is None (unknown) unless a provider actually reports a
+    dollar cost -- providers that don't (bare API endpoints) must never be
+    recorded as a free (0.0) run.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
-    total_cost_usd: float = 0.0
+    total_cost_usd: float | None = None
     num_turns: int = 0
     duration_ms: float = 0.0
 
@@ -262,17 +267,21 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
 
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
     """Sum provider-reported usage across all AssistantResponse messages on branch.
-    Keys: input_tokens, output_tokens, total_cost_usd, num_turns; all zero when
-    no provider data is available (subscription runs, tests)."""
+    Keys: input_tokens, output_tokens, total_cost_usd, num_turns. input_tokens/
+    output_tokens/num_turns are additive and default to 0 (no usage reported is
+    indistinguishable from zero usage). total_cost_usd defaults to None (unknown)
+    and is only ever set to a float once at least one message actually reports a
+    cost -- most providers (bare API endpoints) never report a dollar cost, and
+    that must read as "unknown", not "free" (subscription runs, tests)."""
     input_tokens = 0
     output_tokens = 0
-    total_cost_usd = 0.0
+    total_cost_usd: float | None = None
     num_turns = 0
 
     try:
         messages = list(branch.msgs.messages)
     except Exception:  # noqa: BLE001
-        return {"input_tokens": 0, "output_tokens": 0, "total_cost_usd": 0.0, "num_turns": 0}
+        return {"input_tokens": 0, "output_tokens": 0, "total_cost_usd": None, "num_turns": 0}
 
     for msg in messages:
         mr = (
@@ -285,7 +294,7 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         output_tokens += int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
         cost = mr.get("total_cost_usd") or mr.get("cost")
         if isinstance(cost, (int, float)):
-            total_cost_usd += float(cost)
+            total_cost_usd = (total_cost_usd or 0.0) + float(cost)
         num_turns += int(mr.get("num_turns", 0) or 0)
 
     return {
@@ -300,18 +309,20 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
     """Sum _collect_branch_usage across multiple branches (multi-leg DAG runs).
 
     Same keys as _collect_branch_usage. duration_ms is deliberately excluded —
-    wall-clock across parallel legs isn't simply summable.
+    wall-clock across parallel legs isn't simply summable. total_cost_usd stays
+    None unless at least one branch actually reported a cost.
     """
     input_tokens = 0
     output_tokens = 0
-    total_cost_usd = 0.0
+    total_cost_usd: float | None = None
     num_turns = 0
 
     for branch in branches:
         usage = _collect_branch_usage(branch)
         input_tokens += usage["input_tokens"]
         output_tokens += usage["output_tokens"]
-        total_cost_usd += usage["total_cost_usd"]
+        if usage["total_cost_usd"] is not None:
+            total_cost_usd = (total_cost_usd or 0.0) + usage["total_cost_usd"]
         num_turns += usage["num_turns"]
 
     return {

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -292,7 +292,17 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
         input_tokens += int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
         output_tokens += int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
-        cost = mr.get("total_cost_usd") or mr.get("cost")
+        # Presence, not truthiness: a provider that explicitly reports
+        # total_cost_usd=0.0 (a real, known-free call) must not be treated
+        # the same as one that never reported a cost at all -- `x or y`
+        # would silently fall through the falsy 0.0 to the "cost" fallback
+        # (or None), losing the explicit zero.
+        if "total_cost_usd" in mr and mr["total_cost_usd"] is not None:
+            cost = mr["total_cost_usd"]
+        elif "cost" in mr and mr["cost"] is not None:
+            cost = mr["cost"]
+        else:
+            cost = None
         if isinstance(cost, (int, float)):
             total_cost_usd = (total_cost_usd or 0.0) + float(cost)
         num_turns += int(mr.get("num_turns", 0) or 0)

--- a/tests/providers/openai/codex/test_result_usage.py
+++ b/tests/providers/openai/codex/test_result_usage.py
@@ -88,11 +88,16 @@ async def test_turn_completed_without_usage_fabricates_no_tokens_or_cost():
 
 
 @pytest.mark.asyncio
-async def test_multiple_turn_completed_events_last_snapshot_wins():
-    """Codex may emit turn.completed more than once per run(); each is assumed
-    a cumulative-to-date snapshot (codex doesn't report a running turn
-    counter, so this code increments it locally), so the final result chunk
-    should carry the latest (highest) usage."""
+async def test_multiple_turn_completed_events_emit_marginal_deltas():
+    """Codex may emit turn.completed more than once per run(); each event's
+    usage/cost is cumulative-to-date, not a per-turn delta. Regression: this
+    code used to re-emit the raw (cumulative) snapshot on every occurrence.
+    Since _collect_branch_usage SUMS every "result" chunk's usage across all
+    flushed messages, and a tool call between two turn.completed events can
+    flush a separate message for each snapshot, re-emitting cumulative values
+    double-counts earlier turns. Each event must instead carry only its
+    marginal (this-turn-only) contribution, and num_turns must be exactly 1
+    per event (never the running turn count)."""
     events = [
         {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}},
         {"type": "turn.completed", "usage": {"input_tokens": 30, "output_tokens": 15}},
@@ -101,8 +106,10 @@ async def test_multiple_turn_completed_events_last_snapshot_wins():
     result_chunks = [c for c in chunks if c.type == "result"]
     assert len(result_chunks) == 2
     assert result_chunks[0].metadata["num_turns"] == 1
-    assert result_chunks[1].metadata["num_turns"] == 2
-    assert result_chunks[-1].metadata["usage"] == {"input_tokens": 30, "output_tokens": 15}
+    assert result_chunks[1].metadata["num_turns"] == 1
+    assert result_chunks[0].metadata["usage"] == {"input_tokens": 10, "output_tokens": 5}
+    # Second event's cumulative snapshot (30/15) minus the first (10/5).
+    assert result_chunks[1].metadata["usage"] == {"input_tokens": 20, "output_tokens": 10}
 
 
 @pytest.mark.asyncio
@@ -184,3 +191,91 @@ async def test_end_to_end_run_populates_branch_usage_from_codex_turn_completed()
     assert usage["input_tokens"] == 75
     assert usage["output_tokens"] == 25
     assert usage["total_cost_usd"] is None
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_run_does_not_double_count_across_multiple_turns():
+    """Regression for the multi-turn double-counting bug: a tool call between
+    two turn.completed events flushes a separate AssistantResponse for each
+    cumulative snapshot. _collect_branch_usage sums every message's usage, so
+    if turn.completed re-emitted the raw cumulative snapshot each time, the
+    first turn's tokens would be counted twice (once on the message flushed
+    right after turn 1, again inside turn 2's cumulative total on the message
+    flushed at the end). The collected totals must equal the FINAL cumulative
+    snapshot (input=30, output=15) -- not the sum of the two raw snapshots
+    (10+30=40, 5+15=20)."""
+    import types
+    from unittest.mock import AsyncMock
+
+    from lionagi.operations.run.run import RunParam, run
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+    from lionagi.session.signal import _collect_branch_usage
+
+    events = [
+        {"type": "thread.started", "thread_id": "codex-thread-multi"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "turn one"}},
+        {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}},
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "function_call",
+                "id": "call-1",
+                "name": "some_tool",
+                "arguments": {"x": 1},
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "output": "tool result",
+            },
+        },
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "turn two"}},
+        {"type": "turn.completed", "usage": {"input_tokens": 30, "output_tokens": 15}},
+        {"type": "done"},
+    ]
+    chunks = await _chunks_from_events(events)
+
+    m = iModel(provider="openai", model="gpt-5.5-codex", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli"},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+
+    branch = Branch()
+    branch.chat_model = m
+
+    async for _ in run(branch, "hi", RunParam()):
+        pass
+
+    # Sanity: the tool call really did split the turn across two flushed
+    # AssistantResponse messages (the double-counting bug only manifests
+    # with at least two such messages carrying usage metadata).
+    assistant_messages_with_usage = [
+        msg
+        for msg in branch.msgs.messages
+        if isinstance(msg.metadata.get("model_response"), dict) and msg.metadata["model_response"]
+    ]
+    assert len(assistant_messages_with_usage) >= 2
+
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 30
+    assert usage["output_tokens"] == 15

--- a/tests/providers/openai/codex/test_result_usage.py
+++ b/tests/providers/openai/codex/test_result_usage.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: Codex's "turn.completed" (and the legacy "result"/"response"/
+"session.end") events captured usage/cost/turns onto the CodexSession object
+but never re-surfaced them as a StreamChunk, so run.py's "result" chunk
+handler never saw them and every codex-driven session row ended up with
+total_cost_usd frozen at 0.0 and zero token counts. These tests pin the fix:
+both event shapes must also yield a StreamChunk(type="result", metadata=...),
+mirroring gemini_code and claude_code."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.openai.codex import CodexCodeRequest, stream_codex_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _make_request() -> CodexCodeRequest:
+    return CodexCodeRequest(prompt="test", verbose_output=False)
+
+
+async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
+    async def fake_events(_request):
+        for ev in events:
+            yield ev
+
+    collected = []
+    with patch(
+        "lionagi.providers.openai.codex.stream_codex_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_codex_cli(_make_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_turn_completed_yields_result_chunk_with_usage():
+    """Codex's usage schema reports tokens; it typically does not report a
+    dollar cost (unlike claude_code) -- see run.py's own note ("codex:
+    tokens; claude_code: cost/turns/duration")."""
+    events = [
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 200, "output_tokens": 60},
+        }
+    ]
+    chunks = await _chunks_from_events(events)
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    meta = result_chunks[0].metadata
+    assert meta["usage"] == {"input_tokens": 200, "output_tokens": 60}
+    assert meta["num_turns"] == 1
+    assert "total_cost_usd" not in meta  # never reported -> never fabricated
+
+
+@pytest.mark.asyncio
+async def test_turn_completed_with_cost_reports_it():
+    events = [
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 0.002,
+        }
+    ]
+    chunks = await _chunks_from_events(events)
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    assert result_chunks[0].metadata["total_cost_usd"] == pytest.approx(0.002)
+
+
+@pytest.mark.asyncio
+async def test_turn_completed_without_usage_fabricates_no_tokens_or_cost():
+    """num_turns is unconditionally incremented per turn.completed event (codex
+    doesn't report a running turn counter), so a result chunk still appears --
+    but it must never carry a "usage" or "total_cost_usd" key it wasn't given."""
+    chunks = await _chunks_from_events([{"type": "turn.completed"}])
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    meta = result_chunks[0].metadata
+    assert "usage" not in meta
+    assert "total_cost_usd" not in meta
+
+
+@pytest.mark.asyncio
+async def test_multiple_turn_completed_events_last_snapshot_wins():
+    """Codex may emit turn.completed more than once per run(); each is assumed
+    a cumulative-to-date snapshot (codex doesn't report a running turn
+    counter, so this code increments it locally), so the final result chunk
+    should carry the latest (highest) usage."""
+    events = [
+        {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}},
+        {"type": "turn.completed", "usage": {"input_tokens": 30, "output_tokens": 15}},
+    ]
+    chunks = await _chunks_from_events(events)
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 2
+    assert result_chunks[0].metadata["num_turns"] == 1
+    assert result_chunks[1].metadata["num_turns"] == 2
+    assert result_chunks[-1].metadata["usage"] == {"input_tokens": 30, "output_tokens": 15}
+
+
+@pytest.mark.asyncio
+async def test_legacy_result_event_yields_result_chunk():
+    events = [
+        {
+            "type": "result",
+            "result": "done",
+            "usage": {"input_tokens": 50, "output_tokens": 25},
+            "num_turns": 2,
+            "duration_ms": 900,
+        }
+    ]
+    chunks = await _chunks_from_events(events)
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    meta = result_chunks[0].metadata
+    assert meta["usage"] == {"input_tokens": 50, "output_tokens": 25}
+    assert meta["num_turns"] == 2
+    assert meta["duration_ms"] == 900
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_run_populates_branch_usage_from_codex_turn_completed():
+    """Full path: run() consumes the provider's StreamChunks, stamps
+    metadata["model_response"] on the flushed AssistantResponse, and
+    _collect_branch_usage sums it into real totals with total_cost_usd left
+    None (codex doesn't report cost here) -- not the old always-0.0 lie."""
+    import types
+    from unittest.mock import AsyncMock
+
+    from lionagi.operations.run.run import RunParam, run
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+    from lionagi.session.signal import _collect_branch_usage
+
+    events = [
+        {"type": "thread.started", "thread_id": "codex-thread-1"},
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "hi there"},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 75, "output_tokens": 25},
+        },
+        {"type": "done"},
+    ]
+    chunks = await _chunks_from_events(events)
+
+    m = iModel(provider="openai", model="gpt-5.5-codex", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli"},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+
+    branch = Branch()
+    branch.chat_model = m
+
+    async for _ in run(branch, "hi", RunParam()):
+        pass
+
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 75
+    assert usage["output_tokens"] == 25
+    assert usage["total_cost_usd"] is None

--- a/tests/providers/test_claude_code_result_usage.py
+++ b/tests/providers/test_claude_code_result_usage.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the Claude Code CLI's terminal "result" event (usage,
+total_cost_usd, num_turns, duration_ms) was captured onto the CLISession
+object but never re-surfaced as a StreamChunk, so run.py's "result" chunk
+handler (the only channel that stamps usage onto an AssistantResponse's
+metadata["model_response"]) never saw it -- every claude_code-driven session
+row ended up with total_cost_usd frozen at 0.0 and zero token counts, even
+though the CLI reported real values. These tests pin the fix: the "result"
+event must also yield a StreamChunk(type="result", metadata=...) carrying the
+same fields gemini_code already emits.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest, stream_claude_code_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _make_request() -> ClaudeCodeRequest:
+    return ClaudeCodeRequest(prompt="test", verbose_output=False)
+
+
+async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
+    async def fake_events(_request):
+        for ev in events:
+            yield ev
+
+    collected = []
+    with patch(
+        "lionagi.providers.anthropic.claude_code.stream_cc_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_claude_code_cli(_make_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+def _result_event(**over) -> dict:
+    ev = {
+        "type": "result",
+        "result": "done",
+        "usage": {"input_tokens": 120, "output_tokens": 40},
+        "total_cost_usd": 0.0123,
+        "num_turns": 3,
+        "duration_ms": 4500,
+        "duration_api_ms": 4000,
+        "is_error": False,
+    }
+    ev.update(over)
+    return ev
+
+
+@pytest.mark.asyncio
+async def test_result_event_yields_result_chunk_with_usage_and_cost():
+    chunks = await _chunks_from_events([_result_event()])
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    meta = result_chunks[0].metadata
+    assert meta["usage"] == {"input_tokens": 120, "output_tokens": 40}
+    assert meta["total_cost_usd"] == pytest.approx(0.0123)
+    assert meta["num_turns"] == 3
+    assert meta["duration_ms"] == 4500
+
+
+@pytest.mark.asyncio
+async def test_result_event_without_usage_yields_no_result_chunk():
+    """A result event carrying no usage/cost/turns/duration must not fabricate
+    one -- no StreamChunk(type="result") at all, rather than one with zeros."""
+    chunks = await _chunks_from_events(
+        [
+            {
+                "type": "result",
+                "result": "done",
+                "usage": {},
+                "total_cost_usd": None,
+                "num_turns": None,
+                "duration_ms": None,
+                "duration_api_ms": None,
+                "is_error": False,
+            }
+        ]
+    )
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert result_chunks == []
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_run_populates_branch_usage_from_claude_code_result():
+    """Full path: run() consumes the provider's StreamChunks, stamps
+    metadata["model_response"] on the flushed AssistantResponse, and
+    _collect_branch_usage sums it into real (non-zero, non-None-cost) totals --
+    the exact seam that was dead before this fix."""
+    import types
+    from unittest.mock import AsyncMock
+
+    from lionagi.operations.run.run import RunParam, run
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+    from lionagi.session.signal import _collect_branch_usage
+
+    events = [
+        {"type": "system", "session_id": "cc-sess-1", "model": "sonnet-5", "tools": []},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "hello"}]},
+        },
+        _result_event(),
+        {"type": "done"},
+    ]
+    chunks = await _chunks_from_events(events)
+
+    m = iModel(provider="anthropic", model="claude-3-5-sonnet-20241022", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli"},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+
+    branch = Branch()
+    branch.chat_model = m
+
+    async for _ in run(branch, "hi", RunParam()):
+        pass
+
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 120
+    assert usage["output_tokens"] == 40
+    assert usage["total_cost_usd"] == pytest.approx(0.0123)
+    assert usage["num_turns"] == 3

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -111,6 +111,25 @@ def test_collect_branch_usage_openai_convention():
     assert usage["total_cost_usd"] == pytest.approx(0.005)
 
 
+def test_collect_branch_usage_preserves_explicit_zero_cost():
+    """A provider that explicitly reports total_cost_usd=0.0 (a real, known-
+    free call) must not be coerced into the "unknown" None sentinel -- `x or
+    y` truthiness would silently drop the falsy 0.0 and fall through to the
+    "cost" fallback (absent here), losing the explicit zero."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 0.0,
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["total_cost_usd"] == 0.0
+    assert usage["total_cost_usd"] is not None
+
+
 def test_collect_branch_usage_anthropic_convention():
     msg = MagicMock()
     msg.metadata = {

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -67,7 +67,8 @@ def test_run_end_default_usage_fields():
     sig = RunEnd()
     assert sig.input_tokens == 0
     assert sig.output_tokens == 0
-    assert sig.total_cost_usd == 0.0
+    # Unknown, not free -- no provider reported a cost.
+    assert sig.total_cost_usd is None
     assert sig.num_turns == 0
     assert sig.duration_ms == 0.0
 
@@ -89,7 +90,8 @@ def test_collect_branch_usage_empty():
     usage = _collect_branch_usage(branch)
     assert usage["input_tokens"] == 0
     assert usage["output_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
+    # Unknown, not free -- no messages, so no provider reported a cost.
+    assert usage["total_cost_usd"] is None
     assert usage["num_turns"] == 0
 
 
@@ -165,7 +167,8 @@ def test_collect_multi_branch_usage_empty():
     usage = _collect_multi_branch_usage([])
     assert usage["input_tokens"] == 0
     assert usage["output_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
+    # Unknown, not free -- no branches, so no provider reported a cost.
+    assert usage["total_cost_usd"] is None
     assert usage["num_turns"] == 0
 
 


### PR DESCRIPTION
Cost/token telemetry was universally 0.0 for `claude_code` and `codex` sessions. Root cause: `run.py` only stamps usage onto the response's `model_response` metadata when the provider yields a `StreamChunk(type="result", metadata=...)` — `gemini_code.py` does (the one surface with real data), but `claude_code.py` and `codex.py` parsed usage off their CLI's terminal event onto the internal session object and never re-emitted the chunk.

## What

- **claude_code**: the `result` event handler now yields the result StreamChunk carrying `usage` / `total_cost_usd` / `num_turns` / `duration_ms`.
- **codex**: same at `turn.completed` (fires per turn; usage treated as cumulative-to-date snapshot) and the legacy `result`/`session.end` events.
- **API providers**: no change needed — `AssistantResponse.from_response()` already stores the raw usage dict and the collector's field fallback covers Anthropic and OpenAI shapes.
- **0.0 → NULL semantics**: `_collect_branch_usage` / `_collect_multi_branch_usage` / `RunEnd.total_cost_usd` default to `None`; a float is set only when a message actually reports cost. Providers that report tokens but not cost now leave the column NULL instead of lying 0.0.
- **Double-count guard**: `run.py` clears `result_meta` after each flush so a repeated terminal event can't restamp usage onto a second message.

Documented, deliberately not fixed here: `branches.status` is never written on the single-branch path (no terminal-status hook exists); patching only the creation side would leave every `li agent` branch stuck "running" forever. Needs a BRANCH_END-equivalent hook design — filed as follow-up in the PR conversation.

## Verification

- 10 new provider tests (result-event → chunk, absent-usage → no fabrication, repeated turn.completed snapshots, end-to-end `run()` asserting non-zero collected totals; codex end-to-end asserts tokens captured while cost stays None) + 3 contract assertions updated to `is None` — re-run by the reviewer seat post-rebase
- Full sweeps of `tests/providers/ tests/session/ tests/operations/run/ tests/hooks/ tests/state/` green apart from pre-existing optional-extra gaps (verified identical on unmodified base)
- `ruff check` + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)