### PR TITLE
fix(cli,providers,state): classify provider failures into retryable/non-retryable reason codes + preflight bad CLI-endpoint specs

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -295,6 +295,13 @@ def resolve_run_reason(
             None,
         )
     if exception is not None:
+        if isinstance(exception, ProviderError):
+            code = (
+                RunReasons.FAILED_PROVIDER_RETRYABLE
+                if exception.retryable
+                else RunReasons.FAILED_PROVIDER_NONRETRYABLE
+            )
+            return code, f"{type(exception).__name__}: {exception}", None
         return RunReasons.FAILED_EXCEPTION, f"{type(exception).__name__}: {exception}", None
     return RunReasons.FAILED_EXCEPTION, "Run failed.", None
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -369,6 +369,26 @@ async def _run_agent(
                 chat_model=chat_model,
                 log_config=DataLoggerConfig(auto_save_on_exit=False),
             )
+
+        # Fail fast: `li agent` only drives CLI-backed providers (the `run`
+        # operation raises this same ValueError deep inside
+        # operations/run/run.py once the turn is already streaming).
+        # Catching a bare/mistyped model spec here — before
+        # allocate_run/setup_agent_persist — means a bad provider prefix
+        # (e.g. 'gpt-5.3-codex-spark' instead of 'codex/gpt-5.3-codex-spark')
+        # never allocates a run or persists a session that would otherwise be
+        # recorded as a failed reliability event. Scoped to a brand-new
+        # branch only: a --resume/--continue-last model override changes
+        # only the model name under the branch's existing (already-CLI)
+        # provider, never the provider itself, so it can't regress this way.
+        if not branch.chat_model.is_cli:
+            cli_provider = getattr(branch.chat_model.endpoint.config, "provider", provider)
+            raise ConfigurationError(
+                f"run operation only supports CLI endpoints, but got provider={cli_provider!r}. "
+                "Use one of the CLI endpoint prefixes: claude_code, codex, gemini-cli, pi. "
+                "Did you mean 'gemini-cli/<model>' instead of 'gemini/<model>'? "
+                "The 'gemini' prefix routes to the REST API, not the local Gemini CLI."
+            )
     else:
         cfg = branch.chat_model.endpoint.config.kwargs
         if model_str is not None:

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -6,12 +6,23 @@
 from __future__ import annotations
 
 import re
+from typing import ClassVar
 
 # --- Base hierarchy ---
 
 
 class ProviderError(RuntimeError):
-    """Generic error surfaced by a CLI provider subprocess."""
+    """Generic error surfaced by a CLI provider subprocess.
+
+    ``retryable`` is a class-level classification hint (not a retry
+    implementation): True for failures that are transient in nature (rate
+    limits, capacity, dropped streams), False for failures that will recur
+    on an unmodified retry (bad credentials, unsupported model/tool, context
+    overflow, safety rejection). Callers that add retry/backoff logic later
+    can key off this attribute instead of re-deriving it from the message.
+    """
+
+    retryable: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -28,6 +39,8 @@ class ProviderError(RuntimeError):
 class ProviderQuotaError(ProviderError):
     """The provider CLI rejected the request due to usage/rate limits."""
 
+    retryable: ClassVar[bool] = True
+
 
 class ProviderAuthError(ProviderError):
     """The provider CLI rejected the request due to invalid credentials."""
@@ -35,6 +48,35 @@ class ProviderAuthError(ProviderError):
 
 class ProviderContextError(ProviderError):
     """The provider CLI rejected the request because the context is too long."""
+
+
+class ProviderCapacityError(ProviderError):
+    """The provider CLI rejected the request because the selected model is at capacity."""
+
+    retryable: ClassVar[bool] = True
+
+
+class ProviderUnsupportedModelError(ProviderError):
+    """The provider CLI rejected the request because the model or tool is not
+    supported for the current account/configuration (e.g. a model name the
+    signed-in account tier cannot use, or a tool the model doesn't support)."""
+
+
+class ProviderSafetyError(ProviderError):
+    """The provider CLI rejected the request because content was flagged by a safety filter."""
+
+
+class ProviderStreamDisconnectError(ProviderError):
+    """The provider CLI's stream disconnected before the turn completed (network drop, idle timeout)."""
+
+    retryable: ClassVar[bool] = True
+
+
+class ProviderAdapterError(ProviderError):
+    """A CLI adapter reported a non-success status with no more specific cause
+    identified from the message text (e.g. an `agy` turn ending status=ERROR)."""
+
+    retryable: ClassVar[bool] = True
 
 
 class WorkerLivenessError(ProviderError):
