### PR TITLE
chore(runtime): trim comment/docstring verbosity, move keeps to docs/internals

### DIFF
--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -37,13 +37,13 @@ externally-driven sessions mirrored into the DB). Decision order matters:
 3. Confirmed dead (`process_alive is False`) outranks the activity guard below it — the
    process is gone no matter how fresh the last message is.
 4. Unknown liveness (no matchable pid) trusts recent messages more than process visibility,
-   because externally-driven sessions (CLI seats mirrored into the DB) never expose a
+   because externally-driven sessions (mirrored into the DB from another process) never expose a
    matchable pid — an unmatched process only means dead once activity has also gone quiet
    past the kind-aware threshold.
 
 ### `state/transitions.py`
 
-Guarded compare-and-swap state transitions (ADR-0059 slice 1, spec-gate ruling 1) — a minimal
+Guarded compare-and-swap state transitions (ADR-0059 slice 1) — a minimal
 fallback for ADR-0058's proposed-but-unbuilt entity-agnostic `transition()` API. Carries the
 same request/result shape and reason-code discipline so ADR-0058 can absorb it later as a
 refactor, not a migration. Scoped to `entity_type='dispatch'` (`dispatch_outbox`) and
@@ -109,8 +109,8 @@ studio-side change.
   back to `running`. ADR-0035's integrity floor treats every session terminal status (not just
   `completed`) as terminal on the sessions table for orchestrated runs, so reactivating a
   mirror session out of any of them goes through the sanctioned override path — a real,
-  deliberate, well-understood write (not a repair), attributed to a fixed system actor rather
-  than a human operator, landing in `admin_events` like any other override. A mirror session
+  deliberate, well-understood write (not a repair), attributed to the recorded automated
+  override identity, landing in `admin_events` like any other override. A mirror session
   that is idle and already sitting on a non-`completed` terminal status (e.g. independently
   marked `failed` or `cancelled`) is left alone rather than rewritten to `completed` — only a
   live transcript resuming can justify pulling it back to `running`.
@@ -850,11 +850,11 @@ invoked by the `operate()` Middle (not `provide()`), and it is NOT the nudge pla
 proceeds.
 
 `KhiveInjectionPolicy.namespace`, when set, is threaded onto every khive verb the provider
-emits (recall, compose, auto_feedback, remember) as the bench-arm isolation mechanism.
-`auto_feedback` WRITES to the live brain store, so an unpinned "read-only" arm still mutates
-posteriors and contaminates cross-arm comparisons — pinning a namespace is required, not
-optional, for any enabled bench arm. Currently only the write verb honors namespace (read
-verbs reject unknown params); this is forward-wired for when reads grow namespace scoping too.
+emits (recall, compose, auto_feedback, remember) to isolate its writes to a named store.
+`auto_feedback` WRITES to the live brain store, so an unpinned "read-only" caller still mutates
+posteriors — pinning a namespace is required, not optional, wherever writes must stay isolated.
+Currently only the write verb honors namespace (read verbs reject unknown params); this is
+forward-wired for when reads grow namespace scoping too.
 
 ### `sandbox.py`
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -43,9 +43,9 @@ externally-driven sessions mirrored into the DB). Decision order matters:
 
 ### `state/transitions.py`
 
-Guarded compare-and-swap state transitions (ADR-0059 slice 1) — a minimal
-fallback for ADR-0058's proposed-but-unbuilt entity-agnostic `transition()` API. Carries the
-same request/result shape and reason-code discipline so ADR-0058 can absorb it later as a
+Guarded compare-and-swap state transitions (ADR-0059) — a minimal
+counterpart to the entity-agnostic `transition()` API proposed in ADR-0058. Carries the
+same request/result shape and reason-code discipline so ADR-0058 can absorb it as a
 refactor, not a migration. Scoped to `entity_type='dispatch'` (`dispatch_outbox`) and
 `entity_type='schedule_run'` (`schedule_runs`) only — not a general TransitionStore. The
 guarded read/CAS/vocabulary/write algorithm itself lives in `lionagi.state.lifecycle` (shared
@@ -126,8 +126,8 @@ studio-side change.
 
 Completion-trust gate: cheap, local, no-network evidence that a run produced something. A
 session can exit its loop cleanly with nothing to show for it — no commits, no artifacts, no
-diff — and historically that still got stamped `completed`, so operators stopped trusting the
-status and re-verified by hand. This module gives the teardown path a lightweight git-based
+diff — and stamping that `completed` makes the status meaningless as evidence of delivered
+work. This module gives the teardown path a lightweight git-based
 signal to fall back on when no artifact contract caught the emptiness: is HEAD ahead of the
 base ref, or does the working tree carry uncommitted changes? A probe that actually runs and
 fails (transient error, timeout, git hiccup) must never be read as "ran and found nothing" —
@@ -179,11 +179,11 @@ registry, regardless of transport settings.
 ### Keyword registry for the sufficiency proof
 
 Answers exactly one question: is this schema document provably closed against an undeclared
-value? An earlier iteration used a per-property "is this value a key channel" discriminator
-deciding which positions deserve scrutiny — the same defect class as enumerating "dangerous
-keywords," re-entered through the traversal axis: it omitted the conditional applicators
-(`if`/`then`/`else`/`not`) and array applicators (`items`/`prefixItems`), so a property
-carrying one was never visited, and the allowlist check that would have denied it never ran.
+value? A per-property "is this value a key channel" discriminator — deciding which positions
+deserve scrutiny — is the same defect class as enumerating "dangerous keywords," re-entered
+through the traversal axis: omit the conditional applicators (`if`/`then`/`else`/`not`) or
+array applicators (`items`/`prefixItems`) and a property carrying one is never visited, so
+the allowlist check that would have denied it never runs.
 The fix: classify EVERY Draft 2020-12 keyword into EXACTLY ONE of four classes (inert/
 bounding/modeled/denied), then walk the ENTIRE document — every property value, composition
 branch, `$ref` target, `$defs` entry — UNCONDITIONALLY, checking each node's own keywords
@@ -299,10 +299,10 @@ cannot carry a subschema.
 
 ### Walker (`_walk_schema`)
 
-The walker is a WHITELIST, not blacklist. Design history: earlier rounds each closed a
-specific evasion (nested properties, anyOf, `$ref`, additionalProperties, patternProperties;
-then if/then/else, not, items, prefixItems) only to have the next keyword reopen the same
-bypass class. Enumerating "keywords we deny" loses that arms race by construction. Instead the
+The walker is a WHITELIST, not blacklist. Closing specific evasions one at a time (nested
+properties, anyOf, `$ref`, additionalProperties, patternProperties; if/then/else, not, items,
+prefixItems) leaves every future keyword free to reopen the same bypass class — enumerating
+"keywords we deny" loses that arms race by construction. Instead the
 walker enumerates keywords it affirmatively understands; any other subschema-shaped key is
 unresolvable — future/unsupported keywords (unevaluatedProperties, dependentSchemas, contains,
 propertyNames) deny by default for executor-signaling tools instead of admitting by default.
@@ -543,10 +543,9 @@ shell), so shell metacharacters are inert.
 This is a plain library call, not a new schedule `action_kind`: wiring a first-class
 action_kind through the scheduler's fire/subprocess-spawn machinery would require rebuilding
 the `schedules.action_kind` CHECK constraint (the same SQLite rename-rebuild migration
-`_drop_legacy_action_kind_check` performs for the existing enum) — judged out of proportion
-for a slice-1 reference implementation. An operator wires this in today via any schedule
-action that can call a Python function; a first-class action_kind is a natural follow-up once
-a concrete caller needs it.
+`_drop_legacy_action_kind_check` performs for the existing enum) — heavier machinery than a
+library call needs. Any schedule action that can call a Python function can invoke it;
+nothing in the module assumes a dedicated action_kind.
 
 ### `hooks/builtins.py`
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -56,10 +56,9 @@ with `StateDB.update_status()`); this module keeps its own narrower entity-type 
   (`schedule_runs` table, `schedule_id` now nullable), registered here so ALL status movement
   on it routes through this guarded CAS store rather than a second, parallel implementation.
 - `_GUARD_PATCH_COLUMNS` — guard/patch column names are interpolated directly into SQL text
