### PR TITLE
feat(state): add nullable resume_packet column to schedule_runs

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1253,7 +1253,8 @@ class StateDB:
                       execution_target       TEXT,
                       library_ref             TEXT,
                       library_content_hash    TEXT,
-                      dispatched_at           REAL
+                      dispatched_at           REAL,
+                      resume_packet           JSON
                     )
                     """
                 )
@@ -2510,6 +2511,7 @@ class StateDB:
             "error_detail",
             "invocation_id",
             "dispatched_at",
+            "resume_packet",
         }
         bad = set(fields) - allowed
         if bad:
@@ -2543,11 +2545,11 @@ class StateDB:
             sets = ", ".join(f'"{k}" = :{k}' for k in fields)
             params = dict(fields)
             params["_id"] = run_id
+            stmt = text(f"UPDATE schedule_runs SET {sets} WHERE id = :_id")  # noqa: S608
+            if "resume_packet" in fields:
+                stmt = stmt.bindparams(bindparam("resume_packet", type_=JSON))
             async with self._tx() as conn:
-                await conn.execute(
-                    text(f"UPDATE schedule_runs SET {sets} WHERE id = :_id"),  # noqa: S608
-                    params,
-                )
+                await conn.execute(stmt, params)
 
     async def list_schedule_runs(
         self,
@@ -4459,6 +4461,7 @@ class StateDB:
             "artifact_verification_json",
             "status_evidence_refs",
             "payload",
+            "resume_packet",
         ):
             if key in d and isinstance(d[key], str):
                 try:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -533,7 +533,11 @@ CREATE TABLE IF NOT EXISTS schedule_runs (
   -- distinguish "crashed before dispatch, safe to re-fire" from
   -- "dispatched, outcome merely lost" (see SchedulerEngine._fire_inner and
   -- SchedulerEngine._recover_undispatched_fires).
-  dispatched_at           REAL
+  dispatched_at           REAL,
+  -- Nullable sidecar metadata blob for resuming a run, shaped like an
+  -- Element.to_dict(mode="db") payload (arbitrary JSON-serializable dict).
+  -- NULL means no resume state has been captured for this run.
+  resume_packet           JSON
 );
 
 CREATE INDEX IF NOT EXISTS idx_sched_runs_schedule

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -611,6 +611,10 @@ schedule_runs = Table(
     # the external process for this occurrence was actually launched. See
     # the schema.sql CREATE TABLE comment for the full rationale.
     Column("dispatched_at", Float),
+    # Nullable sidecar metadata blob for resuming a run, shaped like an
+    # Element.to_dict(mode="db") payload. NULL means no resume state has
+    # been captured for this run.
+    Column("resume_packet", JSON),
 )
 
 Index("idx_sched_runs_schedule", schedule_runs.c.schedule_id, schedule_runs.c.fired_at)

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -134,6 +134,10 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         # row whose occurrence-insert transaction committed but launch was
         # never confirmed -- see the CREATE TABLE comment in schema.sql.
         ("dispatched_at", "REAL"),
+        # Nullable sidecar metadata blob for resuming a run, shaped like an
+        # Element.to_dict(mode="db") payload. NULL means no resume state
+        # has been captured for this run.
+        ("resume_packet", "JSON"),
     ],
     # Phase C Move 2: engine run persistence.
     # New table created via schema.sql; these columns allow ALTER TABLE on

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -762,6 +762,10 @@ _EXCLUDED_COLUMNS = {
     # confirmed dispatch); excluded here for the same reason as the D2
     # columns above.
     "dispatched_at",
+    # Resume-packet sidecar metadata blob — additive, asserted separately
+    # (must be NULL for a schedule-spawned run that never set it); excluded
+    # here for the same reason as the D2 columns above.
+    "resume_packet",
 }
 
 
@@ -815,6 +819,7 @@ async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
         "library_ref",
         "library_content_hash",
         "dispatched_at",
+        "resume_packet",
     ):
         assert row_after_create[col] is None
     # ADR-0071 D4 additive column — defaults to 0, not NULL.

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -533,7 +533,7 @@ async def test_max_runs_nullable_defaults_unlimited():
     await state.close()
 
 
-# ── resume_packet round-trip (PR 1 — resume_packet column) ──────────────────
+# ── resume_packet round-trip ─────────────────────────────────────────────────
 
 
 async def test_resume_packet_roundtrips_as_dict():

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -246,6 +246,25 @@ async def test_schedule_runs_upgrade_path(old_schema_db):
     assert adr28_cols <= actual, f"Missing cols: {adr28_cols - actual}"
 
 
+async def test_schedule_runs_upgrade_path_gains_resume_packet(old_schema_db):
+    """After upgrade, an existing schedule_runs table gains resume_packet."""
+    db = old_schema_db
+
+    for table, columns in MIGRATION_COLUMNS.items():
+        cur = await db.execute(f"PRAGMA table_info({table})")
+        rows = await cur.fetchall()
+        if not rows:
+            continue
+        existing = {row["name"] for row in rows}
+        for name, defn in columns:
+            if name not in existing:
+                await db.execute(f"ALTER TABLE {table} ADD COLUMN {name} {defn}")
+    await db.commit()
+
+    actual = await _column_names(db, "schedule_runs")
+    assert "resume_packet" in actual
+
+
 async def test_schedules_upgrade_path_gains_budget_columns(old_schema_db):
     """After upgrade, an existing schedules table gains budget_usd/budget_tokens."""
     db = old_schema_db
@@ -510,5 +529,127 @@ async def test_max_runs_nullable_defaults_unlimited():
     )
     fetched = await state.get_schedule("sched-unlimited")
     assert fetched["max_runs"] is None
+
+    await state.close()
+
+
+# ── resume_packet round-trip (PR 1 — resume_packet column) ──────────────────
+
+
+async def test_resume_packet_roundtrips_as_dict():
+    """A dict-shaped resume_packet written via update_schedule_run reads back
+    identical via get_schedule_run, mirroring an Element.to_dict(mode="db")
+    sidecar payload."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-resume-1",
+            "name": "resume-test-1",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    await state.create_schedule_run(
+        {
+            "id": "run-resume-1",
+            "schedule_id": "sched-resume-1",
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": {},
+            "status": "running",
+            "fired_at": 1.0,
+        }
+    )
+
+    packet = {
+        "lion_class": "lionagi.protocols.generic.element.Element",
+        "id": "elem-1",
+        "created_at": 1700000000.0,
+        "metadata": {"turn": 3, "tags": ["a", "b"]},
+    }
+    await state.update_schedule_run(
+        "run-resume-1",
+        resume_packet=packet,
+    )
+
+    fetched = await state.get_schedule_run("run-resume-1")
+    assert fetched is not None
+    assert fetched["resume_packet"] == packet
+
+    await state.close()
+
+
+async def test_resume_packet_null_roundtrips_as_none():
+    """A schedule_run created without resume_packet stores NULL, which reads
+    back as None, not a JSON-decode error or empty dict."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-resume-2",
+            "name": "resume-test-2",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    await state.create_schedule_run(
+        {
+            "id": "run-resume-2",
+            "schedule_id": "sched-resume-2",
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": {},
+            "status": "running",
+            "fired_at": 1.0,
+        }
+    )
+
+    fetched = await state.get_schedule_run("run-resume-2")
+    assert fetched is not None
+    assert fetched["resume_packet"] is None
+
+    await state.close()
+
+
+async def test_update_schedule_run_rejects_unknown_field():
+    """update_schedule_run's field allowlist still rejects unrecognized
+    fields — resume_packet joining the allowed set must not widen it."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-resume-3",
+            "name": "resume-test-3",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    await state.create_schedule_run(
+        {
+            "id": "run-resume-3",
+            "schedule_id": "sched-resume-3",
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": {},
+            "status": "running",
+            "fired_at": 1.0,
+        }
+    )
+
+    with pytest.raises(ValueError, match="Invalid schedule_run field"):
+        await state.update_schedule_run("run-resume-3", not_a_real_field="x")
 
     await state.close()


