### PR TITLE
fix: resolve #1864 — li o fanout: orchestrator plan silently truncated to max_tasks, losing coverage

### DIFF
--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -161,8 +161,9 @@ async def plan(
             continue
         valid.append(ta)
     if max_tasks and len(valid) > max_tasks:
-        logger.warning("plan: truncating %d assignments to max_tasks=%d", len(valid), max_tasks)
-        valid = valid[:max_tasks]
+        raise ValueError(
+            f"plan produced {len(valid)} assignments, exceeds max_tasks={max_tasks}"
+        )
     return valid
 
 


### PR DESCRIPTION
## Summary

fix: resolve #1864 — li o fanout: orchestrator plan silently truncated to max_tasks, losing coverage

## Problem

**Severity**: `High` | **File**: `lionagi/orchestration/patterns.py`

plan() truncates assignments to max_tasks with WARNING only. Excess items never processed; run reports success. Completeness lost silently.

## Solution

Raise on planned_count > max_tasks (fail loud). Or re-plan: pass max_tasks as hard cap in orchestrator prompt so it packs all items into ≤N assignments. Drop silent slice.

## Changes

- `lionagi/orchestration/patterns.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._