### PR TITLE
fix(orchestration): plan() enforces max_tasks via planner constraint + backstop raise

### DIFF
--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -49,6 +49,15 @@ __all__ = (
 # Named "assignments" so a parsed operate() result exposes ``res.assignments``.
 _ASSIGNMENTS_FIELD = FieldModel(list[TaskAssignment], name="assignments")
 
+# Appended to the planning guidance when a worker cap is in effect, so the
+# orchestrator packs coverage into the cap instead of a downstream truncation
+# silently dropping assignments it was never told to avoid.
+_MAX_TASKS_CONSTRAINT = (
+    "HARD CAP: emit AT MOST {max_tasks} assignments total. If the work is "
+    "wider than that, consolidate steps onto shared roles rather than "
+    "dropping coverage — every assignment must still be packed within the cap."
+)
+
 
 def grant_spawn(branch: Branch, *, prompt: bool = True) -> None:
     """Let an agent grow the live DAG by emitting a ``SpawnRequest``; grants the capability and, when *prompt*, injects the instruction block."""
@@ -143,12 +152,24 @@ async def plan(
     max_tasks: int = 0,
     context: dict | None = None,
 ) -> list[TaskAssignment]:
-    """Have orchestrator decompose prompt into TaskAssignments; unknown assignees are dropped."""
+    """Have orchestrator decompose prompt into TaskAssignments; unknown assignees are dropped.
+
+    When *max_tasks* is set, the cap is stated in the planning guidance so a
+    compliant plan never needs truncation. If the orchestrator still returns
+    more assignments than the cap after being told it, this raises
+    ``ValueError`` rather than silently dropping the overflow — a warning
+    alone reads as "covered everything" to a caller that isn't watching logs.
+    """
     instruction = DECOMPOSE_DAG_INSTRUCTION if dag else DECOMPOSE_INSTRUCTION
+    full_guidance = f"{guidance} {DECOMPOSE_DISCIPLINE}".strip()
+    if max_tasks:
+        full_guidance = (
+            f"{full_guidance} {_MAX_TASKS_CONSTRAINT.format(max_tasks=max_tasks)}".strip()
+        )
     res = await orchestrator.operate(
         instruction=instruction,
         context={"task": prompt, **(context or {})},
-        guidance=f"{guidance} {DECOMPOSE_DISCIPLINE}".strip(),
+        guidance=full_guidance,
         field_models=[_ASSIGNMENTS_FIELD],
         reason=True,
     )
@@ -161,8 +182,10 @@ async def plan(
             continue
         valid.append(ta)
     if max_tasks and len(valid) > max_tasks:
-        logger.warning("plan: truncating %d assignments to max_tasks=%d", len(valid), max_tasks)
-        valid = valid[:max_tasks]
+        raise ValueError(
+            f"plan: orchestrator returned {len(valid)} assignments, exceeding "
+            f"max_tasks={max_tasks} even after the cap was stated in its guidance"
+        )
     return valid
 
 

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -339,10 +339,32 @@ class TestPlan:
         assert [a.assignee for a in out] == ["researcher"]
 
     @pytest.mark.asyncio
-    async def test_truncates_to_max_tasks(self):
+    async def test_over_limit_plan_raises_instead_of_truncating(self):
+        """A plan that still exceeds max_tasks after the orchestrator was told
+        the cap must fail loudly, not silently drop the overflow (coverage
+        loss must never read as a clean run)."""
         orc = _FakeOrc([TaskAssignment(task=str(i), assignee="researcher") for i in range(5)])
+        with pytest.raises(ValueError, match=r"5 assignments.*max_tasks=2"):
+            await plan(orc, "task", roles={"researcher"}, max_tasks=2)
+
+    @pytest.mark.asyncio
+    async def test_within_limit_plan_passes_through(self):
+        orc = _FakeOrc([TaskAssignment(task=str(i), assignee="researcher") for i in range(2)])
         out = await plan(orc, "task", roles={"researcher"}, max_tasks=2)
         assert len(out) == 2
+
+    @pytest.mark.asyncio
+    async def test_guidance_states_cap_when_max_tasks_set(self):
+        orc = _FakeOrc([])
+        await plan(orc, "task", roles={"researcher"}, max_tasks=8)
+        assert "8" in orc.calls[0]["guidance"]
+        assert "HARD CAP" in orc.calls[0]["guidance"]
+
+    @pytest.mark.asyncio
+    async def test_guidance_omits_cap_when_max_tasks_unset(self):
+        orc = _FakeOrc([])
+        await plan(orc, "task", roles={"researcher"})
+        assert "HARD CAP" not in orc.calls[0]["guidance"]
 
     @pytest.mark.asyncio
     async def test_dag_vs_fanout_instruction(self):


### PR DESCRIPTION
Fixes #1864 — `li o fanout`'s orchestrator plan was silently truncated to `max_tasks`, losing coverage with only a log warning.

- The cap is now stated in the planning guidance whenever `max_tasks` is set, so a compliant plan packs coverage within the cap instead of relying on downstream truncation.
- The silent `valid[:max_tasks]` truncation is replaced by a backstop `ValueError` naming the returned count and the cap — an over-limit plan fails loudly instead of shipping partial coverage that reads as complete.
- Behavior unchanged when `max_tasks` is unset.
- Regression tests: guidance contains the cap when set (and not when unset); over-limit plan raises; within-limit plan passes through.

Credit to @Nam0101 (#2159) for the diagnosis of the silent-truncation coverage loss.

Verification: `tests/orchestration/ tests/engines/test_planning.py tests/cli/orchestrate/` all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)