### PR TITLE
chore: condense comments in wave-2 set; relocate load-bearing rationale to docs/internals

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -4,8 +4,183 @@ Non-obvious invariants, protocol contracts, and design rationale for the CLI pac
 don't belong inline as long-form comments/docstrings. Organized by module. Source-of-truth
 inline comments stay 1-2 lines; anything needing more context lives here.
 
-Scope note: `lionagi/cli/main.py`, `lionagi/cli/orchestrate/**`, and `lionagi/cli/team.py` are
-not indexed here.
+## `main.py` — `li` entry point
+
+`_handle_play_shortcut`: expands `li play NAME [...]` sugar into `li o flow
+-p NAME [...]` before argparse runs. When a flag precedes NAME (`li play
+--bypass NAME "prompt"`), a throwaway probe parser (the flow subparser's
+base flags only, before playbook-specific schema injection) locates NAME by
+separating recognized flag(+value) pairs from bare positional tokens — the
+real parse happens later once the playbook's own `args:` schema can be
+injected, so only base flags are understood at this point and custom
+playbook flags placed before NAME aren't supported (they must follow it).
+NAME is removed from the exact partition it was selected from, never by
+string value across the whole argv, so an earlier flag VALUE equal to NAME
+(e.g. `--team-mode foo -- foo`) isn't deleted in its place.
+
+`main()`: `-v`/`--verbose` and `--cwd` are scanned before argparse runs
+(before any subcommand parser exists), strictly before the `--` sentinel so
+a scheduled `action_prompt` containing `--verbose` can't flip verbose mode.
+`li agent`, `li o flow`/`li o fanout`, and `li schedule` each parse
+standalone rather than through normal subparser dispatch, because
+`parse_intermixed_args` drops the `--` sentinel between its two passes
+(letting a hostile prompt like `--bypass` placed after `--` toggle real
+flags on the re-parse) and nested subparser dispatch can't intermix flags
+with `[MODEL] PROMPT` positionals. Both `flow` and `fanout` had a
+pre-fix disease from the same root cause: flow silently misassigned a
+flags-preceded prompt to the model slot (both positionals were `nargs='?'`,
+so argparse's greedy left-to-right fill grabbed the first one), while
+fanout hard-rejected with "unrecognized arguments" (a flag between its two
+positionals split them into two groups argparse can't reconcile). All three
+special-cases split manually at the `--` sentinel, parse flags, and fold
+leftover positionals back in order. `li agent status`, `li monitor run
+<id>`, and `li wait <id>` are each intercepted before their command's
+argparse dispatch, because a positional `id`/free-form-ids slot would
+otherwise swallow a literal token like `"status"` or `"run"`.
+
+## `orchestrate/` (`li o fanout` / `li o flow`)
+
+`_common.py`'s `TEAM_COORD_SECTION` / `TEAM_COORD_SECTION_MESSENGER`: two
+variants of the team-mode coordination prompt section, appended onto the
+base worker system prompt. CLI-provider workers (codex/gemini subprocesses,
+no tool-calling surface) get only the bash `li team` channel
+(`TEAM_COORD_SECTION`); API-model workers additionally get the in-process
+`messenger` tool bound to their branch and get the messenger-only variant
+instead. Which variant applies is decided by `messenger_bound` in
+`build_worker_branch` before the system prompt is assembled — see
+`team_worker_system()` in `_orchestration.py`.
+
+`_notify.py`: `--notify` is scoped compatibility sugar over the terminal-
+callback registry. After the flow/play run's own entity id is known, it
+registers the legacy payload shape (kind/playbook/save_dir/cwd/exit_class/
+started_at/ended_at/status/invocation_id) as an exec adapter filtered to
+that one entity, and unregisters it once the run's teardown fires. This is
+deliberately different from the settings-level `notify.on_terminal` handler
+(bootstrapped once per process, unscoped, delivering the new minimal
+envelope) — `--notify` is a per-run override carrying the old payload shape
+for existing consumers, not a second copy of the same delivery. It
+registers as an *override* (`TerminalCallbackRegistry.register`), so it
+replaces the settings-resolved handler for this one run's entity only;
+other runs still get the settings-level handler unaffected. For backward
+compatibility with the documented `{payload}`/`{status}`/`{invocation_id}`
+command-template placeholders and the legacy `LIONAGI_NOTIFY_PAYLOAD`/
+`LIONAGI_NOTIFY_STATUS`/`LIONAGI_NOTIFY_INVOCATION_ID` environment
+variables, both are populated: placeholders are substituted into each
+parsed argv token directly (no shell is ever constructed, so a literal
+`{payload}` inside a quoted argument stays exactly one argv element), and
+the same three values are set as environment variables on the child
+process. There is no longer a direct teardown call into a notify hook: the
+terminal event now comes from the guarded lifecycle transition itself
+(`db.update_status()` on the run's session/invocation), so registering here
+and letting the registry's own post-commit push fire it is what prevents
+double delivery.
+
+### `_orchestration.py` — team-mode worker/coordinator wiring
+
+`team_worker_system()`/`team_history_context()`: a worker never has both
+channels — `messenger_bound` selects which of `TEAM_COORD_SECTION` /
+`TEAM_COORD_SECTION_MESSENGER` (see above) describes its channel.
+`messenger_names` (computed once per team, before any branch exists, via
+`worker_is_cli`) flags teammates that are CLI-provider and therefore
+unreachable via `messenger(action="send", to=...)`, so the prompt never
+names an unreachable target. The orchestrator itself is never bound into
+the live messenger roster — a messenger-bound worker escalates via
+`action="help"` instead, and its roster line is flagged not-a-`to=`-target
+the same way an unreachable CLI teammate is. `team_history_context` handles
+`--team-attach` onto an existing team: a messenger-bound worker's Exchange
+is fresh in-memory state that never replays messages predating the
+messenger tool, so any prior message addressed to it is surfaced instead as
+`operate(context=...)` data — explicitly labeled transcript, never promoted
+into the system prompt, since message content is untrusted prior text, not
+a vetted instruction. A bash-channel worker doesn't need this: `li team
+receive` already gives it live access to the same history.
+
+`build_worker_branch`'s `messenger_bound` return value: True only when
+team messaging is active AND the worker is a non-CLI provider; callers use
+it to decide whether to enable action serialization on that branch.
+
+Rung-2 coordinators (`make_help_coordinator`, `TeamLifecycleCoordinator`):
+plain Python routing, no LLM call — the counterpart to
+`ReactiveExecutor._schedule_escalation` for flow-mode. The help coordinator
+folds "blocked"-urgency signals into `env._escalated_evidence` for the run
+summary; rung 3 (model-bump) and synchronous human paging are out of scope.
+`TeamLifecycleCoordinator` keeps no separate liveness bookkeeping — every
+running/idle/retired fact comes straight from `team.compute_quiescence`
+over the team inbox, so what it decides always matches `li team show` and
+the pure predicate's own unit tests, with no in-memory state to drift out
+of sync with the file. `on_done`/`on_finished` write structured team-inbox
+entries via `team.post_done_signal`/`post_finished_signal` (code, not the
+model); `on_finished` retires a worker permanently — `compute_quiescence`
+never revives it. `build_round_operations` re-invokes one `Operation` per
+pending worker on that worker's OWN branch (session continuity is the
+point of a "round" instead of a fresh spawn), folding unread mail into
+`context` as `prior_team_messages` — never the system prompt, so a
+teammate's message can't smuggle new standing instructions into the
+model's persistent framing. Consuming the unread mail (file inbox via
+`team.pop_unread_messages`, Exchange via `_exchange_prior_messages`) and
+posting a coordinator-authored `wakeup` signal are side effects: the
+`wakeup` post is what flips those workers back to "active" on the next
+quiescence read, which is what prevents the same round from being
+double-injected.
+
+### `flow.py` — reactive DAG orchestrator (`li o flow`)
+
+Artifact contract has two write classes to `artifact_contract_json`: `_build_dag`
+does the planned-leg write once at DAG-build time (all roles resolved, before
+any leg runs), and `_execute_dag` does a second, append-only write after each
+reactively spawned node completes. Both are sound because what's expected of a
+spawned node (role defaults + spawn_id) is frozen before it's ever queued — the
+append only adds entries, never edits the planned-leg set. The planned-leg
+write must reach the session row directly (not just `env._live_persist`) so a
+crash or orphan exit before teardown still leaves the DB accurate.
+
+`_reconstruct_spawned_nodes` rebuilds a checkpoint's `spawned` entries into a
+fresh graph on resume, checked BEFORE any node is added so a refusal never
+leaves the graph partially mutated. Three soundness checks per entry: (1) it
+must carry `operation` (CHECKPOINT_VERSION 2+; older checkpoints have nothing
+to rebuild from); (2) if it has a `parent_id`, that parent must itself be
+checkpointed terminal (completed/failed) or be another entry in the same
+`checkpoint_spawned` list — a parent merely existing in the DAG isn't enough,
+since resuming while that parent reruns live risks duplicating or dropping the
+spawn decision; (3) an entry with `assignee` must also carry `spawn_id` (both
+are stamped together unconditionally by `role_node_builder`, so one without
+the other means the checkpoint predates that field or is corrupt). Any failure
+refuses resume for only the affected node(s), never the whole run.
+
+Spawn-id sequencing: on resume, the ordinal sequence must start past the MAX
+existing ordinal among restored spawns + 1 (not `count`, since a crashed run
+can leave gaps — an allocated-but-never-completed spawn never made it into
+`spawned`), or a live spawn this generation could reissue a restored spawn_id
+and its artifact directory. `n_spawned` accounting always includes restored
+spawns from a prior checkpoint generation, not just what the live executor
+spawned this generation — otherwise a resume that reconstructs every spawned
+node as already-terminal would report `n_spawned=0` and silently skip the
+`with_synthesis`-or-`n_spawned` gate in `_run_flow_inner`.
+
+## `team.py` — `li team` persistent messaging (inbox pattern)
+
+`_locked_team`: read-modify-write under an exclusive POSIX flock. Explicit
+`fp.flush()` + `os.fsync()` before releasing the lock is required — without
+it, a waiting reader can acquire the lock the instant it releases and
+observe stale (pre-write) content, since `fp.write()` only fills a buffer
+and doesn't guarantee bytes have left the process; under concurrent writers
+this showed up as a spurious "No team found" moment after a team plainly
+existed on disk.
+
+`compute_quiescence`: pure predicate over message `kind`/`from`/`to`/
+`read_by` only, never touching a file/branch/agent. Lifecycle model,
+derived purely from message kinds: every named worker starts **active**
+(presumed still running, nobody has said otherwise yet); a `kind="done"`
+message *from* a worker makes it **idle** (finished this turn, may be
+revived by a later round); a `kind="finished"` message *from* a worker
+**retires** it permanently (never revived again, mirroring
+`LionMessenger`'s `finished` action); a `kind="wakeup"` message addressed
+*to* a worker makes it **active** again, whether from a teammate (peer
+wakeup) or the coordinator's own round injection. The run is quiescent once
+every worker has settled (none **active**) AND there is nothing left for
+the coordinator to do about it: no unread `kind="message"` mail sitting in
+an **idle** worker's inbox, and either the round budget is exhausted or the
+caller isn't asking for one more round anyway.
 
 ## `_context_from.py` — context-ref resolution and distillation
 

--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -6,6 +6,20 @@ path. Inline comments stay short; the full contract lives here.
 
 ## `operations/`
 
+**`flow.py`** — `run_dag()` returns `{completed_operations, operation_results,
+final_context, skipped_operations}` always; with `reactive=True` also
+`spawned_operations` (successful-spawn count), `escalated_operations` (emitter
+ids), and `dropped_spawns` (rejected spawn/inject attempts as `{reason,
+assignee, emitter_id, ...}`; reasons: builder_error, null_child, cycle,
+max_spawn_exceeded, duplicate). `spawn_branch_setup`, when given, runs after
+each reactively-spawned node's branch is cloned (reactive mode only) — the
+seam `cli/orchestrate/flow.py` uses to retarget a CLI-backed chat_model's
+writable workspace to the spawn's own artifact dir (the clone otherwise
+inherits the emitter's `repo` kwarg). `on_op_complete` (reactive mode only)
+runs synchronously at the tail of every node's execution — the only
+race-free point for a caller's `inject()` against the task group's
+convergence; `cli/orchestrate/flow.py`'s team-round wakeup logic is wired here.
+
 **`lndl_middle/lndl_middle.py`** — LNDL seam Middle (ADR-0024 §1-2): advances
 a branch one LNDL round per inner chat call, looping internally up to a round
 budget (default 3). Opt-in via `branch.operate(instruction=..., middle=lndl_middle)`;
@@ -314,6 +328,40 @@ populated with whichever names/tools happened to validate first.
 loaded, not the full pool — `MCPConnectionPool` accumulates configs
 process-globally across loads, so enumerating the pool here would silently
 re-register every server from previously loaded, unrelated configs.
+`invoke()`: every tool routed through this method (function tools, `Tool`
+objects, MCP-discovered tools) passes through the same tool-pre/tool-post
+hook layer; constructing `FunctionCalling` directly bypasses it entirely
+(documented, tested limit). Pre hooks run before the tool's own
+`preprocessor` chain and may rewrite arguments; a denial raises before the
+tool is invoked. Rewritten arguments are revalidated against the tool's
+declared request model inside `FunctionCalling._invoke()`, after the
+spec-level chain has also had a chance to mutate them — the re-validation
+step means a rewrite can never bypass the tool's declared schema, and a
+tool with no `request_options` never had schema enforcement to bypass. Post
+hooks run after invocation completes (success or failure) and are advisory
+only — they observe final arguments/result/error and cannot change any of
+them. `_resolve_plugin_tool` (ADR-0088 D3): on a registry miss, asks the
+plugin registry whether a trusted, enabled, version-compatible plugin
+declares the tool. Import of `lionagi.plugins` is deferred until an actual
+miss (see `tests/test_import_laziness.py`); resolution and trust are
+re-checked fresh on every call, never cached onto `self.registry`, so a
+plugin disabled or edited mid-session stops being reachable immediately.
+Raises `PluginToolCollisionError` unmodified when two enabled plugins
+declare the same tool name (ADR-0088 D6) — a hard error, not a miss.
+
+**`action/tool_hooks.py`** — Hook contract at the `ActionManager.invoke`
+chokepoint: the mutation-capable layer outermost around every tool call,
+deliberately separate from `lionagi.hooks.bus.HookBus` (summary-payload
+audit plane) and the per-`Tool` `preprocessor`/`postprocessor` chain wired
+by `lionagi.agent.spec.HooksMixin` (spec-level security/user chain, runs
+innermost). A pre hook returns `None` (allow, unchanged), a plain `dict`
+(allow, replace arguments), or a `ToolPreDecision` (`"allow"` optionally
+with `updated_input`, `"deny"`, `"ask"` — fails closed, no interactive
+approval surface exists — or any other value, which fails closed with a
+diagnostic). A post hook receives the tool name, final arguments, result
+(`None` on failure), and error (`None` on success); post hooks are advisory
+only since the action already happened, matching the harness convention
+that `block` on a post-invocation event cannot un-run the call.
 
 ## `orchestration/`
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -134,6 +134,136 @@ that would silently turn a git error into a false `completed_empty` on real work
 that *succeeds* is allowed to report an absence of evidence; any decisive failure bails the
 whole check out as unchecked (`checked=False`) so the caller keeps trusting `completed`.
 
+### `state/lifecycle/`
+
+Unified lifecycle transition service: one guarded read-check-write-history
+algorithm shared by every managed entity type's status transitions,
+replacing per-surface transition logic. Public surface: immutable
+command/result records (`models`), the policy registry (`policy`), the
+SQLAlchemy transaction implementation (`service`), and the
+StateDB/legacy-transition compatibility mapping (`adapters`).
+
+- `service.py` — `transition()` is the public entry point, enforcing the
+  policy's declared-edge graph: an undeclared move is a "rejected" outcome
+  with a rejection audit row, not a raise, so callers get the same outcome
+  shape for terminal-exit and undeclared-edge refusals alike; a valid
+  override is the audited escape hatch for either. `_transition()` accepts
+  additional keyword-only parameters outside the public `TransitionCommand`
+  shape, used only by `lionagi.state.lifecycle.adapters` to keep the two
+  legacy compatibility wrappers behaviorally identical to their
+  pre-existing selves: `extra_guard` (an arbitrary per-column WHERE-clause
+  guard, e.g. dispatch's `delivering -> delivering` crash-recovery claim
+  guarding on `attempt`, which the public typed command has no generic
+  field for), `enforce_edges` (`StateDB.update_status()` never enforced a
+  declared-edge graph, only terminal-exit-requires-override and vocabulary
+  membership, so it calls with `enforce_edges=False`; the legacy
+  `lionagi.state.transitions.transition()` did enforce one, for
+  schedule_run, so it calls with `enforce_edges=True`), and
+  `raise_on_unguarded_conflict` (an unguarded zero-row UPDATE is a storage
+  anomaly `StateDB.update_status()` has always raised `RuntimeError` on,
+  from inside the transaction so a same-transaction rollback still occurs).
+  A self-edge's `required_guard_fields` must be satisfied by either
+  `extra_guard` covering those exact columns or a generic
+  `expected_version` guard (`updated_at`, which the write always bumps) —
+  either is an equally strong optimistic-concurrency guard against two
+  callers holding the same snapshot both winning a crash-recovery claim;
+  missing both is a caller-contract violation, so it raises rather than
+  returning a conflict/rejected outcome. Commit (via the `_tx()` context
+  exit) happens strictly before the terminal-callback registry push, so a
+  handler can never delay, observe-before-commit, or roll back the write.
+  `_write()`'s `write_reason_columns` mirrors legacy per-surface behavior:
+  `StateDB.update_status()` always denormalized the reason onto the
+  entity row's own `status_reason_*` columns (the default); the legacy
+  `lionagi.state.transitions.transition()` surface never did, and
+  `dispatch_outbox` (only reachable through that surface) doesn't even
+  have those columns.
+- `callbacks.py` — a `RunTerminalEnvelope` is constructed by the lifecycle
+  service only after a guarded transition commits and lands on a terminal
+  status for an execution entity (session, invocation, schedule_run, play);
+  the registry then pushes it to every matching handler concurrently under
+  one shared deadline (best-effort — a handler failure, timeout, or
+  cancellation is logged and swallowed, never affecting the already-committed
+  transition or delaying the caller past budget). Within `schema_version ==
+  1` the envelope's guaranteed fields never change name/type/semantics/
+  requiredness; new optional fields may be added without a version bump.
+  `register()`'s `override` marks a per-run override: for any envelope it
+  matches, only override registrations fire, replacing any non-override
+  match for that run's scope only — other envelopes the override doesn't
+  match are unaffected. In `emit()`'s handler fan-out, a plain
+  (non-async-def) handler is offloaded to a worker thread rather than run
+  directly (which would block the event loop and starve the shared
+  `move_on_after` deadline); `abandon_on_cancel=True` is required (not the
+  default) so the deadline can still cut the await short without waiting for
+  the thread to finish on its own — the thread itself is only abandoned, not
+  killed, and may keep running in the background after return.
+- `notify_settings.py` — resolves `notify.on_terminal` (a string
+  compatibility form, or a mapping `{enabled, adapter: {kind: exec|python,
+  ...}, filter: {kinds, ids}}`) into a handler installable on a
+  `TerminalCallbackRegistry`. Precedence is per-run override > project
+  settings > global settings > disabled; absent key and explicit `enabled:
+  false` are both disabled. No configuration shape ever reaches a shell: a
+  plain command string is POSIX-word-split (`shlex.split`) and launched via
+  `asyncio.create_subprocess_exec`, never `create_subprocess_shell`; a
+  string that fails to split or needs shell features (pipes, redirection,
+  conjunction, variable expansion) warns with a migration diagnostic and
+  resolves to disabled, as does any resolution producing an empty argv. A
+  resolution error never fails or delays the run it would have described. In
+  the exec adapter, on cancellation the registry's own shared deadline races
+  the call's identical `wait_for` timeout (the outer one started first and
+  typically wins); either way the child (launched with
+  `start_new_session=True`, its own process group) must be reaped or it
+  orphans a live subprocess, so cleanup runs inside a shielded `CancelScope`
+  since the enclosing scope is already cancelled.
+- `deliveries.py` — acknowledgment is durable state written only by a named
+  reconciliation consumer, never by the in-process push path
+  (`TerminalCallbackRegistry` stays fire-and-forget and records nothing
+  here). The reconciliation query is a read-only anti-join: terminal
+  transitions on execution entities with no delivery row yet for the
+  requesting consumer, with no age filter on either side — a late-committing
+  older row, or an event from a long-offline consumer, stays unacknowledged
+  indefinitely (this module never expires an unacked event on its own).
+- `schema_meta.py`'s `session_controls` table — apply/stamp ordering is
+  verb-classed: `pause`/`resume` are idempotent (apply, then stamp — safe to
+  re-apply on a poller crash); `message` is not (stamp `'applying'`, then
+  apply, then finalize — a crash surfaces as an unapplied `'applying'` row
+  rather than risking a double injection). `'stop'` is schema-reserved and
+  rejected by the current poller as unsupported; no CLI verb emits it yet.
+
+## lionagi/plugins/registry.py
+
+Combines discovery + trust + settings into one snapshot, two-stage lazy like
+`EndpointRegistry._ensure_loaded`. Stage 1 (`_ensure_loaded`): manifests are
+scanned/parsed the first time any consumer asks, cached for the process.
+Stage 2 (`activate_target`): a declared target/module is imported only when
+that capability is actually invoked, never as a side effect of discovery or
+an unrelated capability firing. Eligibility (compatible + enabled) and trust
+are revalidated fresh on *every* call, re-reading `plugin.yaml`, settings,
+and every declared file from disk — an already-activated target stops being
+handed out the moment the plugin is disabled or a declared file/manifest
+changes, not just refusing brand-new activations. The specific target file
+is read exactly once: that read's hash (checked against the currently
+recorded trust entry) and the bytes that get compiled/exec'd are the same
+`read_bytes()` call (`_read_and_verify_target_bytes`), never a hash-then-
+reopen sequence that would leave a TOCTOU window for the file to be swapped.
+`_exec_bundle_module` compiles the pre-read bytes directly rather than going
+through importlib's `spec_from_file_location`/`exec_module` path, which
+writes/reads a `__pycache__` `.pyc` validated by second-granularity mtime —
+two writes within the same wall-clock second are indistinguishable to it, so
+a re-import right after a re-trusted edit could silently execute stale
+bytecode. Import results (success or failure) are cached per `(plugin,
+target, content hash)`, so re-trusting changed content is a guaranteed cache
+miss rather than depending on an earlier call having evicted the old entry.
+`_rescan()` re-reads and re-parses `plugin.yaml` itself rather than reusing
+the cached `record.manifest` — a stale cached manifest object always
+re-derives the same "trusted" hash regardless of what's actually on disk,
+since the manifest hash is computed by re-serializing the parsed object, not
+by re-reading the file. `_target_resolution_map` builds target ->
+(module_path, attr) from the manifest's own typed capability lists using the
+same `parse_tool_target` split the hashing path (`discovery
+._collect_declared_paths`) uses — two independently written splitting
+expressions could disagree on where a path ends and a callable begins; one
+shared parser can't. Nothing in this module runs at `import lionagi` time.
+
 ## lionagi/service/connections/mcp_wrapper.py
 
 Security-critical admission-control gate for MCP (Model Context Protocol) tool descriptors:
@@ -692,6 +822,22 @@ file on retry without this snapshot.
   `gemini_code.py`'s `agy` note above).
 
 ## lionagi/service/ (remaining)
+
+### `connections/registry.py`
+
+`EndpointRegistry.match()` — on a registry miss, consults the plugin
+registry (ADR-0088 D3) before falling back to the generic
+OpenAI-compatible endpoint: `_consult_plugin_providers()` imports every
+ACTIVE plugin's declared provider module (never at import time or
+discovery, preserving import-time O(1)), exclusively through
+`PluginRegistry.activate_target` — never a direct `importlib` call on
+plugin code — so the trust/enabled/active chokepoints enforced there apply
+here too. Each activation is cached by the plugin registry itself, so
+repeated misses are cheap. A plugin supplying no matching provider (or none
+at all) leaves the fallback identical to the no-plugin case.
+`_revalidate_plugin_entry` keeps a plugin-sourced registry entry available
+only while its declared target remains trusted, removing it on
+`PluginActivationError`.
 
 ### Retry & sentinel-exclusion contract (`connections/endpoint.py`, `providers.py`, `resilience.py`)
 

--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -4,6 +4,40 @@ Non-obvious invariants, protocol contracts, and design rationale for
 `lionagi/studio/` that don't belong inline as long-form comments. Terse
 reference — not a narrative. Organized by module path.
 
+## lionagi/studio/app.py
+
+**Host-header validation (`_HOST_AUTHORITY_RE`/`validate_host_header`)** —
+strict authority grammar (`host` or `host:port`, or bracketed IPv6 `[addr]`
+with optional `:port`), deliberately stricter than `request.url.hostname`,
+which normalizes/mis-parses authorities like `"127.0.0.1:8765.evil.com"` or
+`"[::1]evil.com"` into an accepted hostname. `validate_host_header` defends
+against DNS rebinding, where a malicious page points a browser at
+`http://127.0.0.1:<port>` with an attacker-controlled Host and, once past
+CORS/auth, reaches the daemon as if same-origin — registered outermost
+(added after CORSMiddleware, so it runs first under Starlette's LIFO
+middleware wrapping) so every request, including preflight OPTIONS, has its
+Host checked before CORS can answer.
+
+**Middleware order** in `create_app()`: Host validation -> CORS ->
+Content-Type/CSRF check -> bearer-token gate -> route. A real preflight
+never reaches the bearer-token/Content-Type middlewares because CORS
+answers it first.
+
+**`require_json_content_type`** — rejects state-changing `/api` requests
+that don't declare a JSON body. FastAPI parses request bodies as JSON
+regardless of declared Content-Type, so a cross-site "simple request"
+(`text/plain`, no CORS preflight) carrying a JSON-shaped body would
+otherwise reach route handlers unchecked — the classic form-based JSON CSRF
+vector. The SPA always sends `application/json` on requests carrying a body
+(`apps/studio/frontend/src/lib/api.ts` `fetchJson`) and no body at all for
+routes that need none, so this only rejects traffic the frontend itself
+never produces.
+
+**`_mount_spa`** — uses a 404 exception handler, not a catch-all route, for
+the SPA fallback: a catch-all `/{full_path:path}` route would intercept
+`/api/shows` before FastAPI's trailing-slash redirect fires, whereas an
+exception handler runs only after every route has been tried and missed.
+
 ## lionagi/studio/cli.py
 
 **`_validate_chain_action_node`** — Validates one `chain_action` node, recursing

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -217,9 +217,8 @@ def _build_parser(selected: _CommandSpec | None) -> tuple[argparse.ArgumentParse
         version=f"%(prog)s {_get_version()}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    # Every command is always registered so the root usage line and error
-    # messages list the full command set; only the selected command loads its
-    # real parser module, the rest stay metadata-only stubs.
+    # Every command is registered for usage/error listing; only the selected
+    # one loads its real parser module, the rest stay metadata-only stubs.
     selected_parser = None
     for spec in _COMMAND_REGISTRY:
         if selected is not None and spec.name == selected.name:
@@ -349,9 +348,7 @@ def _print_playbook_help(name: str) -> int:
 
 
 # The unknown-subfield warning is shared with the runtime spec validator
-# (lionagi/cli/orchestrate/__init__.py) — see warn_unknown_artifact_keys
-# in lionagi/state/artifact_verifier.py. Importing here keeps the
-# pre-flight and runtime warnings in lockstep.
+# (warn_unknown_artifact_keys in lionagi/state/artifact_verifier.py).
 
 
 def _handle_play_check(argv: list[str]) -> int:
@@ -378,11 +375,8 @@ def _handle_play_check(argv: list[str]) -> int:
         return 1
 
     artifacts_block = spec.get("artifacts")
-    # Load the agent profile the playbook names so its artifact_defaults
-    # participate in the merge — a real invocation sees them. The actual
-    # `li play` path raises if the profile is missing, so pre-flight
-    # must FAIL in the same case rather than silently green-light an
-    # invocation that will crash at execution start.
+    # Load the named agent profile so artifact_defaults join the merge; must
+    # FAIL here (not green-light) when the real `li play` path would raise.
     agent_defaults = None
     agent_name = spec.get("agent")
     if agent_name:
@@ -405,9 +399,8 @@ def _handle_play_check(argv: list[str]) -> int:
         return 0
 
     if artifacts_block:
-        # Same warning the runtime spec validator emits (via
-        # logger.warning there); on the pre-flight surface we want it
-        # visible in the operator's terminal, so default print is fine.
+        # Same warning the runtime validator emits via logger.warning;
+        # printed here so it's visible on the pre-flight terminal.
         warn_unknown_artifact_keys(artifacts_block, source=f"playbook '{name}'")
 
     try:
@@ -479,22 +472,15 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
         return ["o", "flow", *rest]
 
     if not head.startswith("-"):
-        # NAME already comes first — unchanged fast path. Custom playbook
-        # args declared in the playbook's own `args:` schema are only
-        # registered once NAME is known (via inject_playbook_schema_into_parser,
-        # downstream), so they can only be recognized when they follow NAME;
-        # this path leaves them untouched, exactly as before.
+        # NAME comes first — fast path. Custom playbook args (from the
+        # playbook's own `args:` schema) are only recognized once they
+        # follow NAME, so this path leaves them untouched.
         name, other = head, rest[1:]
     else:
-        # A flag precedes NAME (`li play --bypass NAME "prompt"`). Probe with
-        # the flow subparser's own base flags (before playbook-specific
-        # schema injection) to separate recognized flag(+value) pairs from
-        # bare positional tokens — same sentinel-safe split-and-fold shape as
-        # the `agent`/`o flow` interception below, minus dispatch (we only
-        # need to locate NAME here; the real parse happens later once the
-        # playbook's own args: schema can be injected). Only base flags are
-        # understood at this point, so this path does not support custom
-        # playbook flags placed before NAME — they must follow it.
+        # A flag precedes NAME; probe with the flow subparser's base flags
+        # only (playbook-specific args aren't injected yet) just to locate
+        # NAME — see docs/internals/cli.md. Custom flags before NAME aren't
+        # supported; they must follow it.
         probe_parser = argparse.ArgumentParser(prog="li", add_help=False)
         probe_sub = probe_parser.add_subparsers(dest="command")
         fl_probe = _load_orchestrate().add_orchestrate_subparser(probe_sub)["flow"]
@@ -503,11 +489,8 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
             p_head, p_post = rest[:i], rest[i + 1 :]
         else:
             p_head, p_post = rest, []
-        # Keep the probe help-inert: argparse executes --help/-h during
-        # parse_known_args (printing flow help and exiting) before the
-        # playbook-specific help check below could run. Strip help tokens
-        # from the probe input only; the reconstruction below still works
-        # from the original partitions, so the help check sees them.
+        # Strip help tokens from the probe input only (argparse would print
+        # flow help and exit); the reconstruction below still sees them.
         p_head_probe = [t for t in p_head if t not in ("--help", "-h")]
         p_ns, p_extras = fl_probe.parse_known_args(p_head_probe)
         unknown = [e for e in p_extras if e.startswith("-") and e != "-"]
@@ -523,11 +506,9 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
             )
             return 1
         name = bare[0]
-        # Remove the NAME occurrence from the partition it was actually
-        # selected from, never by string value across the whole argv: an
-        # earlier flag VALUE equal to NAME (e.g. `--team-mode foo -- foo`)
-        # must not be deleted in its place. Within a single partition,
-        # identical strings rewrite equivalently, so first-match is safe.
+        # Remove NAME from the partition it was selected from, never by
+        # string value across argv (an earlier flag VALUE equal to NAME
+        # must not be deleted in its place).
         if p_ns.query or p_extras:
             head_tokens = list(p_head)
             head_tokens.remove(name)
@@ -550,13 +531,10 @@ def _get_version() -> str:
 def main(argv: list[str] | None = None) -> int:
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-    # Resolve verbose once before any CLI code emits. argparse happens
-    # below but we need the flag now to configure log levels.
+    # Resolve verbose before any CLI code emits (argparse hasn't run yet).
     _argv = argv if argv is not None else sys.argv[1:]
-    # Only scan for -v/--verbose BEFORE the '--' end-of-options sentinel so that
-    # a scheduled action_prompt containing '--verbose' does not flip verbose mode.
-    # Human CLI invocations (e.g. `li agent -v sonnet "hi"`) place -v before '--',
-    # so their behaviour is unchanged.
+    # Scan only before the '--' sentinel so a scheduled action_prompt
+    # containing '--verbose' can't flip verbose mode.
     try:
         _sentinel_idx = _argv.index("--")
         _pre_sentinel = _argv[:_sentinel_idx]
@@ -565,11 +543,8 @@ def main(argv: list[str] | None = None) -> int:
     verbose = "-v" in _pre_sentinel or "--verbose" in _pre_sentinel
     configure_cli_logging(verbose)
 
-    # Same pre-argparse scan as verbose above, for the same reason: this
-    # bootstrap runs before any subcommand parser has seen `--cwd`, so a
-    # project-scoped `.lionagi/settings.yaml` next to a `--cwd DIR` target
-    # (e.g. `li o flow --cwd /project ...`) would otherwise be missed in
-    # favor of the shell's own current directory.
+    # Same pre-argparse scan, so a project-scoped .lionagi/settings.yaml
+    # next to a `--cwd DIR` target isn't missed in favor of the shell's cwd.
     _cwd_override: str | None = None
     for _i, _tok in enumerate(_pre_sentinel):
         if _tok == "--cwd" and _i + 1 < len(_pre_sentinel):
@@ -579,50 +554,39 @@ def main(argv: list[str] | None = None) -> int:
             _cwd_override = _tok.split("=", 1)[1]
             break
 
-    # One of the two settings-driven notify bootstrap points: resolve
-    # notify.on_terminal from settings once per process and register it on
-    # the shared terminal-callback registry (the other is Studio service
-    # startup).
-    # Settings-resolution failures are already swallowed inside this call
-    # (a malformed .lionagi/settings.yaml must never block a CLI command).
+    # The first of the two settings-driven notify bootstrap points (Studio
+    # service startup is the other); resolution failures are swallowed inside.
     from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
 
     register_settings_terminal_callback(project_dir=_cwd_override)
 
-    # `li skill NAME` prints a CC-compatible skill body to stdout.
-    # Never falls through to argparse — dispatch directly.
+    # `li skill NAME` dispatches directly, never falling through to argparse.
     if _argv and _argv[0] == "skill":
         return run_skill(_argv[1:])
 
-    # `li play NAME [...]` is sugar for `li o flow -p NAME [...]`.
-    # Rewrite argv before argparse runs. Also handles `li play list`.
+    # `li play NAME [...]` is sugar for `li o flow -p NAME [...]`; rewrite
+    # argv before argparse runs (also handles `li play list`).
     rewritten = _handle_play_shortcut(_argv)
     if isinstance(rewritten, int):
         return rewritten
     _argv = rewritten
 
-    # `li agent status [<id>] [--json]` is a pure-read status surface, not a
-    # prompt to send — must be intercepted before the intermixed agent-flag
-    # parsing below, which otherwise treats "status" as query text.
+    # `li agent status` is a pure-read surface, not a prompt to send — must
+    # be intercepted before intermixed agent-flag parsing below.
     if _argv and _argv[0] == "agent" and len(_argv) > 1 and _argv[1] == "status":
         from .status import run_agent_status
 
         return run_agent_status(_argv[2:])
 
-    # `li monitor run <id> [...]` / `li mon run <id> [...]` is a scriptable
-    # wait-for-terminal primitive, not a detail-view lookup — must be
-    # intercepted before argparse's positional `id` slot would otherwise
-    # swallow the literal token "run" as an entity-id (same reasoning as the
-    # `agent status` interception above).
+    # `li monitor run <id>` is a wait-for-terminal primitive; intercepted so
+    # argparse's positional `id` slot doesn't swallow "run" as an entity-id.
     if _argv and _argv[0] in ("monitor", "mon") and len(_argv) > 1 and _argv[1] == "run":
         from .monitor import run_monitor_wait
 
         return run_monitor_wait(_argv[2:])
 
-    # `li wait <id> [<id2> ...] [--interval SECS]` — the ADR-0035 completion
-    # contract. Intercepted before argparse for the same reason as `monitor
-    # run` above: free-form positional ids must not go through subparser
-    # dispatch.
+    # `li wait <id> [<id2> ...]` — ADR-0035 completion contract; intercepted
+    # for the same reason as `monitor run` above.
     if _argv and _argv[0] == "wait":
         from .wait import run_wait
 
@@ -637,20 +601,17 @@ def main(argv: list[str] | None = None) -> int:
         log_error(f"command {_argv[0]!r} failed to load: {type(exc).__name__}: {exc}")
         return 1
 
-    # If the user is invoking `li o flow -p NAME`, inject the playbook's
-    # declared args as flags on the flow sub-parser BEFORE argparse runs,
-    # so positional prompts don't swallow flag values.
+    # `li o flow -p NAME`: inject the playbook's declared args as flags on
+    # the flow sub-parser before argparse runs, so prompts don't swallow them.
     orch_parsers: dict[str, argparse.ArgumentParser] | None = None
     if selected is _COMMAND_BY_NAME["orchestrate"]:
         orch_parsers = selected_parser
         _load_orchestrate().inject_playbook_schema_into_parser(orch_parsers["flow"], _argv)
 
     # `li agent` parses standalone so flags may appear anywhere relative to
-    # the [MODEL] PROMPT positionals (subparser dispatch cannot intermix).
-    # parse_intermixed_args is unusable here: it drops the `--` sentinel
-    # between its two passes, letting a hostile prompt like "--bypass" placed
-    # after `--` toggle real flags on the re-parse. Split at the sentinel
-    # ourselves, parse flags, and fold leftover positionals back in order.
+    # [MODEL] PROMPT. parse_intermixed_args is unusable: it drops the `--`
+    # sentinel between passes, letting a prompt like "--bypass" after `--`
+    # toggle real flags on re-parse. Split at the sentinel ourselves instead.
     if selected is _COMMAND_BY_NAME["agent"]:
         agent_parser = selected_parser
         tail = _argv[1:]
@@ -666,15 +627,9 @@ def main(argv: list[str] | None = None) -> int:
         args.query = [*(args.query or []), *extras, *post]
         return run_agent(args)
 
-    # `li o flow` / `li o fanout` (and their `orchestrate` alias) parse
-    # standalone for the same reason as `agent` above: nested subparser
-    # dispatch can't intermix flags with the [MODEL] PROMPT positionals.
-    # Both had the disease pre-fix — flow silently misassigned a
-    # flags-preceded prompt to the model slot (both positionals were
-    # nargs='?', so argparse's greedy left-to-right fill grabbed the first
-    # one), while fanout hard-rejected with "unrecognized arguments" (a flag
-    # between its two positionals split them into two separate groups
-    # argparse can't reconcile). Same sentinel-safe split + fold as `agent`.
+    # `li o flow` / `li o fanout` parse standalone for the same reason as
+    # `agent` above (nested subparser dispatch can't intermix flags with
+    # the [MODEL] PROMPT positionals). See docs/internals/cli.md.
     if (
         _argv
         and selected is _COMMAND_BY_NAME["orchestrate"]
@@ -708,10 +663,8 @@ def main(argv: list[str] | None = None) -> int:
         if extras:
             from lionagi.studio.cli import suggest_schedule_flag
 
-            # Any leftover token — flag-shaped or not — is unrecognized and
-            # must error like plain argparse would (rc=2); did-you-mean
-            # suggestions only make sense for dash-prefixed tokens, since a
-            # bare positional like a surplus id has no "real flag" to guess.
+            # Did-you-mean only applies to dash-prefixed tokens; a bare
+            # positional has no "real flag" to guess.
             for tok in extras:
                 if tok.startswith("-") and tok != "-":
                     suggestion = suggest_schedule_flag(tok)

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -680,10 +680,8 @@ def add_orchestrate_subparser(
     )
     add_common_cli_args(fl)
 
-    # `li o ctl status <id>` is a generic alias into the same status renderer as
-    # `li agent status` / `li play status`. `pause` / `resume` / `msg` queue
-    # session_controls rows for the control poller while a live flow runs.
-    # `stop` is unsupported by the current CLI.
+    # `li o ctl status <id>` aliases the same status renderer as `li agent
+    # status`; pause/resume/msg queue session_controls rows for the poller.
     ctl = orch_sub.add_parser(
         "ctl",
         help="Control-plane surfaces for a run (status, pause, resume, msg).",

--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -85,20 +85,10 @@ BARE_WORKER_SYSTEM = _bare_worker_system()
 
 
 # ── Team-mode coordination section ────────────────────────────────────────
-#
-# Appended onto the base worker system prompt (BARE_WORKER_SYSTEM or a
-# profile's system_prompt) when the worker runs in team mode. This is a
-# SECTION, not a replacement — workers still need the artifact protocol
-# and tool guidance from the base prompt.
-#
-# Two variants exist because a team-mode worker reaches the team through
-# exactly one of two disjoint channels, never both: CLI-provider workers
-# (codex/gemini subprocesses, no tool-calling surface) get only the bash
-# `li team` channel; API-model workers additionally get the in-process
-# `messenger` tool bound to their branch and should coordinate through that
-# instead. Which variant applies is decided by `messenger_bound` in
-# `build_worker_branch` before the system prompt is assembled — see
-# `team_worker_system()` in `_orchestration.py`.
+# Appended (a section, not a replacement) onto the base worker system prompt
+# in team mode. Two variants: CLI-provider workers get the bash `li team`
+# channel; API-model workers get the in-process `messenger` tool instead —
+# see docs/internals/cli.md and `messenger_bound` in `_orchestration.py`.
 
 TEAM_COORD_SECTION = """\
 ## Team Coordination
@@ -201,13 +191,7 @@ After this round, teammates or the orchestrator can follow up:
 - `li agent -r {{branch_id}} "follow-up"` to continue your session\
 """
 
-# Deprecated: TEAM_WORKER_SYSTEM is a backward-compatible composed alias for
-# the old standalone template ("You are a specialist..." + TEAM_COORD_SECTION).
-# It has no production caller in this repository. A module-level constant
-# cannot emit a call-time DeprecationWarning without added attribute-access
-# machinery, so this comment (plus the changelog and docs) is the deprecation
-# signal for this cycle. Use TEAM_COORD_SECTION directly, appended onto the
-# worker's own system prompt, instead of importing TEAM_WORKER_SYSTEM.
+# Deprecated, no production caller: use TEAM_COORD_SECTION directly instead.
 TEAM_WORKER_SYSTEM = BARE_WORKER_SYSTEM + "\n\n" + TEAM_COORD_SECTION
 
 
@@ -221,9 +205,8 @@ def _build_worker_operate_node(
     depends_on: list[str] | None = None,
 ) -> str:
     """Add the static `operate` node for a worker branch (shared by fanout.py
-    and flow.py). Passes `actions=True` only when this worker actually got
-    the in-process messenger tool bound (team messaging active AND a
-    non-CLI worker), so Branch.operate() serializes branch.acts for it."""
+    and flow.py); passes `actions=True` only when the messenger tool is bound.
+    """
     return builder.add_operation(
         "operate",
         branch=branch,

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -1,36 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 """Flow/play `--notify` compatibility sugar over the terminal-callback
-registry.
-
-`--notify` remains scoped compatibility sugar: after the flow/play run's own
-entity id is known, it registers the legacy payload shape
-(kind/playbook/save_dir/cwd/exit_class/started_at/ended_at/status/
-invocation_id) as an exec adapter filtered to that one entity, and
-unregisters it once the run's teardown has fired. This is deliberately
-different from the settings-level `notify.on_terminal` handler (bootstrapped
-once per process, unscoped, delivering the new minimal envelope) -- the
-`--notify` flag is a per-run override carrying the old payload shape for
-existing consumers, not a second copy of the same delivery. It registers as
-an *override* (see `TerminalCallbackRegistry.register`), so it replaces the
-settings-resolved handler for this one run's entity only -- other runs still
-get the settings-level handler unaffected.
-
-For backward compatibility with the documented `{payload}`/`{status}`/
-`{invocation_id}` command-template placeholders and the legacy
-`LIONAGI_NOTIFY_PAYLOAD`/`LIONAGI_NOTIFY_STATUS`/`LIONAGI_NOTIFY_INVOCATION_ID`
-environment variables, both are still populated for this adapter -- the
-placeholders are substituted into each parsed argv token directly (no shell
-is ever constructed, so a literal `{payload}` inside a quoted argument is
-still exactly one argv element, never re-parsed), and the same three values
-are set as environment variables on the child process for consumers that
-read them from the environment instead of argv or stdin.
-
-There is no longer a direct teardown call into a notify hook: the terminal
-event that used to trigger it now comes from the guarded lifecycle
-transition itself (`db.update_status()` on the run's session/invocation),
-so registering here and letting the registry's own post-commit push fire it
-is what prevents double delivery.
+registry: registers the legacy payload shape as a scoped, overriding exec
+adapter for this run's entity. See docs/internals/cli.md.
 """
 
 from __future__ import annotations
@@ -95,13 +67,9 @@ def register_flow_notify_scope(
     started_at: float,
 ) -> str | None:
     """Register the `--notify` legacy-payload adapter scoped to this run's
-    own terminal entity (its invocation if tracked, else its session).
-
-    Returns the registration name (pass to ``unregister_flow_notify_scope``
-    in a ``finally`` block), or ``None`` if *override* resolved to the
-    disabled state (empty, shell-feature, unparseable, or a malformed
-    adapter -- already logged by ``resolve_notify_config``/``build_handler``;
-    never raised).
+    own terminal entity. Returns the registration name (pass to
+    ``unregister_flow_notify_scope`` in a ``finally`` block), or ``None`` if
+    *override* resolved to disabled (never raised).
     """
     resolved = resolve_notify_config(override=override)
     if resolved is None:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -128,9 +128,8 @@ def mode_roster(pack: Pack | None = None) -> str:
     for r in available_roles():
         cfg = role_config(r, pack)
         if cfg is not None and cfg.modes_allow:
-            # Advertise only names the mode catalog recognizes — resolve_modes
-            # existence-checks every mode, so an unknown allowlist entry from a
-            # custom pack would be advertised here yet dropped at execution.
+            # Advertise only catalog-recognized names; an unknown allowlist
+            # entry would otherwise be advertised yet dropped at execution.
             valid = sorted(m for m in cfg.modes_allow if m in known)
             if valid:
                 restricted.append(f"{r} accepts only {', '.join(valid)}")
@@ -174,12 +173,8 @@ def role_config(role: str, pack: Pack | None = None) -> Any:
 def resolve_modes(
     role: str, override: list[str] | None = None, pack: Pack | None = None
 ) -> list[str]:
-    """Cognitive modes for *role*: validated per-task override, else pack defaults.
-
-    A per-task *override* is gated by the role's ``modes_allow`` (empty =
-    unrestricted); every mode is existence-checked against the casts roster.
-    Invalid/disallowed modes are dropped with a warning.
-    """
+    """Cognitive modes for *role*: validated per-task override, else pack
+    defaults. Invalid/disallowed modes are dropped with a warning."""
     import logging
 
     from lionagi.casts.pattern import Mode
@@ -268,37 +263,8 @@ def team_worker_system(
     messenger_names: frozenset[str] | None = None,
 ) -> str | None:
     """TEAM coordination section to append to worker system prompt, or None.
-
-    ``messenger_bound`` selects which channel's instructions the section
-    describes: the in-process `messenger` tool (bound to API-model workers)
-    or the bash `li team` channel (the only path CLI-provider workers have).
-    A worker never has both, so the section must never describe both.
-
-    ``messenger_names`` is the set of team members that ARE messenger-bound
-    (computed once for the whole team, before any worker branch is built —
-    see `worker_is_cli`). In a mixed-provider team some teammates listed in
-    `team_data["members"]` won't be messenger-bound (CLI-provider workers);
-    when this worker IS messenger-bound, those teammates are flagged in the
-    roster and called out explicitly, so the prompt never tells a worker to
-    `messenger(action="send", to=...)` a name the tool will reject.
-
-    The orchestrator itself is never registered into the live messenger
-    roster (`build_worker_branch` only binds worker branches) — nothing
-    reads a coordinator inbox mid-run, escalation goes through
-    `action="help"` instead. For a messenger-bound worker the roster line
-    reflects that: it's listed for context but flagged as not a `to=`
-    target, same as an unreachable CLI teammate. Bash-channel workers are
-    unaffected — `li team send --to orchestrator` always succeeds against
-    the shared file channel, so that line stays plain there.
-
-    Prior team messages (attached-team history) are NOT included here even
-    for messenger-bound workers — see `team_history_context`. Message
-    *content* is untrusted transcript data (arbitrary prior user/agent
-    text), not an instruction; inlining it into the system prompt would
-    hand it the same authority as the coordination instructions in this
-    section. It belongs in operation context instead, clearly labeled as
-    data.
-    """
+    See docs/internals/cli.md for the messenger-bound vs bash-channel
+    contract, roster-flagging, and why prior messages are excluded here."""
     if not team_data:
         return None
     from ._common import (  # avoid import cycle
@@ -355,23 +321,8 @@ def team_history_context(
     messenger_bound: bool,
 ) -> dict | None:
     """Prior team messages relevant to this worker, shaped for operation
-    CONTEXT — never the system prompt.
-
-    A messenger-bound worker's Exchange is fresh in-memory state created new
-    every run; it never replays messages sent before the messenger tool
-    existed. For `--team-attach` onto an existing team, a bash-channel
-    worker can still read that history live with `li team receive`; a
-    messenger-bound worker has no other path to it, so any prior message
-    addressed to it (or broadcast) is surfaced here instead — as data the
-    caller passes into `operate(context=...)`, clearly labeled as an
-    untrusted transcript rather than promoted into the system prompt (prior
-    message *content* is arbitrary prior user/agent text, not a vetted
-    instruction).
-
-    Returns None when there's nothing to add: not messenger-bound, no
-    team_data, or (the common case — a freshly created team) no prior
-    messages exist yet.
-    """
+    CONTEXT — never the system prompt. See docs/internals/cli.md for the
+    `--team-attach` Exchange-replay contract; None if there's nothing to add."""
     if not messenger_bound or not team_data:
         return None
     prior = [
@@ -446,12 +397,9 @@ class OrchestrationEnv:
     messenger: LionMessenger | None = None
     roster: dict[str, UUID] | None = None
 
-    # Names of team members that WILL be messenger-bound, computed once for
-    # the whole team before any worker branch is built (mixed-provider teams
-    # build workers one at a time, so `roster` above is only ever partially
-    # populated mid-loop — this set is known up front instead, from each
-    # assignment's resolved role/model, independent of build order). None
-    # when team messaging isn't active for this run.
+    # Team members that WILL be messenger-bound, computed once up front (not
+    # from `roster`, which is only partially populated mid-loop for
+    # mixed-provider teams). None when team messaging isn't active.
     messenger_names: frozenset[str] | None = None
 
     # None falls through to the default pack for role_config / resolve_modes.
@@ -499,8 +447,7 @@ async def setup_orchestration(
     from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
 
     # Fail fast: a nonexistent --cwd must never silently spawn into a
-    # provider-created directory — validate before any run is allocated.
-    # Forward the returned tilde-expanded path; providers never expand `~`.
+    # provider-created directory. Forward the tilde-expanded path (providers never expand `~`).
     cwd = validate_cwd_exists(cwd)
 
     cache_cancelled_exc_class()
@@ -597,10 +544,8 @@ def _resolve_worker_model_spec(
     model_override: str | None = None,
 ) -> tuple[str, AgentProfile | None, Any]:
     """Resolve which model spec a worker with this role/override would use,
-    without building anything. Shared by `build_worker_branch` (real branch
-    construction) and `worker_is_cli` (a cheap pre-pass over a whole team's
-    assignments, run before any branch exists) so the resolution logic lives
-    in exactly one place."""
+    without building anything. Shared by `build_worker_branch` and
+    `worker_is_cli` so the resolution logic lives in exactly one place."""
     # Pack per-role config (ADR-0043): model/effort/modes defaults for casts
     # roles. Ignored in bare mode (workers are the raw CLI spec there).
     w_cfg = None if env.bare else role_config(role, env.pack)
@@ -627,12 +572,10 @@ def worker_is_cli(
     role: str,
     model_override: str | None = None,
 ) -> bool:
-    """Whether a worker with this role/model_override resolves to a CLI-provider
-    iModel (no tool-calling surface, never messenger-bound). Cheap — just parses
-    the model spec and constructs an iModel with a dummy key, no network I/O —
-    so it is safe to call once per team member ahead of the per-worker build
-    loop, to know which teammates will end up messenger-bound for the WHOLE
-    team regardless of the order workers are actually built in."""
+    """Whether a worker with this role/model_override resolves to a
+    CLI-provider iModel (no tool-calling surface, never messenger-bound).
+    Cheap (no network I/O) — safe to call once per team member ahead of
+    the per-worker build loop."""
     w_model, _, _ = _resolve_worker_model_spec(env, role, model_override)
     return bool(getattr(build_imodel_from_spec(w_model), "is_cli", False))
 
@@ -648,13 +591,9 @@ async def build_worker_branch(
     grant_spawn: bool = False,
     modes: list[str] | None = None,
 ) -> tuple[Branch, str, AgentProfile | None, bool]:
-    """Resolve model/profile/system and build a worker Branch.
-
-    The fourth return value is ``messenger_bound``: True when this worker
-    actually got the in-process messenger tool registered (team messaging
-    active AND a non-CLI worker), so callers building `operate` DAG nodes
-    know to enable action serialization for this branch.
-    """
+    """Resolve model/profile/system and build a worker Branch. The fourth
+    return value, ``messenger_bound``, is True when this worker got the
+    in-process messenger tool registered — see docs/internals/cli.md."""
     from ._common import BARE_WORKER_SYSTEM
 
     w_model, w_profile, w_cfg = _resolve_worker_model_spec(env, role, model_override)
@@ -695,12 +634,9 @@ async def build_worker_branch(
     else:
         wname = env.assign_name(role)
 
-    # In-process team messaging: only API-model workers can call tools
-    # (operate() only surfaces branch.acts for non-CLI providers); CLI
-    # workers keep the existing file-based `li team` channel untouched.
-    # Decided here, before the system prompt is assembled below, so the
-    # coordination section names the channel this worker actually gets
-    # instead of unconditionally instructing the bash `li team` path.
+    # Only API-model workers can call tools (operate() only surfaces
+    # branch.acts for non-CLI providers); decided before the system prompt
+    # is assembled so the coordination section names the right channel.
     exchange = getattr(env, "exchange", None)
     messenger = getattr(env, "messenger", None)
     messenger_bound = (
@@ -773,16 +709,10 @@ async def build_worker_branch(
 
 
 def make_help_coordinator(env: OrchestrationEnv) -> Any:
-    """Build the rung-2 coordinator callback for ``LionMessenger``'s "help" event.
-
-    Plain Python routing logic — no LLM call, matching the shape
-    ``ReactiveExecutor._schedule_escalation`` already uses for flow-mode.
-    Every help signal is logged for bring-up visibility; a "blocked"-urgency
-    signal is additionally folded into ``env._escalated_evidence``, the same
-    list the human rung already surfaces post-hoc in the run summary (rung 4
-    stays post-hoc by default). Model-bump (rung 3) and
-    synchronous human paging are out of scope for this coordinator.
-    """
+    """Build the rung-2 coordinator callback for ``LionMessenger``'s "help"
+    event. Plain Python routing, no LLM call; a "blocked"-urgency signal is
+    folded into ``env._escalated_evidence`` for the run summary. Model-bump
+    (rung 3) and synchronous human paging are out of scope here."""
 
     def _on_help(*, name: str, sender_id: Any, reason: str, urgency: str = "fyi") -> None:
         _log_orch.info(
@@ -802,17 +732,9 @@ def make_help_coordinator(env: OrchestrationEnv) -> Any:
 @dataclass
 class TeamLifecycleCoordinator:
     """Rung-2 coordinator (plain Python, no LLM call) for a team-mode run's
-    done/finished/wakeup lifecycle — the counterpart to
-    ``make_help_coordinator`` for LionMessenger's "help" event.
-
-    Deliberately keeps no separate liveness bookkeeping of its own: every
-    fact about who is running, idle, or retired comes straight from the
-    team inbox via ``team.compute_quiescence`` (a pure function over message
-    ``kind``), so what a live coordinator decides is always exactly what
-    ``li team show`` displays and what the pure predicate's own unit tests
-    already cover — there's no separate in-memory state to drift out of
-    sync with the file.
-    """
+    done/finished/wakeup lifecycle, counterpart to ``make_help_coordinator``.
+    Keeps no liveness state of its own — reads it from ``team.compute_quiescence``
+    each time, so it never drifts from what ``li team show`` displays."""
 
     team_id: str
     worker_names: tuple[str, ...]
@@ -825,10 +747,8 @@ class TeamLifecycleCoordinator:
     rounds_run: int = field(default=0, init=False)
 
     def on_done(self, *, name: str, sender_id: Any, reason: str) -> None:
-        """Wired to ``LionMessenger.on("done", ...)``: a messenger-bound
-        worker calling ``action="done"`` reaches here; the actual structured
-        team-inbox entry is written by ``team.post_done_signal`` (code, not
-        the model), never by the worker formatting JSON itself."""
+        """Wired to ``LionMessenger.on("done", ...)``; writes the structured
+        team-inbox entry via ``team.post_done_signal`` (code, not the model)."""
         from lionagi.cli import team
 
         with contextlib.suppress(FileNotFoundError):
@@ -869,9 +789,8 @@ class TeamLifecycleCoordinator:
 
         from lionagi.cli import team
 
-        # Force-deliver queued outbox sends before the terminal read — the
-        # periodic async collect may not have ticked, and this sync hook
-        # cannot await it.
+        # Force-deliver queued outbox sends: the periodic async collect may
+        # not have ticked, and this sync hook cannot await it.
         if self.exchange is not None:
             with contextlib.suppress(Exception):
                 self.exchange.collect_all_sync()
@@ -926,20 +845,10 @@ class TeamLifecycleCoordinator:
 
     def build_round_operations(self, state: Any, *, prompt: str) -> list[Any]:
         """One re-invocation ``Operation`` per worker in
-        ``state.pending_targets``, each targeting that worker's OWN branch
-        (session continuity — the whole point of a "round" instead of a
-        fresh spawn) with its unread mail folded into ``context`` as
-        ``prior_team_messages`` — never the system prompt, so a teammate's
-        message content can never smuggle new standing instructions into
-        the model's persistent framing.
-
-        Consumes the pending workers' unread mail as a side effect (file
-        inbox via ``team.pop_unread_messages``, Exchange via
-        ``_exchange_prior_messages``) and posts a coordinator-authored
-        ``wakeup`` signal for each — the second effect is what flips those
-        workers back to "active" in the very next quiescence read, so the
-        same round is never double-injected.
-        """
+        ``state.pending_targets``, targeting each worker's own branch with
+        unread mail folded into ``context`` (never the system prompt).
+        See docs/internals/cli.md for the unread-mail-consumption and
+        wakeup-signal side effects that prevent double-injecting a round."""
         from lionagi.cli import team
         from lionagi.operations.node import create_operation
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -72,10 +72,8 @@ async def _persist_session_phase(env, phase: str) -> None:
 
 
 # ── Artifact-contract text — shared by planned legs and spawned nodes ─────────
-# Extracted so a planned leg (_build_dag) and a reactively spawned node
-# (_execute_dag's decorate_instruction closure) mirror each other by
-# construction: one namespacing rule, one sentence of REQUIRED-file prose,
-# used from both call sites, rather than the two copies quietly drifting.
+# Shared by _build_dag and _execute_dag's decorate_instruction closure so
+# both use one namespacing rule instead of two copies drifting apart.
 
 
 def _leg_artifact_entries(node_id: str, role_defaults: dict | None) -> list[dict]:
@@ -112,32 +110,23 @@ def _artifact_directive(run, node_id: str, leg_expected: list[dict]) -> str:
 
 # ── Control poller (ADR-0069 D1–D3: session-control transport) ──────────────
 # `li o ctl pause|resume|msg` enqueues a session_controls row from a separate
-# process; this poller is the only consumer and applies each row against the
-# live executor with verb-specific apply/stamp ordering.
+# process; this poller is the only consumer, verb-specific apply/stamp order.
 
 _CONTROL_POLL_INTERVAL = 2.0
 
-# Sentinel: the row's apply ran but no finalize write landed, so it is still
-# pending in the DB. The poller must stop the tick rather than let later
-# controls overtake it — the whole batch re-reads in order next tick.
+# Sentinel: apply ran but no finalize write landed. The poller must stop the
+# tick here rather than let later controls overtake it in the DB.
 _CONTROL_UNSTAMPED = "unstamped"
 
 # ── Team lifecycle (done-signal / wakeup rounds / quiescence) ───────────────
-# Driven by ReactiveExecutor's on_op_complete hook, not a poll loop — a poll
-# loop's next tick races the executor's own task-group teardown. See
-# TeamLifecycleCoordinator in _orchestration.py for the decision logic.
+# Driven by ReactiveExecutor's on_op_complete hook, not a poll loop (which
+# would race the executor's task-group teardown) — see TeamLifecycleCoordinator.
 
 
 async def _apply_session_control(db, executor, row: dict) -> str | None:
-    """Apply one session_controls row against *executor*. Returns the finalize
-    result, or None if left untouched (mid-apply from a prior poller crash).
-
-    pause/resume are idempotent (safe to re-apply after a crash). message is
-    at-most-once: stamped 'applying' before injection so a crash mid-apply is
-    visible via `li o ctl status` rather than risking a double injection.
-    Never raises — apply/finalize failures are recorded as rejected so a bad
-    control row can't crash the run it rides alongside.
-    """
+    """Apply one session_controls row against *executor*. Returns the
+    finalize result, or None if left untouched (mid-apply from a prior
+    poller crash). Never raises — failures are recorded as rejected."""
     control_id = row["id"]
     verb = row["verb"]
     try:
@@ -151,9 +140,8 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
 
         if verb == "message":
             if row.get("result") == "applying":
-                # A prior poller crashed between stamp and apply. At-most-once:
-                # leave it untouched — re-attempting could double-inject the
-                # message if the earlier apply actually landed before the crash.
+                # Prior poller crashed between stamp and apply; leave it
+                # untouched — re-attempting could double-inject the message.
                 return None
             await db.mark_session_control_applying(control_id)
 
@@ -177,9 +165,8 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
             deep_update(executor.context.content, {"operator_messages": [*existing, entry]})
             return await _finalize_applied(db, control_id)
 
-        # 'stop' is schema-reserved for a later slice (the checkpoint writer);
-        # any other verb is unrecognised. Reject loudly instead of leaving a
-        # row that would be polled forever.
+        # 'stop' is schema-reserved for a later slice (checkpoint writer);
+        # reject other verbs loudly instead of polling them forever.
         result = f"rejected:unsupported-verb:{verb}"
         await db.finalize_session_control(control_id, result=result)
         return result
@@ -189,19 +176,15 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
         try:
             await db.finalize_session_control(control_id, result=result)
         except Exception:  # noqa: BLE001
-            # The row is still pending: a later control applied this tick
-            # would be overtaken by this one re-applying next tick (e.g. a
-            # stuck pause re-pausing after its resume). Signal the poller to
-            # end the tick so ordering is preserved on the retry.
+            # Still pending: signal the poller to end the tick so a later
+            # control isn't overtaken by this one re-applying next tick.
             return _CONTROL_UNSTAMPED
         return result
 
 
 async def _finalize_applied(db, control_id: str) -> str:
-    """Stamp 'applied' after a successful apply; never mislabel it rejected.
-    On finalize failure, retry once then return the unstamped sentinel so the
-    poller hands the row back for the next tick.
-    """
+    """Stamp 'applied' after a successful apply; on finalize failure, retry
+    once then return the unstamped sentinel for the next poller tick."""
     for _ in range(2):
         try:
             await db.finalize_session_control(control_id, result="applied")
@@ -259,8 +242,7 @@ async def _resolve_invocation_terminal_flow(
 
         # Precedence: timed_out > failed > aborted > cancelled > completed_empty
         # > completed. completed_empty outranks completed so one silently
-        # empty leg still taints the whole flow's terminal status instead of
-        # being averaged away by its siblings' real completions.
+        # empty leg still taints the flow's terminal status.
         if child_statuses:
             if any(s == "timed_out" for s in child_statuses):
                 return (
@@ -412,12 +394,10 @@ class _DagState:
     # contract for a reactively spawned node run under that role — spawned
     # nodes don't exist yet at DAG-build time so can't be folded in there.
     role_artifact_defaults: dict[str, dict | None] = field(default_factory=dict)
-    # agent_id → its own worker branch (not just role_base's one-per-role
-    # entry — team-lifecycle wakeup rounds re-invoke a SPECIFIC worker's own
-    # session, which role_base can't address once a role has >1 named
-    # instance) and agent_id → whether it got the in-process messenger tool
-    # bound, so a round-injected node mirrors the same actions= wiring its
-    # planned leg got. Both populated in _build_dag's per-assignment loop.
+    # agent_id → its own worker branch (role_base is one-per-role and can't
+    # address a specific named instance for team-lifecycle wakeup rounds)
+    # and agent_id → messenger-bound, so a round-injected node mirrors its
+    # planned leg's actions= wiring. Populated in _build_dag's per-leg loop.
     worker_branches: dict[str, object] = field(default_factory=dict)
     messenger_bound: dict[str, bool] = field(default_factory=dict)
 
@@ -478,11 +458,8 @@ async def _build_dag(
         role_base.setdefault(ta.assignee, w_branch)
 
         # Fold this leg's OWN declared artifact contract (profile first, else
-        # the casts role's artifact_defaults — e.g. reviewer/critic) into the
-        # flow-wide contract, namespaced under this leg's own artifact
-        # subdirectory (ADR-0064 D3: per-leg role-default artifact
-        # expectations). A role that declares nothing leaves the contract
-        # untouched — this only fires for a real declaration.
+        # the casts role's artifact_defaults) into the flow-wide contract,
+        # namespaced under this leg's own artifact subdirectory (ADR-0064 D3).
         if ta.assignee in role_artifact_defaults:
             role_defaults = role_artifact_defaults[ta.assignee]
         else:
@@ -570,25 +547,10 @@ async def _build_dag(
                 ctx_lp["session_id"], node_metadata=json.dumps({**early_graph, **_markers})
             )
 
-    # Persist the per-leg role/profile artifact declarations collected above.
-    # start_live_persist already ran (playbook/whole-flow contract, if any) —
-    # this extends that contract now that per-leg roles are resolved, so
-    # teardown's verify_artifact_contract (reading ctx["artifact_contract"])
-    # sees the full picture. Validated eagerly: a malformed role declaration
-    # should fail loudly here, not be silently dropped.
-    #
-    # ADR-0064 extension (see db.py _SESSION_COLUMNS comment): this is the
-    # planned-leg write to artifact_contract_json, happening once here at
-    # DAG-build time, before _execute_dag runs any leg. It must reach the
-    # session row (not just env._live_persist) — a crash or orphan exit
-    # before teardown should still leave the DB row showing what was
-    # actually expected, matching what Studio/`li state show-session` read
-    # directly from artifact_contract_json. A SECOND, append-only write class
-    # exists for reactively spawned nodes (_execute_dag, after a spawned
-    # node completes) — see the "Reactive-spawn exception" paragraph in
-    # ADR-0064, which explains why folding a spawned node's entries in after
-    # it runs is still sound: what is expected of it was frozen (role
-    # defaults + spawn_id) before it was ever queued.
+    # Persist the per-leg role/profile artifact declarations (ADR-0064 D3),
+    # validated eagerly; must reach the session row directly, not just
+    # env._live_persist — see docs/internals/cli.md for the write-class split
+    # with reactively spawned nodes' append-only write in _execute_dag.
     if role_artifact_entries and ctx_lp is not None:
         from lionagi.state.artifact_verifier import validate_artifact_contract
 
@@ -626,41 +588,10 @@ def _reconstruct_spawned_nodes(
     checkpoint_ops: dict[str, dict],
     checkpoint_spawned: list[dict],
 ) -> None:
-    """Rebuild reactively spawned nodes from a checkpoint into the fresh graph.
-
-    A reactively spawned node has no entry in the persisted plan (only
-    planned legs do) — it must be reconstructed from what its own `spawned`
-    checkpoint entry recorded, then pre-completed exactly like a planned node
-    so the executor's terminal-status short-circuit (never a live re-run)
-    picks it up.
-
-    Three things must hold for a given entry, checked BEFORE any node is added
-    to the graph so a refusal never leaves it partially mutated:
-
-    1. It must carry `operation` (added in CHECKPOINT_VERSION 2, alongside
-       `assignee`/`instruction`/`parent_id`/`spawn_id`) — a checkpoint written
-       before that field set existed has nothing to rebuild an Operation node
-       from.
-    2. If it has a `parent_id`, that id must resolve to either a planned node
-       that is ITSELF checkpointed terminal (completed or failed in
-       `checkpoint_ops`), or another entry in this same `checkpoint_spawned`
-       list. A planned parent merely existing in the DAG is not enough — if
-       it crashed before its own checkpoint write landed, resume would
-       pre-complete this child while rerunning that parent live, and the
-       rerun can emit the same follow-up spawn again (duplicate work). If
-       the parent hasn't reached a checkpointed terminal state at all, the
-       spawn decision cannot be soundly replayed — resuming risks either
-       duplicating or silently dropping that work.
-    3. If it recorded an `assignee` (role-routed spawn), it must also carry a
-       `spawn_id` — role_node_builder stamps both together unconditionally at
-       construction time, and the finalize-time result-collection scan raises
-       a hard invariant error for any assignee-bearing node it finds without
-       one. A checkpoint entry missing `spawn_id` despite an `assignee` is
-       itself corrupt/pre-dates that field, not soundly replayable.
-
-    Either failure refuses resume for only the affected node(s), named in the
-    error, never the whole run merely because a spawn occurred.
-    """
+    """Rebuild reactively spawned nodes from a checkpoint into the fresh
+    graph, pre-completed like a planned node. See docs/internals/cli.md for
+    the three soundness checks (operation field, parent-terminal, spawn_id)
+    each entry must pass before any node is added to the graph."""
     from uuid import UUID as _UUID
 
     from lionagi.operations.node import create_operation
@@ -770,18 +701,10 @@ def _apply_checkpoint_precompletion(
     checkpoint_spawned: list[dict] | None = None,
 ) -> None:
     """Mark nodes the checkpoint recorded as terminal so the executor's
-    pre-completed seam short-circuits them instead of re-running.
-
-    completed ops restore their response; failed ops are restored as terminal
-    FAILED rather than silently re-run (they may have had side effects before
-    the process died). A pending op with inherit_context is refused unless the
-    caller passes allow_degraded_context — resume restores results-context
-    only, not conversation history (v1). checkpoint_spawned entries are
-    rebuilt into the graph and pre-completed the same way (see
-    _reconstruct_spawned_nodes) — resume refuses only the specific spawned
-    node(s) it genuinely cannot replay soundly, never the whole run just
-    because a spawn occurred.
-    """
+    pre-completed seam short-circuits them. A pending op with inherit_context
+    is refused unless allow_degraded_context is passed (v1 resume restores
+    results-context only). checkpoint_spawned is rebuilt the same way — see
+    _reconstruct_spawned_nodes."""
     from lionagi.protocols.types import EventStatus
 
     if checkpoint_spawned:
@@ -833,20 +756,9 @@ async def _execute_dag(
     team_max_rounds: int = 2,
 ) -> _ExecResult:
     """Drive the planning engine over the DAG and collect per-agent results.
-
-    checkpoint_config is the opt-in gate for the checkpoint writer: only when
-    not None is a CheckpointWriter constructed and wired into the
-    completion/failure observers. checkpoint_flow_context seeds the
-    executor's shared context workspace on resume with what was accumulated
-    before the crash, so pending ops see the same workspace they would live.
-    checkpoint_spawned_seed carries forward any reactively spawned entries a
-    prior checkpoint already recorded (reconstructed into the graph by
-    _apply_checkpoint_precompletion before this call) — without it, this
-    generation's first flush would overwrite `spawned` with `[]`, and since
-    pre-completed nodes never re-emit a completion signal to re-record
-    themselves, a second crash before any NEW spawn occurs would silently
-    lose all the previously reconstructed work.
-    """
+    checkpoint_config gates the checkpoint writer (opt-in); checkpoint_spawned_seed
+    carries forward prior-checkpoint spawn entries so a flush before any NEW
+    spawn doesn't overwrite `spawned` with `[]` and lose reconstructed work."""
     assignments = plan_result.assignments
     agent_ids = plan_result.agent_ids
 
@@ -860,10 +772,9 @@ async def _execute_dag(
     role_base = dag_state.role_base
     _op_segments = dag_state.op_segments
 
-    # Shared out-of-band handle for the live executor, populated synchronously
-    # by DependencyAwareExecutor.__init__ the moment run_dag() constructs it —
-    # both the control poller and the checkpoint writer's per-completion hook
-    # (below) read from it.
+    # Shared out-of-band handle for the live executor, populated by
+    # DependencyAwareExecutor.__init__; both the control poller and the
+    # checkpoint writer's per-completion hook read from it.
     _executor_ref: dict[str, object] = {}
     _checkpoint_tasks: list = []
 
@@ -876,11 +787,8 @@ async def _execute_dag(
             prompt=checkpoint_prompt,
             plan=checkpoint_plan or [],
             config=checkpoint_config,
-            # Seed with whatever was restored from a prior checkpoint (empty
-            # on a fresh, non-resumed run) so this generation's checkpoint
-            # carries the context forward even if zero ops complete before
-            # the next crash — otherwise a resume-of-a-resume would silently
-            # lose it despite nothing having gone wrong with restoration.
+            # Seed with prior-checkpoint state (empty on a fresh run) so a
+            # resume-of-a-resume can't silently lose context before the next flush.
             flow_context=dict(checkpoint_flow_context or {}),
             ops=dict(checkpoint_ops_seed or {}),
             spawned=list(checkpoint_spawned_seed or []),
@@ -895,27 +803,15 @@ async def _execute_dag(
     else:
         progress(f"Executing DAG (reactive off): {len(assignments)} assignments...")
     conc = max_concurrent if max_concurrent > 0 else max(len(assignments), 1)
-    # Restored spawns (from a prior checkpoint's `spawned` list, reconstructed
-    # into the graph before this call) already consumed part of the run's
-    # spawn budget and already exist as completed/failed work — both the
-    # live budget below and this generation's spawn accounting must count
-    # them, or a resumed --max-ops run could accept spawns beyond what was
-    # ever allowed, and restored-only spawned work would look like zero
-    # spawns happened at all.
+    # Restored spawns already consumed spawn budget and exist as completed/
+    # failed work; both the budget below and spawn accounting must count them.
     restored_spawn_count = len(checkpoint_spawned_seed or [])
-    # Spawn budget: when --max-ops is set, the initial plan + spawns share it.
-    # Otherwise fall back to a conservative default so an un-capped reactive run
-    # cannot quietly fan out to dozens of (costly) child agents. Either way,
-    # spawns already restored from a checkpoint count against it.
+    # --max-ops shares budget between initial plan + spawns; default cap of
+    # 20 otherwise so an un-capped reactive run can't fan out unbounded.
     max_spawn = max(0, (max_ops - len(assignments) if max_ops > 0 else 20) - restored_spawn_count)
-    # role_node_builder's spawn-id sequence is closure-scoped and rebuilt
-    # fresh below every generation — on resume it must start past whatever
-    # ordinals the restored spawns already used, or a live spawn this
-    # generation reissues the same spawn_id (and artifact directory) as a
-    # restored one. Takes the MAX existing ordinal + 1 rather than assuming
-    # count == max: a crashed run can have gaps (a spawn allocated but never
-    # completed before the crash never made it into `spawned` at all), so
-    # counting restored entries would double-allocate into that gap.
+    # Resume must start the spawn-id ordinal sequence past whatever restored
+    # spawns already used (MAX existing + 1, not count — crashes can leave
+    # gaps) or a live spawn could reissue a restored spawn_id/artifact dir.
     _spawn_seq_start = 1
     for _entry in checkpoint_spawned_seed or []:
         _sid = _entry.get("spawn_id")
@@ -990,13 +886,9 @@ async def _execute_dag(
         _persist_segments()
 
     def _checkpoint_record(sig, status: str) -> None:
-        """Fire-and-forget the checkpoint write for one op's outcome.
-
-        sig.name is untrustworthy as a key on its own (a spawned node's clone
-        can share a planned agent_id's name), so sig.op_id is checked against
-        known_node_strs to route planned nodes to record() and spawned nodes
-        to record_spawned(), preventing them from colliding.
-        """
+        """Fire-and-forget the checkpoint write for one op's outcome. sig.op_id
+        (not sig.name, which a spawned clone can share with a planned node)
+        routes to record() vs record_spawned() to avoid key collisions."""
         if _checkpoint_writer is None:
             return
         executor = _executor_ref.get("executor")
@@ -1018,15 +910,10 @@ async def _execute_dag(
                 )
             )
         else:
-            # Capture what resume needs to rebuild this node into a fresh
-            # graph: the operation type, its routed role (if any), and the
-            # instruction it ran with, read back off the still-live graph
-            # node (never removed once _accept_node adds it). parent_id
-            # comes straight off the signal — flow_progress_signals already
-            # resolves it (including through reactive spawns) via its own
-            # NodeSpawned observer. A lookup failure (should not normally
-            # happen) leaves operation/assignee/instruction unset, which
-            # resume treats as unreconstructable for this node alone.
+            # Capture what resume needs to rebuild this node: operation type,
+            # routed role, and instruction, read off the still-live graph
+            # node. A lookup failure leaves these unset, which resume treats
+            # as unreconstructable for this node alone (see flow.py's resume path).
             spawn_fields: dict[str, Any] = {"parent_id": sig.parent_id}
             with contextlib.suppress(Exception):
                 from uuid import UUID as _UUID
@@ -1041,12 +928,8 @@ async def _execute_dag(
                         if isinstance(params, dict)
                         else getattr(params, "instruction", None)
                     )
-                    # role_node_builder stamps spawn_id unconditionally
-                    # (lionagi/orchestration/patterns.py), independent of
-                    # whether the request carried an assignee — captured the
-                    # same way regardless so reconstruction can restore it
-                    # and the finalize-time assignee-without-spawn_id
-                    # invariant check never trips for a resumed node.
+                    # role_node_builder stamps spawn_id unconditionally, so
+                    # it's captured the same way regardless of assignee.
                     spawn_fields["spawn_id"] = spawned_node.metadata.get("spawn_id")
             _checkpoint_tasks.append(
                 _asyncio.ensure_future(
@@ -1094,12 +977,9 @@ async def _execute_dag(
                         "with no completion — possible hung child process"
                     )
 
-    # ADR-0069 D1: control poller — the only consumer of session_controls
-    # rows queued by `li o ctl pause|resume|msg`. _executor_ref (declared
-    # above, shared with the checkpoint writer's completion hook) is
-    # populated synchronously by DependencyAwareExecutor.__init__ the moment
-    # run_dag() constructs it, so the "executor not yet available" window
-    # below is at most one event-loop tick, well inside poll_interval.
+    # ADR-0069 D1: control poller, the only consumer of session_controls rows.
+    # _executor_ref is populated synchronously by DependencyAwareExecutor's
+    # __init__, so the window below is at most one event-loop tick.
     _control_log: list[dict] = []
 
     def _persist_control_log() -> None:
@@ -1233,11 +1113,9 @@ async def _execute_dag(
         return f"{req.instruction}\n\n{note}"
 
     def _spawn_branch_setup(operation: Any, branch: Any) -> None:
-        """Retarget a spawned node's cloned CLI workspace to its own
-        spawn_id subdir — Branch.clone inherits the emitter's repo kwarg, but
-        the artifact contract points at a sibling dir, so without this the
-        spawned CLI child can only write into the emitter's directory.
-        No-op for non-CLI chat models (no writable-root concept)."""
+        """Retarget a spawned node's cloned CLI workspace to its own spawn_id
+        subdir (Branch.clone inherits the emitter's repo kwarg otherwise).
+        No-op for non-CLI chat models."""
         spawn_id = operation.metadata.get("spawn_id") if operation is not None else None
         if not spawn_id:
             return
@@ -1295,37 +1173,22 @@ async def _execute_dag(
             await _exchange.collect_all()
     t_exec_elapsed = time.monotonic() - t_exec
 
-    # Drain every scheduled checkpoint write before returning — the whole
-    # point of the writer is surviving a crash right after this function
-    # returns, so the last op's completion must be durably on disk by now,
-    # not still queued behind a fire-and-forget task.
+    # Drain every scheduled checkpoint write before returning — the last op's
+    # completion must be durably on disk, not queued behind a fire-and-forget task.
     if _checkpoint_tasks:
         with contextlib.suppress(Exception):
             await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
 
     op_results = dag_result.get("operation_results", {})
-    # Total spawn count for this run includes restored spawns from a prior
-    # checkpoint generation, not just what this generation's live executor
-    # spawned — otherwise a resume that reconstructs every spawned node as
-    # already-terminal (zero NEW spawns this generation) would report
-    # n_spawned=0 and silently skip the automatic synthesis path that gates
-    # on it (see the with_synthesis-or-n_spawned check in _run_flow_inner).
+    # Includes restored spawns from a prior checkpoint generation, not just
+    # this generation's — else a resume with zero NEW spawns would report
+    # n_spawned=0 and skip the with_synthesis gate in _run_flow_inner.
     n_spawned = restored_spawn_count + dag_result.get("spawned_operations", 0)
 
-    # Escalation backstop: a leg the executor tracked as escalated (gave up
-    # instead of producing a result — see NodeEscalated / EscalationRequest)
-    # reads as a normal completed op_result to the loop below. Without this,
-    # a reviewer/critic that emits EscalationRequest(route="give_up") instead
-    # of writing its artifact is indistinguishable from a clean completion
-    # once execution finishes — this makes it loud at teardown even when no
-    # artifact_defaults declaration exists to catch it.
-    #
-    # The escalation tracker itself is plan-agnostic: it records any emitting
-    # node's id whether that node was planned up front or spawned mid-run via
-    # SpawnRequest (reactive mode). Spawned nodes never appear in node_ids/
-    # agent_ids (those are fixed-size arrays built once from the initial
-    # assignments), so they must be checked separately against known_nodes
-    # rather than only via the plan-time index walk below.
+    # Escalation backstop: an escalated leg (gave up via EscalationRequest
+    # instead of producing a result) reads as a normal completed op_result
+    # below without this — makes it loud at teardown. Spawned nodes aren't
+    # in node_ids/agent_ids (fixed-size, plan-time only), so checked separately.
     graph_nodes = getattr(env.builder.get_graph(), "internal_nodes", {}) or {}
     escalated_op_ids = {str(x) for x in dag_result.get("escalated_operations", [])}
     escalated_evidence = [
@@ -1334,10 +1197,8 @@ async def _execute_dag(
         if node_ids[i] in escalated_op_ids
     ]
     for spawned_nid in sorted(escalated_op_ids - known_nodes):
-        # Spawned nodes carry role_node_builder's stamped spawn_id (e.g.
-        # "spawn-3") in their graph node metadata — surface that instead of
-        # the internal Operation UUID so evidence reads the same as the
-        # artifact dirs/contract entries the run actually produced.
+        # Surface the stamped spawn_id (e.g. "spawn-3") instead of the
+        # internal UUID, matching the artifact dirs/contract entries produced.
         graph_node = graph_nodes.get(spawned_nid)
         spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
         evidence_id = spawn_id or spawned_nid
@@ -1346,9 +1207,8 @@ async def _execute_dag(
         )
     escalated_agent_ids = [entry["id"] for entry in escalated_evidence]
     if escalated_evidence:
-        # Merge, don't overwrite: a team-mode "blocked" help signal (see
-        # make_help_coordinator) may already have appended entries to
-        # env._escalated_evidence mid-run via the messenger callback.
+        # Merge, don't overwrite: a team-mode "blocked" help signal may
+        # already have appended entries to env._escalated_evidence mid-run.
         prior_evidence = getattr(env, "_escalated_evidence", None) or []
         env._escalated_evidence = [*prior_evidence, *escalated_evidence]
 
@@ -1377,22 +1237,14 @@ async def _execute_dag(
             }
         )
 
-    # Reactively spawned nodes are in the result map but not in our plan. Their
-    # graph node still carries the spawn_id + assignee role_node_builder
-    # stamped on it at construction time (lionagi/orchestration/patterns.py)
-    # and the branch the executor ultimately ran it on, so all three are
-    # recovered here — plan-time arrays (agent_ids/worker_models) are
+    # Reactively spawned nodes are in the result map but not in our plan —
+    # recovered here from graph node metadata since plan-time arrays are
     # fixed-size and can't cover nodes injected mid-run via SpawnRequest.
-    # (graph_nodes computed above, ahead of the escalation-evidence block.)
     spawned_contract_entries: list[dict] = []
 
-    # Pre-scan every builder-stamped spawn_id BEFORE assigning any fallback —
-    # a node injected without going through role_node_builder (escalation
-    # children, public Session.flow inject()) carries no spawn_id and needs a
-    # synthesized one, but that synthesis must never collide with (or, worse,
-    # race ahead of and steal) an id role_node_builder already allocated at
-    # construction time. Completion order alone is exactly the bug this whole
-    # change fixes, so it can no longer be trusted to hand out spawn-1.
+    # Pre-scan every builder-stamped spawn_id BEFORE assigning any fallback:
+    # synthesis must never collide with an id role_node_builder already
+    # allocated (completion order alone can't be trusted to hand out spawn-1).
     stamped_spawn_ids: set[str] = set()
     for nid in op_results:
         if nid in known_nodes:
@@ -1420,12 +1272,9 @@ async def _execute_dag(
         sid = graph_node.metadata.get("spawn_id") if graph_node is not None else None
         if not sid:
             if assignee:
-                # role_node_builder stamps spawn_id unconditionally, whether
-                # or not the request carried an assignee — a role-attributed
-                # node reaching here without one means that invariant broke
-                # upstream. Fail loudly instead of silently minting a fresh
-                # id that would hide the defect behind a plausible-looking
-                # contract entry.
+                # role_node_builder stamps spawn_id unconditionally; reaching
+                # here without one means that invariant broke upstream — fail
+                # loudly rather than mint a fresh id that hides the defect.
                 raise RuntimeError(
                     f"spawned node {nid!r} carries role assignee {assignee!r} "
                     "but no spawn_id — role_node_builder must stamp spawn_id "
@@ -1457,12 +1306,9 @@ async def _execute_dag(
         )
 
         # Record the spawned node's role-declared artifacts in the session
-        # contract for post-run visibility (synthesis, Studio), namespaced
-        # under the node's own subdir. Required entries now stay required:
-        # decorate_instruction (wired into role_node_builder above) tells the
-        # spawned node its own artifact dir + REQUIRED files before it runs,
-        # the same way a planned leg is told — so an explicitly-required
-        # declaration is enforceable here, not just observability.
+        # contract, namespaced under its own subdir — required entries stay
+        # enforceable, not just observability, since decorate_instruction
+        # already told the spawned node its dir + REQUIRED files before it ran.
         if assignee:
             role_defaults = dag_state.role_artifact_defaults.get(assignee)
             spawned_contract_entries.extend(_leg_artifact_entries(sid, role_defaults))
@@ -1527,10 +1373,8 @@ async def _synthesize(
     leaf_nodes = [n for n in node_ids if n not in depended] or list(node_ids)
 
     artifacts = [f"[{r['id']} via {r['name']}]: {r['response']}" for r in agent_results]
-    # Derived from agent_results (the executor's ground truth), not the
-    # plan-time agent_ids array — reactively spawned nodes have their own
-    # artifact dir (agent_results[i]["agent_id"]) and would otherwise be
-    # silently omitted from what the synthesizer is told to read.
+    # Derived from agent_results, not the plan-time agent_ids array, so
+    # reactively spawned nodes' own artifact dirs aren't omitted here.
     adirs = [str(env.run.agent_artifact_dir(r["agent_id"])) for r in agent_results]
     team_synth_note = ""
     if env.team_data:
@@ -1602,11 +1446,9 @@ def _finalize_flow(
     if env.team_data:
         _post_results_to_team(env.team_data, agent_results, agent_ids, synthesis_result)
 
-    # "agents" must cover every id that "operations" (below) can reference —
-    # operations is built from agent_results, which already includes
-    # reactively spawned nodes (spawned=True), so agents has to walk the same
-    # ground truth rather than only the fixed-size plan-time assignments, or
-    # a spawned op's id resolves to nothing in UI/Studio agent lookups.
+    # "agents" must cover every id "operations" (below) references, so it
+    # walks agent_results (which includes spawned nodes), not just the
+    # fixed-size plan-time assignments, or a spawned id resolves to nothing.
     agents_meta = [
         {
             "id": agent_ids[i],
@@ -1713,10 +1555,8 @@ async def _run_flow(
     _invocation_kind = "play" if playbook_name else "flow"
 
     # The checkpoint's own "config" replays THIS call's kwargs verbatim on
-    # --resume (dry_run/show_graph excluded deliberately — those are
-    # presentation flags for the CURRENT invocation, not "what happened").
-    # Built unconditionally: a resumed run's own checkpoint must be just as
-    # resumable as the first one.
+    # --resume (dry_run/show_graph excluded — presentation flags, not "what
+    # happened"). Built unconditionally so a resumed run stays resumable.
     _checkpoint_config = {
         "model_spec": model_spec,
         "with_synthesis": with_synthesis,
@@ -1764,12 +1604,10 @@ async def _run_flow(
         pack=pack,
     )
 
-    # `--notify` is scoped compatibility sugar over the terminal-callback
-    # registry: registered here against this run's own
-    # entity (its invocation if tracked, else its session), unregistered in
-    # the `finally` block below. There is no longer a direct notify call at
-    # teardown -- the registered handler fires from the same guarded
-    # lifecycle transition that persists the terminal status itself.
+    # `--notify` is compatibility sugar over the terminal-callback registry:
+    # registered against this run's own entity, unregistered in `finally`
+    # below. The handler fires from the same guarded lifecycle transition
+    # that persists the terminal status — no direct notify call at teardown.
     _notify_scope_name: str | None = None
     if notify:
         _notify_entity_kind = "invocation" if invocation_id else "session"
@@ -1863,15 +1701,9 @@ async def _run_flow(
                 _terminal_status = effective_status
             import time as _time
 
-            # ended_at is meaningful regardless of whether an invocation_id
-            # is tracked. The terminal-notify hook no longer fires from a
-            # direct call here: stop_live_persist()'s own session status
-            # write, and the invocation status write just below, are both
-            # guarded lifecycle transitions that push through the
-            # terminal-callback registry on commit -- whatever was
-            # registered by register_flow_notify_scope() above (or by the
-            # settings-level handler bootstrapped at process start) fires
-            # from there, exactly once, on whichever entity is authoritative.
+            # Terminal-notify no longer fires from a direct call here: the
+            # session/invocation status writes below are guarded lifecycle
+            # transitions that push through the terminal-callback registry.
             _ended_at = _time.time()
             if invocation_id:
                 from lionagi.state.db import StateDB
@@ -1953,11 +1785,8 @@ async def _run_flow_inner(
         ]
         agent_ids: list[str] = [entry["agent_id"] for entry in plan_entries]
         dep_indices = [list(entry.get("dep_indices") or []) for entry in plan_entries]
-        # Replay the naming bookkeeping so a role that reactively spawns
-        # again post-resume gets a name that doesn't collide with one
-        # already used in the run being resumed (build_worker_branch
-        # re-registers each restored agent_id into _all_names itself, via
-        # the explicit_name path _build_dag already takes below).
+        # Replay the naming bookkeeping so a reactive spawn post-resume
+        # doesn't collide with a name already used in the resumed run.
         for ta in assignments:
             env._name_counts[ta.assignee] = env._name_counts.get(ta.assignee, 0) + 1
         t_plan = 0.0
@@ -2082,13 +1911,10 @@ async def _run_flow_inner(
         env.messenger = LionMessenger(env.exchange)
         env.messenger.on("help", make_help_coordinator(env))
         env.roster = {}
-        # Mixed-provider teams (heterogeneous --workers pool) build one worker
-        # branch at a time, so which teammates end up messenger-bound isn't
-        # fully known until _build_dag's loop below finishes. Resolve it here,
-        # for every team member up front, so each worker's prompt can flag
-        # CLI-provider teammates as unreachable via messenger regardless of
-        # build order (worker_is_cli is a cheap, side-effect-free pre-pass —
-        # no branch/iModel with real I/O is constructed).
+        # Mixed-provider teams build one worker branch at a time, so which
+        # teammates end up messenger-bound isn't known until _build_dag's
+        # loop finishes. Resolve it here up front (worker_is_cli is a cheap,
+        # side-effect-free pre-pass) so build order can't affect the prompt.
         env.messenger_names = frozenset(
             agent_ids[i]
             for i, ta in enumerate(assignments)
@@ -2190,12 +2016,8 @@ async def _resume_flow(
     notify: str | None = None,
 ) -> tuple[str, str]:
     """Resolve a checkpointed run/session id and replay it through _run_flow.
-
-    dry_run/show_graph/notify come from the CURRENT invocation, not the
-    checkpoint — presentation overrides for the replay, not part of what
-    already happened. Every other _run_flow kwarg replays the persisted
-    config verbatim.
-    """
+    dry_run/show_graph/notify come from the CURRENT invocation (presentation
+    overrides); every other _run_flow kwarg replays the persisted config."""
     _run_dir, checkpoint = await resolve_checkpoint_target(target)
     config = dict(checkpoint.get("config") or {})
     config["dry_run"] = dry_run

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -23,12 +23,8 @@ from ._logging import log_error, warn
 TEAMS_DIR = LIONAGI_HOME / "teams"
 
 # ── Message kinds ────────────────────────────────────────────────────────
-#
-# "message" (the default) is ordinary coordination content. The other three
-# are lifecycle SIGNALS a worker's messenger tool (or, for CLI workers, `li
-# team send --kind ...`) emits about itself, not content addressed to a
-# reader — `compute_quiescence` below reads them to derive who is still
-# running, who has gone idle, and who is permanently retired.
+# "message" is ordinary content; the other three are lifecycle SIGNALS a
+# worker emits about itself, read by `compute_quiescence` below.
 MESSAGE_KIND = "message"
 DONE_KIND = "done"
 FINISHED_KIND = "finished"
@@ -73,9 +69,7 @@ def _team_file(team_id: str) -> Path:
 def _locked_team(team_id: str, *, create_path: Path | None = None):
     """Read-modify-write a team file under an exclusive POSIX lock; concurrent sends serialize."""
     path = create_path if create_path is not None else _team_file(team_id)
-    # Open in r+ so we can read current contents AND truncate+rewrite.
-    # If the file doesn't exist yet (create flow), the caller supplies
-    # create_path and we open w+ to initialize.
+    # r+ to read-then-rewrite; w+ to initialize on the create flow.
     mode = "r+" if path.exists() else "w+"
     with open(path, mode) as fp:
         fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
@@ -87,13 +81,9 @@ def _locked_team(team_id: str, *, create_path: Path | None = None):
             fp.seek(0)
             fp.truncate()
             fp.write(json.dumps(data, indent=2, default=str))
-            # Push the write out of Python's io buffer and the OS page cache
-            # BEFORE releasing the lock. Without this, a waiting reader can
-            # acquire the lock the instant it's released and observe stale
-            # (pre-write) content, since fp.write() only fills a buffer —
-            # it does not guarantee bytes have left this process. Under
-            # concurrent writers that showed up as a spurious "No team
-            # found" a moment after a team plainly existed on disk.
+            # flush+fsync before unlock: otherwise a waiting reader can
+            # acquire the lock and observe stale content (write() only fills
+            # a buffer) — see docs/internals/cli.md.
             fp.flush()
             os.fsync(fp.fileno())
         finally:
@@ -270,11 +260,8 @@ def cmd_send(args: argparse.Namespace) -> int:
 
 
 # ── Lifecycle signals (done / finished / wakeup) ────────────────────────────
-#
-# Every writer here goes through `_build_message` and the same `_locked_team`
-# flock discipline `cmd_send`/`cmd_receive` use — a worker's "I'm done"
-# never depends on an LLM formatting a JSON blob correctly; the structure is
-# always produced by this code.
+# Every writer here goes through `_build_message` and `_locked_team`'s flock
+# discipline — the structure is always produced by this code, never an LLM.
 
 
 def post_done_signal(
@@ -335,13 +322,9 @@ def post_wakeup_signal(
 
 
 def pop_unread_messages(team_id: str, member: str) -> list[dict]:
-    """Read + consume *member*'s unread ``kind="message"`` mail under lock,
-    mirroring ``cmd_receive``'s read/mark semantics but filtered to plain
-    coordination content — lifecycle signals (done/finished/wakeup) are
-    bookkeeping, not something a revived worker needs echoed back to it.
-
-    Returns plain ``{"from", "content", "timestamp"}`` dicts, shaped for
-    embedding into a round-injection's ``prior_team_messages`` context.
+    """Read + consume *member*'s unread ``kind="message"`` mail under lock
+    (lifecycle signals are bookkeeping, excluded here). Returns plain
+    ``{"from", "content", "timestamp"}`` dicts for round-injection context.
     """
     with _locked_team(team_id) as data:
         if not data:
@@ -400,26 +383,9 @@ def compute_quiescence(
     coordinator_wants_round: bool = False,
 ) -> QuiescenceState:
     """Pure predicate: is this team-mode run done, or does it need another
-    wakeup round? Reads only message ``kind``/``from``/``to``/``read_by`` —
-    never touches a file, a branch, or an agent.
-
-    Lifecycle model, derived purely from message kinds:
-    - every named worker starts **active** (presumed still running its
-      current turn — nobody has said otherwise yet);
-    - a ``kind="done"`` message *from* a worker makes it **idle** (it
-      finished this turn and may be revived by a later round);
-    - a ``kind="finished"`` message *from* a worker **retires** it
-      permanently — a retired worker is never revived again, mirroring
-      ``LionMessenger``'s ``finished`` action;
-    - a ``kind="wakeup"`` message addressed *to* a worker makes it
-      **active** again, whether the wakeup came from a teammate (peer
-      wakeup) or the coordinator's own round injection.
-
-    The run is quiescent once every worker has settled (none **active**)
-    AND there is nothing left for the coordinator to do about it: no unread
-    ``kind="message"`` mail sitting in an **idle** worker's inbox, and
-    either the round budget is exhausted or the caller isn't asking for one
-    more round anyway.
+    wakeup round? Reads only message ``kind``/``from``/``to``/``read_by``,
+    never a file/branch/agent. See docs/internals/cli.md for the lifecycle
+    model (active/idle/retired) and the quiescence condition.
     """
     names = list(dict.fromkeys(worker_names))  # de-dup, preserve order
     state: dict[str, str] = dict.fromkeys(names, "active")

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -1,13 +1,9 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dependency-aware graph execution.
-
-Graph scheduling and executor construction live in this module. New APIs, commands,
-and services that execute operation graphs must delegate through ``Session.flow`` or
-the existing streaming flow kernel. Keep executor construction here and add
-conformance coverage for every new graph-execution surface.
-"""
+"""Dependency-aware graph execution. New graph-execution surfaces must
+delegate through ``Session.flow`` or the existing streaming flow kernel,
+not build their own executor."""
 
 import asyncio
 import contextlib
@@ -72,13 +68,9 @@ def _format_operator_ts(ts: Any) -> str:
 
 
 def _render_operator_messages(operation: "Operation", context: dict[str, Any]) -> None:
-    """Lift ``operator_messages`` out of context and render unconsumed entries into the instruction.
-
-    Always pops the key so it never rides along as raw JSON in the model's
-    context, whether or not there was anything new to render. Consume-once:
-    an entry already carrying a ``rendered_into_op`` breadcrumb was rendered
-    into an earlier operation and is skipped here.
-    """
+    """Lift ``operator_messages`` out of context and render unconsumed
+    entries into the instruction. Always pops the key so it never rides
+    along as raw JSON; consume-once via the ``rendered_into_op`` breadcrumb."""
     messages = context.pop("operator_messages", None)
     if not messages:
         return
@@ -138,12 +130,10 @@ class DependencyAwareExecutor:
         self._alcall = alcall_params or AlcallParams()
         self._default_branch = default_branch
         self.on_progress = None
-        # Persistence-only seam: a caller
-        # (e.g. Studio's workflow_run) can pass a sync callback invoked with
-        # every branch this executor clones during pre-allocation, so it can
-        # wire per-branch persistence (register_branch_hook) on branches that
-        # did not exist yet when the caller set up persistence for the
-        # session's initial branches. Never touches execution/branch semantics.
+        # Persistence-only seam: a caller (e.g. Studio's workflow_run) can
+        # pass a sync callback invoked with every branch this executor clones
+        # during pre-allocation, to wire per-branch persistence on branches
+        # that didn't exist when the caller set up the session's initial ones.
         self._on_branch_created = on_branch_created
         self.results = {}
         self.completion_events = {}
@@ -155,10 +145,9 @@ class DependencyAwareExecutor:
         # NodeSpawned), retained until each finishes so a weakly referenced
         # task can't disappear before it runs. See _emit_best_effort().
         self._signal_tasks: set[asyncio.Task[Any]] = set()
-        # An out-of-band handle lets a control poller running alongside this flow
-        # reach pause()/resume()/context/graph on the live executor. Set
-        # synchronously here (before any awaiting) so it is available the
-        # instant execute() starts.
+        # Out-of-band handle for a control poller running alongside this flow
+        # to reach pause()/resume()/context/graph; set synchronously before
+        # any awaiting so it's available the instant execute() starts.
         if executor_ref is not None:
             executor_ref["executor"] = self
         for node in graph.internal_nodes.values():
@@ -261,13 +250,9 @@ class DependencyAwareExecutor:
             logger.debug("Pre-allocated %d branches", len(operations_needing_branches))
 
     def _get_predecessors(self, operation: Operation) -> tuple[Any, ...]:
-        """Return a cached, immutable predecessor tuple for executor-internal use.
-
-        Delegates to Graph's own memoized accessor, which is invalidated by
-        Graph's own mutators (add_edge/remove_edge/etc.) — including the
-        add_node/add_edge/remove_edge calls a running reactive flow makes to
-        rewire a node — so this always reflects current topology.
-        """
+        """Return a cached, immutable predecessor tuple for executor-internal
+        use. Delegates to Graph's own memoized accessor, invalidated by
+        Graph's own mutators, so this always reflects current topology."""
         return self.graph.get_predecessors_cached(operation)
 
     def pause(self) -> None:
@@ -282,16 +267,10 @@ class DependencyAwareExecutor:
             self._pause_event = None
 
     def _emit_best_effort(self, factory: Callable[[], "Signal"]) -> None:
-        """Build and schedule a fire-and-forget flow signal on the session bus.
-
-        `factory` is called (never the already-built signal) so that imports,
-        payload extraction, and signal construction all live inside the same
-        failure-isolation boundary. Every failure mode — construction, no
-        running loop, scheduling, or the awaited `session.emit()` call — is
-        logged as a structured warning here and never changes the caller's
-        (pause / escalation / spawn) outcome. Delivery is intentionally
-        best-effort: these are observations, not an outbox.
-        """
+        """Build and schedule a fire-and-forget flow signal on the session
+        bus. `factory` (not a pre-built signal) keeps construction inside
+        this failure-isolation boundary; every failure mode is logged and
+        never changes the caller's outcome — delivery is best-effort."""
         try:
             sig = factory()
         except Exception as e:  # noqa: BLE001
@@ -445,11 +424,10 @@ class DependencyAwareExecutor:
 
     async def _check_edge_conditions(self, operation: Operation) -> bool:
         """Return True if at least one valid incoming path exists or no edges; False if all incoming edges failed."""
-        # Snapshot before awaiting: reactive injection can attach an edge to
-        # this operation while a predecessor is awaited, and iterating the
-        # live adjacency dict across that await would raise RuntimeError. A
-        # dependency added after the snapshot is deferred to the next check,
-        # matching the previous full-scan's stable-list semantics.
+        # Snapshot before awaiting: iterating the live adjacency dict across
+        # an await would raise RuntimeError if reactive injection attaches an
+        # edge mid-wait. A dependency added after the snapshot is deferred
+        # to the next check.
         incoming_edge_ids = tuple(self.graph.node_edge_mapping[operation.id]["in"])
         if not incoming_edge_ids:
             return True
@@ -554,14 +532,10 @@ class DependencyAwareExecutor:
         self.operation_branches[operation.id] = branch
 
     def _render_pending_operator_steers(self, operation: Operation) -> None:
-        """Last-chance render, called immediately before the provider call.
-
-        A steer can land in ``self.context.content["operator_messages"]``
-        after this operation's own ``_prepare_operation`` already ran (e.g.
-        a control-plane poller appending mid-run). Re-reading the canonical
-        queue here, right before ``invoke()``, catches that window instead
-        of silently dropping the steer for the rest of the flow.
-        """
+        """Last-chance render, called immediately before the provider call —
+        catches a steer landing in ``operator_messages`` after this
+        operation's own ``_prepare_operation`` already ran (e.g. a
+        control-plane poller appending mid-run)."""
         messages = self.context.content.get("operator_messages")
         if not messages:
             return
@@ -710,17 +684,13 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.spawn_type = spawn_type
         self.node_builder = node_builder
         self.max_spawn = max_spawn
-        # CLI-workspace seam: a caller (cli/orchestrate/flow.py) can pass a
-        # sync callback invoked with (spawned_operation, cloned_branch) right
-        # after a reactively-spawned node's branch is cloned, so it can
-        # retarget a CLI-backed chat_model's writable workspace (endpoint
-        # kwargs["repo"]) to that spawn's own artifact dir instead of the
-        # planned leg's — the clone otherwise inherits the emitter's repo,
-        # which sits outside the spawned node's own artifact directory.
+        # CLI-workspace seam: called with (spawned_operation, cloned_branch)
+        # right after a spawned node's branch is cloned, so a caller can
+        # retarget a CLI-backed chat_model's writable workspace to that
+        # spawn's own artifact dir (the clone otherwise inherits the emitter's).
         self.spawn_branch_setup = spawn_branch_setup
-        # Sync callback fired once per node at the tail of _run_tracked,
-        # before that task returns to the task group — the only point a
-        # caller's inject() is race-free against the group's convergence.
+        # Fired once per node at the tail of _run_tracked, before that task
+        # returns to the task group — the only race-free point for inject().
         self.on_op_complete = on_op_complete
         self._spawn_count = 0
         self._dropped_spawns: list[dict[str, Any]] = []
@@ -883,15 +853,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._schedule_escalation(req, emitter=_CURRENT_OP.get())
 
     def _schedule_escalation(self, req: Any, *, emitter: Operation | None) -> None:
-        """Consume an EscalationRequest/help signal.
-
-        Route resolution: an explicit ``context["route"]`` always wins.
-        Otherwise the default route follows ``urgency`` — "blocked" (the
-        historical default) still defaults to "higher_tier" (retry); a soft
-        "fyi" help signal defaults to "notify" (informational, no retry, the
-        emitting node's own completion is untouched — an unanswered help
-        semantics: a help signal must never hang or redirect the worker).
-        """
+        """Consume an EscalationRequest/help signal. An explicit
+        ``context["route"]`` always wins; otherwise the route follows
+        ``urgency`` — "blocked" defaults to "higher_tier" (retry), "fyi"
+        defaults to "notify" (no retry; the emitter's completion is untouched)."""
         if id(req) in self._seen_reqs:
             return
         self._seen_reqs.add(id(req))
@@ -1149,21 +1114,11 @@ async def flow(
     spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
     on_op_complete: Callable[[Operation], None] | None = None,
 ) -> dict[str, Any]:
-    """Execute a graph with dependency management and optional reactive self-expansion.
-
-    Returns ``{completed_operations, operation_results, final_context,
-    skipped_operations}`` always; with ``reactive=True`` also
-    ``spawned_operations`` (successful-spawn count), ``escalated_operations``
-    (emitter ids), and ``dropped_spawns`` (rejected spawn/inject attempts as
-    ``{reason, assignee, emitter_id, ...}``; reasons: builder_error,
-    null_child, cycle, max_spawn_exceeded, duplicate).
-
-    ``spawn_branch_setup``, when given, runs after each reactively-spawned
-    node's branch is cloned (reactive mode only) — see ``ReactiveExecutor``.
-
-    ``on_op_complete`` (reactive mode only) runs synchronously at the tail
-    of every node's execution, race-free for a caller's ``inject()``.
-    """
+    """Execute a graph with dependency management and optional reactive
+    self-expansion. Returns ``{completed_operations, operation_results,
+    final_context, skipped_operations}`` always, plus ``spawned_operations``/
+    ``escalated_operations``/``dropped_spawns`` when ``reactive=True`` — see
+    docs/internals/core.md for the full return-shape and hook contracts."""
 
     if not parallel:
         max_concurrent = 1

--- a/lionagi/plugins/registry.py
+++ b/lionagi/plugins/registry.py
@@ -1,30 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""The plugin registry: combines discovery + trust + settings into one snapshot.
-
-Two-stage laziness, mirroring ``EndpointRegistry._ensure_loaded``:
-
-- **Stage 1 (this module, ``_ensure_loaded``)** — manifests are scanned and
-  parsed the first time any consumer asks the registry anything. Cheap,
-  data-only, cached for the process.
-- **Stage 2 (``activate_target``)** — a declared ``target``/``module`` is
-  imported only when that specific capability is actually invoked, never as a
-  side effect of discovery, listing, or an unrelated capability of the same
-  plugin firing. Trust is revalidated fresh on *every* call, re-reading
-  ``plugin.yaml`` from disk rather than trusting the process-cached snapshot
-  (see ``_rescan``) — a previously-activated target stops being handed out
-  the moment a declared file, or the manifest itself, no longer verifies.
-  The target file that actually gets executed is read exactly once and its
-  hash checked against the currently-recorded trust entry for that path in
-  that same read (see ``_read_and_verify_target_bytes``) — the check and the
-  bytes that get compiled/exec'd are never two separate reads of the file,
-  which would leave a window for the file to be swapped in between. Import
-  results (success or failure) are cached per ``(plugin, target, content
-  hash)``, so re-trusting changed content is a guaranteed cache miss rather
-  than depending on an earlier call happening to have evicted the old entry.
-
-Nothing in this module runs at ``import lionagi`` time — the registry is
-inert until a consumer calls one of its classmethods.
+"""The plugin registry: combines discovery + trust + settings into one
+snapshot. Two-stage laziness (scan-only, then per-call revalidated
+activation); nothing runs at ``import lionagi`` time. See docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -63,10 +41,8 @@ class PluginState(str, Enum):
     UNTRUSTED = "untrusted"
     CHANGED = "changed"
     INCOMPATIBLE = "incompatible"
-    # Extensions beyond the core lifecycle-state vocabulary, needed so a
-    # broken or colliding bundle is still visible in `li plugin list` instead
-    # of silently vanishing — an unparseable manifest or a same-name
-    # collision must surface loudly, not disappear.
+    # Extensions beyond the core lifecycle vocabulary, so a broken/colliding
+    # bundle stays visible in `li plugin list` instead of vanishing silently.
     INVALID = "invalid"
     COLLISION = "collision"
 
@@ -101,23 +77,16 @@ class PluginActivationError(RuntimeError):
 
 @dataclass
 class ToolTarget:
-    """A plugin-declared tool resolved for a consumer, e.g. ``ActionManager``.
-
-    Carries just enough to activate it: which plugin owns the name, and the
-    manifest's bundle-relative ``target`` string to hand to ``activate_target``.
-    """
+    """A plugin-declared tool resolved for a consumer (e.g. ``ActionManager``):
+    which plugin owns it, and its ``target`` string for ``activate_target``."""
 
     plugin_name: str
     target: str
 
 
 class PluginToolCollisionError(RuntimeError):
-    """ADR-0088 D6: two enabled plugins declare the same non-namespaced tool name.
-
-    Tool names are called bare by the model with no namespace to disambiguate
-    them, so this is a hard error rather than a shadow — the diagnostic names
-    both plugins and the surface, and resolution is human: disable one.
-    """
+    """ADR-0088 D6: two enabled plugins declare the same non-namespaced tool
+    name (called bare, no namespace to disambiguate) — a hard error, not a shadow."""
 
     def __init__(self, tool_name: str, message: str) -> None:
         self.tool_name = tool_name
@@ -145,14 +114,8 @@ def _tool_names(manifest: PluginManifest) -> list[str]:
     return [t.name for t in manifest.capabilities.tools]
 
 
-# Cross-plugin same-name hard-collision applies only to the global,
-# non-namespaced surface: tool names are called bare by the model, so there
-# is no way to disambiguate two plugins both declaring the same tool name.
-# Agent profiles and playbooks are addressable as `<plugin>/<name>` — two
-# plugins each shipping (say) a "researcher" profile is not an error, it
-# just makes the *bare* name ambiguous (resolved, or not, at the resolver —
-# see lionagi.cli._providers); each stays independently reachable via its
-# namespaced token. Packs follow the same reasoning.
+# Hard-collision applies only to the global, non-namespaced tool surface;
+# profiles/playbooks/packs are addressable as `<plugin>/<name>` instead.
 _NAMED_SURFACES: tuple[tuple[str, Any], ...] = (("tools", _tool_names),)
 
 
@@ -342,22 +305,9 @@ def _build_snapshot() -> list[PluginRecord]:
 
 
 def _rescan(record: PluginRecord) -> DiscoveredPlugin | None:
-    """Re-scan *record*'s bundle directory fresh, right now — including re-reading
-    and re-parsing ``plugin.yaml`` itself, not the already-parsed manifest object
-    cached on the process-wide snapshot (``record.manifest``).
-
-    The process-wide snapshot (``PluginRegistry._snapshot``) is built once and
-    cached — an ``ACTIVE`` record in it can go stale the moment any declared
-    file, *or the manifest itself*, is edited after that first scan, and
-    nothing re-scans it until ``reset()``. Reusing ``record.manifest`` to
-    recompute trust only catches drift in the individually-hashed target
-    files; the manifest hash is computed by re-serializing the *parsed
-    manifest object*, so a stale cached object always re-derives the same
-    "trusted" hash regardless of what's actually on disk in ``plugin.yaml``
-    right now. Returns ``None`` if the manifest no longer parses at all
-    (edited into something invalid, corrupted, or a declared path no longer
-    validates) — definitely not the content that was ever hashed and
-    approved.
+    """Re-scan *record*'s bundle directory fresh, re-reading and re-parsing
+    ``plugin.yaml`` itself rather than the cached ``record.manifest``.
+    Returns ``None`` if the manifest no longer parses. See docs/internals/runtime.md.
     """
     fresh = _scan_one(record.bundle_dir)
     return fresh if fresh.manifest is not None else None
@@ -378,13 +328,8 @@ def _fresh_active_plugins(
     dict[str, list[str]],
     dict[str, list[DiscoveredPlugin]],
 ]:
-    """Rebuild live eligibility and tool ownership from freshly scanned manifests.
-
-    The process-cached records are only bundle-directory candidates. Duplicate
-    manifest names and named-capability collisions must be recomputed from the
-    current manifests before any capability is exposed. Ownership lists retain
-    repeated declarations from one manifest so they collide just like declarations
-    from separate plugins.
+    """Rebuild live eligibility and tool ownership from freshly scanned
+    manifests; process-cached records are only bundle-directory candidates.
     """
     by_name: dict[str, list[DiscoveredPlugin]] = {}
     for record in records:
@@ -426,25 +371,9 @@ def _fresh_active_plugins(
 
 
 def _target_resolution_map(manifest: PluginManifest) -> dict[str, tuple[str, str | None]]:
-    """Map each declared, activatable target string to ``(module_path, attr_or_None)``.
-
-    Built directly from the manifest's own typed capability lists — a
-    tool's path/callable split comes from ``parse_tool_target`` on
-    ``tool.target`` (the exact call ``discovery._collect_declared_paths``
-    makes when deciding what to hash), never by re-splitting the caller's
-    ``target`` argument independently. That's what makes the file that gets
-    imported here provably the same file that got content-hashed at trust
-    time — two separately written splitting expressions could disagree on
-    where a target's path ends and its callable begins; one shared parser
-    over the manifest's own field can't.
-
-    Only tools and providers name Python-importable code; hooks run as
-    external commands and agents/playbooks/packs are read as file content,
-    so those never flow through this path. A caller-supplied target that
-    isn't literally a key in this map (an extra file in the bundle, a
-    traversal-shaped string, a typo) is rejected before any import is
-    attempted — activation must stay confined to what the trust disclosure
-    actually showed the approver.
+    """Map each declared, activatable target string to ``(module_path,
+    attr_or_None)``, using the same ``parse_tool_target`` split the hashing
+    path uses. Only tools/providers are Python-importable; see docs/internals/runtime.md.
     """
     resolved: dict[str, tuple[str, str | None]] = {}
     for tool in manifest.capabilities.tools:
@@ -456,19 +385,9 @@ def _target_resolution_map(manifest: PluginManifest) -> dict[str, tuple[str, str
 
 
 def _read_and_verify_target_bytes(*, bundle_dir: Path, module_path: str, plugin_name: str) -> bytes:
-    """Read the activation target's bytes exactly once, verify them against the
-    currently-recorded trust hash for that exact declared path, and hand back
-    those same bytes for the caller to compile/exec directly.
-
-    An earlier, broader trust check (``_trust_state`` over a freshly rescanned
-    manifest) also hashes this same file as part of validating the whole
-    plugin, but that read is not
-    what gets executed — if the file were hashed there and then reopened
-    separately for import, an atomic replacement of the file in between
-    would execute content that was never verified. This function is the one
-    read that matters for that guarantee: the hash it checks and the bytes
-    it returns come from the exact same ``read_bytes()`` call, with nothing
-    reopening the path in between.
+    """Read the activation target's bytes exactly once, verify against the
+    trust hash, and return those same bytes to compile/exec — the single
+    read closes a TOCTOU window a hash-then-reopen sequence would leave open.
     """
     file_path = bundle_dir / module_path
     try:
@@ -489,19 +408,10 @@ def _read_and_verify_target_bytes(*, bundle_dir: Path, module_path: str, plugin_
 
 
 def _exec_bundle_module(source: bytes, *, file_path: Path, module_key: str) -> Any:
-    """Compile and exec pre-read *source* bytes into a fresh module.
-
-    Deliberately takes already-read bytes rather than a file path: a version
-    of this function that re-read the file itself would reopen it, undoing
-    the single-read guarantee ``_read_and_verify_target_bytes`` exists to
-    provide. Also deliberately not ``importlib``'s
-    ``spec_from_file_location``/``exec_module`` path, which writes and reads
-    a ``__pycache__`` ``.pyc`` validated by a *second*-granularity source
-    mtime: two writes to the same target within the same wall-clock second
-    are indistinguishable to it, so a re-import right after a re-trusted
-    edit can silently execute stale bytecode instead of the content that was
-    just re-hashed and approved. Compiling the given bytes directly has no
-    cache to go stale.
+    """Compile and exec pre-read *source* bytes into a fresh module. Takes
+    bytes, not a path (preserves the single-read guarantee), and compiles
+    directly rather than through importlib's mtime-cached ``.pyc`` path.
+    See docs/internals/runtime.md.
     """
     module = types.ModuleType(module_key)
     module.__file__ = str(file_path)
@@ -520,11 +430,8 @@ class PluginRegistry:
 
     _snapshot: ClassVar[list[PluginRecord] | None] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
-    # Keyed by (plugin_name, target, content_hash-of-the-target-file) rather
-    # than just (plugin_name, target): a stale entry from before an edit
-    # simply lives under a different key than the post-re-trust content, so
-    # re-trusting changed bytes is structurally a cache miss, not something
-    # that depends on an earlier call having evicted the old entry first.
+    # Keyed by (plugin_name, target, content_hash) so re-trusted content is
+    # structurally a cache miss, not dependent on prior eviction.
     _activation_cache: ClassVar[dict[tuple[str, str, str], Any]] = {}
     _activation_errors: ClassVar[dict[tuple[str, str, str], str]] = {}
 
@@ -558,10 +465,8 @@ class PluginRegistry:
 
     @classmethod
     def active_agent_profile_files(cls) -> dict[str, tuple[str, Path]]:
-        """``<plugin>/<name>`` -> (plugin name, absolute profile path), for every ACTIVE plugin.
-
-        Consumed by ``lionagi.cli._providers``: a miss in the project/global
-        agent-profile search joins this list.
+        """``<plugin>/<name>`` -> (plugin name, absolute profile path), for
+        every ACTIVE plugin. Consumed by ``lionagi.cli._providers``.
         """
         out: dict[str, tuple[str, Path]] = {}
         active, _, _ = _fresh_active_plugins(cls._ensure_loaded())
@@ -574,20 +479,9 @@ class PluginRegistry:
 
     @classmethod
     def active_provider_targets(cls) -> list[tuple[str, str]]:
-        """``(plugin_name, module)`` pairs for every declared provider capability, across every live-eligible plugin.
-
-        Consumed by ``EndpointRegistry.match`` (``lionagi.service.connections.registry``)
-        on a provider-resolution miss: the manifest schema names only the
-        bundle-relative module to import (a provider module self-registers
-        the provider name it serves via ``@register_endpoint`` as an import
-        side effect — there is no separate declared-name field to filter on
-        ahead of time), so the caller imports each returned module through
-        ``activate_target`` and re-runs its match afterward.
-
-        Eligibility comes from ``_fresh_active_plugins`` — the same rescanned
-        manifests and collision handling every other capability surface uses —
-        never from the process-cached record state, which goes stale the
-        moment a plugin is disabled without a ``reset()``.
+        """``(plugin_name, module)`` pairs for every declared provider
+        capability, across every live-eligible plugin. Consumed by
+        ``EndpointRegistry.match`` on a resolution miss; see docs/internals/runtime.md.
         """
         active, _, _ = _fresh_active_plugins(cls._ensure_loaded())
         out: list[tuple[str, str]] = []
@@ -599,16 +493,9 @@ class PluginRegistry:
 
     @classmethod
     def resolve_tool_target(cls, tool_name: str) -> ToolTarget | None:
-        """ADR-0088 D3 consumer trigger: ``ActionManager`` tool-name-resolution miss.
-
-        ``_ensure_loaded()`` is only a candidate index of bundle directories;
-        eligibility and the declared target are both re-derived per call from
-        the same rescanned manifest, never from the cached ``PluginRecord``
-        (its ``state``/``enabled`` go stale without a ``reset()``). Returns
-        the target when exactly one live-eligible plugin declares
-        *tool_name*, ``None`` on a true miss (caller's own error applies
-        unchanged), and raises ``PluginToolCollisionError`` when more than
-        one live-eligible plugin claims it (ADR-0088 D6).
+        """ADR-0088 D3: ``ActionManager`` tool-name-resolution miss. Returns
+        the target when exactly one live-eligible plugin declares *tool_name*,
+        ``None`` on a true miss, raises ``PluginToolCollisionError`` on >1 (D6).
         """
         active, tool_owners, _ = _fresh_active_plugins(cls._ensure_loaded())
         owner_names = tool_owners.get(tool_name, [])
@@ -633,27 +520,10 @@ class PluginRegistry:
 
     @classmethod
     def activate_target(cls, plugin_name: str, target: str) -> Any:
-        """Stage 2: resolve a bundle-relative ``path.py:callable`` (or bare ``path.py`` module) reference.
-
-        Eligibility (compatible + enabled) and trust are both revalidated
-        fresh on *every* call, re-reading ``plugin.yaml``, current settings,
-        and every declared file from disk right now rather than trusting the
-        process-cached snapshot: an already-activated target must stop being
-        handed out the moment the plugin is disabled, or a declared file or
-        the manifest itself changes — not just refuse brand-new activations.
-        Once that broad check passes, the specific target file is read
-        exactly once more — that read's hash, checked against the
-        currently-recorded trust entry for it, and the bytes that get
-        compiled/exec'd, are the same read (see
-        ``_read_and_verify_target_bytes``); nothing here hashes the file and
-        then separately reopens it to execute, which would leave a window
-        for the file to be swapped in between.
-
-        Imported only on first use, cached (success or failure) by
-        ``(plugin, target, content hash)`` — a raising module is reported
-        once and never retried for the *same* content, but re-trusted,
-        changed content always misses the cache rather than depending on an
-        earlier call having evicted the stale entry.
+        """Stage 2: resolve a bundle-relative ``path.py:callable`` (or bare
+        ``path.py`` module) reference. Eligibility and trust are revalidated
+        fresh on every call, never from the cached snapshot. See
+        docs/internals/runtime.md for the single-read and cache-key contract.
         """
         active, _, by_name = _fresh_active_plugins(cls._ensure_loaded())
         fresh = active.get(plugin_name)

--- a/lionagi/protocols/action/function_calling.py
+++ b/lionagi/protocols/action/function_calling.py
@@ -63,15 +63,8 @@ class FunctionCalling(Event):
                     self.arguments, **self.func_tool.preprocessor_kwargs
                 )
 
-        # A tool-hook layer above this event (ActionManager.invoke) may have
-        # rewritten self.arguments before invoke() was even called, and the
-        # preprocessor above may have rewritten it again -- neither rewrite
-        # re-runs the request-model validation that already happened once at
-        # construction time. Re-validate the final dict here, after every
-        # pre-stage mutation and before the callable executes, so a rewrite
-        # can never bypass the tool's declared schema. A tool with no
-        # request_options never had schema enforcement, and this step does
-        # not invent one.
+        # Re-validate after any pre-stage rewrite (hook layer or preprocessor
+        # above) so a rewrite can never bypass the tool's declared schema.
         if self.func_tool.request_options:
             try:
                 validated = self.func_tool.request_options(**self.arguments)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -159,19 +159,8 @@ class ActionManager(Manager):
         return FunctionCalling(func_tool=tool, arguments=args)
 
     def _resolve_plugin_tool(self, name: str) -> Tool | None:
-        """ADR-0088 D3 consumer: on a registry miss, ask the plugin registry whether a
-        trusted, enabled, version-compatible plugin declares a tool named *name*.
-
-        Deferred import — `lionagi.plugins` must stay out of the import graph
-        until an actual miss occurs (see tests/test_import_laziness.py).
-        Resolution and trust are re-checked fresh on every call (never cached
-        onto ``self.registry``), so a plugin disabled or edited mid-session
-        stops being reachable through this path immediately. Returns ``None``
-        when no plugin declares *name* — the caller's existing "not
-        registered" error applies unchanged. Raises ``PluginToolCollisionError``
-        unmodified when two enabled plugins declare the same tool name
-        (ADR-0088 D6): that is a hard error, not a miss.
-        """
+        """ADR-0088 D3: on a registry miss, resolve *name* against the plugin
+        registry (fresh trust check each call). See docs/internals/core.md."""
         from lionagi.libs.schema.function_to_schema import function_to_schema
         from lionagi.plugins.registry import PluginRegistry
 
@@ -194,25 +183,8 @@ class ActionManager(Manager):
     ) -> FunctionCalling:
         """Match, run tool-pre hooks, invoke, then run tool-post hooks.
 
-        Every tool routed through this method -- plain function tools,
-        ``Tool`` objects, and MCP-discovered tools alike -- passes through
-        the same tool-pre/tool-post hook layer. A construction directly on
-        ``FunctionCalling`` (bypassing this manager) skips this layer
-        entirely; that is a documented, tested limit, not an oversight.
-
-        Tool-pre hooks run before the tool's own ``preprocessor`` chain (the
-        spec-level security/user hooks, which keep running last of the
-        pre-stage validators) and may rewrite the arguments; a denial raises
-        directly out of this call, before the tool is ever invoked. The
-        rewritten arguments are revalidated against the tool's declared
-        request model inside ``FunctionCalling._invoke()``, after the
-        spec-level chain has also had a chance to mutate them and before the
-        callable executes.
-
-        Tool-post hooks run after invocation completes (success or failure)
-        and are advisory only -- they observe the final arguments, the
-        result (``None`` on failure), and the error (``None`` on success),
-        and cannot change either.
+        Bypassing this manager (constructing ``FunctionCalling`` directly)
+        skips the hook layer entirely. See docs/internals/core.md.
         """
         function_calling = self.match_tool(func_call)
         tool_name = function_calling.function

--- a/lionagi/protocols/action/tool_hooks.py
+++ b/lionagi/protocols/action/tool_hooks.py
@@ -3,29 +3,9 @@
 
 """Tool-event hook contract at the ``ActionManager.invoke`` chokepoint.
 
-This is the mutation-capable layer that sits outermost around every tool
-call routed through ``ActionManager`` (plain function tools, ``Tool``
-objects, and MCP-discovered tools alike). It is deliberately separate from
-``lionagi.hooks.bus.HookBus`` (the summary-payload audit plane) and from the
-per-``Tool`` ``preprocessor``/``postprocessor`` chain wired by
-``lionagi.agent.spec.HooksMixin`` (the spec-level security/user chain,
-which keeps running innermost, closest to the tool).
-
-A pre hook receives the tool name and the current argument dict and returns
-a verdict:
-
-- ``None`` -- allow, arguments unchanged.
-- a plain ``dict`` -- allow, replace the arguments with this dict.
-- a :class:`ToolPreDecision` -- full control: ``"allow"`` (optionally with
-  ``updated_input``), ``"deny"``, ``"ask"`` (fails closed -- no interactive
-  approval surface exists), or any other value (fails closed with a
-  diagnostic naming the unrecognized value).
-
-A post hook receives the tool name, the final arguments, the result (or
-``None`` on failure), and the error (or ``None`` on success). Post hooks are
-advisory only: the action has already happened, so a post hook cannot deny
-or rewrite anything, matching the harness convention that ``block`` on a
-post-invocation event cannot un-run the call.
+Mutation-capable layer around every tool call, outermost and distinct from
+``HookBus`` (audit-only) and the spec-level pre/postprocessor chain
+(innermost). See docs/internals/core.md for the full pre/post verdict shape.
 """
 
 from __future__ import annotations
@@ -58,12 +38,8 @@ _SNAPSHOT_FAILED = object()
 
 @dataclass(frozen=True, slots=True)
 class ToolPreDecision:
-    """One pre-hook's verdict on a pending tool call.
-
-    ``decision`` follows the cross-harness intersection vocabulary
-    (``allow | deny | ask``); any other value is treated as unrecognized and
-    fails closed the same as ``deny``.
-    """
+    """One pre-hook's verdict: ``decision`` in ``allow | deny | ask``; any
+    other value fails closed the same as ``deny``."""
 
     decision: str = _ALLOW
     reason: str = ""
@@ -114,12 +90,10 @@ async def run_tool_pre_hooks(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    """Run pre hooks in config order; return the (possibly rewritten) arguments.
+    """Run pre hooks in order; return the (possibly rewritten) arguments.
 
-    Raises ``ToolHookDeniedError`` -- a ``PermissionError`` subtype -- on the
-    first ``deny``, ``ask``, or unrecognized decision (fail closed), or when
-    a hook itself raises. ``ask`` has no interactive-approval surface in this
-    runtime, so it is treated exactly like ``deny``.
+    Raises ``ToolHookDeniedError`` on the first ``deny``/``ask``/unrecognized
+    decision, or when a hook itself raises (fail closed).
     """
     for hook_handler in hooks:
         name = _hook_name(hook_handler)
@@ -168,10 +142,8 @@ async def run_tool_post_hooks(
 ) -> list[str]:
     """Run post hooks in order; advisory only, never affects the outcome.
 
-    A post hook that raises is logged and skipped -- an observer must not be
-    able to take down a call that already completed. Returns the non-empty
-    ``reason`` strings collected from hooks that returned a
-    :class:`ToolPostDecision`.
+    A raising hook is logged and skipped. Returns the non-empty ``reason``
+    strings collected from hooks that returned a :class:`ToolPostDecision`.
     """
     canonical_arguments = _snapshot(arguments)
     canonical_result = _snapshot(result)

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -122,14 +122,9 @@ class EndpointRegistry:
 
     @classmethod
     def match(cls, provider: str, endpoint: str = "", **kwargs) -> Any:
-        """Find and instantiate the best matching endpoint.
-
-        On a registry miss, consults the plugin registry (ADR-0088 D3) before
-        falling back to the generic OpenAI-compatible endpoint: any
-        trusted + enabled + still-trusted plugin's declared provider modules
-        are imported (firing their ``@register_endpoint`` decorators), and
-        the match is re-run once. A plugin that supplies no matching provider
-        — or none at all — leaves the fallback identical to today's.
+        """Find and instantiate the best matching endpoint. On a registry
+        miss, consults the plugin registry (ADR-0088 D3) before falling back
+        to the generic OpenAI-compatible endpoint; see docs/internals/runtime.md.
         """
         cls._ensure_loaded()
 
@@ -206,16 +201,9 @@ class EndpointRegistry:
 
     @classmethod
     def _consult_plugin_providers(cls) -> bool:
-        """Import every ACTIVE plugin's declared provider module (ADR-0088 D3), lazily.
-
-        Runs only from ``match()`` after a registered-entry miss — never at
-        import time or discovery, preserving import-time O(1). Goes through
-        ``PluginRegistry.activate_target`` exclusively (never a direct
-        ``importlib`` call on plugin code), so the trust/enabled/active
-        chokepoints already enforced there apply here too. Each activation is
-        cached by the plugin registry itself, so repeated misses are cheap.
-        Returns whether any module import succeeded — the caller only retries
-        the match when this is true.
+        """Import every ACTIVE plugin's declared provider module (ADR-0088
+        D3), lazily, only from ``match()`` after a registered-entry miss —
+        never at import time. Returns whether any import succeeded.
         """
         try:
             from lionagi.plugins import PluginActivationError, PluginRegistry

--- a/lionagi/state/lifecycle/__init__.py
+++ b/lionagi/state/lifecycle/__init__.py
@@ -1,12 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 """Unified lifecycle transition service: one guarded status-transition
-algorithm shared by every managed entity type, replacing per-surface
-transition logic.
-
-Public surface: immutable command/result records (`models`), the policy
-registry (`policy`), the SQLAlchemy transaction implementation (`service`),
-and the StateDB/legacy-transition compatibility mapping (`adapters`).
+algorithm shared by every managed entity type. See docs/internals/runtime.md.
 """
 
 from __future__ import annotations

--- a/lionagi/state/lifecycle/callbacks.py
+++ b/lionagi/state/lifecycle/callbacks.py
@@ -1,15 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 """Post-commit terminal-event envelope and the process-wide handler registry
-that delivers it.
-
-A ``RunTerminalEnvelope`` is constructed by the lifecycle service only after
-a guarded transition has committed and landed on a terminal status for an
-execution entity (session, invocation, schedule_run, play). The registry
-then pushes that envelope to every matching registered handler, concurrently,
-under one shared deadline. The push is best-effort: a handler failure,
-timeout, or cancellation is logged and swallowed, and can never affect the
-already-committed transition or delay the caller past the shared budget.
+that delivers it. Best-effort fan-out under one shared deadline; see
+docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -47,16 +40,12 @@ __all__ = (
 SCHEMA_NAME = "lionagi.run-terminal"
 SCHEMA_VERSION = 1
 
-# The closed set of entity kinds the lifecycle service constructs terminal
-# events for — everything else (dispatch, team, show, ...) never reaches
-# the registry.
+# Closed set of entity kinds the lifecycle service emits terminal events for.
 EXECUTION_ENTITY_KINDS: frozenset[str] = frozenset(
     {"session", "invocation", "schedule_run", "play"}
 )
 
-# One shared deadline for the whole handler fan-out, not a per-handler
-# timeout: a hanging handler is cancelled at this point, but
-# never starves the others, and never delays the transition caller past it.
+# Shared deadline for the whole fan-out, not per-handler.
 HANDLER_BUDGET_SECONDS = 10.0
 
 # A handler may be sync or async; either return value is discarded.
@@ -74,12 +63,8 @@ class EntityRef:
 
 @dataclass(frozen=True)
 class Correlation:
-    """Stable but nullable correlation keys.
-
-    The lifecycle service never performs a surface-specific join to
-    populate these beyond the transitioning entity's own id — a play's
-    envelope, for instance, does not carry its underlying invocation id.
-    """
+    """Stable but nullable correlation keys, populated only from the
+    transitioning entity's own id (no surface-specific join)."""
 
     invocation_id: str | None = None
     session_id: str | None = None
@@ -97,14 +82,8 @@ class Correlation:
 
 @dataclass(frozen=True)
 class RunTerminalEnvelope:
-    """The minimal versioned terminal-event fact.
-
-    Within ``schema_version == 1`` the guaranteed fields below never change
-    name, type, semantics, or requiredness; new optional fields may be added
-    without a version bump. ``event_id`` is the committed
-    ``status_transitions.id`` for a durable event, or a synthetic id for the
-    sole non-durable exception (``--no-persist`` engine runs).
-    """
+    """The minimal versioned terminal-event fact; see docs/internals/runtime.md
+    for the schema-version stability contract."""
 
     event_id: str
     entity: EntityRef
@@ -152,11 +131,7 @@ class _Registration:
 
 class TerminalCallbackRegistry:
     """Process-local registry of post-commit terminal-event handlers.
-
-    Registration is idempotent by name: registering the same name again
-    replaces its handler/filters in place rather than adding a second entry,
-    so a caller that re-registers on every call site never double-fires.
-    """
+    Registration is idempotent by name (replaces in place)."""
 
     def __init__(self, *, budget_seconds: float = HANDLER_BUDGET_SECONDS) -> None:
         self._registrations: dict[str, _Registration] = {}
@@ -172,15 +147,8 @@ class TerminalCallbackRegistry:
         override: bool = False,
     ) -> None:
         """Register *handler* under *name* (replaces an existing same-name
-        registration in place).
-
-        *override* marks this registration as a per-run override: for any
-        envelope it matches, only override registrations fire -- any
-        non-override registration that would otherwise also match (e.g. an
-        unscoped settings-level handler) is skipped for that one envelope.
-        This is scoped strictly to the envelopes the override itself
-        matches (normally via ``ids``); it never disables a non-override
-        handler for entities outside the override's own filter.
+        registration in place). ``override`` semantics: see
+        docs/internals/runtime.md.
         """
         self._registrations[name] = _Registration(
             name=name,
@@ -201,22 +169,16 @@ class TerminalCallbackRegistry:
 
     async def emit(self, envelope: RunTerminalEnvelope) -> None:
         """Invoke every matching handler concurrently under one deadline.
-
         Never raises: a handler exception or timeout is logged and
-        swallowed. Cancellation of the emitting task itself still
-        propagates (this must not turn a real shutdown into a silent
-        no-op), it is only the *handlers'* own failures that are absorbed.
+        swallowed; cancellation of the emitting task itself still propagates.
         """
         targets = [r for r in self._registrations.values() if r.matches(envelope)]
         if not targets:
             return
         overrides = [r for r in targets if r.override]
         if overrides:
-            # A per-run override wins this envelope outright -- any
-            # non-override handler that would also have matched (typically
-            # an unscoped settings-level handler) is skipped, replacing it
-            # for this run's scope only. Other envelopes the override does
-            # not match are entirely unaffected.
+            # A per-run override wins this envelope outright, replacing any
+            # non-override match for this run's scope only.
             targets = overrides
 
         async def _run_one(reg: _Registration) -> None:
@@ -224,26 +186,9 @@ class TerminalCallbackRegistry:
                 if is_coro_func(reg.handler):
                     await maybe_await(reg.handler(envelope))
                 else:
-                    # A plain (non-async-def) handler is invoked in a worker
-                    # thread, not on this event loop. Calling it directly
-                    # here would run its body -- and any blocking I/O or
-                    # time.sleep() inside it -- synchronously on the loop,
-                    # during which the shared move_on_after deadline can
-                    # never fire (nothing yields back to it) and no other
-                    # handler in this fan-out can make progress either.
-                    # abandon_on_cancel=True is required, not just the
-                    # default offload: with the default (False), anyio
-                    # defers delivering cancellation to this awaiting task
-                    # until the worker thread finishes on its own, which
-                    # would let a slow handler silently re-block the shared
-                    # deadline it was just moved off of. With True, the
-                    # move_on_after deadline can still cut this await short
-                    # -- but the thread itself is only abandoned, not
-                    # killed: its body may keep running to completion in
-                    # the background after this returns. The budget
-                    # guarantees the fan-out and the caller are never
-                    # blocked by a slow sync handler, not that the handler
-                    # itself stops.
+                    # Offload to a worker thread (never run sync handler body
+                    # on the loop); abandon_on_cancel=True so a slow handler
+                    # can't re-block the shared deadline — see runtime.md.
                     await maybe_await(
                         await anyio.to_thread.run_sync(
                             reg.handler, envelope, abandon_on_cancel=True

--- a/lionagi/state/lifecycle/deliveries.py
+++ b/lionagi/state/lifecycle/deliveries.py
@@ -1,18 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Durable reconciliation-consumer acknowledgment ledger.
-
-Acknowledgment is durable state written only by a named reconciliation
-consumer, never by the in-process push path (``TerminalCallbackRegistry``
-stays fire-and-forget and records nothing here). The reconciliation query is
-a read-only anti-join: terminal transitions on execution entities with no
-delivery row yet for the requesting consumer. Neither side of that join
-carries an age filter — a late-committing older row, or an event from a
-consumer that has been offline far longer than any retention horizon,
-remains in the unacknowledged set until it is acknowledged. What may
-eventually be pruned is the *other* side: already-acknowledged delivery rows
-older than a retention horizon (not implemented here — out of scope for this
-slice; the query below never expires an unacked event on its own).
+"""Durable reconciliation-consumer acknowledgment ledger. Written only by a
+named reconciliation consumer, never by the fire-and-forget push path
+(``TerminalCallbackRegistry``); see docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -31,11 +21,7 @@ __all__ = ("ack_delivery", "is_acknowledged", "reconcile_unacknowledged")
 
 async def ack_delivery(db: StateDB, transition_id: str, consumer: str) -> None:
     """Record that *consumer* has durably processed *transition_id*.
-
-    Idempotent by construction (``INSERT ... ON CONFLICT DO NOTHING`` on the
-    composite primary key): concurrent or repeated acks of the same
-    (transition_id, consumer) pair collapse to a single row and neither
-    write errors.
+    Idempotent by construction (``ON CONFLICT DO NOTHING`` on the composite key).
     """
     await db.execute(
         "INSERT INTO terminal_deliveries (transition_id, consumer, acked_at) "
@@ -63,12 +49,9 @@ async def reconcile_unacknowledged(
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
     """Every terminal transition on an execution entity that *consumer* has
-    not yet acknowledged, oldest first.
-
-    "Terminal" is re-derived per entity kind from the same policy registry
-    the lifecycle service itself consults when deciding whether to emit a
-    callback in the first place — one definition of "terminal", not two.
-    This is a plain read; it never writes an acknowledgment itself.
+    not yet acknowledged, oldest first. "Terminal" is re-derived per entity
+    kind from the same policy registry the lifecycle service itself consults
+    (one definition, not two). Plain read; never writes an acknowledgment.
     """
     entity_kinds = kinds if kinds is not None else EXECUTION_ENTITY_KINDS
     clauses: list[str] = []
@@ -91,8 +74,8 @@ async def reconcile_unacknowledged(
     if not clauses:
         return []
 
-    # clauses/params above hold only bind placeholders (:kindN, :kindN_statusM)
-    # built from the fixed policy registry, never caller-supplied SQL text.
+    # clauses/params hold only bind placeholders built from the fixed policy
+    # registry, never caller-supplied SQL text.
     sql = (
         "SELECT st.id AS transition_id, st.entity_type, st.entity_id, "  # noqa: S608
         "st.previous_status, st.status AS terminal_status, st.reason_code, "

--- a/lionagi/state/lifecycle/notify_settings.py
+++ b/lionagi/state/lifecycle/notify_settings.py
@@ -1,24 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Settings-driven terminal-callback handler.
-
-Resolves ``notify.on_terminal`` -- a string (compatibility form) or a mapping
-(``{enabled, adapter: {kind: exec|python, ...}, filter: {kinds, ids}}``) --
-into a handler installable on a ``TerminalCallbackRegistry``. Precedence is
-per-run override > project settings > global settings > disabled; the
-absent key and an explicit ``enabled: false`` are both the disabled state.
-
-No configuration shape ever reaches a shell. A plain command string is
-POSIX-word-split (``shlex.split``) and launched via
-``asyncio.create_subprocess_exec`` -- never ``create_subprocess_shell``. A
-string that fails to split, or whose intent requires shell features (pipes,
-redirection, conjunction, variable expansion), warns with a migration
-diagnostic naming the argv-list mapping form and resolves to disabled. Any
-resolution producing an empty argv (empty string, whitespace-only string, an
-explicit empty ``argv`` array, or the same via a per-run override or
-``--notify``) resolves to disabled the same way, before any process is
-launched. A resolution error never fails or delays the run it would have
-described.
+"""Settings-driven terminal-callback handler. Resolves ``notify.on_terminal``
+into a handler installable on a ``TerminalCallbackRegistry``; no
+configuration shape ever reaches a shell. See docs/internals/runtime.md.
 """
 
 from __future__ import annotations
@@ -106,11 +90,8 @@ def resolve_notify_config(
     project_dir: str | None = None,
 ) -> ResolvedNotifyHandler | None:
     """Resolve ``notify.on_terminal`` to a handler spec, or ``None`` (disabled).
-
-    *override* wins outright when supplied (the per-run/``--notify`` case);
-    otherwise settings are loaded once (snapshot semantics -- a settings edit
-    takes effect on the next process, not this one) and resolved through the
-    project-then-global merge ``load_settings`` already implements.
+    *override* wins outright when supplied; otherwise settings are loaded
+    once (snapshot semantics) via the project-then-global merge.
     """
     if override is not None:
         return _resolve_shape(override, scope="override")
@@ -340,18 +321,9 @@ def _make_exec_handler(
             logger.warning("notify.on_terminal exec adapter %r timed out", launch_argv)
             return
         except get_cancelled_exc_class():
-            # The registry's own shared deadline (TerminalCallbackRegistry's
-            # move_on_after, HANDLER_BUDGET_SECONDS by default) races this
-            # call's identical wait_for timeout -- the outer one started
-            # counting first, so it typically wins and delivers cancellation
-            # here instead of the asyncio.TimeoutError branch above. Either
-            # way the child must be reaped: it was launched with
-            # start_new_session=True (its own process group), so leaving it
-            # unkilled orphans a live notify.on_terminal/--notify subprocess
-            # after this run has already returned. Cleanup runs inside a
-            # shielded scope since the enclosing scope is already cancelled
-            # -- an unshielded await here would itself be cancelled before
-            # the kill completes.
+            # The registry's shared deadline races this call's own timeout and
+            # typically wins; the child (its own process group) must still be
+            # reaped, shielded since the enclosing scope is already cancelled.
             if proc is not None:
                 with CancelScope(shield=True):
                     await aterminate_process_group(proc, grace=None)
@@ -387,19 +359,8 @@ def build_handler(
     env_fn: EnvBuilder | None = None,
 ) -> TerminalCallbackHandler | None:
     """Build the process-local handler for a resolved adapter spec, or
-    ``None`` if the spec fails to build (never raises).
-
-    *payload_fn* only affects the exec adapter (whose stdin bytes are the
-    only surface an external payload shape controls); a python adapter is
-    called with the envelope object directly regardless. *argv_fn*/*env_fn*
-    let a caller (the flow/play `--notify` legacy adapter) derive per-event
-    argv substitutions or extra environment variables from the same
-    envelope; the generic settings-driven adapter leaves both unset.
-
-    A python adapter ref is imported eagerly here (at build time, not at
-    call time), so a malformed ``module:callable`` reference is caught and
-    logged rather than raised -- a typo in configuration must resolve to
-    disabled, never crash the bootstrap call site.
+    ``None`` if the spec fails to build (never raises). A python adapter ref
+    is imported eagerly here so a bad ref resolves to disabled, not a crash.
     """
     if resolved.python_ref is not None:
         try:
@@ -421,13 +382,9 @@ def register_settings_terminal_callback(
     name: str = "notify.settings.on_terminal",
     project_dir: str | None = None,
 ) -> bool:
-    """Resolve ``notify.on_terminal`` from settings once and register it.
-
-    This is one of the two bootstrap points: the CLI entry
-    point and the Studio service startup each call this once per process
-    rather than every command growing its own ``--notify``-style flag.
-    Returns ``True`` if a handler was installed, ``False`` for the disabled
-    state (absent key, ``enabled: false``, or an invalid value).
+    """Resolve ``notify.on_terminal`` from settings once and register it (the
+    CLI entry point and Studio service startup each call this once per
+    process). Returns ``True`` iff a handler was installed.
     """
     resolved = resolve_notify_config(project_dir=project_dir)
     if resolved is None:

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -2,27 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """SQLAlchemy transaction implementation of the guarded lifecycle transition
 algorithm: one atomic read-check-write-history sequence shared by every
-managed entity type's status transitions.
-
-``transition()`` is the public entry point, enforcing the policy's
-declared-edge graph: an undeclared move is a "rejected" outcome with a
-rejection audit row, and a valid override is the audited escape hatch.
-``_transition()`` accepts additional keyword-only parameters not part of the
-public ``TransitionCommand`` shape, used only by
-``lionagi.state.lifecycle.adapters`` to keep the two legacy compatibility
-wrappers behaviorally identical to their pre-existing selves:
-
-- ``extra_guard``: an arbitrary per-column WHERE-clause guard (e.g.
-  dispatch's ``delivering -> delivering`` crash-recovery claim guarding on
-  ``attempt``), which the public typed command has no generic field for.
-- ``enforce_edges``: ``StateDB.update_status()`` never enforced a
-  declared-edge graph — only terminal-exit-requires-override and vocabulary
-  membership — so it calls with ``enforce_edges=False`` (the default).
-  ``lionagi.state.transitions.transition()`` did enforce one (for
-  schedule_run), so it calls with ``enforce_edges=True``.
-- ``raise_on_unguarded_conflict``: an unguarded zero-row UPDATE is a storage
-  anomaly ``StateDB.update_status()`` has always raised ``RuntimeError`` on,
-  from inside the transaction so a same-transaction rollback still occurs.
+managed entity type's status transitions. See docs/internals/runtime.md for
+the ``_transition()`` adapter-only kwargs contract.
 """
 
 from __future__ import annotations
@@ -52,12 +33,8 @@ if TYPE_CHECKING:
 
 
 class _TxProvider(Protocol):
-    """Structural requirement on the object handed to SQLAlchemyLifecycleService.
-
-    Satisfied by ``lionagi.state.db.StateDB`` without importing it here (that
-    module imports this package's adapters, so importing StateDB at module
-    scope would be circular).
-    """
+    """Structural requirement satisfied by ``lionagi.state.db.StateDB``
+    without importing it here (would be circular)."""
 
     dialect: str
 
@@ -69,10 +46,7 @@ def _json_list(evidence_refs: tuple) -> list:
 
 
 def _correlation_for(entity_type: str, entity_id: str) -> Correlation:
-    # The lifecycle service never performs a surface-specific join to
-    # populate correlation keys beyond the transitioning entity's own id --
-    # a play's envelope, for instance, does not carry its underlying
-    # invocation id.
+    # Populated only from the transitioning entity's own id (no join).
     if entity_type == "session":
         return Correlation(session_id=entity_id)
     if entity_type == "invocation":
@@ -112,10 +86,7 @@ class SQLAlchemyLifecycleService:
     ) -> None:
         self._db = db
         self._registry = registry
-        # A process-wide TerminalCallbackRegistry is injected into the
-        # lifecycle service by default; callers may inject their own
-        # instance (tests, isolated bootstraps) so ordinary callers need
-        # not wire one up.
+        # Process-wide registry by default; callers may inject their own.
         self._terminal_callbacks = (
             terminal_callbacks if terminal_callbacks is not None else DEFAULT_TERMINAL_CALLBACKS
         )
@@ -211,22 +182,15 @@ class SQLAlchemyLifecycleService:
     # ── public entry point ──────────────────────────────────────────────
 
     async def transition(self, command: TransitionCommand) -> TransitionOutcome:
-        # The public entry point enforces the policy's declared-edge graph.
-        # An undeclared move is a "rejected" outcome (with rejection audit),
-        # not a raise, so callers get the same outcome shape for both
-        # terminal-exit and undeclared-edge refusals; a valid override is the
-        # audited escape hatch for either.
-        # The legacy wrappers validate the reason code before calling in; the
-        # public API must do the same or it becomes the one path that writes
-        # uncontrolled reason_code values into status_transitions.
+        # Enforces the declared-edge graph; undeclared moves reject with an
+        # audit row rather than raise, so a valid override is the escape hatch.
         if command.reason.code not in VALID_REASON_CODES:
             raise LifecycleValidationError(
                 f"invalid reason_code: {command.reason.code!r}; must be one of "
                 "the codes registered in lionagi.state.reasons.VALID_REASON_CODES"
             )
-        # A globally registered code from another entity's domain (e.g. a
-        # dispatch.* code on a schedule_run row) would still corrupt audit
-        # semantics; the policy declares which prefixes belong to this entity.
+        # The policy declares which reason-code prefixes belong to this entity
+        # (a globally registered code from another domain would still corrupt audit).
         policy = self._registry.get(command.entity_type)
         prefix = command.reason.code.split(".", 1)[0]
         if prefix not in policy.reason_prefixes:
@@ -237,9 +201,7 @@ class SQLAlchemyLifecycleService:
             )
         if not command.actor.id:
             raise LifecycleValidationError("TransitionCommand.actor.id must be non-empty")
-        # ActorRecord is a plain dataclass; the ActorType Literal is not
-        # enforced at runtime, and status_transitions.source is a controlled
-        # vocabulary the legacy surfaces validated.
+        # ActorType is a Literal, not enforced at runtime by the dataclass itself.
         if command.actor.type not in get_args(ActorType):
             raise LifecycleValidationError(
                 f"invalid actor type: {command.actor.type!r}; must be one of "
@@ -299,7 +261,7 @@ class SQLAlchemyLifecycleService:
         now = time.time()
 
         async with self._db._tx() as conn:
-            # Step 4: SELECT (FOR UPDATE on PostgreSQL).
+            # SELECT (FOR UPDATE on PostgreSQL).
             guard_cols = list(extra_guard)
             select_cols = ", ".join(["status", "updated_at", *guard_cols])
             sel = f"SELECT {select_cols} FROM {policy.table} WHERE id = :id"  # noqa: S608
@@ -307,14 +269,13 @@ class SQLAlchemyLifecycleService:
                 sel += " FOR UPDATE"
             row = (await conn.execute(text(sel), {"id": command.entity_id})).mappings().first()
 
-            # Step 5: missing row.
             if row is None:
                 raise LifecycleNotFoundError(
                     f"{command.entity_type} {command.entity_id!r} not found (table={policy.table})"
                 )
             previous_status = row["status"]
 
-            # Step 6: expected_statuses / expected_version guards.
+            # expected_statuses / expected_version guards.
             if (
                 command.expected_statuses is not None
                 and previous_status not in command.expected_statuses
@@ -344,9 +305,8 @@ class SQLAlchemyLifecycleService:
             rejected = False
 
             if self_edge is not None:
-                # Step 7: an ordinary declared edge (covers both regular
-                # moves and a declared same-status edge like dispatch's
-                # delivering -> delivering crash-recovery claim).
+                # An ordinary declared edge, or a declared same-status edge
+                # (e.g. dispatch's delivering -> delivering recovery claim).
                 if (
                     self_edge.actor_types is not None
                     and command.actor.type not in self_edge.actor_types
@@ -364,20 +324,10 @@ class SQLAlchemyLifecycleService:
                         f"{sorted(missing_patch)}"
                     )
                 if self_edge.required_guard_fields:
-                    # A crash-recovery same-status claim (e.g. dispatch's
-                    # delivering -> delivering) must never let two callers
-                    # holding the same snapshot both win. The edge's own
-                    # required_guard_fields is satisfied either by an
-                    # extra_guard covering those exact columns (the legacy
-                    # `guard=` kwarg the pre-existing transition surface
-                    # used) or by a generic expected_version guard
-                    # (updated_at, which this same write always bumps) —
-                    # either is an equally strong optimistic-concurrency
-                    # guard against the same race.
-                    # Without one, the edge is refused before BEGIN does any
-                    # work; this is a caller-contract violation, not a
-                    # legitimate lost race, so it raises rather than
-                    # returning a "conflict"/"rejected" outcome.
+                    # required_guard_fields must be satisfied by extra_guard or
+                    # expected_version (equally strong race guards) so two
+                    # callers holding the same snapshot can't both win; missing
+                    # either is a caller-contract violation, so this raises.
                     guarded_by_extra = self_edge.required_guard_fields <= set(extra_guard)
                     guarded_by_version = command.expected_version is not None
                     if not (guarded_by_extra or guarded_by_version):
@@ -388,9 +338,7 @@ class SQLAlchemyLifecycleService:
                             "an equivalent guard); none was supplied"
                         )
             elif same_status:
-                # Step 7 (same-status, no declared self-edge): policy's
-                # same_status rule governs — "append" is the only rule any
-                # built-in policy currently uses.
+                # No declared self-edge: policy's same_status rule governs.
                 if policy.same_status == "noop":
                     return TransitionOutcome(
                         result="applied",
@@ -402,18 +350,9 @@ class SQLAlchemyLifecycleService:
                     rejected = True
                 # "append": falls through to the guarded write below.
             elif enforce_edges:
-                # Undeclared edge (terminal or not), with the declared-edge
-                # graph enforced. A valid override is the audited escape
-                # hatch. Otherwise `undeclared_edge_mode` selects the
-                # refusal shape: the legacy
-                # `lionagi.state.transitions.transition()` surface never had
-                # an override/rejection-audit concept — an undeclared move
-                # there was and remains a plain vocabulary-violation
-                # ValueError ("raise") — while the public `transition()`
-                # entry point reports the same "rejected" outcome (with
-                # rejection audit) it uses for terminal exits ("reject").
-                # This must be checked before the terminal_statuses branch
-                # below (which is only reachable when enforce_edges=False).
+                # Undeclared edge, declared-edge graph enforced. A valid
+                # override is the escape hatch; else undeclared_edge_mode
+                # selects raise (legacy) vs reject (public entry point).
                 if command.override is not None:
                     override_admin_event = True
                 elif undeclared_edge_mode == "reject":
@@ -426,24 +365,18 @@ class SQLAlchemyLifecycleService:
                         f"{sorted(e.to_status for e in declared_edges)})"
                     )
             elif previous_status in policy.terminal_statuses:
-                # Step 7/8/9: undeclared edge exiting a terminal status —
-                # rejected unless a valid override is supplied.
-                # `StateDB.update_status()` never enforced a declared-edge
-                # graph at all (enforce_edges=False), only this
-                # terminal-exit-requires-override check and vocabulary
-                # membership.
+                # Undeclared edge exiting a terminal status — rejected unless
+                # a valid override is supplied (enforce_edges=False path).
                 if command.override is not None:
                     override_admin_event = True
                 else:
                     rejected = True
             # else: enforce_edges=False, nonterminal, no self-edge, not
-            # same-status — an ordinary unrestricted move. Falls through to
-            # the guarded write, matching StateDB.update_status()'s legacy
-            # permissiveness (it never had a declared-edge graph).
+            # same-status — an ordinary unrestricted move falls through to
+            # the guarded write (legacy StateDB.update_status() permissiveness).
 
             if rejected:
-                # Step 8: rejection audit commits; ordinary history is not
-                # appended (current status did not change).
+                # Rejection audit commits; ordinary history is not appended.
                 await conn.execute(
                     text(
                         "INSERT INTO admin_events "
@@ -462,11 +395,8 @@ class SQLAlchemyLifecycleService:
                             "reason_code": command.reason.code,
                             "source": command.actor.type,
                         },
-                        # admin_events.actor is NOT NULL; legacy
-                        # update_status() wrote `actor or source` here (the
-                        # id is often None — a system-initiated write), unlike
-                        # status_transitions.actor below, which stores the
-                        # raw (possibly-None) id as given.
+                        # admin_events.actor is NOT NULL; falls back to the
+                        # actor type for a system-initiated write with no id.
                         "actor": command.actor.id or command.actor.type,
                     },
                 )
@@ -478,7 +408,7 @@ class SQLAlchemyLifecycleService:
                 )
 
             if override_admin_event:
-                # Step 9: override audit, same transaction as the write.
+                # Override audit, same transaction as the write.
                 await conn.execute(
                     text(
                         "INSERT INTO admin_events "
@@ -501,9 +431,8 @@ class SQLAlchemyLifecycleService:
                     },
                 )
 
-            # extra_guard columns re-checked here (post edge/terminal
-            # validation, matching the legacy transitions.transition()
-            # ordering: CAS -> vocabulary -> guard columns -> UPDATE).
+            # Ordering matches legacy transitions.transition(): CAS ->
+            # vocabulary -> guard columns -> UPDATE.
             for col, expected in extra_guard.items():
                 if row[col] != expected:
                     return TransitionOutcome(
@@ -513,7 +442,7 @@ class SQLAlchemyLifecycleService:
                         transition_id=None,
                     )
 
-            # Steps 10-12: guarded UPDATE + status_transitions append.
+            # Guarded UPDATE + status_transitions append.
             transition_id = await self._write(
                 conn,
                 policy.table,
@@ -524,20 +453,16 @@ class SQLAlchemyLifecycleService:
                 write_reason_columns=write_reason_columns,
             )
             if transition_id is None:
-                # Step 11: zero rows -> conflict, append nothing.
+                # Zero rows -> conflict, append nothing.
                 guarded = (
                     command.expected_statuses is not None
                     or command.expected_version is not None
                     or bool(extra_guard)
                 )
                 if raise_on_unguarded_conflict and not guarded:
-                    # No guard of any kind was supplied, yet the row changed
-                    # between the SELECT and this UPDATE — a storage-level
-                    # anomaly, not a legitimate lost race. Raising here
-                    # (inside the still-open transaction) rolls back
-                    # whatever else happened in this transaction, matching
-                    # the pre-existing `_apply_status_write` behavior of
-                    # raising before the `async with` block could commit.
+                    # No guard supplied, yet the row changed between SELECT
+                    # and UPDATE — a storage anomaly; raising here (inside
+                    # the open transaction) rolls back the whole transaction.
                     raise RuntimeError(
                         f"status CAS lost for {command.entity_type} "
                         f"{command.entity_id!r}: row changed under update_status"
@@ -549,10 +474,8 @@ class SQLAlchemyLifecycleService:
                     transition_id=None,
                 )
 
-        # Step 13: commit (via _tx() context exit) -> applied. The registry
-        # push happens strictly after this point -- the transaction has
-        # already exited successfully, so a handler can never delay,
-        # observe-before-commit, or roll back the write.
+        # Commit (via _tx() context exit) happens before this point, so a
+        # terminal-callback handler can never delay or roll back the write.
         if (
             transition_id is not None
             and previous_status != command.to_status
@@ -585,19 +508,8 @@ class SQLAlchemyLifecycleService:
         write_reason_columns: bool = True,
     ) -> str | None:
         """The guarded UPDATE and its status_transitions append, factored out
-        so both the ordinary and override paths share it (and so tests can
-        inject a concurrent write immediately before this runs, the same
-        seam the pre-existing `StateDB._apply_status_write` provided).
-
-        *write_reason_columns* mirrors legacy per-surface behavior: the
-        `StateDB.update_status()` surface always denormalized the reason onto
-        the entity row's own `status_reason_*` columns (True, the default);
-        the legacy `lionagi.state.transitions.transition()` surface never
-        did (False) — and `dispatch_outbox` (only reachable through that
-        surface) does not even have those columns.
-
-        Returns the new transition id, or ``None`` if the guarded UPDATE
-        matched zero rows (conflict — caller appends nothing further).
+        so both the ordinary and override paths share it. Returns the new
+        transition id, or ``None`` on a zero-row UPDATE (conflict).
         """
         set_clauses = ["status = :status", "updated_at = :now"]
         if write_reason_columns:

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -520,18 +520,10 @@ schedules = Table(
     Column("budget_usd", Float),
     Column("budget_tokens", Integer),
     Column("project", Text),
-    # Metric threshold alerts: {metric, op, value, window_minutes} config
-    # blob + the timestamp of the last breach fire (doubles as the cooldown
-    # anchor -- see schema.sql for the fuller comment).
+    # Metric threshold alerts config + last breach fire; see schema.sql.
     Column("threshold_config", JSON),
     Column("last_alert_at", Float),
-    # Observer self-health (github_poll poller): last_healthy_poll_at is
-    # stamped on any 2xx/304 github_poll() read (including a healthy-empty
-    # one); poller_consecutive_401 counts consecutive 401s and resets only
-    # on a healthy read (a transient error/non-200 between 401s does not
-    # reset the run). Read by StateDB.metric_value's
-    # github_poll_healthy_age_minutes / github_poll_consecutive_401
-    # threshold metrics -- see SchedulerEngine._tick_github for the stamp.
+    # Observer self-health (github_poll poller); see schema.sql.
     Column("last_healthy_poll_at", Float),
     Column("poller_consecutive_401", Integer, nullable=False, server_default="0"),
     Column("created_at", Float, nullable=False),
@@ -554,10 +546,7 @@ Index(
 )
 
 # ── schedule_runs ─────────────────────────────────────────────────────────────
-# ADR-0071 D2: generalized into the durable task-application entity. schedule_id
-# is nullable (an ad-hoc task application has schedule_id IS NULL); the status
-# CHECK carries the full ADR-0072 lifecycle; queued_at/leased_by/
-# lease_expires_at/concurrency_key are ADR-0071's queue columns.
+# ADR-0071 D2: generalized task-application entity, schedule_id nullable.
 
 schedule_runs = Table(
     "schedule_runs",
@@ -607,9 +596,7 @@ schedule_runs = Table(
     Column("execution_target", Text),
     Column("library_ref", Text),
     Column("library_content_hash", Text),
-    # Delivery-contract marker: stamped once the scheduler engine confirms
-    # the external process for this occurrence was actually launched. See
-    # the schema.sql CREATE TABLE comment for the full rationale.
+    # Delivery-contract marker; see schema.sql.
     Column("dispatched_at", Float),
 )
 
@@ -642,8 +629,7 @@ Index(
 )
 
 # ── workers ─────────────────────────────────────────────────────────────────
-# ADR-0071 D5: capability-matching worker registry -- the only genuinely new
-# table this ADR pair adds.
+# ADR-0071 D5: capability-matching worker registry.
 
 workers = Table(
     "workers",
@@ -688,9 +674,8 @@ artifacts = Table(
     Column("invocation_id", Text, ForeignKey("invocations.id", ondelete="CASCADE")),
     Column("session_id", Text, ForeignKey("sessions.id")),
     Column("created_at", Float, nullable=False),
-    # updated_at has a SQLite server_default in schema.sql but the MIGRATION_COLUMNS
-    # comment notes it must be nullable in ALTER TABLE because expressions are not
-    # valid column defaults there; the insert path always sets it explicitly.
+    # Nullable here (unlike schema.sql's server_default) because ALTER TABLE
+    # rejects expression defaults; the insert path always sets it explicitly.
     Column("updated_at", Float, nullable=False),
     Column("kind", Text, nullable=False),
     Column("name", Text, nullable=False),
@@ -797,12 +782,8 @@ Index(
 Index("idx_status_transitions_created", status_transitions.c.created_at)
 
 # ── terminal_deliveries ─────────────────────────────────────────────────────────
-# Durable reconciliation-consumer acknowledgment ledger for post-commit
-# terminal-event callbacks (never written by the in-process push path itself —
-# only a registered reconciliation consumer inserts a row, once it has
-# durably processed a terminal event). The composite primary key makes
-# concurrent/repeated acks of the same event by the same consumer a
-# single-row no-op.
+# Reconciliation-consumer acknowledgment ledger; see
+# lionagi/state/lifecycle/deliveries.py and docs/internals/runtime.md.
 
 terminal_deliveries = Table(
     "terminal_deliveries",
@@ -899,8 +880,8 @@ Index("idx_engine_defs_kind", engine_defs.c.kind)
 Index("idx_engine_defs_updated", engine_defs.c.updated_at)
 
 # ── workflow_defs ─────────────────────────────────────────────────────────────
-# Named workflow definitions authored in the Studio Designer. spec_json holds
-# the versioned node/edge graph; validation lives in the studio service layer.
+# Named workflow definitions from the Studio Designer; spec_json is the
+# versioned node/edge graph, validated in the studio service layer.
 
 workflow_defs = Table(
     "workflow_defs",
@@ -917,15 +898,9 @@ Index("idx_workflow_defs_name", workflow_defs.c.name)
 Index("idx_workflow_defs_updated", workflow_defs.c.updated_at)
 
 # ── session_controls (ADR-0069 D1–D3: live-control transport) ─────────────────
-# One row per operator control verb queued against a live session. A poller task
-# in `cli/orchestrate/flow.py`'s `_execute_dag` reads unapplied rows and applies
-# them against the running executor. Apply/stamp ordering is verb-classed:
-# pause/resume are
-# idempotent (apply, then stamp — safe to re-apply on a poller crash); message
-# is not (stamp 'applying', then apply, then finalize — a crash surfaces as an
-# unapplied 'applying' row rather than risking a double injection). 'stop' is
-# schema-reserved and rejected by the current poller as unsupported; no CLI
-# verb emits it yet.
+# One row per operator control verb queued against a live session, polled by
+# `cli/orchestrate/flow.py`'s `_execute_dag`; see docs/internals/runtime.md
+# for the verb-classed apply/stamp ordering.
 
 session_controls = Table(
     "session_controls",
@@ -963,9 +938,8 @@ Index(
 )
 
 # ── dispatch_outbox (ADR-0059: durable dispatch outbox) ─────────────────────
-# Producer-driven at-least-once outbound delivery. A row survives independent
-# of any consumer's liveness; the scheduler tick re-attempts the configured
-# notify template until it succeeds, backs off, or exhausts max_attempts.
+# Producer-driven at-least-once delivery; the scheduler tick re-attempts
+# until success, backoff exhaustion, or max_attempts.
 
 dispatch_outbox = Table(
     "dispatch_outbox",
@@ -1014,9 +988,8 @@ Index(
 )
 
 # ── run_tags ──────────────────────────────────────────────────────────────────
-# Free-form review labels attached to a run (session). Kept in the canonical
-# metadata (not only schema.sql) so StateDB.open()/create_all builds it on every
-# backend, keeping the SQLite, Postgres, and schema-parity paths consistent.
+# Free-form review labels on a run (session); kept in canonical metadata (not
+# only schema.sql) so create_all builds it consistently on every backend.
 
 run_tags = Table(
     "run_tags",
@@ -1032,8 +1005,7 @@ run_tags = Table(
 )
 
 # ── approvals (studio operator permission ledger) ──────────────────────────
-# Server-side confirm-flow: a mutating action is proposed, a human grants or
-# denies it, and the real endpoint consumes the granted approval exactly once.
+# Server-side confirm-flow: proposed, granted/denied, consumed exactly once.
 
 approvals = Table(
     "approvals",
@@ -1072,9 +1044,7 @@ Index(
 )
 
 # ── approval_evidence (hash-chained audit trail on the approval ledger) ────
-# Append-only: every approval lifecycle event writes one row in the same
-# transaction as the approvals status change. See schema.sql for the full
-# chain-hash design note.
+# Append-only, same transaction as the approvals status change; see schema.sql.
 
 approval_evidence = Table(
     "approval_evidence",

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -21,9 +21,8 @@ from .registry import iter_studio_routes, load_studio_route_modules
 
 _log = logging.getLogger(__name__)
 
-# Paths that remain reachable without a bearer token regardless of whether
-# LIONAGI_STUDIO_AUTH_TOKEN is set.  This is intentionally a very small set:
-# only pure liveness probes that carry no application state belong here.
+# Reachable without a bearer token regardless of LIONAGI_STUDIO_AUTH_TOKEN;
+# deliberately just pure liveness probes with no application state.
 _PUBLIC_PATHS = frozenset({"/health"})
 
 # FastAPI built-in schema/docs routes that are NOT under /api but expose API
@@ -39,12 +38,8 @@ _GUARDED_NON_API_PATHS = frozenset(
 
 
 def _collect_cors_methods(application: FastAPI) -> list[str]:
-    """Derive the CORS method allowlist from the app's actual route table.
-
-    Hardcoding is brittle: FastAPI auto-generates HEAD for every GET route, so
-    a manual list silently omits served methods (CORS preflight then 400s).
-    Walking routes after all routers are mounted keeps the allowlist in sync.
-    OPTIONS is always included so CORSMiddleware can answer preflight requests.
+    """Derive the CORS method allowlist from the app's actual route table
+    (hardcoding silently omits FastAPI's auto-generated HEAD routes).
     """
     methods: set[str] = {"OPTIONS"}
     for route in application.routes:
@@ -95,9 +90,7 @@ def _start_claude_mirror() -> tuple[asyncio.Event, asyncio.Task] | tuple[None, N
     )
 
     def _log_unexpected_exit(t: asyncio.Task) -> None:
-        # The retained task handle suppresses asyncio's "exception was never
-        # retrieved" warning, so a raised failure is otherwise silent; surface
-        # it loudly here instead.
+        # Retained handle suppresses asyncio's own warning; surface it loudly instead.
         if t.cancelled():
             return
         exc = t.exception()
@@ -126,9 +119,8 @@ async def _stop_claude_mirror(stop: asyncio.Event | None, task: asyncio.Task | N
 
 
 async def _startup_warmup() -> None:
-    """Deferred WAL checkpoint, kept off the critical path so /health serves as
-    soon as reconciliation completes rather than waiting on it. Guarded so an
-    unexpected failure is logged, not silently dropped, at shutdown."""
+    """Deferred WAL checkpoint, off the critical path so /health serves as
+    soon as reconciliation completes."""
     try:
         from .services.db_maintenance import checkpoint_state_db
 
@@ -138,8 +130,8 @@ async def _startup_warmup() -> None:
 
 
 async def _finalize_warmup(task: asyncio.Task | None) -> None:
-    """Cancel the warmup task if still running, then await it so it's retrieved
-    (avoids an un-retrieved-task warning); a failure is logged, not dropped."""
+    """Cancel the warmup task if still running, then await it (avoids an
+    un-retrieved-task warning)."""
     if task is None:
         return
     if not task.done():
@@ -158,20 +150,15 @@ async def lifespan(app_instance):
     from .services.lifecycle import run_startup_reconciliation
 
     _emit_startup_warnings()
-    # The other of the two settings-driven notify bootstrap points (the CLI
-    # entry point is the first): resolve notify.on_terminal from settings
-    # once per process and register it on the shared terminal-callback
-    # registry so Studio-launched runs get the same settings-driven handler
-    # as `li`.
+    # The second of the two settings-driven notify bootstrap points (CLI is the first).
     from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
 
     register_settings_terminal_callback()
     await scheduler.start()
-    # Corrects phantom/stale-status rows that stateful /api routes read
-    # directly, so it must complete before we serve.
+    # Corrects phantom/stale-status rows /api routes read directly; must precede serving.
     await run_startup_reconciliation()
     mirror_stop, mirror_task = _start_claude_mirror()
-    # WAL checkpoint is pure maintenance; defer so readiness isn't gated on it.
+    # Pure maintenance; deferred so readiness isn't gated on it.
     warmup_task = asyncio.create_task(_startup_warmup(), name="studio-startup-warmup")
     yield
     from .services.launches import shutdown_launches
@@ -182,19 +169,15 @@ async def lifespan(app_instance):
     await scheduler.stop()
 
 
-# Strict Host-header authority grammar: `host` or `host:port` (1-5 digit
-# port), or a bracketed IPv6 literal `[addr]` with an optional `:port` after
-# the closing bracket -- nothing else. Deliberately stricter than
-# `request.url.hostname`, which normalizes/mis-parses authorities like
-# "127.0.0.1:8765.evil.com" or "[::1]evil.com" into an accepted hostname.
+# Strict Host-header authority grammar, deliberately stricter than
+# `request.url.hostname`; see docs/internals/studio.md.
 _HOST_AUTHORITY_RE = re.compile(r"^(?P<host>[A-Za-z0-9.\-]+)(?::(?P<port>\d{1,5}))?$")
 _IPV6_AUTHORITY_RE = re.compile(r"^\[(?P<host>[0-9A-Fa-f:]+)\](?::(?P<port>\d{1,5}))?$")
 
 
 def _parse_host_authority(raw_host: str) -> str | None:
-    """Strictly parse a raw Host header value, returning the normalized host
-    (lowercased, brackets stripped for IPv6) or None if it doesn't match the
-    exact authority grammar above."""
+    """Strictly parse a raw Host header value: normalized host (lowercased,
+    brackets stripped for IPv6), or None if it doesn't match the grammar."""
     raw_host = (raw_host or "").strip()
     if not raw_host:
         return None
@@ -211,11 +194,8 @@ def _parse_host_authority(raw_host: str) -> str | None:
 
 async def validate_host_header(request: Request, call_next):
     """Reject requests whose Host header doesn't match an expected value —
-    defends against DNS rebinding, where a malicious page points a browser at
-    http://127.0.0.1:<port> with an attacker-controlled Host and, once past
-    CORS/auth, reaches the daemon as if same-origin. Registered outermost
-    (outside CORSMiddleware) so every request, including preflight, is checked
-    before anything answers."""
+    defends against DNS rebinding; see docs/internals/studio.md.
+    """
     hostname = _parse_host_authority(request.headers.get("host", ""))
     bind_host = os.getenv("LIONAGI_STUDIO_HOST", HOST)
     allowed_hosts = {"localhost", "127.0.0.1", "::1"}
@@ -230,11 +210,8 @@ async def validate_host_header(request: Request, call_next):
 
 
 def _mount_studio_routes(application: FastAPI) -> None:
-    """Add every route registered via the @studio_route decorator to `application`.
-
-    Area modules listed in _STUDIO_ROUTE_MODULES are imported here so their
-    @studio_route decorators fire and populate _ROUTES; import_module caches
-    modules, so calling this once per app instance is cheap and idempotent.
+    """Add every route registered via the @studio_route decorator to
+    `application`; importing the area modules here fires the decorators.
     """
     load_studio_route_modules()
     for _route in iter_studio_routes():
@@ -264,11 +241,8 @@ def _mount_studio_routes(application: FastAPI) -> None:
 
 
 def _resolve_frontend_dist() -> Path | None:
-    """Return the dist/ directory to serve, or None if absent.
-
-    Reads LIONAGI_STUDIO_FRONTEND_DIST; when unset (e.g. raw uvicorn without
-    the CLI), the app starts in API-only mode.
-    """
+    """Return the dist/ directory to serve, or None if absent (reads
+    LIONAGI_STUDIO_FRONTEND_DIST; unset means API-only mode)."""
     env_override = os.environ.get("LIONAGI_STUDIO_FRONTEND_DIST")
     if not env_override:
         return None
@@ -277,12 +251,9 @@ def _resolve_frontend_dist() -> Path | None:
 
 
 def _mount_spa(application: FastAPI, dist: Path) -> None:
-    """Mount static assets and register an SPA 404 fallback.
-
-    Uses a 404 exception handler (not a catch-all route) for the SPA fallback:
-    a catch-all /{full_path:path} route intercepts /api/shows before FastAPI's
-    trailing-slash redirect fires, whereas an exception handler runs only after
-    all routes have been tried and none matched.
+    """Mount static assets and register an SPA 404 fallback. Uses a 404
+    exception handler, not a catch-all route (which would intercept
+    /api/shows before FastAPI's trailing-slash redirect fires).
     """
     assets_dir = dist / "assets"
     if assets_dir.is_dir():
@@ -292,7 +263,7 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
 
     @application.exception_handler(404)
     async def _spa_fallback(request: Request, exc: Exception) -> FileResponse | JSONResponse:
-        # /api/* paths that reach here stay 404 JSON, not the SPA HTML shell.
+        # /api/* paths stay 404 JSON here, not the SPA HTML shell.
         path = request.url.path
         if path.startswith("/api/") or path == "/api":
             return JSONResponse({"detail": "Not Found"}, status_code=404)
@@ -308,9 +279,8 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
 
 
 def create_app() -> FastAPI:
-    """Build and return a fresh Studio FastAPI app instance, so callers that
-    need a clean app (notably tests that monkeypatch service globals first) can
-    get one without `importlib.reload`-ing this module's shared singleton."""
+    """Build and return a fresh Studio FastAPI app instance, so callers
+    (notably tests) can get a clean one without `importlib.reload`."""
     application = FastAPI(title="Lion Studio Server", lifespan=lifespan)
 
     @application.exception_handler(LionError)
@@ -323,17 +293,14 @@ def create_app() -> FastAPI:
 
     @application.middleware("http")
     async def require_studio_bearer_token(request: Request, call_next):
-        # CORS preflight arrives without an Authorization header by design;
-        # let it through so CORSMiddleware can answer with Allow-* headers.
+        # CORS preflight has no Authorization header by design; let it through.
         if request.method == "OPTIONS":
             return await call_next(request)
         token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
         path = request.url.path
         if token and request.headers.get("authorization") != f"Bearer {token}":
-            # All /api/* paths and the FastAPI schema/docs endpoints are
-            # gated. Non-API GET/HEAD (SPA shell, hashed assets, liveness)
-            # stay public -- browsers navigate without an Authorization
-            # header, so gating the shell would make the UI unloadable.
+            # /api/* and schema/docs are gated; non-API GET/HEAD (SPA shell,
+            # hashed assets) stay public or the UI becomes unloadable.
             is_api = path == "/api" or path.startswith("/api/")
             is_guarded_non_api = path in _GUARDED_NON_API_PATHS
             is_public_static = (
@@ -345,16 +312,10 @@ def create_app() -> FastAPI:
 
     @application.middleware("http")
     async def require_json_content_type(request: Request, call_next):
-        """Reject state-changing /api requests that don't declare a JSON body.
-
-        FastAPI parses request bodies as JSON regardless of the declared
-        Content-Type, so a cross-site "simple request" (text/plain, no CORS
-        preflight) carrying a JSON-shaped body would otherwise reach route
-        handlers unchecked -- the classic form-based JSON CSRF vector. The SPA
-        always sends `application/json` on requests that carry a body (see
-        apps/studio/frontend/src/lib/api.ts `fetchJson`) and sends no body at all
-        for the handful of routes that need none, so this only rejects traffic
-        the frontend itself never produces.
+        """Reject state-changing /api requests that don't declare a JSON
+        body — closes the form-based JSON CSRF vector where a cross-site
+        "simple request" carries a JSON-shaped body with no CORS preflight.
+        See docs/internals/studio.md.
         """
         if request.method in ("GET", "HEAD", "OPTIONS"):
             return await call_next(request)
@@ -379,21 +340,14 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, Any]:
         return {"status": "ok"}
 
-    # Mount the SPA before CORSMiddleware so _collect_cors_methods sees the
-    # Mount entry (the 404 handler itself is order-independent).
+    # Mount SPA before CORSMiddleware so _collect_cors_methods sees the Mount entry.
     dist = _resolve_frontend_dist()
     if dist is not None:
         _mount_spa(application, dist)
 
-    # Starlette wraps middleware LIFO (most-recently-added sees the request
-    # first). CORSMiddleware is added after every router/mount so its method
-    # allowlist reflects the full route table. Host validation is added
-    # after CORS, making it OUTERMOST: every request -- including preflight
-    # OPTIONS -- has its Host checked before CORS can answer, closing the
-    # window where an invalid-Host request could get a valid preflight
-    # response. Request order: Host validation -> CORS -> Content-Type/CSRF
-    # check -> bearer-token gate -> route. A real preflight never reaches the
-    # bearer-token/Content-Type middlewares because CORS answers it first.
+    # Starlette wraps middleware LIFO; added-after-CORS makes Host validation
+    # OUTERMOST (checked before CORS answers preflight). See docs/internals/studio.md
+    # for the full request order.
     application.add_middleware(
         CORSMiddleware,
         allow_origins=CORS_ORIGINS,


### PR DESCRIPTION
Wave-2 of the comment-condensation series. Two commits:

1. **Source trim** (20 files, +471/-1406): multi-line comments and docstrings condensed to their causal core across protocols/action, cli/orchestrate, cli (team/main), operations/flow, session, studio, plugins/registry, service/connections/registry, state/lifecycle, and state/schema_meta. Comment/docstring-only - no behavior changes.
2. **Docs relocation** (+405 across docs/internals/{cli,core,runtime,studio}.md): load-bearing rationale that was too long for inline comments moved to the internals docs it belongs in - team-mode coordination wiring, reactive-DAG resume/checkpoint invariants, run_dag() return-shape and hook contracts, plugin trust/activation laziness model, Host-header/CSRF middleware ordering.

Deliberately untouched: triple-quoted prompt-template string literals in cli/orchestrate/_common.py and flow.py (actual instruction content sent to agents - editing them is a behavior change), and short docstrings pinning non-obvious invariants with no natural docs home. Five files in the original set were already terse and left alone.

Verification: fastapi-dependent suites (tests/cli/test_argv_injection.py, tests/apps_studio_server/, tests/studio/) run against the modified source - all passed. Full suite: ~10,250 passed; all 115 failures trace to missing optional extras in the local venv (fastapi/pandas/asyncpg/croniter/docling/pydapter import errors), zero non-import failures, verified per-traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)