### PR TITLE
docs(adr): accept ADR-0048 and ADR-0088 with implementation-status annexes

### DIFF
--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -1,6 +1,6 @@
 # ADR-0048: Interoperable external hooks (Claude Code / Codex hook contract)
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Area**: hooks
 - **Date**: 2026-07-12
@@ -647,3 +647,82 @@ imported entry. The tiers:
   appended here naming what changed and which side LionAGI takes; the loader and
   import command reference the profile version they implement. No revision happens
   silently.
+
+## Implementation status (2026-07-13)
+
+As of 2026-07-13, this ADR's internal-plumbing decisions are implemented and
+tested; its namesake capability — running an actual external hook binary — does
+not exist yet.
+
+**Implemented and tested:**
+
+- **D2, turn-origin verification.** The `USER_PROMPT_SUBMIT` `HookPoint` and its
+  turn-origin token mechanism are fully wired: minted at the public ingresses,
+  forwarded (never re-originated) through nested calls such as
+  `chat_and_record()` → `chat()`, and consumed exactly once at the
+  model-submission boundary. Internal turns (parse-repair, `ReAct` extension and
+  final-answer steps) correctly carry the no-origin disposition and emit
+  nothing. The acceptance matrix's exact-once emission counts are covered by
+  dedicated integration tests, and this is the most rigorously tested area of
+  the ADR.
+- **D3, the `ActionManager` chokepoint.** `ActionManager.invoke()` carries a
+  tool pre/post hook layer that runs for every tool routed through it — plain
+  function tools, `Tool` objects, and MCP-discovered tools alike — closing the
+  MCP coverage gap named in the Context. Ordering (external pre before the
+  spec-level chain, tool call, spec-level post, external post),
+  argument-rewrite revalidation against the tool's declared request model, and
+  the invariant that `security_pre` always sees post-rewrite arguments are all
+  implemented and covered by dedicated tests. The direct-`FunctionCalling`-
+  construction bypass is deliberately preserved and is itself covered by a test
+  asserting hooks do not fire on that path, matching this ADR's documented,
+  tested-limit framing.
+
+**Partially present (in-process analog only, no external wire mechanism):**
+
+- The `allow`/`deny`/`ask`/unrecognized-decision semantics of D5 exist as a
+  typed in-process decision object consumed by the tool-hook chain, and are
+  tested there. Nothing yet parses a `hookSpecificOutput` JSON payload off a
+  subprocess's stdout, so this semantics layer has no external hook to serve.
+- The event-vocabulary mapping of D2 for `SessionStart`/`SessionEnd`/
+  `PostToolUseFailure` targets `HookBus` points that pre-date this ADR and
+  remain wired; no code parses an external event-name string out of a
+  configuration file to route to them.
+- The fail-closed-on-timeout principle of Dv1-4/D1 is implemented and tested
+  for the in-process `ask` → deny path; no subprocess timeout code exists to
+  apply the same principle to an external hook process.
+- Argv-only, non-empty-list enforcement (D4) exists, but only as a plugin
+  manifest validator (`HookCommand`) for ADR-0088 bundles, not as a check on
+  any `.lionagi/settings.yaml` `hooks_external:` entry, because that settings
+  surface does not exist (see below).
+- A content-hash trust mechanism exists (`lionagi/plugins/trust.py`), but it
+  pins whole declared files for plugin bundles under ADR-0088, not a
+  per-hook-command argv hash gating a `hooks_external:` settings entry as D7
+  specifies. The two mechanisms overlap in shape (hash-pin, revert-on-change)
+  but differ in what they pin, what triggers them, and which configuration
+  surface they gate.
+
+**Not yet started:**
+
+The capability of executing an external hook binary against LionAGI does not
+exist yet. Concretely absent: the stdin wire envelope (D1) and any code that
+constructs or serializes it; the dedicated exec adapter (D4) that would parse
+stdout, distinguish exit 2 from other nonzero exits, and apply a configurable
+per-hook timeout — the pre-existing `_make_shell_hook` executor is unmodified
+and still collapses every nonzero exit to a single `PermissionError` with no
+stdout read-back; the `hooks_external:` block in `.lionagi/settings.yaml` and
+its loader (D6) — the settings loader reads only the legacy `hooks:` key; the
+`li hooks import claude|codex` and `li hooks trust` CLI commands (D6, D7) —
+neither verb exists in the CLI registry; and the cross-harness conformance
+matrix (D1's own acceptance gate) — the closest existing test asserts internal
+emission counts, not fixture hooks run against current Claude Code/Codex
+schemas. Until this layer lands, no foreign hook suite can run under LionAGI
+and no config can declare one.
+
+One additional defect, unrelated to the above scope but found while
+reconciling this ADR's D5 language against the current implementation:
+`ActionManager.invoke()` awaits its post-hook run inside a `finally` block
+without capturing the return value, so the `notes` list `run_tool_post_hooks`
+computes (populated when a post hook returns a block reason) is discarded and
+never reaches the branch as a system-visible message. This is a correctness
+gap in already-merged code, independent of the unstarted work above, and
+should be tracked as a bug fix on its own.

--- a/docs/adr/ADR-0048-interoperable-external-hooks.md
+++ b/docs/adr/ADR-0048-interoperable-external-hooks.md
@@ -718,11 +718,7 @@ emission counts, not fixture hooks run against current Claude Code/Codex
 schemas. Until this layer lands, no foreign hook suite can run under LionAGI
 and no config can declare one.
 
-One additional defect, unrelated to the above scope but found while
-reconciling this ADR's D5 language against the current implementation:
-`ActionManager.invoke()` awaits its post-hook run inside a `finally` block
-without capturing the return value, so the `notes` list `run_tool_post_hooks`
-computes (populated when a post hook returns a block reason) is discarded and
-never reaches the branch as a system-visible message. This is a correctness
-gap in already-merged code, independent of the unstarted work above, and
-should be tracked as a bug fix on its own.
+On D5's note surfacing: post-hook reason notes are collected by the hook
+runner and attached to the returned tool-call event's metadata. The stronger
+D5 shape, surfacing them into the branch as a system-visible message, belongs
+to the external-hook adapter layer above and remains unbuilt with it.

--- a/docs/adr/ADR-0088-plugin-system.md
+++ b/docs/adr/ADR-0088-plugin-system.md
@@ -1,6 +1,6 @@
 # ADR-0088: Plugin system (directory-bundle manifest with lazy activation)
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Area**: substrates
 - **Date**: 2026-07-12
@@ -436,3 +436,74 @@ The design, recorded in full for the follow-up:
   dual manifests per the Consequences note.
 - The `x-` manifest-key escape hatch exists so downstream tooling can annotate
   bundles (provenance stamps, registry metadata) without schema violations.
+
+## Implementation status (2026-07-13)
+
+As of 2026-07-13, this ADR is materially further along than ADR-0048, with the
+bundle format, manifest schema, two-stage laziness, and trust boundary fully
+implemented and tested, and three of five declared consumer surfaces wired
+end-to-end.
+
+**Implemented and tested:**
+
+- **D1, bundle shape and discovery.** The directory-bundle layout under
+  `.lionagi/plugins/<name>/plugin.yaml`, discovery via `find_lionagi_dirs()` in
+  project-then-global order, missing-manifest-is-ignored, schema-failure-is-
+  excluded-not-partial, and the path-traversal check on every bundle-relative
+  reference are all implemented and covered by dedicated tests.
+- **D2, manifest schema.** The `name` pattern, the `version`/`lionagi:`
+  compatibility-specifier gate, the six capability fields (tools,
+  `hooks_external`, agents, playbooks, providers, packs), the
+  parse-imports-nothing guarantee, and the unknown-key-errors-except-`x-`-
+  prefix rule are all implemented and tested.
+- **D3, two-stage laziness.** Manifest discovery stays data-only; code import
+  is deferred to first use of a specific capability; `import lionagi` alone
+  triggers neither stage, verified by a dedicated import-laziness test. Three
+  of the five named consumer trigger points are wired end-to-end with tests:
+  the `ActionManager` tool-name-miss path, the endpoint registry's
+  match-miss interception before the generic OpenAI-compatible fallback, and
+  agent-profile resolution miss. A per-plugin failed-import cache (distinct
+  from the built-in provider loader's memoryless swallow-and-continue
+  behavior) is implemented and tested.
+- **D5, trust.** An untrusted plugin is fully inert across every consumer
+  path; the `li plugin trust` display contract renders every declared
+  capability (tool targets, hook argv, agent/playbook/pack files) without
+  truncation before approval; the trust hash pins the manifest plus every
+  declared file, not only executables, which is exercised by a test proving
+  non-executable files are pinned too; and trust records are written to
+  user-level settings, never project-level. This is the most rigorously
+  implemented and tested section of either ADR-0048 or ADR-0088.
+- **D6, collisions (partial) and D7, lifecycle.** Two enabled plugins
+  declaring the same tool name raise a hard collision error; a plugin colliding
+  with a user's own local agent-profile file resolves to the user's file with
+  a logged warning; and the full `li plugin list/info/trust/enable/disable`
+  command set is implemented, with disable implemented as a settings flag that
+  leaves the bundle directory untouched, matching the ADR's stated design.
+  Namespacing (`<plugin>/<name>`) is implemented and tested for agent profiles.
+
+**Known gaps:**
+
+- **Playbook discovery is not unified onto `find_lionagi_dirs()`.** Playbook
+  resolution still globs only the global `~/.lionagi/playbooks/` directory and
+  has no awareness of project-local or plugin-provided playbooks. The path
+  validator on the playbook-name argument rejects any component containing a
+  `/`, which is exactly the shape of the `<plugin>/<name>` token this ADR
+  specifies for referencing a plugin-provided playbook — so today that token
+  is rejected outright, not merely left unresolved. This is the one consumer
+  trigger point named in D3 that has not been started, and it also leaves the
+  playbook half of D6's namespacing commitment unimplemented (the agent-profile
+  half is done).
+- **The `hooks_external` capability has no runtime consumer.** A plugin's
+  `hooks_external` block is parsed, path-validated, and content-hashed for
+  trust, and rendered in `li plugin info`/`trust` output, but nothing joins it
+  into the session hook bus or agent-factory hook wiring. This is a direct
+  consequence of ADR-0048's external-hook execution layer not existing yet
+  (see that ADR's own implementation-status annex): a plugin's declared hooks
+  have nowhere to attach until that layer lands.
+- Two smaller, contained gaps: providers and tools have no explicit,
+  user-facing diagnostic when a plugin capability collides with an
+  already-registered built-in — the safety property holds today only because
+  the plugin-consultation branch is structurally unreachable once a built-in
+  match succeeds, not because a rejection path was exercised and reported; and
+  trust records for a plugin whose directory has since been deleted are not
+  garbage-collected, so they persist indefinitely in the user's settings file.


### PR DESCRIPTION
Both ADRs carried Status: Proposed despite five merged feature PRs implementing large parts of them — the design decisions are de facto accepted, and the status line was the fiction. Flipped to Accepted, each with an "Implementation status (2026-07-13)" annex putting the gap on record instead of leaving it implied.

- **ADR-0048** annex: turn-origin verification (D2) and the ActionManager chokepoint (D3) implemented and tested; decision semantics/event mapping/fail-closed timeout exist as in-process analogs only; the namesake capability — executing an external Claude-Code/Codex-shaped hook binary — does not exist yet (no wire envelope, exec adapter, settings surface, import/trust commands, or conformance matrix). Post-hook reason notes are described at their current metadata seam.
- **ADR-0088** annex: bundle format, manifest schema, two-stage laziness, and the content-pinned trust boundary implemented and tested; three of five consumer trigger points wired end-to-end. Gaps on record: playbook discovery not unified onto find_lionagi_dirs() (the path validator rejects the plugin-qualified name token outright), hooks_external parsed but with zero runtime consumer, no built-in-collision diagnostic, no trust-record GC.

Every annex claim was re-verified against source at HEAD before writing (test suites re-run: 250 passed). markdownlint and the ADR status-set check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)