### PR TITLE
fix(mcp): explicit transport-trust decision at load time; permission chain applied to MCP-discovered tools

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import Any
 
 from lionagi._errors import ConfigurationError
+from lionagi.ln.concurrency import is_coro_func
 from lionagi.session.branch import Branch
 
 from .spec import AgentSpec
@@ -198,6 +199,39 @@ def _chain_post_hooks(tool_name: str, hooks: list[Callable]) -> Callable | None:
     return chained
 
 
+def _compose_preprocessor(original: Callable | None, new: Callable) -> Callable:
+    """Compose a spec-derived preprocessor in front of a tool's existing one.
+
+    Ordering keeps the security recheck closest to the actual invocation:
+    the tool's own preprocessor (if any) runs first, then the spec chain.
+    """
+    if original is None:
+        return new
+
+    async def composed(args: dict, **kw) -> Any:
+        args = await original(args, **kw) if is_coro_func(original) else original(args, **kw)
+        return await new(args, **kw) if is_coro_func(new) else new(args, **kw)
+
+    return composed
+
+
+def _compose_postprocessor(original: Callable | None, new: Callable) -> Callable:
+    """Compose a spec-derived postprocessor around a tool's existing one.
+
+    Ordering mirrors `_compose_preprocessor`: the spec chain runs immediately
+    after the tool call (closest to invocation), then the tool's own
+    postprocessor (if any) runs last.
+    """
+    if original is None:
+        return new
+
+    async def composed(result: Any, **kw) -> Any:
+        result = await new(result, **kw) if is_coro_func(new) else new(result, **kw)
+        return await original(result, **kw) if is_coro_func(original) else original(result, **kw)
+
+    return composed
+
+
 def _attach_hooks(tool: Any, spec: AgentSpec, canonical_name: str) -> Any:
     security_hooks = _tool_hooks(spec, "security_pre", canonical_name)
     user_pre_hooks = _tool_hooks(spec, "pre", canonical_name)
@@ -205,9 +239,9 @@ def _attach_hooks(tool: Any, spec: AgentSpec, canonical_name: str) -> Any:
     pre = _chain_pre_hooks(canonical_name, security_hooks, user_pre_hooks)
     post = _chain_post_hooks(canonical_name, post_hooks)
     if pre is not None:
-        tool.preprocessor = pre
+        tool.preprocessor = _compose_preprocessor(tool.preprocessor, pre)
     if post is not None:
-        tool.postprocessor = post
+        tool.postprocessor = _compose_postprocessor(tool.postprocessor, post)
     return tool
 
 

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -323,10 +323,38 @@ async def _load_mcp(
     if mcp_path is None:
         return
 
-    await branch.acts.load_mcp_config(
+    from lionagi.service.connections.mcp_wrapper import MCPSecurityConfig
+
+    # ActionManager.load_mcp_config() no longer implies trust when its
+    # `mcp_security` argument is omitted (ADR-0011 delta row 3) -- an
+    # omitted policy now falls through to the wrapper's fail-closed
+    # default instead. Reaching this point already required an explicit
+    # trust act: either `spec.mcp_config_path` was set directly, or
+    # `mcp_path` resolved from the operator's own home-level `.mcp.json`
+    # (the same "global config is inherently trusted" precedent as
+    # settings.yaml's always-loaded global file), or the caller opted into
+    # `trust_project_settings=True` for a project-level file. This is the
+    # one, explicit, documented compatibility decision for lionagi's own
+    # MCP auto-load consumer -- not a silent default buried in the generic
+    # library call.
+    loaded = await branch.acts.load_mcp_config(
         mcp_path,
         server_names=spec.mcp_servers,
+        mcp_security=MCPSecurityConfig.trusted(),
     )
+
+    # Apply the same hook chain static tools get (security_pre/pre/post from
+    # spec.hook_handlers, wired via _attach_hooks in _register_tools) to
+    # MCP-discovered tools too -- they are registered after built-in tool
+    # interception and would otherwise keep their bare default preprocessor
+    # (ADR-0041 delta row 2). Reuses _attach_hooks, the same function static
+    # registration uses, so both paths stay on one shared chain-application
+    # path rather than a copied block.
+    for tool_names in loaded.values():
+        for tool_name in tool_names:
+            tool = branch.acts.registry.get(tool_name)
+            if tool is not None:
+                _attach_hooks(tool, spec, tool_name)
 
 
 def _forward_mcp_to_cli_request(

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -411,15 +411,14 @@ class ActionManager(Manager):
         update: bool = False,
         mcp_security: "MCPSecurityConfig | None" = None,
     ) -> dict[str, list[str]]:
-        from lionagi.service.connections.mcp_wrapper import (
-            MCPConnectionPool,
-            MCPSecurityConfig,
-        )
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
-        # Explicit config load trusts declared transports by default.
-        if mcp_security is None:
-            mcp_security = MCPSecurityConfig(allow_commands=True, allow_urls=True)
-
+        # An omitted policy is no longer implicitly trusted (ADR-0011 delta
+        # row 3): `mcp_security` stays None and flows through to
+        # `register_mcp_server` -> `MCPConnectionPool.get_client`, which
+        # falls back to the wrapper's own fail-closed `MCPSecurityConfig()`
+        # default. A caller that wants the previous permissive behavior must
+        # pass `mcp_security=MCPSecurityConfig.trusted()` explicitly.
         loaded_names = MCPConnectionPool.load_config(config_path)
 
         if server_names is None:
@@ -451,15 +450,13 @@ async def load_mcp_tools(
     update: bool = False,
     mcp_security: "MCPSecurityConfig | None" = None,
 ) -> list[Tool]:
-    from lionagi.service.connections.mcp_wrapper import (
-        MCPConnectionPool,
-        MCPSecurityConfig,
-    )
+    from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
     manager = ActionManager()
 
-    if mcp_security is None:
-        mcp_security = MCPSecurityConfig(allow_commands=True, allow_urls=True)
+    # See load_mcp_config's matching comment: an omitted policy stays None
+    # and falls through to the wrapper's fail-closed default rather than
+    # being silently upgraded to a permissive one (ADR-0011 delta row 3).
 
     if config_path:
         MCPConnectionPool.load_config(config_path)

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -1476,21 +1476,46 @@ class MCPConnectionPool:
     _server_security: dict[str, MCPSecurityConfig] = {}
 
     @staticmethod
-    def _policy_key(server_config: dict[str, Any]) -> str:
-        """Content-based key for per-server policy registry."""
-        if "server" in server_config:
-            return f"server:{server_config['server']}"
-        material = {k: v for k, v in server_config.items() if not k.startswith("_")}
+    def _policy_key(config: dict[str, Any]) -> str:
+        """Content-based key for the per-server policy registry.
+
+        Callers MUST pass an already-*resolved* transport config (see
+        `_resolve_config`) -- never a bare `{"server": name}` reference.
+        Keying on the logical name alone would let a server that is later
+        reloaded with a different command/URL under the same name recover
+        a policy that was only ever authorized for the prior transport.
+        """
+        material = {k: v for k, v in config.items() if not k.startswith("_")}
         blob = json.dumps(material, sort_keys=True, default=str)
-        return f"inline:{compute_hash(blob)}"
+        return compute_hash(blob)
+
+    @classmethod
+    def _resolve_config(cls, server_config: dict[str, Any]) -> dict[str, Any]:
+        """Resolve a `{"server": name}` reference to its concrete transport
+        config (command/args/env or url), loading `.mcp.json` first if the
+        name hasn't been loaded yet. Inline configs pass through unchanged.
+
+        Policy and cached-client identity must always be derived from the
+        RESOLVED config returned here, never from the bare server name.
+        """
+        if "server" in server_config:
+            server_name = server_config["server"]
+            if server_name not in cls._configs:
+                cls.load_config()
+            if server_name not in cls._configs:
+                raise ValueError(f"Unknown MCP server: {server_name}")
+            return cls._configs[server_name]
+        return server_config
 
     @classmethod
     def remember_security(
         cls, server_config: dict[str, Any], security: MCPSecurityConfig | None
     ) -> None:
-        """Record the policy a server was authorized under. No-op if None."""
+        """Record the policy a server was authorized under, keyed by its
+        resolved transport config. No-op if None."""
         if security is not None:
-            cls._server_security[cls._policy_key(server_config)] = security
+            config = cls._resolve_config(server_config)
+            cls._server_security[cls._policy_key(config)] = security
 
     @classmethod
     def _get_lock(cls) -> Lock:
@@ -1536,6 +1561,19 @@ class MCPConnectionPool:
         if not isinstance(servers, dict):
             raise ValueError("mcpServers must be a dictionary")
 
+        for name, new_server_config in servers.items():
+            old_server_config = cls._configs.get(name)
+            if old_server_config is not None and old_server_config != new_server_config:
+                # This name now resolves to a different transport. Drop the
+                # policy and any pooled client keyed off the OLD transport's
+                # fingerprint so a subsequent omitted-policy get_client()
+                # cannot recover a trust decision that was never made for
+                # the new one.
+                cls._server_security.pop(cls._policy_key(old_server_config), None)
+                stale_prefix = f"server:{name}:"
+                for cache_key in [k for k in cls._clients if k.startswith(stale_prefix)]:
+                    cls._clients.pop(cache_key, None)
+
         cls._configs.update(servers)
         return list(servers.keys())
 
@@ -1546,25 +1584,28 @@ class MCPConnectionPool:
         security: MCPSecurityConfig | None = None,
     ) -> Any:
         """Get or create a pooled MCP client."""
-        # Explicit policy authorizes this server for future reconnects;
-        # absent one, recover the policy the server was loaded under.
-        if security is not None:
-            cls.remember_security(server_config, security)
-        else:
-            security = cls._server_security.get(cls._policy_key(server_config))
-
+        # Resolve `{"server": name}` references to their concrete transport
+        # config FIRST: policy recovery and cache identity must bind to the
+        # RESOLVED transport, not the bare logical name. Otherwise reloading
+        # a different command/URL under the same name would let an
+        # omitted-policy call recover (and reconnect using) a policy that
+        # was only ever authorized for the prior transport.
         if "server" in server_config:
             server_name = server_config["server"]
-            if server_name not in cls._configs:
-                cls.load_config()
-            if server_name not in cls._configs:
-                raise ValueError(f"Unknown MCP server: {server_name}")
-
-            config = cls._configs[server_name]
-            cache_key = f"server:{server_name}"
+            config = cls._resolve_config(server_config)
+            policy_key = cls._policy_key(config)
+            cache_key = f"server:{server_name}:{policy_key}"
         else:
             config = server_config
+            policy_key = cls._policy_key(config)
             cache_key = f"inline:{config.get('command')}:{id(config)}"
+
+        # Explicit policy authorizes this resolved transport for future
+        # reconnects; absent one, recover the policy it was loaded under.
+        if security is not None:
+            cls._server_security[policy_key] = security
+        else:
+            security = cls._server_security.get(policy_key)
 
         async with cls._get_lock():
             if cache_key in cls._clients:

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -69,6 +69,16 @@ class MCPSecurityConfig:
     filter_sensitive_env: bool = True
     max_connections_per_server: int = 5
 
+    @classmethod
+    def trusted(cls) -> MCPSecurityConfig:
+        """The named, observable transport-trust decision (ADR-0011 delta row 3).
+
+        Allows command and URL transports. A caller must reach for this
+        deliberately -- omitting a policy at MCP load time no longer implies
+        trust; it now preserves the fail-closed default above instead.
+        """
+        return cls(allow_commands=True, allow_urls=True)
+
 
 # --- Generic-executor admission rule -----------------------------------
 # Registration-time admission control, independent of MCPSecurityConfig

--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -80,7 +80,7 @@ async def _call_khive(ops: str, mcp_config: dict) -> Any:
     transport is only touched here, never at module load."""
     from lionagi.service.connections.mcp_wrapper import MCPConnectionPool, MCPSecurityConfig
 
-    security = MCPSecurityConfig(allow_commands=True, allow_urls=True)
+    security = MCPSecurityConfig.trusted()
     client = await MCPConnectionPool.get_client(mcp_config, security=security)
     result = await client.call_tool("request", {"ops": ops})
     return _unwrap(result)

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -94,7 +94,10 @@ async def test_create_agent_with_permissions_sets_preprocessor():
     config.permissions = PermissionPolicy.read_only()
     branch = await _make(config)
 
-    # Only coding tools get permission preprocessors (MCP tools from ambient env are unaffected)
+    # No MCP servers are configured/resolvable in this test, so only the
+    # statically-registered coding tools exist to check here; MCP-discovered
+    # tools get the same preprocessor chain applied (see
+    # test_mcp_discovered_tool_gets_permission_preprocessor below).
     for name in _CODING_TOOLS:
         tool = branch.acts.registry.get(name)
         assert tool is not None, f"Coding tool '{name}' not registered"
@@ -115,6 +118,46 @@ async def test_create_agent_permission_deny_all_preprocessor_raises():
         await reader_tool.preprocessor(
             {"action": "read", "path": "/tmp/x.py"},
         )
+
+
+async def test_mcp_discovered_tool_gets_permission_preprocessor(tmp_path, monkeypatch):
+    """ADR-0041 delta row 2: a permission rule that blocks a static tool must
+    equally block a same-shaped MCP-discovered tool. MCP registration happens
+    after built-in tool interception (_register_tools) and must not bypass
+    the resolved permission/interceptor chain -- _load_mcp applies the same
+    _attach_hooks() used for static tools to every tool name MCP discovery
+    reports, not a copied/parallel chain."""
+    from lionagi.agent.permissions import PermissionPolicy
+    from lionagi.protocols.action.manager import ActionManager
+    from lionagi.protocols.action.tool import Tool
+
+    mcp_file = tmp_path / "custom.mcp.json"
+    mcp_file.write_text('{"mcpServers": {"demo": {"command": "true"}}}')
+
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
+        # Mimic what register_mcp_server does after real discovery: put a
+        # plain Tool straight into the registry, bypassing hook attachment
+        # entirely -- exactly the gap this fix closes.
+        async def demo_tool(**kwargs):
+            return "ok"
+
+        demo_tool.__name__ = "demo_tool"
+        self.register_tool(Tool(func_callable=demo_tool), update=update)
+        return {"demo": ["demo_tool"]}
+
+    monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp_config)
+
+    config = AgentSpec.compose("implementer")
+    config.mcp_config_path = str(mcp_file)
+    config.permissions = PermissionPolicy.deny_all()
+    branch = await create_agent(config, load_settings=False)
+
+    mcp_tool = branch.acts.registry["demo_tool"]
+    assert mcp_tool.preprocessor is not None, "MCP-discovered tool missing the spec's hook chain"
+    with pytest.raises(PermissionError):
+        await mcp_tool.preprocessor({"action": "call", "foo": "bar"})
 
 
 async def test_create_agent_coding_permissions_recheck_user_mutated_args(tmp_path):
@@ -191,7 +234,9 @@ async def test_create_agent_does_not_autoload_project_mcp_without_trust(tmp_path
 
     calls = []
 
-    async def fake_load_mcp_config(self, config_path, server_names=None, update=False):
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
         calls.append((config_path, server_names, update))
         return {}
 
@@ -216,9 +261,13 @@ async def test_create_agent_autoloads_project_mcp_when_trusted(tmp_path, monkeyp
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
 
     calls = []
+    security_seen = []
 
-    async def fake_load_mcp_config(self, config_path, server_names=None, update=False):
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
         calls.append((config_path, server_names, update))
+        security_seen.append(mcp_security)
         return {}
 
     monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp_config)
@@ -230,6 +279,11 @@ async def test_create_agent_autoloads_project_mcp_when_trusted(tmp_path, monkeyp
     )
 
     assert calls == [(str(mcp_path), None, False)]
+    # _load_mcp makes the transport-trust decision explicit at its one call
+    # site (ADR-0011 delta row 3) rather than relying on an implicit default.
+    from lionagi.service.connections.mcp_wrapper import MCPSecurityConfig
+
+    assert security_seen == [MCPSecurityConfig.trusted()]
 
 
 # ---------------------------------------------------------------------------
@@ -569,7 +623,7 @@ async def test_load_mcp_explicit_config_path_used(tmp_path, monkeypatch):
 
     calls = []
 
-    async def fake_load_mcp(self, config_path, server_names=None, update=False):
+    async def fake_load_mcp(self, config_path, server_names=None, update=False, mcp_security=None):
         calls.append(config_path)
         return {}
 
@@ -600,7 +654,7 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
 
     calls = []
 
-    async def fake_load_mcp(self, config_path, server_names=None, update=False):
+    async def fake_load_mcp(self, config_path, server_names=None, update=False, mcp_security=None):
         calls.append(config_path)
         return {}
 

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -160,6 +160,55 @@ async def test_mcp_discovered_tool_gets_permission_preprocessor(tmp_path, monkey
         await mcp_tool.preprocessor({"action": "call", "foo": "bar"})
 
 
+async def test_mcp_discovered_tool_composes_existing_preprocessor(tmp_path, monkeypatch):
+    """_attach_hooks() must compose with a pre-existing tool preprocessor
+    instead of replacing it outright: an MCP-discovered Tool that already
+    carries one (e.g. an arg normalizer wired at construction) must still
+    run it, and the spec's permission gate must still block."""
+    from lionagi.agent.permissions import PermissionPolicy
+    from lionagi.protocols.action.manager import ActionManager
+    from lionagi.protocols.action.tool import Tool
+
+    mcp_file = tmp_path / "custom.mcp.json"
+    mcp_file.write_text('{"mcpServers": {"demo": {"command": "true"}}}')
+
+    calls = []
+
+    async def existing_preprocessor(args, **kw):
+        calls.append(dict(args))
+        return args
+
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
+        async def demo_tool(**kwargs):
+            return "ok"
+
+        demo_tool.__name__ = "demo_tool"
+        self.register_tool(
+            Tool(func_callable=demo_tool, preprocessor=existing_preprocessor),
+            update=update,
+        )
+        return {"demo": ["demo_tool"]}
+
+    monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp_config)
+
+    config = AgentSpec.compose("implementer")
+    config.mcp_config_path = str(mcp_file)
+    config.permissions = PermissionPolicy.deny_all()
+    branch = await create_agent(config, load_settings=False)
+
+    mcp_tool = branch.acts.registry["demo_tool"]
+    assert mcp_tool.preprocessor is not existing_preprocessor, (
+        "the spec's hook chain must be composed in, not left as a bare passthrough"
+    )
+    with pytest.raises(PermissionError):
+        await mcp_tool.preprocessor({"action": "call", "foo": "bar"})
+
+    # The tool's own preprocessor ran before the permission gate raised.
+    assert calls == [{"action": "call", "foo": "bar"}]
+
+
 async def test_create_agent_coding_permissions_recheck_user_mutated_args(tmp_path):
     """User pre-hooks must not be able to rewrite safe args after permission checks."""
     from lionagi.agent.permissions import PermissionPolicy

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -35,6 +35,19 @@ class TestMCPSecurityConfig:
         with pytest.raises(AttributeError):
             config.filter_sensitive_env = False
 