@@ -79,6 +121,11 @@ _QUOTA_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"usage\s+limit\s+reached", re.IGNORECASE),
     re.compile(r"rate[\s._-]?limit[\s._-]?exceeded", re.IGNORECASE),
     re.compile(r"try\s+again\s+at\s+\d", re.IGNORECASE),
+    # Date-formatted retry times ("try again at Jul 6th, 2026 11:08 PM") don't
+    # have a digit immediately after "at", so the pattern above misses them —
+    # match the quota phrasing itself instead of the retry-time suffix.
+    re.compile(r"hit\s+your\s+usage\s+limit", re.IGNORECASE),
+    re.compile(r"purchase\s+more\s+credits", re.IGNORECASE),
 ]
 
 _AUTH_PATTERNS: list[re.Pattern[str]] = [
@@ -89,6 +136,34 @@ _AUTH_PATTERNS: list[re.Pattern[str]] = [
 
 _CONTEXT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"context[\s._-]?(window|length)[\s._-]?(exceeded|too\s+long)", re.IGNORECASE),
+    # "Codex ran out of room in the model's context window." never uses the
+    # exceeded/too-long wording the pattern above expects.
+    re.compile(r"ran\s+out\s+of\s+room.*context\s+window", re.IGNORECASE),
+]
+
+_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"model\s+is\s+at\s+capacity", re.IGNORECASE),
+]
+
+_UNSUPPORTED_MODEL_PATTERNS: list[re.Pattern[str]] = [
+    # Covers both "the '<model>' model is not supported when using Codex with
+    # a ChatGPT account" and "Tool '<name>' is not supported with <model>".
+    re.compile(r"is\s+not\s+supported", re.IGNORECASE),
+]
+
+_SAFETY_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"flagged\s+for\s+(possible\s+)?cybersecurity\s+risk", re.IGNORECASE),
+]
+
+_STREAM_DISCONNECT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"stream\s+disconnected\s+before\s+completion", re.IGNORECASE),
+]
+
+# Catch-all for adapters (e.g. `agy`) that report a bare non-success status
+# with no parseable cause in the message. Checked last — a more specific
+# pattern above always wins when the adapter's own text names one.
+_ADAPTER_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"agy\s+returned\s+status=", re.IGNORECASE),
 ]
 
 