### PR DESCRIPTION
## Summary

First rung of the operating-layer ladder (SPEC: `.khive/workspaces/20260713/operating-layer-packet/SPEC.md`, signed): adds a nullable `resume_packet` JSON column to `schedule_runs` so a submission can carry a structured resume/context packet that survives into the run row and round-trips through the read surface.

Pure additive schema + plumbing — no behavior change for existing writers, no new verbs.

## Mechanism

`schedule_runs` columns must stay in sync at **four** sites, all covered here:

1. `lionagi/state/schema.sql` — canonical DDL
2. `lionagi/state/schema_meta.py` — SQLAlchemy `Table` (JSON type)
3. `lionagi/state/schema_migrations.py` — `MIGRATION_COLUMNS` additive migration entry
4. `lionagi/state/db.py` — `_drop_legacy_schedule_runs_check()`'s literal `schedule_runs_new` rebuild DDL

Plus write/read plumbing:

- `update_schedule_run` allowlist accepts `resume_packet` with `bindparam(..., type_=JSON)` so dict payloads serialize correctly on both SQLite and Postgres.
- `_row_to_dict` JSON-decodes the column on read (SQLite returns TEXT).

## Tests

- Round-trip tests (dict packet in → dict out; NULL default) in `tests/state/test_migrations.py`
- Fresh-schema vs migrated-schema column parity
- Golden-schema updates in `tests/state/test_adr0101_task_queue_migration.py`
- `tests/state/`: 696 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