+    def test_trusted_preset_allows_command_and_url_transports(self):
+        """MCPSecurityConfig.trusted() is the named, observable transport-
+        trust decision (ADR-0011 delta row 3) -- a caller reaches for it
+        deliberately; it is not the default."""
+        config = MCPSecurityConfig.trusted()
+        assert config.allow_commands is True
+        assert config.allow_urls is True
+        # Everything else keeps the fail-closed field defaults.
+        assert config == MCPSecurityConfig(allow_commands=True, allow_urls=True)
+        # The plain default constructor is unaffected by the preset existing.
+        assert MCPSecurityConfig().allow_commands is False
+        assert MCPSecurityConfig().allow_urls is False
+
 
 class TestFilterEnv:
     def test_filters_sensitive_keys(self):
@@ -236,7 +249,9 @@ class TestMCPConnectionPoolFailClosed:
 
 
 class TestLoadMcpConfigTrustedLoad:
-    """load_mcp_config is a trust action: must default to allow policy and surface denials loudly."""
+    """load_mcp_config's omitted policy must preserve the fail-closed default
+    (ADR-0011 delta row 3) while an explicit trust decision still threads
+    through and denials still surface loudly, never swallowed to []."""
 
     async def test_default_load_registers_only_the_loaded_files_servers(
         self, tmp_path, monkeypatch
@@ -271,7 +286,11 @@ class TestLoadMcpConfigTrustedLoad:
         assert result == {"local": ["local_echo"]}
         assert "earlier-server" not in result
 
-    async def test_default_load_sets_allow_policy_and_registers(self, tmp_path, monkeypatch):
+    async def test_default_load_leaves_policy_unset(self, tmp_path, monkeypatch):
+        """Omitting mcp_security no longer manufactures a permissive policy --
+        it stays None and is threaded through unchanged, so a fail-closed
+        downstream default (MCPConnectionPool.get_client/_create_client)
+        applies unless the caller opts in via MCPSecurityConfig.trusted()."""
         import json
 
         from lionagi.protocols.action.manager import ActionManager
@@ -283,18 +302,65 @@ class TestLoadMcpConfigTrustedLoad:
         seen = {}
 
         async def fake_register(server_config, update=False, security=None):
-            # The policy is THREADED in as an argument, not set on the global.
+            seen["security"] = security
+            return ["local_echo"]
+
+        monkeypatch.setattr(mgr, "register_mcp_server", fake_register)
+
+        result = await mgr.load_mcp_config(str(cfg))
+        # Normal usage must still register tools, not silently return [].
+        assert result == {"local": ["local_echo"]}
+        assert seen["security"] is None
+
+    async def test_explicit_trusted_preset_threads_through(self, tmp_path, monkeypatch):
+        """The named, observable trusted mode (MCPSecurityConfig.trusted())
+        allows command/URL transports when a caller opts in explicitly."""
+        import json
+
+        from lionagi.protocols.action.manager import ActionManager
+
+        cfg = tmp_path / ".mcp.json"
+        cfg.write_text(json.dumps({"mcpServers": {"local": {"command": "echo", "args": ["hi"]}}}))
+
+        mgr = ActionManager()
+        seen = {}
+
+        async def fake_register(server_config, update=False, security=None):
             seen["allow_commands"] = security.allow_commands
             seen["allow_urls"] = security.allow_urls
             return ["local_echo"]
 
         monkeypatch.setattr(mgr, "register_mcp_server", fake_register)
 
-        result = await mgr.load_mcp_config(str(cfg))
-        # Normal usage must register tools, not silently return [].
+        result = await mgr.load_mcp_config(str(cfg), mcp_security=MCPSecurityConfig.trusted())
         assert result == {"local": ["local_echo"]}
         assert seen["allow_commands"] is True
         assert seen["allow_urls"] is True
+
+    async def test_default_load_denies_command_transport_without_explicit_trust(self, tmp_path):
+        """End-to-end (no mocking of register_mcp_server): a command-based
+        server with no mcp_security passed must raise PermissionError, not
+        register anything -- an MCP server cannot contribute callable tools
+        without a recorded transport-trust decision."""
+        import json
+
+        from lionagi.protocols.action.manager import ActionManager
+
+        # Reset pool state and use a server name unused elsewhere in this
+        # file, so no cached client/policy from another test leaks in.
+        MCPConnectionPool._security = None
+        MCPConnectionPool._clients = {}
+        MCPConnectionPool._server_security.pop("server:trustcheck", None)
+
+        cfg = tmp_path / ".mcp.json"
+        cfg.write_text(
+            json.dumps({"mcpServers": {"trustcheck": {"command": "echo", "args": ["hi"]}}})
+        )
+
+        mgr = ActionManager()
+        with pytest.raises(PermissionError, match="allow_commands=False"):
+            await mgr.load_mcp_config(str(cfg))
+        assert mgr.registry == {}
 
     async def test_security_denial_is_raised_not_swallowed(self, tmp_path, monkeypatch):
         import json
@@ -316,7 +382,7 @@ class TestLoadMcpConfigTrustedLoad:
             await mgr.load_mcp_config(str(cfg), mcp_security=MCPSecurityConfig())
 
     async def test_load_does_not_mutate_global_security_scope(self, tmp_path, monkeypatch):
-        """The permissive policy is threaded as an arg, not set on the global; concurrent loads must not share trust scope."""
+        """An explicit policy is threaded as an arg, not set on the global; concurrent loads must not share trust scope."""
         import json
 
         from lionagi.protocols.action.manager import ActionManager
@@ -330,13 +396,14 @@ class TestLoadMcpConfigTrustedLoad:
             mgr = ActionManager()
 
             async def fake_register(server_config, update=False, security=None):
-                # Policy arrives as an argument; the global is NEVER mutated.
+                # An explicit, opted-in trusted policy arrives as an argument;
+                # the global is NEVER mutated.
                 assert security.allow_commands is True
                 assert MCPConnectionPool._security is None
                 return ["local_echo"]
 
             monkeypatch.setattr(mgr, "register_mcp_server", fake_register)
-            await mgr.load_mcp_config(str(cfg))
+            await mgr.load_mcp_config(str(cfg), mcp_security=MCPSecurityConfig.trusted())
 
             # The global default is untouched throughout.
             assert MCPConnectionPool._security is None
@@ -410,8 +477,11 @@ class TestLoadMcpConfigTrustedLoad:
             MCPConnectionPool._security = None
             MCPConnectionPool._clients.clear()
 
-    async def test_load_mcp_tools_helper_trusted_and_loud(self, tmp_path, monkeypatch):
-        """load_mcp_tools mirrors load_mcp_config: trusted-allow threaded, global untouched, denial raised loudly."""
+    async def test_load_mcp_tools_helper_omitted_policy_stays_unset(self, tmp_path, monkeypatch):
+        """load_mcp_tools mirrors load_mcp_config: an omitted policy is no
+        longer manufactured into a permissive one -- it stays None, global
+        untouched -- while an explicit trusted policy still threads through
+        and denials still surface loudly, never swallowed to []."""
         import json
 
         from lionagi.protocols.action.manager import ActionManager, load_mcp_tools
@@ -426,16 +496,22 @@ class TestLoadMcpConfigTrustedLoad:
             async def fake_register(
                 self, server_config, request_options=None, update=False, security=None
             ):
-                seen["allow_commands"] = security.allow_commands
+                seen["security"] = security
                 assert MCPConnectionPool._security is None
                 return ["local_echo"]
 
             monkeypatch.setattr(ActionManager, "register_mcp_server", fake_register)
 
-            # Normal load: no raise, policy permissive (threaded), global untouched.
+            # Normal load, no explicit policy: no raise, security stays None
+            # (fail-closed downstream), global untouched.
             await load_mcp_tools(str(cfg))
-            assert seen["allow_commands"] is True
+            assert seen["security"] is None
             assert MCPConnectionPool._security is None
+
+            # Explicit trusted policy: threaded through as-is.
+            monkeypatch.setattr(ActionManager, "register_mcp_server", fake_register)
+            await load_mcp_tools(str(cfg), mcp_security=MCPSecurityConfig.trusted())
+            assert seen["security"] == MCPSecurityConfig.trusted()
 
             # Restrictive policy: a denial must be raised, not swallowed to [].
             async def deny_register(

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -676,3 +676,36 @@ class TestPerServerPolicyPersistence:
             assert seen[-1] is None
         finally:
             self._reset()
+
+    async def test_reload_different_command_under_same_name_denies_recovered_policy(self, tmp_path):
+        """A policy trusted for one server's resolved transport must not be
+        recoverable after the same server name is reloaded with a different
+        command: register/trust a config under name X, cleanup/reload a
+        different command under the same name X, then an omitted-policy
+        load must stay fail-closed end to end (no `_create_client` stub --
+        the real transport validation must raise)."""
+        import json
+
+        self._reset()
+        try:
+            cfg_path = tmp_path / ".mcp.json"
+            cfg_path.write_text(
+                json.dumps({"mcpServers": {"same-name": {"command": "trusted-server"}}})
+            )
+            MCPConnectionPool.load_config(str(cfg_path))
+            policy = MCPSecurityConfig(allow_commands=True)
+            MCPConnectionPool.remember_security({"server": "same-name"}, policy)
+
+            # Cleanup/reload a DIFFERENT command under the SAME server name.
+            cfg_path.write_text(
+                json.dumps({"mcpServers": {"same-name": {"command": "untrusted-server"}}})
+            )
+            MCPConnectionPool.load_config(str(cfg_path))
+
+            # The omitted-policy path must not recover the prior trusted()
+            # decision for the reloaded transport.
+            with pytest.raises(PermissionError, match="allow_commands=False"):
+                await MCPConnectionPool.get_client({"server": "same-name"})
+        finally:
+            self._reset()
+            MCPConnectionPool._configs.pop("same-name", None)

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -677,13 +677,14 @@ class TestPerServerPolicyPersistence:
         finally:
             self._reset()
 
-    async def test_reload_different_command_under_same_name_denies_recovered_policy(self, tmp_path):
+    async def test_reload_different_command_under_same_name_denies_recovered_policy(
+        self, tmp_path, monkeypatch
+    ):
         """A policy trusted for one server's resolved transport must not be
         recoverable after the same server name is reloaded with a different
-        command: register/trust a config under name X, cleanup/reload a
-        different command under the same name X, then an omitted-policy
-        load must stay fail-closed end to end (no `_create_client` stub --
-        the real transport validation must raise)."""
+        command. The connected client cached for the old transport must also
+        be evicted, and an omitted-policy load must stay fail-closed end to
+        end."""
         import json
 
         self._reset()
@@ -694,16 +695,39 @@ class TestPerServerPolicyPersistence:
             )
             MCPConnectionPool.load_config(str(cfg_path))
             policy = MCPSecurityConfig(allow_commands=True)
-            MCPConnectionPool.remember_security({"server": "same-name"}, policy)
+            cached_client = type("ConnectedClient", (), {"is_connected": lambda self: True})()
+            real_create_client = MCPConnectionPool._create_client
 
-            # Cleanup/reload a DIFFERENT command under the SAME server name.
+            async def fake_create(config, security=None):
+                if config.get("command") == "trusted-server":
+                    assert security is policy
+                    return cached_client
+                return await real_create_client(config, security=security)
+
+            monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+            assert (
+                await MCPConnectionPool.get_client({"server": "same-name"}, security=policy)
+                is cached_client
+            )
+            cached_keys = [
+                key
+                for key, client in MCPConnectionPool._clients.items()
+                if key.startswith("server:same-name") and client is cached_client
+            ]
+            assert len(cached_keys) == 1
+            stale_cache_key = cached_keys[0]
+
+            # Reload a DIFFERENT command under the SAME server name.
             cfg_path.write_text(
                 json.dumps({"mcpServers": {"same-name": {"command": "untrusted-server"}}})
             )
             MCPConnectionPool.load_config(str(cfg_path))
+            assert stale_cache_key not in MCPConnectionPool._clients
+            assert cached_client not in MCPConnectionPool._clients.values()
 
             # The omitted-policy path must not recover the prior trusted()
-            # decision for the reloaded transport.
+            # decision or return the old connected client. The real validator
+            # rejects before any replacement transport is constructed.
             with pytest.raises(PermissionError, match="allow_commands=False"):
                 await MCPConnectionPool.get_client({"server": "same-name"})
         finally:


### PR DESCRIPTION
Closes #2163.

## Item 1 — loading no longer implies trust

`ActionManager.load_mcp_config()` and `load_mcp_tools()` previously upgraded an omitted `mcp_security` to a permissive `MCPSecurityConfig(allow_commands=True, allow_urls=True)` — loading a config was itself the trust decision. Now an omitted policy stays `None` and flows through to `MCPConnectionPool`'s existing fail-closed default (commands and URL transports denied). The named preset `MCPSecurityConfig.trusted()` is the deliberate, observable opt-in.

**Behavior break, on purpose**: a direct caller relying on the old implicit-trust default now gets `PermissionError` for command/URL transports until it passes `mcp_security=MCPSecurityConfig.trusted()`. A prior test explicitly pinning "load_mcp_config must default to allow" was rewritten to pin the new fail-closed contract — that reversal is the point of the issue, not collateral.

For lionagi's own consumer, `create_agent()`'s `_load_mcp()` passes `trusted()` explicitly with the rationale documented at the call site: reaching it already required an explicit trust act (`spec.mcp_config_path` set directly, the operator's home-level `.mcp.json`, or `trust_project_settings=True`). All existing `create_agent()`/CLI behavior is preserved.

## Item 2 — one hook-attachment path

`create_agent()` wired `security_pre:*` hooks (from `spec.permissions`) onto statically registered tools via `_attach_hooks()`, but MCP-discovered tools kept their bare default preprocessor. `_load_mcp()` now applies the same `_attach_hooks()` to every tool name MCP discovery reports — the identical function, not a copied block, so the chains cannot drift.

## Tests

New/updated: fail-closed default when `mcp_security` omitted; `trusted()` preset threading; end-to-end `PermissionError` for a command transport with no trust decision; `deny_all` policy blocking an MCP-discovered tool's preprocessor through `create_agent()`. 694 passed across agent/action/MCP-security/khive-injection/docs suites; broader sweep 1626 passed. Pre-existing gaps (ollama, jsonschema extras) confirmed identical on unmodified main via git stash. Ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)