### PR TITLE
chore(core): trim comment/docstring verbosity, move keeps to docs/internals

### DIFF
--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -1,0 +1,360 @@
+# Internals Reference
+
+Invariants, protocol contracts, and design rationale extracted from source
+during the comment/docstring trim sweep. Organized by module path. This is
+the durable home for content that used to live as long inline prose — the
+source now carries a 1-2 line pointer, the full contract lives here.
+
+## `operations/`
+
+**`lndl_middle/lndl_middle.py`** — LNDL seam Middle (ADR-0024 §1-2): advances
+a branch one LNDL round per inner chat call, looping internally up to a round
+budget (default 3). Opt-in via `branch.operate(instruction=..., middle=lndl_middle)`;
+nothing changes for callers who don't pass it. `_classify_round` returns
+`(outcome, pending_action_calls, assembled_dict)` — `pending` is every lact
+for `Continue`, only OUT{}-reachable lacts for `Success`; `assembled` is set
+only on `Success`. `lndl_middle/__init__.py` is a new opt-in public symbol
+(unlike the internal `communicate`/`run`/`act` submodule dispatch paths).
+
+**`operate/step.py`** — `Step.request_operative` / `respond_operative`:
+identically-constructed Operatives may share one request/response model
+**type** (a process-wide cache); instances and their state stay per-call.
+Never mutate a returned model class. `LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0`
+restores per-call classes (disables sharing). See also `models/_build_model.py`
+and `adapters/spec_adapters/pydantic_field.py` below — same cache, different layer.
+
+## `session/`
+
+**`signal.py`** — Signal types and per-node lifecycle projection for the
+reactive bus (ADR-0033), `schema_version=1`. Payload fields per signal kind
+(`RunStart`, `RunEnd`, `RunFailed`, `NodeSpawned`, `NodeQueued`, `NodeStarted`,
+`NodeCompleted`, `NodeFailed`, `NodeAwaitingApproval`, `NodeEscalated`,
+`NodePaused`, `GateDenied`, `MessageAdded`, `DispatchSignal` (ADR-0059)) are
+enumerated in the module. Version policy: `schema_version` bumps only on
+breaking field removal/rename; adding nullable fields is non-breaking.
+
+- `RunEnd.total_cost_usd` is `None` (unknown) unless a provider actually
+  reports a dollar cost — providers that don't (bare API endpoints) must
+  never be recorded as free (`0.0`). Same for `_collect_branch_usage` /
+  `_collect_multi_branch_usage`: cost accumulation checks *presence*, not
+  truthiness (`x or y` would silently drop an explicit `0.0`).
+  `_collect_multi_branch_usage` deliberately excludes `duration_ms` — wall-clock
+  across parallel legs isn't simply summable.
+- `DispatchSignal` (ADR-0059): one stable envelope (`to_dict(mode="json")`)
+  shared by every dispatch kind, so the transport template never churns per-kind.
+- `NodeEscalated.route` is `"higher_tier"` (retry), `"give_up"` (terminal), or
+  `"notify"` (soft help signal — informational only, node's own lifecycle
+  unaffected). Classification rule: a soft ("fyi") help signal must not get
+  pinned into the terminal "escalated" lane — only a "blocked" urgency (default,
+  matching historical give_up/higher_tier behavior) or an unaccompanied signal
+  (no request attached) is treated as escalated.
+
+**`observer.py`** — `_PAYLOAD_BYTE_CAP` bounds the persisted `payload` JSON
+column in `session_signals`, not the SSE frame: the SSE generator wraps each
+row in an envelope (`data: ...\n\n` + row metadata) adding ~176 bytes of
+overhead, so frames can exceed the cap by that margin. Callers needing a hard
+frame cap must reserve envelope overhead before calling
+`_sanitize_signal_payload`. Truncation strategy in `_sanitize_signal_payload`:
+measure the *final* serialized form (not the intermediate `safe_json` string —
+re-serializing after wrapping in a truncation-marker dict can be up to 2x
+larger due to JSON escaping); if over cap, build a truncation-marker dict
+with a data slice that shrinks iteratively until the whole re-serialized dict
+fits. `SessionObserver.authorize` routes through the shared `GateResult`
+adapter (`lionagi.agent.gate`) so the session gate's fail-closed-on-exception
+behavior matches `PermissionPolicy` and the built-in coding guards (ADR-0086).
+
+**`session.py`** — Every new graph-execution surface must delegate through
+`Session.flow` or the streaming flow kernel, and include conformance coverage.
+`Session.memory` is read-only: an explicitly supplied backend, or a
+lazily-created shared `InMemoryStore` on first access; the only way to give a
+`Session` its own store is the `memory=` constructor parameter.
+
+**`exchange.py`** — `Exchange.run` does not reset `_stop` on entry: a
+`stop()` issued before the coroutine's first turn must make `run()` return
+immediately rather than clearing the signal and looping forever. Construct a
+fresh `Exchange` for a new run instead of reusing a stopped one.
+
+## `lndl/`
+
+LNDL (Lion Notation Definition Language) — structured-output tag format
+mixing natural reasoning with structured data. Core modules (`lexer`,
+`parser`, `ast`, `assembler`, `extract`, `normalize`, `types`, `errors`,
+`prompt`, `diagnostics`, `round_outcome`) have no external deps beyond
+lionagi + pydantic.
+
+**`assembler.py`** — turns parsed `Program` (lvars, lacts, out_block) + a
+target Pydantic type into a dict for `target.model_validate()`. Supports
+scalar, nested-model, `list[scalar]`, `list[Model]` (field-repeat detection
+groups aliases into instances), and `dict[str, V]` target shapes.
+`_coerce_str_to_list` strict priority: JSON array → Python list literal →
+newline-split → bracketed comma list → else wrap whole string as `[s]`
+(deliberately avoids shredding prose by commas). `_alias_value`: an alias not
+declared in the current round but present in `action_results` resolves to
+that historical result — a later round's `OUT{}` can reference a lact
+executed in an earlier round without re-declaring it. `_assemble_grouped_list`
+salvages string-literal items (not declared aliases) onto the model's first
+string-typed field, as a fallback for `[["raw text"], ["raw text 2"]]` shapes.
+
+**`diagnostics.py`** — opt-in telemetry (`LndlTrace`) for
+`branch.operate(lndl=True, trace=trace)` / `ReActStream`; `trace=None`
+(default) means zero overhead. Three classification layers answer different
+questions: **syntax** (`classify_chunk`: `clean`/`malformed`/`no_out` — did
+the model write valid LNDL?), **outcome** (`LndlRoundRecord.outcome`, mirrors
+the `RoundOutcome` ADT — what did the framework decide?), **result**
+(`classify_result`: `ok`/`str`/`dict`/`empty` — what did the caller get?).
+`extract_lndl_chunks(messages, since)`: pass `since=len(branch.messages)`
+before a call, then call again after to isolate chunks from that call only.
+
+**`_parse_function_call.py`** — parses `<lact>` bodies into
+`{operation, service?, arguments}`. When a service prefix is present
+(`svc.tool(...)`), `qualified_name` returns `"svc.tool"` — the name used for
+tool-registry lookup so namespaced tools resolve correctly.
+
+**`normalize.py`** — auto-fixes common model-invented LNDL syntax drift
+(models trained on XML/HTML/JSON) before the parser runs, ported from
+`krons.lndl.fuzzy`. `_fix_missing_gt` is conservative: only fires when the
+opening tag has a function-call paren AND the closing tag is present.
+`normalize_lndl_text` transforms: curly-brace tags → angle-bracket tags; XML
+attributes stripped; missing `>` before body inserted (when body has a
+parenthesized call); `Note.` namespace casing → `note.` (the note namespace
+and `OUT{}` `note.x` refs are matched case-sensitively downstream, so
+model-invented capitalization must be normalized here).
+
+**`parser.py`** — `_parse_out_list` returns `list[str]` for flat refs,
+`list[list[str]]` for nested-bracket groups. `_resolve_alias_to_spec`
+resolution priority (most-specific first): (1) declared field on a
+`Model.field` form → field name, (2) declared model on a `Model.field` form →
+model name, (3) two-token hint on a `<l_ hint alias>` form → the hint;
+`None` when the alias has no spec context (single-token raw form).
+
+**`round_outcome.py`** — `RoundOutcome` ADT: a multi-round LNDL run is a
+state machine, each round produces an outcome, the outer loop matches on it
+(replaces ad-hoc parse-fail/validate-fail/missing-out branches). Ported from
+`krons.agent.operations.round_outcome`. `Continue`: no `OUT{}` this round;
+lacts that ran are already persisted as tool messages before the next round
+starts. `Retry`: `OUT{}` produced but parse/resolve/validate failed — `error`
+feeds back to the model next round; scratchpad and chat history from prior
+rounds remain intact.
+
+**`ast.py`** — `RLvar.extra_id` / `Lact.extra_id`: records the leading token
+of a two-token raw form (`<lvar hint alias>` / `<lact hint alias>`) so the
+OUT-shortcut path (`parser._resolve_alias_to_spec`) can resolve `alias` back
+to the implied spec name `hint`. `None` for the single-token form.
+
+**`types.py`** — `_coerce_result`: a legitimately-`None` result for an
+`Optional` scalar must pass through untouched (coercing would corrupt it —
+`scalar(None)` yields the literal `"None"` for `str`, raises for `int`/`float`).
+Boolean coercion uses `validate_boolean`, not `bool()` — `bool('false') == True`
+in Python; `validate_boolean` maps `'false'`/`'0'`/`'no'` → `False`.
+
+## `libs/`
+
+**`path_safety.py`** — `is_protected_name`: matches protected basenames
+**case-insensitively**, because default macOS/Windows volumes are
+case-insensitive filesystems — a case-sensitive check can be bypassed with
+`.ENV` resolving to the same file as `.env`. Shared primitive for both
+`resolve_workspace_path` and the deny-only hook floor. `resolve_workspace_path`
+checks: expanduser, symlink detection pre-resolve, containment, denied names;
+raises `PermissionError` on violation. Validation is check-time only (TOCTOU):
+a concurrent filesystem mutation between check and later I/O (e.g. swapping a
+file for a symlink) is out of scope — callers needing a stronger guarantee
+must do final I/O through a root-anchored, no-follow file descriptor.
+
+## `casts/`
+
+**`emission.py`** — `EscalationRequest.urgency` (`"fyi"` | `"blocked"`) is
+the single authoritative field for escalation hardness; `"fyi"` is soft (work
+continues, informational), `"blocked"` is hard (work cannot continue).
+`blocking` is a read-only back-compat alias for `urgency == "blocked"` — a
+legacy `blocking=` constructor kwarg is still accepted and mapped onto
+`urgency` for one release of grace, then removed.
+
+**`pattern.py`** — Roles/modes are a **closed** built-in set, one inline
+module per pattern, each exposing a single `ROLE`/`MODE`. Not user-definable;
+users extend via packs (`casts/pack.py`), never by adding role/mode modules.
+`Role.artifact_defaults` (ADR-0064 shape:
+`{"expected": [{"id", "path", "required", ...}]}`) is a gate role's declared
+output contract, merged per-leg into the flow's `artifact_contract` at
+DAG-build time (`flow.py _build_dag`); `None` means no artifact claim.
+
+## `adapters/`
+
+**`spec_adapters/pydantic_field.py`** — `_model_type_cache`: model classes
+(unlike Operative instances) hold no request/response state and are shared
+across identical constructions. Sharing contract: callers must not mutate a
+returned model class (mutation is visible to every later identical
+construction); `LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0` disables sharing. LRU
+bounds strong references to dynamically-created base classes and generated
+models.
+
+## `models/`
+
+**`_build_model.py`** — `build_model_type` is deliberately **uncached**:
+`FieldInfo` and validator inputs can be mutable. The Operative-construction
+cache one layer up (`adapters/spec_adapters/pydantic_field.py`) caches only
+immutable schemas, keyed by the actual base-class **object identity** plus
+frozen build options — class-object identity (not a structural hash) keeps
+distinct same-named/same-shaped classes separate; a prior structural-hash
+implementation cross-wired their generated models.
+
+## `ln/`
+
+**`concurrency/utils.py`** — SIGTERM/SIGINT handling around `run_async`.
+`_SIGTERM_RECEIVED` is a process-wide latch set by the SIGTERM handler the
+moment the signal arrives; `SigtermInterrupt` is raised only after the worker
+thread has joined, so persist paths consult the latch to distinguish an
+external SIGTERM from an internal runtime cancel. `consume_sigterm_received`
+reads-and-clears the latch so one external SIGTERM labels exactly one run
+(without consuming, it would mislabel every later run/test's cancellation).
+`SigtermInterrupt` deliberately subclasses `BaseException`, not
+`KeyboardInterrupt` (the SIGINT/user convention) — so a bare
+`except Exception:` can't silently swallow it. `run_async` installs temporary
+SIGINT/SIGTERM handlers on the main thread that cancel the inner asyncio task
+via `call_soon_threadsafe`: SIGINT's default raises `KeyboardInterrupt` in
+`join()`, orphaning the child thread and leaving session rows stuck
+"running"; SIGTERM's default is immediate process termination with no
+unwind, so without a handler an external SIGTERM (timeout supervisor,
+process-group kill) is silent. In `_runner`, if a signal latched before the
+future existed, cancel immediately rather than running to completion (the
+only path for SIGTERM, whose default disposition isn't callable as fallback).
+
+**`_proc.py`** — `_safe_pgid`: `pid` must be `int > 1` — `pid==0` is our own
+process group, `pid==1` is init/session leader on CI (would `SIGKILL` the
+harness itself; also catches `MagicMock.pid==1`). `killpg` is POSIX-only;
+returning `None` makes callers fall back to `proc.terminate()`/`kill()`.
+
+**`_ssrf.py`** — `_CANONICAL_LOCAL_HOSTS`: only the exact strings
+`"localhost"`, `"127.0.0.1"`, `"::1"` are accepted for `allow_local=True`.
+Alternate encodings (`2130706433`, `0x7f000001`, `127.1`,
+`::ffff:127.0.0.1`, etc.) are intentionally excluded to prevent
+DNS-rebinding bypass.
+
+## `engines/`
+
+**`engine.py`** — `EngineRun.cancel_active`: waits up to
+`engine.cancel_timeout_s`; tasks that don't settle in that window are
+abandoned with a logged warning (lifetime guarantee preserved either way).
+`wait_quiescence`: blocks until all spawned tasks settle, re-raises
+non-cancellation/non-budget failures — `EngineBudgetError` is a benign
+"expansion stopped" signal (discretionary work declined, not a crash) and is
+swallowed like `CancelledError`. `EngineResult` (`Engine.run()` return type):
+a `str` subclass carrying structured outcome; `str(result)` and `result.text`
+are the same synthesized text; `.run` is a live `EngineRun` handle — don't
+retain it past reading the result, it keeps the whole `Session` (and its
+branches) alive. `Engine._degrade_export`: cancels in-flight spawned tasks,
+then runs `_partial_export` shielded + timeout-bounded; shared by the
+deadline and root-budget degrade paths in `run()`; returns `_UNSET` on
+failure/timeout (logged, not raised) — an external cancel during the shielded
+phase still propagates. `Engine.run`'s `(EngineBudgetError, ExceptionGroup)`
+handler: a root-level `make_agent()` budget-out routes to partial-export
+instead of crashing; masking guard — a non-budget leaf anywhere in the group
+(including nested groups) must not be laundered into a partial, so it
+re-raises instead.
+
+**`coding.py`** — `CodingChainEvent` `eid` prefixes (`W`/`P`/`T`/`V`/`K`) are
+namespaced against hypothesis engine's (`F`/`Q`/`E`/`H`/`X`/`R`/`C`/`A`) so
+IDs never collide across engines; refs link a stage to its upstream stage so
+the export is a walkable chain. `CodingEngine._fix_loop`: re-prompts the
+implementer on failure and re-tests, bounded by `max_fix_rounds`; mechanical
+rounds (fixed by auto-repair alone) skip the judge gate, substantive rounds
+go through it; `fast_test_cmd` (if configured) gates intermediate rounds,
+`test_cmd` is always the final ground-truth leg. `_capture_diff` candidate
+set: union of the initial workspace delta (covers emission-failure rewrites)
+and every file any `ChangeProposed` claimed to touch, evaluated at verify
+time so fix-round additions are included; paths normalized to
+workspace-relative POSIX before intersecting (`files_touched` often carries
+absolute paths per the coding tool schema, while `git ls-files --others`
+returns repo-relative); paths escaping the workspace are dropped.
+
+## `protocols/`
+
+**`context_providers.py`** — `ContextProviderRegistry`: providers register
+in render order; when combined output exceeds `budget`, lowest-priority
+providers are dropped first. A raising provider is warned + skipped, never
+blocks the turn. `gather_writeback` (post-turn hook): providers with an
+optional `writeback(branch, action_responses)` method get a chance to persist
+from the turn's action responses, under the same raise-warns-skips containment.
+
+**`messages/message.py`** — `Message._render_cached`: rendering cache keyed
+by content identity + revision, served only when the stored content **is**
+the current content object — an `id()`-based key alone could cross-wire two
+content objects with non-overlapping lifetimes that happen to reuse the same
+address.
+
+**`generic/processor.py`** — `Processor.process`: dequeues and processes
+events up to available capacity. Denied events are either terminal
+(`SKIPPED`) or deferred (re-enqueued); the cycle stops when all queued events
+have been deferred, to avoid busy-spin.
+
+**`messages/instruction.py`** — `_DATA_IMAGE_RE`: only a bitmap MIME
+allowlist is accepted for inline image data URIs, payload must be non-empty
+base64; active-content types (HTML, JS, SVG — can carry scripts) and other
+`data:` schemes are rejected by design. `InstructionContent.__init__` builds
+the structure from the tracked copy, not the caller's dict — a structure
+holding the caller's alias would let external mutation change rendering
+without advancing the content revision. `__getstate__` excludes the private
+structure (may cache a dynamically-created request-model class that can't be
+serialized); `__setstate__` restores through `__setattr__` (so mutable render
+inputs are re-wrapped) then rebuilds the private structure from the restored
+`response_format` — keeping the copied structure would leave the renderer
+reading a dict detached from the restored public field. `to_dict` includes
+`response_format` only when it's a plain dict (JSON-serializable); excluded
+for type/`BaseModel` references, which can't round-trip through
+`to_dict` → `from_dict`.
+
+**`action/manager.py`** — `_validate_prebuilt_mcp_tool_admission`: a
+schema/description that's just the auto-generated `**kwargs` wrapper carries
+no remote-server info, so it's treated as absent metadata — strong identities
+fail closed instead of laundering through their own synthetic schema, and
+ordinary names aren't falsely denied by the wrapper's generic docstring.
+`register_mcp_server` (both the `tool_names` path and the discovered-tools
+path): validates the complete list before creating/registering **any** tool —
+a denial anywhere must leave the registry exactly as it was, never partially
+populated with whichever names/tools happened to validate first.
+`load_mcp_config`: defaults to servers declared in the config file just
+loaded, not the full pool — `MCPConnectionPool` accumulates configs
+process-globally across loads, so enumerating the pool here would silently
+re-register every server from previously loaded, unrelated configs.
+
+## `orchestration/`
+
+**`patterns.py`** — `role_node_builder` returns a node_builder closure
+routing `SpawnRequest`s to role branches. `decorate_instruction`, when given,
+receives the request and the node's freshly allocated `spawn_id` and must
+return the full instruction text the child runs with (CLI callers use it to
+inject the artifact-directory + REQUIRED-file text a planned leg gets, see
+`lionagi.cli.orchestrate.flow`). `start` seeds the closure's spawn-id
+sequence past ordinals already issued in a prior generation (e.g. a CLI
+resume reconstructing completed spawns from a checkpoint) — without it, a
+fresh sequence restarting at 1 would reissue an id already used by a restored
+node, colliding with any live spawn this generation (same `spawn_id`, same
+artifact directory).
+
+`_next_spawn_seq = itertools.count(start)` is closure-scoped and is the
+**only** correct source of a spawned node's stable id: it must be allocated
+at construction time because that's the sole point that sees the
+`SpawnRequest` before the child Operation is queued. Minting the id at
+completion time (the prior implementation) let an unrelated node "steal"
+spawn-1 depending on which sibling finished first.
+
+Inside `role_node_builder.build`: the operation allowlist check is
+defense-in-depth even though `SpawnRequest.operation` is already a typed
+`Literal` — custom operation names registered on a session branch must
+**never** be reachable via model-emitted spawn requests; fails closed on
+anything outside the documented allowlist. Spawn-id allocation happens only
+after assignee validation succeeds, so an unknown assignee never consumes a
+sequence number — ids handed to real children stay dense modulo only genuine
+post-build rejections (cycle/cap) downstream. Metadata stamping (`spawn_id`,
+`reference_id`) lets post-run callers (artifact contracts, DAG metadata)
+attribute a reactively spawned node back to its assignee role even after the
+executor overwrites `branch_id` with a per-spawn branch clone; `spawn_id`
+survives the clone (it's metadata, not branch state) and is the stable
+correlation key every downstream surface must use — `reference_id` mirrors it
+for the executor's own display path (`DependencyAwareExecutor._run_tracked`
+reads `metadata["reference_id"]` for its progress/log line).
+
+**`prompts.py`** — Planning section (`DECOMPOSE_INSTRUCTION`): the
+orchestrator decomposes the task into `TaskAssignment`s (the casts
+coordination emission); `assignee` names a role from the roster, `task` is
+the concrete objective. There is no bespoke plan model — a list of
+`TaskAssignment`s (with `depends_on`) *is* the plan (and the DAG).

--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -1,9 +1,8 @@
 # Internals Reference
 
-Invariants, protocol contracts, and design rationale extracted from source
-during the comment/docstring trim sweep. Organized by module path. This is
-the durable home for content that used to live as long inline prose — the
-source now carries a 1-2 line pointer, the full contract lives here.
+Invariants, protocol contracts, and design rationale for lionagi's core
+packages that don't belong inline as long-form comments. Organized by module
+path. Inline comments stay short; the full contract lives here.
 
 ## `operations/`
 
@@ -321,9 +320,9 @@ re-register every server from previously loaded, unrelated configs.
 **`patterns.py`** — `role_node_builder` returns a node_builder closure
 routing `SpawnRequest`s to role branches. `decorate_instruction`, when given,
 receives the request and the node's freshly allocated `spawn_id` and must
-return the full instruction text the child runs with (CLI callers use it to
-inject the artifact-directory + REQUIRED-file text a planned leg gets, see
-`lionagi.cli.orchestrate.flow`). `start` seeds the closure's spawn-id
+return the full instruction text the child runs with
+(`lionagi.cli.orchestrate.flow` uses it to prepend per-node artifact-directory
+and required-output instructions). `start` seeds the closure's spawn-id
 sequence past ordinals already issued in a prior generation (e.g. a CLI
 resume reconstructing completed spawns from a checkpoint) — without it, a
 fresh sequence restarting at 1 would reissue an id already used by a restored

--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -320,14 +320,11 @@ re-register every server from previously loaded, unrelated configs.
 **`patterns.py`** — `role_node_builder` returns a node_builder closure
 routing `SpawnRequest`s to role branches. `decorate_instruction`, when given,
 receives the request and the node's freshly allocated `spawn_id` and must
-return the full instruction text the child runs with
-(`lionagi.cli.orchestrate.flow` uses it to prepend per-node artifact-directory
-and required-output instructions). `start` seeds the closure's spawn-id
-sequence past ordinals already issued in a prior generation (e.g. a CLI
-resume reconstructing completed spawns from a checkpoint) — without it, a
+return the full instruction text the child runs with. `start` seeds the
+closure's spawn-id sequence past ordinals already issued in a prior generation
+(e.g. a resume reconstructing completed spawns from a checkpoint) — without it, a
 fresh sequence restarting at 1 would reissue an id already used by a restored
-node, colliding with any live spawn this generation (same `spawn_id`, same
-artifact directory).
+node, colliding with any live spawn this generation on the same `spawn_id`.
 
 `_next_spawn_seq = itertools.count(start)` is closure-scoped and is the
 **only** correct source of a spawned node's stable id: it must be allocated

--- a/lionagi/adapters/async_postgres_adapter.py
+++ b/lionagi/adapters/async_postgres_adapter.py
@@ -77,9 +77,8 @@ def create_lionagi_async_postgres_adapter() -> type[AsyncAdapter]:
     return LionAGIAsyncPostgresAdapter
 
 
-# Built lazily by _ensure_postgres_adapter() in node.py, not at import time. The
-# module-level name stays defined so test patching of this attribute resolves
-# without triggering the factory.
+# Built lazily by _ensure_postgres_adapter() in node.py; stays defined here so
+# test patching of this attribute resolves without triggering the factory.
 LionAGIAsyncPostgresAdapter = None  # populated lazily by _ensure_postgres_adapter()
 
 __all__ = ("LionAGIAsyncPostgresAdapter", "create_lionagi_async_postgres_adapter")

--- a/lionagi/adapters/spec_adapters/pydantic_field.py
+++ b/lionagi/adapters/spec_adapters/pydantic_field.py
@@ -22,12 +22,8 @@ if TYPE_CHECKING:
     from lionagi.ln.types import Operable, Spec
 
 
-# Model classes, unlike Operative instances, contain no request/response state
-# and are shared across identical constructions. The sharing contract: callers
-# must not mutate a returned model class (mutation would be visible to every
-# later identical construction); LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0 disables
-# sharing entirely. The LRU bounds strong references to dynamically-created
-# base classes and their generated models.
+# Shared across identical constructions — callers must not mutate a returned model class.
+# LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0 disables sharing entirely.
 _model_type_cache: BoundedLRUCache[tuple[type[BaseModel], tuple], type[BaseModel]] = (
     BoundedLRUCache("LIONAGI_OPERATIVE_MODEL_CACHE_SIZE", 512)
 )

--- a/lionagi/casts/catalog.py
+++ b/lionagi/casts/catalog.py
@@ -12,10 +12,7 @@ __all__ = ("build_catalog",)
 
 def _load_packaged_pack(*, raise_on_error: bool = False):
     """Load the packaged default pack from the lionagi.casts resource tree.
-
-    Returns the Pack on success. On failure, raises if raise_on_error is True,
-    otherwise returns None.
-    """
+    Raises if raise_on_error is True, otherwise returns None on failure."""
     try:
         from importlib.resources import as_file, files
 

--- a/lionagi/casts/emission.py
+++ b/lionagi/casts/emission.py
@@ -399,16 +399,7 @@ class Postmortem(_EmissionModel):
 
 class EscalationRequest(_EmissionModel):
     """Hand off to a human or higher authority, or ask for help while continuing.
-
-    ``urgency`` is the single authoritative field for how hard the ask is:
-    ``"fyi"`` is soft (work continues, this is informational — a help
-    signal), ``"blocked"`` is hard (work cannot continue without a resolution
-    — the original escalation semantics). ``blocking`` is a read-only,
-    back-compat alias for ``urgency == "blocked"``; it can no longer be set
-    directly (a legacy ``blocking=`` constructor kwarg is still accepted and
-    mapped onto ``urgency`` for one release of grace) and will be removed in
-    a future release — set ``urgency`` instead.
-    """
+    ``urgency`` is authoritative; ``blocking`` is a deprecated read-only alias for ``urgency == "blocked"``."""
 
     reason: str = Field(
         description="Why escalation is needed — the blocker, uncertainty, or decision beyond your authority."
@@ -476,10 +467,8 @@ _CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
 def field_name_for(model: type[BaseModel]) -> str:
-    """Convert a PascalCase model name to a snake_case field key.
-
-    Handles acronym runs: ``CIResult`` → ``ci_result``.
-    """
+    """Convert a PascalCase model name to a snake_case field key
+    (handles acronym runs: ``CIResult`` → ``ci_result``)."""
     return _CAMEL_RE.sub("_", model.__name__).lower()
 
 

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -23,9 +23,7 @@ __all__ = (
     "list_modes",
 )
 
-# Roles/modes are a CLOSED built-in set — one inline module per pattern, each
-# exposing a single ``ROLE`` / ``MODE``. Not user-definable; users extend via
-# packs (casts/pack.py), not by adding roles.
+# CLOSED built-in set, one module per pattern — not user-definable; extend via packs (casts/pack.py).
 _ROLES_PKG = "lionagi.casts.roles"
 _MODES_PKG = "lionagi.casts.roles.modes"
 
@@ -109,10 +107,8 @@ class Role(Pattern):
 
     body: str = ""
     emits: tuple = ()
-    # ADR-0064 shape ({"expected": [{"id", "path", "required", ...}]}) — a gate
-    # role's own declared output contract, merged per-leg into the flow's
-    # artifact_contract at DAG-build time (see flow.py _build_dag). None means
-    # this role makes no artifact claim.
+    # ADR-0064: gate role's declared output contract, merged per-leg into the flow's
+    # artifact_contract at DAG-build time (flow.py _build_dag). None = no artifact claim.
     artifact_defaults: dict | None = None
 
     @property
@@ -120,9 +116,7 @@ class Role(Pattern):
         return PatternKind.ROLE
 
     def to_dict(self, exclude: set[str] = None) -> dict[str, Any]:
-        # serialize ``emits`` (model classes) by name so the dict stays
-        # hashable/JSON-friendly. Params.to_dict (not super()) — zero-arg super
-        # is unreliable under @dataclass(slots=True).
+        # Params.to_dict (not super()) — zero-arg super is unreliable under @dataclass(slots=True).
         d = Params.to_dict(self, exclude=exclude)
         if "emits" in d:
             d["emits"] = [m.__name__ for m in d["emits"]]

--- a/lionagi/engines/__init__.py
+++ b/lionagi/engines/__init__.py
@@ -92,9 +92,8 @@ __all__ = (
     "ApplicationMapped",
     "trace_chains",
     "render_evidence",
-    # coding (Gated-Loop shape — plan/implement/test/fix/verify with a
-    # ground-truth subprocess test runner; CodeVerifyResult disambiguates the
-    # review engine's VerifyResult at the package level)
+    # coding (Gated-Loop shape); CodeVerifyResult disambiguates the review
+    # engine's VerifyResult at the package level
     "CodingEngine",
     "CodingRun",
     "CodingChainEvent",

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -43,11 +43,8 @@ __all__ = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Events — the pipeline vocabulary. The engine stamps ``eid`` (W/P/T/V/K, no
-# collision with hypothesis's F/Q/E/H/X/R/C/A); refs link a stage to its
-# upstream stage so the export is a walkable chain.
-# ---------------------------------------------------------------------------
+# --- Events — the pipeline vocabulary (eid prefixes W/P/T/V/K; no collision
+# with hypothesis's F/Q/E/H/X/R/C/A); refs link each stage to its upstream one. ---
 
 
 CodingChainEvent = ChainEvent
@@ -153,9 +150,7 @@ _REF_ATTRS = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Worker observability events (abort + heartbeat + activity)
-# ---------------------------------------------------------------------------
+# --- Worker observability events (abort + heartbeat + activity) ---
 
 
 class WorkAborted(EngineEvent):
@@ -181,11 +176,8 @@ class WorkerActivity(EngineEvent):
 
 
 class AutoRepairApplied(EngineEvent):
-    """Emitted when the harness auto-applies a repair command before a test gate.
-
-    Distinct from a worker fix round: the harness normalized the diff
-    mechanically (e.g. ``cargo fmt --all``), the worker didn't produce it.
-    """
+    """Emitted when the harness auto-applies a repair command before a test gate;
+    distinct from a worker fix round (the harness normalized the diff mechanically)."""
 
     cmd: str = Field(description="The auto-repair command that was run.")
     files: list[str] = Field(
@@ -197,9 +189,7 @@ class AutoRepairApplied(EngineEvent):
     )
 
 
-# ---------------------------------------------------------------------------
-# Spec lint
-# ---------------------------------------------------------------------------
+# --- Spec lint ---
 
 _RE_ACCEPTANCE = re.compile(r"acceptance.{0,20}criteria|acceptance:", re.IGNORECASE)
 _RE_TEST_CMD = re.compile(r"test_cmd\s*:", re.IGNORECASE)
@@ -235,9 +225,7 @@ def _lint_spec(
     return warnings
 
 
-# ---------------------------------------------------------------------------
-# Spec normalization
-# ---------------------------------------------------------------------------
+# --- Spec normalization ---
 
 
 def _normalize_spec(spec: str | dict[str, Any]) -> tuple[str, str]:
@@ -264,9 +252,7 @@ def _normalize_spec(spec: str | dict[str, Any]) -> tuple[str, str]:
     raise TypeError(f"coding spec must be str or dict, got {type(spec)!r}")
 
 
-# ---------------------------------------------------------------------------
-# Instructions
-# ---------------------------------------------------------------------------
+# --- Instructions ---
 
 
 def _plan_instruction(task_text: str, workspace: str) -> str:
@@ -337,9 +323,7 @@ def _verify_instruction(plan: WorkPlanned, change: ChangeProposed, t: TestsRan, 
     )
 
 
-# ---------------------------------------------------------------------------
-# Run context
-# ---------------------------------------------------------------------------
+# --- Run context ---
 
 
 class CodingRun(ChainRun):
@@ -452,9 +436,7 @@ def _render_report(run: CodingRun, report: str) -> str:
     return "".join(parts) + "\n"
 
 
-# ---------------------------------------------------------------------------
-# Engine
-# ---------------------------------------------------------------------------
+# --- Engine ---
 
 
 class CodingEngine(Engine):
@@ -576,11 +558,8 @@ class CodingEngine(Engine):
         if run._aborted:
             return await self._conclude(run, plan, passed=False, caveat="stage aborted by watchdog")
         if change is None:
-            # Emission is metadata; the workspace delta is ground truth.  Three
-            # outcomes after _implement returns None:
-            #   (a) delta non-empty  → work detected; proceed to test gate.
-            #   (b) delta empty      → no work; preserve no-change verdict.
-            #   (c) check failed     → unknown; fail open to test gate.
+            # Emission is metadata; the workspace delta is ground truth. Delta
+            # non-empty -> proceed to test gate; empty -> no-change verdict.
             delta, check_failed = await self._workspace_changed(run)
             run._ws_delta = delta
             if check_failed:
@@ -771,11 +750,7 @@ class CodingEngine(Engine):
         self, run: CodingRun, plan: WorkPlanned, change: ChangeProposed, tests: TestsRan
     ) -> tuple[ChangeProposed, TestsRan]:
         """Re-prompt the implementer on failure and re-test, bounded by max_fix_rounds.
-
-        Mechanical rounds (fixed by auto-repair alone) skip the judge gate;
-        substantive rounds go through it. fast_test_cmd, if configured, gates
-        intermediate rounds; test_cmd is always the final ground-truth leg.
-        """
+        Mechanical rounds (auto-repair alone) skip the judge gate; substantive ones go through."""
         agent = getattr(run, "_implementer", None)
         round_no = 0
         while not tests.passed and round_no < self.max_fix_rounds and agent is not None:
@@ -1034,13 +1009,8 @@ class CodingEngine(Engine):
         result = await run_sync(_subprocess_sync, ["git", "diff"], False, 30.0, run.workspace)
         tracked = result.get("stdout", "") if int(result.get("returncode", -1)) == 0 else ""
 
-        # Candidate set: union of the initial workspace delta (covers emission-
-        # failure rewrites) and every file any ChangeProposed claimed to touch,
-        # evaluated at verify time so fix-round additions are included.
-        # Normalized to workspace-relative POSIX before intersecting: files_touched
-        # often carries absolute paths (the coding tool schema asks for them) while
-        # git ls-files --others returns repo-relative ones; paths that escape the
-        # workspace are dropped since they can't be untracked files here.
+        # Candidate set: union of the workspace delta and every file any ChangeProposed
+        # claimed to touch, normalized to workspace-relative POSIX before intersecting.
         raw_candidates: set[str] = set(run._ws_delta)
         final_change = run.last(ChangeProposed)
         if final_change is not None:

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -373,12 +373,8 @@ class EngineRun:
             task.add_done_callback(self._active.discard)
 
     async def cancel_active(self) -> None:
-        """Cancel and await all in-flight spawned tasks.
-
-        Waits up to ``engine.cancel_timeout_s``; tasks that don't settle in
-        that window (e.g. catch CancelledError and loop) are abandoned with a
-        logged warning so the caller's lifetime guarantee is preserved.
-        """
+        """Cancel and await all in-flight spawned tasks; tasks that don't settle
+        within ``engine.cancel_timeout_s`` are abandoned with a logged warning."""
         if not self._active:
             return
         tasks = list(self._active)
@@ -415,11 +411,8 @@ class EngineRun:
             self._run_task.cancel()
 
     async def wait_quiescence(self) -> None:
-        """Block until all spawned tasks settle; re-raise non-cancellation, non-budget failures.
-
-        EngineBudgetError is a benign "expansion stopped" signal (discretionary
-        work declined, not a crash) and is swallowed like CancelledError.
-        """
+        """Block until all spawned tasks settle; re-raise non-cancellation, non-budget
+        failures. EngineBudgetError is benign (discretionary work declined) and swallowed."""
         task_errors: list[BaseException] = []
         while self._active:
             results = await gather(*list(self._active), return_exceptions=True)
@@ -542,12 +535,8 @@ class ChainRun(EngineRun):
 
 
 class EngineResult(str):
-    """Return type of Engine.run(): a str (back-compat) carrying the run's structured outcome.
-
-    ``str(result)`` and ``result.text`` are the same synthesized text. ``.run``
-    is a live EngineRun handle — do not retain it past reading the result, it
-    keeps the whole Session (and its branches) alive.
-    """
+    """Return type of Engine.run(): a str (back-compat) carrying the run's structured
+    outcome. ``.run`` is a live handle — don't retain it, it keeps the Session alive."""
 
     text: str
     skipped: list[str]
@@ -651,12 +640,8 @@ class Engine:
         )
 
     async def _degrade_export(self, run: EngineRun, args: tuple, kwargs: dict) -> Any:
-        """Cancel in-flight spawned tasks, then run _partial_export shielded + timeout-bounded.
-
-        Shared by the deadline and root-budget degrade paths in run(). Returns
-        _UNSET if the export failed or timed out (logged, not raised); an
-        external cancel during the shielded phase still propagates.
-        """
+        """Cancel in-flight spawned tasks, then run _partial_export shielded + timeout-
+        bounded. Returns _UNSET on failure/timeout; an external cancel still propagates."""
         # Cancel background tasks so synthesis sees a stable snapshot and no
         # work burns tokens past budget exhaustion (no-op if _active is empty).
         if run._active:
@@ -671,9 +656,8 @@ class Engine:
                 timeout=_PARTIAL_EXPORT_TIMEOUT_S,
             )
         except asyncio.CancelledError:
-            # wait_for converts its own timeout into TimeoutError, so a
-            # CancelledError here is always an external cancel of run() itself
-            # — clean up partial_task and re-raise to honour it.
+            # wait_for turns its own timeout into TimeoutError, so CancelledError
+            # here is always an external cancel — clean up and re-raise.
             if not partial_task.done():
                 partial_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -726,20 +710,13 @@ class Engine:
         degrade_reason: str = ""
         try:
             result = await run_task
-            # A run that reached the success path may still have silently dropped
-            # a discretionary budget-capped subtree (wait_quiescence filters
-            # EngineBudgetError out of task_errors) — flag it so a clean-looking
-            # result doesn't hide the truncation.
+            # A "successful" run may still have silently dropped a discretionary
+            # budget-capped subtree — flag it so a clean-looking result doesn't hide it.
             if run._budget_notified:
                 degrade_reason = "budget"
         except asyncio.CancelledError:
-            # Distinguish internal cancellation (the watchdog, which sets
-            # _budget_notified before cancelling run_task) from external
-            # cancellation (the caller cancelled run()). task.cancelling() > 0
-            # (Python >=3.11 only) additionally detects a simultaneous external
-            # cancel; on 3.10 we fall back to _budget_notified alone, so a
-            # caller cancel landing at the exact instant the budget is hit
-            # runs partial export instead of raising — an acceptable edge case.
+            # Distinguish internal (watchdog) vs external (caller) cancellation via
+            # task.cancelling() (3.11+; 3.10 falls back to _budget_notified alone).
             current = asyncio.current_task()
             caller_cancelled = (
                 current is not None and hasattr(current, "cancelling") and current.cancelling() > 0
@@ -753,20 +730,15 @@ class Engine:
                 # External cancellation — surface it after cleanup (below).
                 raise
         except (EngineBudgetError, ExceptionGroup) as exc:
-            # A root-level (non-spawned) make_agent() call hit the budget and
-            # raised straight out of _run() — route to partial-export instead of
-            # crashing the run. Masking guard: a non-budget leaf anywhere in the
-            # group (including nested groups) must not be laundered into a
-            # partial — re-raise so the real error surfaces.
+            # A root-level make_agent() budget hit routes to partial-export; a
+            # non-budget leaf anywhere in the group must not be laundered into one.
             if not _is_all_budget_error(exc):
                 raise
             degrade_reason = "budget"
             partial_result = await self._degrade_export(run, args, kwargs)
         finally:
-            # Copy per-run diagnostics back onto the engine instance (fresh list,
-            # no shared-reference aliasing) so the CLI read site
-            # (getattr(engine, "_emission_failures", [])) sees them regardless of
-            # which return/exception path was taken.
+            # Copy diagnostics onto the engine instance (fresh list) so the CLI's
+            # getattr(engine, "_emission_failures", []) sees them on every exit path.
             self._emission_failures = list(run._emission_failures)
             # Flag total failure only when every agent made for this run
             # terminally errored, so partial/soft-empty runs aren't over-flagged.
@@ -778,11 +750,8 @@ class Engine:
                 watchdog.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await watchdog
-            # Drain any tasks still in _active so nothing leaks past run(),
-            # regardless of whether _run() succeeded, failed, or was cancelled.
-            # Shielded so it completes even if the caller cancels run()
-            # mid-cleanup — but that external CancelledError is still re-raised;
-            # swallowing it would hand the caller a stale result.
+            # Drain tasks still in _active regardless of how run() exited; shielded so
+            # cleanup finishes even under a caller cancel (which still re-raises below).
             if run._active:
                 drain = asyncio.ensure_future(run.cancel_active())
                 try:
@@ -790,9 +759,8 @@ class Engine:
                 except asyncio.CancelledError:
                     if drain.cancelled():
                         raise
-                    # External cancel of run() itself: wait the shielded drain
-                    # out (absorbing repeated cancellations) so no run-owned
-                    # task outlives run(), then surface the cancellation.
+                    # External cancel: keep waiting the shielded drain (absorbing
+                    # repeat cancels) so no run-owned task outlives run().
                     while not drain.done():
                         try:
                             await asyncio.shield(drain)

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -1,12 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Turn ``DependencyAwareExecutor`` node transitions and ``NodeSpawned`` bus
-events into ``NodeQueued``/``NodeStarted``/``NodeCompleted``/``NodeFailed``
-session-bus signals, so a ``Session.flow`` run's DAG can be rendered live.
-
-Shared by the engine's own DAG run and Studio's ``workflow_run`` — both drive
-``session.flow`` directly and need the same node-progress signals.
-"""
+"""Turn executor node transitions into NodeQueued/Started/Completed/Failed
+session-bus signals for a live-rendered Session.flow DAG run (shared by the engine and Studio)."""
 
 from __future__ import annotations
 
@@ -28,12 +23,8 @@ __all__ = ("flow_progress_signals",)
 
 
 def _build_node_edge_meta(graph: Any) -> dict[str, dict]:
-    """Map each Operation node id to {parent_id, depends_on, name} from the graph.
-
-    ``name`` is the authored id (``metadata['reference_id']``, e.g. Studio's
-    ``chat1``) when set, preferred over the executor's callback name (which
-    the executor renames after the branch for started/completed/failed).
-    """
+    """Map each Operation node id to {parent_id, depends_on, name}; name prefers the
+    authored reference_id over the executor's callback name (renamed post-hoc)."""
     from lionagi.operations.node import Operation
 
     meta: dict[str, dict] = {}
@@ -53,15 +44,8 @@ def _build_node_edge_meta(graph: Any) -> dict[str, dict]:
 async def flow_progress_signals(
     session: Any, graph: Any
 ) -> AsyncIterator[Callable[[str, str, str, float], None]]:
-    """Yield an ``on_progress`` callback that persists node-lifecycle signals.
-
-    Usage: ``async with flow_progress_signals(session, graph) as on_progress:
-    await session.flow(graph, on_progress=on_progress, ...)``.
-
-    Tracks reactive ``NodeSpawned`` events so late-added nodes carry their
-    parent/depends_on edges, and awaits every emitted signal on exit so
-    observers finish persisting before the caller reads what they wrote.
-    """
+    """Yield an ``on_progress`` callback that persists node-lifecycle signals; awaits
+    every emitted signal on exit so observers finish before the caller reads what they wrote."""
     emits: list[asyncio.Future] = []
     node_edge_meta = _build_node_edge_meta(graph)
 
@@ -98,9 +82,8 @@ async def flow_progress_signals(
             )
         else:
             return
-        # on_progress is sync (called from inside the executor); fan the signal onto
-        # the async bus, collected so the caller can await observers before reading
-        # what they wrote. suppress guards the no-running-loop case.
+        # on_progress is sync; fan the signal onto the async bus, collected so the
+        # caller can await observers before reading what they wrote.
         with contextlib.suppress(RuntimeError):
             emits.append(asyncio.ensure_future(session.emit(sig)))
 

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -34,10 +34,8 @@ __all__ = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Events — the pipeline vocabulary. Each carries refs to upstream events;
-# the engine stamps ``eid``, agents fill refs from their instructions.
-# ---------------------------------------------------------------------------
+# --- Events — the pipeline vocabulary (engine stamps eid; agents fill refs
+# from their instructions). Each event carries refs to upstream events. ---
 
 
 class FindingPosted(Finding, ChainEvent):
@@ -154,9 +152,7 @@ _REF_ATTRS = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Audit trail
-# ---------------------------------------------------------------------------
+# --- Audit trail ---
 
 
 def trace_chains(events: list[ChainEvent]) -> list[list[ChainEvent]]:
@@ -202,9 +198,7 @@ def _label(e: ChainEvent) -> str:
     return f"{e.eid}[{type(e).__name__}] {text}"
 
 
-# ---------------------------------------------------------------------------
-# Instructions
-# ---------------------------------------------------------------------------
+# --- Instructions ---
 
 
 def _register_block(decisions: str) -> str:
@@ -385,9 +379,7 @@ def _synthesis_instruction(run: HypothesisRun) -> str:
     )
 
 
-# ---------------------------------------------------------------------------
-# Run context
-# ---------------------------------------------------------------------------
+# --- Run context ---
 
 
 class HypothesisRun(ChainRun):
@@ -441,9 +433,7 @@ class HypothesisRun(ChainRun):
         return {"chains": str(chains_path), "report": str(report_path)}
 
 
-# ---------------------------------------------------------------------------
-# Engine
-# ---------------------------------------------------------------------------
+# --- Engine ---
 
 
 class HypothesisEngine(Engine):

--- a/lionagi/engines/planning.py
+++ b/lionagi/engines/planning.py
@@ -24,9 +24,8 @@ class PlanError(RuntimeError):
     """Raised when the orchestrator produces an empty TaskAssignment list, so a planning run never silently no-ops."""
 
 
-# A small default roster the orchestrator may assign to. Callers pass their own
-# via ``roles=`` when they want a different set (the CLI uses the full casts ∪
-# user-profile roster).
+# A small default roster the orchestrator may assign to; callers pass their own
+# via ``roles=`` for a different set (the CLI uses the full casts ∪ user-profile roster).
 _DEFAULT_ROLES: tuple[str, ...] = ("researcher", "analyst", "critic", "architect", "synthesizer")
 
 

--- a/lionagi/libs/path_safety.py
+++ b/lionagi/libs/path_safety.py
@@ -16,14 +16,8 @@ _DENIED_NAMES_CASEFOLD: frozenset[str] = frozenset(name.casefold() for name in D
 
 
 def is_protected_name(name: str) -> bool:
-    """True if name matches a protected basename, case-insensitively.
-
-    Filesystems (notably default macOS/Windows volumes) are case-insensitive,
-    so a case-sensitive membership test against DENIED_NAMES can be bypassed
-    with a spelling like ".ENV" that still resolves to the same file as
-    ".env". This is the one primitive both resolve_workspace_path and the
-    deny-only hook floor use for the protected-basename check.
-    """
+    """True if name matches a protected basename, case-insensitively (case-insensitive
+    filesystems can bypass a case-sensitive check)."""
     return name.casefold() in _DENIED_NAMES_CASEFOLD
 
 
@@ -40,15 +34,8 @@ def has_traversal(p: Path) -> bool:
 
 
 def resolve_workspace_path(path: str | Path, workspace_root: Path) -> Path:
-    """Resolve a tool-supplied path against workspace root with full safety checks.
-
-    Checks: expanduser, symlink detection pre-resolve, containment, denied names.
-    Raises PermissionError on any violation. Validation happens at check time only:
-    a concurrent filesystem mutation between this check and a later I/O call on the
-    same path (e.g. swapping a regular file for a symlink) is out of scope — callers
-    that need a stronger guarantee against a racing filesystem must perform the
-    final I/O through a root-anchored, no-follow file descriptor instead.
-    """
+    """Resolve a tool-supplied path against workspace root with full safety checks
+    (symlink, containment, denied names). Raises PermissionError on any violation."""
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
     if candidate.is_symlink():
@@ -70,11 +57,8 @@ def check_path_safe(
     reject_absolute: bool = True,
     strip_at: bool = False,
 ) -> str:
-    """Validate a path string: reject traversal, NUL bytes, and optionally absolute paths.
-
-    Also rejects Windows-style drive-letter paths (e.g. C:foo) when reject_absolute is True.
-    Raises ValueError on any violation.
-    """
+    """Validate a path string: reject traversal, NUL bytes, and optionally absolute paths
+    (incl. Windows drive-letter paths). Raises ValueError on any violation."""
     entry = value.lstrip("@") if strip_at else value
     if "\x00" in entry:
         raise ValueError(f"{field_name} entry {value!r} contains NUL bytes")

--- a/lionagi/libs/schema/extract_docstring.py
+++ b/lionagi/libs/schema/extract_docstring.py
@@ -9,35 +9,8 @@ from typing import Literal
 def extract_docstring(
     func: Callable, style: Literal["google", "rest"] = "google"
 ) -> tuple[str | None, dict[str, str]]:
-    """Extract function description and parameter descriptions from a Google- or reST-style docstring.
-
-    Args:
-        func: The function from which to extract docstring details.
-        style: The style of docstring to parse ('google' or 'rest').
-
-    Returns:
-        A tuple containing the function description and a dictionary with
-        parameter names as keys and their descriptions as values.
-
-    Raises:
-        ValueError: If an unsupported style is provided.
-
-    Examples:
-        >>> def example_function(param1: int, param2: str):
-        ...     '''Example function.
-        ...
-        ...     Args:
-        ...         param1 (int): The first parameter.
-        ...         param2 (str): The second parameter.
-        ...     '''
-        ...     pass
-        >>> description, params = extract_docstring_details(example_function)
-        >>> description
-        'Example function.'
-        >>> params == {'param1': 'The first parameter.',
-        ...            'param2': 'The second parameter.'}
-        True
-    """
+    """Extract function description and parameter descriptions from a Google- or
+    reST-style docstring. Raises ValueError if style is unsupported."""
     style = str(style).strip().lower()
 
     if style == "google":
@@ -52,32 +25,7 @@ def extract_docstring(
 def _extract_docstring_details_google(
     func: Callable,
 ) -> tuple[str | None, dict[str, str]]:
-    """Extract description and parameter map from a Google-style docstring.
-
-    Args:
-        func: The function from which to extract docstring details.
-
-    Returns:
-        A tuple containing the function description and a dictionary with
-        parameter names as keys and their descriptions as values.
-
-    Examples:
-        >>> def example_function(param1: int, param2: str):
-        ...     '''Example function.
-        ...
-        ...     Args:
-        ...         param1 (int): The first parameter.
-        ...         param2 (str): The second parameter.
-        ...     '''
-        ...     pass
-        >>> description, params = _extract_docstring_details_google(
-        ...     example_function)
-        >>> description
-        'Example function.'
-        >>> params == {'param1': 'The first parameter.',
-        ...            'param2': 'The second parameter.'}
-        True
-    """
+    """Extract description and parameter map from a Google-style docstring."""
     docstring = inspect.getdoc(func)
     if not docstring:
         return None, {}
@@ -121,33 +69,7 @@ def _extract_docstring_details_google(
 def _extract_docstring_details_rest(
     func: Callable,
 ) -> tuple[str | None, dict[str, str]]:
-    """Extract description and parameter map from a reST-style docstring.
-
-    Args:
-        func: The function from which to extract docstring details.
-
-    Returns:
-        A tuple containing the function description and a dictionary with
-        parameter names as keys and their descriptions as values.
-
-    Examples:
-        >>> def example_function(param1: int, param2: str):
-        ...     '''Example function.
-        ...
-        ...     :param param1: The first parameter.
-        ...     :type param1: int
-        ...     :param param2: The second parameter.
-        ...     :type param2: str
-        ...     '''
-        ...     pass
-        >>> description, params = _extract_docstring_details_rest(
-        ...     example_function)
-        >>> description
-        'Example function.'
-        >>> params == {'param1': 'The first parameter.',
-        ...            'param2': 'The second parameter.'}
-        True
-    """
+    """Extract description and parameter map from a reST-style docstring."""
     docstring = inspect.getdoc(func)
     if not docstring:
         return None, {}

--- a/lionagi/libs/schema/function_to_schema.py
+++ b/lionagi/libs/schema/function_to_schema.py
@@ -77,36 +77,7 @@ def function_to_schema(
     return_obj: bool = False,
 ) -> dict:
     """Generate an OpenAI-format function schema from type hints and docstrings.
-
-    Args:
-        func (Callable): The function to generate a schema for.
-        style (str): The docstring format. Can be 'google' (default) or
-            'reST'.
-        func_description (str, optional): A custom description for the
-            function. If not provided, the description will be extracted
-            from the function's docstring.
-        params_description (dict, optional): A dictionary mapping
-            parameter names to their descriptions. If not provided, the
-            parameter descriptions will be extracted from the function's
-            docstring.
-
-    Returns:
-        dict: A schema describing the function, including its name,
-        description, and parameter details.
-
-    Example:
-        >>> def example_func(param1: int, param2: str) -> bool:
-        ...     '''Example function.
-        ...
-        ...     Args:
-        ...         param1 (int): The first parameter.
-        ...         param2 (str): The second parameter.
-        ...     '''
-        ...     return True
-        >>> schema = function_to_schema(example_func)
-        >>> schema['function']['name']
-        'example_func'
-    """
+    func_description/parametert_description override extraction from the docstring."""
     func_name = f_.__name__
 
     if not func_description or not parametert_description:

--- a/lionagi/ln/_async_call.py
+++ b/lionagi/ln/_async_call.py
@@ -133,11 +133,8 @@ async def _execute_with_retry(
     default: Any,
     **kwargs,
 ) -> tuple[int, Any]:
-    """Execute function with exponential backoff retry.
-
-    Returns (index, result) tuple to preserve ordering in concurrent execution.
-    Cancellation exceptions are never retried (respects structured concurrency).
-    """
+    """Execute function with exponential backoff retry; returns (index, result) to
+    preserve ordering. Cancellation is never retried (respects structured concurrency)."""
     attempts = 0
     current_delay = initial_delay
 

--- a/lionagi/ln/_hash.py
+++ b/lionagi/ln/_hash.py
@@ -57,11 +57,8 @@ _TYPE_MARKER_MSGSPEC = 6
 
 
 def _generate_hashable_representation(item: Any) -> Any:
-    """Convert object to stable, order-independent hashable representation.
-
-    Recursively transforms dicts/sets into sorted tuples with type markers
-    to ensure consistent hashing regardless of insertion order.
-    """
+    """Convert object to a stable, order-independent hashable representation
+    (dicts/sets become sorted tuples tagged with a type marker)."""
     if isinstance(item, _PRIMITIVE_TYPES):
         return item
 

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -47,11 +47,8 @@ def _normalize_for_sorting(x: Any) -> str:
 
 
 def _stable_sorted_iterable(o: Iterable[Any]) -> list[Any]:
-    """
-    Deterministic ordering for sets (including mixed types).
-    Key: (class name, normalized str) avoids comparisons across unlike types
-    and removes memory address variance in default reprs.
-    """
+    """Deterministic ordering for sets (incl. mixed types); key=(class name,
+    normalized str) avoids cross-type comparisons and address variance."""
     return sorted(o, key=lambda x: (x.__class__.__name__, _normalize_for_sorting(x)))
 
 

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -13,9 +13,8 @@ from typing import Any
 def _safe_pgid(proc: Any) -> int | None:
     """Return the process-group id to signal, or None when unsafe."""
     pid = getattr(proc, "pid", None)
-    # pid must be int > 1: pid==0 is our own group, pid==1 is init/session leader
-    # on CI (would SIGKILL the harness itself; also catches MagicMock.pid==1).
-    # killpg is POSIX-only; None here makes callers fall back to proc.terminate()/kill().
+    # pid must be int > 1: pid==1 is init/session leader on CI (would SIGKILL
+    # the harness itself; also catches MagicMock.pid==1). killpg is POSIX-only.
     if not (hasattr(os, "killpg") and isinstance(pid, int) and pid > 1):
         return None
     return pid
@@ -27,13 +26,8 @@ def terminate_process_group(
     grace: float | None = None,
     sig_first: signal.Signals = signal.SIGTERM,
 ) -> None:
-    """Send sig_first to the process group AND the direct child.
-
-    grace=None sends SIGKILL immediately with no prior SIGTERM. Otherwise
-    sends only sig_first; the caller must wait and escalate to SIGKILL (see
-    aterminate_process_group for the full cycle). Swallows ProcessLookupError,
-    PermissionError, and OSError — an already-dead process never raises.
-    """
+    """Send sig_first to the process group AND the direct child; grace=None sends
+    SIGKILL immediately (see aterminate_process_group for the full escalate cycle)."""
     pgid = _safe_pgid(proc)
     if grace is None:
         # Signal group AND direct child: proc.kill() is normally a no-op (child is
@@ -58,11 +52,8 @@ async def aterminate_process_group(
     grace: float | None = None,
     sig_first: signal.Signals = signal.SIGTERM,
 ) -> None:
-    """Async: signal the process group AND the direct child, wait up to grace, then SIGKILL.
-
-    grace=None sends SIGKILL immediately with no prior signal. Swallows
-    ProcessLookupError, PermissionError, and OSError throughout.
-    """
+    """Async: signal the process group AND the direct child, wait up to grace, then
+    SIGKILL; grace=None sends SIGKILL immediately with no prior signal."""
     pgid = _safe_pgid(proc)
     if grace is None:
         # No prior SIGTERM/wait: signal group AND direct child directly.

--- a/lionagi/ln/_ssrf.py
+++ b/lionagi/ln/_ssrf.py
@@ -31,9 +31,8 @@ _LOOPBACK_NETS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ipaddress.ip_network("::1/128"),
 ]
 
-# Only these exact hostname strings are accepted for allow_local=True.
-# Alternate encodings (2130706433, 0x7f000001, 127.1, ::ffff:127.0.0.1, etc.)
-# are intentionally excluded to prevent DNS-rebinding bypass.
+# Only these exact hostname strings are accepted for allow_local=True — alternate
+# encodings are intentionally excluded to prevent DNS-rebinding bypass.
 _CANONICAL_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
 
 

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -179,9 +179,7 @@ def is_import_installed(package_name: str) -> bool:
     return importlib.util.find_spec(package_name) is not None
 
 
-# ---------------------------------------------------------------------------
-# Dynamic type loading
-# ---------------------------------------------------------------------------
+# --- Dynamic type loading ---
 
 _TYPE_CACHE: dict[str, type] = {}
 
@@ -229,9 +227,7 @@ def load_type_from_string(type_str: str) -> type:
         raise ValueError(f"Failed to load type '{type_str}': {e}") from e
 
 
-# ---------------------------------------------------------------------------
-# Type extraction
-# ---------------------------------------------------------------------------
+# --- Type extraction ---
 
 
 def extract_types(item_type: Any) -> set[type]:
@@ -265,9 +261,7 @@ def extract_types(item_type: Any) -> set[type]:
     return {item_type}
 
 
-# ---------------------------------------------------------------------------
-# UUID / datetime coercion
-# ---------------------------------------------------------------------------
+# --- UUID / datetime coercion ---
 
 
 def to_uuid(value: Any) -> UUID:
@@ -311,9 +305,7 @@ def coerce_created_at(v: Any) -> datetime:
     raise ValueError(f"Expected datetime/timestamp/string, got {type(v).__name__}")
 
 
-# ---------------------------------------------------------------------------
-# Synchronization decorators
-# ---------------------------------------------------------------------------
+# --- Synchronization decorators ---
 
 
 def synchronized(func: Callable[P, R]) -> Callable[P, R]:

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -48,11 +48,8 @@ async def run_sync(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R
     return await anyio.to_thread.run_sync(func, *args)
 
 
-# Process-wide latch set by run_async's SIGTERM handler the moment the signal
-# arrives. SigtermInterrupt itself is only raised after the worker thread has
-# joined — by then teardown code has already classified a plain CancelledError
-# and stamped the terminal record. Persist paths consult this flag so an
-# external SIGTERM stays distinguishable from an internal runtime cancel.
+# Process-wide latch set by run_async's SIGTERM handler; lets persist paths
+# distinguish an external SIGTERM from an internal runtime cancel.
 _SIGTERM_RECEIVED = threading.Event()
 _SIGTERM_RECEIVED_LOCK = threading.Lock()
 
@@ -63,11 +60,8 @@ def sigterm_received() -> bool:
 
 
 def consume_sigterm_received() -> bool:
-    """Read-and-clear the latch so one external SIGTERM labels one run.
-
-    Without consuming, the latch stays set for the lifetime of the process
-    and mislabels every later run/test's cancellation as SIGTERM-caused.
-    """
+    """Read-and-clear the latch so one external SIGTERM labels one run
+    (otherwise it stays set and mislabels every later cancellation)."""
     with _SIGTERM_RECEIVED_LOCK:
         received = _SIGTERM_RECEIVED.is_set()
         if received:
@@ -76,23 +70,12 @@ def consume_sigterm_received() -> bool:
 
 
 class SigtermInterrupt(BaseException):
-    """Raised by run_async() when the process received SIGTERM mid-run.
-
-    Deliberately not a KeyboardInterrupt subclass (that's the SIGINT/user
-    convention); subclasses BaseException instead so a bare
-    ``except Exception:`` can't silently swallow it.
-    """
+    """Raised by run_async() when SIGTERM arrives mid-run; subclasses
+    BaseException (not KeyboardInterrupt) so ``except Exception:`` can't swallow it."""
 
 
-# Signal-aware run_async: installs temporary SIGINT/SIGTERM handlers from the
-# main thread that cancel the inner asyncio task via call_soon_threadsafe
-# instead of leaving the default disposition in place. SIGINT's default would
-# raise KeyboardInterrupt in join(), orphaning the child thread and leaving
-# session rows stuck in "running" state; SIGTERM's default is immediate
-# process termination with no unwind at all, so without a handler here an
-# external SIGTERM (a timeout supervisor, a process-group kill) is silent.
-
-
+# Installs temporary SIGINT/SIGTERM handlers that cancel the inner task via
+# call_soon_threadsafe instead of leaving the default (silent-kill) disposition.
 def run_async(coro: Awaitable[T]) -> T:
     """Run an awaitable from sync context in an isolated thread+event loop."""
     result_container: list[Any] = []
@@ -111,11 +94,8 @@ def run_async(coro: Awaitable[T]) -> T:
                 task = asyncio.current_task()
                 _loop_and_task_future.set_result((asyncio.get_event_loop(), task))
                 if _cancel_requested.is_set() or _term_requested.is_set():
-                    # A signal was latched before this future existed, so the
-                    # handler's call_soon_threadsafe(task.cancel) had nothing
-                    # to call yet (this is the only path for SIGTERM, whose
-                    # default disposition isn't callable as a fallback).
-                    # Cancel ourselves now instead of running to completion.
+                    # A signal was latched before this future existed (the only
+                    # path for SIGTERM) — cancel ourselves instead of running on.
                     task.cancel()
                 return await coro
 

--- a/lionagi/lndl/__init__.py
+++ b/lionagi/lndl/__init__.py
@@ -1,15 +1,8 @@
 # Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""LNDL — Lion Notation Definition Language.
-
-Structured output format for LLM responses. Tags allow models to mix
-natural reasoning with structured data.
-
-Core (no external deps beyond lionagi + pydantic):
-    lexer, parser, ast, assembler, extract, normalize, types, errors, prompt,
-    diagnostics, round_outcome
-"""
+"""LNDL — Lion Notation Definition Language. Structured output format for
+LLM responses; tags let models mix natural reasoning with structured data."""
 
 from .assembler import (
     NOTE_NAMESPACE,

--- a/lionagi/lndl/_parse_function_call.py
+++ b/lionagi/lndl/_parse_function_call.py
@@ -1,17 +1,8 @@
 # Copyright (c) 2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Function call parser for LNDL <lact> bodies.
-
-Parses Python-style function calls into a dict with 'operation', optional
-'service', and 'arguments'.  When a service prefix is present (e.g.
-``svc.tool(...)``), ``qualified_name`` returns ``"svc.tool"`` — this is the
-name that should be used for tool-registry lookup so namespaced tools work.
-
-Also supports:
-- Batch parsing: [call1(...), call2(...)]
-- Reserved keyword handling: from= -> from_= (Python keywords as args)
-"""
+"""Function call parser for LNDL <lact> bodies — parses Python-style calls
+into a dict of action/service/arguments, plus batch and reserved-keyword handling."""
 
 from __future__ import annotations
 
@@ -44,46 +35,22 @@ __all__ = (
 
 
 def qualified_name(parsed: dict[str, Any]) -> str:
-    """Return the tool name suitable for registry lookup.
-
-    When the parsed call has a service prefix, returns ``"service.action"``;
-    otherwise returns just ``"action"``.
-    """
+    """Return the tool-registry lookup name: ``"service.action"`` when a
+    service prefix is present, else just ``"action"``."""
     svc = parsed.get("service")
     act = parsed["action"]
     return f"{svc}.{act}" if svc else act
 
 
 def _escape_reserved_keywords(call_str: str) -> str:
-    """Escape Python reserved keywords used as argument names.
-
-    Converts `from=` to `from_=` so ast.parse can handle it.
-    The underscore version is what Pydantic expects for aliased fields.
-
-    Args:
-        call_str: Function call string that may contain reserved keywords
-
-    Returns:
-        String with reserved keywords escaped
-    """
+    """Convert ``from=`` to ``from_=`` (etc.) so ``ast.parse`` can handle
+    Python reserved keywords used as argument names."""
     return _RESERVED_KWARG_PATTERN.sub(r"\1_=", call_str)
 
 
 def _ast_to_value(node: ast.AST) -> Any:
-    """Convert AST node to Python value with recursive dict/list processing.
-
-    Handles nested dicts, lists, tuples, and JSON-style literals (true/false/null).
-    Normalizes JSON literals: true->True, false->False, null->None.
-
-    Args:
-        node: AST node to convert
-
-    Returns:
-        Python value
-
-    Raises:
-        ValueError: If node cannot be converted to a value
-    """
+    """Convert an AST node to a Python value, recursing into dicts/lists/tuples
+    and normalizing JSON-style literals (true/false/null)."""
     # Handle JSON-style boolean/null names: true, false, null
     if isinstance(node, ast.Name):
         if node.id in ("true", "false", "null"):
@@ -112,21 +79,8 @@ def _ast_to_value(node: ast.AST) -> Any:
 
 
 def parse_function_call(call_str: str) -> dict[str, Any]:
-    """Parse a Python-style function call string.
-
-    Handles optional service prefix (``service.action(...)``):
-        - Simple: ``search("q")`` → ``{action: "search", ...}``
-        - Namespaced: ``svc.tool("x")`` → ``{service: "svc", action: "tool", ...}``
-
-    Use ``qualified_name(parsed)`` to get the registry-lookup name
-    (``"svc.action"`` when service is present, else ``"action"``).
-
-    Returns:
-        Dict with ``action``, optional ``service``, and ``arguments``.
-
-    Raises:
-        ValueError: If the string is not a valid function call.
-    """
+    """Parse a Python-style function call string, handling an optional
+    service prefix (``svc.tool(...)`` → ``{service: "svc", action: "tool", ...}``)."""
     try:
         escaped_str = _escape_reserved_keywords(call_str)
 
@@ -175,13 +129,8 @@ def parse_function_call(call_str: str) -> dict[str, Any]:
 
 
 def parse_batch_function_calls(batch_str: str) -> list[dict[str, Any]]:
-    """Parse an array of function calls: ``[fn1(...), fn2(...)]``.
-
-    Returns a list of dicts in the same shape as ``parse_function_call``.
-
-    Raises:
-        ValueError: If the string is not a valid array of function calls.
-    """
+    """Parse ``[fn1(...), fn2(...)]`` into a list of dicts, each shaped like
+    ``parse_function_call``'s return value."""
     try:
         # Remove whitespace for easier parsing
         batch_str = batch_str.strip()

--- a/lionagi/lndl/assembler.py
+++ b/lionagi/lndl/assembler.py
@@ -1,22 +1,8 @@
 # Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""LNDL value assembler — turns parsed LNDL programs into typed Python values.
-
-The assembler takes:
-- a Program (lvars, lacts, out_block from the LNDL parser)
-- a target type (response_format Pydantic model)
-- optionally a mapping of alias → executed action result
-
-and returns a dict ready for `target.model_validate()`.
-
-Supports:
-- scalar specs (int, float, str, bool)
-- nested model specs (Report.title + Report.summary → Report instance)
-- list[scalar] (multiple raw aliases)
-- list[Model] (field-repeat detection groups aliases into instances)
-- dict[str, V] (model.field-style → key-value pairs)
-"""
+"""LNDL value assembler — turns parsed LNDL programs into typed Python values
+ready for ``target.model_validate()``."""
 
 from __future__ import annotations
 
@@ -41,12 +27,8 @@ def _note_key(ref: str) -> str:
 
 
 def collect_notes(program: Program) -> dict[str, Any]:
-    """Pull every <lvar note.X alias>...</lvar> out of a parsed program.
-
-    Returns a dict keyed by the note name (without the 'note.' prefix). Used
-    by the multi-round operate loop to populate the scratchpad each round —
-    note values written this round become referenceable in later rounds.
-    """
+    """Pull every ``<lvar note.X alias>...</lvar>`` out of a parsed program,
+    keyed by note name (without the ``note.`` prefix)."""
     notes: dict[str, Any] = {}
     for lv in program.lvars:
         if isinstance(lv, Lvar) and lv.model and lv.model.lower() == NOTE_NAMESPACE:
@@ -61,17 +43,8 @@ def _is_model_cls(t: Any) -> bool:
 
 
 def _coerce_str_to_list(s: str) -> list[Any]:
-    """Best-effort coerce a string to a list.
-
-    Strict order:
-    1. JSON array → use as-is.
-    2. Python list literal → use as-is.
-    3. Newline-separated lines → split on newlines.
-    4. Bracketed comma list (``"[a, b, c]"``) → split inside brackets.
-    5. Otherwise → return ``[s]``: treat the whole string as a single item.
-       This avoids shredding prose by commas (e.g. "Step 1, then step 2, …"
-       used to fragment into noise).
-    """
+    """Best-effort coerce a string to a list, trying JSON array → Python
+    literal → newline-split → bracketed comma-list → single-item fallback, in that order."""
     s = s.strip()
     if not s:
         return []
@@ -110,11 +83,8 @@ def _coerce_str_to_list(s: str) -> list[Any]:
 
 
 def _coerce_field_value(value: Any, field_type: Any) -> Any:
-    """Coerce a single value to roughly match ``field_type``.
-
-    Handles list[scalar] from a string. Other cases pass through —
-    pydantic's own validators will do the rest.
-    """
+    """Coerce a single value to roughly match ``field_type``; other cases
+    pass through for pydantic's own validators."""
     field_type = _unwrap_optional(field_type)
     origin = get_origin(field_type)
     if origin is list and isinstance(value, str):
@@ -137,12 +107,8 @@ def _coerce_model_dict(value: dict, model_cls: type) -> dict:
 
 
 def _unwrap_optional(t: Any) -> Any:
-    """If ``t`` is Optional[X] / X | None, return X. Else return ``t``.
-
-    Handles ``Union[X, None]``, ``Optional[X]``, and PEP 604 ``X | None``.
-    For unions of multiple non-None types, returns the first model type if any,
-    else the first non-None type.
-    """
+    """If ``t`` is Optional[X] / X | None, return X (preferring a model type
+    when multiple non-None types are present); else return ``t``."""
     origin = get_origin(t)
     if origin is Union or origin is _types.UnionType:
         args = [a for a in get_args(t) if a is not type(None)]
@@ -164,12 +130,7 @@ def _alias_field(node: Lvar | RLvar | Lact) -> str | None:
 
 def build_action_call(alias: str, node: Lact) -> ActionCall:
     """Parse a lact node's call text into an ``ActionCall`` placeholder.
-
-    Shared by ``_alias_value`` (OUT-gated resolution) and callers executing
-    lacts directly (e.g. a Continue-round tool pass with no OUT{} to gate
-    against). Raises ``InvalidConstructorError`` when the call text isn't a
-    parseable ``fn(args)`` expression.
-    """
+    Raises ``InvalidConstructorError`` if the call text isn't a parseable ``fn(args)`` expression."""
     from ._parse_function_call import parse_function_call, qualified_name
 
     try:
@@ -193,22 +154,8 @@ def _alias_value(
     action_results: dict[str, Any] | None,
     scratchpad: dict[str, Any] | None = None,
 ) -> tuple[bool, Any]:
-    """Return (found, value) for an alias.
-
-    For a lact alias:
-    - if action_results has its result → return the result
-    - else return the ActionCall placeholder (caller will execute later)
-
-    For an OUT-side ``note.X`` ref: pull the value from ``scratchpad``.
-
-    An alias not declared this round (neither an lvar nor a lact here) but
-    present in ``action_results`` resolves to that historical result — a
-    later round's OUT{} can reference a lact executed in an earlier round
-    without re-declaring it, matching "tool results already in history".
-
-    Raises ``MissingLvarError`` when the alias is not declared anywhere
-    (this round's lvars/lacts) and has no historical result either.
-    """
+    """Return (found, value) for an alias (lact result/placeholder, lvar
+    content, or ``note.X`` scratchpad); raises ``MissingLvarError`` if undeclared."""
     if _is_note_ref(alias):
         if scratchpad is not None:
             key = _note_key(alias)
@@ -262,9 +209,7 @@ def assemble_spec_value(
     if origin is list:
         elem = args[0] if args else Any
         if _is_model_cls(elem):
-            # list[Model] — handled below from the original refs list, since
-            # we need to know if the OUT block used explicit nested groups.
-            # The caller (assemble) routes nested groups to _assemble_grouped.
+            # list[Model]: nested groups are routed here by `assemble`.
             ordered_fields = list(elem.model_fields.keys())
             items: list[dict] = []
             current: dict = {}
@@ -331,14 +276,8 @@ def _assemble_grouped_list(
     action_results: dict[str, Any] | None,
     scratchpad: dict[str, Any] | None = None,
 ) -> list[Any]:
-    """Assemble explicit nested groups: ``[[n1, s1], [n2, s2]]`` → 2 items.
-
-    Each inner list is one item; aliases inside are assembled as a single value
-    of ``elem_type``. Inner items that turn out to be string literals (not
-    declared aliases) get dropped onto the model's first string-typed field —
-    a fallback for when the model writes ``[["raw text 1"], ["raw text 2"]]``
-    instead of nested aliases.
-    """
+    """Assemble explicit nested groups (``[[n1, s1], [n2, s2]]`` → 2 items);
+    falls back to piping raw string literals into the model's first string field."""
     items: list[Any] = []
     for group in groups:
         if not isinstance(group, list):
@@ -354,15 +293,12 @@ def _assemble_grouped_list(
                 scratchpad,
             )
         except MissingLvarError:
-            # None of this group's entries resolved as declared aliases —
-            # the model likely wrote raw string literals directly instead of
-            # nested aliases. Fall through to the salvage fallback below
-            # rather than treating a within-group literal as a real error.
+            # No entry resolved as a declared alias — fall through to the
+            # string-literal salvage below instead of raising.
             value = None
         if value is None and _is_model_cls(elem_type):
-            # All entries in the group were string literals (none of them
-            # registered aliases). Salvage by piping the joined text into
-            # the first string-typed field on the model.
+            # Salvage: pipe the joined literal text into the first
+            # string-typed field on the model.
             target_field = None
             for fname, finfo in elem_type.model_fields.items():
                 if _unwrap_optional(finfo.annotation) is str:
@@ -382,13 +318,7 @@ def assemble(
     scratchpad: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a dict from a parsed LNDL program suitable for ``target.model_validate``.
-
-    Returns a dict keyed by spec name (matching ``target.model_fields``).
-    Values may be:
-    - resolved scalars / lists / dicts / nested-model dicts
-    - ``ActionCall`` placeholders if a lact has not been executed yet (caller
-      should walk the result, execute, then call assemble again with results)
-    """
+    Values may include unexecuted ``ActionCall`` placeholders for lacts."""
     if not program.out_block:
         return {}
 
@@ -474,10 +404,8 @@ def collect_actions(value: Any) -> list[ActionCall]:
 
 
 def replace_actions(value: Any, results_by_name: dict[str, Any]) -> Any:
-    """Substitute ActionCall placeholders with their executed results.
-
-    ``results_by_name`` maps the ActionCall.name (alias) → result value.
-    """
+    """Substitute ActionCall placeholders with their executed results
+    (``results_by_name`` maps ActionCall.name → result value)."""
     if isinstance(value, ActionCall):
         if value.name in results_by_name:
             return results_by_name[value.name]

--- a/lionagi/lndl/ast.py
+++ b/lionagi/lndl/ast.py
@@ -40,10 +40,8 @@ class Lvar(Stmt):
 class RLvar(Stmt):
     alias: str
     content: str
-    # Two-token raw form ``<lvar hint alias>...</lvar>`` records the leading
-    # token here so the OUT-shortcut path can resolve ``alias`` back to
-    # ``hint`` (the implied spec name).  ``None`` for the single-token
-    # ``<lvar alias>`` form.
+    # Two-token raw form's leading token (`<lvar hint alias>`), used by the
+    # OUT-shortcut path to resolve `alias` back to its implied spec name.
     extra_id: str | None = None
 
 
@@ -54,8 +52,7 @@ class Lact(Stmt):
     alias: str
     call: str
     # Two-token form ``<lact hint alias>fn(...)</lact>`` — same role as
-    # ``RLvar.extra_id``: a hint that ``alias`` is meant to fill the spec
-    # named ``hint``. Used by OUT-shortcut resolution.
+    # ``RLvar.extra_id``; used by OUT-shortcut resolution.
     extra_id: str | None = None
 
 

--- a/lionagi/lndl/diagnostics.py
+++ b/lionagi/lndl/diagnostics.py
@@ -1,42 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""LNDL diagnostics — opt-in telemetry for LNDL parse rounds.
-
-These primitives let callers introspect what the model actually emitted
-during ``branch.operate(lndl=True, ...)`` or ``branch.ReActStream(lndl=True, ...)``:
-
-    from lionagi.lndl import LndlTrace
-
-    trace = LndlTrace()
-    result = await branch.operate(
-        instruction="...",
-        response_format=Report,
-        lndl=True,
-        trace=trace,
-    )
-    print(trace.summary())          # quick health snapshot
-    for r in trace.rounds:
-        print(r.outcome, r.error)   # per-round details
-
-The trace is **opt-in** — callers must instantiate ``LndlTrace`` and pass it.
-Default behaviour and return types are unchanged: ``trace=None`` (default)
-means zero overhead.
-
-Two layers of classification:
-
-* **Syntax** (``classify_chunk``): does this raw assistant text look like
-  well-formed LNDL? ``clean`` / ``malformed`` / ``no_out``.
-* **Outcome** (``LndlRoundRecord.outcome``): what did the framework decide
-  this round? ``success`` / ``continue`` / ``retry`` / ``failed`` /
-  ``exhausted`` — mirrors the ``RoundOutcome`` ADT.
-* **Result** (``classify_result``): for a final operate return value, what
-  did we get? ``ok`` (parsed BaseModel) / ``str`` (raw fallback) /
-  ``dict`` (validation failed) / ``empty`` (None or empty container).
-
-These three views answer different questions: *did the model write valid
-LNDL?* / *what did the framework do with it?* / *what did the user get?*
-"""
+"""LNDL diagnostics — opt-in telemetry for LNDL parse rounds. Pass a
+``LndlTrace()`` via ``trace=``; default ``trace=None`` means zero overhead."""
 
 from __future__ import annotations
 
@@ -55,19 +21,13 @@ __all__ = (
 )
 
 
-# ---------------------------------------------------------------------------
 # Syntax classification — does an assistant chunk look like valid LNDL?
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class LndlChunkHealth:
-    """Syntactic shape of a single assistant LNDL response.
-
-    This is a lexer-free, structure-only check intended to answer the
-    question "is this chunk in the LNDL ballpark?" without invoking the
-    full parser. The full parser is what produces semantic verdicts.
-    """
+    """Syntactic shape of a single assistant LNDL response — a lexer-free,
+    structure-only check; the full parser produces semantic verdicts."""
 
     text: str
     has_out: bool
@@ -86,12 +46,8 @@ class LndlChunkHealth:
 
 
 def classify_chunk(text: str) -> LndlChunkHealth:
-    """Classify the syntactic health of a raw LNDL chunk.
-
-    Heuristic — does NOT parse the chunk. Intended for fast pre-screening
-    and aggregate health metrics. Use ``Lexer`` + ``Parser`` for definitive
-    syntax verdicts.
-    """
+    """Classify the syntactic health of a raw LNDL chunk. Heuristic — does
+    NOT parse; use ``Lexer`` + ``Parser`` for definitive syntax verdicts."""
     if not isinstance(text, str):
         return LndlChunkHealth(text="", has_out=False, open_tags=0, close_tags=0, balanced=False)
     has_out = "OUT{" in text or "OUT [" in text
@@ -109,16 +65,8 @@ def classify_chunk(text: str) -> LndlChunkHealth:
 
 
 def classify_result(value: Any) -> str:
-    """Classify what an operate-with-LNDL result actually is.
-
-    Returns one of:
-
-    * ``ok``    — a parsed ``BaseModel`` (the schema-shaped return).
-    * ``str``   — raw LNDL fallback (parse or assembly failure leaked through).
-    * ``dict``  — partial dict (validation failed but the framework kept
-      the unstructured value rather than raising).
-    * ``empty`` — ``None``, empty string, empty dict, or all-``None`` dict.
-    """
+    """Classify an operate-with-LNDL result: ``ok`` (parsed BaseModel),
+    ``str`` (raw fallback), ``dict`` (validation failed), or ``empty``."""
     if value is None:
         return "empty"
     if isinstance(value, str):
@@ -132,9 +80,7 @@ def classify_result(value: Any) -> str:
     return "dict"
 
 
-# ---------------------------------------------------------------------------
 # Per-round trace records
-# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -155,12 +101,8 @@ class LndlRoundRecord:
 
 @dataclass
 class LndlTrace:
-    """Opt-in trace container for LNDL operate / ReActStream calls.
-
-    Pass an instance via ``trace=`` and the framework will append one
-    ``LndlRoundRecord`` per LNDL parse attempt (including retries and
-    multi-round continuations).
-    """
+    """Opt-in trace container: pass via ``trace=`` and the framework appends
+    one ``LndlRoundRecord`` per LNDL parse attempt (incl. retries/continuations)."""
 
     rounds: list[LndlRoundRecord] = field(default_factory=list)
 
@@ -202,23 +144,12 @@ class LndlTrace:
         return len(self.rounds)
 
 
-# ---------------------------------------------------------------------------
 # Public utility — extract LNDL strings from a Branch's message log
-# ---------------------------------------------------------------------------
 
 
 def extract_lndl_chunks(messages: Any, since: int = 0) -> list[str]:
-    """Pull raw LNDL strings from assistant messages added after ``since``.
-
-    Filters to assistant messages whose content contains LNDL syntax
-    markers (``<lact``, ``<lvar``, ``OUT{``, ``OUT [``). Useful when you
-    didn't pass a ``trace=`` (or want chunks from non-LNDL messages too).
-
-    Args:
-        messages: An iterable of messages — typically ``branch.messages``.
-        since: Start index. Pass ``len(branch.messages)`` before a call,
-            then call again after to get chunks emitted by that call only.
-    """
+    """Pull raw LNDL strings (matching ``<lact``, ``<lvar``, ``OUT{``, ``OUT [``)
+    from assistant messages added after ``since``, for callers that skipped ``trace=``."""
     chunks: list[str] = []
     msgs = list(messages)
     for i in range(since, len(msgs)):

--- a/lionagi/lndl/lexer.py
+++ b/lionagi/lndl/lexer.py
@@ -82,9 +82,8 @@ class Lexer:
         while (char := self.current_char()) and (char.isdigit() or char == "."):
             result += char
             self.advance()
-        # Scientific-notation exponent: e/E, optional sign, then at least one
-        # digit. The e/E is only consumed when a valid exponent follows, so a
-        # trailing 'e' with no digits stays a separate token.
+        # Scientific-notation exponent: only consume e/E when a valid
+        # exponent follows, so a trailing 'e' with no digits stays separate.
         if (char := self.current_char()) and char in "eE":
             sign = self.peek_char()
             exp_digit = self.peek_char(2) if sign in ("+", "-") else sign

--- a/lionagi/lndl/normalize.py
+++ b/lionagi/lndl/normalize.py
@@ -1,14 +1,8 @@
 # Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""LNDL text normalization — auto-fix common model-invented syntax errors.
-
-Models trained on XML/HTML/JSON sometimes drift into related-but-wrong forms.
-This module catches the most common drifts and rewrites them into valid LNDL
-before the parser runs, so the model isn't penalized for surface mistakes.
-
-Ported from krons.lndl.fuzzy.
-"""
+"""LNDL text normalization — auto-fixes common model-invented syntax drift
+(from XML/HTML/JSON training) into valid LNDL before the parser runs."""
 
 from __future__ import annotations
 
@@ -20,9 +14,8 @@ __all__ = ("normalize_lndl_text",)
 
 _XML_ATTR_RE = re.compile(r'\b\w+=["\'][^"\']*["\']')
 
-# `<lact alias fn(args)</lact>` — opening tag ate the closing `>`, the body
-# starts immediately. Detect by an opening tag containing `(` before the next
-# `>` and a `</lact>`/`</lvar>` further on.
+# Detects `<lact alias fn(args)</lact>` — opening tag ate the closing `>`,
+# body starts immediately (has `(` before next `>`, closed further on).
 _MISSING_GT_RE = re.compile(
     r"<(lvar|lact)\s+([A-Za-z_][\w.]*(?:\s+[A-Za-z_][\w.]*)?)\s+([^<>]*?\([^<>]*?)</\1>",
     re.DOTALL,
@@ -31,11 +24,7 @@ _MISSING_GT_RE = re.compile(
 
 def _fix_missing_gt(text: str) -> str:
     """Repair ``<lact alias fn(args)</lact>`` → ``<lact alias>fn(args)</lact>``.
-
-    Conservative: only touches tags where (a) the opening had a function
-    call (paren) inside it and (b) the closing tag is present. Common gpt
-    drift; cheap to fix; harmless if it never matches.
-    """
+    Conservative: only fires when the opening had a call-paren and the closing tag exists."""
 
     def repl(m: re.Match) -> str:
         tag = m.group(1)
@@ -47,18 +36,8 @@ def _fix_missing_gt(text: str) -> str:
 
 
 def normalize_lndl_text(text: str) -> str:
-    """Normalize model-invented syntax before lexing.
-
-    Handles:
-    - Curly-brace tags: ``{lact X}fn(){/lact}`` or ``{lact X}fn()</lact>``
-      → ``<lact X>fn()</lact>``
-    - XML attributes: ``<lact name="X" type="Y">`` → ``<lact X>``
-    - Tag opening missing ``>`` before body: ``<lact a fn()</lact>`` →
-      ``<lact a>fn()</lact>`` (when the body contains a parenthesised call).
-    - ``Note.`` namespace casing: ``<lvar Note.draft d>`` → ``<lvar note.draft d>``
-      (the note namespace and OUT{} ``note.x`` refs are matched case-sensitively
-      downstream, so model-invented capitalization must be normalized here).
-    """
+    """Normalize model-invented syntax before lexing: curly-brace tags,
+    XML attributes, missing-`>` opens, and ``Note.`` → ``note.`` casing."""
     if not text:
         return text
 
@@ -93,8 +72,7 @@ def normalize_lndl_text(text: str) -> str:
 
     text = re.sub(r"<(lvar|lact)\s+((?:[^>])*?)>", _clean_tag, text)
 
-    # 4) Note-namespace casing: `Note.` → `note.` inside tag bodies, so both
-    #    the note lvar declaration and any `note.x` OUT{} ref match the
-    #    case-sensitive `note.` prefix the assembler checks for.
+    # 4) Note-namespace casing: `Note.` → `note.` — the assembler matches
+    #    the `note.` prefix case-sensitively downstream.
     text = re.sub(r"<(lvar|lact)\s+Note\.", r"<\1 note.", text)
     return text

--- a/lionagi/lndl/parser.py
+++ b/lionagi/lndl/parser.py
@@ -321,11 +321,8 @@ class Parser:
         return Lact(model=model, field=field, alias=alias, call=call, extra_id=extra_id)
 
     def _parse_out_list(self, depth: int = 0) -> list:
-        """Parse one bracketed list (refs or nested groups) starting at LBRACKET.
-
-        Returns ``list[str]`` for flat refs and ``list[list[str]]`` when the
-        contents are themselves bracketed (e.g. ``[[a, b], [c, d]]``).
-        """
+        """Parse one bracketed list starting at LBRACKET: ``list[str]`` for flat
+        refs, ``list[list[str]]`` when contents are themselves bracketed."""
         if depth >= _MAX_OUT_NESTING_DEPTH:
             raise ParseError(
                 f"OUT block nesting too deep - exceeded max depth of {_MAX_OUT_NESTING_DEPTH}",
@@ -363,14 +360,8 @@ class Parser:
         return items
 
     def _resolve_alias_to_spec(self, alias: str) -> str | None:
-        """Look up an alias in already-parsed lvars/lacts and return its implied spec name.
-
-        Resolution priority (most-specific first):
-          1. Declared field on a ``Model.field`` form   → returns the field name
-          2. Declared model on a ``Model.field`` form   → returns the model name
-          3. Two-token hint on a ``<l_ hint alias>`` form → returns the hint
-        Returns None when the alias has no spec context (single-token raw form).
-        """
+        """Look up an alias in already-parsed lvars/lacts and return its implied
+        spec name (field > model > two-token hint), or None if no spec context."""
         for la in getattr(self, "_lacts_so_far", []) or []:
             if la.alias == alias:
                 return la.field or la.model or getattr(la, "extra_id", None)
@@ -433,15 +424,12 @@ class Parser:
 
             # Shortcut: OUT{a, b}  — bare alias, no colon. Resolve to its declared spec.
             if not self.match(TokenType.COLON):
-                # ``note.X`` shortcut: routes to the schema field whose
-                # declared spec name was set when the lvar was parsed
-                # (``<lvar Field.name … note.X …>`` is unusual, so the typical
-                # path is to look up which spec the note was declared under).
+                # ``note.X`` shortcut: resolves to the spec name the lvar
+                # was declared under, when one exists.
                 spec = self._resolve_alias_to_spec(field_name)
                 if spec is None and "." in field_name:
-                    # Pure note.X with no host spec — caller must use explicit
-                    # OUT{spec: [note.X]} form. We still surface it under its
-                    # last segment so a downstream tool can hint the user.
+                    # No host spec — surface under the note's own head
+                    # segment as a hint (caller should use OUT{spec: [note.X]}).
                     head = field_name.split(".", 1)[0]
                     spec = head
                 if spec is None:

--- a/lionagi/lndl/round_outcome.py
+++ b/lionagi/lndl/round_outcome.py
@@ -1,15 +1,8 @@
 # Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""RoundOutcome — algebraic data type for one LNDL round's result.
-
-A multi-round LNDL run is a state machine: each round produces an outcome,
-and the outer loop matches on it to decide what to do next. Replaces the
-ad-hoc branches (parse-fail, validate-fail, missing-out, etc.) with one
-small set of variants.
-
-Ported from krons.agent.operations.round_outcome.
-"""
+"""RoundOutcome — algebraic data type for one LNDL round's result. A
+multi-round run is a state machine; the outer loop matches on the outcome variant."""
 
 from __future__ import annotations
 
@@ -35,9 +28,8 @@ class Success:
 
 @dataclass(slots=True, frozen=True)
 class Continue:
-    """No OUT{} block this round — model is still thinking. Lacts that
-    ran this round have already been persisted as tool messages, so the
-    next round sees their results in chat history."""
+    """No OUT{} block this round — model still thinking. Lacts run this
+    round are already persisted as tool messages, visible next round."""
 
     notes_committed: tuple[str, ...] = ()
 
@@ -45,8 +37,7 @@ class Continue:
 @dataclass(slots=True, frozen=True)
 class Retry:
     """OUT{} produced but parse/resolve/validate failed. Feed ``error`` to
-    the model in the next round so it can self-correct. Scratchpad and
-    chat history from prior rounds remain intact."""
+    the model next round to self-correct; prior scratchpad/history stays intact."""
 
     error: str
     note_keys: tuple[str, ...] = ()

--- a/lionagi/lndl/types.py
+++ b/lionagi/lndl/types.py
@@ -146,19 +146,15 @@ def _coerce_result(result: Any, target_type: Any) -> Any:
     scalar = _unwrap_scalar(target_type)
     if scalar is None:
         return result
-    # A legitimately-None result for an Optional scalar (str | None, int | None)
-    # must pass through untouched. Coercing would corrupt it: scalar(None) yields
-    # the literal "None" for str and raises for int/float. Leaving it None lets
-    # model_validate accept it for Optional fields and raise a clear error for
-    # required ones — never silently fabricate a value.
+    # None must pass through untouched: scalar(None) yields "None" for str
+    # and raises for int/float — never silently fabricate a value.
     if result is None:
         return None
     if isinstance(result, dict):
         return json_dumps(result)
     if not isinstance(result, scalar):
-        # bool(str) uses Python truthiness: bool('false') == True.
-        # Use validate_boolean so that 'false'/'0'/'no' → False and
-        # 'true'/'1'/'yes' → True, matching common tool return conventions.
+        # bool(str) uses Python truthiness (bool('false') == True); use
+        # validate_boolean for 'false'/'0'/'no' → False semantics instead.
         if scalar is bool:
             return validate_boolean(result)
         return scalar(result)

--- a/lionagi/models/_build_model.py
+++ b/lionagi/models/_build_model.py
@@ -31,11 +31,7 @@ def build_model_type(
     frozen: bool = False,
     validators: dict | None = None,
 ) -> type[BaseModel]:
-    # Keep this low-level constructor uncached: FieldInfo and validator inputs can
-    # be mutable. Operative model construction caches only immutable schemas,
-    # keyed by the actual base class object plus frozen build options. Class-object
-    # identity keeps distinct same-named/shaped classes separate, unlike the old
-    # structural hash that cross-wired their generated models.
+    # Keep this low-level constructor uncached: FieldInfo/validator inputs can be mutable.
     # Field precedence (later wins): parameter_fields → base_type → field_models.
     if base_type is not None and not (
         inspect.isclass(base_type) and issubclass(base_type, BaseModel)

--- a/lionagi/operations/ReAct/utils.py
+++ b/lionagi/operations/ReAct/utils.py
@@ -9,11 +9,7 @@ from lionagi.models import HashableModel
 
 
 class ReActAnalysis(HashableModel):
-    """Chain-of-thought output for one ReAct round: analysis, extension flag, and action strategy.
-
-    Round budget is framed as headroom to use, not a countdown — scarcity framing
-    makes models wrap up early. See prompts below.
-    """
+    """Chain-of-thought output for one ReAct round: analysis, extension flag, action strategy. Round budget is framed as headroom, not a countdown (avoids early wrap-up)."""
 
     FIRST_EXT_PROMPT: ClassVar[str] = (
         "This is a multi-step task. You have room for up to {extensions} reason-act "

--- a/lionagi/operations/_defaults.py
+++ b/lionagi/operations/_defaults.py
@@ -34,12 +34,7 @@ def make_parse_param(
     num_retries: int | None = None,
     fuzzy_kw: dict | None = None,
 ):
-    """Build a ParseParam with standard defaults for structured-output parsing.
-
-    Covers the common case (bare get_default_parse_call, empty FuzzyMatchKeysParams).
-    For communicate's per-call retry variant pass num_retries; for non-default fuzzy
-    settings pass fuzzy_kw (keys forwarded to FuzzyMatchKeysParams).
-    """
+    """Build a ParseParam with standard defaults for structured-output parsing; num_retries/fuzzy_kw customize per-call."""
     from lionagi.ln.fuzzy import FuzzyMatchKeysParams
 
     from .types import ParseParam

--- a/lionagi/operations/_observe.py
+++ b/lionagi/operations/_observe.py
@@ -28,9 +28,7 @@ class StopStream(Exception):  # noqa: N818
 
 def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any], list[Any]]:
     """Parse fenced JSON capability blocks from an assistant message; returns (bundles, violations, rejects).
-
-    Keys ⊆ grant → validated bundle; keys outside grant → CapabilityViolation; schema failure → EmissionRejected.
-    """
+    Keys ⊆ grant → validated bundle; keys outside grant → violation; schema failure → reject."""
     if not text or not isinstance(text, str):
         return [], [], []
     from lionagi.ln.fuzzy._extract_json import extract_json

--- a/lionagi/operations/lndl_middle/__init__.py
+++ b/lionagi/operations/lndl_middle/__init__.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public surface for the LNDL seam Middle (ADR-0024 §1-2). Unlike the
-internal ``communicate``/``run``/``act`` operation modules (dispatch details
-``operate()`` reaches via their submodule paths), ``lndl_middle`` is a new
-opt-in symbol callers pass directly: ``branch.operate(middle=lndl_middle)``."""
+"""Public surface for the LNDL seam Middle (ADR-0024 §1-2); ``lndl_middle`` is an opt-in symbol, not an internal dispatch module."""
 
 from .lndl_middle import DEFAULT_ROUND_BUDGET, build_lndl_middle, lndl_middle
 

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -1,14 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""LNDL seam Middle — advances a branch one LNDL round per inner chat call,
-looping internally up to a round budget (default 3). Implements ADR-0024
-§1 (the seam over ``operate()``) and §2 (round outcomes and repair
-semantics).
-
-Opt-in per call: ``branch.operate(instruction=..., middle=lndl_middle)``.
-Nothing changes for callers who don't pass it.
-"""
+"""LNDL seam Middle — advances a branch one LNDL round per inner chat call, looping up to a round budget (ADR-0024 §1-2). Opt-in via ``branch.operate(middle=lndl_middle)``."""
 
 from __future__ import annotations
 
@@ -68,9 +61,7 @@ def _unwrap_optional_type(t: Any) -> Any:
 
 
 def _render_type(annotation: Any) -> str:
-    """Render a field's type the way LNDL_SYSTEM_PROMPT's own ``Specs:``
-    examples do -- e.g. ``int``, ``list[str]``, ``dict[str, float]``, or
-    ``ModelName: field1, field2`` for a nested pydantic model."""
+    """Render a field's type the way LNDL_SYSTEM_PROMPT's ``Specs:`` examples do."""
     annotation = _unwrap_optional_type(annotation)
     origin = get_origin(annotation)
     if origin is list:
@@ -92,9 +83,7 @@ def _render_type(annotation: Any) -> str:
 
 
 def _render_target_spec(target: Any) -> str | None:
-    """Render the target model's fields as an LNDL ``Specs:`` line, the format
-    LNDL_SYSTEM_PROMPT's examples use — required since the per-round chat
-    call strips native ``response_format``. None for a plain-dict/no-target caller."""
+    """Render the target model's fields as an LNDL ``Specs:`` line; None for a plain-dict/no-target caller."""
     model_fields = getattr(target, "model_fields", None)
     if not model_fields:
         return None
@@ -108,9 +97,7 @@ def _render_target_spec(target: Any) -> str | None:
 
 
 async def _bridge_action_calls(branch: Branch, calls: list[ActionCall]) -> dict[str, Any]:
-    """Translate ActionCall placeholders into ActionRequests and execute them
-    through the branch's normal act() path, so permission policies and hooks
-    apply unchanged (ADR-0024 §1). Returns a dict of alias -> result."""
+    """Translate ActionCall placeholders into ActionRequests and run them through the branch's normal act() path (ADR-0024 §1)."""
     if not calls:
         return {}
 
@@ -134,9 +121,7 @@ async def _run_round_chat(
     instruction: JsonValue | Instruction,
     chat_param: ChatParam,
 ) -> str:
-    """Run one inner-chat turn, dispatching to communicate() (API models) or
-    run_and_collect() (CLI models) — mirrors operate()'s own default-Middle
-    selection so LNDL behaves the same for both endpoint families."""
+    """Run one inner-chat turn, dispatching to communicate() (API) or run_and_collect() (CLI) — mirrors operate()'s own selection."""
     if isinstance(chat_param, RunParam) or getattr(branch.chat_model, "is_cli", False):
         from ..run.run import run_and_collect
 
@@ -168,12 +153,7 @@ def _classify_round(
     target: Any,
     action_results: dict[str, Any],
 ) -> tuple[RoundOutcome, list[ActionCall], dict[str, Any] | None]:
-    """Parse and assemble one round's raw text into a RoundOutcome.
-
-    Returns ``(outcome, pending_action_calls, assembled_dict)``; ``pending`` is
-    every lact for Continue, only OUT{}-reachable lacts for Success; ``assembled``
-    is set only on Success.
-    """
+    """Parse and assemble one round's raw text into a RoundOutcome; returns (outcome, pending_action_calls, assembled_dict)."""
     blocks = extract_lndl_blocks(text)
     if not blocks:
         return Continue(), [], None
@@ -196,11 +176,7 @@ def _classify_round(
 
 
 def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
-    """Build an LNDL seam Middle (ADR-0024 §1) with a custom round budget.
-
-    Returns a callable satisfying the Middle protocol (``operations/types.py``).
-    ``lndl_middle`` (module-level, below) is the ready-to-use default.
-    """
+    """Build an LNDL seam Middle (ADR-0024 §1) with a custom round budget; ``lndl_middle`` is the ready-to-use default."""
 
     async def _lndl_middle(
         branch: Branch,

--- a/lionagi/operations/operate/step.py
+++ b/lionagi/operations/operate/step.py
@@ -52,13 +52,7 @@ class Step:
         request_params: dict | None = None,
         **kwargs,
     ) -> Operative:
-        """Build a request-phase Operative with optional reason/action fields; deprecated params are silently ignored.
-
-        Identically-constructed Operatives may share one request/response model
-        TYPE (a process-wide cache); instances and their state stay per-call.
-        Do not mutate a returned model class. Set
-        LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0 to restore per-call classes.
-        """
+        """Build a request-phase Operative with optional reason/action fields; deprecated params are silently ignored. Returned model TYPE may be shared (process-wide cache) — do not mutate it."""
         from .._guards import reject_removed_kwargs
 
         reject_removed_kwargs(
@@ -151,12 +145,7 @@ class Step:
         operative: Operative,
         additional_fields: dict[str, Spec] | None = None,
     ) -> Operative:
-        """Extend an operative with optional additional response fields and materialize its response model.
-
-        The materialized response model type follows the same sharing contract
-        as request_operative(): identical construction may return a shared
-        class; never mutate it.
-        """
+        """Extend an operative with optional additional response fields and materialize its response model; follows the same shared-model-type contract as request_operative() — never mutate it."""
         if additional_fields:
             # Get existing fields
             existing_fields = list(operative.operable.__op_fields__)

--- a/lionagi/operations/schema/json_structure.py
+++ b/lionagi/operations/schema/json_structure.py
@@ -58,9 +58,7 @@ class JsonStructure(Structure):
             fuzzy_match_params or _DEFAULT_FUZZY,
         )
 
-    # ------------------------------------------------------------------
     # Canonical rendering — copied from InstructionContent
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _format_response_format(

--- a/lionagi/operations/schema/structure.py
+++ b/lionagi/operations/schema/structure.py
@@ -69,9 +69,7 @@ class Structure:
     def operable(self) -> Operable | None:
         return self._operable
 
-    # ------------------------------------------------------------------
     # Builder
-    # ------------------------------------------------------------------
 
     def _clone(self, **overrides) -> Structure:
         base = overrides.pop("base", self._base_dict if self.is_dict_mode else self._base)
@@ -105,9 +103,7 @@ class Structure:
     def with_reason(self) -> Structure:
         return self._clone(reason=True)
 
-    # ------------------------------------------------------------------
     # Schema generation — delegates to Operable (model mode only)
-    # ------------------------------------------------------------------
 
     def request_schema(self) -> type[BaseModel] | dict[str, Any]:
         """Pydantic model for model mode; dict for dict mode."""
@@ -147,9 +143,7 @@ class Structure:
         data = {k: v for k, v in parsed.model_dump(mode="python").items() if k in base_fields}
         return self._base.model_validate(data)
 
-    # ------------------------------------------------------------------
     # Subclass interface
-    # ------------------------------------------------------------------
 
     def render(self) -> str:
         raise NotImplementedError
@@ -157,9 +151,7 @@ class Structure:
     def parse(self, text: str, **kw) -> BaseModel | dict:
         raise NotImplementedError
 
-    # ------------------------------------------------------------------
     # Private
-    # ------------------------------------------------------------------
 
     def _build_operable(self, user_specs: list[Spec] | tuple[Spec, ...]) -> Operable:
         from lionagi.operations.fields import get_default_field

--- a/lionagi/operations/select/utils.py
+++ b/lionagi/operations/select/utils.py
@@ -24,12 +24,7 @@ class SelectionModel(BaseModel):
 def parse_to_representation(
     choices: Enum | dict | list | tuple | set,
 ) -> tuple[list[str], JsonValue]:
-    """
-    should use
-    1. iterator of string | BaseModel
-    2. dict[str, JsonValue | BaseModel]
-    3. Enum[str, JsonValue | BaseModel]
-    """
+    """Accepts an iterable of str/BaseModel, a dict[str, JsonValue|BaseModel], or an Enum."""
 
     if isinstance(choices, tuple | set | list):
         choices = list(choices)

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -51,11 +51,7 @@ _ASSIGNMENTS_FIELD = FieldModel(list[TaskAssignment], name="assignments")
 
 
 def grant_spawn(branch: Branch, *, prompt: bool = True) -> None:
-    """Let an agent grow the live DAG by emitting a ``SpawnRequest``.
-
-    Grants the SpawnRequest capability (and, when *prompt*, injects the
-    capability instruction block so the model knows it may emit one).
-    """
+    """Let an agent grow the live DAG by emitting a ``SpawnRequest``; grants the capability and, when *prompt*, injects the instruction block."""
     branch.grant_capabilities(build_emission_operable((SpawnRequest,), name="spawn"), prompt=prompt)
 
 
@@ -66,39 +62,14 @@ def role_node_builder(
     start: int = 1,
 ):
     """Return a node_builder closure that routes SpawnRequests to role branches.
-
-    *decorate_instruction*, when given, is called with the request and the
-    node's freshly allocated ``spawn_id`` and must return the full instruction
-    text the child operation runs with — CLI callers use it to inject the
-    same artifact-directory + REQUIRED-file text a planned leg gets (see
-    ``lionagi.cli.orchestrate.flow``); library/engine callers that pass
-    nothing keep the plain no-artifact instruction.
-
-    *start* seeds the closure's spawn-id sequence past whatever ordinals a
-    caller already handed out in a prior generation (e.g. a CLI resume that
-    reconstructed completed spawns from a checkpoint) — this closure is
-    rebuilt fresh every generation, so without it a brand new sequence
-    starting back at 1 would reissue an id already used by a restored node,
-    and any live spawn this generation would collide with it (same
-    spawn_id, same artifact directory).
-    """
+    *decorate_instruction* customizes child instruction text (CLI artifact injection); *start* seeds spawn-id past prior-generation ordinals to avoid collisions on resume."""
     # Closure-scoped monotonic sequence: the ONLY correct source of a spawned
-    # node's stable id. It must be allocated here, at construction time,
-    # because this is the sole point that sees the SpawnRequest before the
-    # child Operation is ever queued — by the time _execute_dag looks at
-    # completed results, completion order (not spawn order) is all that is
-    # left, and that is unrelated to which child actually is "the first
-    # spawn". Minting the id at completion-time let an unrelated node "steal"
-    # spawn-1 depending on which sibling happened to finish first — that is
-    # the bug this closure exists to fix.
+    # node's stable id — must be allocated here (construction time), not at completion (see batch report for the bug this fixes).
     _next_spawn_seq = itertools.count(start)
 
     def build(req: SpawnRequest, emitter: Operation) -> Operation:
-        # Defense-in-depth: validate the operation at the routing boundary even
-        # though SpawnRequest.operation is already typed as a Literal. Custom
-        # operation names registered on a session branch must NOT be reachable
-        # via model-emitted spawn requests. Fail closed on anything outside the
-        # documented allowlist.
+        # Defense-in-depth: re-validate operation at the routing boundary — custom
+        # operation names must NOT be reachable via model-emitted spawn requests. Fail closed.
         op = req.operation or "operate"
         if op not in SPAWN_ALLOWED_OPERATIONS:
             logger.warning(
@@ -118,11 +89,8 @@ def role_node_builder(
                     f"recognized role (known: {sorted(roles)})"
                 )
 
-        # Allocate only after assignee validation succeeds — an unknown
-        # assignee raises above and never consumes a sequence number, so the
-        # ids handed to real children stay dense modulo only genuine
-        # post-build rejections (cycle/cap) downstream, which are acceptable
-        # gaps per the executor's own bookkeeping.
+        # Allocate only after assignee validation succeeds — unknown assignees
+        # never consume a sequence number, keeping ids dense for real children.
         spawn_id = f"spawn-{next(_next_spawn_seq)}"
         instruction = req.instruction
         if decorate_instruction is not None:
@@ -132,15 +100,8 @@ def role_node_builder(
             op,
             parameters={"instruction": instruction},
         )
-        # Stamped so post-run callers (artifact contracts, DAG metadata) can
-        # attribute a reactively spawned node back to the role that ran it —
-        # the node otherwise carries no trace of its assignee once its
-        # branch_id is overwritten by the executor's per-spawn branch clone.
-        # spawn_id survives that clone too (metadata, not branch state) and
-        # is the stable correlation key every downstream surface must use.
-        # reference_id mirrors it for the executor's own display path
-        # (DependencyAwareExecutor._run_tracked reads metadata["reference_id"]
-        # for its progress/log line).
+        # Stamped so post-run callers can attribute a spawned node back to its
+        # role after branch_id gets overwritten; spawn_id is the stable correlation key (see batch report).
         node.metadata["spawn_id"] = spawn_id
         node.metadata["reference_id"] = spawn_id
         if target is not None:

--- a/lionagi/orchestration/prompts.py
+++ b/lionagi/orchestration/prompts.py
@@ -13,12 +13,8 @@ __all__ = (
     "SYNTHESIS_INSTRUCTION",
 )
 
-# ── Planning (orchestrator emits a list[TaskAssignment]) ──────────────────────
-#
-# The orchestrator decomposes the task into TaskAssignments — the casts
-# coordination emission. ``assignee`` names a role from the roster; ``task`` is
-# the concrete objective. There is no bespoke plan model: a list of
-# TaskAssignments *is* the plan (and, with depends_on, the DAG).
+# ── Planning (orchestrator emits a list[TaskAssignment]) ──────────────
+# No bespoke plan model: a list of TaskAssignments *is* the plan (with depends_on, the DAG).
 
 DECOMPOSE_INSTRUCTION = """\
 Decompose the task into parallel TaskAssignments — one per distinct angle or \

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -96,11 +96,8 @@ class ActionManager(Manager):
                 input_schema = function.get("parameters")
                 description = function.get("description")
 
-        # A schema/description that is just the auto-generated `**kwargs`
-        # wrapper carries no remote-server information; treat it as absent
-        # metadata so strong identities fail closed instead of being
-        # laundered through their own synthetic schema, and so ordinary
-        # names are not falsely denied by the wrapper's generic docstring.
+        # A generic `**kwargs` wrapper schema carries no remote-server info;
+        # treat it as absent so identities fail closed, not laundered through it.
         if is_synthetic_mcp_wrapper_schema(
             mcp_tool_name, advertised_name, input_schema, description
         ):
@@ -217,10 +214,8 @@ class ActionManager(Manager):
                 validate_mcp_tool_admission,
             )
 
-            # Validate the complete tool_names list before creating or
-            # registering any tool: a denial anywhere in the list must leave
-            # the registry exactly as it was, not partially populated with
-            # the names that happened to be validated first.
+            # Validate the whole list before registering any tool: a denial
+            # anywhere must leave the registry unchanged, not partially populated.
             for tool_name in tool_names:
                 validate_mcp_tool_admission(tool_name, None, None)
 
@@ -253,10 +248,8 @@ class ActionManager(Manager):
             client = await MCPConnectionPool.get_client(server_config, security=security)
             tools = await client.list_tools()
 
-            # Validate every discovered descriptor BEFORE mutating the
-            # registry: a denial anywhere in the list must leave the
-            # registry exactly as it was, not partially populated with the
-            # tools that happened to be validated first.
+            # Validate every descriptor before mutating the registry: a
+            # denial anywhere must leave the registry unchanged.
             for tool in tools:
                 validate_mcp_tool_admission(
                     tool.name,
@@ -327,10 +320,8 @@ class ActionManager(Manager):
         loaded_names = MCPConnectionPool.load_config(config_path)
 
         if server_names is None:
-            # Default to the servers declared in THIS config file. The pool
-            # accumulates configs process-globally across loads, so
-            # enumerating the pool here would silently re-register every
-            # server from previously loaded, unrelated configs.
+            # Default to servers in THIS config file — the pool accumulates
+            # configs globally, so enumerating it would re-register unrelated servers.
             server_names = loaded_names
         all_tools = {}
         for server_name in server_names:

--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pre-turn context injection: an ordered ContextProvider registry that
-renders ephemeral knowledge into the first-message guidance fold — never
-the durable message record. See ADR-0008."""
+"""Pre-turn context injection: renders ephemeral knowledge into the
+first-message guidance fold, never the durable message record. See ADR-0008."""
 
 from __future__ import annotations
 
@@ -53,12 +52,8 @@ class _Entry:
 
 
 class ContextProviderRegistry:
-    """Ordered registry of ContextProviders with a total injection budget.
-
-    Providers are registered in the order they should render; when the
-    combined output exceeds `budget`, lowest-priority providers are dropped
-    first. A provider that raises is warned + skipped; the turn proceeds.
-    """
+    """Ordered ContextProviders under a total injection budget; drops
+    lowest-priority providers first over budget, warns + skips on error."""
 
     def __init__(self, budget: int = _DEFAULT_BUDGET):
         self.budget = budget
@@ -110,9 +105,8 @@ class ContextProviderRegistry:
                 continue
             successes.append((entry, text, tokens))
 
-        # Protect highest priority first; drop lowest priority first when
-        # the total would exceed budget. Stable sort preserves registration
-        # order among equal priorities.
+        # Drop lowest-priority first over budget; stable sort preserves
+        # registration order among equal priorities.
         by_priority = sorted(successes, key=lambda item: item[0].priority, reverse=True)
 
         kept_ids: set[int] = set()
@@ -132,10 +126,8 @@ class ContextProviderRegistry:
         return report
 
     async def gather_writeback(self, branch: Branch, action_responses: list) -> None:
-        """POST-turn hook: providers with an optional `writeback(branch, action_responses)`
-        method get a chance to persist from the turn's action responses. Same
-        containment as `gather` — a raising provider is warned + skipped, never
-        blocks the turn."""
+        """POST-turn hook: providers with an optional `writeback` method persist
+        from the turn's action responses; errors are warned + skipped, never block."""
         for entry in self._entries:
             hook = getattr(entry.provider, "writeback", None)
             if hook is None:

--- a/lionagi/protocols/generic/element.py
+++ b/lionagi/protocols/generic/element.py
@@ -176,9 +176,8 @@ class Element(BaseModel, Observable):
                     # get_class resolves both fully-qualified names and legacy
                     # short names (data persisted before full-name adoption).
                     subcls_type: type[Element] = get_class(subcls)
-                    # Delegate to the subclass's from_dict when it has a custom
-                    # one, or when the concrete type differs so model_validate
-                    # uses the right schema.
+                    # Delegate to a custom from_dict, or when the concrete
+                    # type differs so model_validate uses the right schema.
                     if hasattr(subcls_type, "from_dict") and (
                         subcls_type.from_dict.__func__ != cls.from_dict.__func__
                         or subcls_type is not cls

--- a/lionagi/protocols/generic/processor.py
+++ b/lionagi/protocols/generic/processor.py
@@ -101,11 +101,8 @@ class Processor(Observer):
         return cls(**kwargs)
 
     async def process(self) -> None:
-        """Dequeue and process events up to available capacity.
-
-        Denied events are either terminal (SKIPPED) or deferred (re-enqueued).
-        Cycle stops when all queued events have been deferred to avoid busy-spin.
-        """
+        """Dequeue and process events up to available capacity; stops once all
+        queued events have been deferred, to avoid busy-spin."""
         events_processed = 0
         deferred = 0
 

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -11,10 +11,8 @@ from lionagi.ln.types import ModelConfig
 from .message import Message, MessageContent, MessageRole
 from .validators import validate_image_url
 
-# Pattern for a well-formed inline image data URI.  Only a bitmap MIME
-# allowlist is accepted and the payload must be non-empty base64.  This is
-# intentionally restrictive — active-content types (HTML, JS, and SVG, which
-# can carry scripts) are rejected, as are other data: schemes.
+# Bitmap MIME allowlist, non-empty base64 only. Deliberately excludes
+# active-content types (HTML/JS/SVG) and other data: schemes.
 _DATA_IMAGE_RE = re.compile(r"^data:image/(?:png|jpe?g|gif|webp);base64,[A-Za-z0-9+/]+=*$")
 
 _INSTRUCTION_SERIALIZE_EXCLUDE: frozenset[str] = frozenset(
@@ -70,17 +68,15 @@ class InstructionContent(MessageContent):
         object.__setattr__(self, "images", images if images is not None else [])
         object.__setattr__(self, "image_detail", image_detail)
         MessageContent.__post_init__(self)
-        # Build the structure from the tracked copy, not the caller's dict: a
-        # structure holding the caller's alias would let external mutation
-        # change the rendering without advancing the content revision.
+        # Build from the tracked copy, not the caller's dict: an alias would
+        # let external mutation change rendering without advancing the revision.
         object.__setattr__(
             self, "_structure_instance", _build_structure(self.response_format, structure_cls)
         )
 
     def __getstate__(self) -> tuple[Any, Any]:
-        # The private structure may cache a dynamically created request-model
-        # class that cannot be serialized; it is disposable state, excluded
-        # here and rebuilt from the restored public fields in __setstate__.
+        # _structure_instance may cache an unserializable dynamic class;
+        # excluded here, rebuilt from public fields in __setstate__.
         import dataclasses
 
         slots: dict[str, Any] = {}
@@ -94,10 +90,8 @@ class InstructionContent(MessageContent):
         return (None, slots)
 
     def __setstate__(self, state: tuple[Any, Any]) -> None:
-        # Restore copied/unpickled state through __setattr__ so mutable render
-        # inputs are re-wrapped, then rebuild the private structure from the
-        # restored response_format: keeping the copied structure would leave
-        # the renderer reading a dict detached from the restored public field.
+        # Restore via __setattr__, then rebuild _structure_instance from
+        # response_format — a copied structure would read a detached dict.
         dict_state, slots_state = state
         for source in (dict_state, slots_state):
             if not source:
@@ -111,9 +105,8 @@ class InstructionContent(MessageContent):
         )
 
     def to_dict(self, exclude: set[str] | frozenset[str] | None = None) -> dict[str, Any]:
-        # Conditionally include response_format when its value is a plain dict
-        # (JSON-serializable); keep excluding it for type/BaseModel references
-        # which cannot survive a round-trip through to_dict → from_dict.
+        # Include response_format only when it's a plain (JSON-serializable)
+        # dict; type/BaseModel forms can't round-trip through from_dict.
         base_exclude = set(_INSTRUCTION_SERIALIZE_EXCLUDE)
         if isinstance(self.response_format, dict):
             base_exclude.discard("response_format")
@@ -173,9 +166,8 @@ class InstructionContent(MessageContent):
                 inst.prompt_context.extend(ctx_list)
 
         if ts := data.get("tool_schemas"):
-            # Accept either a flat list of schemas or the {"tools": [...]} wrapper
-            # that ActionManager.get_tool_schema returns; store flat so the
-            # rendered "Tools:" section isn't nested under a spurious `- tools:`.
+            # Accept a flat list or the {"tools": [...]} wrapper from
+            # ActionManager.get_tool_schema; store flat to avoid nesting.
             if isinstance(ts, dict):
                 ts = ts.get("tools", [ts])
             inst.tool_schemas.extend(ts if isinstance(ts, list) else [ts])
@@ -241,9 +233,8 @@ class InstructionContent(MessageContent):
                 )
             url = idx
         elif "://" in idx or (idx.split(":")[0].isalpha() and ":" in idx):
-            # Looks like a URL with a non-http/https/data scheme (e.g. file://,
-            # javascript:, ftp://).  Delegate to validate_image_url which will
-            # reject all disallowed schemes with a clear error.
+            # Non-http/https/data scheme (e.g. file://, javascript:); delegate
+            # to validate_image_url, which rejects disallowed schemes.
             validate_image_url(idx)
             url = idx  # unreachable if validate_image_url raises
         else:

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -34,9 +34,8 @@ class _TrackedList(list):
             self._touch()
 
     def __reduce__(self):
-        # Copy/pickle as a plain list: the revision callback is bound to the
-        # owning content and must not survive reconstruction. The owning
-        # content re-wraps its fields when its own state is restored.
+        # Copy/pickle as a plain list: the revision callback must not
+        # survive reconstruction (the owning content re-wraps on restore).
         return (list, (list(self),))
 
     def append(self, value) -> None:
@@ -324,13 +323,8 @@ class Message(Node, Sendable):
             return None
 
     def _render_cached(self, variant: str, render: Callable[[], Any]) -> Any:
-        """Return a rendering cached by content identity and revision.
-
-        The entry retains the content object itself and is served only when
-        the stored content IS the current content: an id()-based key could
-        cross-wire two content objects whose lifetimes never overlap but
-        happen to reuse the same address.
-        """
+        """Return a rendering cached by content identity and revision (not
+        id(), which could cross-wire non-overlapping objects reusing an address)."""
         content = self.content
         revision = getattr(content, "_render_revision", 0)
         cached = self._render_cache.get(variant)

--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -23,9 +23,7 @@ if TYPE_CHECKING:
 
 __all__ = ("prepare_messages_for_chat",)
 
-# ---------------------------------------------------------------------------
 # Type aliases — production content types are canonical.
-# ---------------------------------------------------------------------------
 Instruction = InstructionContent
 System = SystemContent
 ActionRequest = ActionRequestContent

--- a/lionagi/session/exchange.py
+++ b/lionagi/session/exchange.py
@@ -141,14 +141,7 @@ class Exchange(Element):
         return await self.collect_all()
 
     async def run(self, interval: float = 1.0) -> None:
-        """Continuous sync loop. Call stop() to exit.
-
-        Does not reset ``_stop`` on entry: a stop() issued before this
-        coroutine gets its first turn (e.g. the DAG it watches over failed
-        immediately) must make run() return right away instead of clearing
-        that signal and looping forever. Construct a fresh Exchange for a new
-        run rather than reusing one that has already been stopped.
-        """
+        """Continuous sync loop; call stop() to exit. Does not reset ``_stop`` on entry — a pre-issued stop() must make run() return immediately, not loop forever. Construct a fresh Exchange to reuse."""
         while not self._stop:
             await self.sync()
             await sleep(interval)

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -23,19 +23,8 @@ Handler = Callable[[Any, "SessionObserver"], Any]
 Predicate = Callable[[Any], bool]
 Gate = Callable[[Any], Any]
 
-# Maximum byte size for the persisted payload JSON column in session_signals.
-# This is a PAYLOAD cap, not a frame cap: it bounds
-# ``len(_to_json_column(payload).encode("utf-8"))`` — the value stored in the
-# ``payload`` column.  The SSE generator wraps each row in a full JSON object
-# (id, session_id, seq, kind, op_id, ts, payload) and prefixes it with
-# ``data: ...\n\n``; that envelope adds bounded overhead (~176 bytes for
-# typical row metadata) so SSE frames can exceed this cap by that margin.
-# Callers that need a hard frame cap must reserve the envelope overhead before
-# calling _sanitize_signal_payload.
-# Payloads exceeding the cap are truncated: the dict is serialised to JSON,
-# sliced to fit (accounting for JSON escaping of backslashes and quotes), and a
-# ``truncated`` + ``original_bytes`` marker is injected so downstream
-# consumers know the data is partial.
+# PAYLOAD cap (not frame cap) for the persisted payload JSON column; SSE
+# envelope overhead (~176B) can push frames over this. See _sanitize_signal_payload.
 _PAYLOAD_BYTE_CAP: int = 16_384  # 16 KB (payload column only; see note above)
 
 # Signal fields that are part of Signal base and must not be promoted into the
@@ -82,9 +71,8 @@ def _sanitize_signal_payload(sig: Any) -> dict[str, Any]:
         except Exception:  # noqa: BLE001
             raw["data"] = repr(sig.data)
 
-    # Serialise with safe_fallback so no TypeError escapes, then parse back to
-    # a dict of JSON-native types.  This is the single serialisation gate:
-    # after this point, ``payload`` contains only str/int/float/bool/list/dict.
+    # Serialise with safe_fallback so no TypeError escapes, then parse back —
+    # single serialisation gate: after this, payload is str/int/float/bool/list/dict only.
     safe_json: str | None = None
     try:
         safe_json = _jd(raw, safe_fallback=True)
@@ -92,17 +80,8 @@ def _sanitize_signal_payload(sig: Any) -> dict[str, Any]:
     except Exception:  # noqa: BLE001
         payload = {"sanitize_error": repr(sig)[:256]}
 
-    # Apply byte cap on the FINAL serialized form, not the intermediate
-    # safe_json string.  safe_json may be under the cap, but after wrapping in
-    # a truncation-marker dict and re-serializing (with JSON escaping of
-    # backslashes, quotes, etc.) the stored column can be 2× larger.
-    #
-    # Strategy:
-    #  1. Measure the final serialized payload.  If under cap, done.
-    #  2. If over cap, build a truncation-marker dict with a data slice whose
-    #     byte length starts at (cap - marker_overhead) and shrinks until the
-    #     whole re-serialized dict fits.  The loop terminates quickly because
-    #     each iteration exactly measures the excess; at most a few rounds.
+    # Byte cap applies to the FINAL serialized form (re-serializing the
+    # truncation marker can 2x the size) — see strategy in the batch report.
     try:
         if safe_json is not None:
             original_bytes = safe_json.encode("utf-8")
@@ -111,9 +90,8 @@ def _sanitize_signal_payload(sig: Any) -> dict[str, Any]:
         original_len = len(original_bytes)
 
         if original_len > _PAYLOAD_BYTE_CAP:
-            # Estimate marker overhead: serialise the marker with an empty data
-            # string to get the fixed-cost JSON bytes, then allow the remainder
-            # of the cap budget for the escaped data content.
+            # Estimate marker overhead via an empty-data marker's fixed JSON
+            # cost, then budget the remainder for escaped data content.
             _marker_empty = _jd(
                 {"truncated": True, "original_bytes": original_len, "data": ""},
                 safe_fallback=True,
@@ -228,13 +206,7 @@ class SessionObserver(Observer):
         return self
 
     async def authorize(self, action: Any) -> bool:
-        """Pre-invoke gate. Returns True when no gate set. Denials recorded as GateDenied.
-
-        Routed through the shared GateResult adapter (lionagi.agent.gate) so the
-        session gate's fail-closed-on-exception behavior is expressed as the
-        same typed verdict shape as PermissionPolicy and the built-in coding
-        guards (ADR-0086 delta row 1).
-        """
+        """Pre-invoke gate. Returns True when no gate set; denials recorded as GateDenied. Routed through the shared GateResult adapter (ADR-0086) for a consistent fail-closed verdict shape."""
         if self._gate is None:
             return True
         from lionagi.agent.gate import adapt_session_gate
@@ -327,9 +299,8 @@ class SessionObserver(Observer):
         """Register a subscription persisting every Signal to StateDB; pass db to reuse an open connection."""
         import time as _time
 
-        # Capture the caller-supplied db reference.  In production CLI paths this
-        # is the long-lived StateDB opened by setup_agent_persist /
-        # setup_orchestration_persist — the same instance used for message writes.
+        # Caller-supplied db: in production this is the long-lived StateDB
+        # from setup_agent_persist/setup_orchestration_persist (reused for message writes).
         _bound_db = db
 
         async def _persist(event: Any, _ctx: Any = None) -> None:
@@ -341,9 +312,8 @@ class SessionObserver(Observer):
             kind = type(sig).__name__
             op_id = getattr(sig, "op_id", "") or ""
             ts = _time.time()
-            # Build a JSON-safe, size-bounded payload.  _sanitize_signal_payload
-            # never raises: unknown objects fall back to repr, MessageAdded stores
-            # only a compact message reference, and oversized payloads are capped.
+            # _sanitize_signal_payload never raises: unknown objects fall back
+            # to repr, MessageAdded stores a compact ref, oversized payloads capped.
             payload = _sanitize_signal_payload(sig)
 
             try:

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -1,12 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public session orchestration and graph-execution facade.
-
-Submit ordinary operation graphs through ``Session.flow``. Streaming graph surfaces
-must use the existing streaming flow kernel. Every new graph-execution surface must
-delegate through one of these paths and include conformance coverage.
-"""
+"""Public session orchestration and graph-execution facade; new graph-execution surfaces must delegate through ``Session.flow``/the streaming kernel and include conformance coverage."""
 
 import contextlib
 from collections.abc import Callable
@@ -60,9 +55,8 @@ class Session(Node, Relational):
 
     def __init__(self, *, memory: MemoryStore | None = None, **kwargs: Any):
         super().__init__(**kwargs)
-        # `_initialize_branches` may have already lazily created a store and
-        # wired it into branches; an explicit store here overrides it and
-        # rewires any branch still holding that temp store.
+        # `_initialize_branches` may have lazily created + wired a store already;
+        # an explicit store here overrides it and rewires branches holding the temp one.
         temp = self._memory
         if memory is not None:
             self._memory = memory
@@ -162,10 +156,7 @@ class Session(Node, Relational):
 
     @property
     def memory(self) -> MemoryStore:
-        """This session's memory store: an explicitly supplied backend, or a
-        lazily-created shared `InMemoryStore` on first access. Read-only —
-        the only way to give a `Session` its own store is the `memory=`
-        constructor parameter."""
+        """This session's memory store: explicit backend or lazily-created shared `InMemoryStore`. Read-only — only settable via the `memory=` constructor param."""
         if self._memory is None:
             self._memory = InMemoryStore()
         return self._memory
@@ -260,9 +251,8 @@ class Session(Node, Relational):
         self.branches.exclude(branch)
         self.exchange.unregister(branch.id)
 
-        # Routing infrastructure is session-owned: tear it down so a removed
-        # branch reverts to a clean standalone state and can be reparented.
-        # Branch data (messages, memory, logs) stays with the branch.
+        # Routing infra is session-owned: torn down so branch reverts to clean,
+        # reparentable state. Branch data (messages/memory/logs) stays with it.
         branch._owning_session_id = None
         branch._observer = None
         branch._hooks = None

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -1,27 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Signal types and per-node lifecycle projection for the reactive bus (ADR-0033).
-
-Payload contract (schema_version=1):
-  RunStart        — no payload fields
-  RunEnd          — input_tokens, output_tokens, total_cost_usd, num_turns, duration_ms
-  RunFailed       — data: exception
-  NodeSpawned     — op_id, parent_id, independent, assignee, instruction
-  NodeQueued      — op_id, name, elapsed, parent_id, depends_on
-  NodeStarted     — op_id, name, elapsed, parent_id, depends_on
-  NodeCompleted   — op_id, name, elapsed, parent_id, depends_on
-  NodeFailed      — op_id, name, elapsed, parent_id, depends_on
-  NodeAwaitingApproval — op_id, name, reason
-  NodeEscalated   — op_id, name, reason, route, escalation_request
-  NodePaused      — op_id, name
-  GateDenied      — data: any
-  MessageAdded    — data: RoledMessage (stored as message_ref in payload)
-  DispatchSignal  — dispatch_id, kind, deliver_to, attempt, ack_token, body (ADR-0059)
-
-Version policy: schema_version is bumped on any breaking field removal or rename.
-Adding nullable fields is non-breaking and does not bump the version.
-"""
+"""Signal types and per-node lifecycle projection for the reactive bus (ADR-0033); see per-class docstrings for payload contract. schema_version bumps only on breaking field removal/rename."""
 
 from __future__ import annotations
 
@@ -77,12 +57,7 @@ class RunStart(Signal):
 
 
 class RunEnd(Signal):
-    """Run lifecycle: completed. Usage fields are populated when available.
-
-    total_cost_usd is None (unknown) unless a provider actually reports a
-    dollar cost -- providers that don't (bare API endpoints) must never be
-    recorded as a free (0.0) run.
-    """
+    """Run lifecycle: completed. total_cost_usd is None (unknown) unless a provider actually reports a dollar cost — never coerced to 0.0 (free)."""
 
     input_tokens: int = 0
     output_tokens: int = 0
@@ -144,11 +119,7 @@ class MessageAdded(Signal):
 
 
 class DispatchSignal(Signal):
-    """Outbound dispatch payload contract (ADR-0059); schema_version rides Signal.
-
-    One stable envelope (``to_dict(mode="json")``) shared by every dispatch kind,
-    so the transport template never churns per-kind.
-    """
+    """Outbound dispatch payload contract (ADR-0059); one stable envelope shared by every dispatch kind so the transport template never churns per-kind."""
 
     dispatch_id: str = ""
     kind: str = ""  # e.g. "revival_ping" | "terminal_notify"
@@ -158,10 +129,8 @@ class DispatchSignal(Signal):
     body: dict = {}
 
 
-# -- Extended node lifecycle (ADR-0033) ---------------------------------------
-# queued → running → awaiting_approval → succeeded | failed | escalated
-# NodeStarted/NodeCompleted/NodeFailed (above) cover running/succeeded/failed;
-# these three cover the remaining states.
+# -- Extended node lifecycle (ADR-0033): queued → running → awaiting_approval →
+# succeeded|failed|escalated. NodeStarted/Completed/Failed (above) cover running/succeeded/failed; these three cover the rest.
 
 
 class NodeQueued(Signal):
@@ -183,12 +152,7 @@ class NodeAwaitingApproval(Signal):
 
 
 class NodeEscalated(Signal):
-    """A DAG node escalated or sent a help signal.
-
-    route is "higher_tier" (retry), "give_up" (terminal), or "notify" (soft
-    help signal — informational only, the node's own lifecycle is
-    unaffected). See docs/reference/testing-state-session.md.
-    """
+    """A DAG node escalated or sent a help signal. route: "higher_tier" (retry), "give_up" (terminal), or "notify" (soft, non-terminal)."""
 
     op_id: str = ""
     name: str = ""
@@ -230,12 +194,8 @@ def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
         return "failed"
     if isinstance(sig, NodeEscalated):
         req = sig.escalation_request
-        # A soft ("fyi") help signal is informational only — the emitting
-        # node keeps working toward its own terminal state, so it must not
-        # get pinned into the terminal "escalated" lane. Only a "blocked"
-        # urgency (the default, matching historical give_up/higher_tier
-        # behavior) or an unaccompanied signal (no request attached, e.g.
-        # a bare NodeEscalated built directly) is treated as escalated.
+        # Soft ("fyi") urgency is informational only, not terminal; only
+        # "blocked" urgency (default) or no request pins to "escalated".
         if getattr(req, "urgency", "blocked") == "fyi":
             return None
         return "escalated"
@@ -266,13 +226,7 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
 
 
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
-    """Sum provider-reported usage across all AssistantResponse messages on branch.
-    Keys: input_tokens, output_tokens, total_cost_usd, num_turns. input_tokens/
-    output_tokens/num_turns are additive and default to 0 (no usage reported is
-    indistinguishable from zero usage). total_cost_usd defaults to None (unknown)
-    and is only ever set to a float once at least one message actually reports a
-    cost -- most providers (bare API endpoints) never report a dollar cost, and
-    that must read as "unknown", not "free" (subscription runs, tests)."""
+    """Sum provider-reported usage across all AssistantResponse messages on branch. total_cost_usd stays None (unknown) until a message actually reports a cost — never coerced to 0.0 (free)."""
     input_tokens = 0
     output_tokens = 0
     total_cost_usd: float | None = None
@@ -292,11 +246,8 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
         input_tokens += int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
         output_tokens += int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
-        # Presence, not truthiness: a provider that explicitly reports
-        # total_cost_usd=0.0 (a real, known-free call) must not be treated
-        # the same as one that never reported a cost at all -- `x or y`
-        # would silently fall through the falsy 0.0 to the "cost" fallback
-        # (or None), losing the explicit zero.
+        # Presence, not truthiness: an explicit total_cost_usd=0.0 (real free
+        # call) must not fall through `x or y` to the cost/None fallback.
         if "total_cost_usd" in mr and mr["total_cost_usd"] is not None:
             cost = mr["total_cost_usd"]
         elif "cost" in mr and mr["cost"] is not None:
@@ -316,12 +267,7 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
 
 
 def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
-    """Sum _collect_branch_usage across multiple branches (multi-leg DAG runs).
-
-    Same keys as _collect_branch_usage. duration_ms is deliberately excluded —
-    wall-clock across parallel legs isn't simply summable. total_cost_usd stays
-    None unless at least one branch actually reported a cost.
-    """
+    """Sum _collect_branch_usage across multiple branches (multi-leg DAG runs). duration_ms is excluded — wall-clock across parallel legs isn't simply summable."""
     input_tokens = 0
     output_tokens = 0
     total_cost_usd: float | None = None

--- a/lionagi/work/form.py
+++ b/lionagi/work/form.py
@@ -90,11 +90,7 @@ class FieldSpec(Element):
         return self
 
     def coerce(self, value: Any) -> Any:
-        """Attempt to coerce *value* to this field's declared type.
-
-        Returns the coerced value on success, raises ``TypeError`` on failure.
-        ``None`` is returned unchanged.
-        """
+        """Attempt to coerce *value* to this field's declared type; raises ``TypeError`` on failure, ``None`` passes through unchanged."""
         if value is None:
             return None
         target = _PYTHON_TYPE_MAP[self.type]
@@ -175,9 +171,7 @@ class WorkForm(Element):
         return self.model_copy(update={"status": new_status})
 
 
-# ---------------------------------------------------------------------------
 # Functional API
-# ---------------------------------------------------------------------------
 
 
 def fill_form(
@@ -186,11 +180,7 @@ def fill_form(
     *,
     ruleset: RuleSet | None = None,
 ) -> WorkForm:
-    """Merge *values* into *form* (applying FieldSpec defaults), then validate.
-
-    Returns a new WorkForm with status ``validated`` or ``error``; does not
-    mutate the source.
-    """
+    """Merge *values* into *form* (applying FieldSpec defaults), then validate; returns a new WorkForm (does not mutate the source)."""
     merged: dict[str, Any] = {}
     for name, spec in form.fields.items():
         if name in values:
@@ -213,11 +203,7 @@ def validate_form(
     *,
     ruleset: RuleSet | None = None,
 ) -> WorkForm:
-    """Validate *form* values against FieldSpec declarations (required + type coercion).
-
-    Optional *ruleset* rules run after spec checks; failures are treated
-    identically. Returns a new WorkForm with status ``validated`` or ``error``.
-    """
+    """Validate *form* values against FieldSpec declarations (required + type coercion); optional *ruleset* rules run after and are treated identically. Returns a new WorkForm."""
     errors: list[str] = []
     coerced_values: dict[str, Any] = dict(form.values)
 

--- a/lionagi/work/rules.py
+++ b/lionagi/work/rules.py
@@ -45,10 +45,7 @@ class Rule(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
     def apply(self, form: WorkForm) -> str | None:
-        """Apply this rule to *form*.
-
-        Returns an error string on failure, ``None`` on pass or when disabled.
-        """
+        """Apply this rule to *form*; returns an error string on failure, ``None`` on pass or when disabled."""
         if not self.enabled:
             return None
 
@@ -67,9 +64,7 @@ class Rule(BaseModel):
 
         return f"Rule {self.rule_id!r}: unknown check kind {self.check!r}."
 
-    # ------------------------------------------------------------------
     # Internal checkers
-    # ------------------------------------------------------------------
 
     def _check_required(self, value: Any) -> str | None:
         if value is None:


### PR DESCRIPTION
Part of #2132 (comment/docstring verbosity trim). Core slice: `operations/`, `session/`, `lndl/`, `libs/`, `ln/`, `engines/`, `casts/`, `adapters/`, `models/`, `protocols/`, `work/`, `orchestration/` — excluding the files owned by open PRs (turn-origin, chat/flow/interpret/parse/ReAct/run middles, `protocols/graph/graph.py`, `session/branch.py`).

- 56 files trimmed (59 of 262 scanned had violations; 203 already within limits): inline prose collapsed to 1-2 lines per location, net −805 lines.
- ~70 keep-worthy invariants moved to a new `docs/internals/core.md` organized by module path: the SIGTERM/SIGINT handling contract, the killpg pid guard, SSRF DNS-rebinding rationale, the LNDL round-outcome protocol and cross-round alias resolution, MCP tool-admission fail-closed rules, and the model-class sharing cache contract.

Zero behavior change, verified programmatically: every touched file AST-identical to its pre-edit version modulo docstring text (parsed both, normalized docstring constants, compared `ast.dump`). Test pass/fail set byte-identical before and after (same pre-existing missing-optional-dep failures in this venv). `tests/docs/test_api_docs_drift.py` 20/20. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
