### PR TITLE
fix(scheduler): atomic occurrence recording, recovery scan, schedule_runs reaper

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2487,6 +2487,18 @@ class StateDB:
         )
 
         if fields:
+            # updated_at must move on every write to this row, not only on a
+            # status transition -- update_status() already bumps it as part
+            # of the status UPDATE above, but a plain field-only call (e.g.
+            # the exit_code/ended_at write that lands *before* the terminal
+            # status transition, while the row is still "running") would
+            # otherwise leave it stale. A stale updated_at is exactly the
+            # snapshot value reap_stale_schedule_runs()'s expected_updated_at
+            # guard would still match on a scan landing in that window,
+            # letting the reaper race a legitimately-finishing run to
+            # "timed_out" ahead of its own terminal write.
+            fields = dict(fields)
+            fields["updated_at"] = time.time()
             sets = ", ".join(f'"{k}" = :{k}' for k in fields)
             params = dict(fields)
             params["_id"] = run_id
@@ -2743,24 +2755,36 @@ class StateDB:
         return streak, last_status
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:
-        """True if *schedule_id* already has a schedule_runs row fired at or
-        after *since*.
+        """True if *schedule_id* already has a genuinely-fired schedule_runs
+        row at or after *since*.
 
         Used by the missed-fire recovery scan (``SchedulerEngine.
         _check_missed_fires``) to distinguish "genuinely never fired" from
         "occurrence was durably recorded before a crash interrupted
         whatever bookkeeping came after it" -- firing a fresh recovery run
         for the latter would double-execute the external action for an
-        occurrence that already has a row. Any status counts (running,
-        completed, failed, ...): the row's mere existence is what matters
-        here, not how it resolved.
+        occurrence that already has a row. Any non-skipped status counts
+        (running, completed, failed, ...): the row's mere existence is what
+        matters here, not how it resolved.
+
+        Excludes ``status = 'skipped'`` rows. Two of the three writers of
+        that status (missed-fire skip, overlap skip) advance next_fire_at
+        in the same breath as writing the row, so the schedule is no
+        longer due by the time this scan would run again -- moot either
+        way. But the third, capacity-deferred throttling
+        (``_maybe_record_deferred``), deliberately leaves next_fire_at
+        untouched so the *same* due occurrence retries on the next tick;
+        counting that audit-only row as "already recorded" would make this
+        scan advance the cursor past a due occurrence that never actually
+        ran, silently dropping it if the process dies before that retry.
         """
         async with self._read() as conn:
             row = (
                 await conn.execute(
                     text(
                         "SELECT 1 FROM schedule_runs "
-                        "WHERE schedule_id = :schedule_id AND fired_at >= :since LIMIT 1"
+                        "WHERE schedule_id = :schedule_id AND fired_at >= :since "
+                        "AND status != 'skipped' LIMIT 1"
                     ),
                     {"schedule_id": schedule_id, "since": since},
                 )

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2287,8 +2287,11 @@ class StateDB:
             rows = (await conn.execute(text(query), params)).mappings().all()
         return [self._row_to_dict(r) for r in rows]
 
-    async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
-        allowed = {
+    # Fields update_schedule() (and create_schedule_run_and_advance()'s
+    # folded-in schedule update) may write. A single choke point so the two
+    # write paths can never drift on what's allowed.
+    _SCHEDULE_UPDATE_ALLOWED_FIELDS = frozenset(
+        {
             "name",
             "description",
             "enabled",
@@ -2325,7 +2328,25 @@ class StateDB:
             "last_healthy_poll_at",
             "poller_consecutive_401",
         }
-        bad = set(fields) - allowed
+    )
+
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
+        stmt, params = self._build_update_schedule_stmt(schedule_id, fields)
+        async with self._tx() as conn:
+            await conn.execute(stmt, params)
+
+    @classmethod
+    def _build_update_schedule_stmt(cls, schedule_id: str, fields: dict[str, Any]):
+        """Validate + build the ``UPDATE schedules`` statement + bound
+        params for *fields* without opening a transaction.
+
+        Shared by ``update_schedule`` (its own standalone commit) and
+        ``create_schedule_run_and_advance`` (folded into the same
+        transaction as the occurrence insert) -- the single choke point for
+        both the field allowlist and the SQL shape, so the two write paths
+        can never drift apart.
+        """
+        bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
         if bad:
             raise ValueError(f"Invalid schedule field(s): {bad}")
         json_fields = {
@@ -2336,6 +2357,7 @@ class StateDB:
             "on_fail",
             "threshold_config",
         }
+        fields = dict(fields)
         fields["updated_at"] = time.time()
         sets_parts = []
         bind_params = []
@@ -2348,8 +2370,7 @@ class StateDB:
         stmt = text(f"UPDATE schedules SET {', '.join(sets_parts)} WHERE id = :_id")  # noqa: S608
         if bind_params:
             stmt = stmt.bindparams(*bind_params)
-        async with self._tx() as conn:
-            await conn.execute(stmt, params)
+        return stmt, params
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         async with self._tx() as conn:
@@ -2362,40 +2383,79 @@ class StateDB:
     # ── Schedule Runs (ADR-0070) ──────────────────────────────────────
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
-        now = time.time()
+        stmt, params = self._build_schedule_run_insert_stmt(run)
         async with self._tx() as conn:
-            await conn.execute(
-                text(
-                    """INSERT INTO schedule_runs
-                       (id, schedule_id, invocation_id, trigger_context,
-                        action_kind, action_args, status, exit_code,
-                        chain_parent_id, chain_depth, fired_at, ended_at,
-                        error_detail, created_at)
-                       VALUES (:id, :schedule_id, :invocation_id, :trigger_context,
-                               :action_kind, :action_args, :status, :exit_code,
-                               :chain_parent_id, :chain_depth, :fired_at, :ended_at,
-                               :error_detail, :created_at)"""
-                ).bindparams(
-                    bindparam("trigger_context", type_=JSON),
-                    bindparam("action_args", type_=JSON),
-                ),
-                {
-                    "id": run["id"],
-                    "schedule_id": run["schedule_id"],
-                    "invocation_id": run.get("invocation_id"),
-                    "trigger_context": run["trigger_context"],
-                    "action_kind": run["action_kind"],
-                    "action_args": run["action_args"],
-                    "status": run.get("status", "running"),
-                    "exit_code": run.get("exit_code"),
-                    "chain_parent_id": run.get("chain_parent_id"),
-                    "chain_depth": run.get("chain_depth", 0),
-                    "fired_at": run["fired_at"],
-                    "ended_at": run.get("ended_at"),
-                    "error_detail": run.get("error_detail"),
-                    "created_at": run.get("created_at", now),
-                },
-            )
+            await conn.execute(stmt, params)
+
+    @staticmethod
+    def _build_schedule_run_insert_stmt(run: dict[str, Any]):
+        """Build the ``INSERT INTO schedule_runs`` statement + bound params
+        for *run* without opening a transaction -- shared by
+        ``create_schedule_run`` and ``create_schedule_run_and_advance``."""
+        now = time.time()
+        stmt = text(
+            """INSERT INTO schedule_runs
+               (id, schedule_id, invocation_id, trigger_context,
+                action_kind, action_args, status, exit_code,
+                chain_parent_id, chain_depth, fired_at, ended_at,
+                error_detail, created_at)
+               VALUES (:id, :schedule_id, :invocation_id, :trigger_context,
+                       :action_kind, :action_args, :status, :exit_code,
+                       :chain_parent_id, :chain_depth, :fired_at, :ended_at,
+                       :error_detail, :created_at)"""
+        ).bindparams(
+            bindparam("trigger_context", type_=JSON),
+            bindparam("action_args", type_=JSON),
+        )
+        params = {
+            "id": run["id"],
+            "schedule_id": run["schedule_id"],
+            "invocation_id": run.get("invocation_id"),
+            "trigger_context": run["trigger_context"],
+            "action_kind": run["action_kind"],
+            "action_args": run["action_args"],
+            "status": run.get("status", "running"),
+            "exit_code": run.get("exit_code"),
+            "chain_parent_id": run.get("chain_parent_id"),
+            "chain_depth": run.get("chain_depth", 0),
+            "fired_at": run["fired_at"],
+            "ended_at": run.get("ended_at"),
+            "error_detail": run.get("error_detail"),
+            "created_at": run.get("created_at", now),
+        }
+        return stmt, params
+
+    async def create_schedule_run_and_advance(
+        self,
+        run: dict[str, Any],
+        *,
+        schedule_id: str,
+        schedule_fields: dict[str, Any],
+    ) -> None:
+        """Insert one schedule_runs occurrence row and advance the owning
+        schedule's cursor fields (``next_fire_at`` / ``github_cursor`` /
+        ``last_fired_at``) in a single transaction.
+
+        This closes the gap that let a crash re-fire an already-recorded
+        occurrence: with two independently-committed writes, a process
+        death between them leaves a durable schedule_run row while the
+        schedule's cursor still points before it, so a restart re-derives
+        "still due" and queues another fire for a occurrence that already
+        exists. Wrapping both statements in one ``StateDB.transaction()``
+        means either both land or neither does -- a crash here can only
+        ever discard an occurrence that was never durably recorded, never
+        one that was.
+
+        *schedule_fields* goes through the same allowlist + JSON-column
+        handling as ``update_schedule`` (``_build_update_schedule_stmt`` is
+        the shared choke point for both), so an invalid key raises the same
+        ``ValueError`` here as it would through the public entrypoint.
+        """
+        run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
+        sched_stmt, sched_params = self._build_update_schedule_stmt(schedule_id, schedule_fields)
+        async with self._tx() as conn:
+            await conn.execute(run_stmt, run_params)
+            await conn.execute(sched_stmt, sched_params)
 
     async def update_schedule_run(
         self,
@@ -2681,6 +2741,31 @@ class StateDB:
             if status == "failed":
                 streak += 1
         return streak, last_status
+
+    async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:
+        """True if *schedule_id* already has a schedule_runs row fired at or
+        after *since*.
+
+        Used by the missed-fire recovery scan (``SchedulerEngine.
+        _check_missed_fires``) to distinguish "genuinely never fired" from
+        "occurrence was durably recorded before a crash interrupted
+        whatever bookkeeping came after it" -- firing a fresh recovery run
+        for the latter would double-execute the external action for an
+        occurrence that already has a row. Any status counts (running,
+        completed, failed, ...): the row's mere existence is what matters
+        here, not how it resolved.
+        """
+        async with self._read() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        "SELECT 1 FROM schedule_runs "
+                        "WHERE schedule_id = :schedule_id AND fired_at >= :since LIMIT 1"
+                    ),
+                    {"schedule_id": schedule_id, "since": since},
+                )
+            ).first()
+        return row is not None
 
     async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2434,23 +2434,11 @@ class StateDB:
         schedule_fields: dict[str, Any],
     ) -> None:
         """Insert one schedule_runs occurrence row and advance the owning
-        schedule's cursor fields (``next_fire_at`` / ``github_cursor`` /
-        ``last_fired_at``) in a single transaction.
-
-        This closes the gap that let a crash re-fire an already-recorded
-        occurrence: with two independently-committed writes, a process
-        death between them leaves a durable schedule_run row while the
-        schedule's cursor still points before it, so a restart re-derives
-        "still due" and queues another fire for a occurrence that already
-        exists. Wrapping both statements in one ``StateDB.transaction()``
-        means either both land or neither does -- a crash here can only
-        ever discard an occurrence that was never durably recorded, never
-        one that was.
-
-        *schedule_fields* goes through the same allowlist + JSON-column
-        handling as ``update_schedule`` (``_build_update_schedule_stmt`` is
-        the shared choke point for both), so an invalid key raises the same
-        ``ValueError`` here as it would through the public entrypoint.
+        schedule's cursor fields in a single transaction, so a crash can
+        only ever discard an occurrence that was never durably recorded --
+        never leave the cursor pointing before one that was, which would
+        make a restart re-fire it. *schedule_fields* goes through the same
+        allowlist as ``update_schedule``.
         """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
         sched_stmt, sched_params = self._build_update_schedule_stmt(schedule_id, schedule_fields)
@@ -2466,42 +2454,17 @@ class StateDB:
         expected_orphan_status: str = "running",
     ) -> bool:
         """Flip an undispatched orphan to a terminal status and insert its
-        replacement occurrence row in the SAME transaction.
+        replacement occurrence row in one transaction, so a crash leaves
+        either both writes durable or neither. The CAS also requires
+        ``dispatched_at IS NULL``: if a launch confirmation lands between
+        the recovery scan and this write, the row no longer qualifies as
+        undispatched and the call is a no-op (returns ``False``, nothing
+        inserted) rather than tombstoning a run that actually launched.
 
