### PR TITLE
fix(action): surface tool post-hook reason notes instead of discarding them

### DIFF
--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -212,19 +212,11 @@ class ActionManager(Manager):
         Tool-post hooks run after invocation completes (success or failure)
         and are advisory only -- they observe the final arguments, the
         result (``None`` on failure), and the error (``None`` on success),
-        and cannot change either. A hook that returns a ``ToolPostDecision``
-        with a non-empty ``reason`` has that reason collected into a list of
-        notes; when any notes are collected they are attached to the
-        returned event at ``function_calling.metadata["tool_post_hook_notes"]``
-        and logged, whether the tool itself succeeded or failed (a tool
-        exception is captured onto ``function_calling.status`` without
-        re-raising, so the event -- and its notes -- always reach the
-        caller). The finally block runs the post hooks unconditionally,
-        including on the rarer path where invocation raises a
-        ``BaseException`` that propagates past this call; the notes are
-        recorded on ``function_calling`` before that exception continues
-        outward, but nothing here changes the exception itself or the fact
-        that this method never returns a value on that path.
+        and cannot change either. Non-empty ``ToolPostDecision`` reasons are
+        collected and, when present, attached to the returned event at
+        ``function_calling.metadata["tool_post_hook_notes"]`` and logged, on
+        success and failure paths alike (recorded before any propagating
+        ``BaseException`` continues outward).
         """
         function_calling = self.match_tool(func_call)
         tool_name = function_calling.function

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -212,7 +212,19 @@ class ActionManager(Manager):
         Tool-post hooks run after invocation completes (success or failure)
         and are advisory only -- they observe the final arguments, the
         result (``None`` on failure), and the error (``None`` on success),
-        and cannot change either.
+        and cannot change either. A hook that returns a ``ToolPostDecision``
+        with a non-empty ``reason`` has that reason collected into a list of
+        notes; when any notes are collected they are attached to the
+        returned event at ``function_calling.metadata["tool_post_hook_notes"]``
+        and logged, whether the tool itself succeeded or failed (a tool
+        exception is captured onto ``function_calling.status`` without
+        re-raising, so the event -- and its notes -- always reach the
+        caller). The finally block runs the post hooks unconditionally,
+        including on the rarer path where invocation raises a
+        ``BaseException`` that propagates past this call; the notes are
+        recorded on ``function_calling`` before that exception continues
+        outward, but nothing here changes the exception itself or the fact
+        that this method never returns a value on that path.
         """
         function_calling = self.match_tool(func_call)
         tool_name = function_calling.function
@@ -232,13 +244,16 @@ class ActionManager(Manager):
             raise
         finally:
             if self._tool_post_hooks:
