### PR TITLE
chore(tests): condense comments and docstrings

### DIFF
--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -627,10 +627,7 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolate_mcp_pool_state():
-    """MCPConnectionPool accumulates configs process-globally; tests here load
-    real config files through create_agent, so snapshot and restore the pool's
-    class-level state to keep those loads from leaking into other test files
-    on the same worker."""
+    """MCPConnectionPool accumulates configs process-globally; snapshot and restore its class-level state around tests that load real config files through create_agent, so loads don't leak into other test files on the same worker."""
     from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
     saved_configs = dict(MCPConnectionPool._configs)
@@ -784,14 +781,7 @@ async def test_forward_mcp_global_candidate_trusted_by_default(tmp_path, monkeyp
 
 
 async def test_forward_mcp_explicit_empty_allowlist_forces_zero_servers(tmp_path):
-    """spec.mcp_servers=[] is an EXPLICIT empty selection, not 'no filter'.
-
-    Before the fix, `if spec.mcp_servers:` treated an empty list the same as
-    None (no filter at all) and forwarded every configured server; here it
-    must forward zero servers, and the resulting ClaudeCodeRequest must still
-    emit `--mcp-config {"mcpServers": {}}` (not silently omit the flag and
-    let the claude CLI fall back to its own MCP discovery).
-    """
+    """spec.mcp_servers=[] is an EXPLICIT empty selection, not 'no filter' -- the old `if spec.mcp_servers:` check treated an empty list like None and forwarded every server; it must forward zero and still emit `--mcp-config {"mcpServers": {}}` rather than silently omit the flag."""
     from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
 
     mcp_path = _write_mcp_config(
@@ -823,15 +813,7 @@ async def test_forward_mcp_explicit_empty_allowlist_forces_zero_servers(tmp_path
 async def test_forward_mcp_explicit_empty_allowlist_enforced_with_no_resolvable_config(
     tmp_path, monkeypatch
 ):
-    """spec.mcp_servers=[] must be enforced even when NO config file resolves.
-
-    Before the fix, an unresolvable mcp_path made `_forward_mcp_to_cli_request`
-    return early, leaving `mcp_servers` unset on the request entirely — the
-    claude CLI would then fall back to its OWN MCP discovery instead of
-    honoring the explicit zero-server allowlist. Isolated HOME + cwd with no
-    .mcp.json anywhere (nothing auto-discoverable) reproduces "no resolvable
-    config" while spec.mcp_servers=[] still declares explicit caller intent.
-    """
+    """spec.mcp_servers=[] must be enforced even when no config file resolves -- previously an unresolvable mcp_path made `_forward_mcp_to_cli_request` return early, leaving mcp_servers unset and letting the claude CLI fall back to its own MCP discovery instead of honoring the explicit zero-server allowlist."""
     from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
 
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
@@ -860,12 +842,7 @@ async def test_forward_mcp_explicit_empty_allowlist_enforced_with_no_resolvable_
 
 
 async def test_forward_mcp_does_not_mutate_shared_chat_model_across_branches(tmp_path):
-    """Two create_agent calls sharing one iModel must get independent MCP filters.
-
-    Branch.__init__ keeps a caller-supplied chat_model by reference (no copy),
-    so mutating branch.chat_model.endpoint.config.kwargs in place would leak
-    one branch's MCP server selection into the other's payload.
-    """
+    """Two create_agent calls sharing one iModel must get independent MCP filters: Branch.__init__ keeps a caller-supplied chat_model by reference, so mutating its config.kwargs in place would leak one branch's MCP selection into the other's payload."""
     from lionagi.service.imodel import iModel
 
     mcp_path = _write_mcp_config(
@@ -897,16 +874,7 @@ async def test_forward_mcp_does_not_mutate_shared_chat_model_across_branches(tmp
 
 
 async def test_forward_mcp_preserves_shared_executor_and_session(tmp_path):
-    """Branch-local MCP filtering must not silently drop the caller-supplied
-    iModel's shared rate limiter or CLI session_id.
-
-    Before the fix, ``branch.chat_model.copy()`` (with no share_session/
-    share_executor kwargs) always built a FRESH RateLimitedAPIExecutor and,
-    since share_session defaulted False, dropped any pre-existing CLI
-    session_id — silently changing the runtime semantics of a caller-supplied
-    iModel that two branches were meant to share (rate limits/queue capacity,
-    and mid-session continuation).
-    """
+    """Branch-local MCP filtering must not silently drop the caller-supplied iModel's shared rate limiter or CLI session_id -- the old `chat_model.copy()` (no share_session/share_executor) always built a fresh executor and dropped any pre-existing session_id, changing the runtime semantics of an iModel two branches were meant to share."""
     from lionagi.service.imodel import iModel
 
     mcp_path = _write_mcp_config(
@@ -945,15 +913,7 @@ async def test_forward_mcp_preserves_shared_executor_and_session(tmp_path):
 
 
 async def test_forward_mcp_explicit_path_read_failure_raises(tmp_path):
-    """An explicitly configured mcp_config_path that fails to read/parse is a
-    configuration error (caller declared intent), not a silent skip.
-
-    Exercises ``_forward_mcp_to_cli_request`` directly (island 2) rather than
-    through the full ``create_agent`` flow: island 1's ``_load_mcp`` already
-    raises its own (unrelated, pre-existing) json.JSONDecodeError for the
-    same malformed file before island 2 ever runs, which would make this
-    regression test pass for the wrong reason if routed through create_agent.
-    """
+    """An explicit mcp_config_path that fails to read/parse is a configuration error, not a silent skip -- exercises `_forward_mcp_to_cli_request` directly rather than through create_agent, since island 1's `_load_mcp` would otherwise raise its own JSONDecodeError first and mask the intended regression."""
     from lionagi._errors import ConfigurationError
     from lionagi.agent.factory import _forward_mcp_to_cli_request
     from lionagi.service.imodel import iModel
@@ -995,17 +955,7 @@ async def test_forward_mcp_auto_discovered_path_read_failure_soft_skips(tmp_path
 
 
 async def test_explicit_mcp_config_path_missing_file_raises_configuration_error(tmp_path):
-    """An explicitly set spec.mcp_config_path pointing at a nonexistent path
-    is a configuration error, not a silent no-op.
-
-    Before the fix, `_resolve_mcp_path` returned None for ANY unresolved
-    mcp_config_path — indistinguishable from "no path configured at all" —
-    so both `_load_mcp` and `_forward_mcp_to_cli_request` silently no-opped
-    even though the caller explicitly declared intent to load a specific
-    file. Exercised through the full create_agent() flow since either island
-    raising is sufficient evidence of the fix (island 1's _load_mcp runs
-    first and shares the same _resolve_mcp_path).
-    """
+    """An explicit spec.mcp_config_path pointing at a nonexistent path is a configuration error, not a silent no-op -- previously `_resolve_mcp_path` returned None for any unresolved path, indistinguishable from 'no path configured', so both islands silently no-opped despite the caller's declared intent."""
     from lionagi._errors import ConfigurationError
 
     config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
@@ -1018,14 +968,7 @@ async def test_explicit_mcp_config_path_missing_file_raises_configuration_error(
 async def test_explicit_empty_string_mcp_config_path_raises_not_autodiscovers(
     tmp_path, monkeypatch
 ):
-    """An explicit empty-string mcp_config_path is a declared (malformed)
-    path, not absence: it must raise, never fall through into auto-discovery.
-
-    Presence is checked with `is not None`, not truthiness — otherwise
-    `mcp_config_path=""` silently auto-discovers whatever candidate exists
-    (e.g. ~/.lionagi/.mcp.json) and loads a config the caller never pointed
-    at.
-    """
+    """An explicit empty-string mcp_config_path is a declared malformed path, not absence -- it must raise, never fall through to auto-discovery; presence is checked with `is not None`, not truthiness, so `mcp_config_path=""` can't silently auto-discover an unrelated config."""
     from lionagi._errors import ConfigurationError
     from lionagi.agent.factory import _resolve_mcp_path
 
@@ -1043,12 +986,7 @@ async def test_explicit_empty_string_mcp_config_path_raises_not_autodiscovers(
 
 
 async def test_search_tool_gets_workspace_root_from_cwd(tmp_path):
-    """tools=["search"] must wire spec.cwd into SearchTool.workspace_root.
-
-    Regression: the standalone search branch registered SearchTool() with no
-    workspace_root, so normal agents got no containment. Here a search outside
-    the configured cwd must be rejected fail-closed.
-    """
+    """tools=['search'] must wire spec.cwd into SearchTool.workspace_root -- previously the standalone search branch registered SearchTool() with no workspace_root, so normal agents got no containment and a search outside the configured cwd wasn't rejected."""
     ws = tmp_path / "workspace"
     ws.mkdir()
     outside = tmp_path / "outside"

--- a/tests/apps_studio_server/test_cas_race_conditions.py
+++ b/tests/apps_studio_server/test_cas_race_conditions.py
@@ -99,13 +99,7 @@ async def _flip_status(db_path: Path, entity_type: str, entity_id: str, new_stat
 
 
 def test_session_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch):
-    """An unguarded write out of a terminal session status is rejected loudly.
-
-    Terminal protection does not depend on the caller remembering to pass
-    expected_statuses: the write path itself refuses to move a session out of a
-    terminal status without an explicit override, so the reaper race cannot
-    corrupt a 'completed' session into 'failed'.
-    """
+    """An unguarded write out of a terminal session status is rejected loudly: the write path itself refuses to move a session out of a terminal status without an explicit override (independent of the caller passing expected_statuses), so the reaper race cannot corrupt a 'completed' session into 'failed'."""
     from lionagi.state.reasons import SessionReasons
 
     db_path = tmp_path / "state.db"
@@ -141,11 +135,7 @@ def test_session_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch):
 
 
 def test_session_race_guarded_preserves_terminal(tmp_path, monkeypatch):
-    """WITH the CAS guard (expected_statuses={"running"}), 'completed' is preserved.
-
-    This is the PASS-after demonstration: the fix blocks the overwrite because
-    'completed' is not in expected_statuses={"running"}.
-    """
+    """PASS-after: WITH the CAS guard (expected_statuses={'running'}), 'completed' is preserved because 'completed' is not in the expected set."""
     from lionagi.state.reasons import SessionReasons
 
     db_path = tmp_path / "state.db"
@@ -181,12 +171,7 @@ def test_session_race_guarded_preserves_terminal(tmp_path, monkeypatch):
 
 
 def test_invocation_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch):
-    """An unguarded write out of a terminal invocation status is rejected loudly.
-
-    The deadline reaper cannot corrupt a 'completed' invocation into 'timed_out':
-    the write path refuses to leave a terminal status without an explicit
-    override, independent of expected_statuses.
-    """
+    """An unguarded write out of a terminal invocation status is rejected loudly: the write path refuses to leave a terminal status without an explicit override, independent of expected_statuses, so the deadline reaper cannot corrupt a 'completed' invocation into 'timed_out'."""
     from lionagi.state.reasons import RunReasons
 
     db_path = tmp_path / "state.db"
@@ -221,10 +206,7 @@ def test_invocation_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch
 
 
 def test_invocation_race_guarded_preserves_terminal(tmp_path, monkeypatch):
-    """WITH the CAS guard (expected_statuses={"running"}), 'completed' is preserved.
-
-    PASS-after for the invocation deadline reaper race.
-    """
+    """PASS-after for the invocation deadline reaper race: WITH the CAS guard (expected_statuses={'running'}), 'completed' is preserved."""
     from lionagi.state.reasons import RunReasons
 
     db_path = tmp_path / "state.db"
@@ -259,12 +241,7 @@ def test_invocation_race_guarded_preserves_terminal(tmp_path, monkeypatch):
 
 
 def test_null_status_reaper_cas_blocks_nonnull(tmp_path, monkeypatch):
-    """Null-status reaper must not touch a session that already has a status.
-
-    The candidate query selects status IS NULL; by the time update_status runs,
-    the session may have received a status.  The CAS guard with expected_statuses={None}
-    must block the overwrite.
-    """
+    """Null-status reaper must not touch a session that already has a status: the candidate query selects status IS NULL, but by the time update_status runs the session may have received one -- the CAS guard with expected_statuses={None} must block the overwrite."""
     from lionagi.state.reasons import RunReasons
 
     db_path = tmp_path / "state.db"
@@ -328,12 +305,7 @@ def test_null_status_reaper_cas_allows_null(tmp_path, monkeypatch):
 
 
 def test_prune_cleans_orphaned_messages_and_progressions(tmp_path, monkeypatch):
-    """prune_old_data() leaves zero orphaned progressions and messages.
-
-    Scenario: one old terminal session (will be pruned), one recent session
-    (must be preserved).  Each session has a progression with two messages.
-    After pruning, only the recent session's progression and messages remain.
-    """
+    """prune_old_data() leaves zero orphaned progressions/messages: one old terminal session is pruned, one recent session (each with a progression of two messages) is preserved."""
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
@@ -347,10 +319,7 @@ def test_prune_cleans_orphaned_messages_and_progressions(tmp_path, monkeypatch):
     recent_ts = time.time() - 1 * 86400
 
     async def _seed() -> tuple[str, str, list[str], list[str]]:
-        """Create two sessions, each with a progression and two messages.
-
-        Returns (old_sid, recent_sid, old_msg_ids, recent_msg_ids).
-        """
+        """Create two sessions, each with a progression and two messages; returns (old_sid, recent_sid, old_msg_ids, recent_msg_ids)."""
         async with StateDB(db_path) as db:
             # ── old session (will be pruned) ──────────────────────────────
             old_pid = str(uuid.uuid4())
@@ -456,11 +425,7 @@ def test_prune_cleans_orphaned_messages_and_progressions(tmp_path, monkeypatch):
 
 
 def _seed_unguarded_global_delete(db_path: Path) -> tuple[str, str]:
-    """Simulate the old global-delete code path for FAIL-before demonstration.
-
-    Returns (orphan_prog_id, orphan_msg_id) — both committed without a
-    referencing session, simulating _persist.py mid-startup state.
-    """
+    """Simulate the old global-delete code path for FAIL-before: returns (orphan_prog_id, orphan_msg_id), both committed without a referencing session, simulating _persist.py mid-startup state."""
 
     async def _seed() -> tuple[str, str]:
         orphan_prog_id = str(uuid.uuid4())
@@ -511,13 +476,7 @@ async def _run_global_delete(db_path: Path) -> None:
 
 
 def test_newborn_orphan_global_delete_destroys_progression(tmp_path, monkeypatch):
-    """FAIL-before: the old global-delete deletes a newborn progression with no session yet.
-
-    This reproduces the race: _persist.py commits progression before session.
-    The old NOT IN (SELECT ... FROM sessions UNION ...) query returns nothing for
-    sessions/branches table (session row doesn't exist yet), so the progression
-    is spuriously deleted.
-    """
+    """FAIL-before: the old global-delete spuriously deletes a newborn progression with no session yet -- reproducing the race where _persist.py commits the progression before the session, so the old NOT-IN-sessions/branches query sees no session row and deletes it."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -573,12 +532,7 @@ def test_newborn_orphan_global_delete_destroys_progression(tmp_path, monkeypatch
 
 
 def test_newborn_orphan_scoped_delete_preserves_progression(tmp_path, monkeypatch):
-    """PASS-after: the scoped delete (fix) never touches a newborn progression.
-
-    prune_old_data() only deletes progressions/messages that were captured
-    from the pruned sessions' lineage before the DELETE.  A newborn progression
-    with no referencing session is not in that candidate set — it survives.
-    """
+    """PASS-after: the scoped delete only targets progressions/messages captured from the pruned sessions' lineage before the DELETE, so a newborn progression with no referencing session (not in that candidate set) survives."""
     import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
@@ -635,12 +589,7 @@ def test_newborn_orphan_scoped_delete_preserves_progression(tmp_path, monkeypatc
 
 
 def test_null_in_collection_does_not_stall_message_cleanup(tmp_path, monkeypatch):
-    """A progression collection containing JSON null doesn't block message cleanup.
-
-    The NOT IN (SELECT value FROM progressions, json_each(collection) WHERE value IS NOT NULL)
-    guard ensures that a null entry in the collection array doesn't propagate
-    a NULL into the NOT IN set and silently suppress all message deletions.
-    """
+    """A progression collection containing a JSON null entry must not stall message cleanup: the NOT-IN guard filters out NULL collection values so a null entry can't propagate into the NOT IN set and suppress all message deletions."""
     import json
 
     import lionagi.state.db as state_db_mod
@@ -653,10 +602,7 @@ def test_null_in_collection_does_not_stall_message_cleanup(tmp_path, monkeypatch
     old_ts = time.time() - 40 * 86400
 
     async def _seed() -> tuple[str, str, str]:
-        """Create an old session whose progression collection has a JSON null entry.
-
-        Returns (session_id, prog_id, real_msg_id).
-        """
+        """Create an old session whose progression collection has a JSON null entry; returns (session_id, prog_id, real_msg_id)."""
         async with StateDB(db_path) as db:
             pid = str(uuid.uuid4())
             sid = str(uuid.uuid4())
@@ -719,24 +665,7 @@ def test_null_in_collection_does_not_stall_message_cleanup(tmp_path, monkeypatch
 
 
 async def _seed_shared_message_scenario(db_path: Path) -> tuple[str, str, str, str]:
-    """Seed the shared-message scenario.
-
-    Creates:
-    - pruned_session (old, terminal) whose progression contains shared_msg and unshared_msg
-    - surviving_branch (recent) whose system_msg_id = shared_msg
-
-    The surviving branch belongs to a surviving session that is NOT being pruned.
-    shared_msg is in the pruned progression's collection AND referenced by
-    surviving_branch.system_msg_id.  unshared_msg is only in the pruned progression.
-
-    Note: first_msg_id / last_msg_id on sessions have a real FK REFERENCES messages(id),
-    so SQLite with foreign_keys=ON prevents deletion while the FK is live.  To demonstrate
-    the bug plainly we use system_msg_id on a branch of a DIFFERENT (surviving) session,
-    which also has the FK — but the FAIL-before test disables foreign_keys first, showing
-    what the old collection-only check would have done without the constraint.
-
-    Returns (pruned_sid, surviving_sid, shared_msg_id, unshared_msg_id).
-    """
+    """Seed the shared-message scenario: pruned_session (old, terminal) has a progression referencing both shared_msg and unshared_msg; surviving_branch (on a different, surviving session) holds shared_msg via system_msg_id, a real FK -- so the FAIL-before test disables foreign_keys first to expose what the old collection-only check would do without it. Returns (pruned_sid, surviving_sid, shared_msg_id, unshared_msg_id)."""
     import json
 
     old_ts = time.time() - 40 * 86400
@@ -805,19 +734,7 @@ async def _seed_shared_message_scenario(db_path: Path) -> tuple[str, str, str, s
 
 
 def test_shared_message_collection_only_check_deletes_it(tmp_path, monkeypatch):
-    """FAIL-before: collection-only survivor check spuriously deletes shared message.
-
-    Simulates the old code path with foreign_keys=OFF to expose the bug:
-    NOT IN only checks progressions.collection.  After the pruned session's
-    progression is deleted, shared_msg_id no longer appears in any collection
-    — so it is deleted even though surviving_branch.system_msg_id holds it.
-
-    foreign_keys=OFF is used here to bypass the FK constraint that would
-    ordinarily prevent the delete; this is the exact failure mode in any
-    runtime that doesn't enforce FKs (e.g. a migration path, or prior to
-    the PRAGMA being applied) or if the message is held by a table without
-    a FK constraint (hypothetical future table).
-    """
+    """FAIL-before, foreign_keys=OFF: the old collection-only survivor check (NOT IN progressions.collection) spuriously deletes shared_msg once the pruned progression is gone, even though surviving_branch.system_msg_id still holds it -- the failure mode for any runtime that doesn't enforce FKs."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -873,14 +790,7 @@ def test_shared_message_collection_only_check_deletes_it(tmp_path, monkeypatch):
 
 
 def test_shared_message_fk_survivor_check_preserves_it(tmp_path, monkeypatch):
-    """PASS-after: full survivor check (collection + FK columns) preserves shared message.
-
-    prune_old_data() UNIONs first_msg_id / last_msg_id (sessions) and
-    system_msg_id (branches) in the NOT IN subquery.  shared_msg_id is held
-    by surviving_branch.system_msg_id, so it survives even though the pruned
-    progression's collection no longer exists.
-    The unshared message (only in the pruned progression) is correctly deleted.
-    """
+    """PASS-after: the full survivor check (collection + FK columns) UNIONs first_msg_id/last_msg_id/system_msg_id into the NOT IN subquery, so shared_msg_id survives via surviving_branch.system_msg_id while the unshared message is still correctly deleted."""
     import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
@@ -922,13 +832,7 @@ async def _get_updated_at(db_path: Path, entity_type: str, entity_id: str) -> fl
 
 
 def test_version_guard_blocks_write_when_updated_at_moved(tmp_path, monkeypatch):
-    """expected_updated_at pins the transition to a row version.
-
-    A caller that decided to act on a stale snapshot (status still in the
-    expected set, but the row was re-touched by a concurrent writer) must NOT
-    win: the bumped updated_at makes the guarded write match zero rows and
-    update_status returns False without moving the status.
-    """
+    """expected_updated_at pins the transition to a row version: a caller acting on a stale snapshot (status still in the expected set, but updated_at bumped by a concurrent writer) must not win -- the guarded write matches zero rows and update_status returns False without moving the status."""
     from lionagi.state.reasons import RunReasons
 
     db_path = tmp_path / "state.db"

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -163,35 +163,12 @@ _PARAM_NAME_RE = re.compile(r"\(\?P<\w+>")
 
 
 def _normalize_route_match_shape(path_regex_pattern: str) -> str:
-    """Erase parameter NAMES from a compiled Starlette path_regex pattern,
-    keeping converter/regex semantics.
-
-    Starlette compiles "/x/{id}" and "/x/{schedule_id}" to the same regex
-    BODY under different named groups (`(?P<id>[^/]+)` vs
-    `(?P<schedule_id>[^/]+)`) -- the router dispatches purely on the
-    compiled match, never on the param spelling, so two routes differing
-    only in param name shadow each other exactly like an identical literal
-    path would. A typed converter changes the body itself
-    (`(?P<id>[0-9]+)` for `{id:int}`), so it stays a genuinely distinct
-    shape from the untyped `{id}` -- only the group NAME is erased here,
-    not the pattern inside it.
-    """
+    """Erase parameter NAMES from a compiled Starlette path_regex pattern, keeping converter/regex semantics: the router dispatches on the compiled body, not the param spelling, so `{id}` and `{schedule_id}` shadow each other while a typed `{id:int}` (different regex body) stays a genuinely distinct shape."""
     return _PARAM_NAME_RE.sub("(?P<_>", path_regex_pattern)
 
 
 def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str, str]]:
-    """(method, path, match_shape) for every route on a FastAPI app's route
-    table, as a LIST (not a set) -- a route registered twice at the same
-    match shape produces two entries here, one per registration.
-
-    match_shape is the route's compiled path_regex with parameter names
-    erased (see _normalize_route_match_shape); it is what FastAPI's router
-    actually dispatches on, kept alongside the original `path` so a
-    duplicate report can show a developer both source spellings. HEAD is
-    excluded: FastAPI auto-adds it for every GET, so it is never an
-    independent registration and would double every GET row for no
-    contract value.
-    """
+    """(method, path, match_shape) for every route on a FastAPI app's route table, as a LIST -- a route registered twice at the same match shape produces two entries. HEAD is excluded (FastAPI auto-adds it for every GET, so it would double every GET row for no contract value)."""
     entries: list[tuple[str, str, str]] = []
     for route in app.routes:
         path = getattr(route, "path", None)
@@ -212,17 +189,7 @@ def _entries_from_fastapi_app(app: fastapi.FastAPI) -> list[tuple[str, str, str]
 def _find_duplicate_routes(
     entries: list[tuple[str, str, str]],
 ) -> dict[tuple[str, str], list[str]]:
-    """Return {(method, match_shape): [path, path, ...]} for every match
-    shape registered more than once.
-
-    Keying on match_shape (not the raw path) is what catches two routes
-    that read as different source -- "/x/{schedule_id}" vs "/x/{id}" --
-    but compile to the identical dispatch target: FastAPI's router matches
-    the first registration for a given compiled shape and never even
-    considers a later one, so the second is dead code regardless of what
-    its param happens to be named. The path list preserves both original
-    spellings for the failure message.
-    """
+    """Return {(method, match_shape): [path, path, ...]} for every match shape registered more than once -- keying on match_shape (not the raw path) catches routes that read as different source but compile to the same dispatch target, where FastAPI's router silently drops the later registration as dead code."""
     by_shape: dict[tuple[str, str], list[str]] = {}
     for method, path, match_shape in entries:
         by_shape.setdefault((method, match_shape), []).append(path)
@@ -271,12 +238,7 @@ def test_golden_route_count_pinned():
 
 
 def _compiled_match_shape(path_template: str) -> str:
-    """Real Starlette-compiled match shape for a path template.
-
-    Goes through an actual Route object (the same path_regex Starlette
-    itself computes), rather than a hand-typed regex string, so the test
-    fixtures below can't drift from Starlette's real compile_path() output.
-    """
+    """Real Starlette-compiled match shape for a path template, via an actual Route object (not a hand-typed regex) so the fixtures below can't drift from Starlette's own compile_path() output."""
     from starlette.routing import Route
 
     async def _noop() -> None:
@@ -319,18 +281,7 @@ def test_normalize_route_match_shape_erases_param_names_but_keeps_converters():
 
 
 def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
-    """End-to-end proof, not just a property of the tuple-list helper: a
-    genuinely duplicated route (identical path spelling) on a real FastAPI
-    app's route table is detected by the same collection path
-    _live_app_routes() uses.
-
-    A duplicate can't be produced through the studio_route registry itself
-    (registry.py's dedup guard raises ValueError on a second registration at
-    the same (path, method, module, qualname) -- see test_route_registry.py
-    ::test_dedup_guard_raises_on_duplicate), so this mounts two routes
-    directly on a throwaway FastAPI app the way FastAPI itself would if that
-    guard were ever bypassed or missing.
-    """
+    """End-to-end proof, not just a property of the tuple-list helper: since the studio_route registry's own dedup guard already raises on a same-shape duplicate, this mounts two identical-path routes directly on a throwaway FastAPI app to prove _live_app_routes() would still catch it if that guard were ever bypassed."""
     from fastapi import FastAPI
 
     app = FastAPI()
@@ -351,17 +302,7 @@ def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
 
 
 def test_duplicate_route_registration_with_different_param_names_is_caught():
-    """The reviewer's exact regression: /api/schedules/{schedule_id} and
-    /api/schedules/{id} read as different source but compile to the same
-    dispatch target, so the second shadows the first exactly like an
-    identical-path duplicate would -- the gate must name them as duplicates
-    even though no two path strings in the pair are equal.
-
-    One route is registered through an APIRouter + include_router (with a
-    path prefix, the way every real studio area router mounts), and the
-    other directly on the app, proving match-shape normalization survives
-    prefix compilation rather than only working on a hand-built path string.
-    """
+    """The reviewer's exact regression: /api/schedules/{schedule_id} and /api/schedules/{id} read as different source but compile to the same dispatch target, so the gate must name them as duplicates even though no two path strings are equal -- one route goes through an APIRouter + prefix (like real studio routers), proving match-shape normalization survives prefix compilation."""
     from fastapi import APIRouter, FastAPI
 
     app = FastAPI()
@@ -391,14 +332,7 @@ def test_duplicate_route_registration_with_different_param_names_is_caught():
 
 
 def test_api_prefix_appears_exactly_once_in_every_route_path():
-    """Every mounted studio API route path carries exactly one "/api" segment.
-
-    Guards the double-prefix regression class directly: a client (or a
-    future route-registration change) that prepends "/api" a second time
-    would produce paths like "/api/api/sessions/", which this test catches
-    by counting occurrences of the literal "/api" substring rather than
-    just checking the leading prefix.
-    """
+    """Guards the double-prefix regression class: a route-registration change that prepends '/api' a second time would produce '/api/api/...' paths, caught here by counting occurrences of the literal '/api' substring rather than just checking the leading prefix."""
     for _method, path in _live_app_routes():
         if path == "/health":
             assert "/api" not in path
@@ -413,13 +347,7 @@ def test_api_prefix_appears_exactly_once_in_every_route_path():
 
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
-    """Point every service module's DB reference at a fresh temp path.
-
-    Must run before any seeding call -- StateDB() reads
-    lionagi.state.db.DEFAULT_DB_PATH fresh at each instantiation (see
-    StateDB.__init__), and admin.py/sessions.py additionally cache the path
-    as a plain string in their own module-level `_DB` for aiosqlite.connect.
-    """
+    """Point every service module's DB reference at a fresh temp path; must run before any seeding call since StateDB() re-reads DEFAULT_DB_PATH fresh per instantiation, and admin.py/sessions.py additionally cache the path in their own module-level `_DB`."""
     import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.db_maintenance as db_maintenance_mod
@@ -919,12 +847,7 @@ def test_schedules_disable_success_response_shape(tmp_path, monkeypatch):
 
 
 def test_schedules_trigger_success_response_shape(tmp_path, monkeypatch):
-    """scheduler.fire_now() is mocked out: a real fire spawns a background
-    asyncio task that launches a subprocess (engine.py::_tracked_fire), which
-    has no place in a response-shape pin. This isolates the route handler's
-    own success contract -- {"ok": True, "run_id": <the value fire_now
-    returned>} -- from the scheduler engine's fire machinery, which has its
-    own coverage elsewhere."""
+    """scheduler.fire_now() is mocked out (a real fire spawns a background subprocess with no place in a response-shape pin), isolating the route handler's own success contract -- {'ok': True, 'run_id': ...} -- from the scheduler engine's fire machinery, covered elsewhere."""
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
     schedule_id = _create_gate_schedule(db_path)

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -284,17 +284,7 @@ async def test_checkpoint_writer_record_flow_context_updates_running_snapshot(tm
 async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedups_by_node_id(
     tmp_path: Path,
 ):
-    """Spawned nodes must never share the `ops` keyspace with planned agent_ids
-    -- a spawned child's branch can be named identically to a planned agent_id
-    (clones inherit the source branch's name), so `ops` and `spawned` are kept
-    as two distinct groves, and re-recording the same spawned node id updates
-    its one entry rather than appending a duplicate.
-
-    Also pins the CHECKPOINT_VERSION 2 reconstruction fields (operation,
-    assignee, instruction, parent_id, spawn_id) round-tripping through the
-    same entry, and defaulting to None when the caller (an old-format write
-    path, or one that couldn't resolve the live graph node) omits them.
-    """
+    """Spawned nodes use a separate `spawned` keyspace from planned `ops` (a spawned branch can share a planned agent_id's name); re-recording the same node id updates in place, and CHECKPOINT_VERSION 2 reconstruction fields round-trip, defaulting to None when omitted."""
     path = tmp_path / "checkpoint.json"
     writer = CheckpointWriter(path=path, session_id="s", prompt="p", plan=[], config={})
 
@@ -418,11 +408,7 @@ def test_apply_checkpoint_precompletion_no_degraded_ops_is_a_silent_noop():
 
 
 def test_apply_checkpoint_precompletion_preserves_failed_ops_as_terminal_not_rerun():
-    """A checkpointed 'failed' op must be restored as terminal FAILED, not
-    silently treated as pending and re-run -- it may already have produced
-    side effects or partial artifacts before the process died, and resume
-    must never guess at retry semantics on its own.
-    """
+    """A checkpointed 'failed' op is restored as terminal FAILED, not re-run -- it may have already produced side effects and resume must not guess at retry semantics."""
     nodes = {"n-worker": _FakeNode("n-worker")}
     env = SimpleNamespace(
         builder=SimpleNamespace(get_graph=lambda: SimpleNamespace(internal_nodes=nodes))
@@ -457,15 +443,7 @@ def test_apply_checkpoint_precompletion_preserves_failed_ops_as_terminal_not_rer
 
 
 def test_apply_checkpoint_precompletion_refuses_when_spawned_entries_present():
-    """A checkpoint's `spawned` entries in the pre-CHECKPOINT_VERSION-2 shape
-    (no `operation` recorded) carry nothing resume can rebuild an Operation
-    node from, so they must refuse resume outright rather than silently drop
-    that completed work. Refusal is unconditional -- it is not something
-    --allow-degraded-context (a different concern) can bypass -- and happens
-    before any node is mutated. Contrast with
-    test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without_refusing
-    below, where a CHECKPOINT_VERSION-2-shaped entry resumes cleanly.
-    """
+    """Pre-CHECKPOINT_VERSION-2 `spawned` entries (no `operation` recorded) carry nothing to rebuild from, so resume refuses unconditionally before mutating any node -- contrast with the version-2-shaped entry below, which resumes cleanly."""
     nodes = {"n-worker": _FakeNode("n-worker")}
     env = SimpleNamespace(
         builder=SimpleNamespace(get_graph=lambda: SimpleNamespace(internal_nodes=nodes))
@@ -541,14 +519,7 @@ def _terminal_plan_and_ops(agent_id: str, node_id, status: str = "completed") ->
 
 
 def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_branch():
-    """The core sound-replay case: a reactively spawned node whose own
-    checkpoint entry recorded operation/assignee/instruction/parent_id (the
-    CHECKPOINT_VERSION 2 fields) is rebuilt into the graph, wired to its
-    parent by a 'spawn' edge, routed to the same role branch a live spawn
-    would have used, and pre-completed -- so the executor's terminal-status
-    short-circuit picks it up instead of re-running it. The planned parent
-    is checkpointed completed, satisfying the soundness gate.
-    """
+    """Core sound-replay case: a completed reactively-spawned node with its CHECKPOINT_VERSION 2 fields is rebuilt, wired to its parent by a 'spawn' edge, routed to the same role branch, and pre-completed so the executor's terminal short-circuit skips re-running it."""
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = SimpleNamespace(builder=builder)
     dag_state = _DagState(
@@ -623,10 +594,7 @@ def test_reconstruct_spawned_nodes_marks_failed_child_terminal_not_rerun():
 
 
 def test_reconstruct_spawned_nodes_chains_through_another_reconstructed_spawn():
-    """A grandchild spawn (spawned by a node that was itself reactively
-    spawned) resolves its parent against the other entries in the SAME
-    checkpoint_spawned batch, not just the statically planned nodes.
-    """
+    """A grandchild spawn resolves its parent against the other entries in the same checkpoint_spawned batch, not just the statically planned nodes."""
     builder = OperationGraphBuilder()
     env = SimpleNamespace(builder=builder)
     dag_state = _DagState(
@@ -674,13 +642,7 @@ def test_reconstruct_spawned_nodes_chains_through_another_reconstructed_spawn():
 
 
 def test_reconstruct_spawned_nodes_refuses_when_parent_not_checkpointed_terminal():
-    """The genuinely unsound subcase named in the design: a spawned node
-    whose parent op had NOT itself reached a checkpointed terminal state
-    before the crash. Resuming would either duplicate the spawn (the parent
-    re-runs and emits it again) or lose it outright (the parent never
-    re-emits it) -- a decision this version cannot soundly replay. Refusal
-    names only the affected node, and mutates nothing first.
-    """
+    """A spawned node whose parent op had not itself reached a checkpointed terminal state before the crash can't be soundly replayed (would duplicate or lose the spawn); refusal names only the affected node and mutates nothing first."""
     builder = OperationGraphBuilder()
     env = SimpleNamespace(builder=builder)
     dag_state = _DagState(
@@ -715,16 +677,7 @@ def test_reconstruct_spawned_nodes_refuses_when_parent_not_checkpointed_terminal
 
 
 def test_reconstruct_spawned_nodes_refuses_when_planned_parent_exists_but_is_still_pending():
-    """Tighter parent-soundness case: a spawned child's parent_id names a REAL planned DAG node -- not a
-    stray string -- but that planned node has no terminal entry in
-    checkpoint_ops (still pending at crash time). Accepting this on the old
-    "parent_id is any known planned node" rule would pre-complete the child
-    while the parent reruns live, and the parent can then emit the same
-    follow-up spawn again -- exactly the duplicate-work case the design
-    calls out. Tightening the gate to require the planned parent be
-    checkpointed terminal (same rule already applied to spawn-chain parents)
-    must refuse this the same way.
-    """
+    """Tighter parent-soundness case: parent_id names a real planned node, but it has no terminal entry in checkpoint_ops (still pending at crash time) -- accepting this would pre-complete the child while the parent reruns live and re-emits the same spawn."""
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = SimpleNamespace(builder=builder)
     dag_state = _DagState(
@@ -798,16 +751,7 @@ def test_reconstruct_spawned_nodes_refuses_unrecognized_status():
 
 
 def test_reconstruct_spawned_nodes_refuses_assignee_without_spawn_id():
-    """The defensive counterpart to spawn_id reconstruction: role_node_builder
-    stamps spawn_id and assignee together, unconditionally, at construction
-    time -- so a
-    checkpoint entry recording an assignee but no spawn_id cannot have come
-    from a sound live spawn. Reconstructing it anyway would hand the
-    finalize-time result-collection scan an assignee-bearing node with no
-    spawn_id, which is precisely the RuntimeError invariant violation this
-    fix exists to prevent; refusing resume for the node is the safe
-    alternative to smuggling that broken state through.
-    """
+    """role_node_builder always stamps spawn_id and assignee together, so an entry with assignee but no spawn_id can't have come from a sound live spawn; reconstructing it would hand finalize an assignee-bearing node with no spawn_id, violating its invariant."""
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = SimpleNamespace(builder=builder)
     dag_state = _DagState(
@@ -840,12 +784,7 @@ def test_reconstruct_spawned_nodes_refuses_assignee_without_spawn_id():
 
 
 def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without_refusing():
-    """End-to-end through the actual entry point _run_flow_inner calls: a
-    CHECKPOINT_VERSION-2-shaped spawned entry resumes cleanly alongside the
-    normal planned-op precompletion -- no refusal just because a spawn
-    occurred, matching the design's core fix (contrast with the legacy-format
-    refusal test above).
-    """
+    """End-to-end through _run_flow_inner's entry point: a CHECKPOINT_VERSION-2-shaped spawned entry resumes cleanly alongside normal planned-op precompletion -- no refusal just because a spawn occurred."""
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = SimpleNamespace(builder=builder)
 
@@ -906,11 +845,7 @@ def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without
 
 
 async def test_checkpoint_captures_nonempty_executor_flow_context_on_completion(tmp_path: Path):
-    """The write side of the flow_context guarantee: _checkpoint_record must
-    snapshot the live executor's shared context workspace, not just the
-    completing op's own response -- otherwise --resume has nothing correct to
-    restore even though the checkpoint's `ops` entries look fine on their own.
-    """
+    """Write side of the flow_context guarantee: _checkpoint_record must snapshot the live executor's shared context, not just the completing op's response, or --resume has nothing correct to restore."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -974,12 +909,7 @@ async def test_checkpoint_captures_nonempty_executor_flow_context_on_completion(
 async def test_checkpoint_spawned_node_name_collision_does_not_overwrite_planned_ops_entry(
     tmp_path: Path,
 ):
-    """A reactively spawned child's branch can carry a name identical to a
-    planned agent_id's (clones inherit the source branch's name). Using that
-    name as the checkpoint's `ops` key would silently overwrite the planned
-    op's entry -- spawned completions must route to `spawned`, keyed by their
-    own node id, and never touch `ops`.
-    """
+    """A spawned child's cloned branch can share a planned agent_id's name; using that name as the `ops` key would silently overwrite the planned entry, so spawned completions route to `spawned` keyed by node id instead."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1074,15 +1004,7 @@ async def test_checkpoint_spawned_node_name_collision_does_not_overwrite_planned
 async def test_checkpoint_record_captures_spawn_id_from_live_role_routed_graph_node(
     tmp_path: Path,
 ):
-    """The write-side counterpart: role_node_builder stamps spawn_id/
-    reference_id on a spawned node's metadata unconditionally, whether or
-    not the request
-    carried an assignee (lionagi/orchestration/patterns.py). _checkpoint_record
-    must capture spawn_id off the live graph node the same way it already
-    captures assignee, so a role-routed spawn's checkpoint entry carries
-    what reconstruction later needs to satisfy the finalize-time
-    assignee-without-spawn_id invariant check.
-    """
+    """Write-side counterpart: role_node_builder stamps spawn_id unconditionally on a spawned node's metadata, so _checkpoint_record must capture it off the live graph node the same way it captures assignee, for reconstruction's assignee-without-spawn_id check."""
     builder, parent_id, worker_branch = _real_planned_node("worker")
     env = _make_resume_env(tmp_path)
     env.builder = builder
@@ -1171,17 +1093,7 @@ async def test_checkpoint_record_captures_spawn_id_from_live_role_routed_graph_n
 async def test_execute_dag_seeds_fresh_checkpoint_with_already_reconstructed_spawned_entries(
     tmp_path: Path,
 ):
-    """Double-crash/double-resume: a first resume reconstructs a
-    completed reactively-spawned node from a prior checkpoint's `spawned`
-    list into the graph and pre-completes it (never re-run, so it never
-    emits a fresh completion signal to re-record itself). The NEXT
-    _execute_dag call for this generation constructs a brand new
-    CheckpointWriter; without seeding it with the already-reconstructed
-    entries, its very first flush would overwrite `spawned` back to `[]` --
-    so if this resumed run crashes AGAIN before anything new completes, the
-    second resume would find nothing to reconstruct from and silently lose
-    that already-completed spawned work.
-    """
+    """Double-crash/double-resume: a resume's brand-new CheckpointWriter must be seeded with already-reconstructed spawned entries, or its first flush overwrites `spawned` back to `[]` and a second crash loses that completed work."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1247,17 +1159,7 @@ async def test_execute_dag_seeds_fresh_checkpoint_with_already_reconstructed_spa
 
 
 async def test_execute_dag_max_spawn_budget_accounts_for_restored_spawns(tmp_path: Path):
-    """--max-ops is a TOTAL budget for the whole logical run, including
-    resumes -- _resume_flow replays the checkpoint's persisted config
-    verbatim rather than re-deriving max_ops, and the CLI's own progress
-    text calls it "at most {max_ops} ops total, INCLUDING any reactively
-    spawned" ones. Recomputing the live spawn budget on resume as
-    max_ops - len(assignments), with no adjustment for spawns already
-    restored from a prior checkpoint generation, would silently re-grant
-    the SAME budget every resume -- a run that had already exhausted its
-    spawn budget before a crash could accept spawns beyond what --max-ops
-    ever allowed.
-    """
+    """--max-ops is a total budget across resumes; recomputing the live spawn budget as max_ops - len(assignments) with no adjustment for spawns already restored would silently re-grant the same budget every resume."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1322,13 +1224,7 @@ async def test_execute_dag_max_spawn_budget_accounts_for_restored_spawns(tmp_pat
 
 
 async def test_execute_dag_n_spawned_counts_restored_spawns_alongside_new_ones(tmp_path: Path):
-    """The synthesis gate in _run_flow_inner is `with_synthesis or
-    exec_result.n_spawned`. A resume where every reactively spawned node was
-    already completed before the crash -- so THIS generation's live run_dag
-    produces zero new spawns -- must still report the restored count as
-    n_spawned, or a fully-restored, spawn-having run would silently skip
-    synthesis solely because nothing NEW happened to spawn this generation.
-    """
+    """The synthesis gate is `with_synthesis or exec_result.n_spawned`; a resume where every spawn was already completed before the crash (zero new spawns this generation) must still report the restored count, or synthesis is silently skipped."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1387,16 +1283,7 @@ async def test_execute_dag_n_spawned_counts_restored_spawns_alongside_new_ones(t
 
 
 async def test_resumed_run_with_only_restored_spawns_triggers_synthesis(tmp_path: Path):
-    """End-to-end through _run_flow_inner: the synthesis gate must fire even
-    when every reactively spawned node was already completed before the
-    crash and this generation's live run_dag produces zero new spawns --
-    proving the n_spawned accounting fix actually reaches the gate check,
-    not just the _execute_dag return value in isolation. Reconstruction
-    itself (_apply_checkpoint_precompletion) is stubbed here since its
-    correctness is covered elsewhere; this isolates the downstream
-    accounting/gating consequence of a checkpoint carrying `spawned` entries
-    into a resume.
-    """
+    """End-to-end through _run_flow_inner: the synthesis gate must fire even when every reactively spawned node was already completed and this generation produces zero new spawns -- proves the n_spawned accounting fix reaches the gate check, not just _execute_dag's return value."""
     env = _make_resume_env(tmp_path)
     checkpoint = {
         "version": 2,
@@ -1477,12 +1364,7 @@ async def test_resumed_run_with_only_restored_spawns_triggers_synthesis(tmp_path
 
 
 def test_role_node_builder_start_seeds_first_spawn_id_past_restored_ordinal():
-    """Direct proof of the resume-facing knob: role_node_builder(..., start=2)
-    must issue spawn-2 for the first live spawn built through it, not
-    spawn-1 -- the exact collision (same spawn_id, same artifact directory,
-    since the CLI derives one from the other) a resumed run's fresh closure
-    would otherwise reissue against an already-restored spawn-1.
-    """
+    """role_node_builder(..., start=2) must issue spawn-2 for the first live spawn, not spawn-1 -- the exact id/artifact-directory collision a resumed run's fresh closure would otherwise reissue against an already-restored spawn-1."""
     from lionagi.casts.emission import SpawnRequest
     from lionagi.orchestration.patterns import role_node_builder
 
@@ -1494,12 +1376,7 @@ def test_role_node_builder_start_seeds_first_spawn_id_past_restored_ordinal():
 
 
 async def test_execute_dag_seeds_spawn_sequence_past_restored_ordinal(tmp_path: Path):
-    """When resuming a checkpoint that already restored spawn-1, the fresh
-    role_node_builder(...) this _execute_dag call constructs must start its
-    sequence at 2, not 1 -- otherwise any pending op that emits a new spawn
-    after the resume reuses spawn-1's id (and artifact directory) instead of
-    representing a distinct spawned operation.
-    """
+    """Resuming a checkpoint that already restored spawn-1, the fresh role_node_builder(...) this _execute_dag call constructs must start its sequence at 2, or a new spawn after resume reuses spawn-1's id and artifact directory."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1561,15 +1438,7 @@ async def test_execute_dag_seeds_spawn_sequence_past_restored_ordinal(tmp_path: 
 
 
 async def test_execute_dag_seeds_spawn_sequence_past_gap_in_restored_ordinals(tmp_path: Path):
-    """A crashed run may have gaps -- a spawn allocated (consuming an
-    ordinal from role_node_builder's sequence) but never reaching a
-    checkpointed terminal state before the crash never appears in a
-    checkpoint's `spawned` list at all. The next-ordinal seed must take the
-    MAX existing restored ordinal + 1, not len(restored) + 1, or it would
-    double-allocate into the gap and still collide. Restoring only
-    "spawn-3" (as if spawn-1/spawn-2 existed but crashed before completing)
-    must still seed the next sequence at 4, not 2.
-    """
+    """A crashed run can leave gaps (an allocated spawn ordinal that never reached a checkpointed terminal state, so it's absent from `spawned`); the next-ordinal seed must take MAX(restored)+1, not len(restored)+1, or it double-allocates into the gap."""
     env = _make_resume_env(tmp_path)
     env.session = Session(default_branch=Branch(name="orchestrator"))
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
@@ -1634,11 +1503,7 @@ async def test_execute_dag_seeds_spawn_sequence_past_gap_in_restored_ordinals(tm
 
 
 async def test_resume_skips_planner_and_still_calls_finalize_with_zero_pending_ops(tmp_path: Path):
-    """A checkpoint where every op is already completed must still reach
-    _finalize_flow — no shortcut may skip the finalization tail just because
-    execute_dag had nothing new to run. Also pins the companion guarantee:
-    the planner is never called on resume.
-    """
+    """A checkpoint where every op is already completed must still reach _finalize_flow -- no shortcut skips finalization just because execute_dag had nothing new to run. Also pins: the planner is never called on resume."""
     env = _make_resume_env(tmp_path)
     checkpoint = {
         "version": 1,
@@ -1702,13 +1567,7 @@ async def test_resume_skips_planner_and_still_calls_finalize_with_zero_pending_o
 
 
 async def test_resume_seeds_executor_with_checkpointed_flow_context(tmp_path: Path):
-    """A completed op that wrote into the executor's shared flow_context
-    before a crash must hand that same context to the fresh (post-resume)
-    executor, so pending ops downstream see it exactly as they would have
-    live -- not the empty workspace a brand new DependencyAwareExecutor
-    otherwise starts with. Proven across a simulated process boundary: this
-    _run_flow_inner call knows nothing except what the checkpoint dict carries.
-    """
+    """A completed op's flow_context written before a crash must hand off to the fresh post-resume executor, not the empty workspace a brand-new DependencyAwareExecutor starts with -- proven across a simulated process boundary."""
     env = _make_resume_env(tmp_path)
     checkpoint = {
         "version": 1,
@@ -1769,13 +1628,7 @@ async def test_resume_seeds_executor_with_checkpointed_flow_context(tmp_path: Pa
 async def test_resumed_checkpoint_carries_restored_flow_context_across_zero_completions(
     tmp_path: Path,
 ):
-    """A second-generation checkpoint -- one written by a RESUMED run -- must
-    still carry forward the flow_context restored from the prior checkpoint,
-    even if the resumed run crashes before any op completes and the writer
-    only ever flushes its initial construction-time seed. Otherwise a
-    resume-of-a-resume silently loses shared context that nothing actually
-    went wrong with restoring, across this second simulated process boundary.
-    """
+    """A second-generation checkpoint (written by a resumed run) must still carry forward the flow_context restored from the prior checkpoint, even if it crashes before any op completes and the writer only flushes its initial seed."""
     env = _make_resume_env(tmp_path)
     env.run.checkpoint_path = tmp_path / "checkpoint.json"
     checkpoint = {
@@ -1837,11 +1690,7 @@ async def test_resumed_checkpoint_carries_restored_flow_context_across_zero_comp
 
 
 async def test_resume_refuses_checkpoint_with_spawned_entries(tmp_path: Path):
-    """Replaying reactively spawned work on resume isn't implemented, so a
-    checkpoint that recorded any must refuse resume outright -- silently
-    proceeding would drop that completed spawned work along with its
-    artifact-contract/synthesis participation.
-    """
+    """Replaying reactively spawned work on resume isn't implemented, so a checkpoint recording any must refuse outright rather than silently drop that completed spawned work."""
     env = _make_resume_env(tmp_path)
     checkpoint = {
         "version": 1,
@@ -1891,12 +1740,7 @@ async def test_resume_refuses_checkpoint_with_spawned_entries(tmp_path: Path):
 async def test_resume_missing_artifact_still_flips_status_to_failed(
     temp_db_path: Path, tmp_path: Path
 ):
-    """Concrete DB-level proof of the same gate: resuming a checkpoint whose
-    only op is already 'completed' (nothing left for run_dag to execute) must
-    still drive the artifact-verification teardown check. A required artifact
-    genuinely missing from disk must still flip the session to failed, not
-    silently read as a clean completion because resume had nothing new to run.
-    """
+    """Concrete DB-level proof of the same gate: resuming a checkpoint with nothing left for run_dag to execute must still drive the artifact-verification teardown check, and flip status to failed if a required artifact is missing."""
     env = _minimal_real_env()
     artifacts_dir = tmp_path / "artifacts"
     artifacts_dir.mkdir()
@@ -2083,10 +1927,7 @@ async def test_resolve_checkpoint_target_falls_back_to_session_run_id(
 
 
 def _parse_flow_args(argv: list[str]) -> argparse.Namespace:
-    """Mimic the real CLI pipeline: pre-scan for playbook → inject flags → parse.
-
-    Mirrors tests/cli/orchestrate/test_flow_spec_file.py's helper of the same name.
-    """
+    """Mimics the real CLI pipeline (pre-scan for playbook -> inject flags -> parse); same helper name as test_flow_spec_file.py's, for parity."""
     from lionagi.cli.orchestrate import (
         add_orchestrate_subparser,
         inject_playbook_schema_into_parser,

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -293,10 +293,7 @@ async def test_operate_node_omits_actions_kwarg_for_cli_worker(tmp_path):
 
 @pytest.mark.asyncio
 async def test_fanout_and_flow_call_sites_use_the_same_shared_node_builder():
-    """Regression guard for the exact bug class this module protects against:
-    if either fanout.py or flow.py stopped routing its static operate-node
-    construction through the shared `_build_worker_operate_node` helper (e.g.
-    reverting to an inline, independently-editable conditional), this fails."""
+    """Regression guard: if either fanout.py or flow.py stopped routing its static operate-node construction through the shared `_build_worker_operate_node` helper (e.g. reverting to an inline, independently-editable conditional), this fails."""
     import lionagi.cli.orchestrate.fanout as fanout_mod
     import lionagi.cli.orchestrate.flow as flow_mod
     from lionagi.cli.orchestrate._common import _build_worker_operate_node
@@ -307,12 +304,7 @@ async def test_fanout_and_flow_call_sites_use_the_same_shared_node_builder():
 
 @pytest.mark.asyncio
 async def test_bound_worker_operate_serializes_messenger_tool_schema(tmp_path):
-    """End-to-end: build a real bound worker branch, construct its operate
-    node through the real shared builder, then drive the EXACT request dict
-    produced by production through Branch.operate() with a capturing middle.
-    Confirms actions=True flows through Operation._invoke() -> operate() ->
-    action_param construction -> get_tool_schema(), and that the messenger
-    tool's schema is what gets serialized to the model."""
+    """End-to-end: build a real bound worker branch, construct its operate node through the real shared builder, then drive the exact request dict production produces through Branch.operate() with a capturing middle -- confirms actions=True flows through to get_tool_schema() and the messenger tool's schema is what gets serialized to the model."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}
@@ -557,10 +549,7 @@ def test_team_worker_system_no_unreachable_note_when_all_teammates_bound():
 
 
 def test_team_worker_system_bash_channel_ignores_messenger_names():
-    """A bash-channel (messenger_bound=False) worker's prompt is unaffected by
-    messenger_names — only messenger-bound workers need the reachability
-    filter, since the bash `li team` channel's own reachability is unrelated
-    to Exchange/roster registration."""
+    """A bash-channel (messenger_bound=False) worker's prompt is unaffected by messenger_names -- only messenger-bound workers need the reachability filter, since the bash `li team` channel's own reachability is unrelated to Exchange/roster registration."""
     section = team_worker_system(
         _mixed_team_data(),
         "alice",
@@ -574,10 +563,7 @@ def test_team_worker_system_bash_channel_ignores_messenger_names():
 
 @pytest.mark.asyncio
 async def test_messenger_bound_worker_prompt_flags_cli_teammate_end_to_end(tmp_path):
-    """End-to-end: build_worker_branch's real system prompt for a messenger-bound
-    worker in a mixed-provider team (env.messenger_names precomputed the way
-    fanout.py/flow.py do it) never tells the worker to message a CLI-only
-    teammate as if it were reachable."""
+    """End-to-end: build_worker_branch's real system prompt for a messenger-bound worker in a mixed-provider team (env.messenger_names precomputed the way fanout.py/flow.py do it) never tells the worker to message a CLI-only teammate as if it were reachable."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}
@@ -666,10 +652,7 @@ def test_team_history_context_none_without_team_data():
 
 
 def test_team_worker_system_never_contains_prior_message_content():
-    """The system prompt is the one place attached-team history must NEVER
-    appear — regression guard for the injection-surface concern: message
-    content sent by a prior (potentially untrusted) sender must not be
-    promoted to the same authority as coordination instructions."""
+    """The system prompt is the one place attached-team history must NEVER appear -- regression guard for the injection-surface concern: message content from a prior (potentially untrusted) sender must not be promoted to the same authority as coordination instructions."""
     section = team_worker_system(
         _attached_team_data(),
         "alice",
@@ -686,11 +669,7 @@ def test_team_worker_system_never_contains_prior_message_content():
 async def test_messenger_bound_worker_system_prompt_excludes_attached_history_end_to_end(
     tmp_path,
 ):
-    """End-to-end: build_worker_branch's real system prompt for a messenger-
-    bound worker attaching to a team with prior messages never contains that
-    history — it must only ever reach the worker via operation context,
-    which build_worker_branch itself does not construct (fanout.py/flow.py
-    do, using team_history_context — see the tests above for its content)."""
+    """End-to-end: build_worker_branch's real system prompt for a messenger-bound worker attaching to a team with prior messages never contains that history -- it must only reach the worker via operation context, which build_worker_branch itself does not construct."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}
@@ -764,12 +743,7 @@ def test_team_worker_system_orchestrator_line_stays_plain_for_bash_channel_worke
 
 
 def _parse_advertised_roster(section: str) -> list[tuple[str, bool]]:
-    """Parse the '### Your team' roster block of a rendered coordination
-    section into (name, flagged_unreachable) pairs, driven entirely by the
-    rendered text — never a hardcoded name list. A line is "flagged" when
-    its own annotation says it isn't a valid messenger `to=` target (the
-    same wording team_worker_system uses for both CLI-only teammates and
-    the orchestrator); anything else is advertised as reachable."""
+    """Parse the '### Your team' roster block of a rendered coordination section into (name, flagged_unreachable) pairs, driven entirely by the rendered text, never a hardcoded name list -- a line is 'flagged' when its own annotation says it isn't a valid messenger `to=` target."""
     block = section.split("### Your team", 1)[1].split("\n###", 1)[0]
     parsed = []
     for line in block.splitlines():
@@ -785,14 +759,7 @@ def _parse_advertised_roster(section: str) -> list[tuple[str, bool]]:
 
 @pytest.mark.asyncio
 async def test_every_advertised_messenger_recipient_is_actually_reachable(tmp_path):
-    """Structural guard requested for this class of bug: parse the roster a
-    real messenger-bound worker's OWN rendered prompt advertises, then check
-    each parsed name against the live roster/tool it actually ships with —
-    never hardcode which names should or shouldn't work. A name advertised
-    as plain (not flagged) must be a valid `to=` target; a name flagged
-    unreachable must actually be rejected. This is exactly the assertion
-    that would have failed pre-fix: 'orchestrator' used to appear as a
-    plain roster line while never being registered in env.roster."""
+    """Structural guard: parse the roster a real messenger-bound worker's OWN rendered prompt advertises, then check each parsed name against the live roster/tool it ships with, never hardcoding which names should work -- exactly the assertion that would have failed pre-fix, when 'orchestrator' appeared as a plain roster line while never being registered in env.roster."""
     exchange = Exchange()
     messenger = LionMessenger(exchange)
     roster: dict = {}

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -297,10 +297,7 @@ async def test_poll_pending_once_leaves_running_run_pending(
 async def test_poll_pending_once_across_two_ticks_with_db_mutation_no_real_sleep(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Drives the run from running -> completed between two direct calls to
-    the tick function — the deterministic, zero-wall-clock way to exercise
-    'terminal across different poll iterations' (see also the real-thread
-    variant against _dispatch_wait below)."""
+    """Drives the run from running -> completed between two direct tick calls -- the deterministic, zero-wall-clock way to exercise 'terminal across different poll iterations' (see also the real-thread variant against _dispatch_wait below)."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="running")
@@ -466,11 +463,7 @@ async def test_advance_chains_grace_expires_without_child_resolves_on_parent_exi
 async def test_advance_chains_cancelled_run_resolves_without_grace(
     temp_db_path: Path,
 ) -> None:
-    """A watched run that lands status="cancelled" can never get a chain
-    child fired for it -- the engine's CancelledError branch sets
-    status="cancelled" and skips its chain-fire block entirely -- so even
-    though the schedule declares a matching on_fail, no grace window opens;
-    the root resolves on the very next tick."""
+    """A watched run landing status='cancelled' never gets a chain child fired -- the engine's CancelledError branch skips the chain-fire block entirely -- so even with a matching on_fail declared, no grace window opens; the root resolves on the very next tick."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="declares-on-fail", on_fail={"kind": "agent"})
         run_id = await _make_schedule_run(db, sched_id, status="cancelled", exit_code=None)
@@ -487,11 +480,7 @@ async def test_advance_chains_cancelled_run_resolves_without_grace(
 async def test_advance_chains_skipped_run_resolves_without_grace(
     temp_db_path: Path,
 ) -> None:
-    """A skipped run (overlap or missed-fire policy) is created terminal by
-    create_skipped_run and never goes through the engine's fire path, so no
-    chain child can ever follow it -- even though its schedule declares a
-    matching on_fail (skipped runs have exit_code=None), no grace window
-    opens; the root resolves on the very next tick."""
+    """A skipped run (overlap/missed-fire policy) is created terminal by create_skipped_run and never goes through the fire path, so no chain child can follow it -- even with a matching on_fail declared (skipped runs have exit_code=None), no grace window opens; resolves on the very next tick."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="declares-on-fail-skip", on_fail={"kind": "agent"})
         run_id = await _make_schedule_run(db, sched_id, status="skipped", exit_code=None)
@@ -508,12 +497,7 @@ async def test_advance_chains_skipped_run_resolves_without_grace(
 async def test_advance_chains_failed_run_without_exit_code_resolves_without_grace(
     temp_db_path: Path,
 ) -> None:
-    """A run that failed before its subprocess ever spawned (argv build
-    error or internal exception) lands status="failed" with exit_code=None.
-    The engine's chain block sits after the subprocess returns a real exit
-    code, so such a run can never get a chain child -- even with a matching
-    on_fail declared, no grace window opens; the root resolves on the very
-    next tick."""
+    """A run that failed before its subprocess ever spawned lands status='failed' with exit_code=None; the chain block sits after a real exit code, so it can never get a chain child even with a matching on_fail -- no grace window opens, resolves on the very next tick."""
     async with StateDB() as db:
         sched_id = await _make_schedule(
             db, name="declares-on-fail-noexit", on_fail={"kind": "agent"}
@@ -532,11 +516,7 @@ async def test_advance_chains_failed_run_without_exit_code_resolves_without_grac
 async def test_advance_chains_chain_depth_at_cap_resolves_without_grace(
     temp_db_path: Path,
 ) -> None:
-    """A watched run already at the engine's chain-depth cap can never get a
-    chain child fired for it either -- the engine only fires when
-    chain_depth < _MAX_CHAIN_DEPTH (10) -- so a schedule declaring a
-    matching on_success still gets no grace window; the root resolves on
-    the very next tick."""
+    """A watched run already at the engine's chain-depth cap (chain_depth < _MAX_CHAIN_DEPTH == 10) can never get a chain child fired either -- a matching on_success still gets no grace window; resolves on the very next tick."""
     async with StateDB() as db:
         sched_id = await _make_schedule(
             db, name="declares-on-success", on_success={"kind": "agent"}
@@ -557,11 +537,7 @@ async def test_advance_chains_chain_depth_at_cap_resolves_without_grace(
 async def test_advance_chains_multi_hop_chain_followed_to_final_link(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """(f) a retry-on-failure chain (on_fail declared, no on_success):
-    parent fails -> child1 fails -> child2 succeeds. Depth-2 chain; the
-    final link (child2) decides the aggregate, and child2's own schedule
-    has no on_success declared so it resolves immediately once it succeeds
-    (no further grace, no infinite chase)."""
+    """(f) A retry-on-failure chain (on_fail only): parent fails -> child1 fails -> child2 succeeds. Depth-2 chain; child2 (the final link, no on_success of its own) decides the aggregate and resolves immediately once it succeeds -- no further grace, no infinite chase."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="retry-on-fail", on_fail={"kind": "agent"})
         parent_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
@@ -716,10 +692,7 @@ async def test_dispatch_wait_mixed_unknown_and_resolved_still_returns_exit_unkno
 async def test_dispatch_wait_polls_across_real_iterations_until_background_mutation(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Integration-level companion to the deterministic two-tick test above:
-    a background thread flips the row to terminal partway through, proving
-    the sync orchestration loop (not just the inner tick function) actually
-    polls on a real cadence rather than resolving everything up front."""
+    """Integration companion to the deterministic two-tick test above: a background thread flips the row to terminal partway through, proving the sync orchestration loop -- not just the inner tick function -- actually polls on a real cadence."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="running")
@@ -745,18 +718,7 @@ async def test_dispatch_wait_polls_across_real_iterations_until_background_mutat
 
 
 def _interrupt_dispatch_on_tick(monkeypatch: pytest.MonkeyPatch, *, tick: int) -> None:
-    """Deterministically interrupt a ``_dispatch_wait`` poll/follow loop.
-
-    Firing ``os.kill(os.getpid(), SIGINT)`` from a wall-clock timer thread aims
-    at the shared pytest-xdist worker: if the signal lands after
-    ``_dispatch_wait`` has already returned (during teardown) or while a
-    KeyboardInterrupt-raising handler is momentarily installed, it escapes and
-    crashes the worker. Making ``run_async`` raise ``KeyboardInterrupt`` on the
-    ``tick``-th call exercises the exact clean-exit path ``_dispatch_wait``
-    takes when SIGINT lands mid-tick, with no signal that can outlive the call.
-    Call 1 is the initial resolve, call 2 the first bounded tick, later calls
-    the follow-tail ticks.
-    """
+    """Deterministically interrupt a ``_dispatch_wait`` poll/follow loop: raising KeyboardInterrupt from ``run_async`` on the ``tick``-th call (rather than a real SIGINT, which could land after the loop returns and crash the shared pytest-xdist worker) exercises the same clean-exit path with no signal that can outlive the call. Call 1 is the initial resolve, call 2 the first bounded tick, later calls the follow-tail ticks."""
     import lionagi.ln.concurrency as concurrency_mod
 
     real_run_async = concurrency_mod.run_async
@@ -816,13 +778,7 @@ async def test_dispatch_wait_interrupted_during_resolve_returns_exit_running(
 async def test_dispatch_wait_keyboard_interrupt_after_tick_mutates_state_still_reports_failure(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression: run_async can complete a tick's real work (printing a
-    terminal row, mutating `pending`/`done`) and *then* raise
-    KeyboardInterrupt before _dispatch_wait ever sees the tick's return
-    value -- exactly what happens when SIGINT is delivered right as the
-    tick's coroutine finishes. The already-observed failure must still be
-    reflected in the exit code, not lost to a vacuous empty-`done` success.
-    """
+    """Regression: run_async can mutate state (print a terminal row, update pending/done) and only then raise KeyboardInterrupt before _dispatch_wait sees the tick's return value -- exactly what SIGINT delivered at tick-completion looks like. The already-observed failure must still be reflected in the exit code, not lost to a vacuous empty-done success."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
@@ -852,10 +808,7 @@ async def test_dispatch_wait_keyboard_interrupt_after_tick_mutates_state_still_r
 async def test_dispatch_wait_chain_follow_on_fail_recovery_final_link_wins(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """(b) a failed parent whose schedule declares on_fail, and whose
-    already-fired child succeeded, must report exit 0 -- the chain
-    recovered, and the *final* link decides, not the failed first one. Both
-    links' lines are printed."""
+    """(b) A failed parent whose schedule declares on_fail, whose already-fired child succeeded, must report exit 0 -- the chain recovered and the final link decides, not the failed first one."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="flaky", on_fail={"kind": "agent"})
         parent_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
@@ -937,15 +890,7 @@ async def test_dispatch_wait_no_chain_ignores_fired_children(
 async def test_dispatch_wait_overlapping_roots_child_watched_directly_succeeds(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Regression: a parent AND its already-linked chain child are both
-    passed as initial watch roots (e.g. from comma/list expansion). The
-    parent is terminal from the start, which starts a grace window that
-    discovers the child via chain_parent_id -- but the child is *also* one
-    of the originally-watched roots, and is still running at that moment.
-    The discovery must not clobber the child's own root ownership: once the
-    child later completes on its own, both the parent's root (resolved via
-    the child as its final link) and the child's own root must resolve, not
-    just the parent's."""
+    """Regression: parent and its already-linked chain child are both passed as initial watch roots (e.g. comma/list expansion); the parent's grace-window discovery of the child (via chain_parent_id) must not clobber the child's own root ownership -- once the still-running child later completes, both the parent's root (resolved via the child as final link) and the child's own root must resolve."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
         parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
@@ -979,10 +924,7 @@ async def test_dispatch_wait_overlapping_roots_child_watched_directly_succeeds(
 async def test_dispatch_wait_overlapping_roots_child_watched_directly_fails(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Failure-side variant of the overlapping-roots regression above: the
-    child (also a directly-watched root) completes with a nonzero exit code
-    -- the aggregate must report failure (1), not fall back to EXIT_RUNNING
-    because the child's own root never resolved."""
+    """Failure-side variant of the overlapping-roots regression above: the child (also a directly-watched root) completes with a nonzero exit code -- the aggregate must report failure (1), not fall back to EXIT_RUNNING."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
         parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
@@ -1016,14 +958,7 @@ async def test_dispatch_wait_overlapping_roots_child_watched_directly_fails(
 async def test_dispatch_wait_child_already_terminal_same_tick_prints_once(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Regression: parent AND its chain child are *both* already terminal
-    before `_dispatch_wait` even starts (no background flip needed) -- the
-    very first poll tick prints both directly, then the parent's grace-
-    window discovery finds the child via chain_parent_id. The child's own
-    schedule declares no chain action of its own, so it should already be
-    resolved outright by the time discovery reaches it -- re-adding it to
-    `pending` would make the next tick's `_poll_pending_once` print it a
-    second time."""
+    """Regression: parent and its chain child are both already terminal before _dispatch_wait starts; the first poll tick prints both, then the parent's grace-window discovery finds the child via chain_parent_id -- since the child declares no chain action of its own it is already resolved, so re-adding it to pending would print it a second time."""
     async with StateDB() as db:
         parent_sched = await _make_schedule(db, name="parent-sched", on_success={"kind": "agent"})
         parent_id = await _make_schedule_run(db, parent_sched, status="completed", exit_code=0)
@@ -1049,12 +984,7 @@ async def test_dispatch_wait_child_already_terminal_same_tick_prints_once(
 async def test_dispatch_wait_child_already_terminal_joins_own_grace_prints_once(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """Variant of the above: the already-terminal child's own schedule
-    *also* declares a matching chain action (on_success), so discovery must
-    join the parent's root into the child's own `awaiting_grace` entry
-    instead of resolving it outright -- and once that grace window expires
-    (no grandchild ever fires), both roots resolve together on the child's
-    exit code, each line still printed exactly once."""
+    """Variant of the above: the already-terminal child's own schedule also declares a matching chain action (on_success), so discovery must join the parent's root into the child's own awaiting_grace entry instead of resolving it outright -- both roots then resolve together on the child's exit code, each line printed exactly once."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
         parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
@@ -1075,17 +1005,7 @@ async def test_dispatch_wait_child_already_terminal_joins_own_grace_prints_once(
 async def test_dispatch_wait_deep_chain_follows_handoff_past_terminal_child(
     temp_db_path: Path, capsys: pytest.CaptureFixture, descendant_first: bool
 ) -> None:
-    """Regression: a three-link chain (parent failed -> child failed ->
-    grandchild succeeded), all terminal before the wait starts, watched via
-    both the parent AND the child as overlapping roots. When the child is
-    listed first, its grace window discovers the grandchild and hands its
-    root off BEFORE the parent's grace window discovers the child — so the
-    parent's discovery finds an already-processed child that is no longer
-    in awaiting_grace. It must follow the child's handoff forward to the
-    grandchild (the chain's real tail) instead of resolving the parent's
-    root on the child's intermediate failure: final-link-wins means this
-    recovered chain reports success in both watch orders, each run printed
-    exactly once."""
+    """Regression: a three-link chain (parent failed -> child failed -> grandchild succeeded), all terminal before the wait starts, watched via both parent and child. When the child is listed first its grace window discovers the grandchild and hands its root off before the parent's discovery reaches it -- the parent must follow that handoff to the grandchild (final-link-wins) rather than resolve on the child's intermediate failure, in either watch order, each run printed exactly once."""
     async with StateDB() as db:
         parent_sched = await _make_schedule(db, name="parent-sched", on_fail={"kind": "agent"})
         parent_id = await _make_schedule_run(db, parent_sched, status="failed", exit_code=1)
@@ -1170,11 +1090,7 @@ async def test_dispatch_wait_follow_sigint_clean(
 async def test_dispatch_wait_follow_preserves_initial_failure_exit_code(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression: --follow must not collapse an initial bounded-set FAILURE
-    into a false success just because the follow phase was entered and later
-    interrupted. The initial watched set's aggregate result is the contract
-    --follow's exit code honors; the open-ended tail has no result of its
-    own to report."""
+    """Regression: --follow must not collapse an initial bounded-set FAILURE into a false success just because the follow phase was entered and later interrupted -- the initial watched set's aggregate result is the contract --follow's exit code honors."""
     async with StateDB() as db:
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
@@ -1650,10 +1566,7 @@ async def test_dispatch_wait_follows_linked_engine_session_to_completion(
 async def test_dispatch_wait_persists_reconciled_status_to_profile_row(
     temp_db_path: Path,
 ) -> None:
-    """`li monitor run` resolving a profile session via its linked engine row must
-    not just SYNTHESIZE the terminal status in memory for this one call -- it must
-    PERSIST it through StateDB.update_status() so the profile session's own DB row
-    reads the reconciled terminal status too, not stuck at 'running' forever."""
+    """`li monitor run` resolving a profile session via its linked engine row must PERSIST the reconciled terminal status through StateDB.update_status(), not just synthesize it in memory for this one call, so the profile session's own DB row doesn't stay stuck at 'running' forever."""
     from lionagi import Branch
     from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
     from lionagi.providers._provider_errors import ProviderError
@@ -1862,12 +1775,7 @@ async def test_dispatch_wait_max_wait_bounds_a_stuck_session(temp_db_path: Path)
 async def test_dispatch_wait_default_max_wait_bounds_a_stuck_session_without_caller_bound(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The caller supplies no max_wait at all (the real production default path for
-    `li monitor run` / `li monitor --run` when --max-wait is omitted) and there is no
-    external interrupt -- the built-in bounded default must still stop the wait and
-    report EXIT_RUNNING instead of hanging forever. The module-level default is
-    monkeypatched down to keep this test fast; the caller-facing contract under test
-    is that omitting max_wait entirely still bounds the wait."""
+    """With no max_wait supplied (the real production default for `li monitor run`/`li monitor --run`) and no external interrupt, the built-in bounded default must still stop the wait and report EXIT_RUNNING instead of hanging forever; the module-level default is monkeypatched down to keep the test fast."""
     import lionagi.cli.monitor as monitor_mod
 
     monkeypatch.setattr(monitor_mod, "_DEFAULT_MAX_WAIT_SECONDS", 0.3)

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -235,12 +235,7 @@ async def test_run_error_chunk_raises_and_restores_streaming_processor():
 
 
 async def test_run_preserves_primary_exception_when_aclose_raises_cancelled_error():
-    """The CLI close chain (ndjson_from_cli -> aterminate_process_group ->
-    asyncio.wait_for) can raise asyncio.CancelledError, a BaseException a
-    plain `except Exception` does not catch. Left unguarded, that would
-    escape run()'s cleanup finally and REPLACE the real "error" chunk
-    RuntimeError that was already propagating -- the caller would see a
-    misleading CancelledError instead of the actual provider failure."""
+    """The CLI close chain can raise asyncio.CancelledError, a BaseException a plain `except Exception` doesn't catch -- left unguarded it would escape run()'s cleanup finally and replace the real propagating error with a misleading CancelledError."""
     import asyncio
 
     async def stream(api_call=None):
@@ -261,11 +256,7 @@ async def test_run_preserves_primary_exception_when_aclose_raises_cancelled_erro
 
 
 async def test_run_caller_abandonment_closes_stream_without_raising():
-    """A consumer that stops iterating early (explicit aclose() after
-    consuming into the middle of the stream) triggers GeneratorExit through
-    run()'s own async generator; the finally block's stream_gen.aclose() must
-    complete cleanly (no leaked exception, no traceback) and the underlying
-    CLI stream must be closed."""
+    """A consumer that stops iterating early (explicit aclose() mid-stream) triggers GeneratorExit through run()'s own async generator; the finally block's stream_gen.aclose() must complete cleanly and the underlying CLI stream must be closed."""
     closed = False
 
     async def stream(api_call=None):
@@ -360,12 +351,7 @@ async def test_run_stream_persist_snapshot_dir_default_falls_back_to_persist_dir
 
 
 async def test_run_stream_persist_snapshot_survives_mid_stream_cancellation(tmp_path):
-    """A branch checkpoint exists and is loadable even if the turn is killed
-    before the model produces a single chunk (e.g. SIGTERM mid-stream on a
-    long-running CLI turn). The snapshot is written before streaming starts,
-    not only on clean completion, so `find_branch` + `Branch.from_dict`
-    can resume a branch whose first turn never finished.
-    """
+    """A branch checkpoint exists and is loadable even if the turn is killed before the model produces a single chunk -- the snapshot is written before streaming starts, not only on clean completion, so a branch whose first turn never finished can still be resumed."""
     import anyio as _anyio
 
     branches_dir = tmp_path / "branches"
@@ -437,14 +423,7 @@ async def test_run_stream_persist_snapshot_survives_mid_stream_cancellation(tmp_
 
 
 async def test_write_branch_snapshot_torn_write_keeps_prior_snapshot(tmp_path, monkeypatch):
-    """A kill landing mid-write must never corrupt an existing snapshot.
-
-    The write is staged through a sibling .tmp file, so a failure while the
-    bytes are going out tears only the staging file — the target keeps the
-    previous complete, parseable snapshot. Under a direct open('w') write the
-    target itself would be truncated/torn, so this test pins the staging
-    behavior: it fails if the helper ever writes the target in place again.
-    """
+    """A kill landing mid-write must never corrupt an existing snapshot: the write stages through a sibling .tmp file, so a failure mid-write tears only the staging file and the target keeps its previous complete snapshot -- fails if the helper ever writes the target in place."""
     import anyio as _anyio
 
     branch = Branch()
@@ -491,11 +470,7 @@ async def test_write_branch_snapshot_torn_write_keeps_prior_snapshot(tmp_path, m
 
 
 async def test_write_branch_snapshot_failed_replace_keeps_prior_snapshot(tmp_path, monkeypatch):
-    """If the final rename fails, the target must be untouched — pinning that
-    the helper publishes via os.replace rather than writing the target
-    directly (a direct write would have already clobbered it by this point,
-    and os.replace would never be reached at all).
-    """
+    """If the final rename fails, the target must be untouched, pinning that the helper publishes via os.replace rather than writing the target directly."""
     import os as _os
 
     branch = Branch()
@@ -865,12 +840,7 @@ async def test_imodel_stream_propagates_cancellation():
 
 
 def _make_hanging_cli_model(create_event_calls: list, streams_first_output_early: bool = True):
-    """A CLI iModel whose stream() never yields anything — simulates a worker
-    subprocess that dies at/near spawn and never produces a first chunk.
-
-    ``streams_first_output_early`` mirrors the endpoint capability flag that
-    gates run.py's config-default watchdog; defaults True (claude_code/codex-
-    style early streamer) since that's what most of these fakes stand in for."""
+    """A CLI iModel whose stream() never yields anything, simulating a worker subprocess that dies at/near spawn; streams_first_output_early defaults True (claude_code/codex-style early streamer) since that's what most of these fakes stand in for."""
     import anyio
 
     m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
@@ -934,10 +904,7 @@ def _make_retry_recovers_cli_model(create_event_calls: list):
 
 
 def _make_buffered_delay_cli_model(create_event_calls: list, delay: float):
-    """A CLI iModel that stands in for a buffered transport (e.g. gemini_code):
-    it does not declare ``streams_first_output_early``, and its stream() sleeps
-    ``delay`` before yielding its one and only chunk — indistinguishable from a
-    dead worker to a naive first-chunk watchdog until the delay elapses."""
+    """A CLI iModel standing in for a buffered transport (e.g. gemini_code): it doesn't declare streams_first_output_early, and its stream() sleeps `delay` before its one chunk -- indistinguishable from a dead worker until the delay elapses."""
     import anyio
 
     m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
@@ -1025,10 +992,7 @@ async def test_run_liveness_watchdog_disabled_by_zero():
 
 
 async def test_run_liveness_watchdog_uses_configured_default_when_absent(monkeypatch):
-    """When the caller doesn't pass liveness_timeout, run() falls back to
-    lionagi.config.settings.LIONAGI_WORKER_LIVENESS_TIMEOUT (monkeypatched
-    here to a small value so the test stays fast) — for an endpoint that
-    declares streams_first_output_early (the default of this fake)."""
+    """When the caller omits liveness_timeout, run() falls back to LIONAGI_WORKER_LIVENESS_TIMEOUT (monkeypatched small here) for an endpoint that declares streams_first_output_early."""
     import lionagi.config as config_module
     from lionagi.providers._provider_errors import WorkerLivenessError
 
@@ -1061,10 +1025,7 @@ async def test_run_liveness_watchdog_strips_kwarg_from_create_event():
 
 
 async def test_run_liveness_watchdog_yields_to_caller_stream_timeout():
-    """When the caller's own overall stream `timeout` is tighter than the
-    liveness window, the caller's TimeoutError fires unmodified (no retry) —
-    the caller asked for that total-stream budget deliberately, and it must
-    not be reinterpreted as a worker-liveness failure."""
+    """When the caller's own stream `timeout` is tighter than the liveness window, the caller's TimeoutError fires unmodified -- that deliberate total-stream budget must not be reinterpreted as a worker-liveness failure."""
     import time
 
     create_event_calls: list = []
@@ -1088,11 +1049,7 @@ async def test_run_liveness_watchdog_yields_to_caller_stream_timeout():
 
 
 async def test_run_liveness_watchdog_default_path_skips_buffered_endpoint(monkeypatch):
-    """A buffered transport (streams_first_output_early absent/False) whose
-    first chunk legitimately arrives after the configured default liveness
-    window must complete successfully with no retry and no
-    WorkerLivenessError under the config-default path — the default watchdog
-    is not applied at all for endpoints that don't declare the capability."""
+    """A buffered transport whose first chunk legitimately arrives after the default liveness window must complete successfully with no retry -- the default watchdog isn't applied at all for endpoints that don't declare streams_first_output_early."""
     import lionagi.config as config_module
 
     create_event_calls: list = []
@@ -1113,10 +1070,7 @@ async def test_run_liveness_watchdog_default_path_skips_buffered_endpoint(monkey
 
 
 async def test_run_liveness_watchdog_explicit_timeout_enforced_on_buffered_endpoint():
-    """An explicitly-passed liveness_timeout is always honored, even for a
-    buffered endpoint that doesn't declare streams_first_output_early — the
-    caller opted in deliberately, so the watchdog must still retry then
-    raise WorkerLivenessError on a worker that never produces output."""
+    """An explicitly-passed liveness_timeout is always honored, even for a buffered endpoint -- the caller opted in deliberately, so the watchdog still retries then raises WorkerLivenessError on a worker that never produces output."""
     from lionagi.providers._provider_errors import WorkerLivenessError
 
     create_event_calls: list = []

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -152,13 +152,7 @@ async def test_dependent_spawn_runs_after_emitter():
 
 @pytest.mark.asyncio
 async def test_spawn_branch_setup_fires_with_operation_and_cloned_branch():
-    """spawn_branch_setup(operation, cloned_branch) must run for every
-    reactively-spawned node right after its branch clone is created — the
-    seam cli/orchestrate/flow.py uses to retarget a CLI-backed chat_model's
-    writable workspace to the spawn's own artifact dir instead of silently
-    inheriting the emitter's. The stamped spawn_id (set by node_builder,
-    mirroring role_node_builder in production) must already be on the
-    operation's metadata by the time the callback fires."""
+    """spawn_branch_setup(operation, cloned_branch) must run for every reactively-spawned node right after its branch clone is created -- the seam cli/orchestrate/flow.py uses to retarget a CLI-backed chat_model's writable workspace to the spawn's own artifact dir. The stamped spawn_id must already be on the operation's metadata by the time the callback fires."""
     from lionagi.session.branch import Branch
 
     async def spawner(**kw):
@@ -207,17 +201,7 @@ async def test_spawn_branch_setup_fires_with_operation_and_cloned_branch():
 )
 @pytest.mark.asyncio
 async def test_reactive_flow_notifies_for_preallocated_clone():
-    """A dependency-created (preallocated) branch clone must fire
-    on_branch_created exactly once, the same guarantee non-reactive flow
-    already provides. It currently fires zero times: this reproduces the
-    confirmed gap so a future runtime fix turns this into a loud XPASS
-    instead of silently leaving the branch-created persistence hook unfired
-    for reactive runs. Pinned to AssertionError so an unrelated exception
-    from either production `flow(...)` call surfaces as a real failure
-    instead of being swallowed as this known violation, and split from the
-    injected-clone leg below so a partial repair (one leg fixed, not the
-    other) surfaces as an XPASS on exactly one test instead of being hidden
-    inside a combined assertion."""
+    """A dependency-created (preallocated) branch clone must fire on_branch_created exactly once, like non-reactive flow already does; it currently fires zero times, reproducing the confirmed gap so a future fix turns this into a loud XPASS rather than silently leaving the hook unfired. Pinned to AssertionError, and split from the injected-clone leg below, so a partial repair surfaces as an XPASS on exactly one test."""
 
     # A dependent two-node graph — the second node has no explicit branch, so
     # the executor preallocates a clone of the default branch.
@@ -245,16 +229,7 @@ async def test_reactive_flow_notifies_for_preallocated_clone():
 )
 @pytest.mark.asyncio
 async def test_reactive_flow_notifies_for_injected_clone():
-    """A reactively injected (SpawnRequest) branch clone must fire
-    on_branch_created exactly once, the same guarantee non-reactive flow
-    already provides. It currently fires zero times: this reproduces the
-    confirmed gap so a future runtime fix turns this into a loud XPASS
-    instead of silently leaving the branch-created persistence hook unfired
-    for reactive runs. Pinned to AssertionError so an unrelated exception
-    from the production `flow(...)` call surfaces as a real failure instead
-    of being swallowed as this known violation, and split from the
-    preallocated-clone leg above so a partial repair surfaces as an XPASS on
-    exactly one test instead of being hidden inside a combined assertion."""
+    """A reactively injected (SpawnRequest) branch clone must fire on_branch_created exactly once, like non-reactive flow already does; it currently fires zero times, reproducing the confirmed gap so a future fix turns this into a loud XPASS rather than silently leaving the hook unfired. Pinned to AssertionError, and split from the preallocated-clone leg above, so a partial repair surfaces as an XPASS on exactly one test."""
 
     # A spawner node injects a follow-up node via SpawnRequest — the injected
     # node's branch is cloned by _assign_injected_branch.
@@ -490,16 +465,7 @@ async def test_no_spawn_behaves_like_normal_flow():
 
 @pytest.mark.asyncio
 async def test_execute_subscribes_via_public_observer_not_private():
-    """ReactiveExecutor.execute() must reach the bus via session.observer (public property).
-
-    Strategy: after normal session construction (which initialises _observer via
-    the model_validator), we forcibly clear _observer back to None to simulate
-    the scenario where the private attr is uninitialised.  If execute() still
-    used getattr(session, '_observer', None) it would see None and skip
-    subscribing, causing SpawnRequests to be silently dropped.  With the fix,
-    execute() calls session.observer (the property) which re-creates the
-    observer and the spawn is received.
-    """
+    """ReactiveExecutor.execute() must reach the bus via session.observer (the public property), not the private `_observer` attr: after construction, `_observer` is forced back to None to simulate an uninitialized private attr -- if execute() used `getattr(session, '_observer', None)` it would see None and silently drop SpawnRequests, whereas the property re-creates the observer and the spawn is received."""
     executed: list[str] = []
 
     async def spawner(**kw):

--- a/tests/state/test_lifecycle_gate.py
+++ b/tests/state/test_lifecycle_gate.py
@@ -80,14 +80,7 @@ _REAPABLE_PLAY_STATUSES = frozenset({"running", "running_complete", "prepared", 
 
 
 def _wait_clock_past(ts: float) -> None:
-    """Block until time.time() is strictly greater than ``ts``.
-
-    updated_at is a float-seconds timestamp; on a coarse clock two immediate
-    writes can land the same value, which would let a "stale" version
-    snapshot accidentally still match. Version-guard tests call this between
-    taking the snapshot and the concurrent write so staleness is guaranteed,
-    not clock-dependent.
-    """
+    """Block until time.time() is strictly greater than ``ts``: updated_at is a float-seconds timestamp, and on a coarse clock two immediate writes can land the same value, which would let a 'stale' version snapshot accidentally still match. Version-guard tests call this between the snapshot and the concurrent write so staleness is guaranteed, not clock-dependent."""
     while time.time() <= ts:
         time.sleep(0.001)
 
@@ -190,10 +183,7 @@ async def _make_entity(entity_type: str, db: StateDB, status: str) -> str:
 
 
 def _schema_check_status_values(table: str) -> frozenset[str]:
-    """Extract the exact ``CHECK(status IN (...))`` value list for *table*
-    directly out of ``schema.sql`` — the authoritative on-disk vocabulary,
-    read fresh rather than hand-copied, so this test cannot itself drift
-    from the schema it is meant to police."""
+    """Extract the exact ``CHECK(status IN (...))`` value list for *table* directly out of ``schema.sql`` -- the authoritative on-disk vocabulary, read fresh rather than hand-copied, so this test cannot itself drift from the schema it polices."""
     schema_text = _SCHEMA_PATH.read_text()
     table_match = re.search(
         rf"CREATE TABLE IF NOT EXISTS {re.escape(table)} \((.*?)\n\);",
@@ -285,30 +275,20 @@ _CHECK_ENFORCED_TABLES: dict[str, str] = {
 
 
 def test_status_vocabulary_covers_every_status_managed_entity() -> None:
-    """Every entity type the update_status() gate manages must have a pinned
-    expected list above — a new status-managed entity added to the registry
-    without a matching golden entry here would otherwise sit outside the
-    drift gate entirely."""
+    """Every entity type the update_status() gate manages must have a pinned expected list above -- a new status-managed entity added to the registry without a matching golden entry here would otherwise sit outside the drift gate entirely."""
     assert sorted(_EXPECTED_STATUSES) == sorted(VALID_STATUSES_BY_ENTITY_TYPE)
 
 
 @pytest.mark.parametrize("entity_type", sorted(_EXPECTED_STATUSES))
 def test_status_vocabulary_golden_against_policy_registry(entity_type: str) -> None:
-    """`VALID_STATUSES_BY_ENTITY_TYPE` (the update_status() gate) and the
-    PolicyRegistry's own `.statuses` must both equal the pinned list — they
-    are sourced from the same registry today, but this test would still
-    catch either one drifting independently."""
+    """`VALID_STATUSES_BY_ENTITY_TYPE` (the update_status() gate) and the PolicyRegistry's own `.statuses` must both equal the pinned list -- sourced from the same registry today, but this test would still catch either one drifting independently."""
     assert sorted(VALID_STATUSES_BY_ENTITY_TYPE[entity_type]) == _EXPECTED_STATUSES[entity_type]
     assert sorted(DEFAULT_REGISTRY.get(entity_type).statuses) == _EXPECTED_STATUSES[entity_type]
 
 
 @pytest.mark.parametrize("entity_type", sorted(_CHECK_ENFORCED_TABLES))
 def test_status_vocabulary_golden_against_schema_check(entity_type: str) -> None:
-    """A status the PolicyRegistry declares but the schema CHECK omits (or
-    vice versa) is a live footgun: update_status() would accept a value
-    SQLite itself rejects at the UPDATE (an IntegrityError surfacing far
-    from the actual mistake), or the CHECK would silently admit a value the
-    unified policy never validates. Pin exact parity between the two."""
+    """A status the PolicyRegistry declares but the schema CHECK omits (or vice versa) is a live footgun: update_status() would accept a value SQLite itself rejects at the UPDATE, or the CHECK would silently admit a value the unified policy never validates. Pin exact parity between the two."""
     table = _CHECK_ENFORCED_TABLES[entity_type]
     assert sorted(_schema_check_status_values(table)) == _EXPECTED_STATUSES[entity_type]
 
@@ -460,10 +440,7 @@ async def test_cas_miss_on_expected_statuses_returns_false_silently(db: StateDB)
 
 @pytest.mark.asyncio
 async def test_cas_miss_on_expected_updated_at_returns_false_silently(db: StateDB) -> None:
-    """The version guard (`expected_updated_at`) is a distinct CAS channel
-    from `expected_statuses` — pinned separately because a caller could
-    plausibly drop one and keep the other without any status-only test
-    noticing. A stale version snapshot is also a silent `False`."""
+    """The version guard (`expected_updated_at`) is a distinct CAS channel from `expected_statuses` -- pinned separately because a caller could plausibly drop one and keep the other without any status-only test noticing. A stale version snapshot is also a silent `False`."""
     sid = await _make_session(db, status="running")
     stale_snapshot = await db.get_session(sid)
     stale_version = stale_snapshot["updated_at"]
@@ -495,12 +472,7 @@ async def test_cas_miss_on_expected_updated_at_returns_false_silently(db: StateD
 
 @pytest.mark.asyncio
 async def test_terminal_overwrite_without_override_raises_not_returns_false(db: StateDB) -> None:
-    """The OTHER update_status() contract: attempting to move a *terminal*
-    entity to a different status, with no guard supplied at all and no
-    override, is not a conflict/False — it is a raised
-    TransitionRejectedError. Confusing this with the CAS-miss case above
-    (e.g. treating a caught exception as an ordinary skip, or vice versa) is
-    the exact bug class this test pins."""
+    """The OTHER update_status() contract: moving a *terminal* entity to a different status, with no guard and no override, is not a conflict/False -- it is a raised TransitionRejectedError. Confusing this with the CAS-miss case (e.g. treating a caught exception as an ordinary skip, or vice versa) is the exact bug class this test pins."""
     sid = await _make_session(db, status="completed")
 
     with pytest.raises(TransitionRejectedError) as exc_info:
@@ -520,14 +492,7 @@ async def test_terminal_overwrite_without_override_raises_not_returns_false(db: 
 
 @pytest.mark.asyncio
 async def test_terminal_row_with_stale_guard_returns_false_not_raise(db: StateDB) -> None:
-    """The two contracts *interact*: the exact same terminal row and the
-    exact same attempted write raises TransitionRejectedError with no guard
-    (previous test), but returns a silent False when the caller supplies an
-    expected_statuses guard that the row's actual status fails — because the
-    guard check runs before the terminal-exit check in
-    SQLAlchemyLifecycleService._transition(). A caller relying on "terminal
-    writes always raise" would be surprised here; this pins the real
-    behavior so a future refactor can't silently swap which one fires."""
+    """The two contracts *interact*: the same terminal row and write raises TransitionRejectedError with no guard, but returns a silent False when the caller supplies an expected_statuses guard the row's actual status fails -- because the guard check runs before the terminal-exit check in SQLAlchemyLifecycleService._transition(). Pins the real behavior so a future refactor can't silently swap which one fires."""
     sid = await _make_session(db, status="completed")
 
     applied = await db.update_status(
@@ -578,12 +543,7 @@ async def test_reaper_pattern_stale_row_is_reaped(db: StateDB) -> None:
 async def test_reaper_pattern_row_claimed_between_read_and_write_is_not_clobbered(
     db: StateDB,
 ) -> None:
-    """A play legitimately re-claimed (re-touched, updated_at bumped) between
-    the reaper's scan and its guarded write must survive untouched — even
-    though its status is STILL a member of the reapable set, since
-    status-membership alone cannot distinguish "still stale" from "just
-    re-touched". Dropping expected_updated_at from the guarded write would
-    pass every status-only test and still over-reap this exact case."""
+    """A row legitimately re-claimed (re-touched, updated_at bumped) between the reaper's scan and its guarded write must survive untouched, even though its status is STILL in the reapable set -- status-membership alone can't distinguish 'still stale' from 'just re-touched'. Dropping expected_updated_at from the guarded write would pass every status-only test and still over-reap this exact case."""
     play_id = await _make_play(db, status="running")
     snapshot = await db.get_play(play_id)
     _wait_clock_past(snapshot["updated_at"])

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -56,12 +56,7 @@ def _run_row(run_id: str, schedule_id: str, *, fired_at: float, **overrides) -> 
 
 @pytest.mark.asyncio
 async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
-    """(a) A process death between the occurrence insert and the cursor
-    advance must roll back BOTH halves -- not just leave the schedule's
-    cursor behind while the occurrence row survives. Otherwise a restart
-    that recomputes "still due" from the stale cursor would fire again for
-    an occurrence that the crashed attempt already (partially) recorded.
-    """
+    """(a) A process death between the occurrence insert and cursor advance must roll back BOTH halves, not leave the cursor behind while the occurrence row survives -- otherwise a restart recomputing 'still due' from the stale cursor fires again for an already-recorded occurrence."""
     db_path = tmp_path / "state.db"
     sid = "sched-a"
 
@@ -109,14 +104,7 @@ async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
 
 @pytest.mark.asyncio
 async def test_github_path_crash_before_second_event_refires_only_second(tmp_path):
-    """(b) Two github_poll events are dispatched in the same poll batch.
-    The first event's occurrence-insert + github_cursor advance commits
-    cleanly; the process then dies mid-transaction for the second event.
-    A restart must see the first event as already recorded (so it is never
-    re-fired) while the second is still open (schedule_run_exists_since is
-    False for it, and the cursor has not moved past it) -- so the next poll
-    re-fires ONLY the second event, never both.
-    """
+    """(b) Two github_poll events dispatch in the same batch; the first's insert+cursor-advance commits, then the process dies mid-transaction for the second. A restart must see the first as already recorded (never re-fired) and the second still open, so the next poll re-fires ONLY the second."""
     db_path = tmp_path / "state.db"
     sid = "sched-b"
     event1_time = "2026-07-07T10:00:00Z"
@@ -188,13 +176,7 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
 async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
     tmp_path, monkeypatch
 ):
-    """(c) Startup/missed-fire recovery must consult schedule_runs before
-    queuing a recovery fire. A schedule whose next_fire_at is past-due but
-    which already has a schedule_run row recorded at-or-after that time
-    (the atomic transaction committed, then the process died before the
-    run's terminal write) must NOT be re-fired -- only have its cursor
-    advanced past the already-handled occurrence.
-    """
+    """(c) Startup/missed-fire recovery must consult schedule_runs before queuing a recovery fire: a past-due schedule that already has a schedule_run row at-or-after that time (committed, then the process died before the terminal write) must NOT be re-fired -- only have its cursor advanced past it."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -245,15 +227,7 @@ async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
 
 @pytest.mark.asyncio
 async def test_missed_fire_recovery_still_fires_past_capacity_deferred_skip(tmp_path, monkeypatch):
-    """(c2) A capacity-deferred fire (global concurrent-fire cap reached)
-    writes an audit-only 'skipped' schedule_run row via
-    _maybe_record_deferred() and deliberately leaves next_fire_at
-    untouched, so the same due occurrence retries on the next tick. If the
-    process restarts before that retry, the recovery scan must not mistake
-    this audit row for a genuine fire -- schedule_run_exists_since()
-    excludes status='skipped' rows precisely so this occurrence still gets
-    a real recovery fire instead of being silently cursor-advanced past.
-    """
+    """(c2) A capacity-deferred fire writes an audit-only 'skipped' schedule_run row and deliberately leaves next_fire_at untouched so the occurrence retries next tick; recovery must not mistake that audit row for a genuine fire -- schedule_run_exists_since() excludes status='skipped' rows so this occurrence still gets a real recovery fire."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -309,17 +283,7 @@ async def test_missed_fire_recovery_still_fires_past_capacity_deferred_skip(tmp_
 
 @pytest.mark.asyncio
 async def test_recovery_refires_occurrence_committed_but_never_dispatched(tmp_path, monkeypatch):
-    """(e) A crash between the occurrence-insert/cursor-advance transaction
-    committing and spawn_and_wait() confirming the external process
-    launched leaves a durable status='running' row with dispatched_at
-    still NULL, and the schedule's cursor already moved past it -- so
-    ordinary missed-fire recovery (schedule_run_exists_since) will never
-    reconsider this schedule as due again; the occurrence would otherwise
-    be silently lost. _recover_undispatched_fires() must tombstone the
-    orphaned row (failed / FAILED_NEVER_DISPATCHED) and re-fire a fresh
-    occurrence carrying the SAME trigger_context the orphaned attempt
-    never got to use -- the at-least-once side of the delivery contract.
-    """
+    """(e) A crash between the occurrence-insert/cursor-advance commit and spawn_and_wait() confirming launch leaves a durable status='running' row with dispatched_at NULL, past the cursor -- invisible to ordinary missed-fire recovery. _recover_undispatched_fires() must tombstone the orphan and re-fire a fresh occurrence carrying the same trigger_context, the at-least-once side of the delivery contract."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -395,13 +359,7 @@ async def test_recovery_refires_occurrence_committed_but_never_dispatched(tmp_pa
 
 @pytest.mark.asyncio
 async def test_recovery_never_touches_a_row_with_confirmed_dispatch(tmp_path, monkeypatch):
-    """Once dispatched_at is set, the row is outside
-    _recover_undispatched_fires()'s scan entirely -- the external process is
-    confirmed to exist, so this is the contract's at-most-once boundary: a
-    daemon crash from here on is left to the ordinary stale-run reaper
-    (timed_out), never auto-retried, to avoid a duplicate real-world side
-    effect from an action that may already be running or finished.
-    """
+    """Once dispatched_at is set, the row is outside _recover_undispatched_fires()'s scan entirely -- the at-most-once boundary: a crash from here on is left to the ordinary stale-run reaper, never auto-retried, to avoid a duplicate real-world side effect."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -437,12 +395,7 @@ async def test_recovery_never_touches_a_row_with_confirmed_dispatch(tmp_path, mo
 
 @pytest.mark.asyncio
 async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_path, monkeypatch):
-    """An undispatched chain child (chain_depth > 0, an on_success/on_fail
-    follow-on) is tombstoned like any other orphan, but NOT auto-retried --
-    the narrower, documented gap in _fire_inner()'s delivery contract: the
-    parent occurrence's own recorded outcome is unaffected, only a
-    follow-on step is lost rather than automatically replayed.
-    """
+    """An undispatched chain child (chain_depth > 0) is tombstoned like any other orphan, but NOT auto-retried -- the documented gap in _fire_inner()'s delivery contract: only the follow-on step is lost, the parent occurrence's own recorded outcome is unaffected."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -493,24 +446,7 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
 
 @pytest.mark.asyncio
 async def test_tombstone_and_replace_schedule_run_is_atomic(tmp_path):
-    """The OLD shape recovery briefly took (flip the orphan via a standalone
-    update_status() call, THEN separately -- in a backgrounded fire task --
-    insert the replacement row once _fire_inner() got around to it) had a
-    real gap: a crash between those two independent writes left the orphan
-    durably 'failed' (terminal, so dropped from every future
-    list_undispatched_schedule_runs() scan) with no replacement ever
-    recorded -- the occurrence lost for good, invisible to recovery AND
-    never retried.
-
-    tombstone_and_replace_schedule_run() closes that by doing both writes
-    in ONE transaction. Prove it directly: force the second statement
-    (the replacement INSERT) to raise mid-transaction and confirm the
-    first statement (the orphan's UPDATE) rolled back too -- the orphan
-    must come back out exactly as it went in, still 'running', still
-    undispatched, still visible to a fresh scan. A crash here can only
-    ever discard a replacement that was never durably recorded, never
-    leave a flipped orphan with nothing to show for it.
-    """
+    """The old two-write recovery shape (flip the orphan, then separately insert the replacement) could crash between the writes and lose the occurrence for good; tombstone_and_replace_schedule_run() does both in ONE transaction -- proven by forcing the replacement INSERT to raise mid-transaction and confirming the orphan's UPDATE rolled back too, still 'running' and visible to a fresh scan."""
     db_path = tmp_path / "state.db"
     sid = "sched-atomic"
 
@@ -568,15 +504,7 @@ async def test_tombstone_and_replace_schedule_run_is_atomic(tmp_path):
 async def test_recovery_leaves_orphan_untouched_when_refire_crashes_before_atomic_write(
     tmp_path, monkeypatch
 ):
-    """A crash during a recovery re-fire attempt, at any point BEFORE
-    _write_occurrence()'s atomic transaction runs (e.g. while building the
-    replacement invocation or resolving the action), must leave the
-    orphan completely untouched -- neither half of the tombstone+insert
-    pair exists yet, so there is nothing to roll back; the orphan is
-    simply still exactly where it started. A fresh recovery pass over the
-    same state must find and retry it again, proving the occurrence is
-    never lost even when the re-fire attempt itself fails early.
-    """
+    """A crash during recovery re-fire, at any point before _write_occurrence()'s atomic transaction runs, must leave the orphan completely untouched (nothing to roll back yet); a fresh recovery pass over the same state must find and retry it, proving the occurrence is never lost even when the re-fire attempt itself fails early."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -657,14 +585,7 @@ async def test_recovery_leaves_orphan_untouched_when_refire_crashes_before_atomi
 
 @pytest.mark.asyncio
 async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypatch):
-    """Running _recover_undispatched_fires() a second time over state left
-    behind by a first, fully-completed pass must find nothing left to do:
-    once the replacement occurrence from pass one is durably dispatched
-    (dispatched_at set), it is entirely out of scope for pass two, and the
-    original orphan it superseded is already terminal. Two passes over the
-    same eventually-successful recovery must produce exactly one re-fire,
-    never two.
-    """
+    """A second _recover_undispatched_fires() pass over state left by a first, fully-completed pass must find nothing left to do: the replacement occurrence is already dispatched and the original orphan already terminal -- two passes over the same recovery must produce exactly one re-fire."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -723,15 +644,7 @@ async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypat
 
 @pytest.mark.asyncio
 async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirmed(tmp_path):
-    """The CAS predicate must require dispatched_at IS NULL, not just
-    status='running'. A launch confirmation (dispatched_at stamped, status
-    unchanged -- see _mark_dispatched()) landing between a recovery scan and
-    this write means the row is no longer undispatched; tombstoning it and
-    inserting a replacement would flip a run that actually launched to
-    'failed' and fire a duplicate. Reviewer repro: dispatched_at already set
-    on the orphan before the call -- must refuse (applied=False), inserting
-    nothing.
-    """
+    """The CAS predicate requires dispatched_at IS NULL, not just status='running': a launch confirmation landing between a recovery scan and this write means the row is no longer undispatched, and tombstoning it would flip an actually-launched run to 'failed' and fire a duplicate -- reviewer repro: dispatched_at already set must refuse (applied=False), inserting nothing."""
     db_path = tmp_path / "state.db"
     sid = "sched-dispatched-race"
 
@@ -763,16 +676,7 @@ async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirme
 
 @pytest.mark.asyncio
 async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path, monkeypatch):
-    """The reviewer-specified race: recovery's scan finds "run-live" as
-    undispatched, but a concurrently-confirmed launch (dispatched_at
-    stamped) lands after the scan and before the recovery re-fire's own
-    atomic write. The strengthened CAS makes that write a no-op, so the
-    live run must come out completely untouched -- still 'running', its
-    dispatched_at preserved, no replacement row -- and the abandonment path
-    must cancel ONLY the pre-spawn recovery invocation it created for this
-    doomed attempt, never the live run's own (separate, still-running)
-    invocation.
-    """
+    """The reviewer-specified race: a concurrently-confirmed launch (dispatched_at stamped) lands after recovery's scan but before its atomic re-fire write; the strengthened CAS makes that write a no-op, leaving the live run completely untouched, and abandonment cancels only the doomed pre-spawn recovery invocation, never the live run's own."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"


### PR DESCRIPTION
Tests-tree slice of the comment-condensation series: 10 files, +121/-856.

Roughly 80 multi-line test docstrings condensed to a single dense line each, preserving the causal "why" (the regression or invariant the test pins) and dropping restatement. No test logic, fixtures, parametrization, or assertions changed - verified by AST diffing (only string-literal content differs) on every touched file.

Deliberately untouched:
- Lines containing ADR references (0 modified, enforced mechanically).
- test_graph_entrypoint_conformance.py and the MCP wrapper security suite - their docstrings are load-bearing correctness/security documentation, not narrative filler.
- Files already terse per-test.

Verification: each touched file's suite passes individually; full tree run traced - every failure is a pre-existing missing-optional-extra (pandas/jsonschema/docling/psycopg) or a known timing flake in untouched files, each confirmed by isolated rerun. Ruff check and format clean on all 10 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)