-        This is the write ``SchedulerEngine._recover_undispatched_fires()``
-        uses instead of two independent writes (a CAS status flip, then a
-        separate later insert once the replacement's fire task gets around
-        to it). Two independent writes leave a real window: a crash between
-        them leaves the orphan durably terminal (so it drops out of any
-        future ``list_undispatched_schedule_runs()`` scan -- terminal rows
-        are never selected) while the replacement was never durably
-        recorded (the in-memory task that would have inserted it is gone),
-        permanently losing the occurrence. Wrapping both writes in one
-        transaction closes that window the same way
-        ``create_schedule_run_and_advance()`` closes the occurrence-insert /
-        cursor-advance one: either both land or neither does, so a crash
-        here can only ever leave the orphan exactly as it was (still
-        'running', still undispatched, still visible to the next recovery
-        scan) -- never flipped with no replacement to show for it.
-
-        Only a bare status flip (status + updated_at) is written for the
-        orphan here, no reason-code/history bookkeeping -- callers follow
-        up with an ordinary ``update_status()`` same-status call afterward
-        for that (mirroring the existing pattern at the invalid-action
-        and happy-path insert sites in ``_fire_inner()``, which set status
-        directly in ``create_schedule_run_and_advance()``'s INSERT and only
-        layer reason/history on with a separate follow-up call). A crash
-        between this method returning and that follow-up call leaves the
-        orphan correctly terminal but without its reason annotation -- a
-        cosmetic gap, not a durability one, identical to the existing
-        pattern's own gap.
-
-        Returns ``False`` (inserting nothing) if the orphan's status no
-        longer matches *expected_orphan_status* -- something else (e.g. the
-        stale-run reaper, or an operator action) already resolved it
-        between the scan that found this orphan and this write; there is
-        nothing left to recover and no replacement should be created for
-        an occurrence someone else already finalized.
+        Returns ``False`` if the orphan's status no longer matches
+        *expected_orphan_status* or is no longer undispatched -- something
+        else already resolved it between the scan and this write, so there
+        is nothing to recover and no replacement should be created.
         """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(replacement_run)
         now = time.time()
@@ -2509,7 +2472,8 @@ class StateDB:
             result = await conn.execute(
                 text(
                     "UPDATE schedule_runs SET status = 'failed', updated_at = :now "
-                    "WHERE id = :orphan_id AND status = :expected_status"
+                    "WHERE id = :orphan_id AND status = :expected_status "
+                    "AND dispatched_at IS NULL"
                 ),
                 {"now": now, "orphan_id": orphan_id, "expected_status": expected_orphan_status},
             )
@@ -2823,28 +2787,12 @@ class StateDB:
         return streak, last_status
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:
-        """True if *schedule_id* already has a genuinely-fired schedule_runs
-        row at or after *since*.
-
-        Used by the missed-fire recovery scan (``SchedulerEngine.
-        _check_missed_fires``) to distinguish "genuinely never fired" from
-        "occurrence was durably recorded before a crash interrupted
-        whatever bookkeeping came after it" -- firing a fresh recovery run
-        for the latter would double-execute the external action for an
-        occurrence that already has a row. Any non-skipped status counts
-        (running, completed, failed, ...): the row's mere existence is what
-        matters here, not how it resolved.
-
-        Excludes ``status = 'skipped'`` rows. Two of the three writers of
-        that status (missed-fire skip, overlap skip) advance next_fire_at
-        in the same breath as writing the row, so the schedule is no
-        longer due by the time this scan would run again -- moot either
-        way. But the third, capacity-deferred throttling
-        (``_maybe_record_deferred``), deliberately leaves next_fire_at
-        untouched so the *same* due occurrence retries on the next tick;
-        counting that audit-only row as "already recorded" would make this
-        scan advance the cursor past a due occurrence that never actually
-        ran, silently dropping it if the process dies before that retry.
+        """True if *schedule_id* has a genuinely-fired schedule_runs row at
+        or after *since* -- used by missed-fire recovery to tell "never
+        fired" from "fired but crashed before follow-up bookkeeping".
+        Excludes ``status = 'skipped'`` rows so a capacity-deferred skip
+        (whose next_fire_at is deliberately left untouched) still counts as
+        due and retries, rather than being treated as already handled.
         """
         async with self._read() as conn:
             row = (
@@ -2861,27 +2809,12 @@ class StateDB:
 
     async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]:
         """Scheduler-fired occurrence rows whose transaction committed but
-        whose external process launch was never confirmed.
-
-        A row lands here when ``create_schedule_run_and_advance()`` commits
-        (the occurrence exists, the schedule's cursor has moved past it) but
-        the scheduler engine crashes before ``spawn_and_wait()``'s
-        ``on_launched`` callback stamps ``dispatched_at`` -- i.e. sometime
-        between the transaction committing and the OS process actually
-        existing. Because the cursor already moved, ``schedule_run_exists_
-        since()``-based missed-fire recovery will never reconsider this
-        occurrence (the schedule no longer looks due), and the external
-        action was never attempted -- so without a dedicated scan the fire
-        is silently lost, eventually just marked ``timed_out`` by the
-        stale-run reaper. ``SchedulerEngine._recover_undispatched_fires()``
-        runs this once at startup and re-fires each row.
-
-        Scoped to ``schedule_id IS NOT NULL`` (scheduler-fired rows only --
-        mirrors the same exclusion ``reap_stale_schedule_runs()`` applies to
-        the leased ad-hoc task queue, which has its own dispatch/lease model
-        entirely and is never launched through ``spawn_and_wait``'s
-        ``on_launched`` path in the first place, so it never sets
-        dispatched_at and would otherwise false-positive here).
+        whose external process launch was never confirmed (cursor already
+        moved, so ordinary missed-fire recovery will never reconsider them).
+        ``SchedulerEngine._recover_undispatched_fires()`` runs this once at
+        startup and re-fires each row. Scoped to ``schedule_id IS NOT NULL``
+        to exclude the leased ad-hoc task queue, which has its own
+        dispatch/lease model and never sets dispatched_at.
         """
         async with self._read() as conn:
             rows = (

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2458,6 +2458,66 @@ class StateDB:
             await conn.execute(run_stmt, run_params)
             await conn.execute(sched_stmt, sched_params)
 
+    async def tombstone_and_replace_schedule_run(
+        self,
+        orphan_id: str,
+        replacement_run: dict[str, Any],
+        *,
+        expected_orphan_status: str = "running",
+    ) -> bool:
+        """Flip an undispatched orphan to a terminal status and insert its
+        replacement occurrence row in the SAME transaction.
+
+        This is the write ``SchedulerEngine._recover_undispatched_fires()``
+        uses instead of two independent writes (a CAS status flip, then a
+        separate later insert once the replacement's fire task gets around
+        to it). Two independent writes leave a real window: a crash between
+        them leaves the orphan durably terminal (so it drops out of any
+        future ``list_undispatched_schedule_runs()`` scan -- terminal rows
+        are never selected) while the replacement was never durably
+        recorded (the in-memory task that would have inserted it is gone),
+        permanently losing the occurrence. Wrapping both writes in one
+        transaction closes that window the same way
+        ``create_schedule_run_and_advance()`` closes the occurrence-insert /
+        cursor-advance one: either both land or neither does, so a crash
+        here can only ever leave the orphan exactly as it was (still
+        'running', still undispatched, still visible to the next recovery
+        scan) -- never flipped with no replacement to show for it.
+
+        Only a bare status flip (status + updated_at) is written for the
+        orphan here, no reason-code/history bookkeeping -- callers follow
+        up with an ordinary ``update_status()`` same-status call afterward
+        for that (mirroring the existing pattern at the invalid-action
+        and happy-path insert sites in ``_fire_inner()``, which set status
+        directly in ``create_schedule_run_and_advance()``'s INSERT and only
+        layer reason/history on with a separate follow-up call). A crash
+        between this method returning and that follow-up call leaves the
+        orphan correctly terminal but without its reason annotation -- a
+        cosmetic gap, not a durability one, identical to the existing
+        pattern's own gap.
+
+        Returns ``False`` (inserting nothing) if the orphan's status no
+        longer matches *expected_orphan_status* -- something else (e.g. the
+        stale-run reaper, or an operator action) already resolved it
+        between the scan that found this orphan and this write; there is
+        nothing left to recover and no replacement should be created for
+        an occurrence someone else already finalized.
+        """
+        run_stmt, run_params = self._build_schedule_run_insert_stmt(replacement_run)
+        now = time.time()
+        async with self._tx() as conn:
+            result = await conn.execute(
+                text(
+                    "UPDATE schedule_runs SET status = 'failed', updated_at = :now "
+                    "WHERE id = :orphan_id AND status = :expected_status"
+                ),
+                {"now": now, "orphan_id": orphan_id, "expected_status": expected_orphan_status},
+            )
+            if result.rowcount == 0:
+                return False
+            await conn.execute(run_stmt, run_params)
+        return True
+
     async def update_schedule_run(
         self,
         run_id: str,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1243,7 +1243,8 @@ class StateDB:
                       required_capabilities  JSON,
                       execution_target       TEXT,
                       library_ref             TEXT,
-                      library_content_hash    TEXT
+                      library_content_hash    TEXT,
+                      dispatched_at           REAL
                     )
                     """
                 )
@@ -2469,7 +2470,14 @@ class StateDB:
         **fields: Any,
     ) -> None:
         """Update schedule_run fields; route status through update_status()."""
-        allowed = {"status", "exit_code", "ended_at", "error_detail", "invocation_id"}
+        allowed = {
+            "status",
+            "exit_code",
+            "ended_at",
+            "error_detail",
+            "invocation_id",
+            "dispatched_at",
+        }
         bad = set(fields) - allowed
         if bad:
             raise ValueError(f"Invalid schedule_run field(s): {bad}")
@@ -2790,6 +2798,45 @@ class StateDB:
                 )
             ).first()
         return row is not None
+
+    async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]:
+        """Scheduler-fired occurrence rows whose transaction committed but
+        whose external process launch was never confirmed.
+
+        A row lands here when ``create_schedule_run_and_advance()`` commits
+        (the occurrence exists, the schedule's cursor has moved past it) but
+        the scheduler engine crashes before ``spawn_and_wait()``'s
+        ``on_launched`` callback stamps ``dispatched_at`` -- i.e. sometime
+        between the transaction committing and the OS process actually
+        existing. Because the cursor already moved, ``schedule_run_exists_
+        since()``-based missed-fire recovery will never reconsider this
+        occurrence (the schedule no longer looks due), and the external
+        action was never attempted -- so without a dedicated scan the fire
+        is silently lost, eventually just marked ``timed_out`` by the
+        stale-run reaper. ``SchedulerEngine._recover_undispatched_fires()``
+        runs this once at startup and re-fires each row.
+
+        Scoped to ``schedule_id IS NOT NULL`` (scheduler-fired rows only --
+        mirrors the same exclusion ``reap_stale_schedule_runs()`` applies to
+        the leased ad-hoc task queue, which has its own dispatch/lease model
+        entirely and is never launched through ``spawn_and_wait``'s
+        ``on_launched`` path in the first place, so it never sets
+        dispatched_at and would otherwise false-positive here).
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT * FROM schedule_runs WHERE status = 'running' "
+                            "AND dispatched_at IS NULL AND schedule_id IS NOT NULL"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        return [self._row_to_dict(r) for r in rows]
 
     async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -86,6 +86,11 @@ class RunReasons:
     # ADR-0071 D4: task-application worker lease outcomes.
     QUEUED_LEASE_EXPIRED = "run.queued.lease_expired"
     FAILED_LEASE_ATTEMPTS_EXHAUSTED = "run.failed.lease_attempts_exhausted"
+    # The occurrence's transaction committed but the scheduler crashed
+    # before confirming the external process launched; a startup recovery
+    # scan tombstones the orphaned row with this code and re-fires a fresh
+    # occurrence in its place.
+    FAILED_NEVER_DISPATCHED = "run.failed.never_dispatched"
 
 
 class SessionReasons:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -523,7 +523,17 @@ CREATE TABLE IF NOT EXISTS schedule_runs (
   required_capabilities  JSON,
   execution_target       TEXT,
   library_ref             TEXT,
-  library_content_hash    TEXT
+  library_content_hash    TEXT,
+  -- Delivery-contract marker: stamped the moment the scheduler engine
+  -- confirms the external process for this occurrence was actually
+  -- launched (create_subprocess_exec returned), separate from fired_at
+  -- (when the occurrence + cursor advance committed) and updated_at (any
+  -- write). NULL means the occurrence's transaction committed but launch
+  -- was never confirmed -- the signal a startup recovery scan uses to
+  -- distinguish "crashed before dispatch, safe to re-fire" from
+  -- "dispatched, outcome merely lost" (see SchedulerEngine._fire_inner and
+  -- SchedulerEngine._recover_undispatched_fires).
+  dispatched_at           REAL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sched_runs_schedule

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -607,6 +607,10 @@ schedule_runs = Table(
     Column("execution_target", Text),
     Column("library_ref", Text),
     Column("library_content_hash", Text),
+    # Delivery-contract marker: stamped once the scheduler engine confirms
+    # the external process for this occurrence was actually launched. See
+    # the schema.sql CREATE TABLE comment for the full rationale.
+    Column("dispatched_at", Float),
 )
 
 Index("idx_sched_runs_schedule", schedule_runs.c.schedule_id, schedule_runs.c.fired_at)

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -129,6 +129,11 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("library_content_hash", "TEXT"),
         # ADR-0071 D4: bounds the lease-expiry recovery loop (worker.py's reaper).
         ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
+        # Delivery-contract marker: stamped once the scheduler engine
+        # confirms the external process was actually launched. NULL on a
+        # row whose occurrence-insert transaction committed but launch was
+        # never confirmed -- see the CREATE TABLE comment in schema.sql.
+        ("dispatched_at", "REAL"),
     ],
     # Phase C Move 2: engine run persistence.
     # New table created via schema.sql; these columns allow ALTER TABLE on

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -77,6 +77,17 @@ PHANTOM_STALE_HOURS: float = float(os.environ.get("LIONAGI_STUDIO_PHANTOM_STALE_
 # whose child session process is still alive is never reaped regardless of
 # this value; it only bites orphaned/dead-runner rows.
 PLAY_STALE_HOURS: float = float(os.environ.get("LIONAGI_STUDIO_PLAY_STALE_HOURS", "6.0"))
+# Staleness threshold for the schedule_run reaper -- a schedule_run row can be
+# left at status="running" forever when the scheduler process dies after its
+# occurrence-insert transaction commits but before its own terminal write
+# lands (e.g. mid-spawn). There is no process-liveness signal to check
+# against for a schedule_run row the way sessions/plays have (the scheduler
+# daemon itself is the "process"; its own restart is what triggers reaping),
+# so this is a pure wall-clock backstop, deliberately generous rather than a
+# tight SLA.
+SCHEDULE_RUN_STALE_HOURS: float = float(
+    os.environ.get("LIONAGI_STUDIO_SCHEDULE_RUN_STALE_HOURS", "24.0")
+)
 # Minimum seconds between consecutive periodic reaper runs (throttle).
 REAPER_INTERVAL_SECONDS: int = int(os.environ.get("LIONAGI_STUDIO_REAPER_INTERVAL_SECONDS", "300"))
 

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -502,14 +502,29 @@ class SchedulerEngine:
         usefully catch mid-lifetime; running this once at startup (mirroring
         ``_check_missed_fires()``, called right alongside it) is sufficient.
 
-        Each orphaned row is tombstoned (never resurrected as "running" --
-        that status is reserved for a fire this engine currently owns) and,
-        for a top-level occurrence (chain_depth == 0), replaced with a fresh
-        fire carrying the SAME trigger_context the orphaned attempt never
-        got to use, so a github_poll event (or any other occurrence-specific
-        context) is retried faithfully rather than generically. Chain
-        children are tombstoned only -- see _fire_inner()'s docstring for
-        why that narrower gap is accepted.
+        Two shapes, depending on whether this orphan will get a replacement:
+
+        - Chain children (chain_depth != 0), and top-level occurrences whose
+          owning schedule is missing or disabled: tombstoned directly, right
+          here, via an ordinary CAS ``update_status()`` call -- no
+          replacement will ever be created for these, so there is no
+          insert-vs-flip ordering to get wrong (nothing else needs to become
+          durable alongside the flip).
+
+        - Everything else (a top-level occurrence of a live, enabled
+          schedule): handed to ``_tracked_fire(..., supersedes_run_id=...)``,
+          which tombstones this orphan AND inserts the replacement
+          occurrence row in ONE transaction inside ``_fire_inner()`` (see
+          its delivery-contract docstring) -- carrying the SAME
+          trigger_context the orphaned attempt never got to use, so a
+          github_poll event (or any other occurrence-specific context) is
+          retried faithfully rather than generically. The tombstone does
+          NOT happen here in the scan loop for this shape; it happens
+          atomically with the insert, inside the (backgrounded) fire task.
+          A crash before that task runs leaves the orphan completely
+          untouched -- still 'running', still visible to the next boot's
+          scan -- which is exactly the same "never fired" starting point as
+          before this scan ever ran, not a lost occurrence.
         """
         try:
             orphans = await self._svc.list_undispatched_schedule_runs()
@@ -520,44 +535,19 @@ class SchedulerEngine:
         for row in orphans:
             run_id = row["id"]
             sid = row.get("schedule_id")
-            try:
-                written = await self._svc.update_status(
-                    "schedule_run",
-                    run_id,
-                    new_status="failed",
-                    reason_code=RunReasons.FAILED_NEVER_DISPATCHED,
-                    reason_summary=(
-                        "Scheduler crashed after committing this occurrence but "
-                        "before confirming the external process launched."
-                    ),
-                    evidence_refs=[{"kind": "schedule", "id": sid}] if sid else [],
-                    source="system",
-                    actor="scheduler_startup_recovery",
-                    expected_statuses={"running"},
-                )
-            except Exception:
-                _log.exception("Failed to tombstone undispatched schedule_run %s", run_id)
-                continue
-            if not written:
-                # Raced with something else finalizing this row between the
-                # scan and here (e.g. the stale-run reaper); nothing left to
-                # recover -- it already resolved through some other path.
-                continue
 
             if row.get("chain_depth", 0) != 0:
-                _log.info(
-                    "Undispatched chain-child schedule_run %s tombstoned; not auto-retried",
-                    run_id,
+                await self._tombstone_orphan_only(
+                    run_id, sid=sid, log_note="chain-child, not auto-retried"
                 )
                 continue
 
             schedule = await self._svc.get_schedule(sid) if sid else None
             if schedule is None or not schedule.get("enabled"):
-                _log.info(
-                    "Skipping re-fire for undispatched schedule_run %s: "
-                    "owning schedule %s missing or disabled",
+                await self._tombstone_orphan_only(
                     run_id,
-                    sid,
+                    sid=sid,
+                    log_note=f"owning schedule {sid} missing or disabled, not auto-retried",
                 )
                 continue
 
@@ -572,7 +562,42 @@ class SchedulerEngine:
                 schedule,
                 new_run_id,
                 trigger_context=row.get("trigger_context") or {},
+                supersedes_run_id=run_id,
             )
+
+    async def _tombstone_orphan_only(self, run_id: str, *, sid: str | None, log_note: str) -> None:
+        """CAS-tombstone an undispatched orphan with no replacement to
+        follow -- the simple case _recover_undispatched_fires() uses when
+        it has already decided not to re-fire (chain child, or owning
+        schedule missing/disabled). Safe as an ordinary standalone write:
+        with no replacement row for anything to race against, there is no
+        insert-vs-flip ordering concern here at all.
+        """
+        try:
+            written = await self._svc.update_status(
+                "schedule_run",
+                run_id,
+                new_status="failed",
+                reason_code=RunReasons.FAILED_NEVER_DISPATCHED,
+                reason_summary=(
+                    "Scheduler crashed after committing this occurrence but "
+                    "before confirming the external process launched."
+                ),
+                evidence_refs=[{"kind": "schedule", "id": sid}] if sid else [],
+                source="system",
+                actor="scheduler_startup_recovery",
+                expected_statuses={"running"},
+            )
+        except Exception:
+            _log.exception("Failed to tombstone undispatched schedule_run %s", run_id)
+            return
+        if written:
+            _log.info("Undispatched schedule_run %s tombstoned: %s", run_id, log_note)
+        else:
+            # Raced with something else finalizing this row between the
+            # scan and here (e.g. the stale-run reaper); nothing left to
+            # recover -- it already resolved through some other path.
+            pass
 
     async def _check_missed_fires(self) -> None:
         try:
@@ -1400,6 +1425,7 @@ class SchedulerEngine:
         global_slot_claim: _GlobalSlotClaim | None = None,
         threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
+        supersedes_run_id: str | None = None,
     ) -> None:
         """Thin wrapper around _fire_inner() that guarantees max_runs_claim,
         global_slot_claim, and threshold_cooldown_claim are each released
@@ -1418,6 +1444,11 @@ class SchedulerEngine:
         _tick_github() uses this, to fold that event's github_cursor
         advance into the SAME atomic transaction as its occurrence insert
         (see _fire_inner()'s docstring).
+
+        *supersedes_run_id*: passed through to _fire_inner() -- only
+        _recover_undispatched_fires() uses this, to atomically tombstone
+        the orphan it names in the SAME transaction as this fire's own
+        occurrence insert (see _fire_inner()'s docstring).
         """
         try:
             await self._fire_inner(
@@ -1427,6 +1458,7 @@ class SchedulerEngine:
                 chain_parent_id=chain_parent_id,
                 chain_depth=chain_depth,
                 extra_schedule_fields=extra_schedule_fields,
+                supersedes_run_id=supersedes_run_id,
             )
         finally:
             if max_runs_claim is not None:
@@ -1462,6 +1494,102 @@ class SchedulerEngine:
             return {}
         return {"last_alert_at": now}
 
+    async def _write_occurrence(
+        self,
+        run: dict[str, Any],
+        *,
+        schedule_id: str,
+        schedule_fields: dict[str, Any],
+        supersedes_run_id: str | None,
+    ) -> bool:
+        """Durably record one occurrence row -- the single choke point both
+        _fire_inner() write sites (the invalid-action failure path and the
+        happy path) go through, so they don't each need their own
+        ordinary-fire-vs-recovery-refire branch.
+
+        An ordinary tick-triggered fire (*supersedes_run_id* is None) is
+        atomic with the schedule's own cursor advance
+        (``create_schedule_run_and_advance()``) and always succeeds. A
+        recovery re-fire (*supersedes_run_id* set, by
+        ``_recover_undispatched_fires()``) is instead atomic with
+        tombstoning the orphan it replaces (``tombstone_and_replace_
+        schedule_run()``), and skips the cursor advance entirely -- the
+        cursor already moved when the orphan's own occurrence was first
+        recorded; a re-fire is not a new occurrence, just a fresh attempt
+        at the same one. See _fire_inner()'s delivery-contract docstring
+        for why these two writes must land atomically with their
+        respective counterpart.
+
+        Returns ``False`` only for the recovery path, when the orphan no
+        longer matched its expected status (raced away by something else,
+        e.g. the stale-run reaper, between the scan that found it and this
+        write) -- no replacement is inserted in that case, and *run* was
+        never durably recorded.
+        """
+        if supersedes_run_id is not None:
+            applied = await self._svc.tombstone_and_replace_schedule_run(
+                supersedes_run_id, run, expected_orphan_status="running"
+            )
+            if applied:
+                # The atomic write above only sets status + updated_at (no
+                # reason columns -- see tombstone_and_replace_schedule_run()'s
+                # docstring); layer the reason code/history on now, same
+                # pattern as create_schedule_run_and_advance()'s own callers
+                # (they set status directly in the INSERT and only add
+                # reason/history with a separate follow-up update_status()
+                # call). A same-status "failed"->"failed" append, not a CAS
+                # -- the orphan is already durably terminal by this point.
+                await self._svc.update_status(
+                    "schedule_run",
+                    supersedes_run_id,
+                    new_status="failed",
+                    reason_code=RunReasons.FAILED_NEVER_DISPATCHED,
+                    reason_summary=(
+                        "Scheduler crashed after committing this occurrence but "
+                        "before confirming the external process launched."
+                    ),
+                    evidence_refs=[{"kind": "schedule_run", "id": run["id"]}],
+                    source="system",
+                    actor="scheduler_startup_recovery",
+                )
+            return applied
+        await self._svc.create_schedule_run_and_advance(
+            run, schedule_id=schedule_id, schedule_fields=schedule_fields
+        )
+        return True
+
+    async def _abandon_superseded_recovery_fire(self, inv_id: str, *, orphan_id: str) -> None:
+        """A recovery re-fire's occurrence write was refused because the
+        orphan it was meant to supersede (*orphan_id*) no longer matched
+        its expected status -- something else (the stale-run reaper, an
+        operator action) already resolved it between
+        _recover_undispatched_fires()'s scan and this write landing. No
+        schedule_run row was ever created for this attempt; only the
+        invocation _fire_inner() already durably created before reaching
+        that write needs cleaning up.
+        """
+        _log.info(
+            "Abandoning recovery re-fire for invocation %s: orphan %s was "
+            "already resolved by something else",
+            inv_id,
+            orphan_id,
+        )
+        await self._svc.update_invocation(inv_id, ended_at=time.time())
+        await self._guarded_terminal_status(
+            "invocation",
+            inv_id,
+            new_status="cancelled",
+            reason_code=RunReasons.CANCELLED_STALE_AUTO,
+            reason_summary=(
+                f"Recovery re-fire abandoned: the orphaned schedule_run "
+                f"{orphan_id} it was meant to supersede was already resolved "
+                "by something else before this re-fire's own write landed."
+            ),
+            evidence_refs=[{"kind": "schedule_run", "id": orphan_id}],
+            source="system",
+            actor="scheduler_startup_recovery",
+        )
+
     async def _fire_inner(
         self,
         schedule: dict,
@@ -1471,6 +1599,7 @@ class SchedulerEngine:
         chain_parent_id: str | None = None,
         chain_depth: int = 0,
         extra_schedule_fields: dict[str, Any] | None = None,
+        supersedes_run_id: str | None = None,
     ) -> None:
         """Fire one occurrence of *schedule*.
 
@@ -1491,15 +1620,39 @@ class SchedulerEngine:
            schedule as due again -- so a dedicated startup scan,
            ``_recover_undispatched_fires()``, finds every top-level
            (chain_depth == 0) ``status='running' AND dispatched_at IS
-           NULL`` row, tombstones it (``failed`` /
-           ``RunReasons.FAILED_NEVER_DISPATCHED``), and re-fires a fresh
-           occurrence with the SAME ``trigger_context`` it never got to
-           use. This is the at-least-once guarantee: an occurrence that
-           was committed to is retried until it is genuinely attempted.
-           Chain children (chain_depth > 0) are tombstoned but not
-           auto-retried -- narrower, accepted gap; the parent occurrence's
-           own outcome is unaffected, only a follow-on on_success/on_fail
-           step is lost.
+           NULL`` row and re-fires it by calling back into THIS method
+           with *supersedes_run_id* set to the orphan's id.
+
+           That re-fire's own occurrence-insert transaction (below) does
+           double duty when *supersedes_run_id* is set: it tombstones the
+           orphan (``failed`` / ``RunReasons.FAILED_NEVER_DISPATCHED``) AND
+           inserts this fresh occurrence's row IN THE SAME TRANSACTION,
+           via ``tombstone_and_replace_schedule_run()`` instead of
+           ``create_schedule_run_and_advance()`` (and skips the cursor
+           advance entirely -- the cursor already moved when the orphan's
+           own occurrence was first recorded; a re-fire is not a new
+           occurrence, just a fresh attempt at the same one). Flipping the
+           orphan and inserting its replacement as two independent writes
+           would reopen exactly this window one level up: a crash between
+           them would leave the orphan durably terminal (dropped from any
+           future undispatched-scan) with no replacement ever recorded,
+           losing the occurrence for good. Atomic together, a crash here
+           can only ever leave the orphan exactly as it was -- still
+           'running', still undispatched, still visible to the next
+           recovery scan -- never flipped with nothing to show for it.
+
+           The re-fire carries the orphan's SAME ``trigger_context`` (it
+           never got to use it), so a github_poll event (or any other
+           occurrence-specific context) is retried faithfully rather than
+           generically. This is the at-least-once guarantee: an occurrence
+           that was committed to is retried until it is genuinely
+           attempted -- and each retry is itself covered by the same
+           guarantee, recursively, until one actually dispatches. Chain
+           children (chain_depth > 0) are tombstoned by
+           ``_recover_undispatched_fires()`` directly, without going
+           through this re-fire path at all -- narrower, accepted gap; the
+           parent occurrence's own outcome is unaffected, only a follow-on
+           on_success/on_fail step is lost.
 
         3. After ``dispatched_at`` is confirmed: the external process
            genuinely exists. A crash from here on is NOT retried -- the
@@ -1572,7 +1725,10 @@ class SchedulerEngine:
             # invalid-action failure path -- otherwise a permanently
             # misconfigured github_poll schedule would never advance its
             # cursor past the offending event and re-fail it forever.
-            await self._svc.create_schedule_run_and_advance(
+            # (A recovery re-fire skips the cursor advance and is instead
+            # atomic with tombstoning the orphan it supersedes -- see
+            # _write_occurrence()'s docstring.)
+            written_occurrence = await self._write_occurrence(
                 {
                     "id": run_id,
                     "schedule_id": sid,
@@ -1589,7 +1745,11 @@ class SchedulerEngine:
                 },
                 schedule_id=sid,
                 schedule_fields=failed_schedule_fields,
+                supersedes_run_id=supersedes_run_id,
             )
+            if not written_occurrence:
+                await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
+                return
             written = await self._svc.update_status(
                 "schedule_run",
                 run_id,
@@ -1668,8 +1828,11 @@ class SchedulerEngine:
             # A crash AFTER this commits but before spawn_and_wait confirms
             # launch is the second window in this method's delivery-
             # contract docstring above -- _recover_undispatched_fires()
-            # handles it at the next startup, not here.
-            await self._svc.create_schedule_run_and_advance(
+            # handles it at the next startup, not here. (A recovery
+            # re-fire skips the cursor advance and is instead atomic with
+            # tombstoning the orphan it supersedes -- see
+            # _write_occurrence()'s docstring.)
+            written_occurrence = await self._write_occurrence(
                 {
                     "id": run_id,
                     "schedule_id": sid,
@@ -1684,7 +1847,11 @@ class SchedulerEngine:
                 },
                 schedule_id=sid,
                 schedule_fields=update_fields,
+                supersedes_run_id=supersedes_run_id,
             )
+            if not written_occurrence:
+                await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
+                return
             await self._svc.update_status(
                 "schedule_run",
                 run_id,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -473,6 +473,7 @@ class SchedulerEngine:
         return run_id
 
     async def _tick_loop(self) -> None:
+        await self._recover_undispatched_fires()
         await self._check_missed_fires()
         while not self._stopping:
             try:
@@ -480,6 +481,98 @@ class SchedulerEngine:
             except Exception:
                 _log.exception("Scheduler tick error")
             await asyncio.sleep(_TICK_INTERVAL)
+
+    async def _mark_dispatched(self, run_id: str) -> None:
+        """Stamp ``dispatched_at`` the instant spawn_and_wait confirms the
+        external process exists -- see _fire_inner()'s delivery-contract
+        docstring for what this closes."""
+        await self._svc.update_schedule_run(run_id, dispatched_at=time.time())
+
+    async def _recover_undispatched_fires(self) -> None:
+        """Startup-only recovery for the delivery-contract gap _fire_inner()
+        documents: an occurrence whose transaction committed (row exists,
+        schedule cursor already advanced past it) but whose external
+        process launch was never confirmed, because the engine crashed
+        somewhere between the two.
+
+        Only meaningful right after a restart. Under normal (non-crash)
+        operation this window is a single non-blocking DB write immediately
+        following ``create_subprocess_exec`` -- it always closes itself
+        within the same fire, so there is nothing for a periodic scan to
+        usefully catch mid-lifetime; running this once at startup (mirroring
+        ``_check_missed_fires()``, called right alongside it) is sufficient.
+
+        Each orphaned row is tombstoned (never resurrected as "running" --
+        that status is reserved for a fire this engine currently owns) and,
+        for a top-level occurrence (chain_depth == 0), replaced with a fresh
+        fire carrying the SAME trigger_context the orphaned attempt never
+        got to use, so a github_poll event (or any other occurrence-specific
+        context) is retried faithfully rather than generically. Chain
+        children are tombstoned only -- see _fire_inner()'s docstring for
+        why that narrower gap is accepted.
+        """
+        try:
+            orphans = await self._svc.list_undispatched_schedule_runs()
+        except Exception:
+            _log.exception("Failed to scan for undispatched schedule_runs")
+            return
+
+        for row in orphans:
+            run_id = row["id"]
+            sid = row.get("schedule_id")
+            try:
+                written = await self._svc.update_status(
+                    "schedule_run",
+                    run_id,
+                    new_status="failed",
+                    reason_code=RunReasons.FAILED_NEVER_DISPATCHED,
+                    reason_summary=(
+                        "Scheduler crashed after committing this occurrence but "
+                        "before confirming the external process launched."
+                    ),
+                    evidence_refs=[{"kind": "schedule", "id": sid}] if sid else [],
+                    source="system",
+                    actor="scheduler_startup_recovery",
+                    expected_statuses={"running"},
+                )
+            except Exception:
+                _log.exception("Failed to tombstone undispatched schedule_run %s", run_id)
+                continue
+            if not written:
+                # Raced with something else finalizing this row between the
+                # scan and here (e.g. the stale-run reaper); nothing left to
+                # recover -- it already resolved through some other path.
+                continue
+
+            if row.get("chain_depth", 0) != 0:
+                _log.info(
+                    "Undispatched chain-child schedule_run %s tombstoned; not auto-retried",
+                    run_id,
+                )
+                continue
+
+            schedule = await self._svc.get_schedule(sid) if sid else None
+            if schedule is None or not schedule.get("enabled"):
+                _log.info(
+                    "Skipping re-fire for undispatched schedule_run %s: "
+                    "owning schedule %s missing or disabled",
+                    run_id,
+                    sid,
+                )
+                continue
+
+            new_run_id = uuid.uuid4().hex[:12]
+            _log.info(
+                "Re-firing undispatched schedule_run %s as %s for schedule %s",
+                run_id,
+                new_run_id,
+                sid,
+            )
+            self._tracked_fire(
+                schedule,
+                new_run_id,
+                trigger_context=row.get("trigger_context") or {},
+            )
 
     async def _check_missed_fires(self) -> None:
         try:
@@ -1381,21 +1474,44 @@ class SchedulerEngine:
     ) -> None:
         """Fire one occurrence of *schedule*.
 
-        The occurrence-insert (``create_schedule_run``) and the schedule's
-        cursor advance (``last_fired_at``/``next_fire_at``, plus whatever
-        *extra_schedule_fields* adds -- e.g. ``github_cursor`` for a
-        github_poll event) land in a SINGLE transaction via
-        ``create_schedule_run_and_advance()``, executed BEFORE
-        ``spawn_and_wait()`` ever runs the external action. A crash at any
-        point before that transaction commits leaves neither the row nor
-        the cursor move durable, so a restart sees "never fired" and fires
-        fresh -- never a duplicate. A crash any time after it commits
-        (including mid-spawn) leaves a row + advanced cursor that will
-        never be re-derived as "still due" (closing the double-fire this
-        replaces), at the cost of the row staying at status="running"
-        until the schedule_runs reaper (lifecycle.reap_stale_schedule_runs)
-        or the run's own terminal write, whichever comes first, resolves
-        it.
+        DELIVERY CONTRACT -- at-least-once up to confirmed process launch,
+        at-most-once past it. Three windows, three outcomes:
+
+        1. Before the transaction commits (below): a crash here leaves
+           neither the occurrence row nor the cursor move durable, so a
+           restart sees "never fired" and fires fresh. Never a duplicate.
+
+        2. Between the transaction committing and ``spawn_and_wait()``
+           confirming the external process actually launched (its
+           ``on_launched`` callback stamping ``dispatched_at``): the
+           occurrence row and cursor advance ARE durable, but the external
+           action was never attempted. Because the cursor already moved,
+           ordinary missed-fire recovery (``_check_missed_fires`` /
+           ``schedule_run_exists_since``) will never reconsider this
+           schedule as due again -- so a dedicated startup scan,
+           ``_recover_undispatched_fires()``, finds every top-level
+           (chain_depth == 0) ``status='running' AND dispatched_at IS
+           NULL`` row, tombstones it (``failed`` /
+           ``RunReasons.FAILED_NEVER_DISPATCHED``), and re-fires a fresh
+           occurrence with the SAME ``trigger_context`` it never got to
+           use. This is the at-least-once guarantee: an occurrence that
+           was committed to is retried until it is genuinely attempted.
+           Chain children (chain_depth > 0) are tombstoned but not
+           auto-retried -- narrower, accepted gap; the parent occurrence's
+           own outcome is unaffected, only a follow-on on_success/on_fail
+           step is lost.
+
+        3. After ``dispatched_at`` is confirmed: the external process
+           genuinely exists. A crash from here on is NOT retried -- the
+           row is left at status="running" until the schedule_runs reaper
+           (``lifecycle.reap_stale_schedule_runs``) or the run's own
+           terminal write resolves it to ``timed_out``/``completed``/
+           ``failed``. Re-firing here would risk running the same external
+           action twice (it may already be running independently in its
+           own process group, or have already finished) -- the explicit
+           at-most-once boundary of this contract, chosen because a
+           duplicate real-world side effect is worse than one lost/
+           unretried outcome once launch is confirmed.
         """
         sid = schedule["id"]
         now = time.time()
@@ -1549,6 +1665,10 @@ class SchedulerEngine:
             # spawn_and_wait() below always runs AFTER this transaction
             # commits, never inside it, so a crash before this call can at
             # worst discard an occurrence that was never durably recorded.
+            # A crash AFTER this commits but before spawn_and_wait confirms
+            # launch is the second window in this method's delivery-
+            # contract docstring above -- _recover_undispatched_fires()
+            # handles it at the next startup, not here.
             await self._svc.create_schedule_run_and_advance(
                 {
                     "id": run_id,
@@ -1591,6 +1711,12 @@ class SchedulerEngine:
                 tmp_path=_tmp_path,
                 cwd=action_cwd,
                 action_kind=schedule.get("action_kind"),
+                # Stamps dispatched_at the instant the OS process is
+                # confirmed to exist -- the signal _recover_undispatched_
+                # fires() uses to tell "committed but never launched" (safe
+                # to re-fire) apart from "launched, outcome merely lost"
+                # (never re-fired; see this method's docstring).
+                on_launched=lambda: self._mark_dispatched(run_id),
             )
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -339,12 +339,9 @@ class SchedulerEngine:
         still ahead of now — the timezone-migration correction case this
         hook exists for — are recomputed here.
 
-        This method never fires anything itself (it only rewrites a
-        not-yet-due next_fire_at), so it has no occurrence-insert to
-        reconcile against schedule_runs. Any due schedule always goes
-        through _check_missed_fires(), which is where that consultation
-        happens (schedule_run_exists_since() before queuing a recovery
-        fire — see its docstring for why).
+        This method never fires anything itself, so it has no
+        occurrence-insert to reconcile against schedule_runs -- that
+        consultation happens in _check_missed_fires() for any due schedule.
         """
         try:
             schedules = await self._svc.list_schedules(enabled=True)
@@ -489,42 +486,12 @@ class SchedulerEngine:
         await self._svc.update_schedule_run(run_id, dispatched_at=time.time())
 
     async def _recover_undispatched_fires(self) -> None:
-        """Startup-only recovery for the delivery-contract gap _fire_inner()
-        documents: an occurrence whose transaction committed (row exists,
-        schedule cursor already advanced past it) but whose external
-        process launch was never confirmed, because the engine crashed
-        somewhere between the two.
-
-        Only meaningful right after a restart. Under normal (non-crash)
-        operation this window is a single non-blocking DB write immediately
-        following ``create_subprocess_exec`` -- it always closes itself
-        within the same fire, so there is nothing for a periodic scan to
-        usefully catch mid-lifetime; running this once at startup (mirroring
-        ``_check_missed_fires()``, called right alongside it) is sufficient.
-
-        Two shapes, depending on whether this orphan will get a replacement:
-
-        - Chain children (chain_depth != 0), and top-level occurrences whose
-          owning schedule is missing or disabled: tombstoned directly, right
-          here, via an ordinary CAS ``update_status()`` call -- no
-          replacement will ever be created for these, so there is no
-          insert-vs-flip ordering to get wrong (nothing else needs to become
-          durable alongside the flip).
-
-        - Everything else (a top-level occurrence of a live, enabled
-          schedule): handed to ``_tracked_fire(..., supersedes_run_id=...)``,
-          which tombstones this orphan AND inserts the replacement
-          occurrence row in ONE transaction inside ``_fire_inner()`` (see
-          its delivery-contract docstring) -- carrying the SAME
-          trigger_context the orphaned attempt never got to use, so a
-          github_poll event (or any other occurrence-specific context) is
-          retried faithfully rather than generically. The tombstone does
-          NOT happen here in the scan loop for this shape; it happens
-          atomically with the insert, inside the (backgrounded) fire task.
-          A crash before that task runs leaves the orphan completely
-          untouched -- still 'running', still visible to the next boot's
-          scan -- which is exactly the same "never fired" starting point as
-          before this scan ever ran, not a lost occurrence.
+        """Startup-only scan for occurrences whose transaction committed but
+        whose launch was never confirmed (see _fire_inner()'s delivery
+        contract). Chain children and orphans of a missing/disabled schedule
+        are tombstoned directly (no replacement to race against); everything
+        else is re-fired via ``_tracked_fire(..., supersedes_run_id=...)``,
+        which tombstones the orphan and inserts the replacement atomically.
         """
         try:
             orphans = await self._svc.list_undispatched_schedule_runs()
@@ -567,12 +534,7 @@ class SchedulerEngine:
 
     async def _tombstone_orphan_only(self, run_id: str, *, sid: str | None, log_note: str) -> None:
         """CAS-tombstone an undispatched orphan with no replacement to
-        follow -- the simple case _recover_undispatched_fires() uses when
-        it has already decided not to re-fire (chain child, or owning
-        schedule missing/disabled). Safe as an ordinary standalone write:
-        with no replacement row for anything to race against, there is no
-        insert-vs-flip ordering concern here at all.
-        """
+        follow (chain child, or owning schedule missing/disabled)."""
         try:
             written = await self._svc.update_status(
                 "schedule_run",
@@ -1440,15 +1402,9 @@ class SchedulerEngine:
         _check_max_runs() (e.g. create_invocation() raising), which is the
         leak this wrapper exists to close.
 
-        *extra_schedule_fields*: passed through to _fire_inner() -- only
-        _tick_github() uses this, to fold that event's github_cursor
-        advance into the SAME atomic transaction as its occurrence insert
-        (see _fire_inner()'s docstring).
-
-        *supersedes_run_id*: passed through to _fire_inner() -- only
-        _recover_undispatched_fires() uses this, to atomically tombstone
-        the orphan it names in the SAME transaction as this fire's own
-        occurrence insert (see _fire_inner()'s docstring).
+        *extra_schedule_fields* and *supersedes_run_id* pass straight
+        through to _fire_inner() (github cursor fold-in and recovery
+        re-fire, respectively -- see its docstring).
         """
         try:
             await self._fire_inner(
@@ -1502,29 +1458,13 @@ class SchedulerEngine:
         schedule_fields: dict[str, Any],
         supersedes_run_id: str | None,
     ) -> bool:
-        """Durably record one occurrence row -- the single choke point both
-        _fire_inner() write sites (the invalid-action failure path and the
-        happy path) go through, so they don't each need their own
-        ordinary-fire-vs-recovery-refire branch.
-
-        An ordinary tick-triggered fire (*supersedes_run_id* is None) is
-        atomic with the schedule's own cursor advance
-        (``create_schedule_run_and_advance()``) and always succeeds. A
-        recovery re-fire (*supersedes_run_id* set, by
-        ``_recover_undispatched_fires()``) is instead atomic with
-        tombstoning the orphan it replaces (``tombstone_and_replace_
-        schedule_run()``), and skips the cursor advance entirely -- the
-        cursor already moved when the orphan's own occurrence was first
-        recorded; a re-fire is not a new occurrence, just a fresh attempt
-        at the same one. See _fire_inner()'s delivery-contract docstring
-        for why these two writes must land atomically with their
-        respective counterpart.
-
-        Returns ``False`` only for the recovery path, when the orphan no
-        longer matched its expected status (raced away by something else,
-        e.g. the stale-run reaper, between the scan that found it and this
-        write) -- no replacement is inserted in that case, and *run* was
-        never durably recorded.
+        """Durably record one occurrence row -- the choke point both
+        _fire_inner() write sites go through. An ordinary fire is atomic
+        with the schedule's cursor advance; a recovery re-fire
+        (*supersedes_run_id* set) is instead atomic with tombstoning the
+        orphan it replaces, and skips the cursor advance. Returns ``False``
+        only for the recovery path, when the orphan no longer qualified for
+        tombstoning by the time this write landed -- nothing is inserted.
         """
         if supersedes_run_id is not None:
             applied = await self._svc.tombstone_and_replace_schedule_run(
@@ -1559,14 +1499,10 @@ class SchedulerEngine:
         return True
 
     async def _abandon_superseded_recovery_fire(self, inv_id: str, *, orphan_id: str) -> None:
-        """A recovery re-fire's occurrence write was refused because the
-        orphan it was meant to supersede (*orphan_id*) no longer matched
-        its expected status -- something else (the stale-run reaper, an
-        operator action) already resolved it between
-        _recover_undispatched_fires()'s scan and this write landing. No
-        schedule_run row was ever created for this attempt; only the
-        invocation _fire_inner() already durably created before reaching
-        that write needs cleaning up.
+        """A recovery re-fire's occurrence write was refused -- the orphan it
+        was meant to supersede no longer qualified by the time the write
+        landed. No schedule_run row was created for this attempt; only its
+        own invocation (never the orphan's) needs cleaning up.
         """
         _log.info(
             "Abandoning recovery re-fire for invocation %s: orphan %s was "
@@ -1604,67 +1540,21 @@ class SchedulerEngine:
         """Fire one occurrence of *schedule*.
 
         DELIVERY CONTRACT -- at-least-once up to confirmed process launch,
-        at-most-once past it. Three windows, three outcomes:
-
-        1. Before the transaction commits (below): a crash here leaves
-           neither the occurrence row nor the cursor move durable, so a
-           restart sees "never fired" and fires fresh. Never a duplicate.
-
-        2. Between the transaction committing and ``spawn_and_wait()``
-           confirming the external process actually launched (its
-           ``on_launched`` callback stamping ``dispatched_at``): the
-           occurrence row and cursor advance ARE durable, but the external
-           action was never attempted. Because the cursor already moved,
-           ordinary missed-fire recovery (``_check_missed_fires`` /
-           ``schedule_run_exists_since``) will never reconsider this
-           schedule as due again -- so a dedicated startup scan,
-           ``_recover_undispatched_fires()``, finds every top-level
-           (chain_depth == 0) ``status='running' AND dispatched_at IS
-           NULL`` row and re-fires it by calling back into THIS method
-           with *supersedes_run_id* set to the orphan's id.
-
-           That re-fire's own occurrence-insert transaction (below) does
-           double duty when *supersedes_run_id* is set: it tombstones the
-           orphan (``failed`` / ``RunReasons.FAILED_NEVER_DISPATCHED``) AND
-           inserts this fresh occurrence's row IN THE SAME TRANSACTION,
-           via ``tombstone_and_replace_schedule_run()`` instead of
-           ``create_schedule_run_and_advance()`` (and skips the cursor
-           advance entirely -- the cursor already moved when the orphan's
-           own occurrence was first recorded; a re-fire is not a new
-           occurrence, just a fresh attempt at the same one). Flipping the
-           orphan and inserting its replacement as two independent writes
-           would reopen exactly this window one level up: a crash between
-           them would leave the orphan durably terminal (dropped from any
-           future undispatched-scan) with no replacement ever recorded,
-           losing the occurrence for good. Atomic together, a crash here
-           can only ever leave the orphan exactly as it was -- still
-           'running', still undispatched, still visible to the next
-           recovery scan -- never flipped with nothing to show for it.
-
-           The re-fire carries the orphan's SAME ``trigger_context`` (it
-           never got to use it), so a github_poll event (or any other
-           occurrence-specific context) is retried faithfully rather than
-           generically. This is the at-least-once guarantee: an occurrence
-           that was committed to is retried until it is genuinely
-           attempted -- and each retry is itself covered by the same
-           guarantee, recursively, until one actually dispatches. Chain
-           children (chain_depth > 0) are tombstoned by
-           ``_recover_undispatched_fires()`` directly, without going
-           through this re-fire path at all -- narrower, accepted gap; the
-           parent occurrence's own outcome is unaffected, only a follow-on
-           on_success/on_fail step is lost.
-
-        3. After ``dispatched_at`` is confirmed: the external process
-           genuinely exists. A crash from here on is NOT retried -- the
-           row is left at status="running" until the schedule_runs reaper
-           (``lifecycle.reap_stale_schedule_runs``) or the run's own
-           terminal write resolves it to ``timed_out``/``completed``/
-           ``failed``. Re-firing here would risk running the same external
-           action twice (it may already be running independently in its
-           own process group, or have already finished) -- the explicit
-           at-most-once boundary of this contract, chosen because a
-           duplicate real-world side effect is worse than one lost/
-           unretried outcome once launch is confirmed.
+        at-most-once past it. Three windows: (1) before the occurrence
+        transaction commits, a crash leaves nothing durable, so a restart
+        fires fresh -- never a duplicate. (2) Between commit and
+        ``spawn_and_wait()`` confirming launch (``on_launched`` stamping
+        ``dispatched_at``), the row is durable but undispatched;
+        ``_recover_undispatched_fires()`` finds it on startup and re-fires
+        via *supersedes_run_id*, which routes the occurrence insert through
+        ``tombstone_and_replace_schedule_run()`` to tombstone the orphan and
+        insert the replacement atomically (its CAS also requires
+        ``dispatched_at IS NULL``, so a launch that gets confirmed in the
+        race against recovery wins and the tombstone is a no-op). (3) Once
+        ``dispatched_at`` is confirmed, the process genuinely exists and is
+        never re-fired -- the row is resolved by the stale-run reaper or its
+        own terminal write. This boundary is deliberate: a duplicate
+        real-world side effect is worse than one unretried outcome.
         """
         sid = schedule["id"]
         now = time.time()

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -338,6 +338,13 @@ class SchedulerEngine:
         past-due timestamp. Only schedules whose stored next_fire_at is
         still ahead of now — the timezone-migration correction case this
         hook exists for — are recomputed here.
+
+        This method never fires anything itself (it only rewrites a
+        not-yet-due next_fire_at), so it has no occurrence-insert to
+        reconcile against schedule_runs. Any due schedule always goes
+        through _check_missed_fires(), which is where that consultation
+        happens (schedule_run_exists_since() before queuing a recovery
+        fire — see its docstring for why).
         """
         try:
             schedules = await self._svc.list_schedules(enabled=True)
@@ -481,6 +488,34 @@ class SchedulerEngine:
             for s in schedules:
                 next_fire_at = s.get("next_fire_at")
                 if next_fire_at is None or next_fire_at > now:
+                    continue
+                # Recovery scan before recompute: with occurrence-insert +
+                # cursor-advance atomic (create_schedule_run_and_advance),
+                # a schedule_run row can only exist here for one of two
+                # reasons -- (a) the atomic transaction committed and then
+                # the process died before spawn_and_wait/its terminal write
+                # (next_fire_at should already be in the future in that
+                # case, so this branch shouldn't normally see it due at
+                # all), or (b) a pre-existing row from before this fix
+                # shipped, or some other write path, left an occurrence
+                # recorded without the cursor having moved. Either way,
+                # firing again here would double-execute the external
+                # action for an occurrence that already has a durable row
+                # -- so treat "already recorded" as evidence the slot was
+                # handled and just advance the cursor past it, the same
+                # bookkeeping _record_missed_fire_skip does, without
+                # queuing a second fire.
+                if await self._svc.schedule_run_exists_since(s["id"], next_fire_at):
+                    next_at = self._compute_next_fire(s, now)
+                    if next_at:
+                        try:
+                            await self._svc.update_schedule(s["id"], next_fire_at=next_at)
+                        except Exception:
+                            _log.exception(
+                                "Failed to advance next_fire_at past an already-recorded "
+                                "occurrence for schedule %s",
+                                s.get("id"),
+                            )
                     continue
                 policy = s.get("missed_fire_policy")
                 if policy == "run_once":
@@ -771,13 +806,27 @@ class SchedulerEngine:
                         trigger_context=ctx,
                         max_runs_claim=max_runs_claim,
                         global_slot_claim=slot_claim,
+                        # Advances github_cursor to this event's own
+                        # updated_at INSIDE the same atomic transaction as
+                        # this event's occurrence insert (_fire_inner ->
+                        # create_schedule_run_and_advance), durably before
+                        # spawn_and_wait() runs the actual action. This is
+                        # what closes the double-fire hazard: batching the
+                        # cursor write until after the whole loop (the old
+                        # shape, still mirrored below for trailing
+                        # non-dispatched items) left a window where 1..N
+                        # events could be fully fired and executed while the
+                        # persisted cursor still pointed before all of them,
+                        # so a crash mid-poll made the next poll re-fetch
+                        # and re-fire every already-executed event.
+                        extra_schedule_fields={"github_cursor": item.updated_at},
                     )
-                    # Only advance the cursor past a dispatchable event once
-                    # it has actually been fired — the invariant this
-                    # rewrite exists to hold. Any event left undispatched by
-                    # a break above (and everything after it, since PRs are
-                    # processed oldest-first) must be re-listed on the next
-                    # poll.
+                    # Track locally too, for the batched trailing-write
+                    # safety net below (covers only non-dispatched/filtered
+                    # items after the last fire, or an all-filtered poll
+                    # with no fire at all -- harmless/idempotent to re-write
+                    # the same value this event's own fire already
+                    # persisted).
                     cursor = item.updated_at
                 finally:
                     # slot_claim is None when MAX_SCHEDULED_CONCURRENT is
@@ -798,6 +847,14 @@ class SchedulerEngine:
                     dropped_prs,
                 )
 
+            # Safety-net batched write: every DISPATCHED event already
+            # advanced github_cursor atomically with its own occurrence
+            # insert above. This only still does work when the loop ends
+            # on non-dispatched/filtered items (dispatchable=False, cursor
+            # advances past them with no fire) or when nothing was fired
+            # at all -- both no-occurrence cases with nothing to be
+            # atomic with. For a dispatched item it re-writes the same
+            # value already committed, a harmless no-op.
             if cursor != schedule.get("github_cursor"):
                 await self._svc.update_schedule(sid, github_cursor=cursor)
         finally:
@@ -1249,6 +1306,7 @@ class SchedulerEngine:
         max_runs_claim: _MaxRunsClaim | None = None,
         global_slot_claim: _GlobalSlotClaim | None = None,
         threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
+        extra_schedule_fields: dict[str, Any] | None = None,
     ) -> None:
         """Thin wrapper around _fire_inner() that guarantees max_runs_claim,
         global_slot_claim, and threshold_cooldown_claim are each released
@@ -1262,6 +1320,11 @@ class SchedulerEngine:
         even when _fire_inner() blows up before ever reaching
         _check_max_runs() (e.g. create_invocation() raising), which is the
         leak this wrapper exists to close.
+
+        *extra_schedule_fields*: passed through to _fire_inner() -- only
+        _tick_github() uses this, to fold that event's github_cursor
+        advance into the SAME atomic transaction as its occurrence insert
+        (see _fire_inner()'s docstring).
         """
         try:
             await self._fire_inner(
@@ -1270,6 +1333,7 @@ class SchedulerEngine:
                 trigger_context=trigger_context,
                 chain_parent_id=chain_parent_id,
                 chain_depth=chain_depth,
+                extra_schedule_fields=extra_schedule_fields,
             )
         finally:
             if max_runs_claim is not None:
@@ -1313,7 +1377,26 @@ class SchedulerEngine:
         trigger_context: dict,
         chain_parent_id: str | None = None,
         chain_depth: int = 0,
+        extra_schedule_fields: dict[str, Any] | None = None,
     ) -> None:
+        """Fire one occurrence of *schedule*.
+
+        The occurrence-insert (``create_schedule_run``) and the schedule's
+        cursor advance (``last_fired_at``/``next_fire_at``, plus whatever
+        *extra_schedule_fields* adds -- e.g. ``github_cursor`` for a
+        github_poll event) land in a SINGLE transaction via
+        ``create_schedule_run_and_advance()``, executed BEFORE
+        ``spawn_and_wait()`` ever runs the external action. A crash at any
+        point before that transaction commits leaves neither the row nor
+        the cursor move durable, so a restart sees "never fired" and fires
+        fresh -- never a duplicate. A crash any time after it commits
+        (including mid-spawn) leaves a row + advanced cursor that will
+        never be re-derived as "still due" (closing the double-fire this
+        replaces), at the cost of the row staying at status="running"
+        until the schedule_runs reaper (lifecycle.reap_stale_schedule_runs)
+        or the run's own terminal write, whichever comes first, resolves
+        it.
+        """
         sid = schedule["id"]
         now = time.time()
 
@@ -1361,7 +1444,19 @@ class SchedulerEngine:
             _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             next_at = self._compute_next_fire(schedule, now)
-            await self._svc.create_schedule_run(
+            failed_schedule_fields: dict[str, Any] = {"last_fired_at": now}
+            if next_at:
+                failed_schedule_fields["next_fire_at"] = next_at
+            failed_schedule_fields.update(
+                self._threshold_alert_update_fields(schedule, chain_depth, now)
+            )
+            if extra_schedule_fields:
+                failed_schedule_fields.update(extra_schedule_fields)
+            # Occurrence-insert + cursor-advance atomic even on this
+            # invalid-action failure path -- otherwise a permanently
+            # misconfigured github_poll schedule would never advance its
+            # cursor past the offending event and re-fail it forever.
+            await self._svc.create_schedule_run_and_advance(
                 {
                     "id": run_id,
                     "schedule_id": sid,
@@ -1375,7 +1470,9 @@ class SchedulerEngine:
                     "fired_at": now,
                     "ended_at": _end_time,
                     "error_detail": str(exc),
-                }
+                },
+                schedule_id=sid,
+                schedule_fields=failed_schedule_fields,
             )
             written = await self._svc.update_status(
                 "schedule_run",
@@ -1428,11 +1525,8 @@ class SchedulerEngine:
                 # per-run_id map forever (it never gets a second flush call
                 # for this run_id to consume them).
                 self._signal_bus.pop_run_counters(run_id)
-            update_fields: dict[str, Any] = {"last_fired_at": now}
-            if next_at:
-                update_fields["next_fire_at"] = next_at
-            update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
-            await self._svc.update_schedule(sid, **update_fields)
+            # last_fired_at/next_fire_at (and any extra_schedule_fields)
+            # already landed atomically with the occurrence insert above.
             await self._check_max_runs(schedule, chain_depth)
             return
 
@@ -1440,7 +1534,22 @@ class SchedulerEngine:
         # cancellation in the DB ops below, before spawn_and_wait() runs.
         # suppress(OSError) makes double-unlink (spawn_and_wait already cleaned up) safe.
         try:
-            await self._svc.create_schedule_run(
+            next_at = self._compute_next_fire(schedule, now)
+            update_fields: dict[str, Any] = {"last_fired_at": now}
+            if next_at:
+                update_fields["next_fire_at"] = next_at
+            update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
+            if extra_schedule_fields:
+                update_fields.update(extra_schedule_fields)
+
+            # Occurrence-insert + cursor-advance MUST land atomically: a
+            # crash between two independently-committed writes here is
+            # exactly what let a restart re-derive "still due" for an
+            # occurrence that was already durably recorded (double-fire).
+            # spawn_and_wait() below always runs AFTER this transaction
+            # commits, never inside it, so a crash before this call can at
+            # worst discard an occurrence that was never durably recorded.
+            await self._svc.create_schedule_run_and_advance(
                 {
                     "id": run_id,
                     "schedule_id": sid,
@@ -1452,7 +1561,9 @@ class SchedulerEngine:
                     "chain_parent_id": chain_parent_id,
                     "chain_depth": chain_depth,
                     "fired_at": now,
-                }
+                },
+                schedule_id=sid,
+                schedule_fields=update_fields,
             )
             await self._svc.update_status(
                 "schedule_run",
@@ -1468,13 +1579,6 @@ class SchedulerEngine:
 
             if chain_depth == 0:
                 self._running[sid] = run_id
-
-            next_at = self._compute_next_fire(schedule, now)
-            update_fields = {"last_fired_at": now}
-            if next_at:
-                update_fields["next_fire_at"] = next_at
-            update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
-            await self._svc.update_schedule(sid, **update_fields)
 
             _log.info(
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import sys
 import tempfile
+from collections.abc import Awaitable, Callable
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
@@ -552,6 +553,7 @@ async def spawn_and_wait(
     tmp_path: str | None = None,
     cwd: str | None = None,
     action_kind: str | None = None,
+    on_launched: Callable[[], Awaitable[None]] | None = None,
 ) -> tuple[int, str]:
     """Spawn subprocess and wait for completion. Returns (exit_code, stderr_tail).
 
@@ -573,6 +575,16 @@ async def spawn_and_wait(
     does not stop a spawn checked only at build_argv time. Passing
     *action_kind* here closes that gap: the check runs with no intervening
     await before ``create_subprocess_exec``.
+
+    *on_launched*, if given, is awaited immediately after
+    ``create_subprocess_exec`` returns -- i.e. once the OS process genuinely
+    exists -- and before waiting on its completion. The scheduler engine uses
+    this to durably mark a schedule_run "dispatched" the moment launch is
+    confirmed, closing the window a delivery-contract recovery scan would
+    otherwise treat as "committed but never launched" (see
+    SchedulerEngine._fire_inner). A failing callback is logged and swallowed,
+    never allowed to fail (or duplicate-spawn) the process that already
+    launched.
     """
     if action_kind == "command":
         command = argv[0] if argv else ""
@@ -594,6 +606,16 @@ async def spawn_and_wait(
         start_new_session=True,
     )
     # Pgid == proc.pid; pid-guard and platform check live in aterminate_process_group.
+
+    if on_launched is not None:
+        try:
+            await on_launched()
+        except Exception:
+            _log.exception(
+                "on_launched callback failed for invocation %s; the process "
+                "is already running regardless",
+                invocation_id,
+            )
 
     try:
         _, stderr = await proc.communicate()

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -453,13 +453,103 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
     return reaped
 
 
+# ── schedule_run staleness reaper ─────────────────────────────────────────────
+
+
+async def reap_stale_schedule_runs(*, stale_hours: float | None = None) -> int:
+    """Transition ``schedule_runs`` rows stuck at ``status="running"`` to
+    ``timed_out``.
+
+    A schedule_run row is created and its owning schedule's cursor
+    (``next_fire_at``/``github_cursor``) advanced atomically in the same
+    transaction (``StateDB.create_schedule_run_and_advance``), so by the
+    time this row is durable the scheduler has already committed to firing
+    it -- but the process can still die anywhere between that commit and
+    the run's own terminal write (mid-spawn, or before
+    ``update_schedule_run``'s exit-code write lands), leaving the row
+    orphaned at ``running`` forever. ``count_schedule_runs()`` already
+    excludes ``running`` from budget bookkeeping, so these rows are
+    harmless for max_runs, but they are audit-trail zombies that (unlike
+    stale sessions/plays) have no process-liveness signal to check against
+    -- the "process" here is the scheduler daemon itself, and its own
+    restart is what triggers reaping. This is a pure wall-clock deadline
+    against the row's own ``updated_at`` (falling back to ``fired_at`` for
+    a row that was never otherwise touched), mirroring
+    ``reap_stale_invocations``'s deadline condition, with the version guard
+    (``expected_updated_at``) revalidating the row hasn't moved between the
+    scan and the write -- the same optimistic-lock pattern
+    ``reap_stale_plays`` uses.
+    """
+    from lionagi.studio.config import SCHEDULE_RUN_STALE_HOURS
+
+    if stale_hours is None:
+        stale_hours = SCHEDULE_RUN_STALE_HOURS
+    stale_seconds = stale_hours * 3600
+
+    if not DEFAULT_DB_PATH.exists():
+        return 0
+
+    now = time.time()
+    deadline_cutoff = now - stale_seconds
+    reaped = 0
+
+    try:
+        async with StateDB() as db:
+            rows = await db.fetch_all(
+                "SELECT id, fired_at, updated_at FROM schedule_runs WHERE status = 'running'"
+            )
+            for row in rows:
+                run_id = row["id"]
+                fired_at = row.get("fired_at") or now
+                updated_at_raw = row.get("updated_at")
+                reference = updated_at_raw if updated_at_raw is not None else fired_at
+                if reference >= deadline_cutoff:
+                    continue
+
+                _log.info(
+                    "Reaping stale schedule_run %s: running past deadline (%.1fh)",
+                    run_id,
+                    stale_hours,
+                )
+                try:
+                    transitioned = await db.update_status(
+                        "schedule_run",
+                        run_id,
+                        new_status="timed_out",
+                        reason_code=RunReasons.TIMED_OUT_DEADLINE,
+                        reason_summary="schedule_run_stale_running_reaped",
+                        evidence_refs=[{"kind": "schedule_run", "id": run_id}],
+                        source="system",
+                        actor="studio_lifecycle_reaper",
+                        metadata={
+                            "stale_hours": stale_hours,
+                            "fired_at": fired_at,
+                            "reference": reference,
+                        },
+                        expected_statuses={"running"},
+                        expected_updated_at=updated_at_raw,
+                    )
+                    if transitioned:
+                        reaped += 1
+                    else:
+                        _log.debug(
+                            "schedule_run %s skipped (status changed before CAS lock)", run_id
+                        )
+                except LookupError:
+                    pass
+    except Exception:
+        _log.exception("reap_stale_schedule_runs error")
+
+    return reaped
+
+
 # ── Startup + periodic entry points ──────────────────────────────────────────
 
 
 async def run_startup_reconciliation() -> dict[str, int]:
     """One-shot reconciliation called on Studio startup.
 
-    Runs all three reapers so stale rows left from an unclean shutdown are
+    Runs all reapers so stale rows left from an unclean shutdown are
     cleaned up before the scheduler begins firing new invocations.
     """
     results: dict[str, int] = {}
@@ -483,6 +573,11 @@ async def run_startup_reconciliation() -> dict[str, int]:
     except Exception:
         _log.exception("Startup play reaper failed")
         results["stale_plays"] = 0
+    try:
+        results["stale_schedule_runs"] = await reap_stale_schedule_runs()
+    except Exception:
+        _log.exception("Startup schedule_run reaper failed")
+        results["stale_schedule_runs"] = 0
     if any(v for v in results.values()):
         _log.info("Startup reconciliation: %s", results)
     return results
@@ -516,6 +611,11 @@ async def run_periodic_reapers(now: float | None = None) -> dict[str, int]:
     except Exception:
         _log.exception("Periodic play reaper failed")
         results["stale_plays"] = 0
+    try:
+        results["stale_schedule_runs"] = await reap_stale_schedule_runs()
+    except Exception:
+        _log.exception("Periodic schedule_run reaper failed")
+        results["stale_schedule_runs"] = 0
     return results
 
 

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -479,6 +479,17 @@ async def reap_stale_schedule_runs(*, stale_hours: float | None = None) -> int:
     (``expected_updated_at``) revalidating the row hasn't moved between the
     scan and the write -- the same optimistic-lock pattern
     ``reap_stale_plays`` uses.
+
+    Scoped to ``schedule_id IS NOT NULL`` -- scheduler-fired occurrence
+    rows only. schedule_runs also backs the ad-hoc task queue (schedule_id
+    IS NULL, claimed via a lease: ``leased_by``/``lease_expires_at``/
+    ``lease_attempts``), which has its own recovery loop and policy
+    (``worker.reap_expired_leases``, run every ``worker_tick``): a task
+    whose lease is still live but has been running longer than this
+    reaper's stale window would otherwise get marked ``timed_out`` here
+    before the lease even expires, bypassing the lease's own
+    requeue/retry-budget semantics entirely. Excluding those rows leaves
+    them exclusively to the lease reaper.
     """
     from lionagi.studio.config import SCHEDULE_RUN_STALE_HOURS
 
@@ -496,7 +507,8 @@ async def reap_stale_schedule_runs(*, stale_hours: float | None = None) -> int:
     try:
         async with StateDB() as db:
             rows = await db.fetch_all(
-                "SELECT id, fired_at, updated_at FROM schedule_runs WHERE status = 'running'"
+                "SELECT id, fired_at, updated_at FROM schedule_runs "
+                "WHERE status = 'running' AND schedule_id IS NOT NULL"
             )
             for row in rows:
                 run_id = row["id"]

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -49,6 +49,14 @@ class SchedulerStateService(Protocol):
 
     async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]: ...
 
+    async def tombstone_and_replace_schedule_run(
+        self,
+        orphan_id: str,
+        replacement_run: dict[str, Any],
+        *,
+        expected_orphan_status: str = "running",
+    ) -> bool: ...
+
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
 
     async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
@@ -129,6 +137,20 @@ class _DBSchedulerStateService:
     async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]:
         async with StateDB() as db:
             return await db.list_undispatched_schedule_runs()
+
+    async def tombstone_and_replace_schedule_run(
+        self,
+        orphan_id: str,
+        replacement_run: dict[str, Any],
+        *,
+        expected_orphan_status: str = "running",
+    ) -> bool:
+        async with StateDB() as db:
+            return await db.tombstone_and_replace_schedule_run(
+                orphan_id,
+                replacement_run,
+                expected_orphan_status=expected_orphan_status,
+            )
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -47,6 +47,8 @@ class SchedulerStateService(Protocol):
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool: ...
 
+    async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]: ...
+
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
 
     async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
@@ -123,6 +125,10 @@ class _DBSchedulerStateService:
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:
         async with StateDB() as db:
             return await db.schedule_run_exists_since(schedule_id, since)
+
+    async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.list_undispatched_schedule_runs()
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -37,6 +37,16 @@ class SchedulerStateService(Protocol):
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
 
+    async def create_schedule_run_and_advance(
+        self,
+        run: dict[str, Any],
+        *,
+        schedule_id: str,
+        schedule_fields: dict[str, Any],
+    ) -> None: ...
+
+    async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool: ...
+
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
 
     async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
@@ -97,6 +107,22 @@ class _DBSchedulerStateService:
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         async with StateDB() as db:
             await db.create_schedule_run(run)
+
+    async def create_schedule_run_and_advance(
+        self,
+        run: dict[str, Any],
+        *,
+        schedule_id: str,
+        schedule_fields: dict[str, Any],
+    ) -> None:
+        async with StateDB() as db:
+            await db.create_schedule_run_and_advance(
+                run, schedule_id=schedule_id, schedule_fields=schedule_fields
+            )
+
+    async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:
+        async with StateDB() as db:
+            return await db.schedule_run_exists_since(schedule_id, since)
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None:
         async with StateDB() as db:

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -416,7 +416,9 @@ class TestFireCancellationRecorded:
 
         started = asyncio.Event()
 
-        async def blocking_spawn(argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None):
+        async def blocking_spawn(
+            argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None, on_launched=None
+        ):
             started.set()
             await asyncio.Event().wait()  # block until the _fire task is cancelled
 

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -81,6 +81,44 @@ async def _seed_schedule_run(
     return rid
 
 
+async def _seed_leased_task_row(
+    db_path: Path,
+    *,
+    run_id: str | None = None,
+    status: str = "running",
+    fired_at: float | None = None,
+    updated_at: float | None = None,
+    lease_expires_at: float | None = None,
+) -> str:
+    """Seed an ad-hoc task-queue row: schedule_id IS NULL, claimed via the
+    lease columns worker.py's own reap_expired_leases() consults -- distinct
+    from a scheduler-fired occurrence row."""
+    rid = run_id or str(uuid.uuid4())
+    now = time.time()
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run(
+            {
+                "id": rid,
+                "schedule_id": None,
+                "trigger_context": {"source": "task_queue"},
+                "action_kind": "agent",
+                "action_args": {"prompt": "do the thing"},
+                "status": status,
+                "fired_at": fired_at or now,
+            }
+        )
+        await db.execute(
+            "UPDATE schedule_runs SET leased_by = ?, lease_expires_at = ? WHERE id = ?",
+            ("worker-1", lease_expires_at, rid),
+        )
+        if updated_at is not None:
+            await db.execute(
+                "UPDATE schedule_runs SET updated_at = ? WHERE id = ?",
+                (updated_at, rid),
+            )
+    return rid
+
+
 async def _get_schedule_run(db_path: Path, run_id: str) -> dict | None:
     async with StateDB(db_path) as db:
         return await db.get_schedule_run(run_id)
@@ -144,6 +182,41 @@ def test_reap_stale_schedule_runs_skips_terminal_status(tmp_path, monkeypatch):
 
     run = run_async(_get_schedule_run(db_path, run_id))
     assert run["status"] == "completed"
+
+
+def test_reap_stale_schedule_runs_excludes_leased_task_queue_rows(tmp_path, monkeypatch):
+    """schedule_runs also backs the ad-hoc task queue (schedule_id IS NULL,
+    claimed via leased_by/lease_expires_at) which worker.reap_expired_leases()
+    already owns via its own lease-attempts retry policy. A leased task row
+    stuck at 'running' past this reaper's stale window must survive
+    untouched -- reaping it here would mark it timed_out before the lease
+    even expires, bypassing the lease's requeue/retry-budget semantics
+    entirely. A scheduler-fired row (schedule_id set) in the same scan must
+    still be reaped as usual."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    task_run_id = run_async(
+        _seed_leased_task_row(
+            db_path,
+            status="running",
+            updated_at=_STALE,
+            lease_expires_at=time.time() + 3600,  # lease still live
+        )
+    )
+    sid = run_async(_seed_schedule(db_path))
+    sched_run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 1
+
+    task_run = run_async(_get_schedule_run(db_path, task_run_id))
+    assert task_run["status"] == "running"
+
+    sched_run = run_async(_get_schedule_run(db_path, sched_run_id))
+    assert sched_run["status"] == "timed_out"
 
 
 def test_reap_stale_schedule_runs_falls_back_to_fired_at_when_never_touched(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the schedule_runs staleness reaper.
+
+A schedule_run row has no process-liveness signal to check against (the
+"process" is the scheduler daemon itself, and its own restart is what
+triggers reaping), so this reaper is a pure wall-clock deadline against the
+row's own updated_at/fired_at, guarded by the same optimistic-lock
+(expected_updated_at) pattern reap_stale_plays uses.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+from ._helpers import run_async
+
+
+def _monkey_db(monkeypatch, db_path: Path) -> None:
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
+    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+
+
+async def _seed_schedule(db_path: Path, *, schedule_id: str | None = None) -> str:
+    sid = schedule_id or str(uuid.uuid4())
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            {
+                "id": sid,
+                "name": f"sched-{sid[:8]}",
+                "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
+                "action_kind": "agent",
+                "action_model": "gpt-4.1-mini",
+                "action_prompt": "ping",
+            }
+        )
+    return sid
+
+
+async def _seed_schedule_run(
+    db_path: Path,
+    schedule_id: str,
+    *,
+    run_id: str | None = None,
+    status: str = "running",
+    fired_at: float | None = None,
+    updated_at: float | None = None,
+) -> str:
+    rid = run_id or str(uuid.uuid4())
+    now = time.time()
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run(
+            {
+                "id": rid,
+                "schedule_id": schedule_id,
+                "trigger_context": {"source": "cron"},
+                "action_kind": "agent",
+                "action_args": {"prompt": "ping"},
+                "status": status,
+                "fired_at": fired_at or now,
+            }
+        )
+        if updated_at is not None:
+            await db.execute(
+                "UPDATE schedule_runs SET updated_at = ? WHERE id = ?",
+                (updated_at, rid),
+            )
+    return rid
+
+
+async def _get_schedule_run(db_path: Path, run_id: str) -> dict | None:
+    async with StateDB(db_path) as db:
+        return await db.get_schedule_run(run_id)
+
+
+_STALE = time.time() - 100 * 3600  # 100h ago, well past any reasonable stale_hours
+
+
+def test_reap_stale_schedule_runs_transitions_stuck_running_row(tmp_path, monkeypatch):
+    """(d) A schedule_run stuck at status='running' with an old updated_at
+    is transitioned to 'timed_out' -- the terminal status a crashed-mid-fire
+    occurrence should land in once the daemon restarts and the reaper scans."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 1
+
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run is not None
+    assert run["status"] == "timed_out"
+    assert run["status_reason_code"] == "run.timed_out.deadline"
+
+
+def test_reap_stale_schedule_runs_skips_fresh_running_row(tmp_path, monkeypatch):
+    """A running row updated recently (well inside the stale window) is left
+    alone -- it may still be legitimately in flight."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=time.time()))
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 0
+
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run["status"] == "running"
+
+
+def test_reap_stale_schedule_runs_skips_terminal_status(tmp_path, monkeypatch):
+    """A row already in a terminal status is outside the reapable set and
+    left untouched, even if stale by wall clock."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="completed", updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 0
+
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run["status"] == "completed"
+
+
+def test_reap_stale_schedule_runs_falls_back_to_fired_at_when_never_touched(tmp_path, monkeypatch):
+    """A row that was inserted and never subsequently touched has
+    updated_at=NULL (create_schedule_run's INSERT does not set it) -- the
+    reaper must fall back to fired_at rather than treating a NULL
+    updated_at as "just touched, not stale"."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="running", fired_at=_STALE))
+
+    run_before = run_async(_get_schedule_run(db_path, run_id))
+    assert run_before["updated_at"] is None
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 1
+
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run["status"] == "timed_out"
+
+
+def test_reap_stale_schedule_runs_version_guard_skips_row_touched_between_scan_and_write(
+    tmp_path, monkeypatch
+):
+    """A row that is legitimately touched (e.g. its terminal write lands)
+    between the reaper's scan and its guarded write must not be
+    clobbered -- update_status()'s expected_updated_at optimistic-lock
+    guard sees the row's updated_at no longer matches the snapshot the
+    reaper scanned and skips the transition, mirroring
+    reap_stale_plays_cas_guard_skips_concurrently_transitioned_row."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=_STALE))
+
+    import lionagi.state.db as state_db_mod
+
+    original_update_status = state_db_mod.StateDB.update_status
+    flipped = {"done": False}
+
+    async def _flip_then_call(self, entity_type, entity_id, **kwargs):
+        if entity_type == "schedule_run" and entity_id == run_id and not flipped["done"]:
+            flipped["done"] = True
+            # Simulate a concurrent legitimate write landing first (e.g.
+            # the run's own terminal update_schedule_run() call) -- bumps
+            # updated_at so the reaper's stale snapshot is now out of date.
+            await self.execute(
+                "UPDATE schedule_runs SET status = 'completed', updated_at = ? WHERE id = ?",
+                (time.time(), entity_id),
+            )
+        return await original_update_status(self, entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(state_db_mod.StateDB, "update_status", _flip_then_call)
+
+    from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+    count = run_async(reap_stale_schedule_runs(stale_hours=6.0))
+    assert count == 0
+
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run["status"] == "completed"
+
+
+def test_run_startup_reconciliation_includes_stale_schedule_runs_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    from lionagi.studio.services.lifecycle import run_startup_reconciliation
+
+    results = run_async(run_startup_reconciliation())
+    assert "stale_schedule_runs" in results
+    assert isinstance(results["stale_schedule_runs"], int)
+
+
+def test_run_periodic_reapers_includes_stale_schedule_runs_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    from lionagi.studio.services.lifecycle import run_periodic_reapers
+
+    results = run_async(run_periodic_reapers())
+    assert "stale_schedule_runs" in results
+    assert isinstance(results["stale_schedule_runs"], int)

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -219,6 +219,67 @@ def test_reap_stale_schedule_runs_excludes_leased_task_queue_rows(tmp_path, monk
     assert sched_run["status"] == "timed_out"
 
 
+def test_pre_terminal_write_bumps_updated_at_so_reaper_does_not_race_completion(
+    tmp_path, monkeypatch
+):
+    """A schedule_run legitimately running past the stale window is about
+    to finish: _fire_inner() first writes exit_code/ended_at via
+    update_schedule_run() (fields-only, no status), then transitions the
+    row to its terminal status via update_status(). If a periodic reaper
+    scan landed in that gap while the row's updated_at was still the old
+    stale snapshot, its expected_updated_at guard would still match and it
+    could mark the row timed_out out from under the run that is in the
+    middle of legitimately completing.
+
+    update_schedule_run()'s field-only write now bumps updated_at on every
+    call (mirroring update_status()'s own behavior), so a reaper scan
+    landing in this exact window sees a fresh updated_at and skips the row
+    outright -- it never even reaches the CAS write. This directly
+    simulates that interleaving: seed a stale running row, perform the
+    pre-terminal field write, run the reaper, then perform the terminal
+    transition -- the row must land in its true terminal status, not
+    timed_out.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(_seed_schedule(db_path))
+    run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=_STALE))
+
+    async def _interleaving():
+        async with StateDB(db_path) as db:
+            # Pre-terminal write: exit_code/ended_at land while status is
+            # still "running" -- exactly what _fire_inner() does right
+            # before its terminal update_status() call.
+            await db.update_schedule_run(run_id, exit_code=0, ended_at=time.time())
+
+        from lionagi.studio.services.lifecycle import reap_stale_schedule_runs
+
+        # A periodic reaper tick lands in the gap between the field write
+        # and the terminal status transition.
+        count = await reap_stale_schedule_runs(stale_hours=6.0)
+
+        async with StateDB(db_path) as db:
+            # Terminal transition, as _fire_inner() performs it next.
+            await db.update_status(
+                "schedule_run",
+                run_id,
+                new_status="completed",
+                reason_code="run.completed.ok",
+                reason_summary="Scheduled process completed successfully.",
+                source="executor",
+                actor=run_id,
+                expected_statuses={"running"},
+            )
+        return count
+
+    count = run_async(_interleaving())
+
+    assert count == 0  # the reaper skipped it -- updated_at was fresh
+    run = run_async(_get_schedule_run(db_path, run_id))
+    assert run["status"] == "completed"
+
+
 def test_reap_stale_schedule_runs_falls_back_to_fired_at_when_never_touched(tmp_path, monkeypatch):
     """A row that was inserted and never subsequently touched has
     updated_at=NULL (create_schedule_run's INSERT does not set it) -- the

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -757,6 +757,11 @@ _EXCLUDED_COLUMNS = {
     # for a schedule-spawned run); excluded here for the same reason as the
     # D2 columns above.
     "lease_attempts",
+    # Delivery-contract marker (see schema.sql) — additive, asserted
+    # separately (must be NULL for a schedule-spawned run that hasn't
+    # confirmed dispatch); excluded here for the same reason as the D2
+    # columns above.
+    "dispatched_at",
 }
 
 
@@ -809,6 +814,7 @@ async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
         "execution_target",
         "library_ref",
         "library_content_hash",
+        "dispatched_at",
     ):
         assert row_after_create[col] is None
     # ADR-0071 D4 additive column — defaults to 0, not NULL.

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -49,6 +49,8 @@ def _make_svc() -> AsyncMock:
     svc.list_schedules = AsyncMock(return_value=[])
     svc.update_schedule = AsyncMock()
     svc.create_schedule_run = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
     svc.update_schedule_run = AsyncMock()
     svc.create_invocation = AsyncMock()
     svc.update_invocation = AsyncMock()
@@ -197,7 +199,14 @@ async def test_fire_happy_path_records_invocation_and_run():
         await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
 
     svc.create_invocation.assert_awaited_once()
-    svc.create_schedule_run.assert_awaited_once()
+    # Occurrence-insert + cursor-advance land together, atomically, through
+    # create_schedule_run_and_advance() -- not two separate service calls.
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
+    (run_payload,), kwargs = svc.create_schedule_run_and_advance.await_args
+    assert run_payload["status"] == "running"
+    assert kwargs["schedule_id"] == "sched-001"
+    assert "last_fired_at" in kwargs["schedule_fields"]
     svc.update_schedule_run.assert_awaited_once()
     # update_status called for schedule_run AND invocation
     assert svc.update_status.await_count == 3  # running + completed + invocation
@@ -205,7 +214,11 @@ async def test_fire_happy_path_records_invocation_and_run():
     # flush_run_telemetry's read-modify-write of node_metadata["coordination"]
     # after the invocation's terminal write lands (see scheduler_state.py).
     assert svc.update_invocation.await_count == 2
-    svc.update_schedule.assert_awaited()
+    # update_schedule() itself isn't called for a plain fire -- its old job
+    # (last_fired_at/next_fire_at) now rides create_schedule_run_and_advance's
+    # schedule_fields above; update_schedule stays for other paths (backfill,
+    # max_runs auto-disable, etc.).
+    svc.update_schedule.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -285,8 +298,9 @@ async def test_fire_executable_resolution_failure_records_failed_run_with_action
         await engine._fire(schedule, "run-003", trigger_context={"scheduled": True})
 
     spawn_mock.assert_not_awaited()
-    svc.create_schedule_run.assert_awaited_once()
-    (run_payload,), _kwargs = svc.create_schedule_run.await_args
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
+    (run_payload,), _kwargs = svc.create_schedule_run_and_advance.await_args
     assert run_payload["status"] == "failed"
     assert "resolve" in run_payload["error_detail"]
     assert "shutil.which" in run_payload["error_detail"]
@@ -344,7 +358,8 @@ async def test_fire_build_argv_exception_records_failed_run():
         await engine._fire(schedule, "run-003", trigger_context={"scheduled": True})
 
     mock_spawn.assert_not_awaited()
-    svc.create_schedule_run.assert_awaited_once()
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     failed_calls = [
         c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "failed"
     ]
@@ -1876,6 +1891,16 @@ class _StatefulSvc:
     async def create_schedule_run(self, run):
         self.runs[run["id"]] = dict(run)
 
+    async def create_schedule_run_and_advance(self, run, *, schedule_id, schedule_fields):
+        self.runs[run["id"]] = dict(run)
+        self.schedule_updates.append((schedule_id, dict(schedule_fields)))
+
+    async def schedule_run_exists_since(self, schedule_id, since):
+        return any(
+            r.get("schedule_id") == schedule_id and (r.get("fired_at") or 0) >= since
+            for r in self.runs.values()
+        )
+
     async def update_schedule_run(self, run_id, **fields):
         self.runs[run_id].update(fields)
 
@@ -2164,13 +2189,13 @@ async def test_fire_command_kind_skips_li_resolution():
         await engine._fire(schedule, "run-cmd-001", trigger_context={"scheduled": True})
 
     resolve_mock.assert_not_called()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     failed_calls = [
         c
         for c in svc.update_status.await_args_list
         if c.args[0] == "schedule_run" and c.kwargs.get("new_status") == "failed"
     ]
     assert not failed_calls, "command-kind fire must not fail from a missing `li` resolution"
-    svc.create_schedule_run.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -51,6 +51,7 @@ def _make_svc() -> AsyncMock:
     svc.create_schedule_run = AsyncMock()
     svc.create_schedule_run_and_advance = AsyncMock()
     svc.schedule_run_exists_since = AsyncMock(return_value=False)
+    svc.list_undispatched_schedule_runs = AsyncMock(return_value=[])
     svc.update_schedule_run = AsyncMock()
     svc.create_invocation = AsyncMock()
     svc.update_invocation = AsyncMock()

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -52,6 +52,8 @@ def _make_svc() -> AsyncMock:
     svc.list_schedules = AsyncMock(return_value=[])
     svc.update_schedule = AsyncMock()
     svc.create_schedule_run = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
     svc.update_schedule_run = AsyncMock()
     svc.create_invocation = AsyncMock()
     svc.update_invocation = AsyncMock()
@@ -122,15 +124,30 @@ async def test_multi_event_poll_fires_once_per_dispatchable_event():
 
     # One create_invocation per dispatched event -- not one for the whole batch.
     assert svc.create_invocation.await_count == 3
+    # Occurrence-insert + cursor-advance land atomically through
+    # create_schedule_run_and_advance() now, not a bare create_schedule_run().
     contexts = [
         call.args[0]["trigger_context"]["github_events"]
-        for call in svc.create_schedule_run.await_args_list
+        for call in svc.create_schedule_run_and_advance.await_args_list
     ]
     assert [ctx[0]["pr_number"] for ctx in contexts] == [1, 2, 3]
     for ctx in contexts:
         assert len(ctx) == 1  # each fire's trigger_context carries exactly its own event
 
-    # Cursor advances to the newest dispatched event.
+    # Each event's own atomic call advances github_cursor to its own updated_at.
+    github_cursors = [
+        call.kwargs["schedule_fields"]["github_cursor"]
+        for call in svc.create_schedule_run_and_advance.await_args_list
+    ]
+    assert github_cursors == [
+        "2026-07-07T10:00:00Z",
+        "2026-07-07T11:00:00Z",
+        "2026-07-07T12:00:00Z",
+    ]
+
+    # Trailing safety-net batched write still lands on the newest event too
+    # (harmless re-write of what the last event's own atomic call already
+    # persisted).
     svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T12:00:00Z")
     assert engine._global_inflight == 0
 
@@ -158,9 +175,10 @@ async def test_single_event_poll_behavior_unchanged():
         await engine._tick_github(schedule, now=10_000.0)
 
     assert svc.create_invocation.await_count == 1
-    (run_payload,), _ = svc.create_schedule_run.await_args
+    (run_payload,), kwargs = svc.create_schedule_run_and_advance.await_args
     assert [e["pr_number"] for e in run_payload["trigger_context"]["github_events"]] == [7]
     assert run_payload["trigger_context"]["repo"] == "acme/widgets"
+    assert kwargs["schedule_fields"]["github_cursor"] == "2026-07-07T10:00:00Z"
     svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T10:00:00Z")
     assert engine._global_inflight == 0
 
@@ -175,11 +193,11 @@ async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(ca
     svc = _make_svc()
     fired = 0
 
-    async def _create_schedule_run(_payload):
+    async def _create_schedule_run_and_advance(_payload, *, schedule_id, schedule_fields):
         nonlocal fired
         fired += 1
 
-    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
 
     engine = SchedulerEngine(svc=svc)
@@ -379,11 +397,11 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
     svc = _make_svc()
     fired = 0
 
-    async def _create_schedule_run(_payload):
+    async def _create_schedule_run_and_advance(_payload, *, schedule_id, schedule_fields):
         nonlocal fired
         fired += 1
 
-    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
 
     engine = SchedulerEngine(svc=svc)
@@ -460,10 +478,10 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     svc = _make_svc()
     fired_prs: list[int] = []
 
-    async def _create_schedule_run(payload):
+    async def _create_schedule_run_and_advance(payload, *, schedule_id, schedule_fields):
         fired_prs.append(payload["trigger_context"]["github_events"][0]["pr_number"])
 
-    svc.create_schedule_run = AsyncMock(side_effect=_create_schedule_run)
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: len(fired_prs))
 
     engine = SchedulerEngine(svc=svc)

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -719,3 +719,128 @@ async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypat
     assert statuses["run-orphaned"] == "failed"
     replacement_id = next(rid for rid in statuses if rid != "run-orphaned")
     assert statuses[replacement_id] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirmed(tmp_path):
+    """The CAS predicate must require dispatched_at IS NULL, not just
+    status='running'. A launch confirmation (dispatched_at stamped, status
+    unchanged -- see _mark_dispatched()) landing between a recovery scan and
+    this write means the row is no longer undispatched; tombstoning it and
+    inserting a replacement would flip a run that actually launched to
+    'failed' and fire a duplicate. Reviewer repro: dispatched_at already set
+    on the orphan before the call -- must refuse (applied=False), inserting
+    nothing.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-dispatched-race"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-live", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        # Launch confirmed -- status stays 'running', only dispatched_at
+        # moves (mirrors spawn_and_wait's on_launched callback).
+        await db.update_schedule_run("run-live", dispatched_at=1000.5)
+
+    async with StateDB(db_path) as db:
+        applied = await db.tombstone_and_replace_schedule_run(
+            "run-live",
+            _run_row("run-replacement", sid, fired_at=1500.0),
+            expected_orphan_status="running",
+        )
+        live = await db.get_schedule_run("run-live")
+        replacement = await db.get_schedule_run("run-replacement")
+
+    assert applied is False
+    assert live["status"] == "running"
+    assert live["dispatched_at"] == 1000.5
+    assert replacement is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path, monkeypatch):
+    """The reviewer-specified race: recovery's scan finds "run-live" as
+    undispatched, but a concurrently-confirmed launch (dispatched_at
+    stamped) lands after the scan and before the recovery re-fire's own
+    atomic write. The strengthened CAS makes that write a no-op, so the
+    live run must come out completely untouched -- still 'running', its
+    dispatched_at preserved, no replacement row -- and the abandonment path
+    must cancel ONLY the pre-spawn recovery invocation it created for this
+    doomed attempt, never the live run's own (separate, still-running)
+    invocation.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-race"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_invocation({"id": "inv-live", "skill": "test", "started_at": 1000.0})
+        await db.create_schedule_run_and_advance(
+            _run_row("run-live", sid, fired_at=1000.0, invocation_id="inv-live"),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    original_create_invocation = svc.create_invocation
+    recovery_inv_ids: list[str] = []
+
+    async def _create_invocation_then_confirm_launch(invocation):
+        # Recovery already scanned and decided to re-fire "run-live" by the
+        # time this runs (it is _fire_inner()'s very first durable write for
+        # the re-fire attempt). Simulate a concurrent scheduler -- or the
+        # original background task -- confirming the ORIGINAL launch right
+        # here, strictly between the scan and the re-fire's own atomic
+        # tombstone-and-replace write further down in _fire_inner().
+        recovery_inv_ids.append(invocation["id"])
+        await original_create_invocation(invocation)
+        await svc.update_schedule_run("run-live", dispatched_at=1234.5)
+
+    with (
+        patch.object(svc, "create_invocation", side_effect=_create_invocation_then_confirm_launch),
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["true"], None),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.build_argv", return_value=(["true"], None)),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._recover_undispatched_fires()
+        if engine._fire_tasks:
+            await asyncio.gather(*engine._fire_tasks)
+
+    assert len(recovery_inv_ids) == 1
+    recovery_inv_id = recovery_inv_ids[0]
+
+    async with StateDB(db_path) as db:
+        live = await db.get_schedule_run("run-live")
+        runs = await db.list_schedule_runs(sid)
+        live_invocation = await db.get_invocation("inv-live")
+        recovery_invocation = await db.get_invocation(recovery_inv_id)
+
+    # The live, actually-launched run is untouched: never flipped to
+    # 'failed', and its dispatched_at survives exactly as the racing
+    # confirmation set it. No replacement occurrence was ever inserted.
+    assert live["status"] == "running"
+    assert live["dispatched_at"] == 1234.5
+    assert len(runs) == 1
+
+    # The live run's OWN invocation is completely untouched.
+    assert live_invocation["status"] == "running"
+
+    # Only the doomed recovery attempt's invocation was cancelled.
+    assert recovery_invocation["status"] == "cancelled"
+    assert recovery_invocation["status_reason_code"] == RunReasons.CANCELLED_STALE_AUTO

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -11,12 +11,14 @@ is a genuine transaction boundary: a simulated mid-write crash must leave
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler.engine import SchedulerEngine
 from lionagi.studio.services.scheduler_state import _DBSchedulerStateService
 
@@ -303,3 +305,187 @@ async def test_missed_fire_recovery_still_fires_past_capacity_deferred_skip(tmp_
         )
         exists = await db.schedule_run_exists_since(sid, since=due_at)
     assert exists is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_refires_occurrence_committed_but_never_dispatched(tmp_path, monkeypatch):
+    """(e) A crash between the occurrence-insert/cursor-advance transaction
+    committing and spawn_and_wait() confirming the external process
+    launched leaves a durable status='running' row with dispatched_at
+    still NULL, and the schedule's cursor already moved past it -- so
+    ordinary missed-fire recovery (schedule_run_exists_since) will never
+    reconsider this schedule as due again; the occurrence would otherwise
+    be silently lost. _recover_undispatched_fires() must tombstone the
+    orphaned row (failed / FAILED_NEVER_DISPATCHED) and re-fire a fresh
+    occurrence carrying the SAME trigger_context the orphaned attempt
+    never got to use -- the at-least-once side of the delivery contract.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-e"
+    fired_at = 1000.0
+    orphaned_trigger_context = {"source": "github_poll", "pr_number": 42}
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        # Simulate _fire_inner()'s atomic commit landing (row + cursor
+        # advance both durable), then the daemon dying before
+        # spawn_and_wait's on_launched callback ever stamps dispatched_at.
+        await db.create_schedule_run_and_advance(
+            _run_row(
+                "run-orphaned",
+                sid,
+                fired_at=fired_at,
+                trigger_context=orphaned_trigger_context,
+            ),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": fired_at},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    tracked_calls: list[tuple] = []
+    original_tracked_fire = engine._tracked_fire
+
+    def _spy_tracked_fire(*args, **kwargs):
+        tracked_calls.append((args, kwargs))
+        return original_tracked_fire(*args, **kwargs)
+
+    engine._tracked_fire = _spy_tracked_fire  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["true"], None),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.build_argv", return_value=(["true"], None)),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._recover_undispatched_fires()
+        if engine._fire_tasks:
+            await asyncio.gather(*engine._fire_tasks)
+
+    # The orphaned row is tombstoned, never left dangling at "running".
+    async with StateDB(db_path) as db:
+        orphaned = await db.get_schedule_run("run-orphaned")
+        remaining_undispatched = await db.list_undispatched_schedule_runs()
+    assert orphaned["status"] == "failed"
+    assert orphaned["status_reason_code"] == RunReasons.FAILED_NEVER_DISPATCHED
+    assert remaining_undispatched == []
+
+    # A fresh occurrence was re-fired with the SAME trigger_context.
+    assert len(tracked_calls) == 1
+    _args, kwargs = tracked_calls[0]
+    assert kwargs["trigger_context"] == orphaned_trigger_context
+
+    async with StateDB(db_path) as db:
+        runs = await db.list_schedule_runs(sid)
+    statuses = {r["id"]: r["status"] for r in runs}
+    assert statuses["run-orphaned"] == "failed"
+    # The retried run landed a second, independent occurrence row.
+    assert len(runs) == 2
+
+
+@pytest.mark.asyncio
+async def test_recovery_never_touches_a_row_with_confirmed_dispatch(tmp_path, monkeypatch):
+    """Once dispatched_at is set, the row is outside
+    _recover_undispatched_fires()'s scan entirely -- the external process is
+    confirmed to exist, so this is the contract's at-most-once boundary: a
+    daemon crash from here on is left to the ordinary stale-run reaper
+    (timed_out), never auto-retried, to avoid a duplicate real-world side
+    effect from an action that may already be running or finished.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-f"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-dispatched", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        # Launch confirmed, mirroring spawn_and_wait's on_launched callback.
+        await db.update_schedule_run("run-dispatched", dispatched_at=1000.5)
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked_fire:
+        await engine._recover_undispatched_fires()
+
+    mock_tracked_fire.assert_not_called()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run("run-dispatched")
+    # Untouched -- still "running", exactly as a genuinely in-flight (or
+    # merely lost-outcome) dispatched action should be left for the
+    # stale-run reaper, not this recovery scan.
+    assert run["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_path, monkeypatch):
+    """An undispatched chain child (chain_depth > 0, an on_success/on_fail
+    follow-on) is tombstoned like any other orphan, but NOT auto-retried --
+    the narrower, documented gap in _fire_inner()'s delivery contract: the
+    parent occurrence's own recorded outcome is unaffected, only a
+    follow-on step is lost rather than automatically replayed.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-g"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        # The chain-parent row must exist first -- chain_parent_id is a real
+        # FK reference to schedule_runs(id). Its own status is irrelevant to
+        # this test; only its existence satisfies the constraint.
+        await db.create_schedule_run_and_advance(
+            _run_row("run-parent", sid, fired_at=999.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 1000.0, "last_fired_at": 999.0},
+        )
+        # Mark the parent as confirmed-dispatched so it isn't itself picked
+        # up by the recovery scan below (it's top-level, chain_depth == 0) --
+        # this test isolates the chain-child-specific tombstone-without-retry
+        # behavior from the ordinary top-level re-fire path.
+        await db.update_schedule_run("run-parent", dispatched_at=999.5)
+        await db.create_schedule_run_and_advance(
+            _run_row(
+                "run-chain-child",
+                sid,
+                fired_at=1000.0,
+                chain_parent_id="run-parent",
+                chain_depth=1,
+            ),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked_fire:
+        await engine._recover_undispatched_fires()
+
+    mock_tracked_fire.assert_not_called()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run("run-chain-child")
+    assert run["status"] == "failed"
+    assert run["status_reason_code"] == RunReasons.FAILED_NEVER_DISPATCHED

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -489,3 +489,233 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
         run = await db.get_schedule_run("run-chain-child")
     assert run["status"] == "failed"
     assert run["status_reason_code"] == RunReasons.FAILED_NEVER_DISPATCHED
+
+
+@pytest.mark.asyncio
+async def test_tombstone_and_replace_schedule_run_is_atomic(tmp_path):
+    """The OLD shape recovery briefly took (flip the orphan via a standalone
+    update_status() call, THEN separately -- in a backgrounded fire task --
+    insert the replacement row once _fire_inner() got around to it) had a
+    real gap: a crash between those two independent writes left the orphan
+    durably 'failed' (terminal, so dropped from every future
+    list_undispatched_schedule_runs() scan) with no replacement ever
+    recorded -- the occurrence lost for good, invisible to recovery AND
+    never retried.
+
+    tombstone_and_replace_schedule_run() closes that by doing both writes
+    in ONE transaction. Prove it directly: force the second statement
+    (the replacement INSERT) to raise mid-transaction and confirm the
+    first statement (the orphan's UPDATE) rolled back too -- the orphan
+    must come back out exactly as it went in, still 'running', still
+    undispatched, still visible to a fresh scan. A crash here can only
+    ever discard a replacement that was never durably recorded, never
+    leave a flipped orphan with nothing to show for it.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-atomic"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-orphan", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+
+    original_execute = AsyncConnection.execute
+
+    async def _crash_on_insert(self, statement, *args, **kwargs):
+        if "INSERT INTO schedule_runs" in str(statement):
+            raise RuntimeError("simulated crash between flip and insert")
+        return await original_execute(self, statement, *args, **kwargs)
+
+    async with StateDB(db_path) as db:
+        with patch.object(AsyncConnection, "execute", _crash_on_insert):
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                await db.tombstone_and_replace_schedule_run(
+                    "run-orphan",
+                    _run_row("run-replacement", sid, fired_at=1500.0),
+                    expected_orphan_status="running",
+                )
+
+    # Post-crash: the orphan's flip rolled back along with the aborted
+    # insert -- never neither, never "flipped but replacement missing".
+    async with StateDB(db_path) as db:
+        orphan = await db.get_schedule_run("run-orphan")
+        replacement = await db.get_schedule_run("run-replacement")
+        undispatched = await db.list_undispatched_schedule_runs()
+    assert orphan["status"] == "running"
+    assert orphan["dispatched_at"] is None
+    assert replacement is None
+    assert [r["id"] for r in undispatched] == ["run-orphan"]
+
+    # "Restart": a real (non-crashing) call now succeeds atomically.
+    async with StateDB(db_path) as db:
+        applied = await db.tombstone_and_replace_schedule_run(
+            "run-orphan",
+            _run_row("run-replacement", sid, fired_at=1500.0),
+            expected_orphan_status="running",
+        )
+        orphan = await db.get_schedule_run("run-orphan")
+        replacement = await db.get_schedule_run("run-replacement")
+    assert applied is True
+    assert orphan["status"] == "failed"
+    assert replacement["status"] == "running"
+    assert replacement["dispatched_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_leaves_orphan_untouched_when_refire_crashes_before_atomic_write(
+    tmp_path, monkeypatch
+):
+    """A crash during a recovery re-fire attempt, at any point BEFORE
+    _write_occurrence()'s atomic transaction runs (e.g. while building the
+    replacement invocation or resolving the action), must leave the
+    orphan completely untouched -- neither half of the tombstone+insert
+    pair exists yet, so there is nothing to roll back; the orphan is
+    simply still exactly where it started. A fresh recovery pass over the
+    same state must find and retry it again, proving the occurrence is
+    never lost even when the re-fire attempt itself fails early.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-early-crash"
+    orphaned_trigger_context = {"source": "cron"}
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_schedule_run_and_advance(
+            _run_row(
+                "run-orphaned", sid, fired_at=1000.0, trigger_context=orphaned_trigger_context
+            ),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    # Simulate a crash mid-fire, well before _write_occurrence() ever runs:
+    # create_invocation() succeeds (it always durably lands first, same as
+    # the ordinary happy path), but build_argv() (a plain sync function)
+    # blows up with something that is NOT the ordinary "invalid action"
+    # exception path -- an unrecoverable crash of the fire task itself.
+    # A BaseException that is deliberately NOT KeyboardInterrupt/SystemExit:
+    # those two are special-cased by asyncio's event loop and by pytest-xdist
+    # itself (a KeyboardInterrupt propagating out of an awaited task reads as
+    # a real Ctrl-C and takes the whole worker process down with it) -- this
+    # only needs to be something _fire_inner()'s `except Exception` does not
+    # catch, not literally the SIGINT-flavored crash signal.
+    class _SimulatedHardCrash(BaseException):
+        pass
+
+    def _crash(*_args, **_kwargs):
+        raise _SimulatedHardCrash("simulated hard crash mid-fire")
+
+    with patch("lionagi.studio.scheduler.subprocess.build_argv", side_effect=_crash):
+        await engine._recover_undispatched_fires()
+        for task in list(engine._fire_tasks):
+            with pytest.raises(_SimulatedHardCrash):
+                await task
+
+    # Untouched: no atomic write ever ran, so nothing changed.
+    async with StateDB(db_path) as db:
+        orphan = await db.get_schedule_run("run-orphaned")
+        runs = await db.list_schedule_runs(sid)
+        undispatched = await db.list_undispatched_schedule_runs()
+    assert orphan["status"] == "running"
+    assert orphan["dispatched_at"] is None
+    assert len(runs) == 1  # no replacement row was ever inserted
+    assert [r["id"] for r in undispatched] == ["run-orphaned"]
+
+    # A fresh recovery pass (no crash this time) finds and retries it.
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["true"], None),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.build_argv", return_value=(["true"], None)),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._recover_undispatched_fires()
+        if engine._fire_tasks:
+            await asyncio.gather(*engine._fire_tasks)
+
+    async with StateDB(db_path) as db:
+        orphan = await db.get_schedule_run("run-orphaned")
+        runs = await db.list_schedule_runs(sid)
+    assert orphan["status"] == "failed"
+    assert orphan["status_reason_code"] == RunReasons.FAILED_NEVER_DISPATCHED
+    assert len(runs) == 2
+
+
+@pytest.mark.asyncio
+async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypatch):
+    """Running _recover_undispatched_fires() a second time over state left
+    behind by a first, fully-completed pass must find nothing left to do:
+    once the replacement occurrence from pass one is durably dispatched
+    (dispatched_at set), it is entirely out of scope for pass two, and the
+    original orphan it superseded is already terminal. Two passes over the
+    same eventually-successful recovery must produce exactly one re-fire,
+    never two.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-no-double-fire"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-orphaned", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["true"], None),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.build_argv", return_value=(["true"], None)),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        # Pass one: finds the orphan, re-fires it, and the mocked
+        # spawn_and_wait's on_launched callback stamps dispatched_at on
+        # the replacement -- a fully successful recovery cycle.
+        await engine._recover_undispatched_fires()
+        if engine._fire_tasks:
+            await asyncio.gather(*engine._fire_tasks)
+
+        async with StateDB(db_path) as db:
+            undispatched_after_pass_one = await db.list_undispatched_schedule_runs()
+        assert undispatched_after_pass_one == []
+
+        with patch.object(engine, "_tracked_fire") as mock_tracked_fire:
+            # Pass two: nothing left to recover.
+            await engine._recover_undispatched_fires()
+        mock_tracked_fire.assert_not_called()
+
+    async with StateDB(db_path) as db:
+        runs = await db.list_schedule_runs(sid)
+    # Exactly one re-fire happened across both passes: the original orphan
+    # plus its single replacement, never a second independent retry.
+    assert len(runs) == 2
+    statuses = {r["id"]: r["status"] for r in runs}
+    assert statuses["run-orphaned"] == "failed"
+    replacement_id = next(rid for rid in statuses if rid != "run-orphaned")
+    assert statuses[replacement_id] == "completed"

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Crash-interleaving regression tests for the scheduler's occurrence-insert
++ cursor-advance atomicity.
+
+These exercise a real temp-dir sqlite ``StateDB`` (never the process-wide
+``~/.lionagi/state.db``) rather than mocks, because the property under test
+is a genuine transaction boundary: a simulated mid-write crash must leave
+*zero* durable trace, and only a real database rollback proves that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from lionagi.state.db import StateDB
+from lionagi.studio.scheduler.engine import SchedulerEngine
+from lionagi.studio.services.scheduler_state import _DBSchedulerStateService
+
+
+def _schedule_row(schedule_id: str, **overrides) -> dict:
+    base = {
+        "id": schedule_id,
+        "name": f"sched-{schedule_id}",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "enabled": 1,
+        "next_fire_at": 1_000.0,
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _run_row(run_id: str, schedule_id: str, *, fired_at: float, **overrides) -> dict:
+    base = {
+        "id": run_id,
+        "schedule_id": schedule_id,
+        "trigger_context": {"source": "cron"},
+        "action_kind": "agent",
+        "action_args": {"prompt": "ping"},
+        "status": "running",
+        "fired_at": fired_at,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
+    """(a) A process death between the occurrence insert and the cursor
+    advance must roll back BOTH halves -- not just leave the schedule's
+    cursor behind while the occurrence row survives. Otherwise a restart
+    that recomputes "still due" from the stale cursor would fire again for
+    an occurrence that the crashed attempt already (partially) recorded.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-a"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=1000.0))
+
+    original_execute = AsyncConnection.execute
+
+    async def _crash(self, statement, *args, **kwargs):
+        if "UPDATE schedules" in str(statement):
+            raise RuntimeError("simulated crash before cursor advance")
+        return await original_execute(self, statement, *args, **kwargs)
+
+    async with StateDB(db_path) as db:
+        with patch.object(AsyncConnection, "execute", _crash):
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                await db.create_schedule_run_and_advance(
+                    _run_row("run-1", sid, fired_at=1000.0),
+                    schedule_id=sid,
+                    schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+                )
+
+    # Post-crash: neither half landed -- the occurrence row is absent and
+    # the schedule's cursor is untouched.
+    async with StateDB(db_path) as db:
+        runs = await db.list_schedule_runs(sid)
+        schedule = await db.get_schedule(sid)
+    assert runs == []
+    assert schedule["next_fire_at"] == 1000.0
+
+    # "Restart": the same occurrence is retried for real (no crash this
+    # time) and must produce exactly one durable row -- proving the
+    # crashed attempt left nothing behind to double up against.
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run_and_advance(
+            _run_row("run-1", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        runs = await db.list_schedule_runs(sid)
+        schedule = await db.get_schedule(sid)
+    assert len(runs) == 1
+    assert schedule["next_fire_at"] == 2000.0
+
+
+@pytest.mark.asyncio
+async def test_github_path_crash_before_second_event_refires_only_second(tmp_path):
+    """(b) Two github_poll events are dispatched in the same poll batch.
+    The first event's occurrence-insert + github_cursor advance commits
+    cleanly; the process then dies mid-transaction for the second event.
+    A restart must see the first event as already recorded (so it is never
+    re-fired) while the second is still open (schedule_run_exists_since is
+    False for it, and the cursor has not moved past it) -- so the next poll
+    re-fires ONLY the second event, never both.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-b"
+    event1_time = "2026-07-07T10:00:00Z"
+    event2_time = "2026-07-07T11:00:00Z"
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            _schedule_row(
+                sid,
+                trigger_type="github_poll",
+                github_repo="acme/widgets",
+                github_cursor=None,
+            )
+        )
+
+        # Event 1: normal atomic commit.
+        await db.create_schedule_run_and_advance(
+            _run_row("run-event1", sid, fired_at=1000.0),
+            schedule_id=sid,
+            schedule_fields={"github_cursor": event1_time, "last_fired_at": 1000.0},
+        )
+
+    original_execute = AsyncConnection.execute
+
+    async def _crash(self, statement, *args, **kwargs):
+        if "UPDATE schedules" in str(statement):
+            raise RuntimeError("simulated crash before cursor advance")
+        return await original_execute(self, statement, *args, **kwargs)
+
+    async with StateDB(db_path) as db:
+        with patch.object(AsyncConnection, "execute", _crash):
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                await db.create_schedule_run_and_advance(
+                    _run_row("run-event2", sid, fired_at=1100.0),
+                    schedule_id=sid,
+                    schedule_fields={"github_cursor": event2_time, "last_fired_at": 1100.0},
+                )
+
+    async with StateDB(db_path) as db:
+        runs = await db.list_schedule_runs(sid)
+        schedule = await db.get_schedule(sid)
+        exists_since_event2 = await db.schedule_run_exists_since(sid, since=1100.0)
+
+    # Only event 1 is durable; the cursor sits at event 1, never advanced
+    # to (or past) event 2.
+    assert len(runs) == 1
+    assert runs[0]["id"] == "run-event1"
+    assert schedule["github_cursor"] == event1_time
+    assert exists_since_event2 is False
+
+    # "Restart": re-fire for event 2 only (event 1 is never re-dispatched
+    # because the poll's own cursor filter -- github_cursor -- excludes it;
+    # this call models the recorded outcome of that re-poll).
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run_and_advance(
+            _run_row("run-event2", sid, fired_at=1100.0),
+            schedule_id=sid,
+            schedule_fields={"github_cursor": event2_time, "last_fired_at": 1100.0},
+        )
+        runs = await db.list_schedule_runs(sid)
+        schedule = await db.get_schedule(sid)
+
+    assert len(runs) == 2
+    assert {r["id"] for r in runs} == {"run-event1", "run-event2"}
+    assert schedule["github_cursor"] == event2_time
+
+
+@pytest.mark.asyncio
+async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
+    tmp_path, monkeypatch
+):
+    """(c) Startup/missed-fire recovery must consult schedule_runs before
+    queuing a recovery fire. A schedule whose next_fire_at is past-due but
+    which already has a schedule_run row recorded at-or-after that time
+    (the atomic transaction committed, then the process died before the
+    run's terminal write) must NOT be re-fired -- only have its cursor
+    advanced past the already-handled occurrence.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-c"
+    due_at = 1000.0
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            _schedule_row(sid, next_fire_at=due_at, missed_fire_policy="run_once")
+        )
+        # Simulate: the atomic transaction already committed this
+        # occurrence + advanced the cursor once (to a value that is itself
+        # still in the past relative to "now" in this test, so the
+        # schedule is still seen as due -- exercising the recovery path
+        # rather than the ordinary tick).
+        await db.create_schedule_run_and_advance(
+            _run_row("run-crashed", sid, fired_at=due_at),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": due_at, "last_fired_at": due_at},
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch.object(engine, "_tracked_fire") as mock_tracked_fire,
+        patch.object(engine, "_recover_missed_fire_run_once") as mock_recover,
+        patch.object(engine, "_record_missed_fire_skip") as mock_skip,
+    ):
+        await engine._check_missed_fires()
+
+    mock_tracked_fire.assert_not_called()
+    mock_recover.assert_not_called()
+    mock_skip.assert_not_called()
+
+    async with StateDB(db_path) as db:
+        schedule = await db.get_schedule(sid)
+        runs = await db.list_schedule_runs(sid)
+
+    # No second occurrence was recorded, and the cursor moved past the
+    # already-handled fire time instead of staying stuck due-in-the-past.
+    assert len(runs) == 1
+    assert schedule["next_fire_at"] is not None
+    assert schedule["next_fire_at"] > due_at

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -239,3 +239,67 @@ async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
     assert len(runs) == 1
     assert schedule["next_fire_at"] is not None
     assert schedule["next_fire_at"] > due_at
+
+
+@pytest.mark.asyncio
+async def test_missed_fire_recovery_still_fires_past_capacity_deferred_skip(tmp_path, monkeypatch):
+    """(c2) A capacity-deferred fire (global concurrent-fire cap reached)
+    writes an audit-only 'skipped' schedule_run row via
+    _maybe_record_deferred() and deliberately leaves next_fire_at
+    untouched, so the same due occurrence retries on the next tick. If the
+    process restarts before that retry, the recovery scan must not mistake
+    this audit row for a genuine fire -- schedule_run_exists_since()
+    excludes status='skipped' rows precisely so this occurrence still gets
+    a real recovery fire instead of being silently cursor-advanced past.
+    """
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid = "sched-c2"
+    due_at = 1000.0
+
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            _schedule_row(sid, next_fire_at=due_at, missed_fire_policy="run_once")
+        )
+        # The capacity-deferred audit row: status='skipped', schedule_id
+        # cursor untouched (mirrors _maybe_record_deferred + create_skipped_run,
+        # which calls create_schedule_run() directly -- never
+        # create_schedule_run_and_advance() -- exactly so next_fire_at stays
+        # put for the retry).
+        await db.create_schedule_run(
+            _run_row(
+                "run-deferred",
+                sid,
+                fired_at=due_at,
+                status="skipped",
+                trigger_context={"deferred_capacity": True, "fired_at": due_at},
+            )
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch.object(engine, "_recover_missed_fire_run_once") as mock_recover,
+        patch.object(engine, "_record_missed_fire_skip") as mock_skip,
+    ):
+        await engine._check_missed_fires()
+
+    # The deferred-skip audit row must not be treated as "already fired":
+    # recovery proceeds through the normal missed_fire_policy branch
+    # instead of taking the already-recorded shortcut that would silently
+    # advance the cursor without ever firing this occurrence.
+    mock_recover.assert_called_once()
+    mock_skip.assert_not_called()
+
+    # Genuinely-fired rows are unaffected by the exclusion: a completed run
+    # still counts as "already recorded".
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run(
+            _run_row("run-completed", sid, fired_at=due_at, status="completed")
+        )
+        exists = await db.schedule_run_exists_since(sid, since=due_at)
+    assert exists is True

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -69,6 +69,8 @@ def _make_svc() -> AsyncMock:
     svc.list_schedules = AsyncMock(return_value=[])
     svc.update_schedule = AsyncMock()
     svc.create_schedule_run = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
     svc.update_schedule_run = AsyncMock()
     svc.create_invocation = AsyncMock()
     svc.update_invocation = AsyncMock()
@@ -869,7 +871,8 @@ async def test_broken_handler_surfaces_admin_event_and_fire_completes(tmp_path, 
     # The schedule_run's own bookkeeping (invocation/run rows, status writes,
     # max_runs check) still ran normally despite the broken handler.
     svc.create_invocation.assert_awaited_once()
-    svc.create_schedule_run.assert_awaited_once()
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     assert svc.update_status.await_count == 3  # running + completed + invocation
 
     async with StateDB(fake_db) as db:
@@ -967,4 +970,4 @@ async def test_unrelated_fire_still_succeeds_after_a_prior_handler_failure(tmp_p
         # have crashed the tick loop or left the bus/engine in a bad state.
         await engine._fire(schedule, "run-009", trigger_context={"scheduled": True})
 
-    assert svc.create_schedule_run.await_count == 2
+    assert svc.create_schedule_run_and_advance.await_count == 2

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -44,6 +44,8 @@ def _make_svc() -> AsyncMock:
     svc.list_schedules = AsyncMock(return_value=[])
     svc.update_schedule = AsyncMock()
     svc.create_schedule_run = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
     svc.update_schedule_run = AsyncMock()
     svc.create_invocation = AsyncMock()
     svc.update_invocation = AsyncMock()
@@ -527,7 +529,14 @@ def _threshold_ctx(**overrides) -> dict:
 
 
 def _last_alert_calls(svc: AsyncMock) -> list:
-    return [c for c in svc.update_schedule.await_args_list if "last_alert_at" in c.kwargs]
+    """last_alert_at now rides create_schedule_run_and_advance()'s
+    schedule_fields, folded into the same atomic call as the occurrence
+    insert -- not a standalone update_schedule() call."""
+    return [
+        c
+        for c in svc.create_schedule_run_and_advance.await_args_list
+        if "last_alert_at" in c.kwargs.get("schedule_fields", {})
+    ]
 
 
 @pytest.mark.asyncio
@@ -559,10 +568,11 @@ async def test_fire_threshold_schedule_stamps_last_alert_at_after_run_persisted(
     ):
         await engine._fire(schedule, "run-alert-1", trigger_context=_threshold_ctx())
 
-    svc.create_schedule_run.assert_awaited_once()
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     calls = _last_alert_calls(svc)
     assert len(calls) == 1
-    assert calls[0].args[0] == "sched-001"
+    assert calls[0].kwargs["schedule_id"] == "sched-001"
 
 
 @pytest.mark.asyncio
@@ -617,7 +627,8 @@ async def test_fire_invalid_action_still_stamps_last_alert_at_after_failed_run_p
     ):
         await engine._fire(schedule, "run-alert-2", trigger_context=_threshold_ctx())
 
-    svc.create_schedule_run.assert_awaited_once()
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     calls = _last_alert_calls(svc)
     assert len(calls) == 1
 
@@ -655,7 +666,8 @@ async def test_fire_invalid_action_releases_threshold_cooldown_claim():
             threshold_cooldown_claim=claim,
         )
 
-    svc.create_schedule_run.assert_awaited_once()
+    svc.create_schedule_run.assert_not_awaited()
+    svc.create_schedule_run_and_advance.assert_awaited_once()
     assert sid not in engine._threshold_pending
 
 


### PR DESCRIPTION
Fixes #2107 (all three findings).

## What

1. **Atomic occurrence-insert + cursor-advance** — new `StateDB.create_schedule_run_and_advance()` wraps the `schedule_runs` INSERT and the `schedules` cursor UPDATE in one transaction; `SchedulerEngine._fire_inner()` uses it on both happy-path and error branches. The GitHub poll path passes each event's own cursor through the fire so every dispatched event's advance rides inside that event's own transaction — a crash mid-batch can no longer double-fire already-dispatched events on restart.
2. **Recovery scans before recompute** — `_check_missed_fires()` consults new `schedule_run_exists_since()` before queuing a recovery fire; an already-recorded occurrence advances the cursor instead of firing again.
3. **schedule_runs reaper** — `reap_stale_schedule_runs()` wired into startup reconciliation and periodic reapers; wall-clock deadline on `updated_at` (falling back to `fired_at`), guarded by the existing `expected_updated_at` optimistic lock, new `SCHEDULE_RUN_STALE_HOURS` knob (default 24h).

## Verification

- New `tests/studio/test_scheduler_occurrence_atomicity.py` (3 crash-interleaving tests — the crash is a real rolled-back transaction, not a mock: `AsyncConnection.execute` raises on the `UPDATE schedules` statement inside `engine.begin()`) and `tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py` (7 tests incl. version-guard race and both wiring points)
- `tests/studio/`: 524 passed post-rebase (re-run by the reviewer seat); `tests/apps_studio_server/` green; state-suite failures limited to pre-existing asyncpg-extra gaps
- 4 existing mock-based scheduler test files updated for the single-call service shape
- `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)