@@ -111,5 +186,25 @@ def classify_provider_error(
     for pat in _CONTEXT_PATTERNS:
         if pat.search(combined):
             return ProviderContextError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _CAPACITY_PATTERNS:
+        if pat.search(combined):
+            return ProviderCapacityError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _UNSUPPORTED_MODEL_PATTERNS:
+        if pat.search(combined):
+            return ProviderUnsupportedModelError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _SAFETY_PATTERNS:
+        if pat.search(combined):
+            return ProviderSafetyError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _STREAM_DISCONNECT_PATTERNS:
+        if pat.search(combined):
+            return ProviderStreamDisconnectError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _ADAPTER_PATTERNS:
+        if pat.search(combined):
+            return ProviderAdapterError(content, stderr_tail=stderr_tail, raw=content)
 
     return ProviderError(content, stderr_tail=stderr_tail, raw=content)

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -146,9 +146,13 @@ _CAPACITY_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 _UNSUPPORTED_MODEL_PATTERNS: list[re.Pattern[str]] = [
-    # Covers both "the '<model>' model is not supported when using Codex with
-    # a ChatGPT account" and "Tool '<name>' is not supported with <model>".
-    re.compile(r"is\s+not\s+supported", re.IGNORECASE),
+    # "the '<model>' model is not supported when using Codex with a ChatGPT
+    # account" — anchored on "model" so an incidental "is not supported"
+    # inside a transient message (e.g. a dropped-stream notice mentioning
+    # reconnect support) is not misread as a permanent model rejection.
+    re.compile(r"model\s+is\s+not\s+supported", re.IGNORECASE),
+    # "Tool '<name>' is not supported with <model>".
+    re.compile(r"tool\s+'[^']+'\s+is\s+not\s+supported", re.IGNORECASE),
 ]
 
 _SAFETY_PATTERNS: list[re.Pattern[str]] = [

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -63,6 +63,12 @@ class RunReasons:
     COMPLETED_OK = "run.completed.ok"
     FAILED_EXIT_NONZERO = "run.failed.exit_nonzero"
     FAILED_EXCEPTION = "run.failed.exception"
+    # A terminal ProviderError (provider CLI subprocess failure) classified
+    # by lionagi.providers._provider_errors.classify_provider_error, split by
+    # its retryable classification (rate limit / capacity / dropped stream vs
+    # bad credentials / unsupported model / context overflow / safety block).
+    FAILED_PROVIDER_RETRYABLE = "run.failed.provider_retryable"
+    FAILED_PROVIDER_NONRETRYABLE = "run.failed.provider_nonretryable"
     FAILED_MISSING_ARTIFACT = "run.failed.missing_artifact"  # ADR-0029
     # The schedule's persisted execution root (action_cwd) or its
     # action_project's registered path no longer existed at fire time (e.g.

--- a/tests/cli/test_agent_cli_endpoint_preflight.py
+++ b/tests/cli/test_agent_cli_endpoint_preflight.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li agent <model> <prompt>` with a non-CLI provider (e.g. a bare
+'gpt-5.3-codex-spark' instead of 'codex/gpt-5.3-codex-spark') must fail fast,
+before any run is allocated or persisted — instead of allocating a run,
+persisting a session, and only then failing deep inside operations/run/run.py
+once the turn is already streaming, which records a spurious reliability
+failure for what is actually a CLI usage error.
+
+Covers the preflight guard wired into `_run_agent` right before
+`allocate_run()`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi._errors import ConfigurationError
+
+# ---------------------------------------------------------------------------
+# _run_agent: fails before any spawn / run allocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_rejects_non_cli_provider_before_any_spawn(monkeypatch):
+    """A model spec resolving to a non-CLI provider must raise before
+    allocate_run/setup_agent_persist ever run — i.e. before any run record
+    could be created."""
+    import lionagi.cli.agent as agent_mod
+
+    def _boom_allocate_run():
+        raise AssertionError(
+            "allocate_run must not be reached — CLI-endpoint validation must fire first"
+        )
+
+    monkeypatch.setattr(agent_mod, "allocate_run", _boom_allocate_run)
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await _run_agent("openai/gpt-4.1-mini", "do the thing")
+
+    msg = str(exc_info.value)
+    assert "only supports CLI endpoints" in msg
+    assert "openai" in msg
+
+
+@pytest.mark.asyncio
+async def test_run_agent_non_cli_provider_message_names_cli_prefixes(monkeypatch):
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: (_ for _ in ()).throw(AssertionError("must not reach allocate_run")),
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await _run_agent("openai/gpt-4.1-mini", "do the thing")
+
+    msg = str(exc_info.value)
+    for prefix in ("claude_code", "codex", "gemini-cli", "pi"):
+        assert prefix in msg
+
+
+@pytest.mark.asyncio
+async def test_run_agent_accepts_cli_provider_and_reaches_allocate_run(monkeypatch, tmp_path):
+    """Regression guard: a genuine CLI-backed model must not be rejected —
+    the preflight only fires for a non-CLI endpoint."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/model")
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    reached = {"allocate_run": False}
+
+    def _fake_allocate_run():
+        reached["allocate_run"] = True
+        return SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        )
+
+    monkeypatch.setattr(agent_mod, "allocate_run", _fake_allocate_run)
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, *, status="completed", **kw):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+
+    _result, _provider, _bid, terminal_status, _sid = await agent_mod._run_agent(
+        "codex/model", "do the thing"
+    )
+
+    assert terminal_status == "completed"
+    assert reached["allocate_run"] is True

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -181,6 +181,23 @@ def test_classify_unsupported_tool_returns_unsupported_error():
     assert isinstance(err, ProviderUnsupportedModelError)
 
 
+def test_stream_disconnect_mentioning_unsupported_reconnect_stays_retryable():
+    err = classify_provider_error(
+        "stream disconnected before completion; automatic reconnect is not supported by the proxy"
+    )
+    assert isinstance(err, ProviderStreamDisconnectError)
+    assert err.retryable is True
+
+
+def test_agy_wrapped_stream_disconnect_stays_retryable():
+    err = classify_provider_error(
+        "agy returned status=ERROR: stream disconnected before completion; "
+        "automatic reconnect is not supported by the proxy"
+    )
+    assert isinstance(err, ProviderStreamDisconnectError)
+    assert err.retryable is True
+
+
 # ---------------------------------------------------------------------------
 # Safety patterns
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -3,7 +3,11 @@
 
 """Unit tests for lionagi/providers/_provider_errors.py.
 
-classify_provider_error matches quota/auth/context patterns case-insensitively; unmatched text returns base ProviderError; all subclasses are RuntimeError; EmissionError attrs preserved.
+classify_provider_error matches quota/auth/context/capacity/unsupported-model/
+safety/stream-disconnect/adapter patterns case-insensitively; unmatched text
+returns base ProviderError; all subclasses are RuntimeError; EmissionError
+attrs preserved; the retryable classification is grounded in real
+`li agent`/`li o flow` failure-message signatures.
 """
 
 from __future__ import annotations
@@ -12,10 +16,15 @@ import pytest
 
 from lionagi.providers._provider_errors import (
     EmissionError,
+    ProviderAdapterError,
     ProviderAuthError,
+    ProviderCapacityError,
     ProviderContextError,
     ProviderError,
     ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderStreamDisconnectError,
+    ProviderUnsupportedModelError,
     classify_provider_error,
 )
 
@@ -107,6 +116,125 @@ def test_classify_context_case_insensitive():
     assert isinstance(err, ProviderContextError)
 
 
+def test_classify_codex_ran_out_of_room_returns_context_error():
+    """Real cohort signature: Codex's own context-overflow message never uses
+    the exceeded/too-long wording — grounded in `li agent` telemetry."""
+    err = classify_provider_error(
+        "Codex ran out of room in the model's context window. Start a new "
+        "thread or clear earlier history before retrying."
+    )
+    assert isinstance(err, ProviderContextError)
+    assert err.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Quota — date-formatted retry time (real cohort gap: no digit after "at")
+# ---------------------------------------------------------------------------
+
+
+def test_classify_usage_limit_with_date_formatted_retry_time():
+    err = classify_provider_error(
+        "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage "
+        "to purchase more credits or try again at Jul 6th, 2026 11:08 PM."
+    )
+    assert isinstance(err, ProviderQuotaError)
+    assert err.retryable is True
+
+
+def test_classify_hit_your_usage_limit_returns_quota_error():
+    err = classify_provider_error(
+        "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now."
+    )
+    assert isinstance(err, ProviderQuotaError)
+
+
+# ---------------------------------------------------------------------------
+# Capacity patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_model_at_capacity_returns_capacity_error():
+    err = classify_provider_error("Selected model is at capacity. Please try a different model.")
+    assert isinstance(err, ProviderCapacityError)
+    assert err.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Unsupported model/tool patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_unsupported_model_for_account_returns_unsupported_error():
+    err = classify_provider_error(
+        '{"type":"error","status":400,"error":{"type":"invalid_request_error",'
+        '"message":"The \'gpt-5.6\' model is not supported when using Codex '
+        'with a ChatGPT account."}}'
+    )
+    assert isinstance(err, ProviderUnsupportedModelError)
+    assert err.retryable is False
+
+
+def test_classify_unsupported_tool_returns_unsupported_error():
+    err = classify_provider_error(
+        "Tool 'image_generation' is not supported with gpt-5.3-codex-spark-1p."
+    )
+    assert isinstance(err, ProviderUnsupportedModelError)
+
+
+# ---------------------------------------------------------------------------
+# Safety patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_cybersecurity_safety_block_returns_safety_error():
+    err = classify_provider_error(
+        "This content was flagged for possible cybersecurity risk. If this "
+        "seems wrong, try rephrasing your request."
+    )
+    assert isinstance(err, ProviderSafetyError)
+    assert err.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Stream-disconnect patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_stream_disconnected_returns_stream_disconnect_error():
+    err = classify_provider_error(
+        "Reconnecting... 2/5 (stream disconnected before completion: idle "
+        "timeout waiting for websocket)"
+    )
+    assert isinstance(err, ProviderStreamDisconnectError)
+    assert err.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Adapter catch-all (agy) — only fires when nothing more specific matches
+# ---------------------------------------------------------------------------
+
+
+def test_classify_agy_generic_error_status_returns_adapter_error():
+    err = classify_provider_error("agy returned status=ERROR")
+    assert isinstance(err, ProviderAdapterError)
+    assert err.retryable is True
+
+
+def test_classify_agy_status_with_substantial_content_returns_adapter_error():
+    err = classify_provider_error(
+        "agy returned status=ERROR: I will start by checking the git show of "
+        "the specified commit to understand the changes."
+    )
+    assert isinstance(err, ProviderAdapterError)
+
+
+def test_classify_agy_quota_message_still_wins_over_adapter_catchall():
+    """A more specific pattern embedded in an agy payload must classify as
+    that specific error, not fall through to the generic adapter bucket."""
+    err = classify_provider_error("agy returned status=ERROR: hit your usage limit")
+    assert isinstance(err, ProviderQuotaError)
+
+
 # ---------------------------------------------------------------------------
 # Unmatched → base ProviderError (not a subclass)
 # ---------------------------------------------------------------------------
@@ -155,6 +283,44 @@ def test_emission_error_is_runtime_error():
 def test_classify_result_is_runtime_error():
     err = classify_provider_error("usage limit reached")
     assert isinstance(err, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# retryable classification — the machine-readable retry/non-retry split
+# ---------------------------------------------------------------------------
+
+
+def test_base_provider_error_defaults_to_non_retryable():
+    assert ProviderError.retryable is False
+    assert ProviderError("unclassified").retryable is False
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        ProviderQuotaError,
+        ProviderCapacityError,
+        ProviderStreamDisconnectError,
+        ProviderAdapterError,
+    ],
+)
+def test_transient_classes_are_retryable(cls):
+    assert cls.retryable is True
+    assert cls("msg").retryable is True
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        ProviderAuthError,
+        ProviderContextError,
+        ProviderUnsupportedModelError,
+        ProviderSafetyError,
+    ],
+)
+def test_permanent_classes_are_non_retryable(cls):
+    assert cls.retryable is False
+    assert cls("msg").retryable is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -517,6 +517,49 @@ class TestTeardownReasonResolution:
         assert "ValueError" in summary
         assert "bad input" in summary
 
+    def test_non_provider_exception_stays_generic_failed_exception(self):
+        """A plain RuntimeError (not a classified ProviderError) must keep the
+        generic bucket — only provider-classified failures get the retryable
+        split below."""
+        from lionagi.cli._runs import resolve_run_reason as _resolve_run_reason
+
+        code, _, _ = _resolve_run_reason(status="failed", exception=RuntimeError("boom"))
+        assert code == RunReasons.FAILED_EXCEPTION
+
+    @pytest.mark.parametrize(
+        "cls_name,message,expected",
+        [
+            ("ProviderQuotaError", "usage limit reached", "retryable"),
+            ("ProviderCapacityError", "model is at capacity", "retryable"),
+            ("ProviderStreamDisconnectError", "stream disconnected before completion", "retryable"),
+            ("ProviderAdapterError", "agy returned status=ERROR", "retryable"),
+            ("ProviderAuthError", "not logged in", "nonretryable"),
+            ("ProviderContextError", "context window exceeded", "nonretryable"),
+            ("ProviderUnsupportedModelError", "model is not supported", "nonretryable"),
+            ("ProviderSafetyError", "flagged for cybersecurity risk", "nonretryable"),
+        ],
+    )
+    def test_classified_provider_error_maps_to_retryable_reason_code(
+        self, cls_name, message, expected
+    ):
+        """A terminal ProviderError subclass must carry a reason code that
+        distinguishes retryable from non-retryable — the rank-2 reliability
+        cohort's classification requirement (ADR-0057 vocabulary)."""
+        import lionagi.providers._provider_errors as provider_errors
+        from lionagi.cli._runs import resolve_run_reason as _resolve_run_reason
+
+        error_cls = getattr(provider_errors, cls_name)
+        code, summary, _ = _resolve_run_reason(status="failed", exception=error_cls(message))
+
+        expected_code = (
+            RunReasons.FAILED_PROVIDER_RETRYABLE
+            if expected == "retryable"
+            else RunReasons.FAILED_PROVIDER_NONRETRYABLE
+        )
+        assert code == expected_code
+        assert code in VALID_REASON_CODES
+        assert cls_name in summary
+
 
 # ── ADR-0057 Phase 2: invocation transition writes reason ────────────
 

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -537,6 +537,8 @@ class TestTeardownReasonResolution:
             ("ProviderContextError", "context window exceeded", "nonretryable"),
             ("ProviderUnsupportedModelError", "model is not supported", "nonretryable"),
             ("ProviderSafetyError", "flagged for cybersecurity risk", "nonretryable"),
+            # The unclassified base class defaults to non-retryable.
+            ("ProviderError", "something unrecognized went wrong", "nonretryable"),
         ],
     )
     def test_classified_provider_error_maps_to_retryable_reason_code(


### PR DESCRIPTION
## Summary

Reliability follow-up (rank 2 of the failure-telemetry report): the 80-failure cohort in the run ledger showed every provider-CLI failure collapsing into the generic `run.failed.exception` bucket, and 5 runs allocated/persisted before dying on an obviously mis-typed model spec. This PR classifies terminal provider failures into retryable/non-retryable reason codes and fails fast on non-CLI endpoint specs before a run is ever allocated.

## Changes

**Reason vocabulary** (`lionagi/state/reasons.py`): `run.failed.provider_retryable` / `run.failed.provider_nonretryable`.

**Classification** (`lionagi/providers/_provider_errors.py`):
- `ProviderError.retryable` ClassVar (default False) — a classification hint, not a retry implementation.
- Five new subclasses grounded in exact message strings observed in the live ledger: `ProviderCapacityError` (retryable), `ProviderUnsupportedModelError`, `ProviderSafetyError`, `ProviderStreamDisconnectError` (retryable), `ProviderAdapterError` (retryable catch-all for bare adapter `status=ERROR`, matched last).
- Widened quota patterns (date-formatted retry times fell through) and context patterns (the "ran out of room in the model's context window" phrasing fell through).

**Wiring** (`lionagi/cli/_runs.py`): `resolve_run_reason` maps a classified `ProviderError` to the retryable/non-retryable code via the class attribute; non-provider exceptions unchanged.

**Preflight** (`lionagi/cli/agent.py`): a new-branch `li agent` invocation whose model resolves to a non-CLI provider raises `ConfigurationError` before `allocate_run()`/persistence — no more phantom failed sessions from a bad provider prefix. Deliberately scoped to the new-branch path only: `--resume`/`--continue-last` overrides swap the model name under the existing (already-CLI) provider, never the provider class, and gating there regressed 11 resume tests during development.

Left unclassified deliberately: 3 ledger records with no persisted exception (nothing to match) and 1 flow-escalation record that already has its own reason code.

## Tests

- `tests/providers/test_provider_errors.py`: classification per new signature + retryable-flag assertions, grounded in the exact ledger strings.
- `tests/state/test_status_reasons.py`: `resolve_run_reason` mapping tests.
- `tests/cli/test_agent_cli_endpoint_preflight.py`: new, mirrors the cwd fail-fast test pattern.
- Targeted trio post main-sync: 102 passed. Full `tests/cli/` + `tests/state/` ran green except pre-existing missing-extra (`asyncpg`) failures verified identical on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