-  (values stay bound params) inside the lifecycle service. Every production call site today
-  passes literal dicts, but this module is a generic surface a future full transition backend
-  will absorb, so a per-entity allowlist closes the latent injection surface for future
-  callers instead of trusting the caller's dict keys outright.
+  (values stay bound params) inside the lifecycle service. Production call sites pass
+  literal dicts, but this module is a generic surface, so a per-entity allowlist closes
+  the latent injection surface instead of trusting the caller's dict keys outright.
 - `transition()` — `UPDATE ... WHERE id=:id AND status=:from`, writing the row status and an
   atomic `status_transitions` append inside one transaction. A mismatched current state
   reports a conflict rather than raising or silently overwriting (the CAS guard). An

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -1,0 +1,907 @@
+# Runtime internals reference
+
+Terse, per-module reference for invariants, protocol contracts, and non-obvious design
+rationale that used to live as long-form docstrings/comments in the runtime source
+(`lionagi/state/`, `lionagi/service/`, `lionagi/providers/`, `lionagi/tools/`,
+`lionagi/agent/`, `lionagi/testing/`, `lionagi/dispatch/`, `lionagi/hooks/`). The source
+now carries a 1-2 line pointer; this file carries the substance. Organized by module path.
+
+## lionagi/state/
+
+### `state/engine.py`
+
+- `make_readonly_engine()` — read-only `AsyncEngine` over an **existing** SQLite file, opened
+  through SQLite's own URI read-only mode (`mode=ro`), not through `make_engine()`. This
+  matters because: (1) no schema/PRAGMA write ever reaches the file — the OS-level open is
+  read-only and SQLite raises on any write attempt; (2) none of `make_engine()`'s mutating
+  connect-time PRAGMAs (`journal_mode`, `synchronous`, `wal_autocheckpoint`) are applied here
+  on purpose, since they persist into the database file itself; (3) only `busy_timeout`
+  (session-scoped, never persisted) and `query_only` (belt-and-suspenders — SQLite itself
+  rejects any write statement) are set. SQLite only — a genuinely read-only Postgres
+  connection should use a read-only DB role instead; there is no equivalent "connect without
+  side effects" mode to fake at this layer for Postgres.
+
+### `state/health.py`
+
+`classify_session_health()` — pure function; `process_alive` is tri-state: `True` = observed
+alive, `False` = confirmed dead (positive evidence — a recorded pid that is no longer
+running), `None` = unknown (no recorded pid and no process match, the normal case for
+externally-driven sessions mirrored into the DB). Decision order matters:
+
+1. Terminal sessions (`completed`/`failed`/`timed_out`/`aborted`/`cancelled`): done means done
+   unless stale locks were left behind (→ `ZOMBIE`). `has_artifacts` alone is not zombie
+   evidence — artifacts are a *good* outcome; stale locks are the operational signal.
+2. Orphan check runs first among the non-terminal branches: a session advertised but never
+   producing a single message AND no artifacts on disk crashed before doing anything;
+   transitioning it to `failed` is harmless, deleting it is also safe.
+3. Confirmed dead (`process_alive is False`) outranks the activity guard below it — the
+   process is gone no matter how fresh the last message is.
+4. Unknown liveness (no matchable pid) trusts recent messages more than process visibility,
+   because externally-driven sessions (CLI seats mirrored into the DB) never expose a
+   matchable pid — an unmatched process only means dead once activity has also gone quiet
+   past the kind-aware threshold.
+
+### `state/transitions.py`
+
+Guarded compare-and-swap state transitions (ADR-0059 slice 1, spec-gate ruling 1) — a minimal
+fallback for ADR-0058's proposed-but-unbuilt entity-agnostic `transition()` API. Carries the
+same request/result shape and reason-code discipline so ADR-0058 can absorb it later as a
+refactor, not a migration. Scoped to `entity_type='dispatch'` (`dispatch_outbox`) and
+`entity_type='schedule_run'` (`schedule_runs`) only — not a general TransitionStore. The
+guarded read/CAS/vocabulary/write algorithm itself lives in `lionagi.state.lifecycle` (shared
+with `StateDB.update_status()`); this module keeps its own narrower entity-type boundary, its
+`guard`/`patch` column allowlist, and the legacy `TransitionResult` return shape.
+
+- `_ENTITY_TABLES` — `"schedule_run"` is ADR-0071 D2's generalized task-application entity
+  (`schedule_runs` table, `schedule_id` now nullable), registered here so ALL status movement
+  on it routes through this guarded CAS store rather than a second, parallel implementation.
+- `_GUARD_PATCH_COLUMNS` — guard/patch column names are interpolated directly into SQL text
+  (values stay bound params) inside the lifecycle service. Every production call site today
+  passes literal dicts, but this module is a generic surface a future full transition backend
+  will absorb, so a per-entity allowlist closes the latent injection surface for future
+  callers instead of trusting the caller's dict keys outright.
+- `transition()` — `UPDATE ... WHERE id=:id AND status=:from`, writing the row status and an
+  atomic `status_transitions` append inside one transaction. A mismatched current state
+  reports a conflict rather than raising or silently overwriting (the CAS guard). An
+  undeclared status move (per the shared policy registry's edge graph) raises `ValueError` —
+  this surface has no override mechanism, unlike `StateDB.update_status()`. `guard` adds extra
+  `column = :expected` equality constraints to the WHERE clause beyond `status` — required
+  whenever a transition can be a same-state no-op (e.g. `delivering -> delivering` recovery
+  claims), where the status guard alone would match trivially and let two concurrent callers
+  both believe they won the claim; callers pass the value they read *before* the transition as
+  the expected guard value, and only the caller whose guard value still matches at UPDATE time
+  wins. `patch` adds extra `column = :value` assignments to the SET clause, applied atomically
+  with the status change and the `status_transitions` append — for callers (e.g. an
+  operator-forced retry resetting attempt counters) that would otherwise need a second,
+  non-atomic write.
+- `"rejected"` is unreachable through this surface: `run_legacy_transition()` passes
+  `raise_on_undeclared_edge=True`, so an undeclared edge (terminal or not) raises `ValueError`
+  above rather than resolving to `"rejected"`, and `TransitionRequest` carries no override
+  field to trigger the override path either.
+
+### `state/claude_mirror.py`
+
+Mirrors Claude Code session transcripts (`~/.claude/projects/*.jsonl`) into StateDB. A Claude
+Code session is just another writer to `state.db`: each JSONL event maps to one or more
+lionagi messages, written under a session/branch/progression with deterministic ids so
+re-reading the same transcript never duplicates rows. The studio SSE reader polls the same
+tables, so mirrored sessions stream live in the dashboard and the VS Code extension with no
+studio-side change.
+
+- `mirror_session()` — re-calling with already-seen events is a no-op: message ids are
+  deterministic (upsert), and progression appends dedupe. Creates the session/branch on first
+  call with a rich row (project, model, agent_name) so it groups correctly in the runs
+  explorer. Live/idle transitions are owned by `reconcile_session_status`, not this writer.
+  Scaffold writes (progressions → session → branch) are `INSERT OR IGNORE` and re-run every
+  call in dependency order, so if an earlier pass died mid-scaffold (e.g. the branch write
+  raised after the session row committed) the next pass repairs the partial state instead of
+  skipping scaffolding just because the session row now exists. The project-backfill branch
+  (`elif project and not existing.get("project")`) exists because `INSERT OR IGNORE` never
+  updates an existing row — without it, an already-seen "(no project)" session stays that way
+  forever; the backfill write does not disturb the liveness clock.
+- `reconcile_session_status()` — a mirror session's `completed` means dormant, not terminal:
+  when the transcript resumes, the next reconcile brings it back to `running`. Liveness is
+  judged by `last_message_at` (the timestamp of the newest mirrored message) so an idle
+  session converges to `completed` before the reaper can mark it failed, and an active one
+  shows `running` (a live spinner in studio and the VS Code extension). **It must NOT read
+  `updated_at`**: the status write below bumps `updated_at`, so keying liveness off it would
+  let a just-marked `completed` session read as fresh again on the next pass and oscillate
+  back to `running`. ADR-0035's integrity floor treats every session terminal status (not just
+  `completed`) as terminal on the sessions table for orchestrated runs, so reactivating a
+  mirror session out of any of them goes through the sanctioned override path — a real,
+  deliberate, well-understood write (not a repair), attributed to a fixed system actor rather
+  than a human operator, landing in `admin_events` like any other override. A mirror session
+  that is idle and already sitting on a non-`completed` terminal status (e.g. independently
+  marked `failed` or `cancelled`) is left alone rather than rewritten to `completed` — only a
+  live transcript resuming can justify pulling it back to `running`.
+- `link_session_lineage()` — a continued conversation (after compaction, `--resume`, or a
+  fresh window picking up an earlier thread) starts a new transcript whose first message
+  points, via `parentUuid`, at the last message of the session it continues. When the mirror
+  resolves that pointer to a different session it stores a `lineage` link on the child's
+  `node_metadata` so studio and the VS Code extension can show provenance and walk the chain
+  back. Written without moving the liveness clock; idempotent (re-linking rewrites the same
+  value).
+
+### `state/completion_evidence.py`
+
+Completion-trust gate: cheap, local, no-network evidence that a run produced something. A
+session can exit its loop cleanly with nothing to show for it — no commits, no artifacts, no
+diff — and historically that still got stamped `completed`, so operators stopped trusting the
+status and re-verified by hand. This module gives the teardown path a lightweight git-based
+signal to fall back on when no artifact contract caught the emptiness: is HEAD ahead of the
+base ref, or does the working tree carry uncommitted changes? A probe that actually runs and
+fails (transient error, timeout, git hiccup) must never be read as "ran and found nothing" —
+that would silently turn a git error into a false `completed_empty` on real work. Only a probe
+that *succeeds* is allowed to report an absence of evidence; any decisive failure bails the
+whole check out as unchecked (`checked=False`) so the caller keeps trusting `completed`.
+
+## lionagi/service/connections/mcp_wrapper.py
+
+Security-critical admission-control gate for MCP (Model Context Protocol) tool descriptors:
+decides whether an externally-supplied MCP tool schema is safe to register, defending
+specifically against a generic command/process/script executor (a "bash"-shaped tool)
+masquerading as something narrower via an insufficiently-bounded JSON Schema. This is
+orthogonal to two other security mechanisms: `MCPSecurityConfig` governs transport
+authorization (is this command/URL allowed to connect at all), and `PermissionPolicy` governs
+invocation-time authorization keyed by tool name. This admission rule sits before both: it
+rejects a caller-shaped generic executor descriptor before the tool is ever admitted into the
+registry, regardless of transport settings.
+
+### Identifier/key classification
+
+- `_is_identifier_like_key()` — identifies dynamic-but-benign resource identifiers
+  (`service_id`, `resource_path`, `request_id`, matching `*_id`/`*_path`/`*_uri`/`*_url`/
+  `*_uuid`/`*_slug`). Excluded from the strong-executor-name "must be affirmatively bounded"
+  fallback: a tool with a strong executor name but whose only free-form field is an
+  identifier-shaped key is NOT treated as executor-shaped — a fixed-operation tool addressing
+  a resource by free-form ID differs legitimately from one taking a free-form command/script,
+  even though the identifier field itself is an unbounded string.
+- `_EXEC_TAINTED_KEY_TOKENS` — tokens that make an otherwise identifier-shaped key still
+  executor-shaped. A key like `executable_path`/`script_path`/`command_path` lexically matches
+  the identifier-suffix exemption but its root token names an executor channel — a
+  caller-controlled executor target, not a benign locator — so it must NOT be exempted from
+  the strong-name fallback.
+- `_is_exec_tainted_key()` — companion to the above: true when a key's own `_`-split tokens
+  name an executor channel (command, cmd, shell, script, program, binary, executable, argv,
+  args), overriding the identifier-suffix exemption.
+- `_UNBOUNDED_NON_OBJECT_TYPES` — non-object types (string/number/integer/array) whose
+  instances aren't intrinsically finite. A root `type` union including one, without a
+  top-level `enum`/`const` pinning the instance, has a branch admitting an arbitrary value,
+  bypassing every object-shaped constraint entirely because the instance never has to be an
+  object.
+- `_ANNOTATION_ONLY_REF_SIBLING_KEYWORDS` / `_has_structural_ref_siblings()` — keywords that,
+  as siblings of `$ref`, are annotation-only and never constrain the instance (description,
+  title, `$comment`, examples, default, `$defs`, definitions). Per Draft 2020-12, `$ref`
+  siblings are NOT discarded — they constrain the same instance and must be evaluated in their
+  own right, so a non-annotation sibling forces the sufficiency proof to also evaluate it as
+  its own schema node.
+
+### Keyword registry for the sufficiency proof
+
+Answers exactly one question: is this schema document provably closed against an undeclared
+value? An earlier iteration used a per-property "is this value a key channel" discriminator
+deciding which positions deserve scrutiny — the same defect class as enumerating "dangerous
+keywords," re-entered through the traversal axis: it omitted the conditional applicators
+(`if`/`then`/`else`/`not`) and array applicators (`items`/`prefixItems`), so a property
+carrying one was never visited, and the allowlist check that would have denied it never ran.
+The fix: classify EVERY Draft 2020-12 keyword into EXACTLY ONE of four classes (inert/
+bounding/modeled/denied), then walk the ENTIRE document — every property value, composition
+branch, `$ref` target, `$defs` entry — UNCONDITIONALLY, checking each node's own keywords
+against the registry. There is no longer a discriminator deciding "should this node be
+visited"; a keyword not in the registry is UNKNOWN and fails closed unless its value provably
+cannot carry a subschema.
+
+- `_INERT_ANNOTATION_KEYWORDS` (`contentSchema` caveat) — `contentSchema` is inert with an
+  individually-argued exception, not by default: its value is a mapping describing the DECODED
+  content of a string instance, like `contentEncoding`/`contentMediaType` — none assert
+  anything about the instance itself, but ONLY while the content-assertion vocabulary stays
+  disabled (the default dialect this module validates against). A future dialect enabling that
+  vocabulary would require `contentSchema` to leave this class — a maintenance tripwire.
+- `_DENIED_APPLICATOR_KEYWORDS` — applicators recognized BY NAME but deliberately NOT modeled
+  (patternProperties, propertyNames, unevaluatedProperties, unevaluatedItems,
+  dependentSchemas, if, then, else, not, contains, items, prefixItems, `$dynamicRef`,
+  `$dynamicAnchor`, `$recursiveRef`, `$recursiveAnchor`): presence anywhere denies the node
+  outright, and the proof never recurses beneath one since an ancestor denial already covers
+  everything nested. Promoting one to modeled (e.g. bounded-array support via
+  items/prefixItems) is a separate, individually-argued change with its own soundness argument
+  — never a silent reclassification.
+- `_classify_keyword()` — classifies a keyword into inert/bounding/modeled/denied;
+  unrecognized names are UNKNOWN. The registry is a CLOSED enumeration, not a spelling
+  heuristic — an unseen keyword fails closed rather than being guessed at.
+
+### Object-boundedness proof
+
+- `_property_value_may_be_object_shaped()` — true when a declared property's VALUE could
+  itself resolve to an OBJECT instance, requiring the boundedness proof to recurse.
+  Deliberately narrow: only answers "does closedness apply here," never "is a keyword modeled"
+  — that's answered totally and unconditionally by `_structural_coverage_insufficient`
+  regardless of whether this gate recurses, so an omission here (e.g. a value reachable only
+  through a DENIED applicator) is harmless. A scalar/array/annotation/free-form-string
+  property value returns False on purpose — it remains the walker's territory by key name
+  (`service_id: {"type": "string"}` stays admitted).
+- `_schema_is_insufficient()` — top-level gate: insufficient if EITHER the object-boundedness
+  proof OR the structural-coverage proof fails. The two proofs are deliberately independent
+  (type/closedness vs. keyword coverage), combined by OR.
+- `_object_boundedness_insufficient()` — recursive, union-aware TYPE-GATE + CLOSEDNESS check,
+  orthogonal to `_structural_coverage_insufficient` (never denies on keyword identity, only on
+  whether the instance is provably constrained to a closed, finite object shape). Binding
+  order of checks (applicator delegation MUST run before omitted-type denial, or a
+  legitimately-type-omitting applicator-root would false-deny): (1) budget/depth cap fails
+  closed; (2) `type` excludes `"object"` → insufficient; (3) `type` union has a free-form
+  alternative with no `const`/`enum` pin → insufficient; (4) APPLICATOR DELEGATION — `$ref`
+  (local only, intersect structural siblings), then `oneOf`/`anyOf` (UNION: every branch must
+  prove sufficient), then `allOf` (INTERSECTION: one bounded branch suffices), each recursing;
+  (5) top-level `const`/`enum` pins the instance → sufficient regardless of type; (6)
+  LEAF-OBJECT branch: omitted type (no const/enum) → insufficient (bare non-object never
+  reaches object keywords); non-empty `properties` only bounded if CLOSED
+  (`additionalProperties: False` or itself enum/const-restricted); empty/absent properties
+  still needs `additionalProperties: False`; once the outer object is closed, each declared
+  property's own object-shaped value is re-checked by this same predicate recursively, or
+  insufficient — non-object-shaped values are left to the walker's key-name policy since any
+  denied applicator they carry is caught independently by `_structural_coverage_insufficient`.
+  Returns True (fail closed) for external/cyclic/unresolvable/exhausted references or
+  compositions.
+  - Type-array handling: a Draft 2020-12 type array (e.g. `["object","null"]`) is still an
+    object schema if `"object"` is among its types, and properties must still be inspected;
+    only excluding `"object"` entirely is insufficient.
+  - Type-union weak-link: a type union including `"object"` plus a free-form alternative
+    (string/number/integer/array, absent enum/const) is only as bounded as its LEAST-bounded
+    branch — an instance satisfying the non-object branch never reaches the object-specific
+    keywords checked below.
+  - `$ref` sibling re-check: Draft 2020-12 evaluates `$ref` siblings; a closed reference target
+    doesn't make the node sufficient if a sibling keyword (evaluated against the same
+    instance) reopens it. Pure annotation siblings contribute nothing and must not force an
+    otherwise-open target's insufficiency onto an unrelated property.
+  - const/enum pin: a top-level const/enum pins the instance to literal value(s), satisfying
+    the type-gate regardless of type (or its absence).
+  - Closedness default trap: `additionalProperties` defaults to permissive (implicit true); a
+    fixed `operation` enum/const does NOT stop an undeclared `command` property from riding
+    alongside it unless `additionalProperties` is explicitly `false` (or itself enum/const-
+    restricted). This is the concrete attack shape: a schema that looks locked down because
+    one property is enum-restricted while every other key name is still wide open.
+
+### Structural-coverage proof
+
+- `_structural_coverage_insufficient()` — total, registry-driven traversal: does any
+  schema-bearing position carry a keyword the sufficiency proof does not model? Independent of
+  `_object_boundedness_insufficient`'s type-gate/closedness reasoning — applies neither. A
+  scalar leaf `{"type": "string"}` is sufficient on its own, preserving a free-form identifier-
+  key property (`service_id`) alongside a fixed operation. Every schema-bearing position is
+  visited UNCONDITIONALLY — every properties value, additionalProperties schema
+  (Mapping-valued), composition branch, resolved local `$ref` target, and `$defs`/definitions
+  entry (even unreferenced ones, a deliberate fail-closed choice). Totality argument: every
+  position is reached by exactly one of three routes — (i) under a chain of MODELED
+  applicators (this function's recursion visits it); (ii) under a DENIED applicator (ancestor
+  already returned True before looking inside); or (iii) under an UNKNOWN keyword (checked for
+  subschema-shaped value and denied there). No fourth route exists. The unconditional `$defs`
+  visit specifically guards against a future reference, or tooling resolving `$defs` by
+  convention rather than explicit `$ref`, smuggling an unmodeled keyword through an entry
+  never inspected.
+- `_property_is_bounded()` — deliberately has no array carve-out: array boundedness needs BOTH
+  `prefixItems` members AND the `items` (rest-of-array) schema checked together (see
+  `_array_reaches_free_form`); a bounded `items` alone says nothing about an unbounded
+  `prefixItems` member alongside it.
+- `_item_schema_reaches_free_form_string()` — true when an array's items/prefixItems member
+  schema may admit an arbitrary string, i.e. a free-form argv-shaped channel. Item schemas are
+  ALWAYS treated conservatively (unlike keyed object properties, which get the
+  identifier-suffix exemption): an opaque/unconstrained/malformed item shape is presumed
+  free-form. Local `$ref` and allOf/anyOf/oneOf/if/then/else/not composition are resolved/
+  recursed so indirection is still caught. Critically, a nested `type: "array"` item is NOT
+  automatically bounded — it's only bounded if its own item schema is bounded, otherwise a
+  caller can smuggle a free-form channel one array level deeper
+  (`args: [["sh", "-c", ...]]`).
+- `_array_reaches_free_form()` — true when an array-shaped node admits a free-form element.
+  Relies on Draft 2020-12 semantics: `prefixItems` validates only prefix positions; `items`
+  validates everything at-or-after. A MISSING `items` keyword defaults to `true`
+  (unconstrained rest), so an array whose prefixItems are all enum/const-bounded is STILL
+  free-form unless `items` is explicitly present and bounded (or `false`). Every prefixItems
+  member is checked too — bounded `items` says nothing about an unbounded prefix member.
+
+### Walker (`_walk_schema`)
+
+The walker is a WHITELIST, not blacklist. Design history: earlier rounds each closed a
+specific evasion (nested properties, anyOf, `$ref`, additionalProperties, patternProperties;
+then if/then/else, not, items, prefixItems) only to have the next keyword reopen the same
+bypass class. Enumerating "keywords we deny" loses that arms race by construction. Instead the
+walker enumerates keywords it affirmatively understands; any other subschema-shaped key is
+unresolvable — future/unsupported keywords (unevaluatedProperties, dependentSchemas, contains,
+propertyNames) deny by default for executor-signaling tools instead of admitting by default.
+
+- `_SCALAR_ONLY_SCHEMA_KEYWORDS` — keywords whose value never carries a subschema (or, for
+  `$defs`/definitions, only reachable via `$ref` resolution). `contentSchema` included on the
+  same footing as its `_INERT_ANNOTATION_KEYWORDS` inclusion — the two caveats must be kept in
+  sync if the content-assertion vocabulary assumption ever changes.
+- `_UNRESOLVABLE_REFERENCE_KEYWORDS` — `$dynamicRef`/`$recursiveRef` are schema-bearing like
+  `$ref` but their VALUE is a plain string, not a Mapping — so `_could_carry_subschema`'s
+  Mapping-shape test never flags them, and a command channel reachable only behind one would
+  otherwise be SILENTLY ADMITTED. Recognized by keyword identity instead, always treated as
+  unresolvable — deliberately conservative since dynamic-scope `$dynamicAnchor` resolution
+  isn't something this walker can safely reproduce.
+- `_NUMERIC_BOUND_KEYWORDS` — explicit enumeration, deliberately NOT a `min*`/`max*` spelling
+  heuristic: a prefix test would exempt an arbitrary unknown key like `minCustomThing` from the
+  could-carry-subschema check purely by name, reopening the whitelist bypass.
+- `_could_carry_subschema()` — true when an unrecognized keyword's value is shaped like it
+  could hold a schema (mapping, or list at any depth containing one). Recurses through nested
+  lists under the walker's depth cap so a schema-bearing value can't be laundered past the
+  whitelist via extra list nesting. Charges every element against the shared node budget and
+  fails closed on exhaustion, preventing a pathologically wide/deep value from being used as a
+  denial-of-service against the admission check itself.
+- `_is_inert_annotation_value()` — true when a value cannot itself carry a subschema
+  (recursively scalar, or list/mapping of such with no schema-vocabulary key anywhere inside).
+  A vendor annotation with genuinely descriptive metadata is inert; one embedding real schema
+  vocabulary is not, regardless of key spelling — shape decides inertness, not the key. Fails
+  closed (not-inert) on budget exhaustion, mirroring `_could_carry_subschema`.
+- `_is_vendor_annotation_keyword()` — true for annotation-only keywords whose value carries no
+  schema-bearing content. Narrow on two axes: (1) only the `x-` vendor-extension convention and
+  `$comment` are even considered; (2) even for those, the value must be demonstrably inert — a
+  vendor extension whose value is itself schema-shaped is exactly the hidden channel this
+  walker exists to catch, so it is NOT exempted just for starting with `x-`. NEVER exempts
+  `$`-prefixed keywords generally — that's exactly where real reference/applicator keywords
+  live, so a blanket `$*` exemption would reopen the reference-bypass class this walker
+  closes.
+- `_mark_unknown_schema_keywords()` — whitelist enforcement: any unrecognized keyword with a
+  subschema-shaped value is unresolvable, applied to every schema node the classifier inspects
+  (including leaf-treated property schemas). Two carve-outs: (1) `$dynamicRef`/`$recursiveRef`
+  anywhere makes the node unresolvable outright regardless of value shape; (2) a
+  vendor-extension keyword is exempt even when Mapping-valued, since it's never an applicator.
+  Value inspection shares the walker's node budget; exhaustion fails closed via the same
+  helpers, preventing an enormous/deeply nested non-subschema value from burning unbounded CPU
+  as a side channel around the traversal budget.
+- `_OBJECT_CONTAINER_KEYWORDS` — presence of any of these (properties, patternProperties,
+  additionalProperties, `$ref`, allOf, anyOf, oneOf, if, then, else, not) on a property's own
+  schema means the property IS ITSELF a restated/composed schema — recurse rather than treat
+  as a scalar leaf.
+- `_ARRAY_ITEM_KEYWORDS` — an array property can be BOTH a free-form leaf channel in its own
+  right AND hide a command channel inside an object-shaped item (items/prefixItems); both must
+  be checked, so — unlike object-applicator keywords — these do NOT short-circuit leaf
+  classification.
+- `_SchemaWalkResult.unresolvable` — true when a channel could not be proven bounded
+  (unresolvable/cyclic `$ref`, budget/depth trip, malformed shape, unrecognized keyword). Fed
+  into fail-closed handling specifically for tools whose name/description signals an
+  executor; otherwise it's just insufficient evidence, not an automatic denial.
+- `_SchemaWalkResult.nodes_visited` — total-work budget companion to the depth cap, bounding
+  runtime against a harmless but extremely wide fan-out (e.g. tens of thousands of anyOf
+  branches) that the depth cap alone wouldn't stop.
+- `_consume_node_budget()` — counts one unit of walker work; returns False once the
+  total-node budget is exceeded so callers can stop iterating early — this is the mechanism
+  that actually enforces `_MAX_SCHEMA_WALK_NODES` per-iteration, not just once at entry.
+- `_composition_branch_reaches_free_form()` — true when any composition/conditional/`$ref`
+  branch of a keyed property resolves to a free-form leaf. `{"anyOf": [{"type": "string"}]}`
+  or `{"if": ..., "then": {"type": "string"}}` constrains the same instance the key names, so
+  the key is unbounded even though the leaf type is indirect — without this, wrapping a plain
+  string schema in one applicator layer would strip the key-to-leaf-type association the
+  classifier relies on, evading detection with one layer of indirection.
+- `_consider_property()` — leaf-shaped property schema never reaches `_walk_schema`, so the
+  unknown-keyword whitelist is enforced directly here too (redundant for container properties,
+  already walked, but harmless — closes the coverage gap for leaf properties that would
+  otherwise skip the whitelist entirely). A container property is not itself a command value;
+  the walker recurses into its reachable properties instead of classifying the container's
+  key — but BEFORE recursing, it first attributes to the key any free-form leaf reachable
+  purely through composition/conditional branches, because those constrain the key's own value
+  even though expressed indirectly (ordering matters so a composed free-form leaf isn't missed
+  just because the property also looks like a container). Array handling walks
+  items/prefixItems for a hidden object-shaped command channel nested in array elements, but
+  deliberately falls through to the leaf free-form check rather than returning early — the
+  array property itself may ALSO be free-form (e.g. `argv: array-of-strings`), so both checks
+  must run.
+- `_walk_schema()` — bounded, cycle-safe, budgeted traversal collecting classifier evidence.
+  Recognizes properties (including nested objects), allOf/anyOf/oneOf, if/then/else/not,
+  items/prefixItems, local `$ref` resolution, patternProperties, and additionalProperties
+  (both as a scalar free-form map channel and, when object-valued, as a nested subschema). Any
+  other subschema-shaped keyword is unresolvable — the walker's instance of the whitelist
+  rationale above. Draft 2020-12 evaluates `$ref` siblings; after resolving/recursing into the
+  target, the function falls through (no early return) so every other keyword on this node is
+  still walked for a free-form channel reachable alongside the reference, mirroring the same
+  rule in `_object_boundedness_insufficient`. An object-valued additionalProperties map-entry
+  schema is a reachable subschema in its own right; walked so a command channel hidden behind
+  a dynamic (unnamed) map key isn't missed — but no fixed key name exists for a free-form
+  additionalProperties map channel, so it only counts as executor-shaped evidence when
+  corroborated by the tool's own name or description, mirroring the same corroboration
+  requirement `unbounded-script-payload` demands of payload keys (an uncorroborated free-form
+  map alone is too weak a signal to deny registration).
+
+### Top-level classification and API
+
+- `_classify_generic_executor()` — an unbounded command-shaped field
+  (`has_free_form_command`) is dangerous on its own; unrelated extra properties do NOT make it
+  safe, and — unlike the strong-name/description signals — no corroboration is required to
+  deny it. Highest-priority, least-corroborated denial reason (`unbounded-command-input`),
+  checked first. A strong executor identity (e.g. `bash`, `exec`, `run_command`) must be
+  AFFIRMATIVELY demonstrated safe: empty/no schema, every property bounded via enum/const, or
+  only auxiliary/identifier-like free-form fields. An unresolvable channel or a remaining
+  executor-shaped free-form property leaves the identity uncorroborated — i.e. the default
+  posture for a strong executor name is DENY unless the schema actively proves itself safe,
+  the inverse burden-of-proof from ordinary tools (`executor-identity-with-insufficient-
+  schema`).
+- `_SYNTHETIC_MCP_WRAPPER_PARAMETERS` / `is_synthetic_mcp_wrapper_schema()` —
+  `create_mcp_tool()` wraps every MCP tool in `async def mcp_callable(**kwargs)`. When a Tool
+  is built without an explicit `tool_schema` (e.g. constructed directly rather than via server
+  discovery), `function_to_schema()` reflects that wrapper into this exact deterministic
+  shape. It carries NO information from the remote server — it's a fixed artifact of the
+  wrapper's own signature/docstring — and must not be treated as remote descriptor metadata by
+  the admission rule; `is_synthetic_mcp_wrapper_schema` detects and exempts this case.
+  `mcp_tool_name` is the key under which the tool was registered in `Tool.mcp_config` — the
+  identity `create_mcp_tool()` used to name/document the wrapper, distinguishing it from
+  `advertised_name` (what the caller claims the tool is called).
+- `validate_mcp_tool_admission()` — raises `PermissionError` when an MCP descriptor exposes a
+  generic executor. Explicitly PURE and SYNCHRONOUS: no reads of MCPSecurityConfig,
+  environment, files, pool state, or client acquisition — zero side effects, trivially
+  unit-testable, impossible to bypass via mocking transport state. Registration-time admission
+  control ONLY; does not change transport authorization (MCPSecurityConfig) or
+  invocation-time permissions (PermissionPolicy) — those remain separate, independently
+  enforced gates.
+- `MCPConnectionPool.load_config()` — returns the server names declared in THIS file only. The
+  pool accumulates configs ACROSS loads (`_configs` is process-global class state), so callers
+  meaning "the servers from the file I just loaded" must use this method's return value rather
+  than enumerating `_configs` afterward, since it may contain servers from earlier, unrelated
+  calls in the same process.
+
+## lionagi/agent/, lionagi/dispatch/, lionagi/hooks/
+
+### `agent/factory.py`
+
+- `_chain_pre_hooks()` — security-hook composition contract (ADR-0086 delta row 1): every
+  security control (PermissionPolicy pre-hook, guard_destructive/guard_paths) is adapted into
+  a `GateResult` evaluator run through the shared gate pass runner — each control evaluates
+  exactly once per pass, and an evaluator that raises unexpectedly is treated as a fail-closed
+  deny. When user pre-hooks are present, the security pass runs *twice* (before user hooks,
+  then again after against the final possibly-mutated args), so a user hook can never rewrite
+  arguments past a control that already approved them.
+- `_resolve_mcp_path()` — shared by `_load_mcp` and `_forward_mcp_to_cli_request` so both agree
+  on the authoritative `.mcp.json` and trust gate: explicit `spec.mcp_config_path` always wins;
+  project-scoped `.lionagi/.mcp.json`/`.mcp.json` only considered when
+  `trust_project_settings=True`; user-home `~/.lionagi/.mcp.json` trusted unconditionally. An
+  explicit `mcp_config_path` that doesn't resolve raises `ConfigurationError` (declared intent
+  = configuration error, not a soft no-op); only auto-discovered candidates fall through
+  silently.
+- `_forward_mcp_to_cli_request()` — two-"island" MCP design: `_load_mcp` only reaches
+  lionagi-native `branch.acts` tools (inert for CLI providers, which spawn their own subprocess
+  and never call back into `branch.acts`); this function reaches the second island — the CLI
+  subprocess's own per-turn request kwargs (`ClaudeCodeRequest.mcp_servers`, forwarded via
+  `as_cmd_args()` as `--mcp-config`). It deliberately sets `mcp_servers` (a plain dict field)
+  rather than `mcp_config` (path field): `mcp_config`'s validator unconditionally rejects
+  absolute paths, and both resolved candidates here are always absolute, so using
+  `mcp_config` would raise `ValidationError` on the very next turn. An explicit
+  `spec.mcp_servers=[]` with no resolvable config file still forwards `{}` (forcing zero MCP
+  servers) rather than leaving the CLI to fall back to its own discovery.
+- Mutating `chat_model.endpoint.config.kwargs` in place would corrupt any other Branch sharing
+  the same iModel instance (Branch keeps a caller-supplied chat_model by reference, not copy).
+  The fix copies chat_model before mutating, sharing `share_session`/`share_executor` with the
+  original so only the endpoint config (MCP filter) becomes branch-local.
+
+### `agent/gate.py`
+
+`GateResult` is the one immutable verdict shape every tool-invocation security control
+produces (ADR-0086 delta row 1); adapters convert PermissionPolicy, guard_destructive/
+guard_paths, and the session-level gate into that shape. Legacy hooks signal denial by raising
+`PermissionError` and an argument rewrite by returning a `dict`; any other exception is
+treated as an evaluator failure and turned into a fail-closed deny rather than propagating
+uncaught.
+
+### `agent/hooks.py`
+
+`_resolve_against_any_root()` / `guard_paths()` — multi-root path-containment contract: a
+relative path formed against the first allowed root is accepted as long as the resolved
+location falls under *any* configured root, not only the first. A symlink or protected-
+basename denial fails identically against every root and always surfaces over a generic
+denial. `guard_paths` validation is check-time only — a TOCTOU race (swapping a validated file
+for a symlink after the check passes) is explicitly out of scope.
+
+### `agent/nudge.py`
+
+`NudgeEngine.evaluate()`/`_merge()` — firing bookkeeping (once/cooldown state) is committed
+only for rules whose message actually survives the token-cap merge; a message dropped by the
+cap must never be treated as delivered. A rule whose condition or render raises is skipped and
+logged without breaking other rules.
+
+### `agent/spec.py`
+
+`_wire_secure_guards()` — guards are registered into the `security_pre` bucket, not the
+ordinary user `pre` bucket, so they participate in the same security→user→security recheck as
+an explicit PermissionPolicy (ties to the same ADR-0086 double-pass contract as
+`_chain_pre_hooks` above).
+
+### `dispatch/outbox.py`
+
+Durability and delivery are separate guarantees: an outbox row persists in `state.db`
+independent of consumer liveness; a surviving producer (Studio daemon scheduler tick)
+re-attempts the notify template until success/backoff-exhaustion/`max_attempts`. Transport is
+a shell command template (ADR-0059 D3), argv-safe: `payload`/`deliver_to` are substituted as
+whole argv elements (never string-interpolated), and the template always runs via `exec` (no
+shell), so shell metacharacters are inert.
+
+- `enqueue_dispatch()` — idempotent on `dedup_key` (re-enqueue with the same key returns the
+  existing row id). `max_attempts` bounds delivery regardless of `ack_required`: an
+  ack-required row that keeps sending successfully but never gets acked still exhausts at
+  `max_attempts` sends (`dead_letter`/`DEAD_LETTER_ACK_TIMEOUT`) rather than re-delivering
+  forever. `expires_at` is an *additional* optional bound on top of `max_attempts`.
+- `deliver_due_dispatches()` / `_deliver_one_due_row()` — ack-required rows loop back to
+  `pending` (not `delivered`) on transport success, so the same due-scan re-attempts with
+  backoff until acked/expired/`max_attempts` exhausted; the default tier stops at `delivered`
+  on first success. `delivering` rows are re-scanned for crash recovery, but a claim is
+  exclusive only for `_CLAIM_LEASE_SECONDS` — the guarded attempt-counter CAS in `transition()`
+  (guard on pre-claim `attempt`, not just status) prevents two overlapping scans from
+  double-running the transport for the same attempt. Race hardening: the due-row snapshot and
+  each row's `transition()` call are separate transactions, so a concurrent
+  `purge_dispatch(es)` can delete a snapshotted row; `transition()` raises `LookupError` in
+  that case, caught per-row so one purged row is skipped without aborting the rest of the
+  batch.
+- `purge_dispatch()` / `purge_dispatches()` — `purge_dispatch` accepts any status (naming an
+  exact id is already deliberate non-bulk intent) and writes one `admin_events` audit row on
+  success. `purge_dispatches` requires `status` and/or `before` (bare call raises
+  `ValueError`, guards against accidental full-table delete); status semantics are
+  deliberately asymmetric — an explicit status is honored exactly as given (including
+  in-flight `pending`/`delivering`, treated as deliberate operator override), while a
+  status-less call defaults to terminal-only (`delivered`/`acked`/`dead_letter`/`expired`) so
+  it can never implicitly sweep in-flight rows a live scheduler tick may still claim. Distinct
+  from the automatic terminal-only retention sweep in `db_maintenance.prune_old_data`. Always
+  writes an `admin_events` row, including on `dry_run` calls, and preserves
+  `status_transitions` rows for purged ids.
+
+### `dispatch/revival.py`
+
+This is a plain library call, not a new schedule `action_kind`: wiring a first-class
+action_kind through the scheduler's fire/subprocess-spawn machinery would require rebuilding
+the `schedules.action_kind` CHECK constraint (the same SQLite rename-rebuild migration
+`_drop_legacy_action_kind_check` performs for the existing enum) — judged out of proportion
+for a slice-1 reference implementation. An operator wires this in today via any schedule
+action that can call a Python function; a first-class action_kind is a natural follow-up once
+a concrete caller needs it.
+
+### `hooks/builtins.py`
+
+`persist_session_end()` — in the normal CLI flow, `teardown_persist()` always stamps the
+terminal status via `_teardown_common()`'s `update_status()` call before emitting
+`SESSION_END`, so the session row is already terminal by the time this handler runs. In that
+case only pure usage fields are written (input/output tokens, cost, turns, duration) — the
+status/reason_code/ended_at transition is skipped (avoids a duplicate `status_transitions` row
+and a double-fire clobbering an already-recorded status), and `node_metadata` is left
+untouched since `_teardown_common()` already owns it for a terminal row and `update_session()`
+does a plain column SET, not a merge (writing `{"error": ...}` here would clobber richer
+existing data). Related: `persist_session_start`'s explicit `reason_code` on the "running"
+transition avoids tripping a deprecation shim that would otherwise raise and get swallowed by
+the bus, silently dropping all the provenance fields passed alongside it.
+
+## lionagi/providers/
+
+### `_cli_subprocess.py`
+
+`ndjson_from_cli` PGID capture: the process-group id must be captured immediately after
+spawn, not at teardown — if the child has already exited and been reaped by the time teardown
+runs, `os.getpgid(proc.pid)` raises `ProcessLookupError`. Since `start_new_session=True`,
+`pgid == proc.pid`, so capturing `proc.pid` right after spawn is equivalent and safe. The
+actual pid-guard/platform check lives in `aterminate_process_group`.
+
+### `anthropic/claude_code.py`
+
+- **CLI flag metadata protocol.** Every CLI-mappable `ClaudeCodeRequest` field carries a
+  `json_schema_extra` dict built by `_cli()`/`make_cli_flag()`, consumed by
+  `build_declarative_cli_args()`. Kind semantics: `value` → `--flag <str(val)>`; `bool` →
+  `--flag` when truthy else omitted; `bool_pair` → `--flag` when True, `--neg-flag` when False,
+  omitted when None; `list_args` → one flag followed by many positional args; `json_value` →
+  dict/list serialized to a JSON string; `repeat` → the flag repeated once per item. Anyone
+  adding a new CLI-mappable field must pick the right kind or the arg won't round-trip.
+- **`mcp_servers` None-vs-`{}` invariant.** Defaults to `None`, not `{}`, specifically so a
+  request that never touched the field is distinguishable from a caller that explicitly
+  forwarded an empty server selection. The `is not None` check (not truthiness) in
+  `as_cmd_args()` means `mcp_servers={}` still emits `--mcp-config {"mcpServers":{}}`, forcing
+  zero MCP servers, rather than silently omitting the flag and letting the CLI fall back to its
+  own MCP discovery. Flattening this to a truthiness check would silently break "explicitly
+  disable all MCP servers."
+- **Repo-containment scope for `add_dir`.** The write-target path containment check
+  (`contain_paths_in_repo`) covers `system_prompt_file`, `append_system_prompt_file`,
+  `mcp_config`, `settings` — deliberately excluding `add_dir`. `add_dir` is a read-only grant
+  validated separately by `_validate_add_dir`; absolute paths there are intentional grants, not
+  escapes, and must not be rejected by the write-target containment logic.
+
+### `google/gemini_code.py`
+
+Google folded Gemini Code Assist CLI into Antigravity (`agy`). This provider drives `agy` in
+headless print mode (`--output-format json`), which emits exactly one terminal JSON object
+(one NDJSON record) consumed unchanged by the shared `ndjson_from_cli` plumbing.
+`conversation_id` is stored as `session.session_id` so native resume works via `--conversation`.
+The public names/aliases `gemini-code` / `gemini-cli` / `gemini_cli` are kept for backward
+compat even though the underlying binary is `agy`.
+
+- **`resolve_agy_model` resolution/precedence rules.** `agy` has no separate effort flag;
+  effort is expressed only via a Low/Medium/High suffix baked into the model display name.
+  lionagi's effort scale (`none|minimal|low|medium|high|xhigh|max`) is clamped onto Gemini 3.1
+  Pro's Low/High-only range via `_clamp_gemini_effort`. An exact, already-`(...)`-qualified
+  `model` (a concrete agy display name) wins over `effort` by default. `reapply_effort=True`
+  exists specifically to let a new `effort` replace the suffix baked into a *persisted* prior
+  resolution (e.g. `li agent -r ... --effort ...`), while a `model` the caller explicitly typed
+  in the current turn still wins regardless.
+- **No per-tool stdout events.** `stream_gemini_cli`'s `on_tool_use`/`on_tool_result`
+  callbacks are accepted for interface parity with other CLI providers but never fire in this
+  transport, because `agy`'s json output surfaces no per-tool events on stdout (they exist only
+  in the per-session transcript file).
+- **Relative-path/stdin quirks.** `agy` resolves relative `--add-dir` entries against the
+  process cwd and has no `-C`-style flag to change that, so the resolved workspace must be
+  passed as the subprocess `cwd`. Default stdin is `DEVNULL` since print mode reads nothing
+  from stdin.
+- **`streams_first_output_early` stays False.** `agy`'s json print mode only yields output
+  after the entire result object arrives (no incremental streaming), so a healthy long-running
+  call looks identical to a dead/hung worker to a first-chunk watchdog — the endpoint can't opt
+  into the early-first-output fast path other CLI providers use.
+
+### `openai/_chat_schemas.py`
+
+`uses_developer_messages` — the `system`-vs-`developer` message-role gate is deliberately
+conservative and prefix-based: only o1/o3/o4/gpt-5 families (including dated variants, matched
+by prefix after stripping any provider prefix) are gated onto `developer`. Unknown or missing
+models fail closed and keep `system` — the default behavior on an unrecognized model string is
+the safe, backward-compatible one, not the newer `developer` role.
+
+### `groq/audio_transcription.py`, `openai/audio.py`, `openai/images.py`
+
+`_replayable_file_factory` retry-safety contract (identical helper duplicated in all three
+files): returns a zero-arg callable that produces a *fresh* file object for each retry
+attempt. Bytes/bytearray are snapshotted once and re-wrapped in a new `BytesIO` per attempt; a
+seekable stream is seeked back to its starting position before each attempt; a non-seekable
+stream cannot be replayed safely, so when a retry could occur (`require_replayable=True`) it
+raises before any network I/O rather than silently resending an exhausted stream (single-shot
+endpoints get the raw stream handed through once). The stream is snapshotted once and its
+position restored immediately — handing the *live* stream object to each attempt isn't
+sufficient, because an explicit `RetryConfig` retry re-invokes `_call`, which rebuilds this
+factory around the now-consumed stream (already at EOF), and would silently upload an empty
+file on retry without this snapshot.
+
+### `openai/codex.py`
+
+- **cwd/-C double-resolution gotcha.** `_ndjson_from_cli` deliberately does NOT pass `cwd=`
+  to `ndjson_from_cli`, because the Codex CLI already receives the workspace via the
+  `-C <repo>` argument emitted by `as_cmd_args()`. Setting `cwd=` as well would make the CLI
+  resolve `-C repo` from inside `repo`, producing a bogus `repo/repo` path.
+- **Error envelope shape varies by event type.** Codex CLI's error payload location differs by
+  event type: `"error"`-type events carry a top-level `"message"` key with no nested `"error"`
+  key, while `"turn.failed"` events nest the message under `error.message` — both must be
+  checked. The raw `error` value is captured *before* null-normalization (`_raw_err`)
+  specifically because the benign-EOS check further down must distinguish an explicit
+  `"error": null` (a malformed envelope — a real error) from the bare `{}` sentinel (benign
+  EOF).
+- **Benign-EOS sentinel on resumed sessions.** Some Codex CLI versions emit
+  `{"type": "error", "error": {}}` when a resumed session ends normally — this is a benign
+  end-of-stream, not a real failure, and is tagged so `run()` treats it as clean EOS rather
+  than raising `RunFailed`. All of the following must hold for the benign-EOS classification:
+  `type == "error"` exactly (`"turn.failed"` is never considered benign); the *raw* payload is
+  exactly `{}` (an explicit `null`, once normalised to `{}`, must NOT qualify, hence checking
+  `_raw_err` pre-normalization); and no other failure-indicating keys (`code`/`message`/
+  `status`) are present in the outer event. Getting any of these three conditions wrong either
+  misclassifies a real failure as benign or vice versa.
+
+### `pi/cli.py`
+
+- **`_PI_MODEL_PROVIDER_MAP` design rationale.** Model-name prefixes are mapped to
+  `pi --provider` values, but only for *unambiguous* prefixes where the model name uniquely
+  identifies the provider. Ambiguous family names (`llama`, `gemma`, `mistral` — available on
+  multiple providers) are deliberately omitted from the map, so callers must set the provider
+  explicitly or let `pi` resolve it itself, rather than the code guessing wrong. `strip=True`
+  entries remove the prefix from the model string, needed for `openrouter/`-style routing.
+- **Pi CLI arg-parsing quirk.** Pi's CLI arg parser has no `--` terminator support, so the
+  prompt is passed as a bare positional argument. Prompts starting with `-` or `@` may be
+  misparsed by Pi's own CLI as flags/file-references — callers should avoid leading dashes (or
+  `@`) in prompts passed through this provider.
+- **Dual meaning of the `"done"` event type.** Pi CLI overloads the `"done"` event type: both
+  the top-level `AgentEvent.done` (true end-of-stream) and a top-level
+  `AssistantMessageEvent.done` (an individual assistant message finishing) use the same
+  `"done"` string, and both may carry a final message with model/usage info that must be
+  captured via `_remember_assistant_message`.
+- **`streams_first_output_early` stays False.** Pi's transport emits an `"agent_start"` event
+  right after spawn, but `stream()` discards raw dict events and only yields its first
+  `StreamChunk` once a `PiChunk` actually carries text/thinking/tool content — so the first
+  output a caller can observe may lag the process spawn by the model's full "thinking" time,
+  making the early-first-output optimization unsafe here (same gotcha class as
+  `gemini_code.py`'s `agy` note above).
+
+## lionagi/service/ (remaining)
+
+### Retry & sentinel-exclusion contract (`connections/endpoint.py`, `providers.py`, `resilience.py`)
+
+- `endpoint.py` — 4xx (non-429) client errors are wrapped in `_NonRetryableClientError` so the
+  original `aiohttp.ClientResponseError` stays inspectable via `__cause__` while retry logic
+  sees an excluded type. The sentinel must stay excluded until whichever retry layer is active
+  (the outer `retry_config`-driven wrapper in `call()`, or the native path in
+  `_call_aiohttp()`) has given up — unwrapping earlier would let a broad
+  `retry_exceptions=(aiohttp.ClientError,)` config replay a 400/401/403 the transport contract
+  intends as single-shot. Request bodies are rebuilt inside the per-attempt function rather
+  than before retry orchestration, because `FormData`/`BytesIO`/file-stream bodies can be
+  consumed by the first POST and must not be silently replayed on a later attempt. In the
+  native (no-`RetryConfig`) path, `config.max_retries` is a total-attempt cap (formerly
+  backoff's `max_tries`), but `retry_with_backoff` runs `max_retries+1` attempts internally, so
+  the call subtracts one to preserve the configured total attempt count. `_can_retry()`: true
+  when an explicit `RetryConfig` wraps the call, or the native path's total-attempt cap allows
+  a second attempt; single-shot endpoints (`max_retries<=1`, no `RetryConfig`) never replay a
+  body, so callers may hand over non-replayable inputs like one-shot streams only in that case.
+- `resilience.py` — in `retry_with_backoff`, `exclude_exceptions` membership is checked
+  per-instance (`except exclude_exceptions`) rather than per-type, which correctly handles
+  subclass hierarchies — e.g. `retry_on=(OSError,), exclude=(ConnectionError,)` must not retry
+  a `ConnectionError` even though it IS-A `OSError`.
+
+### `connections/agentic_endpoint.py`
+
+`streams_first_output_early` — true when a CLI/agentic transport emits its first `StreamChunk`
+shortly after the subprocess spawns (e.g. an ndjson "system"/"init" event), making a stalled
+first chunk a reliable dead-worker signal. False for transports that buffer all output until
+the run completes, where a slow-but-healthy call is indistinguishable from a dead one until
+the whole result arrives. This flag gates `run.py`'s default liveness watchdog
+(`LIONAGI_WORKER_LIVENESS_TIMEOUT`).
+
+### `connections/endpoint_config.py`
+
+`_FIELD_KEYS_BY_CLASS` is keyed on `id(cls)` rather than the class object itself, because a
+dict lookup by class object would go through `__eq__`/`__hash__`, which a custom metaclass may
+override; each cache entry retains a strong reference to the class (keeping the id stable) and
+is only served when the stored class `is` the lookup class, guarding against id reuse after
+garbage collection. The cached value is the set of accepted field keys (including declared
+aliases) computed once per class from `model_json_schema()`, since subclasses may add
+fields/aliases and rebuilding the JSON schema on every `EndpointConfig` construction would
+cost more than the rest of validation combined.
+
+### `imodel.py`
+
+- `stream()` — the `finally` block pops the in-flight call from `executor.pile` without
+  yielding inside the `finally`, because yielding inside a generator's `finally` would swallow
+  a `CancelledError` arriving during generator cleanup, which would break `anyio.fail_after`
+  timeout enforcement for callers wrapping the stream.
+- `copy(share_session, share_executor)` — creates a new `iModel` with the same config but a
+  fresh ID. `share_session=True` carries the CLI provider's `session_id` onto the copy so
+  cross-turn continuation is preserved (only applies when both endpoints are
+  `AgenticEndpoint`). `share_executor=True` reuses the exact same `RateLimitedAPIExecutor`
+  instance instead of building a fresh one, so a caller-supplied executor's rate limits and
+  queue capacity stay shared between original and copy. Default (`False`/`False`) gives the
+  copy its own independent executor — this is what `Branch.clone()` relies on for CLI
+  providers, where each cloned branch needs its own session and queue rather than contending
+  with the parent's. `circuit_breaker` and `retry_config` objects are shared by reference (not
+  deep-copied) between original and copy; only `config` is deep-copied.
+
+### `manager.py`
+
+`iModelManager.shutdown()` — without explicitly closing every registered `iModel`, each one's
+background rate-limit replenisher task stays scheduled and prevents `anyio.run`/`asyncio.run`
+from returning at process exit. Idempotent; per-model failures (including `CancelledError`)
+are logged and swallowed so one broken endpoint's shutdown failure can't block the others.
+
+### `providers.py`
+
+`normalize_effort()` must be called once at every boundary where a raw effort string enters
+lionagi (CLI flag, profile frontmatter, orchestration spec) because the clamp tables
+downstream are keyed on lowercase effort levels and silently misclamp (no raise) on an
+un-normalized value like `"High"`. Codex reasoning-effort ceilings are model-dependent per the
+codex CLI's live model list: `gpt-5.6-sol`/`gpt-5.6-terra` accept `max`/`ultra`,
+`gpt-5.6-luna` accepts `max` only, and every earlier model tops out at `xhigh`; unrecognized
+(future) models intentionally pass through unclamped so a genuinely supported new tier is
+never silently degraded. agy (the Antigravity CLI) has no effort flag/kwarg at all — effort is
+expressed only as a Low/Medium/High suffix baked into the resolved `--model` name, and Gemini
+3.1 Pro has no Medium tier, so lionagi's 8-level `none|minimal|low|medium|high|xhigh|max|ultra`
+vocabulary collapses onto this 3-tier scale via `_GEMINI_EFFORT_CLAMP`.
+
+### `rate_limited_processor.py`
+
+- `start_replenishing()` — its cancellation handler wraps `await self.start()` too, so a
+  cancel arriving before the main loop is reached is still caught inside the task instead of
+  surfacing as an uncaught error on `stop()`. The periodic re-drive of the queue
+  (`if not self.queue.empty(): await self.process()`) exists because `process()` re-enqueues
+  rate-limited events instead of dropping them, but `forward()` is one-shot — without
+  re-driving on each refresh, deferred events would sit `PENDING` until the caller's
+  `invoke()` safety timeout instead of actually retrying once the budget replenishes.
+- `stop()` — Python 3.11+ re-raises `CancelledError` on `await task` after `task.cancel()`
+  even though the task body already suppressed it internally; this is swallowed explicitly so
+  callers closing multiple iModels in sequence don't abort on the first one's close.
+- `handle_denied()` — rate-limit denial is a deferral, not a rejection — returning `False`
+  makes the base `process()` re-enqueue the event (stays `PENDING`) for retry once the limit
+  replenishes, rather than terminalizing it the way a permission rejection would.
+
+## lionagi/testing/
+
+### `testing/_endpoint.py`
+
+`ScriptedEndpoint.copy_runtime_state_to()` — when an `iModel` is cloned, the script must be
+**deep-copied**, not shared, so the clone gets an independent positional cursor. If the script
+were shared, positional matching would cross-contaminate between clones — clone A consuming
+response entry 0 would advance the shared cursor, so clone B's first call would incorrectly
+receive entry 1 instead of entry 0. Recorded calls (`self.calls`) are shallow-copied instead,
+since each clone only needs its own future calls tracked, not a defensively-copied history.
+
+### `testing/_script.py`
+
+- `_build_entry()` — response entries are dispatched to their concrete subclass
+  (`TextResponse`, `ToolCallResponse`, `StructuredResponse`, `StreamResponse`, `ErrorResponse`)
+  by manually branching on the `type` field rather than relying on Pydantic v2's discriminated-
+  union support. Deliberate: Pydantic v2 won't reliably select a discriminated-union member
+  when fields beyond the discriminator (`type`) differ between candidate models, so manual
+  dispatch is used to get clearer validation errors when a script entry is malformed.
+- `ScriptModel.next()` — response-entry matching has a two-phase precedence contract that test
+  authors writing scripts rely on. **Phase 1**: unless `mode == "positional"`, every entry with
+  a non-empty `when:` matcher is checked (skipping entries already served by a `when:` match)
+  and the first one whose predicate matches (`call_index`, `after_calls`, `prompt_contains`,
+  `prompt_regex`, `has_tool`) is returned; if `mode == "when_only"` and nothing matched, it
+  raises immediately. **Phase 2**: falls back to positional order over entries that do NOT have
+  a `when:` matcher, advancing an internal cursor; raises `ScriptExhaustedError` once positional
+  entries are exhausted. This order (when-matchers-first, then positional) is the core scripted-
+  fixture replay semantic and isn't obvious from the fixture's public surface alone.
+
+## lionagi/tools/
+
+### `sandbox_backend.py`
+
+The sandbox backend seam (ADR-0090): backend divergence (local worktree vs. Daytona vs.
+future backends) is absorbed entirely in `provision()` and `capabilities()`; `run_cell()`'s
+signature never changes per backend. A `Cell` declares a `kind`: `prompt_cell` (the provider
+call runs host-side, already authenticated — no secrets ever cross into the box) or
+`exec_cell` (untrusted code runs inside the box, secrets injected explicitly). Callers must
+read `capabilities()` to decide what a backend can do and must never branch on a backend's
+name/type — this is the load-bearing security/extensibility contract of the whole seam.
+`_SAFE_ENV_KEYS`: `run_cell`'s subprocess never blanket-inherits the host environment
+(credential-leak vector); only `PATH`, `HOME`, `PYTHONPATH`, `VIRTUAL_ENV` are forwarded
+automatically, plus whatever `cell.env` explicitly allow-lists.
+
+### `khive_injection.py`
+
+Reference `ContextProvider` (ADR-0008): recalls/optionally composes from a khive daemon over
+the same MCP transport lionagi already uses for tool servers
+(`service.connections.mcp_wrapper`) — no new transport, and no khive/MCP import at module
+load, so the core import path stays clean without the `mcp` extra installed. Every recall
+emits `brain.auto_feedback` in the same round-trip with the policy's explicit `profile_id`
+(khive's auto_feedback does no binding resolution, so an implicit/default profile
+mis-attributes the event). `writeback()` is a separate opt-in POST-turn hook — rule-based tool
+error/resolution pairs written to `memory.remember` at capped, low-provenance salience,
+invoked by the `operate()` Middle (not `provide()`), and it is NOT the nudge plane. Both
+`provide()` and `writeback()` fully swallow transport failures (logged only) so a turn always
+proceeds.
+
+`KhiveInjectionPolicy.namespace`, when set, is threaded onto every khive verb the provider
+emits (recall, compose, auto_feedback, remember) as the bench-arm isolation mechanism.
+`auto_feedback` WRITES to the live brain store, so an unpinned "read-only" arm still mutates
+posteriors and contaminates cross-arm comparisons — pinning a namespace is required, not
+optional, for any enabled bench arm. Currently only the write verb honors namespace (read
+verbs reject unknown params); this is forward-wired for when reads grow namespace scoping too.
+
+### `sandbox.py`
+
+Git worktree lifecycle (`_cleanup_worktree_sync`, `_merge_sync`, `sandbox_merge`) is
+retry-safe: a resource that's already absent counts as cleaned up, so a partial failure (e.g.
+worktree removed but branch deletion blocked by another checkout) can be completed by a later
+retry instead of failing forever on the step that already succeeded. `SandboxSession.is_active`
+only flips to `False` once both resources are actually gone — a partial failure keeps the
+session marked active so a caller can't mistake it for cleaned up. Merge additionally refuses
+when `repo_root` is in a detached HEAD state, isn't checked out on the session's recorded base
+branch (no auto-checkout), or targets a protected branch name (`main`/`master`/`release*`)
+unless the caller explicitly opts in via `allow_protected`. (`git rev-parse --abbrev-ref HEAD`
+returns the literal string `"HEAD"` when the repo is detached — not an actual branch name — a
+quirk both `_merge_sync` and `create_sandbox` special-case, since unhandled it would let a
+merge move a detached HEAD forward with no branch ref pointing at the result, or let
+`create_sandbox` record a nonexistent branch as its merge target.)
+
+`_list_untracked_files()` uses `git ls-files --others --exclude-standard -z` (NUL-delimited
+raw paths) rather than `git status --porcelain`, which quotes/escapes paths with spaces or
+special characters (breaking naive `line[3:]` slicing) and reports an untracked directory as a
+single `?? dir/` entry instead of the files inside it.
+
+### `communication/messenger.py`
+
+`_fire()` — two related logging design decisions: (1) for the `help` event specifically, a
+raising coordinator callback is caught and logged rather than propagated, because the whole
+point of `help` is fire-and-continue — it must never surface as an unhandled exception on the
+emitting worker's tool-call turn. (2) When no callback is registered at all for an event,
+that's logged at `debug` (not `warning`) — a mis-wired coordinator should stay discoverable
+during bring-up, but debug-level avoids spamming normal runs where some events are legitimately
+unused.
+
+### `coding.py`
+
+`CodingToolkit.__init__`'s `sandbox_allow_protected` — whether the bound sandbox tool's
+`merge` action may target a protected branch name (`main`/`master`/`release*`) is an
+operator-level trust decision, not something the agent can request per call. It's deliberately
+absent from `SandboxRequest` so an in-band agent can never self-approve merging into a
+protected branch — set it only when composing the agent from code you control (e.g. a CI job
+that always merges into main).
+
+`_invalidate_stale_reads()` drops `file_state` entries whose backing reader-read result was
+evicted/compacted by the context tool; otherwise the read-before-edit guard would stay
+"satisfied" for a read the model can no longer actually see, letting it edit blind.
+
+### `_subprocess.py`
+
+`_subprocess_sync()` — `env=None` inherits the full parent environment; callers pass an
+explicit mapping to scope less-trusted commands (e.g. the ADR-0090 sandbox-backend seam) to a
+minimal environment.

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -70,10 +70,8 @@ async def create_agent(
         if spec.yolo:
             extra.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
 
-        # CLI providers (codex/claude_code) auth via subprocess — a placeholder
-        # api_key is fine. API providers must resolve their real key from
-        # settings; forcing "dummy" there silently breaks auth (the model can
-        # never call out). So only pin the placeholder for CLI providers.
+        # CLI providers auth via subprocess, so a placeholder api_key is fine;
+        # API providers need their real key or auth silently breaks.
         if provider in CLI_PROVIDERS:
             extra["api_key"] = "dummy"
 
@@ -146,17 +144,9 @@ def _chain_pre_hooks(
 ) -> Callable | None:
     """Compose security controls and user pre-hooks into one preprocessor.
 
-    Every security hook (an explicit PermissionPolicy's pre-hook, or a
-    built-in guard such as guard_destructive/guard_paths) is adapted into a
-    GateResult evaluator and run through the shared gate pass runner: each
-    control evaluates exactly once per pass, and an evaluator that raises
-    unexpectedly is treated as a fail-closed deny rather than propagating an
-    unrelated exception (ADR-0086 delta row 1).
-
-    When user pre-hooks are present, the security pass runs twice — once
-    before the user hooks and once after, against the final, possibly
-    mutated arguments — so a user hook cannot rewrite arguments past a
-    control that already approved them. With no user pre-hooks it runs once.
+    With user pre-hooks present, the security pass runs twice (before and
+    after) so a user hook cannot rewrite args past an already-approved
+    control. See docs/internals/runtime.md.
     """
     from .gate import GateDeniedError, adapt_legacy_hook, run_gate_pass
 
@@ -284,27 +274,14 @@ def _register_coding_tools(branch: Branch, spec: AgentSpec) -> None:
 def _resolve_mcp_path(spec: AgentSpec, *, trust_project_settings: bool = False) -> str | None:
     """Resolve the ``.mcp.json`` path an AgentSpec's MCP fields point at.
 
-    Shared by ``_load_mcp`` (island 1: lionagi-native ``branch.acts`` tools) and
-    ``_forward_mcp_to_cli_request`` (island 2: the CLI-native request) so
-    both islands agree on which file is authoritative and under what trust
-    gate. An explicit ``spec.mcp_config_path`` always wins; otherwise a
-    project-scoped ``.lionagi/.mcp.json`` / ``.mcp.json`` is only considered
-    when ``trust_project_settings=True`` (mirrors the settings-loading trust
-    gate), while the user-home ``~/.lionagi/.mcp.json`` candidate is trusted
-    unconditionally, since it lives in the user's own home directory rather
-    than an arbitrary project checkout.
-
-    An explicit ``spec.mcp_config_path`` that does not resolve to an existing
-    file raises ``ConfigurationError`` — the caller declared intent, so a
-    missing/typo'd path is a configuration error, not a soft no-op. Only the
-    auto-discovered candidates below fall through silently when none exist.
+    Shared by ``_load_mcp`` and ``_forward_mcp_to_cli_request`` so both agree
+    on the authoritative file and trust gate. See docs/internals/runtime.md.
     """
     from pathlib import Path
 
     if spec.mcp_config_path is not None:
-        # Presence check, not truthiness: an explicit empty string is still a
-        # declared path and must fail loudly below, never fall through into
-        # auto-discovery (which could silently load a different config).
+        # Presence check, not truthiness: an explicit empty string must fail
+        # loudly below, never fall through into auto-discovery.
         p = Path(spec.mcp_config_path)
         if p.is_file():
             return str(p)
@@ -360,46 +337,9 @@ def _forward_mcp_to_cli_request(
 ) -> None:
     """Forward AgentSpec MCP fields into the claude_code CLI's own request.
 
-    ``_load_mcp`` above only reaches island 1 (lionagi-native ``branch.acts``
-    tools, consulted by API function-calling endpoints) — inert for CLI
-    providers, which spawn their own subprocess and parse only that
-    subprocess's own tool_use/tool_result chunks, never calling back into
-    ``branch.acts``. This reaches island 2: the per-turn request kwargs a CLI
-    provider builds (``ClaudeCodeRequest.mcp_servers``, which ``as_cmd_args()``
-    turns into a literal ``--mcp-config`` flag for the ``claude`` CLI
-    subprocess). Setting it onto the chat_model endpoint's ``config.kwargs``
-    makes it land in every per-turn payload (``Endpoint.create_payload``
-    starts from ``config.kwargs`` and merges the per-call request on top),
-    the same mechanism already used for provider-specific extras like a
-    placeholder ``api_key``.
-
-    Why ``mcp_servers`` (dict) rather than ``mcp_config`` (path): although
-    ``as_cmd_args()`` prefers ``mcp_config`` over ``mcp_servers`` when both
-    are set, ``mcp_config``'s field validator
-    (``claude_code.py`` ``_validate_path_fields`` -> ``check_path_safe``)
-    unconditionally rejects absolute paths, and both resolved candidates
-    here (``~/.lionagi/.mcp.json`` and a project ``.mcp.json`` found via
-    parent-directory search) are absolute and not generally repo-relative —
-    so setting ``mcp_config`` would raise a ValidationError on the very next
-    turn for the common case. ``mcp_servers`` (a plain dict field) carries no
-    such validator, so this always loads the resolved file and forwards the
-    (optionally filtered) dict — never the path.
-
-    Only ``claude_code`` has an MCP-capable request model today; other
-    providers get a logged warning
-    rather than a silent no-op — but only when there is actually something
-    to forward (a resolvable config), so a caller can tell "no passthrough
-    exists" apart from "nothing was configured" (mirrors ``_load_mcp``,
-    which no-ops the same way for island 1 when nothing resolves).
-
-    ``spec.mcp_servers`` set (even to an explicit empty list) is itself
-    caller intent independent of whether any config file resolves: an
-    explicit allowlist must be enforced regardless of config presence, so a
-    ``claude_code`` leg with ``mcp_servers=[]`` and no resolvable
-    ``.mcp.json`` anywhere still forwards ``{}`` (filtering nothing against
-    an empty selection), forcing zero MCP servers rather than leaving the
-    per-turn request untouched and letting the CLI fall back to its own MCP
-    discovery.
+    ``_load_mcp`` only reaches lionagi-native ``branch.acts`` tools (inert for
+    CLI providers); this reaches the per-turn request kwargs a CLI provider
+    subprocess actually reads. See docs/internals/runtime.md.
     """
     mcp_path = _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
     if mcp_path is None and spec.mcp_servers is None:
@@ -419,17 +359,13 @@ def _forward_mcp_to_cli_request(
                 "run.",
                 provider,
             )
-        # provider != claude_code has no MCP-capable request model to forward
-        # into at all — an explicit mcp_servers filter with no resolvable
-        # config file has nothing to filter and nowhere to land, so this
-        # stays a silent no-op (mirrors _load_mcp's own no-op shape).
+        # No MCP-capable request model for this provider to forward into,
+        # so this stays a silent no-op (mirrors _load_mcp's own shape).
         return
 
     if mcp_path is None:
-        # claude_code + an explicit spec.mcp_servers filter (possibly empty)
-        # but no config file resolves: there is nothing to read, so the
-        # "servers available" set is empty — filtering it by the allowlist
-        # is still {}, which is exactly the explicit-empty-allowlist case.
+        # No config file resolves: the available-servers set is empty, which
+        # matches the explicit-empty-allowlist case.
         servers: dict = {}
     else:
         import json
@@ -449,9 +385,8 @@ def _forward_mcp_to_cli_request(
                 exc,
             )
             if spec.mcp_config_path:
-                # An explicitly configured path (as opposed to an auto-discovered
-                # candidate) failing to read/parse is a configuration error, not
-                # a soft "nothing to forward" — the caller declared intent.
+                # An explicitly configured path failing to parse is a
+                # configuration error, not a soft no-op.
                 raise ConfigurationError(
                     f"spec.mcp_config_path={spec.mcp_config_path!r} could not be "
                     f"read or parsed as JSON: {type(exc).__name__}: {exc}"
@@ -460,19 +395,12 @@ def _forward_mcp_to_cli_request(
         servers = data.get("mcpServers", {}) if isinstance(data, dict) else {}
 
     if spec.mcp_servers is not None:
-        # A server-name filter is set (possibly an explicit empty list): the
-        # two islands must agree on selection (mirrors _load_mcp's
-        # server_names semantics, where server_names=[] loads nothing).
+        # Explicit filter set (possibly empty): mirrors _load_mcp's
+        # server_names semantics, where an empty list loads nothing.
         servers = {name: cfg for name, cfg in servers.items() if name in spec.mcp_servers}
 
-    # Mutating config.kwargs in place would corrupt any OTHER branch sharing
-    # this same iModel instance (Branch.__init__ keeps a caller-supplied
-    # chat_model by reference, not by copy — two create_agent calls given the
-    # same iModel would otherwise cross-contaminate each other's MCP server
-    # filter through the shared config.kwargs dict). Give this branch its own
-    # copy of the chat_model/endpoint/config before mutating so the change is
-    # branch-local. share_session/share_executor keep the copy's CLI session
-    # and the caller-supplied rate limiter/queue shared with the original —
-    # only the endpoint config (and thus the MCP filter) is branch-local.
+    # Copy chat_model before mutating config.kwargs: Branch keeps a
+    # caller-supplied chat_model by reference, so mutating in place would
+    # cross-contaminate other branches sharing the same iModel.
     branch.chat_model = branch.chat_model.copy(share_session=True, share_executor=True)
     branch.chat_model.endpoint.config.kwargs["mcp_servers"] = servers

--- a/lionagi/agent/gate.py
+++ b/lionagi/agent/gate.py
@@ -3,13 +3,8 @@
 
 """Unified security-control verdict contract (ADR-0086 delta row 1).
 
-``GateResult`` is the one immutable shape every tool-invocation security
-control produces. Adapters convert the shipped controls — ``PermissionPolicy``
-(via its legacy ``to_pre_hook()`` callable), the built-in coding guards
-(``guard_destructive``, ``guard_paths``), and the session-level gate — into
-that shape so callers can run a set of controls exactly once per evaluation
-pass and treat an evaluator exception as a recorded deny instead of an
-uncaught crash or a silent pass.
+``GateResult`` is the one immutable shape every security control produces;
+see docs/internals/runtime.md for the full contract.
 """
 
 from __future__ import annotations
@@ -60,12 +55,8 @@ class GateDeniedError(PermissionError):
 def adapt_legacy_hook(control: str, hook: Callable) -> GateEvaluator:
     """Adapt a legacy ``(tool_name, action, args) -> dict | None`` pre-hook.
 
-    Legacy hooks (``PermissionPolicy.to_pre_hook()``, ``guard_destructive``,
-    ``guard_paths(...)``) signal denial by raising ``PermissionError`` and
-    signal an argument rewrite by returning a ``dict``. Any other raised
-    exception is an evaluator failure, not a policy decision — it is caught
-    here and turned into a deny ``GateResult`` (fail-closed) rather than
-    propagating uncaught.
+    Denial = raise ``PermissionError``; rewrite = return a ``dict``; any
+    other exception fails closed as a deny GateResult. See docs/internals/runtime.md.
     """
 
     async def evaluate(tool_name: str, action: str, args: dict) -> GateResult:

--- a/lionagi/agent/hooks.py
+++ b/lionagi/agent/hooks.py
@@ -58,16 +58,9 @@ def _is_hard_floor_error(exc: PermissionError) -> bool:
 def _resolve_against_any_root(raw_path: str, candidate: Path, allowed_roots: list[Path]) -> Path:
     """Accept iff resolve_workspace_path succeeds for >=1 root.
 
-    `candidate` is already absolute here — either the caller-supplied absolute
-    path, or a relative path pre-joined to the first allowed root — so every
-    root is tried purely as a containment check. This restores the
-    pre-existing multi-root contract: a relative path formed against the
-    first root is accepted as long as the resolved location falls under *any*
-    configured root, not only the first.
-
-    A symlink or protected basename fails the same way against every root (the
-    check runs before containment), so it can never be masked by trying another
-    root — surface that reason instead of a generic denial when it occurs.
+    A relative path is accepted if it resolves under *any* configured root,
+    not only the first; a symlink/protected-name denial always surfaces
+    over a generic one. See docs/internals/runtime.md.
     """
     hard_floor_error: PermissionError | None = None
     for root in allowed_roots:
@@ -97,10 +90,8 @@ def guard_paths(
 ):
     """Factory: return a pre-hook that enforces allowed/denied path constraints.
 
-    Validation happens at check time only: a filesystem mutation racing this
-    check and the tool's later I/O on the same path (e.g. swapping a
-    validated regular file for a symlink after the check passes) is out of
-    scope for this pathname-based guard.
+    Check-time only: a TOCTOU race (swap file for symlink after the check
+    passes) is out of scope. See docs/internals/runtime.md.
     """
 
     allowed_roots = [Path(p).expanduser().resolve(strict=False) for p in (allowed_paths or [])]
@@ -113,10 +104,8 @@ def guard_paths(
         expanded = Path(raw_path).expanduser()
 
         if allowed_roots:
-            # Documented workspace-relative rule: relative paths resolve
-            # against the first allowed root, not the process cwd. The
-            # resulting absolute candidate is then, like any absolute path,
-            # accepted if it is contained by *any* configured allowed root.
+            # Relative paths resolve against the first allowed root, not cwd;
+            # the result is accepted if contained by *any* configured root.
             candidate = expanded if expanded.is_absolute() else allowed_roots[0] / expanded
             resolved = _resolve_against_any_root(raw_path, candidate, allowed_roots)
         else:
@@ -131,9 +120,8 @@ def guard_paths(
                     if resolved == denied_resolved or denied_resolved in resolved.parents:
                         raise PermissionError(f"Path matches deny rule: {raw_path}")
                 else:
-                    # Relative deny pattern: glob patterns (*, ?, [) fnmatch each
-                    # resolved path component; plain-text patterns fall back to a
-                    # substring check so ".env" still blocks ".env.local".
+                    # Glob patterns fnmatch each path component; plain-text
+                    # patterns fall back to a substring check (".env" blocks ".env.local").
                     import fnmatch
 
                     _glob_chars = frozenset("*?[")

--- a/lionagi/agent/nudge.py
+++ b/lionagi/agent/nudge.py
@@ -3,10 +3,8 @@
 
 """NudgeEngine — just-in-time guidance and status nudges for coding-agent tool calls.
 
-Rides the CodingToolkit "*" post-hook plane: on every tool call it assembles a
-NudgeContext (token budget, message counts, recent tool-call history) and asks
-each registered NudgeRule whether it should fire. Triggered messages are merged
-into a single suffix, highest priority first, dropped once a token cap is hit.
+Rides the CodingToolkit "*" post-hook plane, evaluating NudgeRules against
+live branch state and merging triggered messages under a token cap.
 """
 
 from __future__ import annotations
@@ -176,11 +174,9 @@ class NudgeEngine:
     def evaluate(self, *, files_tracked: int = 0) -> str | None:
         """Build a NudgeContext, fire eligible rules, and return the merged suffix.
 
-        Firing bookkeeping (once/cooldown state) is only committed for rules whose
-        message actually survives the token-cap merge — a message dropped by the
-        cap must not be silently consumed as if it had been delivered. A rule whose
-        condition or message raises is skipped and logged; it never breaks the
-        other rules or the caller.
+        Once/cooldown bookkeeping commits only for rules whose message survives
+        the token-cap merge — a dropped message must not count as delivered.
+        See docs/internals/runtime.md.
         """
         self._call_count += 1
         ctx = self._build_context(files_tracked)
@@ -249,9 +245,8 @@ class NudgeEngine:
     def _merge(self, candidates: list[tuple[NudgeRule, str]]) -> tuple[str | None, list[NudgeRule]]:
         """Merge candidate messages under the token cap; return (text, surviving rules).
 
-        Only rules present in the returned survivor list actually had their message
-        delivered — callers must gate once/cooldown bookkeeping on that list, not on
-        `candidates`, or a cap-dropped message is wrongly treated as delivered.
+        Only the returned survivor list had its message delivered — gate
+        once/cooldown bookkeeping on that, not on `candidates`.
         """
         if not candidates:
             return None, []

--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -184,9 +184,8 @@ def _make_shell_hook(command_template: list[str], phase: str, tool_name: str) ->
                     timeout=10,
                 )
             except asyncio.TimeoutError as err:
-                # Kill the whole process group (start_new_session=True guarantees a
-                # new PGID) so lingering child processes cannot continue side effects
-                # after the hook is considered timed-out.
+                # Kill the whole process group so lingering children can't
+                # continue side effects after the hook times out.
                 if proc is not None:
                     await aterminate_process_group(proc, grace=None)
                     await _wait_proc(proc)

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -44,11 +44,8 @@ class HooksMixin:
 def _wire_secure_guards(obj: HooksMixin, cwd: str | None) -> None:
     """Register the standard destructive-command + path-containment guards.
 
-    ``obj`` must support .security_pre() (HooksMixin). Registering into the
-    security_pre bucket (not the ordinary user pre bucket) means these guards
-    participate in the security -> user -> security recheck and evaluate
-    final, post-mutation arguments the same way an explicit PermissionPolicy
-    does (ADR-0086 delta row 1).
+    Uses the security_pre bucket (not user pre) so these guards participate
+    in the security -> user -> security recheck (ADR-0086 delta row 1).
     """
     from lionagi.agent.hooks import guard_destructive, guard_paths
 
@@ -129,12 +126,7 @@ class AgentSpec(HooksMixin):
     ) -> AgentSpec:
         """Preset for a coding agent; ``secure=True`` wires guard_destructive + guard_paths.
 
-        ``role`` defaults to ``"implementer"`` (every existing caller relies on this
-        default). Pass a different role name to compose the preset's tools/hooks
-        around another role's own body and policy block instead.
-
-        ``context_management=False`` drops the context tool from the default coding
-        toolset and skips the context-curation one-liner in the system prompt.
+        ``context_management=False`` drops the context tool and its system-prompt one-liner.
         """
         spec = cls.compose(
             role,
@@ -226,13 +218,8 @@ class AgentSpec(HooksMixin):
         role_name = self.profile.role.name
         policy = pack.policy(role_name)
         if policy is None:
-            # A role that loads (Role.load succeeded) but has no entry in the
-            # active pack must not silently run unconstrained — that is a
-            # privilege gap, not a no-op. A role genuinely meant to run with
-            # no authority/boundary/escalation constraints says so explicitly
-            # via an empty-but-present entry in the pack yaml (e.g. `roles:
-            # {my-role: {}}`), which resolves to an empty RolePolicy here, not
-            # None — distinct from the role being absent from `roles:` entirely.
+            # Missing pack entry = privilege gap, fails loud (not a silent
+            # no-op). An explicit empty entry (`{}`) opts into unconstrained.
             raise ValueError(
                 f"Role {role_name!r} has no policy entry in pack {pack.name!r}. "
                 "Add an entry under `roles:` in the pack yaml — an empty entry "

--- a/lionagi/dispatch/outbox.py
+++ b/lionagi/dispatch/outbox.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Durable dispatch outbox core (ADR-0059 slice 1).
+"""Durable dispatch outbox core (ADR-0059).
 
 Durability and delivery are separate guarantees (row persists; scheduler
 retries with backoff); transport is argv-safe, never shell-interpolated.

--- a/lionagi/dispatch/outbox.py
+++ b/lionagi/dispatch/outbox.py
@@ -2,18 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Durable dispatch outbox core (ADR-0059 slice 1).
 
-Durability and delivery are separate guarantees: an outbox row persists in
-``state.db`` independent of any consumer's liveness (durability); a surviving
-producer — the Studio daemon's scheduler tick — re-attempts the configured
-notify template until it succeeds, backs off, or exhausts ``max_attempts``
-(delivery). The transport is a shell command template (ADR-0059 D3):
-best-effort, argv-safe, no specific messaging CLI baked in — the command is
-configuration.
-
-Argv-safety (binding rider): ``payload`` and ``deliver_to`` are substituted as
-whole argv elements, never string-interpolated into a shell command line, and
-the template always runs via ``exec`` (no shell), so shell metacharacters in
-either value are inert.
+Durability and delivery are separate guarantees (row persists; scheduler
+retries with backoff); transport is argv-safe, never shell-interpolated.
+See docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -53,19 +44,15 @@ _log = logging.getLogger(__name__)
 DEFAULT_MAX_ATTEMPTS = 8
 NOTIFY_TIMEOUT_SECONDS = 10.0
 
-# Terminal dispatch_outbox statuses (ADR-0059 D1's six-value CHECK minus the
-# two in-flight ones). Used as the default status filter for purge_dispatches
-# when the caller supplies no explicit status.
+# Terminal dispatch_outbox statuses (ADR-0059 D1's six minus the two
+# in-flight ones) — default status filter for purge_dispatches.
 _TERMINAL_DISPATCH_STATUSES = ("delivered", "acked", "dead_letter", "expired")
 
 _BASE_BACKOFF_SECONDS = 30
 _MAX_BACKOFF_SECONDS = 1800
 
-# A claim on a row (pending/delivering -> delivering) advances next_attempt_at
-# by this lease so overlapping scans within the transport's execution window
-# cannot re-claim it; a scan only revisits a still-`delivering` row once the
-# lease has lapsed (crash recovery), and by then the guarded attempt-counter
-# CAS in transition() ensures only one claimant ever wins per attempt.
+# Claiming a row advances next_attempt_at by this lease so overlapping scans
+# can't re-claim it; a lapsed lease allows crash-recovery re-scan.
 _CLAIM_LEASE_SECONDS = NOTIFY_TIMEOUT_SECONDS + 5.0
 
 _PAYLOAD_TOKEN = "{payload}"  # noqa: S105 -- template placeholder, not a credential
@@ -162,16 +149,8 @@ async def enqueue_dispatch(
 ) -> str:
     """Insert a pending dispatch_outbox row; returns the dispatch id.
 
-    Idempotent on ``dedup_key``: a re-enqueue with the same key returns the
-    existing row's id rather than inserting a duplicate.
-
-    ``max_attempts`` bounds delivery whether or not ``ack_required`` — an
-    ack-required row that keeps sending successfully but never gets acked
-    still exhausts at ``max_attempts`` sends (``dead_letter``, distinct
-    ``DEAD_LETTER_ACK_TIMEOUT`` reason) rather than re-delivering forever.
-    ``expires_at`` is an *additional*, optional bound honored on top of
-    ``max_attempts``; it is not required for ``ack_required`` rows to be
-    bounded.
+    Idempotent on ``dedup_key``. ``max_attempts`` bounds delivery even for
+    ack_required rows (dead_letter on exhaustion). See docs/internals/runtime.md.
     """
     now = time.time()
     dispatch_id = uuid.uuid4().hex
@@ -323,26 +302,9 @@ async def deliver_due_dispatches(
 ) -> dict[str, int]:
     """Scan due pending/delivering rows and attempt delivery. Called from the scheduler tick.
 
-    Ack-required rows loop back to ``pending`` (not ``delivered``) on transport
-    success, so the same due-scan re-attempts delivery with backoff until the
-    consumer acks, the row expires, or ``max_attempts`` sends have gone out
-    unacked (``dead_letter``, ``DEAD_LETTER_ACK_TIMEOUT``) — the default
-    (``ack_required=0``) tier stops at ``delivered`` on first transport
-    success. ``delivering`` rows are re-scanned for crash recovery, but a
-    claim on one is only exclusive for the duration of a lease
-    (``_CLAIM_LEASE_SECONDS``): the guarded attempt-counter CAS in
-    ``transition()`` prevents two overlapping scans from both running the
-    notify transport for the same attempt.
-
-    Race hardening: the due-row snapshot below and each row's subsequent
-    ``transition()`` calls are separate transactions, so an operator
-    ``purge_dispatch``/``purge_dispatches`` call can delete a snapshotted row
-    in between -- ``transition()`` raises ``LookupError`` when its target row
-    no longer exists (see ``lionagi.state.transitions.transition``, which
-    ``SELECT``s the row inside its own ``_tx()`` and raises if the ``SELECT``
-    misses). That is caught per-row here so one concurrently purged row is
-    skipped (logged at debug) rather than aborting delivery for the rest of
-    the batch.
+    Ack-required rows loop back to pending until acked/expired/exhausted;
+    claims use a time-boxed lease plus a guarded attempt-counter CAS so
+    overlapping scans can't double-deliver. See docs/internals/runtime.md.
     """
     if now is None:
         now = time.time()
@@ -392,13 +354,9 @@ async def _deliver_one_due_row(
     notify_template: list[str] | None,
     counts: dict[str, int],
 ) -> None:
-    """Claim-and-deliver one due row (extracted so ``deliver_due_dispatches`` can catch a
-    mid-scan ``LookupError`` per row without aborting the rest of the batch).
-
-    Every early ``return`` below is a normal outcome for this row (expired,
-    lost the claim race, dead-lettered, retried, ...). A row missing at
-    ``transition()`` time (e.g. an operator purge raced this scan) instead
-    propagates ``LookupError`` to the caller.
+    """Claim-and-deliver one due row; per-row so a mid-scan ``LookupError``
+    (row purged concurrently) can be caught without aborting the batch.
+    Early returns are normal outcomes; see docs/internals/runtime.md.
     """
     dispatch_id = row["id"]
 
@@ -437,13 +395,8 @@ async def _deliver_one_due_row(
             actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
             idempotency_key=f"deliver:{dispatch_id}:{row['attempt']}",
         ),
-        # A `delivering -> delivering` recovery claim is a same-state
-        # match on status alone, so guard on the pre-claim attempt value
-        # too: the atomic patch below bumps attempt as part of THIS
-        # UPDATE, so a second overlapping claimant's guard misses and it
-        # loses instead of also running the transport. The next_attempt_at
-        # lease keeps a live (non-crashed) claim from being re-picked-up
-        # by a later scan until the transport should plausibly be done.
+        # Guard on pre-claim attempt (not just status) so a second
+        # overlapping claimant's guard misses and it loses the race.
         guard={"attempt": row["attempt"]},
         patch={"attempt": next_attempt, "next_attempt_at": now + _CLAIM_LEASE_SECONDS},
     )
@@ -464,11 +417,8 @@ async def _deliver_one_due_row(
         )
 
     if success:
-        # ack_required rows loop back to pending awaiting the consumer's
-        # ack_token, but that must still be bounded by max_attempts (the
-        # ADR's boundedness contract applies to every send while awaiting
-        # ack, not only to transport failures) — otherwise a successful
-        # transport to a dead/non-acking consumer re-delivers forever.
+        # ack_required rows loop back to pending but must still respect
+        # max_attempts, or a non-acking consumer re-delivers forever.
         if row["ack_required"] and next_attempt >= row["max_attempts"]:
             result = await transition(
                 db,
@@ -620,24 +570,17 @@ async def retry_dispatch(db: Any, dispatch_id: str) -> bool:
             actor=Actor(type="operator", id="li_dispatch_retry"),
             idempotency_key=f"operator_retry:{dispatch_id}:{now}",
         ),
-        # Rider B: the status change and the attempt/next_attempt_at/last_error
-        # reset are one guarded write, not two transactions — a crash between
-        # separate writes would otherwise leave a 'pending' row with stale
-        # exhausted accounting.
+        # One guarded write, not two transactions — a crash between separate
+        # writes would leave stale exhausted accounting on a 'pending' row.
         patch={"attempt": 0, "next_attempt_at": now, "last_error": None},
     )
     return result.applied
 
 
 async def purge_dispatch(db: Any, dispatch_id: str, *, actor: str = "li_dispatch_purge") -> bool:
-    """Single-row guarded delete inside BEGIN IMMEDIATE (RIDER B: direct-DB write discipline).
-
-    Accepts any status: naming an exact id is already a deliberate,
-    non-bulk operator action, unlike ``purge_dispatches`` below which
-    requires explicit criteria to guard against a bare mass-delete. Writes
-    one ``admin_events`` row (action="dispatch_purge") on a successful
-    delete so single-row purges are auditable like the bulk path
-    (ADR-0059 delta 3 — the shipped adapter wrote none).
+    """Single-row guarded delete; accepts any status (naming an id is already
+    deliberate). Writes an admin_events audit row on success — see
+    docs/internals/runtime.md.
     """
     async with db._read() as conn:
         row = (
@@ -679,34 +622,9 @@ async def purge_dispatches(
 ) -> dict[str, Any]:
     """Bulk-delete ``dispatch_outbox`` rows matching explicit criteria.
 
-    At least one of ``status`` or ``before`` is required — a bare call with
-    neither raises ``ValueError`` so a mistaken invocation cannot delete the
-    entire table. ``before`` filters on ``updated_at``.
-
-    Status semantics (deliberately asymmetric):
-
-    - An explicit ``status`` is honored exactly as given, including
-      ``pending``/``delivering`` — naming an in-flight status is deliberate
-      operator intent (e.g. force-clearing a stuck row), not an accident.
-    - A status-less call (``status=None``, only ``before`` supplied) is
-      scoped to the terminal statuses only
-      (``delivered``/``acked``/``dead_letter``/``expired``): it can never
-      implicitly sweep ``pending``/``delivering`` rows that a live
-      scheduler tick may still claim or retry.
-
-    This is an operator action distinct from the automatic retention sweep
-    in ``lionagi.studio.services.db_maintenance.prune_old_data`` (which is
-    always terminal-only, on separate success/dead-letter windows); this
-    function is the one path that can touch a non-terminal row, and only
-    when the caller names that status explicitly.
-
-    Writes one ``admin_events`` row (action="dispatch_purge") per call,
-    always, including ``dry_run`` calls (so a dry run leaves an inspectable
-    record of what would have been deleted). ``status_transitions`` rows for
-    purged ids are preserved, matching ``purge_dispatch`` and the automatic
-    sweep — see their docstrings for why.
-
-    Returns ``{"total": N, "dry_run": bool, <status>: count, ...}``.
+    Requires ``status`` and/or ``before``. An explicit status is honored as
+    given (even in-flight); a status-less call defaults to terminal-only.
+    See docs/internals/runtime.md.
     """
     if status is None and before is None:
         raise ValueError("purge_dispatches requires status and/or before criteria")
@@ -739,11 +657,8 @@ async def purge_dispatches(
         counts_by_status = {r["status"]: r["n"] for r in rows}
         total = sum(counts_by_status.values())
     else:
-        # Select the exact match set inside the write transaction, derive the
-        # audit counts from it, and delete by those ids only. A criteria-based
-        # second DELETE could remove a different set than the count saw (the
-        # transaction is not a database-wide lock on PostgreSQL), and the
-        # admin_events record must describe the rows actually deleted.
+        # Select the exact match set first and delete by those ids only — a
+        # criteria-based second DELETE could see a different set on PostgreSQL.
         async with db._tx() as conn:
             matched = (
                 (

--- a/lionagi/dispatch/outbox.py
+++ b/lionagi/dispatch/outbox.py
@@ -60,7 +60,7 @@ _DELIVER_TO_TOKEN = "{deliver_to}"  # noqa: S105 -- template placeholder, not a 
 
 
 def backoff_seconds(attempt: int) -> float:
-    """``min(30 * 2**attempt, 1800)`` seconds (ADR-0059 spec-gate ruling 3, no jitter)."""
+    """``min(30 * 2**attempt, 1800)`` seconds (ADR-0059; no jitter)."""
     return min(_BASE_BACKOFF_SECONDS * (2**attempt), _MAX_BACKOFF_SECONDS)
 
 

--- a/lionagi/dispatch/revival.py
+++ b/lionagi/dispatch/revival.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Revival heartbeat reference implementation (ADR-0059 slice 1, item 5).
+"""Revival heartbeat reference implementation (ADR-0059).
 
 Demonstrates the durable-dispatch case of a consumer dead at fire time;
 dedup_key scoped to the reset epoch keeps re-fires idempotent. Deliberately

--- a/lionagi/dispatch/revival.py
+++ b/lionagi/dispatch/revival.py
@@ -2,19 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Revival heartbeat reference implementation (ADR-0059 slice 1, item 5).
 
-Demonstrates the durable-dispatch end-to-end case the ADR is built for: a
-consumer that is dead at fire time. Enqueues one ``dispatch_outbox`` row per
-seat with a ``dedup_key`` scoped to the reset epoch, so a re-fired heartbeat
-(daemon restart, missed-fire recovery) cannot double-queue.
-
-This is a plain library call, not a new schedule ``action_kind``: wiring a
-brand-new action_kind through the scheduler's fire/subprocess-spawn machinery
-would require rebuilding the ``schedules.action_kind`` CHECK constraint (the
-same SQLite rename-rebuild migration ``_drop_legacy_action_kind_check``
-performs for the existing enum) — out of proportion for a slice-1 reference
-implementation. An operator wires this in today via any schedule action that
-can call a Python function (or a thin wrapper script); a first-class
-``action_kind`` is a natural follow-up once a concrete caller needs it.
+Demonstrates the durable-dispatch case of a consumer dead at fire time;
+dedup_key scoped to the reset epoch keeps re-fires idempotent. Deliberately
+a plain library call, not a new schedule action_kind — see docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -36,9 +26,7 @@ async def enqueue_revival_heartbeat(
 ) -> list[str]:
     """Enqueue one ``revival_ping`` dispatch per seat; returns the dispatch ids.
 
-    ``dedup_key=f"revival:{seat}:{reset_epoch}"`` makes a re-fire idempotent:
-    calling this again with the same ``reset_epoch`` returns the same rows
-    rather than double-queuing.
+    ``dedup_key`` scoped to ``reset_epoch`` makes a re-fire idempotent.
     """
     dispatch_ids: list[str] = []
     for seat in seats:

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -57,11 +57,8 @@ async def persist_session_start(
         return
     await db.update_session(
         session_id,
-        # status="running" routes through update_status(), which requires
-        # a reason_code — pass it explicitly so the transition records a
-        # canonical "started" cause instead of tripping the deprecation
-        # shim (which would raise on the running status and be swallowed by
-        # the bus, silently dropping all the provenance fields above).
+        # Explicit reason_code avoids tripping the deprecation shim, which
+        # would swallow the transition and silently drop provenance fields.
         reason_code=RunReasons.STARTED_OK,
         model=model,
         provider=provider,
@@ -86,21 +83,8 @@ async def persist_session_end(
     duration_ms: float | None = None,
     **_unused: Any,
 ) -> None:
-    """Stamp ended_at/status + usage on the session row.
-
-    teardown_persist() always stamps the terminal status (via
-    _teardown_common()'s update_status() call) before emitting SESSION_END, so
-    by the time this handler runs in the normal CLI flow the row is already
-    terminal. In that case only the pure usage fields (input_tokens,
-    output_tokens, total_cost_usd, num_turns, duration_ms) are written — the
-    status/reason_code/ended_at transition is skipped (avoids a duplicate
-    status_transitions row and keeps a genuine double-fire from clobbering an
-    already-recorded status), and node_metadata is left untouched too, since
-    _teardown_common() already owns it for a terminal row (its own
-    extras/identity-markers write happens before update_status()) and
-    update_session() does a plain column SET, not a merge — writing
-    {"error": ...} here would clobber that richer data rather than add to it.
-    """
+    """Stamp ended_at/status + usage on the session row; usually only usage
+    fields are written since teardown_persist already stamped status."""
     from lionagi.state.db import SESSION_TERMINAL_STATUSES
     from lionagi.state.reasons import RunReasons
 
@@ -115,11 +99,8 @@ async def persist_session_end(
     if not already_terminal:
         fields["ended_at"] = time.time()
         if error is not None:
-            # update_session() binds this as a raw SQL param (no JSON
-            # bindparam), so pre-serialize to avoid sqlite3.InterfaceError.
-            # update_session() also does a plain column SET, not a merge, so
-            # start from whatever node_metadata the row already carries
-            # (e.g. identity markers) rather than clobbering it.
+            # Pre-serialize (raw SQL param, no JSON bindparam) and merge
+            # onto existing node_metadata rather than clobbering it.
             existing_metadata = row.get("node_metadata")
             if not isinstance(existing_metadata, dict):
                 existing_metadata = {}

--- a/lionagi/hooks/persist.py
+++ b/lionagi/hooks/persist.py
@@ -28,18 +28,14 @@ def route_message_persistence(
     bus.off(HookPoint.MESSAGE_ADD, persist_message)
     branch._hooks = bus  # enable Branch._persist_via_bus to emit MESSAGE_ADD
     # Register the async emit hook here (not at construction): the sync
-    # add_message path rejects async callbacks, and the construction-time system
-    # message goes through it. By the time we wire persistence we are in an async
-    # context and only a_add_message runs, so the hook is safe.
+    # add_message path used at construction can't accept async callbacks.
     if branch._persist_via_bus not in branch.on_message_added:
         branch.on_message_added.append(branch._persist_via_bus)
     bid = str(branch.id)
 
     async def _handler(message: Any = None, *, branch_id: str | None = None, **_: Any) -> None:
-        # Per-branch demux on the shared session bus: persist only THIS branch's
-        # messages. ``_persist_via_bus`` always supplies ``branch_id``; a direct
-        # call without it (e.g. a test invoking the handler with a controlled
-        # message) targets this branch unconditionally.
+        # Per-branch demux on the shared session bus: persist only this
+        # branch's messages (a direct call w/o branch_id targets it unconditionally).
         if branch_id is None or branch_id == bid:
             await on_message(message)
 
@@ -52,9 +48,8 @@ def unroute_message_persistence(holder: Any, handler: HookHandler) -> None:
     bus = getattr(holder, "_hooks", None)
     if bus is not None:
         bus.off(HookPoint.MESSAGE_ADD, handler)
-    # Remove the emit hook by its underlying function, not object identity:
-    # ``holder._persist_via_bus`` makes a fresh bound-method object on each
-    # access, so an ``is`` comparison against a re-fetched method never matches.
+    # Remove by underlying function, not identity: a bound-method object is
+    # freshly created on each access, so `is` against a re-fetched one never matches.
     emit_func = getattr(type(holder), "_persist_via_bus", None)
     added = getattr(holder, "on_message_added", None)
     if emit_func is not None and isinstance(added, list):

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -43,10 +43,8 @@ async def ndjson_from_cli(
     if stdin is not _INHERIT_STDIN:
         kwargs["stdin"] = stdin
     proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
-    # Capture PGID immediately — if we wait until teardown, the child may have
-    # exited and been reaped, and os.getpgid(proc.pid) would raise
-    # ProcessLookupError. start_new_session=True makes pgid == proc.pid.
-    # The pid-guard and platform check live in aterminate_process_group.
+    # Capture PGID immediately — waiting until teardown risks ProcessLookupError
+    # if the child already exited. See docs/internals/runtime.md.
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -163,11 +161,7 @@ def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
 
 
 def validate_message_prompt(data: dict) -> dict:
-    """Extract prompt from a messages list when prompt is not already set.
-
-    Shared by Gemini, Pi, and Codex request models. Extracts non-system message
-    content into prompt; hoists the first system message into system_prompt.
-    """
+    """Derive prompt/system_prompt from messages when prompt is unset (shared by Gemini, Pi, Codex request models)."""
     from lionagi import ln
 
     if data.get("prompt"):

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -7,9 +7,7 @@ from __future__ import annotations
 
 import re
 
-# ---------------------------------------------------------------------------
-# Base hierarchy
-# ---------------------------------------------------------------------------
+# --- Base hierarchy ---
 
 
 class ProviderError(RuntimeError):
@@ -40,9 +38,7 @@ class ProviderContextError(ProviderError):
 
 
 class WorkerLivenessError(ProviderError):
-    """The worker CLI subprocess produced no first-stream output within the
-    liveness window across every retry attempt — a spawn/hang failure,
-    distinct from a classified provider-content error (quota/auth/context)."""
+    """Spawn/hang failure: no first-stream output within the liveness window across every retry, distinct from a classified content error."""
 
     def __init__(
         self,
@@ -56,9 +52,7 @@ class WorkerLivenessError(ProviderError):
         self.reason: str = reason
 
 
-# ---------------------------------------------------------------------------
-# Emission error (separate axis — not a provider subprocess failure)
-# ---------------------------------------------------------------------------
+# --- Emission error (separate axis — not a provider subprocess failure) ---
 
 
 class EmissionError(RuntimeError):
@@ -78,9 +72,7 @@ class EmissionError(RuntimeError):
         self.stage: str = stage
 
 
-# ---------------------------------------------------------------------------
-# Regex catalogue (case-insensitive patterns → subclass)
-# ---------------------------------------------------------------------------
+# --- Regex catalogue (case-insensitive patterns → subclass) ---
 
 # Each entry: (compiled_pattern, subclass)
 _QUOTA_PATTERNS: list[re.Pattern[str]] = [

--- a/lionagi/providers/ag2/groupchat.py
+++ b/lionagi/providers/ag2/groupchat.py
@@ -32,9 +32,7 @@ __all__ = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Models (structured output targets)
-# ---------------------------------------------------------------------------
+# --- Models (structured output targets) ---
 
 
 class HandoffCondition(BaseModel):
@@ -117,9 +115,7 @@ class AG2GroupChatRequest(BaseModel):
     context_variables: dict[str, Any] = Field(default_factory=dict)
 
 
-# ---------------------------------------------------------------------------
-# Callback types (parallel to claude_code.py on_* handlers)
-# ---------------------------------------------------------------------------
+# --- Callback types (parallel to claude_code.py on_* handlers) ---
 
 AG2_HANDLER_PARAMS = (
     "on_text",
@@ -130,9 +126,7 @@ AG2_HANDLER_PARAMS = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Runner (in-process — no subprocess, unlike claude_code.py)
-# ---------------------------------------------------------------------------
+# --- Runner (in-process — no subprocess, unlike claude_code.py) ---
 
 
 def build_group_chat(
@@ -141,10 +135,7 @@ def build_group_chat(
     tool_registry: dict[str, Callable] | None = None,
     code_executor: Any | None = None,
 ):
-    """Build AG2 agents and DefaultPattern from a GroupChatSpec.
-
-    Returns (user_proxy, pattern, agents_by_name).
-    """
+    """Build AG2 agents and DefaultPattern from a GroupChatSpec; returns (user_proxy, pattern, agents_by_name)."""
     from autogen import ConversableAgent, register_function
     from autogen.agentchat.conversable_agent import UpdateSystemMessage
     from autogen.agentchat.group import (
@@ -271,10 +262,7 @@ async def stream_group_chat(
     on_speaker: Callable[[str], None] | None = None,
     on_complete: Callable[[Any], None] | None = None,
 ) -> AsyncIterator[Any]:
-    """Stream AG2 GroupChat events. In-process, no subprocess.
-
-    Yields AG2 BaseEvent objects. Optionally calls on_* handlers.
-    """
+    """Stream AG2 GroupChat events in-process (no subprocess), yielding AG2 BaseEvent objects and calling on_* handlers."""
     from autogen.agentchat.group.multi_agent_chat import a_run_group_chat_iter
     from autogen.events.agent_events import (
         GroupChatRunChatEvent,

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -73,18 +73,7 @@ __all__ = ("ClaudeCodeRequest", "stream_claude_code_cli", "ClaudeCodeCLIEndpoint
 
 
 # --------------------------------------------------------------------------- flag metadata
-#
-# Each CLI-mappable field carries a ``json_schema_extra`` dict produced by
-# ``_cli()``.  The generic ``_build_declarative_args()`` loop reads these
-# dicts (sorted by *order*) and emits the correct flag sequence.
-#
-# kind semantics:
-#   value      – ``--flag <str(val)>``
-#   bool       – ``--flag`` when truthy, omit otherwise
-#   bool_pair  – ``--flag`` when True, ``--neg-flag`` when False, omit when None
-#   list_args  – ``--flag arg1 arg2 …`` (one flag, many positional args)
-#   json_value – ``--flag '<json>'``   (dict/list serialised to JSON string)
-#   repeat     – ``--flag a --flag b`` (flag repeated per item)
+# json_schema_extra-driven CLI flag protocol — see docs/internals/runtime.md.
 
 
 # --------------------------------------------------------------------------- request model
@@ -117,8 +106,7 @@ class ClaudeCodeRequest(BaseModel):
     )
 
     # ── model & runtime (order 20–29) ─────────────────────────────
-    # Bare "sonnet" is pinned to Sonnet 5 (see _pin_sonnet_alias) rather than
-    # left to the CLI's own alias resolution.
+    # Bare "sonnet" is pinned to Sonnet 5 — see _pin_sonnet_alias.
     model: Literal["sonnet", "opus", "haiku"] | str | None = Field(
         default="claude-sonnet-5",
         json_schema_extra=_cli("--model", 20),
@@ -191,11 +179,7 @@ class ClaudeCodeRequest(BaseModel):
         json_schema_extra=_cli("--strict-mcp-config", 51, "bool"),
     )
     # Legacy: if set and mcp_config is absent, serialised to --mcp-config JSON.
-    # Default is None (not {}) so a request that never touched this field is
-    # distinguishable from a caller that explicitly forwarded an empty server
-    # selection — the latter must still emit `--mcp-config {"mcpServers":{}}`
-    # to force zero MCP servers rather than silently falling back to the CLI's
-    # own MCP discovery (see as_cmd_args below).
+    # None-vs-{} is a deliberate invariant — see docs/internals/runtime.md.
     mcp_servers: dict[str, Any] | None = Field(default=None, exclude=True)
 
     # ── agents (order 60–69) ──────────────────────────────────────
@@ -405,10 +389,8 @@ class ClaudeCodeRequest(BaseModel):
                     f"Workspace: {cwd_resolved}"
                 ) from None
 
-        # Repo-containment: resolve write-target path fields and reject symlink
-        # escapes.  ``add_dir`` is a read-only grant validated separately by
-        # ``_validate_add_dir`` — absolute paths there are deliberate grants,
-        # not escapes, and must not be rejected here.
+        # Repo-containment on write-target path fields; add_dir is excluded
+        # (read-only grant, validated separately) — see docs/internals/runtime.md.
         repo_root = self.repo.resolve()
         for fname, fval in (
             ("system_prompt_file", self.system_prompt_file),
@@ -464,11 +446,8 @@ class ClaudeCodeRequest(BaseModel):
             else:
                 args.append("--debug")
 
-        # Legacy mcp_servers dict → serialise as --mcp-config JSON inline.
-        # `is not None` (not truthiness) so an explicitly forwarded empty
-        # selection (mcp_servers={}) still emits the flag — forcing zero MCP
-        # servers — rather than silently omitting it and letting the CLI fall
-        # back to its own MCP discovery.
+        # `is not None` (not truthiness) — an explicit {} must still force
+        # zero MCP servers rather than falling back to CLI discovery.
         if self.mcp_servers is not None and not self.mcp_config:
             args.extend(
                 [

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -1,15 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Antigravity CLI (`agy`) backend for the `gemini-code` / `gemini-cli` provider.
-
-Google folded Gemini Code Assist CLI into Antigravity (`agy`); this provider
-drives `agy` in headless print mode (``--output-format json``), which emits
-one terminal JSON object — exactly one NDJSON record, consumed unchanged by
-the shared ``ndjson_from_cli`` plumbing. ``conversation_id`` is stored as
-``session.session_id`` so native resume works via ``--conversation``. Public
-names/aliases (``gemini-code`` / ``gemini-cli`` / ``gemini_cli``) are kept.
-"""
+"""Antigravity CLI (`agy`) backend for the `gemini-code` / `gemini-cli` provider — see docs/internals/runtime.md."""
 
 from __future__ import annotations
 
@@ -84,9 +76,8 @@ CONTEXT_WINDOWS: dict[str, int] = {
 
 # --------------------------------------------------------------------------- model mapping
 
-# `agy --model` wants an exact display name + effort suffix; map legacy Gemini
-# CLI strings / bare family names onto it. Unknown values pass through so agy
-# surfaces a clear error rather than us silently forcing a default.
+# `agy --model` wants an exact display name + effort suffix; unknown values pass
+# through so agy surfaces a clear error rather than us silently forcing a default.
 _AGY_MODELS: frozenset[str] = frozenset(
     {
         "Gemini 3.5 Flash (Medium)",
@@ -133,20 +124,8 @@ def resolve_agy_model(
     *,
     reapply_effort: bool = False,
 ) -> str:
-    """Map a lionagi model spec onto an exact `agy --model` name.
-
-    agy has no effort flag — effort is expressed only via the Low/Medium/High
-    suffix on the model name. `effort` is lionagi's 5-level scale
-    (none|minimal|low|medium|high|xhigh|max), clamped onto Gemini 3.1 Pro's
-    Low/High-only range (`_clamp_gemini_effort`). An exact `(...)`-qualified
-    `model` (already a concrete agy display name) wins over `effort` by
-    default.
-
-    `reapply_effort=True` lets a new `effort` replace the suffix already
-    baked into a *persisted* prior resolution (e.g. `li agent -r ...
-    --effort ...`); a `model` the caller explicitly typed this turn still
-    wins regardless.
-    """
+    """Map a lionagi model spec + effort onto an exact `agy --model` display name (effort folds into
+    the Low/Medium/High suffix; see docs/internals/runtime.md for the precedence rules)."""
     if not model:
         model = "gemini-3.5-flash"
     if model in _AGY_MODELS:
@@ -167,9 +146,8 @@ def resolve_agy_model(
             return f"Gemini 3.1 Pro ({_clamp_gemini_effort(effort, True)})"
         return target  # cross-family alias (Claude/GPT-OSS via agy) — no effort tiers
 
-    # effort given but the string isn't a known alias: still resolve a
-    # gemini family from it (e.g. "gemini-3-pro-experimental") so --effort
-    # keeps working on forward-compatible model names.
+    # Effort given but string isn't a known alias: still resolve a gemini family
+    # from it so --effort works on forward-compatible model names.
     is_pro = "pro" in key
     if effort is not None and (is_pro or "flash" in key or "gemini" in key):
         family = "Gemini 3.1 Pro" if is_pro else "Gemini 3.5 Flash"
@@ -321,9 +299,8 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
             "(it installs to ~/.local/bin/agy); run `agy` once to authenticate."
         )
     cmd = [AGY_CLI, *request.as_cmd_args()]
-    # agy resolves relative --add-dir entries against the process cwd and has no
-    # '-C'-style flag, so pass the resolved workspace as cwd. Default stdin is
-    # DEVNULL — print mode reads nothing from stdin.
+    # agy resolves relative --add-dir entries against process cwd (no '-C' flag).
+    # Default stdin DEVNULL — print mode reads nothing from stdin.
     async with contextlib.aclosing(ndjson_from_cli(cmd, cwd=request.cwd())) as stream:
         async for obj in stream:
             yield obj
@@ -370,12 +347,8 @@ async def stream_gemini_cli(
     on_tool_result: Callable[[dict[str, Any]], None] | None = None,
     on_final: Callable[[CLISession], None] | None = None,
 ) -> AsyncIterator[StreamChunk | CLISession]:
-    """Run agy in json print mode and project its result object into StreamChunks.
-
-    agy's json format surfaces no per-tool events on stdout (they live only in
-    the per-session transcript), so ``on_tool_use`` / ``on_tool_result`` are
-    accepted for interface parity but do not fire in this transport.
-    """
+    """Run agy in json print mode and project its result into StreamChunks; on_tool_use/on_tool_result
+    are accepted for interface parity but never fire (agy's json format has no per-tool stdout events)."""
     if session is None:
         session = CLISession()
     theme = request.cli_display_theme or "light"
@@ -411,10 +384,8 @@ async def stream_gemini_cli(
                 yield sys_sc
 
             if session.is_error:
-                # Error chunk must lead with status, not delivered content —
-                # a degraded termination after a complete response otherwise
-                # impersonates the response. Bounded detail keeps quota/auth
-                # patterns classifiable.
+                # Error chunk leads with status, not delivered content — a degraded
+                # termination after a complete response would otherwise impersonate it.
                 detail = f": {response[:500]}" if response else ""
                 msg = f"agy returned status={status or 'UNKNOWN'}{detail}"
                 sc = StreamChunk(type="error", content=msg, is_error=True, metadata=obj)
@@ -484,10 +455,8 @@ class GeminiCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
     _handler_kwarg = "gemini_handlers"
     _request_model = GeminiCodeRequest
     _filter_model_fields = False
-    # streams_first_output_early stays False (AgenticEndpoint default): agy's
-    # json print mode yields only after the whole result object arrives —
-    # see stream_gemini_cli() above — so a healthy long-running call would
-    # look identical to a dead worker to a first-chunk watchdog.
+    # streams_first_output_early stays False: agy's json mode yields only after
+    # the whole result arrives, so a first-chunk watchdog can't tell it from a hang.
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
         handlers = kwargs.pop("gemini_handlers", None)

--- a/lionagi/providers/groq/audio_transcription.py
+++ b/lionagi/providers/groq/audio_transcription.py
@@ -11,15 +11,8 @@ __all__ = ("GroqAudioTranscriptionEndpoint",)
 
 
 def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one attempt.
-
-    Bytes/bytearray are snapshotted once and re-wrapped in a new BytesIO per
-    attempt. A seekable stream is seeked back to its starting position before
-    each attempt. A non-seekable stream cannot be replayed safely: when a
-    retry can occur (*require_replayable*), it fails here, before any network
-    I/O, instead of silently resending an exhausted stream; on a single-shot
-    endpoint it is handed to aiohttp once, as before.
-    """
+    """Return a zero-arg callable producing a fresh file object for one retry attempt.
+    See docs/internals/runtime.md for the replay-safety invariant."""
     if file_data is None:
         return lambda: None
     if isinstance(file_data, (bytes, bytearray)):
@@ -35,10 +28,8 @@ def _replayable_file_factory(file_data, field_name: str, *, require_replayable: 
                 "max_retries=1 for a non-seekable stream."
             )
         return lambda: file_data
-    # Snapshot the stream once and restore its position. Handing the live
-    # stream to each attempt is not enough: an explicit RetryConfig retries by
-    # re-invoking _call, which would rebuild this factory with the consumed
-    # stream already at EOF and silently upload an empty file.
+    # Snapshot once, restore position — a live stream handed to each attempt would
+    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
     start_pos = file_data.tell()
     snapshot = file_data.read()
     file_data.seek(start_pos)

--- a/lionagi/providers/openai/_chat_schemas.py
+++ b/lionagi/providers/openai/_chat_schemas.py
@@ -411,12 +411,8 @@ class OpenAIChatCompletionsRequest(BaseModel):
 
 
 def uses_developer_messages(model: object) -> bool:
-    """Whether the given model expects `developer` in place of `system` messages.
-
-    Conservative and prefix-based: only o1/o3/o4/gpt-5 families (and dated
-    variants, matched by prefix after stripping any provider prefix) are
-    gated. Unknown or missing models fail closed and keep `system`.
-    """
+    """Whether the given model expects `developer` in place of `system` messages;
+    fails closed (keeps `system`) for unknown or missing models."""
     if not isinstance(model, str):
         return False
     model_name = model.rsplit("/", 1)[-1].lower()

--- a/lionagi/providers/openai/audio.py
+++ b/lionagi/providers/openai/audio.py
@@ -24,15 +24,8 @@ __all__ = (
 
 
 def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one attempt.
-
-    Bytes/bytearray are snapshotted once and re-wrapped in a new BytesIO per
-    attempt. A seekable stream is seeked back to its starting position before
-    each attempt. A non-seekable stream cannot be replayed safely: when a
-    retry can occur (*require_replayable*), it fails here, before any network
-    I/O, instead of silently resending an exhausted stream; on a single-shot
-    endpoint it is handed to aiohttp once, as before.
-    """
+    """Return a zero-arg callable producing a fresh file object for one retry attempt.
+    See docs/internals/runtime.md for the replay-safety invariant."""
     if file_data is None:
         return lambda: None
     if isinstance(file_data, (bytes, bytearray)):
@@ -48,10 +41,8 @@ def _replayable_file_factory(file_data, field_name: str, *, require_replayable: 
                 "max_retries=1 for a non-seekable stream."
             )
         return lambda: file_data
-    # Snapshot the stream once and restore its position. Handing the live
-    # stream to each attempt is not enough: an explicit RetryConfig retries by
-    # re-invoking _call, which would rebuild this factory with the consumed
-    # stream already at EOF and silently upload an empty file.
+    # Snapshot once, restore position — a live stream handed to each attempt would
+    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
     start_pos = file_data.tell()
     snapshot = file_data.read()
     file_data.seek(start_pos)
@@ -139,10 +130,8 @@ class OpenaiAudioTranscriptionEndpoint(Endpoint):
                 )
             return {"data": form}
 
-        # Residual kwargs split two ways: keys create_payload kept in the body
-        # are API fields (never transport options); everything else is a
-        # transport kwarg (proxy, ssl, timeout, ...) that the base endpoints
-        # honor and this one must too.
+        # API fields stay in the multipart body; only transport kwargs
+        # (proxy, ssl, timeout, ...) are forwarded to the HTTP layer.
         transport_kwargs = {k: v for k, v in kwargs.items() if k not in payload}
         return await self._call_aiohttp(
             payload=payload,

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -377,9 +377,8 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
     if CODEX_CLI is None:
         raise RuntimeError("Codex CLI not found. Install with: npm i -g @openai/codex")
     cmd = [CODEX_CLI, *request.as_cmd_args()]
-    # Do NOT pass cwd here: Codex CLI already receives the workspace via the
-    # '-C <repo>' argument emitted by as_cmd_args().  Setting cwd= would cause
-    # the CLI to resolve '-C repo' from inside 'repo', producing 'repo/repo'.
+    # Do NOT pass cwd here — Codex CLI already gets the workspace via -C <repo>;
+    # setting both double-resolves to 'repo/repo'. See docs/internals/runtime.md.
     async with contextlib.aclosing(ndjson_from_cli(cmd)) as stream:
         async for obj in stream:
             yield obj
@@ -464,9 +463,7 @@ async def stream_codex_cli(
                 )
                 session.model = obj.get("model")
                 # Codex uses "thread_id" not "session_id"; normalize into the
-                # metadata key every CLI provider's system chunk carries
-                # (mirrors claude_code.py) so run.py's engine-session-id
-                # capture works for Codex too.
+                # metadata key every CLI provider's system chunk carries.
                 sc = StreamChunk(type="system", metadata={**obj, "session_id": session.session_id})
                 session.chunks.append(sc)
                 yield sc
@@ -634,13 +631,8 @@ async def stream_codex_cli(
             elif typ in ("turn.failed", "error"):
                 session.is_error = True
                 err = obj.get("error", {})
-                # Message location varies by event type: "error" events carry
-                # a top-level "message" with no "error" key; "turn.failed"
-                # nests it under error.message. Check both.
-                # Capture the raw value before null-normalising: the
-                # benign-EOS check below must distinguish an explicit
-                # "error": null (malformed envelope, real error) from the
-                # bare {} sentinel (benign EOF) — see below.
+                # Error message location varies by event type; capture the raw
+                # value pre-normalization for the benign-EOS check below.
                 _raw_err = err
                 if err is None:
                     err = {}
@@ -657,14 +649,8 @@ async def stream_codex_cli(
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )
-                # Some codex CLI versions emit {"type": "error", "error": {}}
-                # when a resumed session ends normally (benign EOS, not a real
-                # failure) — tag it so run() treats it as clean EOS rather
-                # than RunFailed. All must hold: type == "error" ("turn.failed"
-                # is never benign); the RAW payload is exactly {} (a
-                # structured-but-empty payload or explicit null is a real,
-                # if sparse, failure — test _raw_err, pre null-normalisation);
-                # no other failure keys (code/message/status) present.
+                # Benign-EOS sentinel on resumed sessions — see docs/internals/runtime.md
+                # for the exact 3-condition classification.
                 _is_benign_eos = (
                     typ == "error"
                     and "error" in obj  # a bare {"type": "error"} is malformed, not EOF

--- a/lionagi/providers/openai/images.py
+++ b/lionagi/providers/openai/images.py
@@ -99,15 +99,8 @@ __all__ = (
 
 
 def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one attempt.
-
-    Bytes/bytearray are snapshotted once and re-wrapped in a new BytesIO per
-    attempt. A seekable stream is seeked back to its starting position before
-    each attempt. A non-seekable stream cannot be replayed safely: when a
-    retry can occur (*require_replayable*), it fails here, before any network
-    I/O, instead of silently resending an exhausted stream; on a single-shot
-    endpoint it is handed to aiohttp once, as before.
-    """
+    """Return a zero-arg callable producing a fresh file object for one retry attempt.
+    See docs/internals/runtime.md for the replay-safety invariant."""
     if file_data is None:
         return lambda: None
     if isinstance(file_data, (bytes, bytearray)):
@@ -123,10 +116,8 @@ def _replayable_file_factory(file_data, field_name: str, *, require_replayable: 
                 "max_retries=1 for a non-seekable stream."
             )
         return lambda: file_data
-    # Snapshot the stream once and restore its position. Handing the live
-    # stream to each attempt is not enough: an explicit RetryConfig retries by
-    # re-invoking _call, which would rebuild this factory with the consumed
-    # stream already at EOF and silently upload an empty file.
+    # Snapshot once, restore position — a live stream handed to each attempt would
+    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
     start_pos = file_data.tell()
     snapshot = file_data.read()
     file_data.seek(start_pos)

--- a/lionagi/providers/pi/cli.py
+++ b/lionagi/providers/pi/cli.py
@@ -60,11 +60,8 @@ PiThinkingLevel = Literal[
 
 __all__ = ("PiChunk", "PiCodeRequest", "PiSession", "stream_pi_cli", "PiCLIEndpoint")
 
-# Model prefix → pi --provider. Only unambiguous prefixes (model name
-# uniquely identifies the provider); ambiguous names (llama, gemma,
-# mistral — available on multiple providers) are omitted, so set provider
-# explicitly or let pi resolve. strip=True removes the prefix from the
-# model (needed for openrouter/ routing).
+# Model prefix → pi --provider. Only unambiguous prefixes; ambiguous names
+# (llama, gemma, mistral) are omitted — set provider explicitly, or let pi resolve.
 _PI_MODEL_PROVIDER_MAP: list[tuple[str, str, bool]] = [
     ("openrouter/", "openrouter", True),
     ("deepseek-", "deepseek", False),
@@ -244,9 +241,8 @@ class PiCodeRequest(BaseModel):
         for f in self.file_args:
             args.append(f"@{f}" if not f.startswith("@") else f)
 
-        # Pi's arg parser has no -- terminator support; prompt is
-        # positional. Prompts starting with - or @ may be misparsed
-        # by Pi's CLI — callers should avoid leading dashes in prompts.
+        # Pi's arg parser has no -- terminator; prompt is positional and may be
+        # misparsed if it starts with - or @ — callers should avoid leading dashes.
         args.append(self.prompt)
 
         return args
@@ -550,9 +546,8 @@ async def stream_pi_cli(
                 yield chunk
 
             elif typ == "done":
-                # Top-level done: may carry final message with model/usage.
-                # Both AgentEvent.done (end-of-stream) and a top-level
-                # AssistantMessageEvent.done use this type.
+                # Top-level done: may carry final message with model/usage. Both
+                # AgentEvent.done and a top-level AssistantMessageEvent.done use this type.
                 _remember_assistant_message(session, obj.get("message"))
                 break
 
@@ -603,11 +598,8 @@ class PiCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
     _handler_params = _PI_HANDLER_PARAMS
     _handler_kwarg = "pi_handlers"
     _request_model = PiCodeRequest
-    # streams_first_output_early stays False (AgenticEndpoint default): the
-    # transport emits "agent_start" right after spawn, but stream() below
-    # discards raw dict events and yields its first StreamChunk only once a
-    # PiChunk carries text/thinking/tool payload — so the first output the
-    # caller can observe may lag spawn by the model's full think time.
+    # streams_first_output_early stays False: stream() discards raw events and only
+    # yields once a PiChunk carries content, so first output may lag spawn by full think time.
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
         handlers = kwargs.pop("pi_handlers", None)

--- a/lionagi/service/connections/agentic_endpoint.py
+++ b/lionagi/service/connections/agentic_endpoint.py
@@ -14,12 +14,8 @@ class AgenticEndpoint(Endpoint):
 
     is_cli: ClassVar[bool] = True
 
-    # True when the transport yields its first StreamChunk shortly after the
-    # subprocess spawns (e.g. an ndjson "system"/"init" event), so a stalled
-    # first chunk reliably signals a dead worker. False for transports that
-    # buffer all output until the run completes, where a slow-but-healthy
-    # call looks identical to a dead one until the whole result arrives —
-    # gates run.py's default liveness watchdog (LIONAGI_WORKER_LIVENESS_TIMEOUT).
+    # Early-first-chunk transports gate run.py's liveness watchdog (LIONAGI_WORKER_LIVENESS_TIMEOUT).
+    # See docs/internals/runtime.md.
     streams_first_output_early: ClassVar[bool] = False
 
     DEFAULT_CONCURRENCY_LIMIT: ClassVar[int] = 3

--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -19,11 +19,8 @@ from .header_factory import HeaderFactory
 
 
 class _NonRetryableClientError(Exception):
-    """Sentinel: 4xx (non-429) client error that must not be retried.
-
-    Wraps the original aiohttp.ClientResponseError so callers can inspect it
-    via the __cause__ chain while the retry engine sees an excluded type.
-    """
+    """Sentinel: 4xx (non-429) error that must not be retried. Wraps the original
+    via __cause__ so callers can inspect it while the retry engine sees an excluded type."""
 
     def __init__(self, original: Exception):
         super().__init__(str(original))
@@ -190,10 +187,8 @@ class Endpoint:
         if self.retry_config:
 
             async def call_func(p, h, **kw):
-                # The 4xx sentinel must stay excluded until this outer retry
-                # layer has decided not to retry — unwrapping earlier would let
-                # a retry_exceptions=(aiohttp.ClientError,) config replay
-                # 400/401/403 responses the transport contract keeps single-shot.
+                # 4xx sentinel stays excluded until this retry layer gives up, else a
+                # broad retry_exceptions config could replay a single-shot 4xx response.
                 retry_kwargs = self.retry_config.as_kwargs()
                 retry_kwargs["exclude_exceptions"] = (
                     *retry_kwargs.get("exclude_exceptions", ()),
@@ -241,12 +236,8 @@ class Endpoint:
 
     def _can_retry(self) -> bool:
         """Whether more than one request attempt can occur for this endpoint.
-
-        True when an explicit RetryConfig wraps the call, or when the native
-        path's total-attempt cap allows a second attempt. Single-shot
-        endpoints (max_retries<=1, no RetryConfig) never replay a body, so
-        callers may hand over non-replayable inputs like one-shot streams.
-        """
+        Single-shot endpoints (max_retries<=1, no RetryConfig) never replay a body —
+        see docs/internals/runtime.md."""
         if self.retry_config:
             return self.retry_config.max_retries > 0
         return self.config.max_retries > 1
@@ -268,9 +259,8 @@ class Endpoint:
         build_body = request_body_factory or (lambda: {"json": payload})
 
         async def _make_request():
-            # The body is rebuilt inside the per-attempt function, not before retry
-            # orchestration, because FormData/BytesIO/file streams can be consumed by
-            # the first POST and must not be silently replayed by a later attempt.
+            # Body rebuilt per-attempt, not before retry orchestration: FormData/BytesIO/
+            # file streams get consumed by the first POST and must not be silently replayed.
             body_kwargs = build_body()
             collision = set(body_kwargs) & set(request_kwargs)
             if collision:
@@ -321,17 +311,13 @@ class Endpoint:
                     if response is not None and not response.closed:
                         response.release()
 
-        # When retry_config is set, the outer call() wraps _call in retry_with_backoff
-        # and owns both the sentinel exclusion and the unwrap; run the raw request and
-        # let the sentinel propagate to that layer.
+        # When retry_config is set, call() already wraps this in retry_with_backoff and
+        # owns the sentinel unwrap — just run the raw request and let it propagate.
         if self.retry_config:
             return await _make_request()
 
-        # No RetryConfig: use the native retry path with aiohttp transport errors.
-        # _NonRetryableClientError is in exclude_exceptions so 4xx non-429 gives up immediately.
-        # Re-raise the wrapped original so callers see aiohttp.ClientResponseError.
-        # config.max_retries is a total-attempt cap (it was backoff's max_tries); retry_with_backoff
-        # runs max_retries+1 attempts, so subtract one to preserve the same total attempt count.
+        # No RetryConfig: native path excludes the 4xx sentinel so it gives up immediately.
+        # max_retries is a total-attempt cap; retry_with_backoff runs +1 attempts, so subtract one.
         try:
             return await retry_with_backoff(
                 _make_request,

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -21,10 +21,8 @@ from .header_factory import AUTH_TYPES
 
 logger = logging.getLogger(__name__)
 
-# Keyed on true class identity: dict lookup by class object would go through
-# __eq__/__hash__, which a custom metaclass may override, so the index is
-# id(cls) and each entry retains the class itself — the strong reference keeps
-# the id stable, and an entry is served only when the stored class IS cls.
+# Keyed on id(cls), not the class object, to bypass metaclass __eq__/__hash__ overrides —
+# see docs/internals/runtime.md.
 _FIELD_KEYS_BY_CLASS: dict[int, tuple[type, frozenset[str]]] = {}
 
 
@@ -60,10 +58,8 @@ class EndpointConfig(BaseModel):
     @model_validator(mode="before")
     def _validate_kwargs(cls, data: dict):
         kwargs = data.pop("kwargs", {})
-        # Accepted keys are the validation-schema property names (aliases when
-        # a field declares one), computed once per class: subclasses may add
-        # fields or aliases, and rebuilding the JSON schema on every
-        # construction costs more than the rest of model validation combined.
+        # Field keys (aliases included) are cached per class — rebuilding the JSON
+        # schema on every construction costs more than the rest of validation combined.
         entry = _FIELD_KEYS_BY_CLASS.get(id(cls))
         if entry is not None and entry[0] is cls:
             field_keys = entry[1]

--- a/lionagi/service/connections/match_endpoint.py
+++ b/lionagi/service/connections/match_endpoint.py
@@ -12,9 +12,5 @@ def match_endpoint(
     endpoint: str,
     **kwargs,
 ) -> Endpoint:
-    """Match a provider + endpoint to an Endpoint class.
-
-    Delegates to EndpointRegistry which uses @register_endpoint
-    decorators for auto-discovery.
-    """
+    """Match a provider + endpoint to an Endpoint class via EndpointRegistry."""
     return EndpointRegistry.match(provider, endpoint, **kwargs)

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -71,12 +71,8 @@ class MCPSecurityConfig:
 
 
 # --- Generic-executor admission rule -----------------------------------
-#
-# Registration-time admission control for MCP tool descriptors. This is
-# independent of MCPSecurityConfig (transport authorization) and of
-# PermissionPolicy (invocation-time, keyed by tool name): it rejects a
-# caller-shaped generic command/process/script executor before it ever
-# reaches the tool registry, regardless of transport settings.
+# Registration-time admission control, independent of MCPSecurityConfig
+# (transport auth) and PermissionPolicy (invocation-time) — see docs/internals/runtime.md.
 
 AdmissionReason: TypeAlias = Literal[
     "unbounded-command-input",
@@ -233,10 +229,8 @@ _IDENTIFIER_LIKE_KEY_PATTERN = re.compile(
     r"^(?:[a-z0-9]+_)*(?:id|ids|path|paths|uri|url|uuid|slug)$"
 )
 
-# Tokens that make an otherwise identifier-shaped key (`*_path`, `*_id`, ...)
-# still executor-shaped: an `executable_path`/`script_path`/`command_path` is
-# a caller-controlled executor target, not a benign resource locator, even
-# though it lexically matches the identifier-like suffix pattern.
+# Tokens that taint an identifier-shaped key back to executor-shaped (e.g.
+# `executable_path`) — see docs/internals/runtime.md.
 _EXEC_TAINTED_KEY_TOKENS = frozenset(
     {"command", "cmd", "shell", "script", "program", "binary", "executable", "argv", "args"}
 )
@@ -244,27 +238,20 @@ _EXEC_TAINTED_KEY_TOKENS = frozenset(
 
 def _is_identifier_like_key(norm_key: str) -> bool:
     """True for dynamic-but-benign resource identifiers (`service_id`,
-    `resource_path`, `request_id`, ...). These are excluded from the
-    strong-name "must be affirmatively bounded" fallback: a fixed-operation
-    tool with a free-form identifier field is not executor-shaped, even
-    though the identifier itself is an unbounded string."""
+    `resource_path`, ...) — excluded from the strong-name bounding fallback.
+    See docs/internals/runtime.md."""
     return bool(_IDENTIFIER_LIKE_KEY_PATTERN.match(norm_key))
 
 
 def _is_exec_tainted_key(norm_key: str) -> bool:
     """True when a key's own tokens name an executor channel (`executable_path`,
-    `script_path`, `command_path`, `binary_path`, `program_path`, ...), even
-    though the key otherwise lexically matches the identifier-like suffix
-    exemption. Such a key must NOT be exempted from the strong-name fallback:
-    an arbitrary executable/script/command target is itself executor input."""
+    `script_path`, ...), overriding the identifier-suffix exemption.
+    See docs/internals/runtime.md."""
     return any(token in _EXEC_TAINTED_KEY_TOKENS for token in norm_key.split("_"))
 
 
-# Non-object JSON Schema types whose instances are not intrinsically
-# finite: a root `type` UNION that includes one of these (without a
-# top-level `enum`/`const` collapsing the whole instance to a fixed set) has
-# a branch that can carry an arbitrary value, bypassing every object-shaped
-# constraint (`properties`, `additionalProperties`, ...) entirely.
+# Non-object types whose instances aren't intrinsically finite; a type union
+# including one bypasses all object-shaped constraints. See docs/internals/runtime.md.
 _UNBOUNDED_NON_OBJECT_TYPES = frozenset({"string", "number", "integer", "array"})
 
 
@@ -274,45 +261,23 @@ def _type_union_has_free_form_alternative(top_type: list, schema: Mapping) -> bo
     return any(t in _UNBOUNDED_NON_OBJECT_TYPES for t in top_type)
 
 
-# Keywords on a node carrying a `$ref` that are annotation-only and never
-# themselves constrain the instance -- present alongside `$ref`, they add no
-# sibling obligation the sufficiency check needs to evaluate.
+# Keywords that are annotation-only when siblings of $ref — add no sibling
+# obligation. See docs/internals/runtime.md.
 _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS = frozenset(
     {"description", "title", "$comment", "examples", "default", "$defs", "definitions"}
 )
 
 
 def _has_structural_ref_siblings(siblings: Mapping) -> bool:
-    """True when a `$ref` node's sibling keywords (the node minus `$ref`
-    itself) include anything beyond pure annotation -- i.e. something that,
-    per Draft 2020-12, constrains the same instance as the reference target
-    and must be evaluated in its own right rather than discarded."""
+    """True when a $ref node's siblings include anything beyond pure
+    annotation — i.e., per Draft 2020-12, something that constrains the same
+    instance and must be evaluated. See docs/internals/runtime.md."""
     return any(key not in _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS for key in siblings)
 
 
 # --- Keyword registry for the sufficiency proof --------------------------
-#
-# The sufficiency proof answers exactly one question: "is this schema
-# document provably closed against an undeclared value?" An earlier
-# iteration answered it with a per-property "is this value a key channel"
-# discriminator deciding WHICH POSITIONS deserve full scrutiny -- the same
-# defect class as enumerating "which keywords are dangerous", just re-
-# entered through the traversal axis instead of the keyword axis: that
-# discriminator omitted the conditional applicators (`if`/`then`/`else`/
-# `not`) and the array applicators (`items`/`prefixItems`), so a property
-# value carrying one of them was never visited at all, and the allowlist
-# check that would have denied it never ran there.
-#
-# The fix: classify EVERY JSON Schema Draft 2020-12 keyword into EXACTLY ONE
-# of four classes (below), then walk the ENTIRE document -- every property
-# value, every composition branch, every `$ref` target, every `$defs` entry
-# -- UNCONDITIONALLY, checking each node's OWN keywords against this
-# registry (`_structural_coverage_insufficient`, defined further below).
-# There is no longer a discriminator deciding "should this node be
-# visited"; every schema-bearing position is visited, and the registry
-# alone decides what its keywords mean. A keyword not in the registry is
-# UNKNOWN and fails closed unless its value provably cannot carry a
-# subschema.
+# Classifies every Draft 2020-12 keyword into one of four classes, then
+# walks the whole document unconditionally. See docs/internals/runtime.md.
 
 # Annotation-only: carry no assertion that admits/denies an instance value.
 _INERT_ANNOTATION_KEYWORDS = frozenset(
@@ -332,15 +297,8 @@ _INERT_ANNOTATION_KEYWORDS = frozenset(
         "format",
         "contentEncoding",
         "contentMediaType",
-        # `contentSchema` KEEPS its own individually-argued caveat: its
-        # value is a mapping (schema-shaped), describing the DECODED
-        # content of a string instance, like `contentEncoding`/
-        # `contentMediaType` in the Draft 2020-12 Content vocabulary -- it
-        # asserts nothing about the instance itself. This holds ONLY while
-        # the content-assertion vocabulary stays disabled (the default
-        # dialect this module validates against); enabling that vocabulary
-        # in a future dialect configuration would require `contentSchema`
-        # to leave this class.
+        # `contentSchema`'s inertness holds ONLY while the content-assertion
+        # vocabulary is disabled (the default dialect). See docs/internals/runtime.md.
         "contentSchema",
     }
 )
@@ -385,13 +343,9 @@ _MODELED_APPLICATOR_KEYWORDS = frozenset(
     }
 )
 
-# Applicators recognized BY NAME but not modeled: presence anywhere in the
-# document denies the node outright, and the proof never recurses beneath
-# one (an ancestor denial already covers everything nested inside it).
-# Promoting one of these to modeled is a separate, individually-argued
-# change with its own oracle-soundness argument -- never a silent
-# reclassification. (If `items`/`prefixItems` for bounded arrays is ever
-# wanted, that is such a delta -- NOT this change.)
+# Applicators recognized by name but not modeled — presence anywhere denies
+# the node outright; promoting one requires its own soundness argument.
+# See docs/internals/runtime.md.
 _DENIED_APPLICATOR_KEYWORDS = frozenset(
     {
         "patternProperties",
@@ -418,9 +372,7 @@ _KeywordClass: TypeAlias = Literal["inert", "bounding", "modeled", "denied", "un
 
 def _classify_keyword(name: str) -> _KeywordClass:
     """Classify a JSON Schema keyword into exactly one of the four registry
-    classes above. A name in none of them is UNKNOWN -- the registry is a
-    closed enumeration, not a spelling heuristic, so a keyword this module
-    has never seen fails closed rather than being guessed at."""
+    classes; unrecognized names fail closed as UNKNOWN. See docs/internals/runtime.md."""
     if name in _INERT_ANNOTATION_KEYWORDS:
         return "inert"
     if name in _BOUNDING_KEYWORDS:
@@ -434,21 +386,8 @@ def _classify_keyword(name: str) -> _KeywordClass:
 
 def _property_value_may_be_object_shaped(value: object) -> bool:
     """True when a declared property's VALUE could itself resolve to an
-    OBJECT instance -- i.e. the object-boundedness proof's type-gate and
-    closedness reasoning must be re-run on it, rather than left to the
-    walker's key-name policy. Deliberately narrow: it only ever answers
-    "does closedness apply here", never "is a keyword modeled" -- that
-    second question is answered totally and unconditionally, for every
-    keyword at every position, by `_structural_coverage_insufficient`
-    below regardless of whether THIS gate recurses. So an omission here
-    (a value reachable only through a DENIED applicator such as `if`/
-    `then`/`items`) is harmless: the denied applicator's mere presence
-    already makes the whole document insufficient before object-
-    boundedness ever needs to look inside it. A scalar-typed, array-typed,
-    annotation-only, or bare free-form string property value returns
-    False here on purpose -- it is a VALUE, not an object-boundedness
-    position, and remains the walker's territory by key name
-    (`service_id: {"type": "string"}` stays admitted)."""
+    OBJECT instance, requiring the boundedness proof to recurse into it.
+    Deliberately narrow — see docs/internals/runtime.md."""
     if not isinstance(value, Mapping):
         return False
     value_type = value.get("type")
@@ -458,12 +397,9 @@ def _property_value_may_be_object_shaped(value: object) -> bool:
 
 
 def _schema_is_insufficient(input_schema: object) -> bool:
-    """Top-level sufficiency gate: insufficient (fail closed) if EITHER the
-    object-boundedness proof fails (root not provably closed to a finite
-    object shape) OR the structural-coverage proof finds a denied/unknown
-    keyword anywhere in the document. See the two functions below -- they
-    are deliberately independent, run over the same document, and combined
-    by OR."""
+    """Top-level sufficiency gate: insufficient if EITHER the
+    object-boundedness proof OR the structural-coverage proof fails,
+    combined by OR. See docs/internals/runtime.md."""
     if input_schema is None or not isinstance(input_schema, Mapping):
         return True
     if _object_boundedness_insufficient(input_schema, input_schema, frozenset(), 0, [0]):
@@ -478,63 +414,21 @@ def _object_boundedness_insufficient(
     depth: int,
     budget: list[int],
 ) -> bool:
-    """Recursive, union-aware TYPE-GATE + CLOSEDNESS check -- orthogonal to
-    `_structural_coverage_insufficient` below, and unaware of the keyword
-    registry: it never denies on keyword identity, only on whether the
-    instance is provably constrained to a closed, finite object shape.
-
-    Order of checks (binding; applicator delegation MUST run before the
-    omitted-type denial, or an applicator-root node that legitimately omits
-    a top-level `type` because `type` lives in its resolved target/branches
-    would false-deny):
-
-    1. Budget/depth cap -- fail closed.
-    2. `type` present and excludes `"object"` -- insufficient.
-    3. `type` is a union with a free-form (non-object) alternative and no
-       `const`/`enum` pinning the instance -- insufficient.
-    4. APPLICATOR DELEGATION -- `$ref` (resolve local `#/...` only, and
-       intersect structural siblings); then `oneOf`/`anyOf` (UNION: every
-       reachable branch must independently prove sufficient); then `allOf`
-       (INTERSECTION: one provably-bounded branch suffices). Each recurses,
-       re-applying this same predicate.
-    5. A top-level `const`/`enum` pins the whole instance to author-declared
-       literal value(s) -- sufficient, regardless of `type`.
-    6. LEAF-OBJECT branch (no applicator delegated): an omitted `type`
-       (with no `const`/`enum`, already handled above) is insufficient here
-       -- a bare non-object instance never reaches object keywords at all.
-       Otherwise, non-empty `properties` is only bounded if the object is
-       actually CLOSED (`additionalProperties: False`, or itself restricted
-       to a finite `enum`/`const`); empty/absent `properties` still needs
-       `additionalProperties: False` to admit only a bare `{}`. Once the
-       OUTER object is proven closed, each DECLARED property's own VALUE
-       that could itself be object-shaped
-       (`_property_value_may_be_object_shaped`) is re-checked by this same
-       predicate, or the node is insufficient. A value that cannot be
-       object-shaped is left to the walker's key-name policy; any DENIED
-       applicator such a value might carry is caught independently and
-       unconditionally by `_structural_coverage_insufficient`, so skipping
-       it here never reopens a hole.
-
-    Returns True (fail closed / insufficient) for an external, cyclic,
-    unresolvable, or budget/depth-exhausted reference or composition."""
+    """Recursive, union-aware TYPE-GATE + CLOSEDNESS check, orthogonal to
+    `_structural_coverage_insufficient`. See docs/internals/runtime.md for
+    the full 6-step order-of-checks argument."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return True
 
     top_type = schema.get("type")
-    # `type` may be a Draft 2020-12 type array (e.g. `["object", "null"]`);
-    # such a schema is an object schema whenever "object" is one of its
-    # allowed types, and its properties must still be inspected. Only a
-    # top-level type that excludes "object" entirely makes the schema
+    # A Draft 2020-12 type array (e.g. ["object","null"]) is an object schema
+    # if "object" is among its types; only excluding "object" entirely is
     # insufficient.
     if top_type is not None and not _schema_type_includes(top_type, "object"):
         return True
-    # A type UNION that includes "object" alongside a type that can itself
-    # carry a free-form value (`string`/`number`/`integer`/`array`, absent a
-    # top-level `enum`/`const` pinning the whole instance) is only as
-    # bounded as its least-bounded alternative: an instance satisfying the
-    # non-object branch never even reaches the object-specific
-    # `properties`/`additionalProperties` keywords below.
+    # A type union including "object" plus a free-form alternative is only as
+    # bounded as its least-bounded branch — see docs/internals/runtime.md.
     if isinstance(top_type, list) and _type_union_has_free_form_alternative(top_type, schema):
         return True
 
@@ -550,12 +444,9 @@ def _object_boundedness_insufficient(
         )
         if not target_insufficient:
             return False
-        # Draft 2020-12 evaluates `$ref` SIBLINGS -- they are not discarded.
-        # A closed/bounded target does not make the overall node sufficient
-        # if a sibling keyword (evaluated against the SAME instance)
-        # reopens it. Pure annotation siblings (`description`, `title`, ...)
-        # contribute nothing and must not force an otherwise-open target's
-        # insufficiency onto an unrelated, harmless caller-facing property.
+        # Draft 2020-12 evaluates $ref SIBLINGS — a closed target doesn't
+        # make the node sufficient if a structural sibling reopens it.
+        # See docs/internals/runtime.md.
         siblings = {k: v for k, v in schema.items() if k != _REF_KEYWORD}
         if _has_structural_ref_siblings(siblings):
             return _object_boundedness_insufficient(
@@ -587,16 +478,13 @@ def _object_boundedness_insufficient(
                 return False
         return True
 
-    # A top-level `const`/`enum` pins the entire instance to author-declared
-    # literal value(s) -- the caller cannot inject beyond the enumerated
-    # set, so this alone satisfies the type-gate regardless of `type`.
+    # A top-level const/enum pins the whole instance to literal value(s),
+    # satisfying the type-gate regardless of type.
     if "const" in schema or "enum" in schema:
         return False
 
-    # LEAF-OBJECT branch: no applicator delegated above, so `type` is
-    # evaluated node-locally. An omitted `type` (no `const`/`enum`, already
-    # handled) means a bare non-object instance never reaches the
-    # `properties`/`additionalProperties` keywords below at all.
+    # LEAF-OBJECT branch: type evaluated node-locally here; see the
+    # docstring above / docs/internals/runtime.md.
     if top_type is None:
         return True
 
@@ -607,23 +495,16 @@ def _object_boundedness_insufficient(
     additional = schema.get("additionalProperties")
     if not props:
         return additional is not False
-    # A non-empty `properties` mapping only proves the schema bounded if the
-    # object is actually CLOSED: JSON Schema's `additionalProperties`
-    # defaults to permissive (implicit `true`), so a caller can always add
-    # an undeclared key -- a fixed `operation` enum/const does not stop a
-    # `command` property from riding alongside it unless
-    # `additionalProperties` is `false` (or itself restricted to a finite
-    # enum/const of values).
+    # additionalProperties defaults to permissive; a fixed "operation" enum
+    # doesn't stop a sibling "command" property riding alongside it.
+    # See docs/internals/runtime.md.
     object_closed = additional is False or (
         isinstance(additional, Mapping) and ("enum" in additional or "const" in additional)
     )
     if not object_closed:
         return True
-    # The OUTER object being closed against undeclared keys says nothing
-    # about a DECLARED property's own VALUE: a value that could itself be
-    # object-shaped is re-checked with this same predicate (full type-gate
-    # + closedness, budget/depth/`$ref`-cycle guards included), or the node
-    # is insufficient.
+    # OUTER-object closedness says nothing about a DECLARED property's own
+    # object-shaped VALUE — re-checked recursively; see docstring above.
     for prop_value in props.values():
         if _property_value_may_be_object_shaped(prop_value) and _object_boundedness_insufficient(
             prop_value, root_schema, seen_refs, depth + 1, budget
@@ -639,34 +520,8 @@ def _structural_coverage_insufficient(
     depth: int,
     budget: list[int],
 ) -> bool:
-    """Total, registry-driven traversal answering "does any schema-bearing
-    position in this document carry a keyword the sufficiency proof does
-    not model?" -- independent of `_object_boundedness_insufficient`'s
-    type-gate and closedness reasoning; this function applies NEITHER. A
-    scalar leaf `{"type": "string"}` is sufficient here on its own, which is
-    what preserves a free-form identifier-key property (`service_id`)
-    alongside a fixed operation: it carries no denied/unknown keyword, so
-    this traversal has nothing to say about it, and the object-boundedness
-    proof never recurses into it either (it is not object-shaped).
-
-    Every schema-bearing position is visited UNCONDITIONALLY -- not gated
-    by the shape of its own value: every `properties` value, the
-    `additionalProperties` schema (when Mapping-valued), every composition
-    branch (`allOf`/`anyOf`/`oneOf`), every resolved local `$ref` target,
-    and every `$defs`/`definitions` entry (visited even when unreferenced
-    from anywhere in the document -- the fail-closed choice). This closes
-    the traversal-axis gap a per-position discriminator could always
-    reopen: there is no discriminator left that could omit a position.
-
-    Totality argument: every schema-bearing position in the document is
-    reached by exactly one of three routes -- (i) it sits under a chain of
-    MODELED applicators from the root, in which case this function's own
-    recursion visits it; (ii) it sits under a DENIED applicator, in which
-    case the ancestor node already returned True the moment it saw that
-    keyword, before ever needing to look inside it; or (iii) it sits under
-    an UNKNOWN keyword, which is itself checked for subschema-shaped value
-    and denied at that node. No fourth route exists, so no schema-bearing
-    position escapes the registry."""
+    """Total, registry-driven traversal: does any position carry a keyword
+    the sufficiency proof doesn't model? See docs/internals/runtime.md."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return True
@@ -726,12 +581,8 @@ def _structural_coverage_insufficient(
         elif key in ("$defs", "definitions"):
             if not isinstance(value, Mapping):
                 return True
-            # Visited UNCONDITIONALLY, not reachability-gated: an entry
-            # never referenced by any `$ref` in the document is still
-            # covered, so a future reference (or a caller relying on
-            # tooling that resolves `$defs` by convention rather than an
-            # explicit `$ref`) cannot smuggle an unmodeled keyword through
-            # an entry this proof never bothered to look at.
+            # $defs entries visited UNCONDITIONALLY even if unreferenced —
+            # see docs/internals/runtime.md.
             for sub_schema in value.values():
                 if not isinstance(sub_schema, Mapping):
                     return True
@@ -747,12 +598,8 @@ def _property_is_bounded(prop_schema: object) -> bool:
         return False
     if "enum" in prop_schema or "const" in prop_schema:
         return True
-    # Deliberately no array carve-out here: an array's boundedness depends on
-    # BOTH its `prefixItems` members and its `items` (rest-of-array) schema
-    # together (see `_array_reaches_free_form`) -- a bounded `items` alone
-    # (e.g. `items: {"enum": [...]}`) says nothing about an unbounded
-    # `prefixItems` member sitting alongside it, so this shortcut must not
-    # short-circuit before the full array check runs.
+    # Deliberately no array carve-out: array boundedness needs BOTH
+    # prefixItems and items checked together. See docs/internals/runtime.md.
     return False
 
 
@@ -770,27 +617,9 @@ def _item_schema_reaches_free_form_string(
     seen_refs: frozenset[str],
     result: _SchemaWalkResult,
 ) -> bool:
-    """True when an array's `items`/`prefixItems` member schema may itself
-    admit an arbitrary string value -- i.e. the array is a free-form,
-    argv-shaped channel at that position.
-
-    Item schemas are always treated conservatively: unlike a keyed object
-    property (which gets the identifier-suffix exemption), an array element
-    has no name of its own, so an opaque/unsupported/unconstrained item
-    shape -- `true`, `{}` (no constraints), an untyped schema, an external
-    or cyclic `$ref`, a malformed items entry -- is presumed free-form
-    rather than benign. Local `$ref` and `allOf`/`anyOf`/`oneOf`/
-    `if`/`then`/`else`/`not` composition are resolved/recursed so an item
-    schema that only reaches a string through one layer of indirection
-    (`{"anyOf": [{"type": "string"}]}`, a `$ref` to a string schema, ...) is
-    still caught. A nested array item (`items: {type: array, items: ...}`,
-    or `prefixItems` at that position) is itself recursed into with the
-    same depth cap / `$ref`-cycle guard / node budget: an immediate
-    `type: "array"` item is NOT non-string-and-therefore-bounded on its
-    own -- it is only bounded if its OWN item schema is bounded (e.g.
-    `enum`/`const`-restricted), otherwise a caller can smuggle a free-form
-    argv-shaped channel one array level deeper (`args: [["sh", "-c", ...]]`).
-    """
+    """True when an array's items/prefixItems member schema may itself
+    admit an arbitrary string — i.e. a free-form, argv-shaped channel.
+    See docs/internals/runtime.md."""
     if item_schema is True:
         return True
     if item_schema is False:
@@ -854,20 +683,9 @@ def _array_reaches_free_form(
     seen_refs: frozenset[str],
     result: _SchemaWalkResult,
 ) -> bool:
-    """True when an array-shaped schema node (property-level or nested
-    item-level) admits a free-form element -- i.e. is an argv-shaped
-    channel.
-
-    Draft 2020-12 `prefixItems`/`items` semantics: `prefixItems` validates
-    only the array's PREFIX positions; `items` validates every position AT
-    OR AFTER that prefix (the "rest" of the array). Critically, a MISSING
-    `items` keyword defaults to `true` -- an entirely unconstrained rest --
-    so an array whose `prefixItems` are all enum/const-bounded is still a
-    free-form channel unless `items` is explicitly present and itself
-    bounded (or `false`, closing the tuple to exactly its prefix). Every
-    `prefixItems` member is checked too: a bounded `items` schema says
-    nothing about an unbounded value sitting in the fixed prefix.
-    """
+    """True when an array-shaped schema node admits a free-form element
+    (argv-shaped channel). See docs/internals/runtime.md for the
+    prefixItems/items semantics."""
     prefix_items = array_schema.get("prefixItems")
     if isinstance(prefix_items, list):
         for item in prefix_items:
@@ -883,9 +701,7 @@ def _array_reaches_free_form(
 
     items_val = array_schema.get("items")
     if items_val is False:
-        # Explicitly closed: no elements beyond `prefixItems` are permitted
-        # at all, so the array's shape is exactly its (already-checked)
-        # prefix.
+        # items: false closes the tuple to exactly its (already-checked) prefix.
         return False
 
     return _item_schema_reaches_free_form_string(
@@ -923,32 +739,11 @@ _MAX_SCHEMA_WALK_DEPTH = 12
 _MAX_SCHEMA_WALK_NODES = 5000
 
 # --- Walker keyword whitelist -------------------------------------------
-#
-# The walker is a WHITELIST, not a blacklist of applicator keywords: earlier
-# rounds each closed specific evasions (nested `properties`, `anyOf`, `$ref`,
-# `additionalProperties`, `patternProperties`; then `if`/`then`/`else`,
-# `not`, `items`, `prefixItems`) only to have the next JSON Schema keyword
-# reopen the same class of bypass. Enumerating "keywords we deny" loses that
-# arms race by construction. Instead we enumerate keywords we affirmatively
-# understand (and walk or treat as inert scalars); ANY OTHER key whose value
-# could itself carry a subschema (a `dict`, or a `list` containing a `dict`)
-# is unresolvable -- future/unsupported schema-bearing keywords (e.g.
-# `unevaluatedProperties`, `dependentSchemas`, `contains`, `propertyNames`)
-# deny by default for executor-signaling tools instead of admitting by
-# default.
+# WHITELIST not blacklist — enumerating "keywords we understand" avoids the
+# denylist arms race. See docs/internals/runtime.md.
 
-# Keywords whose value never itself carries a subschema (or, for `$defs`/
-# `definitions`, is only reachable indirectly via `$ref` resolution, which
-# `_resolve_local_ref` already handles without needing to pre-walk them).
-# `contentSchema` is included on the same footing, as a deliberate, argued
-# exception rather than a relaxation: its value IS a mapping (schema-shaped),
-# but -- like `contentEncoding`/`contentMediaType` in the Draft 2020-12
-# Content vocabulary -- it describes the DECODED content of a string
-# instance and asserts nothing about the instance the walker is classifying,
-# so it is never itself a command-channel destination worth walking into.
-# This holds ONLY while the content-assertion vocabulary stays disabled (the
-# default dialect this module validates against) -- see the matching caveat
-# on `_INERT_ANNOTATION_KEYWORDS` above.
+# Keywords whose value never carries a subschema; contentSchema included by
+# the same argued exception as above. See docs/internals/runtime.md.
 _SCALAR_ONLY_SCHEMA_KEYWORDS = frozenset(
     {
         "type",
@@ -978,15 +773,9 @@ _PATTERN_PROPERTIES_KEYWORD = "patternProperties"
 _ADDITIONAL_PROPERTIES_KEYWORD = "additionalProperties"
 _REF_KEYWORD = "$ref"
 
-# Reference-bearing keywords the walker does NOT resolve: Draft 2020-12
-# `$dynamicRef` and Draft-2019-09 `$recursiveRef` are schema-bearing exactly
-# like `$ref`, but their VALUE is a plain string (a URI fragment / dynamic
-# anchor lookup), not a Mapping -- so `_could_carry_subschema`'s value-type
-# test (Mapping, or list-of-Mapping) never flags them, and a command channel
-# reachable only behind one of these keywords would otherwise be silently
-# admitted. Recognized by KEYWORD IDENTITY, always treated as unresolvable
-# (conservative: dynamic-scope `$dynamicAnchor` resolution is not something
-# this walker can safely reproduce).
+# $dynamicRef/$recursiveRef are schema-bearing but string-valued, so the
+# Mapping-shape check misses them — recognized by keyword identity instead.
+# See docs/internals/runtime.md.
 _UNRESOLVABLE_REFERENCE_KEYWORDS = frozenset({"$dynamicRef", "$recursiveRef"})
 
 _KNOWN_SCHEMA_KEYWORDS = (
@@ -1003,11 +792,8 @@ _KNOWN_SCHEMA_KEYWORDS = (
 )
 
 
-# The standardized numeric/size-bound keywords, all scalar-valued by spec.
-# An explicit enumeration, NOT a `min*`/`max*` spelling heuristic: a prefix
-# test would exempt an arbitrary unknown vocabulary key (`minCustomThing`)
-# from the could-carry-subschema check and reopen the whitelist bypass this
-# walker exists to close.
+# Explicit enumeration, NOT a min*/max* spelling heuristic — a prefix test
+# would reopen the whitelist bypass. See docs/internals/runtime.md.
 _NUMERIC_BOUND_KEYWORDS = frozenset(
     {
         "minLength",
@@ -1033,16 +819,8 @@ def _is_known_scalar_only_keyword(key: str) -> bool:
 
 def _could_carry_subschema(value: object, budget: list[int], depth: int = 0) -> bool:
     """True when an unrecognized keyword's value is shaped like it could
-    itself hold a schema (a mapping, or a list -- at any nesting depth --
-    containing a mapping) -- the signal that makes an unknown keyword
-    unresolvable rather than inert. Recurses through nested lists (a list of
-    lists of ... of mappings) under the same depth cap as the walker,
-    instead of only inspecting one level, so a schema-bearing value cannot
-    be laundered past the whitelist by wrapping it in extra list nesting.
-    Charges every visited element against the shared node budget and fails
-    closed (treated as could-carry) when either the depth cap or the node
-    budget is exhausted, so a pathologically wide value cannot force
-    unbounded traversal work."""
+    hold a schema (mapping, or nested list containing one) — the signal
+    that makes it unresolvable. See docs/internals/runtime.md."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return True
@@ -1054,16 +832,9 @@ def _could_carry_subschema(value: object, budget: list[int], depth: int = 0) -> 
 
 
 def _is_inert_annotation_value(value: object, budget: list[int], depth: int = 0) -> bool:
-    """True when `value` cannot itself carry a subschema: recursively, a
-    scalar (string/number/bool/None), or a list/mapping built entirely from
-    such values with no JSON-Schema-vocabulary key appearing anywhere inside
-    it. A vendor annotation whose value is genuinely just descriptive
-    UI/ordering metadata (`{"widget": "select", "order": 1}`) is inert; one
-    that embeds real schema vocabulary (`x-input-schema: {"properties":
-    {...}}`) is not, regardless of the `x-`/`$comment` key it hangs off --
-    the value's SHAPE decides inertness, not the key's spelling. Charges
-    every visited element against the shared node budget and fails closed
-    (not inert) on exhaustion, mirroring `_could_carry_subschema`."""
+    """True when value cannot itself carry a subschema (recursively scalar,
+    or a list/mapping of such with no schema-vocabulary keys).
+    See docs/internals/runtime.md."""
     budget[0] += 1
     if budget[0] > _MAX_SCHEMA_WALK_NODES or depth > _MAX_SCHEMA_WALK_DEPTH:
         return False
@@ -1079,48 +850,23 @@ def _is_inert_annotation_value(value: object, budget: list[int], depth: int = 0)
 
 
 def _is_vendor_annotation_keyword(key: str, value: object, budget: list[int]) -> bool:
-    """True for a keyword that is metadata/annotation-only, never an
-    applicator or reference, AND whose value carries no schema-bearing
-    content -- exempt from the unknown-subschema-bearing check. Narrow on
-    two axes: (1) only the `x-` vendor-extension convention (the
-    OpenAPI/JSON-Schema community convention for non-standard annotations,
-    e.g. `x-ui`, `x-order`) and JSON Schema's own `$comment` (annotation-only
-    by spec) are even considered; (2) even for those keys, the VALUE must be
-    demonstrably inert (`_is_inert_annotation_value`) -- a vendor extension
-    whose value is itself schema-shaped (`x-input-schema: {"properties":
-    {"command": {"type": "string"}}}`) is exactly the kind of hidden channel
-    this walker exists to catch, so it is NOT exempted just because its key
-    starts with `x-`. NEVER exempt `$`-prefixed keywords in general -- that
-    prefix is exactly where real reference/applicator keywords live (`$ref`,
-    `$dynamicRef`, `$recursiveRef`, ...), so a blanket `$*` exemption would
-    reopen the reference-bypass class this walker closes."""
+    """True for a keyword that is annotation-only AND whose value carries no
+    schema-bearing content (x- prefix or $comment, and demonstrably inert
+    value). See docs/internals/runtime.md."""
     if key != "$comment" and not key.startswith("x-"):
         return False
     return _is_inert_annotation_value(value, budget)
 
 
 def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) -> None:
-    """Whitelist enforcement: any keyword this walker does not explicitly
-    understand, whose value is shaped like it could itself carry a subschema,
-    is unresolvable. This is what makes an unsupported or future JSON Schema
-    keyword (`unevaluatedProperties`, `dependentSchemas`, `contains`,
-    `propertyNames`, ...) deny-by-default for executor-signaling tools
-    instead of admit-by-default -- applied to every schema node the
-    classifier inspects, including property schemas that are otherwise
-    treated as leaves.
-
-    Two carve-outs on top of the base whitelist test: (1) a `$dynamicRef`/
-    `$recursiveRef` anywhere on this node makes it unresolvable outright,
-    regardless of the (string-shaped) value's container type -- see
-    `_UNRESOLVABLE_REFERENCE_KEYWORDS`; (2) a vendor-extension/annotation
-    keyword (`_is_vendor_annotation_keyword`) is exempt even when
-    Mapping-valued, since it is never an applicator."""
+    """Whitelist enforcement: any keyword this walker doesn't understand,
+    with a subschema-shaped value, is unresolvable — deny-by-default for
+    unmodeled keywords. See docs/internals/runtime.md."""
     if any(key in schema for key in _UNRESOLVABLE_REFERENCE_KEYWORDS):
         result.unresolvable = True
         return
-    # Value inspection shares the walker's node budget: work spent deciding
-    # whether an unknown/annotation value is inert counts against the same
-    # cap as schema traversal, and exhaustion fails closed via the helpers.
+    # Value inspection shares the walker's node budget — exhaustion fails
+    # closed via the helpers. See docs/internals/runtime.md.
     budget = [result.nodes_visited]
     for key, value in schema.items():
         if key in _KNOWN_SCHEMA_KEYWORDS or _is_known_scalar_only_keyword(key):
@@ -1133,9 +879,9 @@ def _mark_unknown_schema_keywords(schema: Mapping, result: _SchemaWalkResult) ->
     result.nodes_visited = max(result.nodes_visited, budget[0])
 
 
-# Object-applicator keywords: presence of any of these on a property's own
-# schema means the property IS itself a restated/composed schema, not a leaf
-# value -- classify by recursing into it instead of treating it as a scalar.
+# Object-applicator keywords — presence means the property is a
+# restated/composed schema, not a leaf value; recurse instead of treating
+# as scalar.
 _OBJECT_CONTAINER_KEYWORDS = (
     _PROPERTIES_KEYWORD,
     _PATTERN_PROPERTIES_KEYWORD,
@@ -1149,11 +895,9 @@ _OBJECT_CONTAINER_KEYWORDS = (
     "else",
     "not",
 )
-# Array-shape keywords: an array property can be BOTH a free-form leaf
-# channel in its own right (e.g. `argv: array-of-strings`, matched by
-# `_property_is_free_form`) AND hide a command channel inside an
-# object-shaped item (`items`/`prefixItems`); both must be checked, so these
-# do not short-circuit leaf classification the way object applicators do.
+# Array-shape keywords — an array can be BOTH a free-form leaf channel AND
+# hide a command channel inside an object-shaped item; both checked, no
+# short-circuit.
 _ARRAY_ITEM_KEYWORDS = (_ITEMS_KEYWORD, "prefixItems")
 
 
@@ -1181,25 +925,18 @@ class _SchemaWalkResult:
         self.non_auxiliary_free_form_keys: set[str] = set()
         self.non_identifier_free_form_keys: set[str] = set()
         self.selector_key_present = False
-        # True when a channel could not be proven bounded: an external/
-        # unresolvable `$ref`, a `$ref` cycle, a depth-cap or node-budget
-        # trip, a malformed `properties`/composition/`patternProperties`
-        # shape, or an unrecognized schema-bearing keyword. Fed into
-        # fail-closed handling for descriptor-bearing tools whose name or
-        # description signals an executor; otherwise it is just
-        # insufficient evidence.
+        # unresolvable = a channel could not be proven bounded (unresolvable
+        # $ref, cycle, budget trip, malformed shape, unrecognized keyword).
+        # See docs/internals/runtime.md.
         self.unresolvable = False
-        # Total-work budget companion to the depth cap: bounds runtime
-        # against a schema with harmless but extremely wide fan-out (e.g.
-        # tens of thousands of `anyOf` branches).
+        # nodes_visited: total-work budget companion to the depth cap,
+        # bounds runtime against extreme fan-out (e.g. huge anyOf lists).
         self.nodes_visited = 0
 
 
 def _consume_node_budget(result: _SchemaWalkResult) -> bool:
-    """Count one unit of walker work; returns False (and marks the result
-    unresolvable) once the total-node budget is exceeded, so callers can stop
-    iterating further branches/properties instead of finishing a huge fan-out
-    node by node."""
+    """Count one unit of walker work; returns False once the node budget is
+    exceeded, so callers can stop early. See docs/internals/runtime.md."""
     result.nodes_visited += 1
     if result.nodes_visited > _MAX_SCHEMA_WALK_NODES:
         result.unresolvable = True
@@ -1224,9 +961,8 @@ def _resolve_local_ref(ref: str, root_schema: Mapping) -> Mapping | None:
 def _compile_pattern_or_mark_unresolvable(
     pattern: object, result: _SchemaWalkResult
 ) -> re.Pattern | None:
-    """Compile a `patternProperties` regex key; a non-string key or an
-    invalid regex cannot be inspected and must fail closed rather than be
-    silently skipped."""
+    """Compile a patternProperties regex key; a non-string key or invalid
+    regex fails closed rather than being silently skipped."""
     if not isinstance(pattern, str):
         result.unresolvable = True
         return None
@@ -1260,13 +996,9 @@ def _composition_branch_reaches_free_form(
     seen_refs: frozenset[str],
     result: _SchemaWalkResult,
 ) -> bool:
-    """True when any composition/conditional/`$ref` branch of a keyed
-    property resolves to a free-form leaf. A property like
-    `{"anyOf": [{"type": "string"}]}` or `{"if": ..., "then": {"type":
-    "string"}}` constrains the SAME instance the key names, so the key is an
-    unbounded channel even though the leaf type is expressed indirectly --
-    without this, wrapping a plain string schema in one applicator layer
-    would strip the key association the classifier relies on."""
+    """True when any composition/conditional/$ref branch of a keyed
+    property resolves to a free-form leaf — catches indirection like
+    anyOf/if-then wrapping. See docs/internals/runtime.md."""
     if not isinstance(prop_schema, Mapping):
         return False
     if depth > _MAX_SCHEMA_WALK_DEPTH:
@@ -1316,17 +1048,13 @@ def _consider_property(
         result.selector_key_present = True
 
     if isinstance(prop_schema, Mapping):
-        # A leaf-shaped property schema is never handed to _walk_schema, so
-        # enforce the unknown-keyword whitelist here as well; redundant for
-        # container-shaped properties (which are walked) but harmless.
+        # Leaf-shaped property schemas never reach _walk_schema, so the
+        # whitelist is enforced here too (redundant-but-harmless for
+        # container properties).
         _mark_unknown_schema_keywords(prop_schema, result)
         if any(k in prop_schema for k in _OBJECT_CONTAINER_KEYWORDS):
-            # A container (e.g. a nested `options` object) is not itself a
-            # command/process/script value; walk its own reachable
-            # properties instead of classifying the container's key -- but
-            # first attribute to the key any free-form leaf reachable purely
-            # through composition/conditional branches, which constrain the
-            # key's own value.
+            # A container isn't itself a command value; walk its properties,
+            # but first attribute composed free-form leaves. See docs/internals/runtime.md.
             if _composition_branch_reaches_free_form(
                 prop_schema,
                 root_schema,
@@ -1347,10 +1075,9 @@ def _consider_property(
             )
             return
         if any(k in prop_schema for k in _ARRAY_ITEM_KEYWORDS):
-            # Walk `items`/`prefixItems` for a hidden object-shaped command
-            # channel, but still fall through to the leaf check below: the
-            # array property itself may also be a free-form channel (e.g.
-            # `argv: array-of-strings`).
+            # Walk items/prefixItems for a hidden channel, but fall through
+            # to the leaf check — the array property itself may also be
+            # free-form.
             _walk_schema(
                 prop_schema,
                 root_schema,
@@ -1405,13 +1132,8 @@ def _walk_schema(
     result: _SchemaWalkResult,
 ) -> None:
     """Bounded, cycle-safe, budgeted traversal collecting classifier
-    evidence. Recognizes `properties` (including nested objects),
-    `allOf`/`anyOf`/`oneOf`, `if`/`then`/`else`/`not`, `items`/`prefixItems`,
-    local `$ref` resolution, `patternProperties`, and `additionalProperties`
-    (both as a scalar free-form map channel and, when object-valued, as a
-    nested subschema to recurse into). Any other keyword whose value could
-    itself carry a subschema is unresolvable -- see the whitelist rationale
-    above `_KNOWN_SCHEMA_KEYWORDS`."""
+    evidence over the whitelist of recognized keywords; any other
+    subschema-shaped keyword is unresolvable. See docs/internals/runtime.md."""
     if depth > _MAX_SCHEMA_WALK_DEPTH:
         result.unresolvable = True
         return
@@ -1440,11 +1162,8 @@ def _walk_schema(
             is_executor_description,
             result,
         )
-        # Draft 2020-12 evaluates `$ref` SIBLINGS -- they are not discarded.
-        # Fall through (no early `return`) so every other keyword on THIS
-        # node (`properties`, `additionalProperties`, `allOf`/`anyOf`, ...)
-        # is still walked for a free-form channel reachable alongside the
-        # reference, instead of being silently skipped.
+        # $ref SIBLINGS are not discarded — fall through so every other
+        # keyword on this node is still walked. See docs/internals/runtime.md.
 
     for comp_key in ("allOf", "anyOf", "oneOf", "prefixItems"):
         branches = schema.get(comp_key)
@@ -1550,10 +1269,9 @@ def _walk_schema(
     additional_properties = schema.get(_ADDITIONAL_PROPERTIES_KEYWORD)
     if additional_properties is not None and additional_properties is not False:
         if isinstance(additional_properties, Mapping) and _consume_node_budget(result):
-            # An object-valued map entry schema (e.g. every value under the
-            # map is itself `{"properties": {"command": ...}}`) is a reachable
-            # subschema in its own right; walk it so a command channel hidden
-            # behind a dynamic map key is not silently admitted.
+            # additionalProperties object-valued schema is a reachable
+            # subschema — walk it so a command channel behind a dynamic map
+            # key isn't missed.
             _walk_schema(
                 additional_properties,
                 root_schema,
@@ -1566,10 +1284,8 @@ def _walk_schema(
         if _property_is_free_form(
             additional_properties, True, root_schema, depth, seen_refs, result
         ):
-            # No fixed key name is available for a free-form map channel; it
-            # only counts as executor-shaped evidence when corroborated by
-            # the tool's own name or description (the same corroboration
-            # `unbounded-script-payload` already requires of payload keys).
+            # No fixed key name for a free-form map channel — only counts
+            # as evidence when corroborated by the tool's name/description.
             if is_strong_name or is_executor_description:
                 _record_free_form_key("<additionalProperties>", result)
 
@@ -1606,9 +1322,8 @@ def _classify_generic_executor(
     )
     s_broad = bool(result.non_auxiliary_free_form_keys)
 
-    # An unbounded command-shaped field is dangerous on its own; unrelated
-    # extra properties (benign or not) do not make it safe, and no name or
-    # description corroboration is required to deny it.
+    # An unbounded command-shaped field is dangerous alone — no name/
+    # description corroboration required to deny it. See docs/internals/runtime.md.
     if has_free_form_command:
         return "unbounded-command-input"
     if s_process:
@@ -1617,11 +1332,9 @@ def _classify_generic_executor(
         return "unbounded-script-payload"
     if is_executor_description and (s_broad or result.unresolvable):
         return "executor-description-with-broad-input"
-    # A strong executor identity must be affirmatively demonstrated safe
-    # (empty/no schema, or every property bounded via enum/const, or only
-    # auxiliary/identifier-like free-form fields); an unresolvable channel
-    # or a remaining executor-shaped free-form property leaves the identity
-    # uncorroborated.
+    # A strong executor identity must be affirmatively demonstrated safe —
+    # unresolvable or executor-shaped remainder leaves it uncorroborated.
+    # See docs/internals/runtime.md.
     if is_strong_name and (
         schema_insufficient or result.unresolvable or result.non_identifier_free_form_keys
     ):
@@ -1629,14 +1342,9 @@ def _classify_generic_executor(
     return None
 
 
-# `create_mcp_tool()` wraps every MCP tool in `async def mcp_callable(**kwargs)`.
-# When a `Tool` is built without an explicit `tool_schema` (e.g. a caller
-# constructs `Tool(mcp_config={"exec": {...}})` directly rather than going
-# through server discovery), `function_to_schema()` reflects that wrapper
-# into this exact deterministic shape. It carries no information from the
-# remote server -- it is a fixed artifact of the wrapper's own signature and
-# docstring -- and must not be treated as remote descriptor metadata by the
-# admission rule.
+# create_mcp_tool() wraps every tool in async def mcp_callable(**kwargs);
+# this is that wrapper's own deterministic reflected schema, not remote
+# descriptor metadata. See docs/internals/runtime.md.
 _SYNTHETIC_MCP_WRAPPER_PARAMETERS = {
     "type": "object",
     "properties": {"kwargs": {"type": "string", "description": None}},
@@ -1650,12 +1358,8 @@ def is_synthetic_mcp_wrapper_schema(
     input_schema: object,
     description: object,
 ) -> bool:
-    """True when a prebuilt `Tool`'s schema is the auto-generated `**kwargs` wrapper.
-
-    `mcp_tool_name` is the key under which the tool was registered in
-    `Tool.mcp_config` -- the identity `create_mcp_tool()` used to name and
-    document the wrapper callable.
-    """
+    """True when a prebuilt Tool's schema is the auto-generated **kwargs
+    wrapper (see the module comment above `_SYNTHETIC_MCP_WRAPPER_PARAMETERS`)."""
     return (
         advertised_name == mcp_tool_name
         and description == f"MCP tool: {mcp_tool_name}"
@@ -1668,13 +1372,8 @@ def validate_mcp_tool_admission(
     input_schema: object | None,
     description: str | None,
 ) -> None:
-    """Raise PermissionError when an MCP descriptor exposes a generic executor.
-
-    Pure and synchronous: does not read MCPSecurityConfig, environment
-    variables, files, pool state, or acquire a client. Registration-time
-    admission control only; it does not change transport authorization or
-    invocation-time permissions.
-    """
+    """Raise PermissionError when an MCP descriptor exposes a generic
+    executor. Pure/synchronous, registration-time only — see docs/internals/runtime.md."""
     reason = _classify_generic_executor(tool_name, input_schema, description)
     if reason is None:
         return
@@ -1805,13 +1504,9 @@ class MCPConnectionPool:
 
     @classmethod
     def load_config(cls, path: str = ".mcp.json") -> list[str]:
-        """Load MCP server configurations from a .mcp.json file.
-
-        Returns the server names declared in THIS file. The pool accumulates
-        configs across loads (``_configs`` is process-global), so callers
-        that mean "the servers from the file I just loaded" must use this
-        return value rather than enumerating ``_configs``.
-        """
+        """Load MCP server configurations from a .mcp.json file; returns
+        only the server names declared in THIS file (see docs/internals/runtime.md
+        for the _configs accumulation gotcha)."""
         config_path = Path(path)
         if not config_path.exists():
             raise FileNotFoundError(f"MCP config file not found: {path}")

--- a/lionagi/service/hooks/hook_registry.py
+++ b/lionagi/service/hooks/hook_registry.py
@@ -127,11 +127,8 @@ class HookRegistry:
     async def pre_event_create(
         self, event_type: type[E], /, should_exit: bool = False, **kw
     ) -> tuple[E | Exception | None, bool, EventStatus]:
-        """Called before an event is created, to modify or validate creation params.
-
-        The hook can return an event instance, return None to use the
-        default creation path, or raise to cancel the event.
-        """
+        """Called before an event is created; may return an event instance, return None
+        for the default creation path, or raise to cancel. See docs/internals/runtime.md."""
         # Pop legacy exit alias from kw so it doesn't collide with should_exit.
         _exit_compat = kw.pop("exit", False)
         _should_exit = should_exit or bool(_exit_compat)
@@ -154,11 +151,8 @@ class HookRegistry:
     async def pre_invocation(
         self, event: E, /, should_exit: bool = False, **kw
     ) -> tuple[Any, bool, EventStatus]:
-        """Called right before a dequeued event is invoked, typically to check permissions.
-
-        Can raise to abort invocation (status: cancelled); cannot modify the
-        event instance.
-        """
+        """Called right before a dequeued event is invoked; can raise to abort
+        (status: cancelled), but cannot modify the event instance."""
         _exit_compat = kw.pop("exit", False)
         _should_exit = should_exit or bool(_exit_compat)
         kw["exit"] = _should_exit
@@ -179,10 +173,8 @@ class HookRegistry:
     async def post_invocation(
         self, event: E, /, should_exit: bool = False, **kw
     ) -> tuple[None | Exception, bool, EventStatus]:
-        """Called right after an event finishes execution.
-
-        Can raise to abort (status: aborted); cannot modify the event instance.
-        """
+        """Called right after an event finishes execution; can raise to abort
+        (status: aborted), but cannot modify the event instance."""
         _exit_compat = kw.pop("exit", False)
         _should_exit = should_exit or bool(_exit_compat)
         kw["exit"] = _should_exit
@@ -203,11 +195,8 @@ class HookRegistry:
     async def handle_streaming_chunk(
         self, chunk_type: str | type, chunk: Any, /, should_exit: bool = False, **kw
     ) -> tuple[Any, bool, EventStatus | None]:
-        """Called to consume streaming chunks, typically for logging or abortion.
-
-        Handler signature: `async def handler(chunk: Any) -> None`. Can raise
-        to mark the invocation "failed" (status: aborted).
-        """
+        """Called to consume streaming chunks; handler signature `async def handler(chunk) -> None`,
+        can raise to mark the invocation "failed" (status: aborted)."""
         _exit_compat = kw.pop("exit", False)
         _should_exit = should_exit or bool(_exit_compat)
         kw["exit"] = _should_exit
@@ -235,11 +224,8 @@ class HookRegistry:
         should_exit: bool = False,
         **kw,
     ):
-        """Call a hook or stream handler; `hook_type` wins if both are given.
-
-        Legacy ``exit`` keyword accepted in ``**kw`` for backward
-        compatibility, normalized to ``should_exit`` before dispatch.
-        """
+        """Call a hook or stream handler; `hook_type` wins if both are given. Legacy
+        ``exit`` keyword in ``**kw`` is normalized to ``should_exit`` before dispatch."""
         if hook_type is None and chunk_type is None:
             raise ValueError("Either method or chunk_type must be provided")
         if hook_type:

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -260,9 +260,8 @@ class iModel:  # noqa: N801
                 except Exception as e:
                     raise ValueError(f"Failed to stream API call: {e}") from e
                 finally:
-                    # Pop without yielding — yield-in-finally swallows
-                    # CancelledError during generator cleanup, breaking
-                    # anyio.fail_after timeout enforcement.
+                    # Pop without yielding — yield-in-finally would swallow CancelledError
+                    # during generator cleanup, breaking anyio.fail_after timeout enforcement.
                     self.executor.pile.pop(api_call.id, None)
         else:
             try:
@@ -335,18 +334,8 @@ class iModel:  # noqa: N801
         await self.executor.stop()
 
     def copy(self, share_session: bool = False, share_executor: bool = False) -> iModel:
-        """Create a new iModel with the same config but a fresh ID.
-
-        ``share_session=True`` carries the CLI provider's session_id onto the
-        copy (cross-turn continuation is preserved). ``share_executor=True``
-        reuses this SAME ``RateLimitedAPIExecutor`` instance instead of
-        building a fresh one, so a caller-supplied executor's rate limits and
-        queue capacity stay shared between the original and the copy. Default
-        (False) gives the copy its own independent executor — what
-        ``Branch.clone()`` wants for CLI providers, where each cloned branch
-        should get its own session and queue rather than contending on the
-        parent's.
-        """
+        """Create a new iModel with the same config but a fresh ID. See
+        docs/internals/runtime.md for what state is/isn't shared with the copy."""
         endpoint_cls = type(self.endpoint)
         new_endpoint = endpoint_cls(
             config=self.endpoint.config.model_copy(deep=True),

--- a/lionagi/service/manager.py
+++ b/lionagi/service/manager.py
@@ -39,13 +39,7 @@ class iModelManager(Manager):  # noqa: N801 — mirrors iModel naming
 
     async def shutdown(self, *, per_model_timeout: float = 10.0) -> None:
         """Close every registered iModel concurrently, with a per-model timeout.
-
-        Without this, each iModel's background replenisher task stays
-        scheduled and prevents ``anyio.run``/``asyncio.run`` from
-        returning. Idempotent; per-model failures (including
-        ``CancelledError``) are logged and swallowed so one broken
-        endpoint can't block the rest.
-        """
+        Idempotent; per-model failures are logged and swallowed. See docs/internals/runtime.md."""
         import asyncio
         import logging
 

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -40,22 +40,13 @@ EFFORT_LEVELS = frozenset(
 
 
 def normalize_effort(effort: str | None) -> str | None:
-    """Case-fold a raw effort string to lionagi's lowercase vocabulary.
-
-    Clamp tables below are keyed on lowercase levels and silently misclamp
-    (no raise) on an un-normalized value like "High" — call this once at
-    each boundary where a raw effort string enters lionagi (CLI flag,
-    profile frontmatter, orchestration spec).
-    """
+    """Case-fold a raw effort string to lionagi's lowercase vocabulary. Call once at
+    each entry boundary — clamp tables silently misclamp un-normalized values. See docs/internals/runtime.md."""
     return effort.lower() if isinstance(effort, str) else effort
 
 
-# Codex reasoning-effort support is model-dependent (source: the codex CLI's
-# live model list): gpt-5.6-sol and gpt-5.6-terra accept max and ultra,
-# gpt-5.6-luna accepts max, and every earlier model tops out at xhigh. Clamp
-# a requested tier down to the target model's ceiling; unrecognized (future)
-# models pass through so a genuinely supported new tier is never silently
-# degraded.
+# Codex reasoning-effort ceilings are model-dependent (source: codex CLI's live model
+# list); unrecognized (future) models pass through unclamped. See docs/internals/runtime.md.
 _CODEX_ULTRA_MODELS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra"})
 _CODEX_MAX_ONLY_MODELS = frozenset({"gpt-5.6-luna"})
 _CODEX_XHIGH_CEILING_MODELS = frozenset(
@@ -92,10 +83,8 @@ def _clamp_claude_effort(effort: str, model: str) -> str:
     return "high"
 
 
-# agy (Antigravity CLI) has no effort flag or kwarg — effort is expressed only
-# as a Low/Medium/High suffix baked into the --model name, and Gemini 3.1 Pro
-# has no Medium tier. lionagi's none|minimal|low|medium|high|xhigh|max|ultra
-# vocabulary collapses onto this 3-tier scale.
+# agy has no effort kwarg — effort is baked into the --model name as Low/Medium/High,
+# and Gemini 3.1 Pro has no Medium tier. See docs/internals/runtime.md.
 _GEMINI_EFFORT_CLAMP: dict[str, str] = {
     "none": "Low",
     "minimal": "Low",
@@ -140,9 +129,8 @@ PROVIDER_EFFORT_KWARG: dict[str, str] = {
     "pi": "thinking",
 }
 
-# agy-backed aliases (see lionagi/providers/google/gemini_code.py) fold effort
-# into the resolved --model name via resolve_agy_model instead of a kwarg —
-# classified separately from PROVIDER_EFFORT_KWARG below.
+# agy-backed aliases fold effort into the resolved --model name via resolve_agy_model
+# instead of a kwarg — classified separately from PROVIDER_EFFORT_KWARG below.
 PROVIDERS_EFFORT_VIA_MODEL_NAME: frozenset[str] = frozenset(
     {
         "gemini_code",
@@ -152,9 +140,8 @@ PROVIDERS_EFFORT_VIA_MODEL_NAME: frozenset[str] = frozenset(
     }
 )
 
-# Bare "gemini" is the direct Google API provider (see
-# providers/google/_config.py:GeminiChatConfigs) — distinct from the agy CLI
-# above — and has no effort concept at all.
+# Bare "gemini" is the direct Google API provider, distinct from the agy CLI
+# above, and has no effort concept at all.
 PROVIDERS_NO_EFFORT: frozenset[str] = frozenset(
     {
         "gemini",

--- a/lionagi/service/rate_limited_processor.py
+++ b/lionagi/service/rate_limited_processor.py
@@ -46,12 +46,8 @@ class RateLimitedAPIProcessor(Processor):
         self._lock = Lock()
 
     async def start_replenishing(self):
-        """Start replenishing rate limit capacities at regular intervals.
-
-        The cancellation handler wraps ``await self.start()`` too, so a
-        cancel arriving before the main loop is reached is still caught
-        inside the task instead of surfacing as an uncaught error on stop().
-        """
+        """Start replenishing rate limit capacities at regular intervals. See
+        docs/internals/runtime.md for the cancellation-handling rationale."""
         try:
             await self.start()
             while not self.is_stopped():
@@ -64,12 +60,8 @@ class RateLimitedAPIProcessor(Processor):
                     if self.limit_tokens is not None:
                         self._available_tokens = self.limit_tokens
 
-                # Re-drive deferred work. process() re-enqueues rate-limited
-                # events (instead of dropping them); without re-driving here,
-                # nothing would retry them after the budget replenishes —
-                # forward() is one-shot — and they would sit PENDING until the
-                # caller's invoke() safety timeout. Draining on each refresh is
-                # what makes the deferral actually complete.
+                # Re-drive deferred work — forward() is one-shot, so without this drain
+                # rate-limited events would sit PENDING until invoke()'s safety timeout.
                 if not self.queue.empty():
                     await self.process()
 
@@ -80,12 +72,8 @@ class RateLimitedAPIProcessor(Processor):
 
     @override
     async def stop(self) -> None:
-        """Stop the replenishment task.
-
-        Python 3.11+ re-raises ``CancelledError`` on ``await task`` after
-        ``task.cancel()`` even though the task body suppressed it; swallow it
-        here so callers iterating multiple iModels don't abort on the first close.
-        """
+        """Stop the replenishment task; swallows the Python 3.11+ re-raised
+        ``CancelledError`` so callers closing multiple iModels don't abort early."""
         if self._rate_limit_replenisher_task:
             self._rate_limit_replenisher_task.cancel()
             try:
@@ -146,12 +134,8 @@ class RateLimitedAPIProcessor(Processor):
 
     @override
     async def handle_denied(self, event: Any) -> bool:
-        """Rate-limit denial is a DEFERRAL, not a rejection.
-
-        Returns ``False`` so the base ``process()`` re-enqueues the event
-        (stays ``PENDING``) for retry once the limit replenishes, instead of
-        terminalizing it like a permission rejection would.
-        """
+        """Rate-limit denial is a DEFERRAL, not a rejection: returns ``False`` so
+        ``process()`` re-enqueues the event (stays ``PENDING``) instead of terminalizing it."""
         return False
 
 

--- a/lionagi/service/resilience.py
+++ b/lionagi/service/resilience.py
@@ -270,10 +270,8 @@ async def retry_with_backoff(
         return await func(*args, **kwargs)
 
     if exclude_exceptions:
-        # Runtime dispatch: exclude_exceptions must be checked per-instance,
-        # not per-type, to correctly handle subclass hierarchies (e.g.
-        # retry_on=(OSError,), exclude=(ConnectionError,) — ConnectionError
-        # IS-A OSError but must not be retried).
+        # Checked per-instance, not per-type, so subclass hierarchies exclude
+        # correctly (e.g. retry_on=(OSError,), exclude=(ConnectionError,)).
         class _Excluded(BaseException):
             def __init__(self, inner: Exception):
                 self.inner = inner

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -15,11 +15,8 @@ from lionagi.libs.path_safety import GLOB_CHARS as _GLOB_CHARS
 _ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _VALIDATION_ROOT = os.path.realpath("/tmp/__contract_validate__")  # noqa: S108 — synthetic root for path-validation only, never written to
 
-# v1 entry fields. `kind`, `min_size`, `mime_type` are reserved for
-# v1.1 — silently accepting them now would let contract files drift
-# into looking stricter than the executor actually is. ADR-0064 D3:
-# both the `li play check` pre-flight AND the real `li play` runtime
-# path emit a warning for unknown subfields via warn_unknown_artifact_keys().
+# v1 entry fields. `kind`/`min_size`/`mime_type` reserved for v1.1 — unknown
+# subfields warn via warn_unknown_artifact_keys() (ADR-0064 D3) rather than silently pass.
 _ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
 
 

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -1,13 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Mirror Claude Code session transcripts (~/.claude/projects/*.jsonl) into StateDB.
-
-A Claude Code session is just another writer to ``state.db``: each JSONL event
-maps to one or more lionagi messages, written under a session/branch/progression
-with deterministic ids so re-reading the same transcript never duplicates rows.
-The studio SSE reader polls the same tables, so mirrored sessions stream live in
-the dashboard and the VS Code extension with no studio-side change.
-"""
+"""Mirror Claude Code session transcripts (~/.claude/projects/*.jsonl) into StateDB,
+one lionagi message per JSONL event, under deterministic ids. See docs/internals/runtime.md."""
 
 from __future__ import annotations
 
@@ -33,9 +27,8 @@ _NS = uuid.UUID("5f1d6e2a-1c3b-4a5d-8e9f-0a1b2c3d4e5f")
 # Only conversation-bearing events become messages; the rest is editor metadata.
 _MESSAGE_TYPES = frozenset({"user", "assistant"})
 
-# Slash-command invocations and local-command output wrap their text in these
-# tags. They are editor machinery, not conversation — a real prompt never opens
-# with one — so they are dropped to keep the mirrored transcript readable.
+# Slash-command/local-command output wraps its text in these tags — editor
+# machinery, not conversation — so it is dropped from the mirrored transcript.
 _COMMAND_NOISE_PREFIXES = ("<command-", "<local-command-")
 
 
@@ -83,11 +76,8 @@ def messages_for_event(
     session_uid: str,
     tool_names: dict[str, str],
 ) -> list[RoledMessage]:
-    """Map one Claude JSONL event to ordered lionagi messages.
-
-    ``tool_names`` is read/written in place: tool_use blocks record their
-    function name so the matching tool_result can label its ActionResponse.
-    """
+    """Map one Claude JSONL event to ordered lionagi messages. ``tool_names`` is
+    read/written in place so a matching tool_result can label its ActionResponse."""
     etype = event.get("type")
     if etype not in _MESSAGE_TYPES or event.get("isMeta"):
         return []
@@ -218,13 +208,7 @@ async def mirror_session(
     status: str = "running",
 ) -> int:
     """Idempotently write a batch of Claude events for one session; returns msgs written.
-
-    Re-calling with already-seen events is a no-op: message ids are deterministic
-    (upsert), and progression appends dedupe. Creates the session/branch on first
-    call with a rich row (project, model, agent_name) so it groups correctly in
-    the runs explorer, with ``status`` as the initial status. Live/idle transitions
-    are owned by ``reconcile_session_status``, not this writer.
-    """
+    Live/idle transitions are owned by ``reconcile_session_status``, not this writer."""
     sid = session_db_id(session_uid)
     branch_id = _det(session_uid, "branch")
     bprog = _det(session_uid, "bprog")
@@ -242,11 +226,8 @@ async def mirror_session(
     last_ts = max((m.created_at for m in messages), default=None)
     created_at = (existing.get("created_at") if existing is not None else None) or first_ts
 
-    # Ensure the full scaffold (progressions -> session -> branch) exists on every
-    # call, in dependency order. Each write is INSERT OR IGNORE, so once present
-    # this is a no-op; if an earlier pass died mid-scaffold (e.g. the branch write
-    # raised after the session row committed) the next pass repairs the partial
-    # instead of skipping scaffolding just because the session row now exists.
+    # Scaffold (progressions -> session -> branch) is INSERT OR IGNORE and re-run
+    # every call, so a prior partial-scaffold failure self-repairs — see docs/internals/runtime.md.
     await db.create_progression(sprog)
     await db.create_progression(bprog)
     if existing is None:
@@ -268,10 +249,8 @@ async def mirror_session(
             }
         )
     elif project and not existing.get("project"):
-        # Backfill attribution for a session first mirrored before its cwd could
-        # be attributed to a project. INSERT OR IGNORE never updates an existing
-        # row, so without this an already-seen "(no project)" session stays that
-        # way forever; this writes it without disturbing the liveness clock.
+        # Backfill attribution for an already-seen session (INSERT OR IGNORE never
+        # updates); writes without disturbing the liveness clock.
         await db.set_session_provenance(sid, project=project, project_source=project_source)
     await db.create_branch(
         {
@@ -304,30 +283,8 @@ async def reconcile_session_status(
     now: float,
     live_window: float,
 ) -> None:
-    """Align a mirrored session's status with its live/idle state — both directions.
-
-    A mirror session's ``completed`` means dormant, not terminal: when the
-    transcript resumes, the next reconcile brings it back to ``running``. Liveness
-    is judged by ``last_message_at`` — the timestamp of the newest mirrored
-    message — so an idle session converges to ``completed`` before the reaper can
-    mark it failed, and an active one shows ``running`` (a live spinner in studio
-    and the VS Code extension). It must NOT read ``updated_at``: the status write
-    below bumps ``updated_at``, so keying liveness off it would let a just-marked
-    ``completed`` session read as fresh again on the next pass and oscillate back
-    to ``running``.
-
-    ADR-0035's integrity floor treats every session terminal status (not just
-    ``completed``) as terminal on the sessions table for orchestrated runs, so
-    reactivating a mirror session out of any of them goes through the
-    sanctioned override path — it is a real, deliberate, well-understood write
-    (not a repair), so it is attributed to a fixed system actor rather than a
-    human operator, and it lands in admin_events like any other override. A
-    mirror session that is idle and already sitting on a non-``completed``
-    terminal status (e.g. it was independently marked ``failed`` or
-    ``cancelled``) is left alone rather than rewritten to ``completed`` — it is
-    already terminal, and only a live transcript resuming can justify pulling
-    it back to ``running``.
-    """
+    """Align a mirrored session's status with its live/idle state, both directions.
+    Liveness keys off ``last_message_at``, never ``updated_at`` — see docs/internals/runtime.md."""
     from lionagi.state.db import SESSION_TERMINAL_STATUSES
     from lionagi.state.reasons import RunReasons
 
@@ -379,17 +336,8 @@ async def link_session_lineage(
     parent_uid: str,
     parent_event_uuid: str,
 ) -> None:
-    """Record that one Claude session continues another (conversation lineage).
-
-    A continued conversation (after compaction, ``--resume``, or a fresh window
-    that picks up an earlier thread) starts a new transcript whose first message
-    points, via ``parentUuid``, at the last message of the session it continues.
-    When the mirror resolves that pointer to a different session it calls this to
-    store a ``lineage`` link on the child's node_metadata, so studio and the VS
-    Code extension can show the provenance and walk the chain back. Written
-    without moving the liveness clock; idempotent (re-linking rewrites the same
-    value).
-    """
+    """Record that one Claude session continues another (conversation lineage) via
+    a ``lineage`` entry on the child's node_metadata. Idempotent; see docs/internals/runtime.md."""
     child_sid = session_db_id(child_uid)
     existing = await db.get_session(child_sid)
     if existing is None:

--- a/lionagi/state/completion_evidence.py
+++ b/lionagi/state/completion_evidence.py
@@ -1,14 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Completion-trust gate: cheap, local, no-network evidence that a run produced something.
-
-A session can exit its loop cleanly with nothing to show for it — no commits,
-no artifacts, no diff. Historically that still got stamped ``completed``, so
-operators stopped trusting the status and re-verified by hand. This module
-gives the teardown path a lightweight git-based signal to fall back on when
-no artifact contract caught the emptiness: is HEAD ahead of the base ref, or
-does the working tree carry uncommitted changes?
-"""
+"""Completion-trust gate: cheap, local, no-network git signal (commits ahead of
+base / dirty tree) for the teardown path when no artifact contract caught an empty run."""
 
 from __future__ import annotations
 
@@ -72,12 +65,8 @@ def check_completion_evidence(
     *,
     base_ref: str | None = None,
 ) -> CompletionEvidence:
-    """Check whether *cwd* shows local evidence of work: commits ahead of a
-    base ref, or an uncommitted (dirty) working tree.
-
-    Returns ``checked=False`` when *cwd* is missing or not a git working
-    tree — callers must treat that as "no opinion", not "no evidence found".
-    """
+    """Check whether *cwd* shows local evidence of work: commits ahead of a base
+    ref, or a dirty tree. ``checked=False`` means "no opinion", not "no evidence"."""
     if not cwd:
         return _no_evidence("no cwd provided")
 
@@ -85,12 +74,8 @@ def check_completion_evidence(
     if rc != 0:
         return _no_evidence("cwd is not a git working tree")
 
-    # A probe that actually runs and fails (transient error, timeout, git
-    # hiccup) must never be read as "ran and found nothing" — that silently
-    # turns a git error into a false completed_empty on real work. Only a
-    # probe that *succeeds* is allowed to report an absence of evidence;
-    # any decisive failure bails the whole check out as unchecked so the
-    # caller keeps trusting "completed".
+    # A probe failure (transient error, timeout) must never read as "ran and found
+    # nothing" — any decisive failure bails out as unchecked, not false-empty.
     rc, status_out = _run_git(cwd, ["status", "--porcelain"])
     if rc != 0:
         return _no_evidence("git status probe failed")

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -98,12 +98,8 @@ def dialect_of(url: str) -> str:
 
 
 def make_engine(url: str, **overrides):
-    """Create and return an AsyncEngine for *url*.
-
-    SQLite: registers a connect-event listener that applies the six pragmas
-    (busy_timeout first) on every new DBAPI connection.
-    PostgreSQL: pool_pre_ping=True; sslmode query param translated to asyncpg ssl arg.
-    """
+    """Create an AsyncEngine for *url*. SQLite gets a busy_timeout-first pragma
+    listener; PostgreSQL gets pool_pre_ping and sslmode→ssl arg translation."""
     from sqlalchemy.event import listen
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -159,24 +155,8 @@ _SQLITE_ASYNC_PREFIX = "sqlite+aiosqlite:///"
 
 
 def make_readonly_engine(url: str, **overrides):
-    """Read-only AsyncEngine over an EXISTING SQLite file.
-
-    Opens the file through SQLite's own URI read-only mode (`mode=ro`) rather
-    than `make_engine()`'s normal path, so:
-
-    - no schema/PRAGMA write ever reaches the file (the OS-level open is
-      read-only; SQLite raises if any statement attempts to write)
-    - none of `make_engine()`'s mutating connect-time PRAGMAs are applied
-      (`journal_mode`, `synchronous`, `wal_autocheckpoint` all persist into
-      the database file itself and are skipped here on purpose)
-    - only `busy_timeout` (session-scoped, never persisted) and `query_only`
-      (belt-and-suspenders: SQLite itself rejects any write statement) are
-      set
-
-    Sqlite only — a caller wanting a genuinely read-only Postgres connection
-    should use a read-only DB role instead; there is no equivalent "connect
-    without side effects" mode to fake at this layer for Postgres.
-    """
+    """Read-only AsyncEngine over an existing SQLite file via URI `mode=ro`.
+    SQLite only — see docs/internals/runtime.md for the read-only contract."""
     from sqlalchemy.event import listen
     from sqlalchemy.ext.asyncio import create_async_engine
 

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -9,9 +9,7 @@ from typing import Any
 
 from .staleness import DEFAULT_STALE_THRESHOLD, STALE_THRESHOLDS
 
-# An idle session is alive and quiet; an unresponsive one is alive and
-# past the kind-aware threshold. The 1h floor here is the "quiet"
-# boundary — anything below is HEALTHY regardless of activity.
+# The 1h "quiet" floor below which a session is HEALTHY regardless of activity.
 IDLE_THRESHOLD: int = 3600
 
 
@@ -46,21 +44,15 @@ def classify_session_health(
     has_artifacts: bool,
     has_stale_locks: bool,
 ) -> SessionHealth:
-    """Classify a session dict into a SessionHealth level; pure function, caller supplies liveness signals.
-
-    ``process_alive`` is tri-state: True = observed alive, False = confirmed
-    dead (positive evidence — a recorded pid that is no longer running),
-    None = unknown (no recorded pid and no process match, the normal case
-    for externally-driven sessions mirrored into the DB).
-    """
+    """Classify a session dict into a SessionHealth level; pure function, caller
+    supplies liveness signals. ``process_alive`` is tri-state — see docs/internals/runtime.md."""
     status = session.get("status") or "completed"
 
     # Terminal sessions: done means done, unless they left litter.
     if status in {"completed", "completed_empty", "failed", "timed_out", "aborted", "cancelled"}:
         if has_stale_locks:
             return SessionHealth.ZOMBIE
-        # ``has_artifacts`` alone isn't enough to mark zombie — artifacts
-        # are a *good* outcome. Stale locks are the operational signal.
+        # has_artifacts alone isn't zombie evidence — stale locks are the signal.
         return SessionHealth.HEALTHY
 
     # Below here: status == 'running' (or legacy NULL → treated as
@@ -78,22 +70,13 @@ def classify_session_health(
     threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
 
     if process_alive is not True:
-        # Orphan check first: the session was advertised but never
-        # produced a single message AND no artifacts on disk. This is
-        # a session that crashed before doing anything; transitioning
-        # it to failed is harmless, deleting it is also safe.
+        # Orphan check first (crashed before any message/artifact) — see docs/internals/runtime.md.
         if not has_artifacts and (session.get("message_count") or 0) == 0:
             return SessionHealth.ORPHANED
         if process_alive is False:
-            # Confirmed dead: positive evidence (a recorded pid no longer
-            # running) outranks the activity guard below — the process is
-            # gone no matter how fresh the last message is.
+            # Confirmed dead outranks the activity guard below.
             return SessionHealth.STALE
-        # Unknown liveness: recent messages are stronger life-evidence
-        # than process visibility — externally-driven sessions (CLI seats
-        # mirrored into the DB) expose no matchable pid, so an unmatched
-        # process only means dead once activity has also gone quiet past
-        # the kind threshold.
+        # Unknown liveness: activity is the stronger life-evidence here — see docs/internals/runtime.md.
         if idle_seconds <= threshold:
             if idle_seconds > IDLE_THRESHOLD:
                 return SessionHealth.IDLE

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -1,19 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Guarded compare-and-swap state transitions (ADR-0059 slice 1, spec-gate ruling 1).
-
-ADR-0058's ``transition()`` API (entity-agnostic, idempotency-key-deduplicated)
-is proposed and unbuilt. This module ships a minimal fallback carrying the same
-request/result shape and reason-code discipline so 0058 can absorb it later as
-a refactor, not a migration. Scoped to ``entity_type='dispatch'``
-(``dispatch_outbox``) and ``entity_type='schedule_run'`` (``schedule_runs``)
-only — it is not a general TransitionStore.
-
-The guarded read/CAS/vocabulary/write algorithm itself now lives in
-``lionagi.state.lifecycle`` (shared with ``StateDB.update_status()``); this
-module keeps its own narrower entity-type boundary, its ``guard``/``patch``
-column allowlist, and the legacy ``TransitionResult`` return shape.
-"""
+"""Guarded compare-and-swap state transitions (ADR-0059 slice 1, spec-gate ruling 1) — minimal
+ADR-0058 fallback scoped to dispatch/schedule_run entities. See docs/internals/runtime.md."""
 
 from __future__ import annotations
 
@@ -66,23 +54,14 @@ class TransitionResult(BaseModel):
     event_id: str | None = None
 
 
-# Entities the minimal fallback knows how to CAS-transition. ADR-0058's full
-# backend generalizes this; slice 1 needs only dispatch_outbox.
-# "schedule_run" is ADR-0071 D2's generalized task-application entity
-# (schedule_runs table, schedule_id now nullable) — registered here so ALL
-# status movement on it can route through this guarded CAS store rather than
-# a second, parallel implementation.
+# Entities the minimal fallback knows how to CAS-transition — see docs/internals/runtime.md.
 _ENTITY_TABLES: dict[str, str] = {
     "dispatch": "dispatch_outbox",
     "schedule_run": "schedule_runs",
 }
 
-# guard/patch column names are interpolated directly into SQL text (values are
-# still bound params) inside the lifecycle service. Every production call site
-# today passes literal dicts, but this module is a generic surface that a
-# future full transition backend will absorb, so a per-entity allowlist closes the
-# latent injection surface for future callers instead of trusting the
-# caller's dict keys outright.
+# guard/patch column names are interpolated into SQL text (values stay bound
+# params); allowlist closes the latent injection surface — see docs/internals/runtime.md.
 _GUARD_PATCH_COLUMNS: dict[str, frozenset[str]] = {
     "dispatch": frozenset({"attempt", "next_attempt_at", "last_error"}),
     "schedule_run": frozenset({"leased_by", "lease_expires_at", "lease_attempts"}),
@@ -97,27 +76,7 @@ async def transition(
     patch: dict[str, Any] | None = None,
 ) -> TransitionResult:
     """Guarded compare-and-swap transition: ``UPDATE ... WHERE id=:id AND status=:from``.
-
-    Writes the row status and an atomic ``status_transitions`` append inside
-    one transaction, via the shared ``lionagi.state.lifecycle`` service.
-    A mismatched current state reports a conflict rather than
-    raising or silently overwriting (CAS guard). An undeclared status move
-    (per the shared policy registry's edge graph) raises ``ValueError`` —
-    this surface has no override mechanism, unlike ``StateDB.update_status()``.
-
-    ``guard`` adds extra ``column = :expected`` equality constraints to the
-    WHERE clause beyond ``status`` — required whenever a transition can be a
-    same-state no-op (e.g. ``delivering -> delivering`` recovery claims),
-    where the status guard alone would match trivially and let two
-    concurrent callers both believe they won the claim. Callers pass the
-    value they read *before* the transition as the expected guard value;
-    only the caller whose guard value still matches at UPDATE time wins.
-
-    ``patch`` adds extra ``column = :value`` assignments to the SET clause,
-    applied atomically with the status change and the ``status_transitions``
-    append — for callers (e.g. an operator-forced retry resetting attempt
-    counters) that would otherwise need a second, non-atomic write.
-    """
+    ``guard``/``patch`` extend the WHERE/SET clauses — see docs/internals/runtime.md."""
     table = _ENTITY_TABLES.get(request.entity_type)
     if table is None:
         raise ValueError(f"transition(): unsupported entity_type {request.entity_type!r}")
@@ -166,11 +125,7 @@ async def transition(
             transition_id=uuid.uuid4().hex,
         )
 
-    # "rejected" is unreachable through this surface: run_legacy_transition()
-    # passes raise_on_undeclared_edge=True, so an undeclared edge (terminal
-    # or not) raises ValueError above rather than resolving to "rejected",
-    # and TransitionRequest carries no override field to trigger the
-    # override path either.
+    # "rejected" is unreachable here (raise_on_undeclared_edge=True) — see docs/internals/runtime.md.
     return TransitionResult(
         applied=True,
         conflict=False,

--- a/lionagi/state/transitions.py
+++ b/lionagi/state/transitions.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Guarded compare-and-swap state transitions (ADR-0059 slice 1, spec-gate ruling 1) — minimal
-ADR-0058 fallback scoped to dispatch/schedule_run entities. See docs/internals/runtime.md."""
+"""Guarded compare-and-swap state transitions (ADR-0059) — minimal counterpart to ADR-0058's
+entity-agnostic API, scoped to dispatch/schedule_run entities. See docs/internals/runtime.md."""
 
 from __future__ import annotations
 

--- a/lionagi/testing/__init__.py
+++ b/lionagi/testing/__init__.py
@@ -3,9 +3,7 @@
 
 """Supported public testing surface for lionagi downstream projects.
 
-Provides scripted endpoints, mock factories, pytest fixtures, async helpers,
-and test-data loaders. Register ``lionagi.testing.pytest_plugin`` in your
-conftest (or ``pytest_plugins``) to get the bundled fixtures automatically.
+Register ``lionagi.testing.pytest_plugin`` in your conftest to get the bundled fixtures.
 """
 
 from __future__ import annotations

--- a/lionagi/testing/_branch.py
+++ b/lionagi/testing/_branch.py
@@ -24,17 +24,8 @@ def scripted_imodel(
     model: str = "scripted-test",
     **imodel_kwargs: Any,
 ) -> iModel:
-    """Build an iModel wired to a ``ScriptedEndpoint``.
-
-    Args:
-        script: a path (str/Path), dict, list of response dicts, or
-            ``ScriptModel`` instance.
-        model: model name to record in payloads (cosmetic for tests).
-        **imodel_kwargs: forwarded to ``iModel(...)``.
-
-    Returns:
-        ``iModel`` ready to plug into a ``Branch``.
-    """
+    """Build an iModel wired to a ``ScriptedEndpoint``. ``script`` accepts a path, dict,
+    list of response dicts, or ``ScriptModel`` instance."""
 
     script_obj = ScriptModel.coerce(script)
     # iModel doesn't know about ``script``; the endpoint pops it. We pass it
@@ -64,11 +55,8 @@ class TestBranch:
         system: Any = None,
         **branch_kwargs: Any,
     ) -> Branch:
-        """Build a branch backed by ``script``.
-
-        ``script`` accepts any input ``ScriptModel.coerce`` accepts: a path
-        (YAML/JSON), a dict, a list of response dicts, or a ``ScriptModel``.
-        """
+        """Build a branch backed by ``script`` (path, dict, list of response dicts, or
+        ``ScriptModel``, per ``ScriptModel.coerce``)."""
         chat_model = scripted_imodel(script, model=model)
         return Branch(
             chat_model=chat_model,
@@ -93,11 +81,7 @@ class TestBranch:
         text: str | list[str],
         **kwargs: Any,
     ) -> Branch:
-        """Cheapest fixture: one or more pure-text responses, in order.
-
-        ``TestBranch.from_text("hi")`` is equivalent to
-        ``TestBranch.from_responses([{"type": "text", "content": "hi"}])``.
-        """
+        """Cheapest fixture: one or more pure-text responses, in order."""
         if isinstance(text, str):
             responses = [{"type": "text", "content": text}]
         else:
@@ -116,11 +100,8 @@ class TestBranch:
 
     @staticmethod
     def scripted(branch: Branch) -> ScriptedEndpoint:
-        """Return the ``ScriptedEndpoint`` driving this branch.
-
-        Raises ``TypeError`` if the branch isn't scripted — useful for
-        defending shared fixtures against accidental real-API leaks.
-        """
+        """Return the ``ScriptedEndpoint`` driving this branch; raises ``TypeError`` if
+        the branch isn't scripted (defends shared fixtures against real-API leaks)."""
         endpoint = branch.chat_model.endpoint
         if not isinstance(endpoint, ScriptedEndpoint):
             raise TypeError(

--- a/lionagi/testing/_endpoint.py
+++ b/lionagi/testing/_endpoint.py
@@ -60,9 +60,8 @@ class ScriptedEndpoint(AgenticEndpoint):
     DEFAULT_CONCURRENCY_LIMIT: ClassVar[int] = 3
 
     def __init__(self, config: Any = None, **kwargs: Any) -> None:
-        # ── pop our test-only kwargs BEFORE super so EndpointConfig doesn't
-        # see them. EndpointConfig drops unknown keys into ``config.kwargs``
-        # which then leak into request payloads.
+        # pop test-only kwargs BEFORE super: EndpointConfig drops unknown keys
+        # into config.kwargs, which then leak into request payloads.
         script = kwargs.pop("script", None)
         script_was_passed = script is not None
         if script is None:
@@ -80,9 +79,8 @@ class ScriptedEndpoint(AgenticEndpoint):
         else:
             self._script = ScriptModel()
             if not script_was_passed:
-                # No script kwarg AND no env var — the first call will raise
-                # a confusing "exhausted" error several layers downstream.
-                # Surface it now so tests fail with a clear message.
+                # No script and no env var: surface a clear warning now instead of
+                # a confusing ScriptExhaustedError several layers downstream.
                 logger.warning(
                     "ScriptedEndpoint constructed with no script and no "
                     "%s env var. The first call will raise "
@@ -222,14 +220,8 @@ class ScriptedEndpoint(AgenticEndpoint):
         return None
 
     def copy_runtime_state_to(self, other: Endpoint) -> None:
-        """Carry script + recorded calls across an ``iModel.copy()`` clone.
-
-        The script is **deep-copied** so the clone gets an independent cursor
-        — otherwise positional matching would cross-contaminate (clone A
-        consuming entry 0, clone B getting entry 1 instead of 0). Recorded
-        calls are shallow-copied for inspection but each clone records its
-        own future calls.
-        """
+        """Carry script + recorded calls across an ``iModel.copy()`` clone. Script is
+        deep-copied for an independent cursor; see docs/internals/runtime.md."""
         super().copy_runtime_state_to(other)
         if isinstance(other, ScriptedEndpoint):
             other._script = copy.deepcopy(self._script)

--- a/lionagi/testing/_env.py
+++ b/lionagi/testing/_env.py
@@ -34,13 +34,8 @@ def is_scripted_provider_active() -> bool:
 
 @contextlib.contextmanager
 def scripted_env(script_path: str | Path, model: str = DEFAULT_SCRIPTED_MODEL) -> Iterator[None]:
-    """Context manager: set env so ``li`` subprocesses pick up the scripted provider.
-
-    Restores prior values on exit. Useful for ``subprocess.run`` tests::
-
-        with scripted_env("/path/to/script.yaml"):
-            r = subprocess.run(["li", "agent", "hi"], capture_output=True, text=True)
-    """
+    """Context manager: set env so ``li`` subprocesses pick up the scripted provider,
+    restoring prior values on exit."""
     previous: dict[str, str | None] = {
         ENV_PROVIDER: os.environ.get(ENV_PROVIDER),
         ENV_MODEL: os.environ.get(ENV_MODEL),
@@ -62,9 +57,8 @@ def scripted_env(script_path: str | Path, model: str = DEFAULT_SCRIPTED_MODEL) -
 def subprocess_env(
     script_path: str | Path, model: str = DEFAULT_SCRIPTED_MODEL, base: dict | None = None
 ) -> dict[str, str]:
-    """Return a dict suitable for passing to ``subprocess.run(env=...)``.
-
-    Layered on top of ``base`` (defaults to a copy of ``os.environ``)."""
+    """Return a dict for ``subprocess.run(env=...)``, layered on ``base`` (defaults to a
+    copy of ``os.environ``)."""
     env = dict(base if base is not None else os.environ)
     env[ENV_PROVIDER] = SCRIPTED_PROVIDER
     env[ENV_MODEL] = model

--- a/lionagi/testing/_legacy.py
+++ b/lionagi/testing/_legacy.py
@@ -23,13 +23,7 @@ def oai_chat_endpoint_config(
     request_options: type | None = None,
     kwargs: dict | None = None,
 ) -> EndpointConfig:
-    """OpenAI chat endpoint config for tests that need a real ``Endpoint`` shell.
-
-    Replaces the ad-hoc ``_get_oai_config`` helper duplicated across the legacy
-    test suite. Tests that build their own ``APICalling`` for cancellation /
-    streaming / hook scenarios should use this rather than re-copying the
-    config kwargs.
-    """
+    """OpenAI chat endpoint config for tests that need a real ``Endpoint`` shell."""
     return EndpointConfig(
         name=name,
         provider="openai",
@@ -61,12 +55,8 @@ class LionAGIMockFactory:
         tools: Any = None,
         api_key: str = "test_key",
     ) -> Branch:
-        """Build a Branch with a mocked iModel and optional system message/tools.
-
-        Subsumes every per-file ``make_mocked_branch_for_*`` /
-        ``_fake_invoke`` pattern in the legacy test suite. Pass
-        ``responses=[...]`` for multi-call tests that need a sequence.
-        """
+        """Build a Branch with a mocked iModel and optional system message/tools. Pass
+        ``responses=[...]`` for multi-call tests that need a sequence."""
         branch = Branch(user=user, name=name, system=system)
         mock_chat_model = LionAGIMockFactory.create_mocked_imodel(
             provider=provider,

--- a/lionagi/testing/_script.py
+++ b/lionagi/testing/_script.py
@@ -24,11 +24,8 @@ from ._types import (
 
 
 def _build_entry(data: dict[str, Any]) -> ResponseEntry:
-    """Construct a ``ResponseEntry`` from a dict, picking the subclass by ``type``.
-
-    Pydantic v2 doesn't pick a discriminated-union member when fields beyond
-    ``type`` differ; we dispatch manually for clearer errors.
-    """
+    """Construct a ``ResponseEntry`` from a dict, dispatching to the subclass by ``type``
+    (manual dispatch, not a pydantic discriminated union — see docs/internals/runtime.md)."""
 
     if not isinstance(data, dict):
         raise TypeError(f"response entry must be dict, got {type(data).__name__}")
@@ -61,10 +58,8 @@ class ScriptModel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _coerce_responses(cls, data: Any) -> Any:
-        """Accept raw dicts in ``responses`` and dispatch to subclasses.
-
-        Works on a shallow copy so the caller-supplied dict is never mutated.
-        """
+        """Accept raw dicts in ``responses`` and dispatch to subclasses; works on a shallow
+        copy so the caller-supplied dict is never mutated."""
 
         if isinstance(data, dict):
             data = dict(data)
@@ -83,11 +78,8 @@ class ScriptModel(BaseModel):
 
     @classmethod
     def coerce(cls, source: Any) -> ScriptModel:
-        """Best-effort load from anything that *could* be a script.
-
-        Accepts: ScriptModel, str/Path (file), dict (script shape), list (raw
-        responses).
-        """
+        """Best-effort load from a ScriptModel, str/Path (file), dict (script shape), or
+        list (raw responses)."""
         if isinstance(source, cls):
             return source.model_copy(deep=True)
         if isinstance(source, str | Path):
@@ -129,20 +121,8 @@ class ScriptModel(BaseModel):
     # ─────────────────────────────── matching ─────────────────────────────
 
     def next(self, payload: dict[str, Any], call_index: int) -> tuple[ResponseEntry, str]:
-        """Pick the next response.
-
-        Args:
-            payload: the request payload (messages, tools, model, ...)
-            call_index: 0-based count of calls already served
-
-        Returns:
-            (entry, matched_by) — ``matched_by`` describes why this entry was
-            picked (``"positional"``, ``"when:prompt_contains:foo"``, etc.).
-
-        Raises:
-            ScriptExhaustedError: when nothing matches and the positional
-                cursor has run out.
-        """
+        """Pick the next response: try ``when:`` matchers first (unless mode is
+        ``positional``), then fall back to positional order — see docs/internals/runtime.md."""
 
         # Phase 1: try ``when:`` matchers (skipped only when mode == positional).
         if self.mode != "positional":

--- a/lionagi/testing/helpers.py
+++ b/lionagi/testing/helpers.py
@@ -43,11 +43,7 @@ class AsyncTestHelpers:
         limit: int = 100,
         timeout: float = 10.0,
     ) -> list[T]:
-        """Collect up to *limit* items from an async generator within *timeout* seconds.
-
-        Uses ``lionagi.ln.move_on_after`` for Python 3.10-compatible timeout handling
-        (``asyncio.timeout`` requires Python 3.11+).
-        """
+        """Collect up to *limit* items from an async generator within *timeout* seconds."""
         results: list[T] = []
         with move_on_after(timeout):
             async for item in async_gen:
@@ -60,20 +56,14 @@ class AsyncTestHelpers:
     async def run_with_timeout(
         coro: Callable[..., Any], timeout: float = 5.0, *args: Any, **kwargs: Any
     ) -> Any:
-        """Run *coro* with a hard timeout, raising ``TimeoutError`` on expiry.
-
-        Uses ``lionagi.ln.fail_after`` for Python 3.10-compatible timeout handling.
-        """
+        """Run *coro* with a hard timeout, raising ``TimeoutError`` on expiry."""
         with fail_after(timeout):
             return await coro(*args, **kwargs)
 
     @staticmethod
     async def wait_for_all(tasks: list[asyncio.Task], timeout: float = 10.0) -> list[Any]:
-        """Await all *tasks* within *timeout* seconds.
-
-        Cancels any incomplete tasks on timeout and re-raises ``TimeoutError``.
-        Uses ``lionagi.ln.fail_after`` for Python 3.10-compatible timeout handling.
-        """
+        """Await all *tasks* within *timeout* seconds; cancels incomplete tasks and
+        re-raises ``TimeoutError`` on expiry."""
         try:
             with fail_after(timeout):
                 return list(await gather(*tasks))
@@ -240,9 +230,8 @@ class IModelKwargCaptor:
         return _Local
 
 
-# Module-level ``MockElement`` — defined once so it's picklable. The
-# duplicated ``class MockElement(Element): value: Any`` snippets in
-# tests/protocols/generic/* should import this instead.
+# Module-level so it's picklable; duplicated per-test snippets should import
+# this instead.
 class MockElement(Element):
     """Minimal ``Element`` subclass for Pile/Progression tests."""
 

--- a/lionagi/testing/pytest_plugin.py
+++ b/lionagi/testing/pytest_plugin.py
@@ -75,20 +75,7 @@ def mocked_branch(mock_factory):
 @pytest.fixture
 def make_mocked_branch(mock_factory) -> Callable[..., Any]:
     """Canonical factory fixture: replaces every per-file ``make_mocked_branch_for_*``.
-
-    Returns a callable accepting any kwargs the underlying ``LionAGIMockFactory``
-    accepts — ``response`` (str or dict), ``responses`` (sequence), ``system``,
-    ``tools``, ``name``, ``user``, ``model``, ``provider``.
-
-    Example::
-
-        async def test_operate(make_mocked_branch):
-            branch = make_mocked_branch(
-                response='{"foo": "bar"}',
-                system="You are a helper.",
-            )
-            result = await branch.operate(instruction="...", response_format=MyModel)
-    """
+    Returns a callable forwarding kwargs to ``LionAGIMockFactory.create_mocked_branch``."""
 
     def _create_branch(**kwargs: Any):
         return mock_factory.create_mocked_branch(**kwargs)
@@ -119,14 +106,7 @@ def test_payload(test_data_helpers):
 
 @pytest.fixture
 def scripted_branch_factory() -> Callable[..., Any]:
-    """Factory: build a scripted branch from a list of response dicts.
-
-    Usage::
-
-        async def test_foo(scripted_branch_factory):
-            branch = scripted_branch_factory([{"type": "text", "content": "hi"}])
-            assert await branch.chat("hello") == "hi"
-    """
+    """Factory: build a scripted branch from a list of response dicts."""
 
     def _make(responses: list[dict[str, Any]], **kwargs: Any):
         return TestBranch.from_responses(responses, **kwargs)
@@ -142,10 +122,8 @@ def scripted_branch(scripted_branch_factory):
 
 @pytest.fixture
 def scripted_endpoint_for(scripted_branch_factory) -> Callable[..., ScriptedEndpoint]:
-    """Factory: return the ScriptedEndpoint behind a branch built by this fixture.
-
-    Useful when a test cares about call inspection more than the branch itself.
-    """
+    """Factory: return the ScriptedEndpoint behind a branch built by this fixture, for
+    tests that care about call inspection more than the branch itself."""
 
     def _make(responses: list[dict[str, Any]], **kwargs: Any) -> ScriptedEndpoint:
         branch = scripted_branch_factory(responses, **kwargs)

--- a/lionagi/tools/_subprocess.py
+++ b/lionagi/tools/_subprocess.py
@@ -48,9 +48,8 @@ def _subprocess_sync(
     timeout_ms: int | None = None,
     env: Mapping[str, str] | None = None,
 ) -> dict:
-    """Run ``cmd`` synchronously. ``env=None`` inherits the full parent
-    environment; pass an explicit mapping to scope less-trusted commands
-    (e.g. the ADR-0090 sandbox-backend seam) to a minimal environment."""
+    """Run ``cmd`` synchronously; ``env=None`` inherits the parent environment,
+    an explicit mapping scopes less-trusted commands to a minimal one."""
     try:
         proc = subprocess.Popen(  # noqa: S603
             cmd,

--- a/lionagi/tools/code/ast_search.py
+++ b/lionagi/tools/code/ast_search.py
@@ -186,21 +186,8 @@ class AstSearchTool(LionTool):
         if self._tool is None:
 
             async def ast_search(**kwargs):
-                """
-                Search source code by AST shape using ast-grep (sg binary) —
-                structural patterns rather than text (e.g. 'except: pass'
-                regardless of whitespace, or all calls with a None first arg).
-
-                Requires the 'sg' or 'ast-grep' binary in PATH; returns
-                status='unavailable' if absent (not an error).
-
-                Pattern syntax: https://ast-grep.github.io/reference/pattern.html
-                  '$X'    — matches any single AST node, captured as X
-                  '$$$'   — matches zero or more nodes (variadic)
-                  '...'   — elides sub-patterns (wildcard for bodies)
-
-                Result status: 'ok' (no matches) | 'matches' (see matches list)
-                | 'unavailable' (sg not installed) | 'error' (tool failed)
+                """Search source code by AST shape using ast-grep (structural patterns, not text — e.g. 'except: pass' regardless of whitespace).
+                Requires the 'sg'/'ast-grep' binary in PATH; returns status='unavailable' if absent, not an error.
                 """
                 return (await self.handle_request(AstSearchRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -130,23 +130,9 @@ class BashTool(LionTool):
         if self._tool is None:
 
             async def bash_tool(**kwargs):
-                """
-                Execute a single shell command and return its output.
-
-                Runs the command safely without shell interpretation. Shell operators
-                (;, &&, ||, |, redirects, backticks, $(...)) are rejected — run one
-                command per call. Use cwd= to set the working directory instead of
-                `cd dir && cmd`. For file search/read/edit, prefer the dedicated
-                reader/editor/search tools.
-
-                Enforces a configurable timeout (default 30 s, max 5 min). Output
-                exceeding 100 KB per stream is truncated — redirect to a file and
-                use the reader tool for large outputs.
-
-                Recovery hints:
-                - 'command not found': check the executable is installed and in PATH
-                - 'timed out': increase timeout= or split into smaller steps
-                - 'operators not supported': use cwd= and separate calls
+                """Execute a single shell command (no shell interpretation) and return stdout, stderr, and return code.
+                Shell operators (;, &&, ||, |, redirects, backticks) are rejected — one command per call; use cwd= instead of `cd dir && cmd`.
+                Recovery: 'command not found' → check PATH; timed out → raise timeout= or split into steps.
                 """
                 return (await self.handle_request(BashRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/check.py
+++ b/lionagi/tools/code/check.py
@@ -267,19 +267,8 @@ class CodeCheckTool(LionTool):
         if self._tool is None:
 
             async def code_check(**kwargs):
-                """
-                Run static analysis on Python files and return structured
-                diagnostics. Call after editing a file for immediate feedback;
-                each diagnostic is file:line:col with code and message so the
-                agent can locate and fix the issue without re-reading the file.
-
-                Supported tools:
-                - 'ruff': fast Python linter (default). Requires ruff in PATH.
-                  Returns status='unavailable' if the binary is absent — not an error.
-
-                Result status: 'ok' (no issues) | 'diagnostics' (issues found,
-                see diagnostics list) | 'unavailable' (tool not installed)
-                | 'error' (tool failed unexpectedly)
+                """Run static analysis (ruff) on Python files and return structured file:line:col diagnostics.
+                Call after editing a file for immediate feedback; returns status='unavailable' if ruff is not installed.
                 """
                 return (await self.handle_request(CodeCheckRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/nav.py
+++ b/lionagi/tools/code/nav.py
@@ -203,16 +203,8 @@ class NavTool(LionTool):
         if self._tool is None:
 
             async def code_nav(**kwargs):
-                """
-                Navigate Python source code without reading the full file.
-
-                Actions:
-                - 'outline': return all class/function signatures (cheaper context than reading).
-                - 'find_definition': locate where a named symbol is defined (class, function, or variable).
-                - 'find_references': find all Name/Attribute nodes referencing a symbol.
-
-                All actions operate on a single Python file via the stdlib ast module.
-                No external dependencies required.
+                """Navigate Python source code without reading the full file — outline signatures, find a definition, or find references.
+                Operates on a single Python file via the stdlib ast module; no external dependencies.
                 """
                 return (await self.handle_request(NavRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/search.py
+++ b/lionagi/tools/code/search.py
@@ -170,9 +170,8 @@ class SearchTool(LionTool):
 
     def __init__(self, workspace_root: str | None = None) -> None:
         self._tool = None
-        # Resolve to an absolute path ONCE here — a stored relative root would
-        # re-resolve against a later os.chdir()'d cwd and could escape the
-        # intended boundary.
+        # Resolved to absolute ONCE — a stored relative root would re-resolve
+        # against a later os.chdir()'d cwd and could escape the boundary.
         self._workspace_root = (
             str(Path(workspace_root).resolve()) if workspace_root is not None else None
         )
@@ -214,14 +213,8 @@ class SearchTool(LionTool):
         if self._tool is None:
 
             async def search_tool(**kwargs):
-                """
-                Search file contents or find files by name.
-
-                Use action='grep' to find lines matching a regex across files — supports
-                include glob to narrow the file set. Use action='find' to locate files
-                whose names match a glob pattern. Both actions use portable POSIX tools
-                (grep -E, find) with no external dependencies. Results are capped at
-                max_results (default 50/100) to avoid flooding context.
+                """Search file contents by regex (action='grep') or find files by name glob (action='find').
+                Uses portable POSIX tools (grep -E, find); results capped at max_results (default 50/100).
                 """
                 return (await self.handle_request(SearchRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -39,14 +39,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Request models (LLM-facing schemas)
-# ---------------------------------------------------------------------------
-# ReaderRequest and EditorRequest are imported from file/reader.py and
-# file/editor.py. BashRequest, SearchAction, and SearchRequest are imported
-# from code/bash.py and code/search.py — those are the canonical definitions.
-# SandboxRequest and SubagentRequest have no standalone equivalent and are
-# defined here.
+# Request models (LLM-facing schemas). Reader/Editor/Bash/Search request types
+# are imported from file/reader.py, file/editor.py, code/bash.py, code/search.py.
 
 
 class SandboxAction(str, Enum):
@@ -103,9 +97,7 @@ class SubagentRequest(BaseModel):
     )
 
 
-# ---------------------------------------------------------------------------
 # Blocking helpers (run via run_sync in async tools)
-# ---------------------------------------------------------------------------
 
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
@@ -272,9 +264,7 @@ def _edit_file_sync(
     }
 
 
-# ---------------------------------------------------------------------------
 # CodingToolkit
-# ---------------------------------------------------------------------------
 
 
 ALL_CODING_TOOLS: tuple[str, ...] = (
@@ -357,14 +347,8 @@ class CodingToolkit(LionTool):
         nudge_rules: Sequence[NudgeRule] | None = None,
         sandbox_allow_protected: bool = False,
     ):
-        """
-        sandbox_allow_protected: whether the bound sandbox tool's 'merge' action
-            is allowed to target a protected branch name (main/master/release*).
-            This is an operator-level trust decision, not something the agent
-            can request per call — it is deliberately absent from
-            ``SandboxRequest`` so an in-band agent cannot self-approve merging
-            into a protected branch. Set it only when composing the agent from
-            code you control (e.g. a CI job that always merges into main).
+        """sandbox_allow_protected: operator-only trust decision (deliberately absent
+        from SandboxRequest) gating whether sandbox merge may target a protected branch.
         """
         self._security_pre_hooks: dict[str, list[Callable]] = {}
         self._pre_hooks: dict[str, list[Callable]] = {}
@@ -404,9 +388,8 @@ class CodingToolkit(LionTool):
         self._bound_nudge_engine = engine
 
         def _invalidate_stale_reads() -> None:
-            """Drop file_state entries whose backing reader-read result was
-            evicted/compacted — otherwise the read-before-edit guard stays
-            satisfied for a read the model can no longer see."""
+            """Drop file_state entries whose backing read was evicted/compacted —
+            otherwise the read-before-edit guard stays satisfied for a read the model can no longer see."""
             if not read_tracked:
                 return
             active = branch.progression
@@ -473,13 +456,8 @@ class CodingToolkit(LionTool):
             recursive: bool = None,
             file_types: list[str] = None,
         ) -> dict:
-            """Read files, convert documents, or list directory contents.
-
-            Use action='read' to get file contents with line numbers.
-            Use action='open' to convert a document (PDF, PPTX, DOCX, HTML) to
-            text via docling — the result is cached by path so you can then use
-            action='read' with offset/limit on the same path to paginate it.
-            Use action='list_dir' to list files. Always read a file before editing it.
+            """Read files, convert documents (PDF/PPTX/DOCX/HTML via docling), or list directory contents.
+            Use action='open' then action='read' with offset/limit to paginate a converted document.
             """
             # Canonical empty-path contract: every reader action requires path,
             # matching ReaderTool.handle_request's pre-dispatch guard.
@@ -521,12 +499,8 @@ class CodingToolkit(LionTool):
             new_string: str = None,
             replace_all: bool = False,
         ) -> dict:
-            """Write or edit files. You must read a file before editing it.
-
-            Use action='write' to create or overwrite. Use action='edit' for
-            exact string replacement — safer than full rewrites. When building
-            old_string from reader output, strip the `<number>\\t` line-number
-            prefix and keep only the code, with its exact indentation.
+            """Write or edit files on disk; you must read a file (via reader) before editing it.
+            action='edit' does exact string replacement — strip the `<number>\\t` prefix from reader output before using it as old_string.
             """
             if action == "write":
                 if content is None:
@@ -568,11 +542,7 @@ class CodingToolkit(LionTool):
             cwd: str = None,
         ) -> dict:
             """Execute a single shell command and return stdout, stderr, and return code.
-
-            Use for running builds, tests, git commands, and any system operations.
-            One command per call — shell operators (&&, ||, |, ;, redirects, backticks,
-            $(...)) are rejected; pass cwd= to run in a directory. Output is truncated
-            if it exceeds 100 KB per stream.
+            One command per call — shell operators (&&, ||, |, ;, redirects, backticks) are rejected; pass cwd= to run in a directory.
             """
             timeout_ms = max(1, min(timeout or 30000, 300000))
             timeout_s = timeout_ms / 1000.0
@@ -610,9 +580,7 @@ class CodingToolkit(LionTool):
             include: str = None,
             max_results: int = None,
         ) -> dict:
-            """Search file contents (grep) or find files by name.
-
-            Use action='grep' to search with regex. Use action='find' for file names.
+            """Search file contents by regex (action='grep') or find files by name (action='find').
             Results are capped at max_results to prevent context overflow.
             """
             if action == "grep":
@@ -668,11 +636,8 @@ class CodingToolkit(LionTool):
             scope: str = None,
             auto: bool = False,
         ) -> dict:
-            """Manage your conversation context — check usage, list messages, evict old ones.
-
-            Use this to stay within context limits during long tasks. Evict verbose
-            tool outputs you no longer need to free space for new work.
-            Evicted messages are hidden from the LLM but preserved in conversation record.
+            """Manage your conversation context — check usage, list messages, evict/restore/compact them.
+            Evicted or compacted messages are hidden from your view but preserved in the full conversation record.
             """
             result = await _ctx_func(
                 action=action,
@@ -726,10 +691,8 @@ class CodingToolkit(LionTool):
             action: str,
             message: str = None,
         ) -> dict:
-            """Work in an isolated git worktree — safe experimentation with easy merge/discard.
-
-            Workflow: create → make changes (edit/bash in sandbox dir) → diff → commit → merge or discard.
-            The sandbox is a real git branch. Merge applies your changes; discard throws them away.
+            """Work in an isolated git worktree — safe experimentation with easy merge or discard.
+            Workflow: create -> edit/bash in the sandbox dir -> diff -> commit -> merge (applies changes) or discard (throws them away).
             """
             from .sandbox import (
                 create_sandbox,
@@ -787,11 +750,8 @@ class CodingToolkit(LionTool):
                 if result.get("worktree_removed") and result.get("branch_deleted"):
                     _sandbox_session[0] = None
                     return result
-                # The merge itself landed (merged=True stays visible) but the
-                # worktree/branch cleanup is incomplete — keep the session so
-                # cleanup can be retried via discard, and report non-success
-                # so the caller cannot mistake a stranded worktree for a
-                # fully closed sandbox.
+                # Merge landed but cleanup is incomplete — keep the session (retry via
+                # discard) and report non-success so callers can't mistake it for closed.
                 return {**result, "success": False}
             elif action == "discard":
                 result = await sandbox_discard(session)
@@ -808,17 +768,8 @@ class CodingToolkit(LionTool):
             max_turns: int = 20,
             cwd: str = None,
         ) -> dict:
-            """Spawn a sub-agent to handle a task independently.
-
-            The sub-agent gets its own Branch with coding tools and runs a
-            ReAct loop. Use for delegating research, exploration, or scoped
-            edits without polluting your own context. Results are returned
-            as a summary — the sub-agent's full conversation stays separate.
-
-            Permission levels control what the sub-agent can do:
-            - read_only: search + read files only (safest for research)
-            - safe: read + write + search, bash restricted (no rm/sudo)
-            - allow_all: full access (use for trusted implementation tasks)
+            """Spawn a sub-agent with its own Branch and coding tools to handle a task independently via a ReAct loop.
+            permissions controls what it can do: read_only (search/read only), safe (read/write/search, bash restricted), or allow_all (full access).
             """
             from lionagi.agent.spec import AgentSpec
 
@@ -876,14 +827,8 @@ class CodingToolkit(LionTool):
             tool: str = "ruff",
             max_diagnostics: int = 50,
         ) -> dict:
-            """Run static analysis on Python files and return structured
-            diagnostics. Call after editing a file for immediate feedback;
-            each diagnostic is file:line:col with code and message so the
-            agent can locate and fix the issue without re-reading the file.
-
-            Supported tools:
-            - 'ruff': fast Python linter (default). Requires ruff in PATH.
-              Returns status='unavailable' if the binary is absent — not an error.
+            """Run static analysis (ruff) on Python files and return structured file:line:col diagnostics.
+            Call after editing a file for immediate feedback; returns status='unavailable' if ruff is not installed.
             """
             resolved_paths, err = _resolve_check_paths(paths, workspace_root)
             if err is not None:
@@ -892,13 +837,7 @@ class CodingToolkit(LionTool):
             return resp.model_dump()
 
         async def code_nav(action: str, path: str, symbol: str | None = None) -> dict:
-            """Navigate Python source without reading the full file.
-
-            Actions:
-            - 'outline': list all class/function signatures in a file (cheap context).
-            - 'find_definition': locate where a named symbol is defined.
-            - 'find_references': find all uses of a symbol in the file.
-            """
+            """Navigate Python source without reading the full file — outline signatures, find a definition, or find references."""
             try:
                 resolved = str(_resolve_workspace_path(path, workspace_root))
             except PermissionError as exc:
@@ -931,11 +870,8 @@ class CodingToolkit(LionTool):
             lang: str = "python",
             max_results: int = 50,
         ) -> dict:
-            """Search source code by AST shape using ast-grep (sg).
-
-            Finds structural patterns rather than text — catches syntax constructs
-            regardless of whitespace. Returns status='unavailable' if the sg binary
-            is absent (not an error).
+            """Search source code by AST shape using ast-grep (sg) — structural patterns, not text (whitespace-independent).
+            Returns status='unavailable' if the sg binary is absent, not an error.
             """
             try:
                 resolved = str(_resolve_workspace_path(path, workspace_root))

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -85,9 +85,8 @@ class LionMessenger(LionTool):
         cb = self._callbacks.get(event)
         if cb:
             if event == "help":
-                # Best-effort: a raising coordinator callback must never
-                # surface as an unhandled exception on the emitting worker's
-                # tool-call turn — the whole point of fire-and-continue.
+                # Best-effort: a raising coordinator callback must never surface as an
+                # unhandled exception on the emitter's tool-call turn (fire-and-continue).
                 try:
                     cb(**kwargs)
                 except Exception:
@@ -99,9 +98,8 @@ class LionMessenger(LionTool):
             else:
                 cb(**kwargs)
         else:
-            # A mis-wired coordinator (nobody called .on(event, ...)) must be
-            # discoverable during bring-up, not silently inert — debug-level
-            # so it doesn't spam normal runs where some events are unused.
+            # A mis-wired coordinator must stay discoverable during bring-up — debug-level
+            # so it doesn't spam normal runs where some events are legitimately unused.
             logger.debug(
                 "LionMessenger: no callback registered for event=%r (kwargs=%r)",
                 event,
@@ -134,13 +132,9 @@ class LionMessenger(LionTool):
             content: str = None,
             urgency: str = None,
         ) -> str:
-            """Send messages to teammates, receive pending ones, signal
-            done/finished, wake a teammate, or send a help signal. action in
-            {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to
-            (name or list of names) and content are required for
-            send/wakeup, neither is required for receive; content (the
-            reason) is required for help, urgency is optional (defaults to
-            'fyi')."""
+            """Send/receive teammate messages, signal done/finished, wake a teammate, or send a help signal.
+            action in {'send','receive','done','finished','wakeup','help'}; 'to'+'content' required for send/wakeup, 'content' required for help.
+            """
             if action == "receive":
                 pending = exchange.receive(sender_id)
                 if not pending:

--- a/lionagi/tools/context/context.py
+++ b/lionagi/tools/context/context.py
@@ -156,9 +156,7 @@ class ContextTool(LionTool):
 
         async def _auto_summarize(uids: list, pile) -> str | None:
             """Generate a compact summary over `uids` with one direct model call.
-
-            Never raises — returns None on any failure so the caller can fall back
-            to asking the model to write the summary itself.
+            Never raises — returns None on failure so the caller can fall back to writing the summary itself.
             """
             texts: list[str] = []
             total = 0
@@ -206,10 +204,8 @@ class ContextTool(LionTool):
             scope: str = None,
             auto: bool = False,
         ) -> dict:
-            """Engineer your own conversation context — check usage, browse, evict,
-            restore, and compact. Evicted/compacted messages are hidden from the
-            model's view but preserved in the conversation record and can be
-            restored at any time.
+            """Engineer your own conversation context — check usage, browse, evict, restore, and compact messages.
+            Evicted/compacted messages stay in the full conversation record and can be restored at any time.
             """
             active = branch.progression  # current view (respects evictions)
             full = msgs.progression  # complete durable record

--- a/lionagi/tools/file/editor.py
+++ b/lionagi/tools/file/editor.py
@@ -241,22 +241,9 @@ class EditorTool(LionTool):
         if self._tool is None:
 
             async def editor_tool(**kwargs):
-                """
-                Write or edit files on disk within the configured workspace root.
-
-                IMPORTANT: Always read the file first (reader action='read') before editing.
-                The reader returns lines as `<number>\\t<code>` — do NOT copy the leading
-                `<number>\\t` prefix into old_string; use only the actual code text.
-
-                Use action='write' to create or fully replace a file. Use action='edit'
-                for targeted exact-string replacement — safer than full rewrites.
-                Parent directories are created automatically on write.
-
-                If an edit fails with 'not found': re-read the file, copy the exact text
-                including all whitespace, and retry.
-                If an edit fails with 'appears N times': expand old_string with more
-                surrounding context to make it unique, or set replace_all=True.
-                Paths outside the workspace root and symlinks are rejected.
+                """Write or edit files on disk within the configured workspace root; you must read a file (reader action='read') before editing it.
+                action='write' creates/overwrites; action='edit' does exact-string replacement — strip the `<number>\\t` reader prefix from old_string.
+                On 'not found': re-read the file and copy the exact text, then retry.
                 """
                 return (await self.handle_request(EditorRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/file/reader.py
+++ b/lionagi/tools/file/reader.py
@@ -344,20 +344,7 @@ class ReaderTool(LionTool):
 
             async def reader_tool(**kwargs):
                 """Read files, convert documents (PDF/PPTX/DOCX/HTML via docling), or list directories.
-
-                Use action='read' for text files. Output format is `<number>\\t<code>` per line;
-                the number prefix is for reference only — strip the leading `<digits>\\t` before
-                using any line as an editor old_string. Use offset+limit to read large files in
-                windows (e.g. offset=200, limit=200 to get lines 200-400).
-
-                Use action='open' for documents needing conversion (PDF, PPTX, HTML) —
-                result is cached by path, then use 'read' with offset/limit on the same path.
-                Chain them in one turn: [open(path="report.pdf"), read(path="report.pdf", offset=0, limit=100)]
-
-                Use action='list_dir' for directory listings.
-
-                All paths are restricted to the configured workspace root. URL conversion
-                requires explicit host allowlisting.
+                action='read' returns `<number>\\t<code>` lines (strip the prefix before using as editor old_string); action='open' converts then caches by path for a follow-up 'read'.
                 """
                 return (await self.handle_request(ReaderRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -1,12 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""KhiveInjectionProvider: the reference ContextProvider (ADR-0008) that recalls
-(and optionally composes) from a khive daemon and renders the result into the
-pre-turn guidance fold. Talks to khive over the same MCP transport lionagi
-already uses for tool servers (`service.connections.mcp_wrapper`) — no new
-transport, and no khive/MCP import at module load, so the core import path
-stays clean without the `mcp` extra installed."""
+"""KhiveInjectionProvider: the reference ContextProvider (ADR-0008) — recalls/composes
+from khive over the existing MCP transport; see docs/internals/runtime.md."""
 
 from __future__ import annotations
 
@@ -57,17 +53,8 @@ class WritebackPolicy:
 
 @dataclass(frozen=True)
 class KhiveInjectionPolicy:
-    """Policy block controlling pre-turn khive injection (ADR-0008).
-
-    ``namespace``, when set, is threaded onto every khive verb this policy's
-    provider emits (recall, compose, auto_feedback, remember) — the bench-arm
-    isolation mechanism. auto_feedback WRITES to the live brain store, so an
-    unpinned "M1 read-only" arm still mutates posteriors and contaminates the
-    M0/M1 comparison: pinning a namespace is required, not optional, for any
-    enabled bench arm. Currently only the write verb honors namespace (read
-    verbs reject unknown params), so this is forward-wired for when reads
-    grow namespace scoping too.
-    """
+    """Policy block controlling pre-turn khive injection (ADR-0008); see
+    docs/internals/runtime.md for the namespace/bench-arm isolation contract."""
 
     profile_id: str
     enabled: bool = True
@@ -213,19 +200,8 @@ def _extract_writeback_pairs(action_responses: list) -> list[dict]:
 
 
 class KhiveInjectionProvider:
-    """Pre-turn ContextProvider (ADR-0008): recall + optional compose against khive,
-    rendered into the guidance fold. Every recall emits `brain.auto_feedback` in the
-    same round-trip with the policy's explicit `profile_id` — khive's auto_feedback
-    does no binding resolution, so an implicit/default profile mis-attributes the event.
-
-    `writeback()` is a separate, opt-in POST-turn hook: rule-based tool
-    error/resolution pairs written to `memory.remember` at capped, low-provenance
-    salience. It is invoked by the operate() Middle, not by `provide()`, and it is not
-    the nudge plane — it writes durable memory, never a tool-result suffix.
-
-    Both `provide()` and `writeback()` are fully contained: any transport failure is
-    logged and swallowed so the turn always proceeds.
-    """
+    """Pre-turn ContextProvider (ADR-0008): recall + optional compose against khive.
+    See docs/internals/runtime.md for the provide()/writeback() contract and failure-swallowing behavior."""
 
     def __init__(self, policy: KhiveInjectionPolicy, mcp_config: dict | None = None):
         if policy.snapshot_id is not None:

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -54,7 +54,7 @@ class WritebackPolicy:
 @dataclass(frozen=True)
 class KhiveInjectionPolicy:
     """Policy block controlling pre-turn khive injection (ADR-0008); see
-    docs/internals/runtime.md for the namespace/bench-arm isolation contract."""
+    docs/internals/runtime.md for the namespace isolation contract."""
 
     profile_id: str
     enabled: bool = True

--- a/lionagi/tools/sandbox.py
+++ b/lionagi/tools/sandbox.py
@@ -72,13 +72,7 @@ def _diff_untracked_file(wt: str, rel_path: str) -> tuple[str, str]:
 
 def _list_untracked_files(wt: str) -> list[str]:
     """List untracked (non-ignored) files, recursing into untracked directories.
-
-    Uses ``git ls-files --others --exclude-standard -z``: NUL-delimited raw
-    paths, unlike ``git status --porcelain`` which quotes/escapes paths with
-    spaces or special characters (breaking naive ``line[3:]`` slicing) and
-    reports an untracked directory as a single ``?? dir/`` entry instead of
-    the files inside it.
-    """
+    Uses NUL-delimited `git ls-files`, not `git status --porcelain` (see docs/internals/runtime.md)."""
     result = _subprocess_sync(
         ["git", "ls-files", "--others", "--exclude-standard", "-z"], False, 30.0, wt
     )
@@ -87,11 +81,7 @@ def _list_untracked_files(wt: str) -> list[str]:
 
 
 def _get_diff_sync(session: SandboxSession) -> dict:
-    """Get diff of all changes in the worktree vs base branch.
-
-    Reads the diff without staging anything — the worktree's index is left
-    exactly as the caller left it.
-    """
+    """Get diff of all changes in the worktree vs base branch, without staging anything (index untouched)."""
     wt = session.worktree_path
     if not Path(wt).is_dir():
         # Without this guard the git calls below fail silently and the
@@ -181,16 +171,8 @@ def _branch_exists(repo_root: str, branch_name: str) -> bool:
 
 
 def _cleanup_worktree_sync(session: SandboxSession) -> dict:
-    """Remove worktree and delete branch.
-
-    Retry-safe: a resource that is already absent counts as cleaned up, so a
-    partial failure (e.g. worktree removed but branch deletion blocked by
-    another checkout) can be completed by a later retry instead of failing
-    forever on the step that already succeeded. ``is_active`` is only flipped
-    to ``False`` once both resources are actually gone — a partial failure
-    keeps the session marked active so a caller cannot mistake it for
-    cleaned up.
-    """
+    """Remove worktree and delete branch; retry-safe (already-absent counts as cleaned up).
+    See docs/internals/runtime.md for the is_active / partial-failure contract."""
     _, err1, rc1 = _run_git(
         ["worktree", "remove", session.worktree_path, "--force"],
         cwd=session.repo_root,
@@ -213,14 +195,8 @@ def _cleanup_worktree_sync(session: SandboxSession) -> dict:
 
 
 def _merge_sync(session: SandboxSession, allow_protected: bool = False) -> dict:
-    """Merge worktree branch back into base branch.
-
-    Refuses to run when ``repo_root`` is in a detached HEAD state, when it is
-    not actually checked out on the session's recorded base branch (no
-    auto-checkout), and refuses to merge into a protected branch name
-    (``main``, ``master``, ``release*``) unless the caller explicitly opts
-    in via ``allow_protected``.
-    """
+    """Merge worktree branch back into base branch; refuses on detached HEAD, a
+    base-branch mismatch, or an unopted-in protected branch (see docs/internals/runtime.md)."""
     current_branch, err, rc = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=session.repo_root)
     if rc != 0:
         return {
@@ -228,9 +204,8 @@ def _merge_sync(session: SandboxSession, allow_protected: bool = False) -> dict:
             "error": f"Could not determine the branch checked out at repo_root: {err}",
         }
     if current_branch == "HEAD":
-        # `--abbrev-ref HEAD` returns the literal string "HEAD" when detached
-        # rather than a branch name — merging here would move a detached
-        # HEAD forward with no branch ref pointing at the result.
+        # `--abbrev-ref HEAD` returns literal "HEAD" when detached — merging here
+        # would move a detached HEAD forward with no branch ref pointing at the result.
         return {
             "success": False,
             "error": "repo_root is in a detached HEAD state; refusing to merge into an unverified target.",
@@ -282,9 +257,8 @@ async def create_sandbox(
     if base_branch is None:
         stdout, _, _ = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_root)
         if stdout == "HEAD":
-            # `--abbrev-ref HEAD` returns the literal string "HEAD" when
-            # repo_root is in a detached HEAD state — there is no branch to
-            # record as the sandbox's merge target.
+            # `--abbrev-ref HEAD` returns literal "HEAD" when detached — there is no
+            # branch to record as the sandbox's merge target.
             raise RuntimeError(
                 "repo_root is in a detached HEAD state; pass an explicit base_branch."
             )
@@ -305,13 +279,8 @@ async def sandbox_commit(session: SandboxSession, message: str) -> dict:
 
 
 async def sandbox_merge(session: SandboxSession, *, allow_protected: bool = False) -> dict:
-    """Merge sandbox changes back and clean up.
-
-    Refuses when ``repo_root`` is in a detached HEAD state or isn't checked
-    out on the sandbox's recorded base branch, and refuses to merge into a
-    protected branch name (``main``, ``master``, ``release*``) unless
-    ``allow_protected=True``.
-    """
+    """Merge sandbox changes back into the base branch and clean up
+    (see _merge_sync's safety-refusal contract in docs/internals/runtime.md)."""
     return await run_sync(_merge_sync, session, allow_protected)
 
 

--- a/lionagi/tools/sandbox_backend.py
+++ b/lionagi/tools/sandbox_backend.py
@@ -1,16 +1,8 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sandbox backend seam — one contract for provision/run_cell/collect/teardown.
-
-Backend divergence (local worktree vs. Daytona vs. future backends) is absorbed
-in ``provision()`` and ``capabilities()``; ``run_cell()``'s signature never
-changes per backend. A ``Cell`` is one scored trial and declares a ``kind``:
-``prompt_cell`` (the provider call runs host-side, already authenticated; no
-secrets cross into the box) or ``exec_cell`` (untrusted code runs inside the
-box; secrets are injected explicitly). Callers read ``capabilities()`` to
-decide what a backend can do; they never branch on a backend's name.
-"""
+"""Sandbox backend seam (ADR-0090) — one contract for provision/run_cell/collect/teardown
+across backends; see docs/internals/runtime.md for the prompt_cell/exec_cell security contract."""
 
 from __future__ import annotations
 
@@ -46,9 +38,7 @@ __all__ = (
     "select_backend_for_cell",
 )
 
-# ---------------------------------------------------------------------------
 # ADR-0090 types, adopted verbatim (frozen, codeless data types).
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,9 +77,7 @@ class ExecutionTarget:
         )
 
 
-# ---------------------------------------------------------------------------
 # ADR-0090's stream event shape, absorbed here (ADR-0090 §4 Lineage).
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,18 +89,14 @@ class SubstrateStreamEvent:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
-# ---------------------------------------------------------------------------
 # New ADR-0090 seam types.
-# ---------------------------------------------------------------------------
 
 BackendName = Literal["local_worktree", "daytona"]
 CellKind = Literal["prompt_cell", "exec_cell"]
 ColdStartClass = Literal["sub100ms", "seconds", "minutes"]
 
-#: Sentinel artifact name: ``collect(handle, [DIFF_ARTIFACT])`` returns the
-#: workspace's unified diff instead of reading a literal file at that path.
-#: The same sentinel works across backends so callers never need a
-#: backend-specific way to ask for "what changed".
+#: Sentinel: ``collect(handle, [DIFF_ARTIFACT])`` returns the unified diff instead of
+#: reading a literal file — same sentinel works across all backends.
 DIFF_ARTIFACT = "__diff__"
 
 
@@ -195,13 +179,10 @@ class SandboxBackend(Protocol):
     def capabilities(self) -> Capabilities: ...
 
 
-# ---------------------------------------------------------------------------
 # local_worktree backend — wraps sandbox.py's SandboxSession lifecycle.
-# ---------------------------------------------------------------------------
 
-#: ``run_cell``'s subprocess never blanket-inherits the host environment
-#: (credential-leak vector). Only these variables are forwarded, plus
-#: whatever ``cell.env`` explicitly allow-lists.
+#: run_cell's subprocess never blanket-inherits the host env (credential-leak vector) —
+#: only these vars are forwarded, plus whatever cell.env explicitly allow-lists.
 _SAFE_ENV_KEYS = ("PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV")
 
 
@@ -298,9 +279,7 @@ class LocalWorktreeBackend:
             await _worktree.sandbox_discard(session)
 
 
-# ---------------------------------------------------------------------------
 # daytona backend — thin adapter over daytona.py; behavior unchanged there.
-# ---------------------------------------------------------------------------
 
 
 class DaytonaBackend:
@@ -421,9 +400,7 @@ class DaytonaBackend:
         await sandbox.delete()
 
 
-# ---------------------------------------------------------------------------
 # Registry + capability-driven selection.
-# ---------------------------------------------------------------------------
 
 _BACKENDS: dict[BackendName, SandboxBackend] = {}
 
@@ -441,11 +418,8 @@ def get_backend(name: BackendName) -> SandboxBackend:
 
 
 def select_backend_for_cell(cell: Cell, candidates: Sequence[SandboxBackend]) -> SandboxBackend:
-    """Pick the first candidate whose ``capabilities()`` can host ``cell``.
-
-    Reads ``capabilities()`` only — never a backend's name or type. This is
-    the pattern every caller is expected to follow (ADR-0090 §1).
-    """
+    """Pick the first candidate whose capabilities() can host cell — by capability
+    only, never by backend name/type (ADR-0090 §1)."""
     for backend in candidates:
         caps = backend.capabilities()
         if cell.kind == "prompt_cell" and not caps.hosts_prompt_cell_host_side:


### PR DESCRIPTION
Part of #2132 (comment/docstring verbosity trim). Runtime slice: `lionagi/agent/`, `dispatch/`, `hooks/` (excl. `bus.py`), `providers/`, `service/`, `state/` (excl. `db.py`, `lifecycle/`, `reasons.py`, `schema*`), `testing/`, `tools/`.

- 60 files trimmed: inline prose collapsed to 1-2 lines per location; net −337 lines in code files.
- Keep-worthy invariants moved to a new `docs/internals/runtime.md` (907 lines) organized by module path — largest sections: the MCP wrapper connection contract, CLI-subprocess provider streaming semantics, service resilience/rate-limiting behavior, and the sandbox backend lifecycle.
- Skip list (files owned by open PRs) confirmed untouched.

Zero behavior change, verified programmatically: every touched file AST-identical (docstring content normalized out) to the branch's fork point on main; test pass/fail/skip set identical before and after across `tests/state`, `tests/service`, `tests/tools`, `tests/agent`, `tests/hooks`, `tests/dispatch`. ruff check + format clean on all 60 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