-                await run_tool_post_hooks(
+                notes = await run_tool_post_hooks(
                     self._tool_post_hooks,
                     tool_name,
                     function_calling.arguments,
                     function_calling.response,
                     error,
                 )
+                if notes:
+                    function_calling.metadata["tool_post_hook_notes"] = notes
+                    logger.info("tool post hook notes for %r: %s", tool_name, notes)
 
         return function_calling
 

--- a/tests/protocols/action/test_tool_invoke_hooks.py
+++ b/tests/protocols/action/test_tool_invoke_hooks.py
@@ -317,6 +317,86 @@ async def test_post_hook_advisory_reason_collected_but_does_not_change_outcome()
     assert fc.response == 2
 
 
+async def test_post_hook_note_surfaced_on_metadata_for_success():
+    """A post hook's ToolPostDecision.reason must not vanish: it is
+    collected by run_tool_post_hooks and attached to the returned
+    FunctionCalling event's metadata so callers/telemetry can observe it."""
+    order: list[str] = []
+    calls: list[tuple[int, int]] = []
+    manager, tool_name = _build_manager(order, calls)
+
+    async def annotate(name: str, arguments: dict, result, error) -> ToolPostDecision:
+        return ToolPostDecision(reason="looked fine to me")
+
+    manager.add_tool_post_hook(annotate)
+
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 1}})
+
+    assert fc.status == EventStatus.COMPLETED
+    assert fc.metadata["tool_post_hook_notes"] == ["looked fine to me"]
+
+
+async def test_post_hook_note_surfaced_on_metadata_for_failure():
+    """The same note-surfacing must happen when the tool itself failed --
+    post hooks are advisory and still run in the finally block, and their
+    notes must reach the caller on the failure path too."""
+
+    async def boom(a: int) -> int:
+        raise RuntimeError("kaboom")
+
+    manager = ActionManager(Tool(func_callable=boom))
+
+    async def annotate(name: str, arguments: dict, result, error) -> ToolPostDecision:
+        return ToolPostDecision(reason=f"observed failure: {error}")
+
+    manager.add_tool_post_hook(annotate)
+
+    fc = await manager.invoke({"function": "boom", "arguments": {"a": 1}})
+
+    assert fc.status == EventStatus.FAILED
+    assert fc.metadata["tool_post_hook_notes"] == ["observed failure: kaboom"]
+
+
+async def test_post_hook_multiple_notes_collected_in_order():
+    order: list[str] = []
+    calls: list[tuple[int, int]] = []
+    manager, tool_name = _build_manager(order, calls)
+
+    async def first_note(name: str, arguments: dict, result, error) -> ToolPostDecision:
+        return ToolPostDecision(reason="first")
+
+    async def no_note(name: str, arguments: dict, result, error) -> ToolPostDecision:
+        return ToolPostDecision()
+
+    async def second_note(name: str, arguments: dict, result, error) -> ToolPostDecision:
+        return ToolPostDecision(reason="second")
+
+    manager.add_tool_post_hook(first_note)
+    manager.add_tool_post_hook(no_note)
+    manager.add_tool_post_hook(second_note)
+
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 1}})
+
+    assert fc.metadata["tool_post_hook_notes"] == ["first", "second"]
+
+
+async def test_post_hook_no_notes_leaves_metadata_key_absent():
+    """When no post hook returns a reason, the metadata key is never added
+    -- absence, not an empty list, is the "nothing to observe" signal."""
+    order: list[str] = []
+    calls: list[tuple[int, int]] = []
+    manager, tool_name = _build_manager(order, calls)
+
+    async def silent(name: str, arguments: dict, result, error) -> None:
+        return None
+
+    manager.add_tool_post_hook(silent)
+
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 1}})
+
+    assert "tool_post_hook_notes" not in fc.metadata
+
+
 async def test_post_hook_error_is_isolated_and_does_not_break_the_caller():
     order: list[str] = []
     calls: list[tuple[int, int]] = []


### PR DESCRIPTION
`ActionManager.invoke()` awaited `run_tool_post_hooks()` in its `finally` block and discarded the return value — the helper collects the non-empty `reason` strings from post hooks returning a `ToolPostDecision` precisely so the caller can surface them, but they went nowhere.

## Fix

The notes are now captured and, when non-empty, attached to the returned event at `function_calling.metadata["tool_post_hook_notes"]` plus one `logger.info` line. The `metadata` dict is the smallest honest seam: it exists on every `Element`/`Event` for exactly this kind of annotation, requires zero new plumbing, and `invoke()` already returns the `FunctionCalling` object to every caller. Extending `Execution` (fixed `__slots__`) would have touched every Event subclass; the eventual system-visible branch note surface described by ADR-0048 D5 belongs to the not-yet-built external-hook adapter layer, and this sits cleanly beneath it.

Finally-block semantics unchanged: post hooks still run unconditionally, original exceptions are never masked, and on a propagating `BaseException` the notes are recorded on the event before the exception continues outward.

## Tests

`tests/protocols/action/test_tool_invoke_hooks.py`: note surfaced on success path, on failure path, multiple notes preserved in order, and no-notes leaves the metadata key absent. 23/23 in the file; 206/206 across protocols/action + message-manager + branch coverage suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)