### PR TITLE
test(studio): cover the 'command' action kind on the on-demand /launches route

### DIFF
--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -1335,3 +1335,267 @@ class TestLaunchFlowYamlKind:
 
         assert captured["schedule"]["action_kind"] == "flow_yaml"
         assert captured["schedule"]["action_flow_yaml"] == "prompt: hi\n"
+
+
+# ---------------------------------------------------------------------------
+# command kind — allow-listed executable, spawned directly (never through `li`)
+# ---------------------------------------------------------------------------
+
+_COMMAND_ALLOWLIST_ENV = "LIONAGI_SCHEDULER_COMMAND_ALLOWLIST"
+
+
+@pytest.mark.integration
+class TestLaunchCommandKind:
+    """POST /api/launches with action_kind='command' — every other action_kind
+    has coverage above; this one previously had none on the on-demand
+    /launches route."""
+
+    def test_launch_command_returns_202(self, tmp_path, monkeypatch):
+        """An allow-listed command must be accepted and return 202."""
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={
+                "action_kind": "command",
+                "action_command": "echo",
+                "action_command_args": ["hi"],
+            },
+        )
+        assert resp.status_code == 202, resp.text
+        data = resp.json()
+        assert "invocation_id" in data
+        assert data["action_kind"] == "command"
+
+    def test_launch_command_missing_command_422(self, tmp_path, monkeypatch):
+        """action_command is required for command launches."""
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post("/api/launches", json={"action_kind": "command"})
+        assert resp.status_code == 422, resp.text
+        assert "action_command is required" in resp.json()["detail"]
+
+    def test_launch_command_not_allowlisted_422(self, tmp_path, monkeypatch):
+        """A command absent from the allow-list must be rejected on this route."""
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "safe-cmd")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "command", "action_command": "rm"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "is not in" in resp.json()["detail"]
+
+    def test_launch_command_empty_allowlist_refuses_everything(self, tmp_path, monkeypatch):
+        """With the allow-list env var unset, every command is refused — this is
+        the entire safety mechanism for a generic command runner; pin it here
+        on the on-demand launch route specifically."""
+        monkeypatch.delenv(_COMMAND_ALLOWLIST_ENV, raising=False)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "command", "action_command": "echo"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "is not in" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("bad_command", ["../evil", "/bin/rm", "a/b", "sub\\dir"])
+    def test_command_path_separator_rejected(self, tmp_path, monkeypatch, bad_command):
+        """A command containing a path separator must be rejected regardless of
+        the allow-list — shape validation runs before the allow-list check."""
+        monkeypatch.delenv(_COMMAND_ALLOWLIST_ENV, raising=False)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "command", "action_command": bad_command},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "path separators" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("bad_command", ["-rf", "--bypass", "-x"])
+    def test_command_leading_dash_rejected(self, tmp_path, monkeypatch, bad_command):
+        """A command starting with '-' must be rejected regardless of the allow-list."""
+        monkeypatch.delenv(_COMMAND_ALLOWLIST_ENV, raising=False)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "command", "action_command": bad_command},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "starts with '-'" in resp.json()["detail"]
+
+    def test_launch_command_args_scalar_rejected_by_route(self, tmp_path, monkeypatch):
+        """action_command_args must be a JSON array; a scalar string must 422
+        (rejected by the Pydantic model's list[str] field on this route)."""
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={
+                "action_kind": "command",
+                "action_command": "echo",
+                "action_command_args": "hi",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_validate_request_rejects_command_args_scalar(self, monkeypatch):
+        """_validate_request carries its own defensive isinstance check for
+        callers that bypass the Pydantic model (e.g. direct launch() callers,
+        or a future non-HTTP caller) — a non-list action_command_args must
+        still be rejected at that layer."""
+        from lionagi.studio.services.launches import _validate_request
+
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        with pytest.raises(ValueError, match="must be a list"):
+            _validate_request(
+                {
+                    "action_kind": "command",
+                    "action_command": "echo",
+                    "action_command_args": 42,
+                }
+            )
+
+    def test_validate_request_accepts_valid_command(self, monkeypatch):
+        """_validate_request must not raise for a clean, allow-listed command request."""
+        from lionagi.studio.services.launches import _validate_request
+
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        _validate_request(
+            {
+                "action_kind": "command",
+                "action_command": "echo",
+                "action_command_args": ["hi"],
+            }
+        )
+
+    def test_command_schedule_carries_command_and_args(self, monkeypatch):
+        """launch() must forward action_command/action_command_args into the
+        schedule dict passed to build_argv (mirrors
+        test_flow_yaml_schedule_carries_yaml above)."""
+        import lionagi.studio.services.launches as svc
+
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        captured = {}
+
+        def _fake_build_argv(schedule, ctx):
+            captured["schedule"] = schedule
+            return (["echo", "hi"], None)
+
+        def _consume(coro, **kw):
+            coro.close()
+            return MagicMock()
+
+        with (
+            patch("lionagi.studio.services.launches.build_argv", side_effect=_fake_build_argv),
+            patch("lionagi.studio.services.launches.StateDB") as MockDB,
+            patch("lionagi.studio.services.launches.asyncio.create_task", side_effect=_consume),
+        ):
+            mock_db = AsyncMock()
+            mock_db.create_invocation = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            asyncio.run(
+                svc.launch(
+                    {
+                        "action_kind": "command",
+                        "action_command": "echo",
+                        "action_command_args": ["hi"],
+                    }
+                )
+            )
+
+        assert captured["schedule"]["action_kind"] == "command"
+        assert captured["schedule"]["action_command"] == "echo"
+        assert captured["schedule"]["action_command_args"] == ["hi"]
+
+    def test_spawn_detached_threads_command_action_kind(self):
+        """_spawn_detached must pass action_kind='command' through to
+        spawn_and_wait — that is what closes the TOCTOU window between
+        argv-build time and the actual subprocess exec: build_argv's allow-list
+        check runs once at schedule-dict-build time, but the caller performs
+        awaited DB work before the process actually spawns, so a second,
+        no-intervening-await check right at spawn_and_wait is required to
+        observe an allow-list revoked in that window."""
+        import lionagi.studio.services.launches as svc
+
+        captured = {}
+
+        async def _fake_spawn(argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None):
+            captured["action_kind"] = action_kind
+            captured["argv"] = argv
+            return (0, "")
+
+        mock_db = AsyncMock()
+        mock_db.update_invocation = AsyncMock()
+        mock_db.update_status = AsyncMock()
+
+        async def _run():
+            with patch("lionagi.studio.services.launches.StateDB") as MockDB:
+                MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+                with patch(
+                    "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                    side_effect=_fake_spawn,
+                ):
+                    await svc._spawn_detached(
+                        ["echo", "hi"], "inv-cmd", tmp_path=None, action_kind="command"
+                    )
+
+        asyncio.run(_run())
+        assert captured["action_kind"] == "command"
+        assert captured["argv"] == ["echo", "hi"]
+
+    def test_launch_command_end_to_end_reaches_spawn_with_action_kind(self, monkeypatch):
+        """Full launch() -> _spawn_detached -> spawn_and_wait path (real
+        build_argv; only StateDB and the actual subprocess spawn are stubbed)
+        must carry action_kind='command' all the way to the spawn-time
+        re-check — the concrete on-demand-launch instance of the TOCTOU gate."""
+        import lionagi.studio.services.launches as svc
+
+        monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
+        captured = {}
+
+        async def _fake_spawn(argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None):
+            captured["action_kind"] = action_kind
+            captured["argv"] = argv
+            return (0, "")
+
+        mock_db = AsyncMock()
+        mock_db.create_invocation = AsyncMock()
+        mock_db.update_invocation = AsyncMock()
+        mock_db.update_status = AsyncMock()
+
+        async def _run():
+            with (
+                patch("lionagi.studio.services.launches.StateDB") as MockDB,
+                patch(
+                    "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                    side_effect=_fake_spawn,
+                ),
+            ):
+                MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                result = await svc.launch(
+                    {
+                        "action_kind": "command",
+                        "action_command": "echo",
+                        "action_command_args": ["hi"],
+                    }
+                )
+                inv_id = result["invocation_id"]
+                task = next(t for t in svc._detached_tasks if t.get_name() == f"launch-{inv_id}")
+                await task
+
+        asyncio.run(_run())
+        assert captured["action_kind"] == "command"
+        assert captured["argv"] == ["echo", "hi"]

--- a/tests/cli/test_command_action_kind.py
+++ b/tests/cli/test_command_action_kind.py
@@ -504,3 +504,81 @@ class TestWorkerDefaultExecuteCommandKind:
         exit_code, stderr = asyncio.run(_go())
         assert exit_code == 1
         assert "cannot resolve li executable" in stderr
+
+
+# ---------------------------------------------------------------------------
+# CLI — _cmd_create's --action-command-args JSON handling. TestCliActionKindChoices
+# above only pins argparse's raw string capture; the JSON-parse/shape error
+# paths inside _cmd_create itself (cli.py lines ~839-848) were untested.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCreateActionCommandArgsJSON:
+    def _parse(self, argv: list[str]):
+        import argparse
+
+        from lionagi.studio.cli import add_schedule_subparser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        add_schedule_subparser(sub)
+        return parser.parse_args(argv)
+
+    def _argv(self, action_command_args_json: str) -> list[str]:
+        return [
+            "schedule",
+            "create",
+            "cli-command-json-test",
+            "--cron",
+            "0 * * * *",
+            "--action-kind",
+            "command",
+            "--action-command",
+            "kdev",
+            "--action-command-args",
+            action_command_args_json,
+        ]
+
+    def test_invalid_json_rejected_before_api_call(self, capsys):
+        """Malformed JSON in --action-command-args must return 1 and never
+        reach the HTTP layer."""
+        from lionagi.studio.cli import _cmd_create
+
+        args = self._parse(self._argv("{not valid json"))
+        with patch("lionagi.studio.cli._api") as mock_api:
+            rc = _cmd_create(args)
+
+        assert rc == 1
+        mock_api.assert_not_called()
+        assert "--action-command-args must be valid JSON" in capsys.readouterr().err
+
+    def test_valid_json_non_array_rejected_before_api_call(self, capsys):
+        """Valid JSON that parses to a non-array (e.g. an object) must return
+        1 and never reach the HTTP layer."""
+        from lionagi.studio.cli import _cmd_create
+
+        args = self._parse(self._argv('{"not": "an array"}'))
+        with patch("lionagi.studio.cli._api") as mock_api:
+            rc = _cmd_create(args)
+
+        assert rc == 1
+        mock_api.assert_not_called()
+        assert "--action-command-args must be a JSON array" in capsys.readouterr().err
+
+    def test_valid_json_array_parsed_and_forwarded(self):
+        """A well-formed JSON array must be parsed and forwarded as the
+        action_command_args field of the POST body."""
+        from lionagi.studio.cli import _cmd_create
+
+        args = self._parse(self._argv('["review-pr", "--repo", "{{repo}}"]'))
+        with patch(
+            "lionagi.studio.cli._api",
+            return_value={"id": "sid1", "name": "cli-command-json-test"},
+        ) as mock_api:
+            rc = _cmd_create(args)
+
+        assert rc == 0
+        mock_api.assert_called_once()
+        body = mock_api.call_args.kwargs["body"]
+        assert body["action_command_args"] == ["review-pr", "--repo", "{{repo}}"]
+        assert body["action_command"] == "kdev"


### PR DESCRIPTION
## Summary
- Add TestLaunchCommandKind to tests/apps_studio_server/test_launches_api.py: happy path,
  missing-command, allow-list rejection (including the empty-allowlist "refuses everything"
  case), path-separator/leading-dash shape rejection, action_command_args-must-be-a-list
  (route + unit level), schedule-dict shape, and two tests proving action_kind="command"
  actually reaches spawn_and_wait's TOCTOU-closing re-check.
- Add TestCmdCreateActionCommandArgsJSON to tests/cli/test_command_action_kind.py, calling
  _cmd_create directly to cover its --action-command-args JSON error paths (invalid JSON,
  valid-JSON-non-array), which the existing argparse-only test in that file didn't reach.

## Test plan
- [x] tests/apps_studio_server/test_launches_api.py::TestLaunchCommandKind — 17 passed
- [x] tests/apps_studio_server/ full suite (studio extra installed) — 942 passed
- [x] tests/cli/test_command_action_kind.py (studio extra installed) — 34 passed
- [x] tests/cli/test_command_action_kind.py (default venv, no studio extra) — 26 passed,
      8 pre-existing fastapi-import failures unchanged from before this PR
- [x] Teeth-proof: disabled the shared allow-list check and the action_kind spawn-time
      kwarg in turn, confirmed the relevant new tests fail (one run genuinely spawned
      `rm`/`echo`), reverted — lionagi/ source is diff-clean
- [x] ruff check / ruff format clean

Closes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
