### PR TITLE
fix(state): finalize branches.status at teardown via BRANCH_END hook

### DIFF
--- a/docs/reference/agent-hooks.md
+++ b/docs/reference/agent-hooks.md
@@ -11,6 +11,7 @@ lifecycle hook points — and the built-in handlers registered via
 | Point | Value | Callsite |
 |-------|-------|---------|
 | `MESSAGE_ADD` | `message.add` | `branch.py _persist_via_bus` — every inbound message |
+| `BRANCH_END` | `branch.end` | `cli/_runs.py teardown_persist` — once per branch the teardown owns, only when the run reached a genuine terminal outcome (never for the "running" reconciliation-suppression case) |
 
 ### Registered in DEFAULT_HOOKS (handlers wired; emit callsite deferred to ADR-0023b)
 
@@ -19,7 +20,6 @@ lifecycle hook points — and the built-in handlers registered via
 | `SESSION_START` | `session.start` | `persist_session_start` |
 | `SESSION_END` | `session.end` | `persist_session_end` |
 | `BRANCH_CREATE` | `branch.create` | `persist_branch_provenance` |
-| `BRANCH_END` | `branch.end` | `persist_branch_end` |
 
 ### Reserved (vocabulary only; no handler and no emit callsite yet, per ADR-0023)
 

--- a/docs/reference/agent-hooks.md
+++ b/docs/reference/agent-hooks.md
@@ -19,6 +19,7 @@ lifecycle hook points — and the built-in handlers registered via
 | `SESSION_START` | `session.start` | `persist_session_start` |
 | `SESSION_END` | `session.end` | `persist_session_end` |
 | `BRANCH_CREATE` | `branch.create` | `persist_branch_provenance` |
+| `BRANCH_END` | `branch.end` | `persist_branch_end` |
 
 ### Reserved (vocabulary only; no handler and no emit callsite yet, per ADR-0023)
 
@@ -56,6 +57,7 @@ keep their defaults.
 | `persist_session_start` | `SESSION_START` |
 | `persist_session_end` | `SESSION_END` |
 | `persist_branch_provenance` | `BRANCH_CREATE` |
