### PR TITLE
fix(runs,studio): create artifact root at allocation; don't phantom-fail sessions for an absent artifact dir

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -158,6 +158,7 @@ def allocate_run(
 
     run = RunDir(run_id=rid, state_root=state_root, artifact_root=artifact_root)
     run.ensure_state_dirs()
+    run.ensure_artifact_root()
     return run
 
 

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -221,6 +221,29 @@ def test_stale_lock_gated_on_staleness(tmp_path):
     )
 
 
+def test_stale_session_empty_but_existing_artifact_root_not_missing_artifacts(tmp_path):
+    """Once allocate_run creates the artifact directory up front, a stale/not-live
+    session whose artifacts dir exists (even empty, e.g. a bare chat run with no
+    artifact_contract) must never classify as missing_artifacts -- only a
+    genuinely absent directory counts as that evidence. It still reaps
+    (process_dead), preserving cleanup for true positives."""
+    import lionagi.studio.services.admin as admin_svc
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()  # exists, but empty -- no lock file, no output written
+
+    now = time.time()
+    row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": str(artifacts_dir),
+    }
+
+    reason = admin_svc._classify_phantom(row, now=now, stale_seconds=3600, ps_snapshot="")
+    assert reason != "missing_artifacts"
+    assert reason == "process_dead"
+
+
 # ─── /api/admin/health + /api/admin/transition ───────────────────────────────
 
 

--- a/tests/cli/test_runs_allocate_artifact_root.py
+++ b/tests/cli/test_runs_allocate_artifact_root.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: allocate_run must create the artifact root it hands out.
+
+A session's artifacts_path is persisted at allocation time (cli/agent.py passes
+str(run.artifact_root) straight into setup_agent_persist), but allocate_run used
+to call only ensure_state_dirs() -- never ensure_artifact_root(). Every fresh
+run's recorded artifacts_path pointed at a directory that didn't exist yet,
+which the Studio lifecycle reaper's phantom classifier reads as evidence of a
+crashed/lost session (see tests/apps_studio_server/test_admin.py's
+_classify_phantom coverage).
+"""
+
+from __future__ import annotations
+
+import lionagi.cli._runs as runs_mod
+from lionagi.cli._runs import allocate_run
+
+
+def test_allocate_run_creates_artifact_root_default(tmp_path, monkeypatch):
+    """Default (no --save) form: artifact_root lives under state_root/artifacts."""
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+
+    run = allocate_run()
+
+    assert run.artifact_root.is_dir()
+    assert run.artifact_root == run.state_root / "artifacts"
+
+
+def test_allocate_run_creates_artifact_root_save_dir(tmp_path, monkeypatch):
+    """Explicit --save dir form: the caller-supplied directory is also created."""
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+    save_dir = tmp_path / "explicit-save" / "nested"
+
+    run = allocate_run(save_dir=str(save_dir))
+
+    assert run.artifact_root == save_dir.resolve()
+    assert run.artifact_root.is_dir()
+
+
+def test_allocate_run_artifact_root_creation_is_idempotent(tmp_path, monkeypatch):
+    """Re-allocating the same run_id (subprocess handoff) doesn't error on an
+    already-existing artifact root."""
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+
+    first = allocate_run(run_id="fixed-run-id")
+    second = allocate_run(run_id="fixed-run-id")
+
+    assert first.artifact_root == second.artifact_root
+    assert second.artifact_root.is_dir()


### PR DESCRIPTION
Root-cause fix for the dominant non-clean-termination class in the 21-day reliability telemetry: 202 of 371 non-clean terminations were sessions reaped as `missing_artifacts` phantoms whose artifact directory had simply never been created.

## Root cause

`allocate_run()` (lionagi/cli/_runs.py) called only `ensure_state_dirs()`, never `ensure_artifact_root()`. The orchestration path compensated with its own `ensure_artifact_root()` call, but the bare `li agent` path did not — while still persisting `str(run.artifact_root)` into the session row as `artifacts_path`. Every bare-agent run's recorded artifact directory was absent from the moment it was recordable, and the Studio lifecycle reaper's `_classify_phantom` reads an absent `artifacts_path` as `missing_artifacts` evidence.

## Fix

`allocate_run()` now calls `run.ensure_artifact_root()` itself, covering the default and `--save` forms uniformly for every caller. The orchestration path's existing call becomes a harmless idempotent duplicate.

No reaper change: once a session is genuinely stale and its process dead, `_classify_phantom` reaps it regardless of which label applies — the label only names the evidence. With the directory now guaranteed to exist, `missing_artifacts` can no longer be spuriously assigned; true positives (genuinely dead + stale) still reap as before, which existing tests pin.

## Tests

- `tests/cli/test_runs_allocate_artifact_root.py` (new): artifact root created for the default form, for an explicit nested `--save` dir, and idempotently on re-allocation of the same run_id.
- `tests/apps_studio_server/test_admin.py`: stale/dead session with an existing-but-empty artifact root classifies as `process_dead`, never `missing_artifacts`.

Verified: `tests/cli/ tests/studio/ tests/apps_studio_server/test_admin.py` green under `-n4`; touched files also green serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)