+| `persist_branch_end` | `BRANCH_END` |
 | `persist_message` | `MESSAGE_ADD` |
 | `log_api_metrics` | (name-addressable; not in DEFAULT_HOOKS) |
 | `log_tool_call` | (name-addressable; not in DEFAULT_HOOKS) |

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -729,14 +729,27 @@ async def teardown_persist(
             # signal (queued-but-never-started, or still "running" when the
             # DAG itself raised) -- persist_branch_end()/finalize_branch()'s
             # own guard skips any branch a per-op writer already finalized.
-            _end_at = time.time()
-            for _b in [_branch] if _branch is not None else _hook_branches:
-                await session_obj.hooks.emit(
-                    HookPoint.BRANCH_END,
-                    branch_id=str(_b.id),
-                    status=final_status,
-                    ended_at=_end_at,
-                )
+            #
+            # final_status is only ever a genuine terminal outcome
+            # (SESSION_TERMINAL_STATUSES) EXCEPT for one case: the
+            # linked-engine reconciliation above suppresses a phantom
+            # "failed" back to "running" when the real engine session is
+            # still alive -- this teardown's own view of the branch is not
+            # actually done. Never emit BRANCH_END for that case; a branch
+            # must never be stamped "ended" with a non-terminal status.
+            # finalize_branch() also rejects a non-terminal status outright,
+            # so this is belt-and-suspenders, not the only guard.
+            from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+            if final_status in SESSION_TERMINAL_STATUSES:
+                _end_at = time.time()
+                for _b in [_branch] if _branch is not None else _hook_branches:
+                    await session_obj.hooks.emit(
+                        HookPoint.BRANCH_END,
+                        branch_id=str(_b.id),
+                        status=final_status,
+                        ended_at=_end_at,
+                    )
 
             await session_obj.hooks.emit(
                 HookPoint.SESSION_END,

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -704,22 +704,40 @@ async def teardown_persist(
             err_str = str(exception) if exception is not None else None
             _usage: dict = {}
             _branch = ctx.get("branch")
+            # Orchestrator/DAG sessions never set a singular ctx["branch"];
+            # every leg (including the orchestrator branch itself) is
+            # tracked in ctx["hooks"] as (branch, handler) pairs instead.
+            _hook_branches = [b for b, _h in ctx.get("hooks", [])]
             try:
                 if _branch is not None:
                     from lionagi.session.signal import _collect_branch_usage
 
                     _usage = _collect_branch_usage(_branch)
-                else:
-                    # Orchestrator/DAG sessions never set a singular ctx["branch"];
-                    # every leg (including the orchestrator branch itself) is
-                    # tracked in ctx["hooks"] as (branch, handler) pairs instead.
-                    _hook_branches = [b for b, _h in ctx.get("hooks", [])]
-                    if _hook_branches:
-                        from lionagi.session.signal import _collect_multi_branch_usage
+                elif _hook_branches:
+                    from lionagi.session.signal import _collect_multi_branch_usage
 
-                        _usage = _collect_multi_branch_usage(_hook_branches)
+                    _usage = _collect_multi_branch_usage(_hook_branches)
             except Exception:  # noqa: BLE001, S110
                 pass
+
+            # BRANCH_END: finalize terminal status/ended_at for every branch
+            # this teardown owns. The single-branch agent path (ctx["branch"])
+            # never gets branches.status written anywhere else, so this is its
+            # only finalize. The multi-leg DAG path (ctx["hooks"]) already gets
+            # per-op status from flow.py's NodeCompleted/NodeFailed handlers;
+            # this is the safety net for legs that never reached a terminal
+            # signal (queued-but-never-started, or still "running" when the
+            # DAG itself raised) -- persist_branch_end()/finalize_branch()'s
+            # own guard skips any branch a per-op writer already finalized.
+            _end_at = time.time()
+            for _b in [_branch] if _branch is not None else _hook_branches:
+                await session_obj.hooks.emit(
+                    HookPoint.BRANCH_END,
+                    branch_id=str(_b.id),
+                    status=final_status,
+                    ended_at=_end_at,
+                )
+
             await session_obj.hooks.emit(
                 HookPoint.SESSION_END,
                 session_id=ctx["session_id"],

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -24,6 +24,7 @@ __all__ = (
     "persist_session_start",
     "persist_session_end",
     "persist_branch_provenance",
+    "persist_branch_end",
     "persist_message",
     "log_api_metrics",
     "log_tool_call",
@@ -173,6 +174,28 @@ async def persist_branch_provenance(
         provider=provider,
         agent_name=agent_name,
     )
+
+
+async def persist_branch_end(
+    *,
+    branch_id: str,
+    status: str = "completed",
+    ended_at: float | None = None,
+    **_unused: Any,
+) -> None:
+    """Stamp the branch row's terminal status/ended_at — the BRANCH_END
+    counterpart to BRANCH_CREATE's persist_branch_provenance.
+
+    Guarded: no-op when the branch row is already in a terminal status
+    ("completed" or "failed"), so this run-level finalize never clobbers a
+    more specific outcome a per-op writer already recorded (e.g. the reactive
+    DAG runner's own NodeCompleted/NodeFailed branch-status updates in
+    cli/orchestrate/flow.py). Also a no-op when the branch row doesn't exist
+    yet (a DAG leg that never got a first message, so create_branch() never
+    ran for it) -- there is nothing to finalize.
+    """
+    db = await _db()
+    await db.finalize_branch(branch_id, status=status, ended_at=ended_at or time.time())
 
 
 async def persist_message(

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -186,13 +186,16 @@ async def persist_branch_end(
     """Stamp the branch row's terminal status/ended_at — the BRANCH_END
     counterpart to BRANCH_CREATE's persist_branch_provenance.
 
-    Guarded: no-op when the branch row is already in a terminal status
-    ("completed" or "failed"), so this run-level finalize never clobbers a
-    more specific outcome a per-op writer already recorded (e.g. the reactive
-    DAG runner's own NodeCompleted/NodeFailed branch-status updates in
-    cli/orchestrate/flow.py). Also a no-op when the branch row doesn't exist
-    yet (a DAG leg that never got a first message, so create_branch() never
-    ran for it) -- there is nothing to finalize.
+    Delegates the actual guard to StateDB.finalize_branch(): a no-op when
+    *status* is not itself a genuine terminal outcome (e.g. "running"), a
+    no-op when the branch row is already at ANY terminal status (not just
+    "completed"/"failed" -- "cancelled", "timed_out", "aborted", and
+    "completed_empty" are equally immutable), so this run-level finalize
+    never clobbers a more specific outcome a per-op writer already recorded
+    (e.g. the reactive DAG runner's own NodeCompleted/NodeFailed
+    branch-status updates in cli/orchestrate/flow.py). Also a no-op when the
+    branch row doesn't exist yet (a DAG leg that never got a first message,
+    so create_branch() never ran for it) -- there is nothing to finalize.
     """
     db = await _db()
     await db.finalize_branch(branch_id, status=status, ended_at=ended_at or time.time())

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -44,6 +44,7 @@ class HookPoint(str, Enum):
     SESSION_START = "session.start"
     SESSION_END = "session.end"
     BRANCH_CREATE = "branch.create"
+    BRANCH_END = "branch.end"
     # not-yet-wired: no emit() call in the codebase
     API_PRE_CALL = "api.pre_call"
     API_POST_CALL = "api.post_call"

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -27,6 +27,7 @@ DEFAULT_HOOKS: dict[HookPoint, list[HookHandler]] = {
     HookPoint.SESSION_END: [_builtins.persist_session_end],
     HookPoint.MESSAGE_ADD: [_builtins.persist_message],
     HookPoint.BRANCH_CREATE: [_builtins.persist_branch_provenance],
+    HookPoint.BRANCH_END: [_builtins.persist_branch_end],
 }
 
 
@@ -34,6 +35,7 @@ _REGISTRY: dict[str, HookHandler] = {
     "persist_session_start": _builtins.persist_session_start,
     "persist_session_end": _builtins.persist_session_end,
     "persist_branch_provenance": _builtins.persist_branch_provenance,
+    "persist_branch_end": _builtins.persist_branch_end,
     "persist_message": _builtins.persist_message,
     "log_api_metrics": _builtins.log_api_metrics,
     "log_tool_call": _builtins.log_tool_call,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -223,10 +223,6 @@ _BRANCH_COLUMNS = frozenset(
     }
 )
 
-# Terminal branches.status values; kept in sync with the literal SQL in
-# StateDB.finalize_branch()'s guard clause below.
-_BRANCH_TERMINAL_STATUSES = frozenset({"completed", "failed"})
-
 VALID_SESSION_STATUSES = frozenset(
     {
         "running",
@@ -260,6 +256,15 @@ TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     for entity_type in ("session", "invocation", "schedule_run", "show", "play", "team")
 }
 SESSION_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["session"]
+
+# Terminal branches.status values. branches has no lifecycle-policy entry of
+# its own (it never goes through update_status()'s ADR-0035 machinery) — but
+# every status finalize_branch() ever receives is a session final_status
+# passed straight through by cli/_runs.py teardown_persist(), so this IS
+# SESSION_TERMINAL_STATUSES, not a second hand-maintained list that could
+# drift from it.
+_BRANCH_TERMINAL_STATUSES = SESSION_TERMINAL_STATUSES
+
 INVOCATION_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE[
     "invocation"
 ]  # invocations share the session terminal-status vocabulary
@@ -3181,20 +3186,40 @@ class StateDB:
     ) -> bool:
         """Guarded terminal-status write for one branch row (BRANCH_END).
 
-        Only touches a row whose status is NULL or not already in
-        ``_BRANCH_TERMINAL_STATUSES`` — a run-level finalize (single-branch
-        agent teardown, or the DAG-orchestration safety net) must never
-        clobber a more specific outcome a per-op writer already recorded
-        (cli/orchestrate/flow.py's NodeCompleted/NodeFailed branch-status
-        updates). A branch row that was never created (a DAG leg that never
-        emitted a first message) matches zero rows and is a harmless no-op.
+        Two-sided guard; both conditions must hold for the write to land:
+
+        - *status* itself must be a genuine terminal outcome
+          (``_BRANCH_TERMINAL_STATUSES`` == ``SESSION_TERMINAL_STATUSES`` —
+          every value BRANCH_END ever carries is a session final_status
+          passed straight through by cli/_runs.py teardown_persist()). A
+          non-terminal payload — e.g. the "running" the linked-engine
+          reconciliation path can produce when it suppresses a phantom
+          "failed" back to "running" — is rejected outright: this method
+          never stamps a branch "ended" with a non-terminal status. Returns
+          False without touching the row.
+        - the EXISTING row must still be in a legitimate pre-terminal state:
+          NULL (never touched) or "running" (the only two values flow.py's
+          own per-op writer -- or anything else -- ever leaves a branch in
+          before its real terminal outcome lands; this method itself never
+          writes "running", it only ever writes a terminal status). Any
+          other existing value — whichever terminal status it already
+          holds — is immutable: a run-level finalize must never flap a
+          branch that already reached its outcome, regardless of which
+          terminal status that was (completed, failed, cancelled,
+          timed_out, aborted, completed_empty) or what this call's own
+          *status* argument is.
+
+        A branch row that was never created (a DAG leg that never emitted a
+        first message) matches zero rows and is a harmless no-op.
         Returns True when a row was actually updated.
         """
+        if status not in _BRANCH_TERMINAL_STATUSES:
+            return False
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
                     "UPDATE branches SET status = :status, ended_at = :ended_at "
-                    "WHERE id = :id AND (status IS NULL OR status NOT IN ('completed', 'failed'))"
+                    "WHERE id = :id AND (status IS NULL OR status = 'running')"
                 ),
                 {
                     "status": status,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -223,6 +223,10 @@ _BRANCH_COLUMNS = frozenset(
     }
 )
 
+# Terminal branches.status values; kept in sync with the literal SQL in
+# StateDB.finalize_branch()'s guard clause below.
+_BRANCH_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+
 VALID_SESSION_STATUSES = frozenset(
     {
         "running",
@@ -3171,6 +3175,34 @@ class StateDB:
         if bind_params:
             stmt = stmt.bindparams(*bind_params)
         await conn.execute(stmt, params)
+
+    async def finalize_branch(
+        self, branch_id: str, *, status: str, ended_at: float | None = None
+    ) -> bool:
+        """Guarded terminal-status write for one branch row (BRANCH_END).
+
+        Only touches a row whose status is NULL or not already in
+        ``_BRANCH_TERMINAL_STATUSES`` — a run-level finalize (single-branch
+        agent teardown, or the DAG-orchestration safety net) must never
+        clobber a more specific outcome a per-op writer already recorded
+        (cli/orchestrate/flow.py's NodeCompleted/NodeFailed branch-status
+        updates). A branch row that was never created (a DAG leg that never
+        emitted a first message) matches zero rows and is a harmless no-op.
+        Returns True when a row was actually updated.
+        """
+        async with self._tx() as conn:
+            result = await conn.execute(
+                text(
+                    "UPDATE branches SET status = :status, ended_at = :ended_at "
+                    "WHERE id = :id AND (status IS NULL OR status NOT IN ('completed', 'failed'))"
+                ),
+                {
+                    "status": status,
+                    "ended_at": ended_at if ended_at is not None else time.time(),
+                    "id": branch_id,
+                },
+            )
+        return result.rowcount > 0
 
     async def repair_branch_progression(
         self,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1022,8 +1022,29 @@ async def test_stop_close_failure_logs_warning_and_clears_context(
 async def test_stop_persists_cancelled_status_with_dag_metadata(
     temp_db_path: Path,
 ):
-    env = _minimal_env()
+    """'cancelled' must land on both the session row AND every DAG leg's
+    branch row -- not just 'completed'/'failed', which finalize_branch()'s
+    guard used to special-case."""
+    from lionagi.protocols.messages.manager import MessageManager
+
+    orc_branch = Branch(name="orchestrator")
+    env = _minimal_env(orc_branch=orc_branch)
     await start_live_persist(env)
+    orc_hook = env._live_persist["hooks"][0][1]
+    await orc_hook(
+        MessageManager.create_instruction(
+            instruction="plan", sender="u", recipient=str(orc_branch.id)
+        )
+    )
+
+    worker = Branch(name="worker-1")
+    env.session.include_branches(worker)
+    _register_branch_hook(env._live_persist, worker)
+    worker_hook = env._live_persist["hooks"][-1][1]
+    await worker_hook(
+        MessageManager.create_instruction(instruction="do", sender="u", recipient=str(worker.id))
+    )
+
     ctx = env._live_persist
     env._finalize_extras = dag_extras()
 
@@ -1031,10 +1052,17 @@ async def test_stop_persists_cancelled_status_with_dag_metadata(
 
     async with StateDB() as db:
         s = await db.get_session(ctx["session_id"])
+        orc_row = await db.get_branch(str(orc_branch.id))
+        worker_row = await db.get_branch(str(worker.id))
 
     assert s["status"] == "cancelled"
     assert_dag_and_identity(s["node_metadata"])
     assert s["ended_at"] is not None
+
+    assert orc_row["status"] == "cancelled"
+    assert orc_row["ended_at"] is not None
+    assert worker_row["status"] == "cancelled"
+    assert worker_row["ended_at"] is not None
 
 
 # ── ADR-0064: artifact contract snapshot and verification ─────────────────────

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -447,6 +447,77 @@ async def test_stop_aggregates_usage_across_all_dag_leg_branches(
     assert s["input_tokens"] not in (0, 10, 100, 200)
 
 
+async def test_stop_finalizes_branch_status_for_all_dag_legs(
+    temp_db_path: Path,
+):
+    """BRANCH_END: every leg tracked via ctx["hooks"] (including the
+    orchestrator branch itself, which never gets a per-op NodeCompleted/
+    NodeFailed status write from cli/orchestrate/flow.py) gets its terminal
+    status/ended_at written at teardown."""
+    from lionagi.protocols.messages.manager import MessageManager
+
+    orc_branch = Branch(name="orchestrator")
+    env = _minimal_env(orc_branch=orc_branch)
+    await start_live_persist(env)
+    orc_hook = env._live_persist["hooks"][0][1]
+    orc_msg = MessageManager.create_instruction(
+        instruction="plan", sender="u", recipient=str(orc_branch.id)
+    )
+    await orc_hook(orc_msg)  # first message -> lazily creates the orc branch row
+
+    worker = Branch(name="worker-1")
+    env.session.include_branches(worker)
+    _register_branch_hook(env._live_persist, worker)
+    worker_hook = env._live_persist["hooks"][-1][1]
+    worker_msg = MessageManager.create_instruction(
+        instruction="do", sender="u", recipient=str(worker.id)
+    )
+    await worker_hook(worker_msg)
+
+    await stop_live_persist(env, status="failed")
+
+    async with StateDB() as db:
+        orc_row = await db.get_branch(str(orc_branch.id))
+        worker_row = await db.get_branch(str(worker.id))
+
+    assert orc_row is not None
+    assert orc_row["status"] == "failed"
+    assert orc_row["ended_at"] is not None
+    assert worker_row is not None
+    assert worker_row["status"] == "failed"
+    assert worker_row["ended_at"] is not None
+
+
+async def test_stop_does_not_clobber_worker_status_flow_already_finalized(
+    temp_db_path: Path,
+):
+    """A worker branch flow.py's own NodeCompleted handler already marked
+    'completed' must survive teardown's coarser run-level BRANCH_END even
+    when the overall session ends 'failed' because a different leg failed."""
+    from lionagi.protocols.messages.manager import MessageManager
+
+    env = _minimal_env()
+    await start_live_persist(env)
+
+    worker = Branch(name="worker-done")
+    env.session.include_branches(worker)
+    _register_branch_hook(env._live_persist, worker)
+    hook = env._live_persist["hooks"][-1][1]
+    msg = MessageManager.create_instruction(instruction="a", sender="u", recipient=str(worker.id))
+    await hook(msg)
+
+    ctx = env._live_persist
+    # Simulate flow.py's NodeCompleted per-op write finalizing this leg early.
+    await ctx["db"].update_branch(str(worker.id), status="completed", ended_at=111.0)
+
+    await stop_live_persist(env, status="failed")
+
+    async with StateDB() as db:
+        worker_row = await db.get_branch(str(worker.id))
+    assert worker_row["status"] == "completed"
+    assert worker_row["ended_at"] == 111.0
+
+
 async def test_stop_removes_persistence_handler_from_bus(
     temp_db_path: Path,
 ):

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -1409,6 +1409,58 @@ async def test_teardown_suppresses_failed_when_linked_engine_session_running(
     assert s["node_metadata"]["linked_engine_session_id"] == session_db_id(engine_uid)
 
 
+async def test_teardown_leaves_branch_untouched_when_suppressed_to_running(
+    temp_db_path: Path,
+):
+    """BRANCH_END must never fire for the phantom-'failed'-suppression case:
+    when the linked engine session is still running, teardown's final_status
+    resolves to 'running' (non-terminal), so the branch row — like the
+    session row above — must be left exactly as create_branch() left it, not
+    stamped with an ended_at from a status that isn't actually final."""
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "still working"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    async with StateDB() as db:
+        before = await db.get_branch(str(branch.id))
+    assert before["status"] is None
+    assert before["ended_at"] is None
+
+    exc = ProviderError("abandoned stream reader")
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid=engine_uid
+    )
+    assert final_status == "running"
+
+    async with StateDB() as db:
+        after = await db.get_branch(str(branch.id))
+    assert after["status"] is None
+    assert after["ended_at"] is None
+
+
 async def test_teardown_suppresses_failed_when_linked_engine_session_completed(
     temp_db_path: Path,
 ):

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -612,6 +612,81 @@ async def test_teardown_updates_session_bookmarks_and_status(
     assert s["ended_at"] is not None
 
 
+async def test_teardown_finalizes_branch_status_and_ended_at(
+    temp_db_path: Path,
+):
+    """The single-branch agent path never gets branches.status written
+    anywhere else (create_branch() doesn't set it and there was no
+    terminal-status hook) — teardown's BRANCH_END emission is its only
+    finalize."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    async with StateDB() as db:
+        before = await db.get_branch(str(branch.id))
+    assert before["status"] is None
+    assert before["ended_at"] is None
+
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        after = await db.get_branch(str(branch.id))
+    assert after["status"] == "completed"
+    assert after["ended_at"] is not None
+
+
+async def test_teardown_finalizes_branch_status_failed_on_exception(
+    temp_db_path: Path,
+):
+    """A branch whose operation raised must not be left with a NULL/'running'
+    status forever — teardown finalizes it to the run's actual outcome."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    await _teardown_live_persist(ctx, status="failed", exception=RuntimeError("boom"))
+
+    async with StateDB() as db:
+        b = await db.get_branch(str(branch.id))
+    assert b["status"] == "failed"
+    assert b["ended_at"] is not None
+
+
+async def test_teardown_branch_end_skipped_when_defer_terminal(
+    temp_db_path: Path,
+):
+    """defer_terminal=True skips ALL DB mutation, including BRANCH_END — the
+    resumed leg's own (non-deferred) teardown owns the real finalize."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    await _teardown_live_persist(ctx, status="timed_out", defer_terminal=True)
+
+    async with StateDB() as db:
+        b = await db.get_branch(str(branch.id))
+    assert b["status"] is None
+    assert b["ended_at"] is None
+
+
+async def test_teardown_branch_end_guard_skips_already_terminal_branch(
+    temp_db_path: Path,
+):
+    """finalize_branch()'s guard: a branch row already in a terminal status
+    (however it got there) is never overwritten by a later teardown's
+    coarser run-level status."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    async with StateDB() as db:
+        await db.update_branch(str(branch.id), status="completed", ended_at=111.0)
+
+    await _teardown_live_persist(ctx, status="failed", exception=RuntimeError("boom"))
+
+    async with StateDB() as db:
+        b = await db.get_branch(str(branch.id))
+    assert b["status"] == "completed"
+    assert b["ended_at"] == 111.0
+
+
 async def test_teardown_detaches_persistence_from_bus(
     temp_db_path: Path,
 ):

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -808,6 +808,132 @@ class TestBranchCreateEmission:
             _m._SHARED.pop(normalize_state_db_url(None), None)
 
 
+class TestBranchEndEmission:
+    """BRANCH_END emit → persist handler fires and is guarded against clobbering
+    a more specific terminal status a per-op writer already recorded."""
+
+    async def test_handler_fires_on_emit(self, monkeypatch, tmp_path):
+        from lionagi.hooks.builtins import persist_branch_end
+        from lionagi.hooks.bus import HookBus, HookPoint
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            sid, sprog = "be-session-1", "prog-be-s1"
+            bid, bprog = "be-branch-1", "prog-be-b1"
+            await _seed_session(db, sid, sprog)
+            await _seed_branch(db, bid, sid, bprog)
+
+            bus = HookBus()
+            bus.on(HookPoint.BRANCH_END, persist_branch_end)
+            await bus.emit(
+                HookPoint.BRANCH_END,
+                branch_id=bid,
+                status="completed",
+                ended_at=42.0,
+            )
+
+            row = await db.get_branch(bid)
+            assert row is not None
+            assert row["status"] == "completed"
+            assert row["ended_at"] == 42.0
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
+    async def test_guard_skips_already_terminal_status(self, monkeypatch, tmp_path):
+        """A per-op writer's more specific outcome (e.g. cli/orchestrate/flow.py's
+        NodeFailed branch-status update) must not be clobbered by a run-level
+        BRANCH_END carrying a different, coarser status."""
+        from lionagi.hooks.builtins import persist_branch_end
+        from lionagi.hooks.bus import HookBus, HookPoint
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            sid, sprog = "be-session-2", "prog-be-s2"
+            bid, bprog = "be-branch-2", "prog-be-b2"
+            await _seed_session(db, sid, sprog)
+            await _seed_branch(db, bid, sid, bprog)
+            await db.update_branch(bid, status="failed", ended_at=10.0)
+
+            bus = HookBus()
+            bus.on(HookPoint.BRANCH_END, persist_branch_end)
+            await bus.emit(
+                HookPoint.BRANCH_END,
+                branch_id=bid,
+                status="completed",
+                ended_at=999.0,
+            )
+
+            row = await db.get_branch(bid)
+            assert row["status"] == "failed"
+            assert row["ended_at"] == 10.0
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
+    async def test_default_status_is_completed(self, monkeypatch, tmp_path):
+        from lionagi.hooks.builtins import persist_branch_end
+        from lionagi.hooks.bus import HookBus, HookPoint
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            sid, sprog = "be-session-3", "prog-be-s3"
+            bid, bprog = "be-branch-3", "prog-be-b3"
+            await _seed_session(db, sid, sprog)
+            await _seed_branch(db, bid, sid, bprog)
+
+            bus = HookBus()
+            bus.on(HookPoint.BRANCH_END, persist_branch_end)
+            await bus.emit(HookPoint.BRANCH_END, branch_id=bid)
+
+            row = await db.get_branch(bid)
+            assert row["status"] == "completed"
+            assert row["ended_at"] is not None
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
+    async def test_missing_branch_row_does_not_raise(self, monkeypatch, tmp_path):
+        """A DAG leg branch that never got a first message (no create_branch()
+        call, so no row) must not make BRANCH_END raise."""
+        from lionagi.hooks.builtins import persist_branch_end
+        from lionagi.hooks.bus import HookBus, HookPoint
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            bus = HookBus()
+            bus.on(HookPoint.BRANCH_END, persist_branch_end)
+            # MUST NOT raise.
+            await bus.emit(HookPoint.BRANCH_END, branch_id="no-such-branch", status="failed")
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
+
 class TestDefaultHookBusEmissions:
     """build_session_bus wires all three handlers; each fires on the correct point."""
 
@@ -883,6 +1009,35 @@ class TestDefaultHookBusEmissions:
 
             row = await db.get_branch(bid)
             assert row["model"] == "m2"
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
+    async def test_branch_end_handler_wired_in_default_bus(self, monkeypatch, tmp_path):
+        from lionagi.hooks.bus import HookPoint
+        from lionagi.hooks.loader import build_session_bus
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            sid, sprog = "dbus-be-s1", "prog-dbus-bes1"
+            bid, bprog = "dbus-be-b1", "prog-dbus-beb1"
+            await _seed_session(db, sid, sprog)
+            await _seed_branch(db, bid, sid, bprog)
+
+            bus = build_session_bus()
+            handlers = bus.handlers_for(HookPoint.BRANCH_END)
+            assert len(handlers) == 1
+            await bus.emit(HookPoint.BRANCH_END, branch_id=bid, status="failed")
+
+            row = await db.get_branch(bid)
+            assert row["status"] == "failed"
+            assert row["ended_at"] is not None
         finally:
             await db.close()
             import lionagi.state.db as _m

--- a/tests/hooks/test_bus.py
+++ b/tests/hooks/test_bus.py
@@ -177,12 +177,13 @@ def test_hook_decorator_rejects_unknown_point():
 
 
 def test_hook_point_vocabulary():
-    """Pin the 11-event vocabulary so a removal is visible in this test."""
+    """Pin the 12-event vocabulary so a removal is visible in this test."""
     values = {p.value for p in HookPoint}
     assert values == {
         "session.start",
         "session.end",
         "branch.create",
+        "branch.end",
         "api.pre_call",
         "api.post_call",
         "api.stream_chunk",

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -26,6 +26,7 @@ def test_builtins_resolvable_by_name():
         "persist_session_start",
         "persist_session_end",
         "persist_branch_provenance",
+        "persist_branch_end",
         "persist_message",
         "log_api_metrics",
         "log_tool_call",
@@ -129,6 +130,7 @@ def test_default_hooks_only_cover_session_lifecycle_and_persistence():
         HookPoint.SESSION_END,
         HookPoint.MESSAGE_ADD,
         HookPoint.BRANCH_CREATE,
+        HookPoint.BRANCH_END,
     }
 
 

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -824,6 +824,90 @@ async def test_finalize_branch_defaults_ended_at_to_now(db: StateDB):
     assert row["ended_at"] >= before
 
 
+@pytest.mark.parametrize(
+    "existing_status",
+    ["completed", "completed_empty", "failed", "timed_out", "aborted", "cancelled"],
+)
+async def test_finalize_branch_skips_every_terminal_status(db: StateDB, existing_status: str):
+    """Every value in the session terminal-status vocabulary is immutable on a
+    branch row, not just 'completed'/'failed' — a branch already at
+    'cancelled', 'timed_out', 'aborted', or 'completed_empty' must survive a
+    later run-level finalize carrying a different terminal status exactly
+    like 'completed'/'failed' already did."""
+    branch = await _make_branch(db, status=existing_status)
+    await db.update_branch(branch["id"], ended_at=555.0)
+
+    updated = await db.finalize_branch(branch["id"], status="completed", ended_at=999.0)
+
+    assert updated is False
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == existing_status
+    assert row["ended_at"] == 555.0
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["completed", "completed_empty", "failed", "timed_out", "aborted", "cancelled"],
+)
+async def test_finalize_branch_stamps_every_terminal_status_from_null(
+    db: StateDB, terminal_status: str
+):
+    """The full session terminal-status vocabulary (not just completed/failed)
+    is a legitimate finalize target from a fresh (NULL-status) row."""
+    branch = await _make_branch(db)
+
+    updated = await db.finalize_branch(branch["id"], status=terminal_status, ended_at=42.0)
+
+    assert updated is True
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == terminal_status
+    assert row["ended_at"] == 42.0
+
+
+async def test_finalize_branch_rejects_running_payload(db: StateDB):
+    """'running' is not a terminal outcome -- BRANCH_END must never be able to
+    stamp a branch 'ended' with a non-terminal status, even against a fresh
+    (NULL-status) row that would otherwise pass the existing-row guard."""
+    branch = await _make_branch(db)
+
+    updated = await db.finalize_branch(branch["id"], status="running", ended_at=42.0)
+
+    assert updated is False
+    row = await db.get_branch(branch["id"])
+    assert row["status"] is None
+    assert row["ended_at"] is None
+
+
+async def test_finalize_branch_rejects_running_payload_against_running_row(db: StateDB):
+    """Same rejection when the existing row is itself 'running' (the state a
+    running payload would otherwise cleanly match against)."""
+    branch = await _make_branch(db, status="running")
+
+    updated = await db.finalize_branch(branch["id"], status="running", ended_at=42.0)
+
+    assert updated is False
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "running"
+    assert row["ended_at"] is None
+
+
+async def test_finalize_branch_repeated_call_does_not_flap_terminal_status(db: StateDB):
+    """A repeated (or concurrent-race-losing) finalization attempt carrying a
+    DIFFERENT terminal status than the one that already landed must not flap
+    either status or ended_at — the first genuine terminal write wins."""
+    branch = await _make_branch(db)
+
+    first = await db.finalize_branch(branch["id"], status="cancelled", ended_at=100.0)
+    assert first is True
+
+    second = await db.finalize_branch(branch["id"], status="completed", ended_at=200.0)
+    assert second is False
+
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "cancelled"
+    assert row["ended_at"] == 100.0
+
+
 # ── Shows ─────────────────────────────────────────────────────────────────────
 
 

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -736,6 +736,94 @@ async def test_get_branch_messages(db: StateDB):
     assert [r["id"] for r in result] == [m["id"] for m in msgs]
 
 
+# ── finalize_branch (BRANCH_END guarded terminal write) ─────────────────────
+
+
+async def _make_branch(db: StateDB, *, status: str | None = None) -> dict:
+    s = await _make_session(db)
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    branch = {
+        "id": uid(),
+        "session_id": s["id"],
+        "progression_id": prog_id,
+        "name": "leg",
+    }
+    await db.create_branch(branch)
+    if status is not None:
+        await db.update_branch(branch["id"], status=status)
+    return branch
+
+
+async def test_finalize_branch_stamps_status_and_ended_at_when_null(db: StateDB):
+    """A branch row that never had a status written (the single-branch agent
+    path's gap) is finalized on the first BRANCH_END-equivalent call."""
+    branch = await _make_branch(db)
+    assert (await db.get_branch(branch["id"]))["status"] is None
+
+    updated = await db.finalize_branch(branch["id"], status="completed", ended_at=123.0)
+
+    assert updated is True
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "completed"
+    assert row["ended_at"] == 123.0
+
+
+async def test_finalize_branch_stamps_failed_status(db: StateDB):
+    """A raising operation must not leave the branch row 'running' forever."""
+    branch = await _make_branch(db, status="running")
+
+    updated = await db.finalize_branch(branch["id"], status="failed", ended_at=456.0)
+
+    assert updated is True
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "failed"
+    assert row["ended_at"] == 456.0
+
+
+async def test_finalize_branch_skips_already_completed(db: StateDB):
+    """A per-op writer's 'completed' must not be clobbered by a coarser run-level finalize."""
+    branch = await _make_branch(db, status="completed")
+    await db.update_branch(branch["id"], ended_at=100.0)
+
+    updated = await db.finalize_branch(branch["id"], status="failed", ended_at=999.0)
+
+    assert updated is False
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "completed"
+    assert row["ended_at"] == 100.0
+
+
+async def test_finalize_branch_skips_already_failed(db: StateDB):
+    """Same guard, the other terminal value: 'failed' is never overwritten either."""
+    branch = await _make_branch(db, status="failed")
+    await db.update_branch(branch["id"], ended_at=200.0)
+
+    updated = await db.finalize_branch(branch["id"], status="completed", ended_at=999.0)
+
+    assert updated is False
+    row = await db.get_branch(branch["id"])
+    assert row["status"] == "failed"
+    assert row["ended_at"] == 200.0
+
+
+async def test_finalize_branch_missing_row_is_noop(db: StateDB):
+    """A branch id with no row (e.g. a DAG leg that never emitted a first
+    message, so create_branch() never ran) matches zero rows — harmless."""
+    updated = await db.finalize_branch(uid(), status="completed")
+    assert updated is False
+
+
+async def test_finalize_branch_defaults_ended_at_to_now(db: StateDB):
+    branch = await _make_branch(db)
+    before = time.time()
+
+    await db.finalize_branch(branch["id"], status="completed")
+
+    row = await db.get_branch(branch["id"])
+    assert row["ended_at"] >= before
+
+
 # ── Shows ─────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #2103.

`branches.status` was written by two disconnected paths: `create_branch()` never set it, and only the reactive-DAG per-op `NodeCompleted`/`NodeFailed` handlers in `cli/orchestrate/flow.py` ever updated it. The single-branch agent path had no terminal-status write at all, so rows sat at `NULL` forever, and a DAG leg whose operation raised before a terminal signal sat at `"running"` forever.

## Change

- New `HookPoint.BRANCH_END` on the hook bus (mirrors `BRANCH_CREATE`), with default handler `persist_branch_end`, emitted from `teardown_persist()` — the one chokepoint both the single-branch path (`ctx["branch"]`) and the multi-leg DAG path (`ctx["hooks"]`, including the orchestrator branch which has no per-op writer) already flow through at run end.
- New `StateDB.finalize_branch()`: a guarded `UPDATE ... WHERE status IS NULL OR status NOT IN ('completed','failed')`, so the run-level finalize never clobbers a more specific status the per-op writer already recorded, and is a no-op for a branch row that was never created.
- Respects `defer_terminal` (skipped entirely, matching session-level terminal-write behavior), so a resumed leg's own teardown owns the real finalize.

## Tests

241 tests across the touched files: single-branch success/failure/`defer_terminal`/guard cases (`tests/cli/test_agent_live_persist.py`), multi-leg DAG finalize + non-clobber (`tests/cli/orchestrate/test_live_persist.py`), DB-level guard/no-op/default-timestamp (`tests/state/test_db.py`), hook emission + default wiring + pinned vocabulary (`tests/hooks/`).