### PR TITLE
feat(hooks,cli): ADR-0048 external-hook exec layer + li hooks import/trust

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -126,8 +126,13 @@ def _wire_external_hooks(branch: Branch, spec: AgentSpec) -> None:
     The remaining supported events attach to ``branch._hooks`` (a ``HookBus``)
     -- present only once the branch is owned by a ``Session``; a standalone
     branch built via ``create_agent`` has none yet, so those entries are
-    skipped with a warning rather than raising, matching the existing
-    no-hooks-bus-attached behavior elsewhere in the runtime.
+    queued on ``branch._pending_hook_bus_entries`` instead of dropped.
+    ``Branch.attach_hook_bus`` -- the only seam that ever assigns
+    ``branch._hooks`` (``Session.include_branches`` and the lazy
+    ``Session.hooks`` property) -- flushes the queue once a bus exists, so a
+    configured ``UserPromptSubmit``/``SessionStart``/``SessionEnd``/
+    ``PostToolUseFailure`` hook still attaches once this branch joins a
+    ``Session``, rather than silently never firing.
     """
     if not spec.external_hooks:
         return
@@ -160,9 +165,11 @@ def _wire_external_hooks(branch: Branch, spec: AgentSpec) -> None:
         elif branch._hooks is not None:
             branch._hooks.on(event_to_point[entry["event"]], handler)
         else:
-            logger.warning(
-                "hooks_external: %r configured but this branch has no HookBus "
-                "attached (not part of a Session yet) -- skipping until it is",
+            branch._pending_hook_bus_entries.append((event_to_point[entry["event"]], handler))
+            logger.debug(
+                "hooks_external: %r configured on a branch with no HookBus "
+                "attached yet (not part of a Session yet) -- queued for "
+                "attachment once it joins one",
                 entry["event"],
             )
 

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -126,13 +126,15 @@ def _wire_external_hooks(branch: Branch, spec: AgentSpec) -> None:
     The remaining supported events attach to ``branch._hooks`` (a ``HookBus``)
     -- present only once the branch is owned by a ``Session``; a standalone
     branch built via ``create_agent`` has none yet, so those entries are
-    queued on ``branch._pending_hook_bus_entries`` instead of dropped.
-    ``Branch.attach_hook_bus`` -- the only seam that ever assigns
+    queued on ``branch._pending_hook_bus_entries`` instead of dropped, and
+    the queue is kept for the branch's lifetime rather than cleared on
+    first use. ``Branch.attach_hook_bus`` -- the only seam that ever assigns
     ``branch._hooks`` (``Session.include_branches`` and the lazy
-    ``Session.hooks`` property) -- flushes the queue once a bus exists, so a
-    configured ``UserPromptSubmit``/``SessionStart``/``SessionEnd``/
-    ``PostToolUseFailure`` hook still attaches once this branch joins a
-    ``Session``, rather than silently never firing.
+    ``Session.hooks`` property) -- syncs unattached entries onto whichever
+    bus is current, so a configured ``UserPromptSubmit``/``SessionStart``/
+    ``SessionEnd``/``PostToolUseFailure`` hook attaches once this branch
+    joins a ``Session`` and re-attaches if it is later reparented to
+    another one, rather than silently never firing.
     """
     if not spec.external_hooks:
         return
@@ -162,16 +164,20 @@ def _wire_external_hooks(branch: Branch, spec: AgentSpec) -> None:
             branch.acts.add_tool_pre_hook(handler)
         elif entry["event"] == "PostToolUse":
             branch.acts.add_tool_post_hook(handler)
-        elif branch._hooks is not None:
-            branch._hooks.on(event_to_point[entry["event"]], handler)
         else:
             branch._pending_hook_bus_entries.append((event_to_point[entry["event"]], handler))
-            logger.debug(
-                "hooks_external: %r configured on a branch with no HookBus "
-                "attached yet (not part of a Session yet) -- queued for "
-                "attachment once it joins one",
-                entry["event"],
-            )
+            if branch._hooks is not None:
+                # Bus already attached (branch already owned by a Session):
+                # sync this newly queued entry onto it right away, and keep
+                # it tracked so it survives a later reparent to another bus.
+                branch.attach_hook_bus(branch._hooks)
+            else:
+                logger.debug(
+                    "hooks_external: %r configured on a branch with no HookBus "
+                    "attached yet (not part of a Session yet) -- queued for "
+                    "attachment once it joins one",
+                    entry["event"],
+                )
 
 
 def _apply_permissions(spec: AgentSpec) -> None:

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -12,6 +13,8 @@ from lionagi.session.branch import Branch
 from .spec import AgentSpec
 
 __all__ = ("create_agent", "_chain_pre_hooks", "_chain_post_hooks")
+
+logger = logging.getLogger(__name__)
 
 
 async def create_agent(
@@ -107,11 +110,61 @@ async def create_agent(
     _register_tools(branch, spec)
     await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
     _forward_mcp_to_cli_request(branch, spec, trust_project_settings=trust_project_settings)
+    _wire_external_hooks(branch, spec)
 
     if op := spec.emission_operable():
         branch.grant_capabilities(op)
 
     return branch
+
+
+def _wire_external_hooks(branch: Branch, spec: AgentSpec) -> None:
+    """Attach ``hooks_external`` entries (parsed by ``apply_hooks_from_settings``)
+    to the seam their event maps to.
+
+    ``PreToolUse``/``PostToolUse`` attach to ``branch.acts`` (always present).
+    The remaining supported events attach to ``branch._hooks`` (a ``HookBus``)
+    -- present only once the branch is owned by a ``Session``; a standalone
+    branch built via ``create_agent`` has none yet, so those entries are
+    skipped with a warning rather than raising, matching the existing
+    no-hooks-bus-attached behavior elsewhere in the runtime.
+    """
+    if not spec.external_hooks:
+        return
+
+    from lionagi.hooks.bus import HookPoint
+    from lionagi.hooks.external import external_hook_adapter
+
+    session_id = str(branch._owning_session_id or branch.id)
+    event_to_point = {
+        "SessionStart": HookPoint.SESSION_START,
+        "SessionEnd": HookPoint.SESSION_END,
+        "UserPromptSubmit": HookPoint.USER_PROMPT_SUBMIT,
+        "PostToolUseFailure": HookPoint.TOOL_ERROR,
+    }
+
+    for entry in spec.external_hooks:
+        handler = external_hook_adapter(
+            event=entry["event"],
+            command=entry["command"],
+            timeout=entry["timeout"],
+            matcher=entry.get("matcher"),
+            source=entry.get("source"),
+            cwd=spec.cwd,
+            session_id=session_id,
+        )
+        if entry["event"] == "PreToolUse":
+            branch.acts.add_tool_pre_hook(handler)
+        elif entry["event"] == "PostToolUse":
+            branch.acts.add_tool_post_hook(handler)
+        elif branch._hooks is not None:
+            branch._hooks.on(event_to_point[entry["event"]], handler)
+        else:
+            logger.warning(
+                "hooks_external: %r configured but this branch has no HookBus "
+                "attached (not part of a Session yet) -- skipping until it is",
+                entry["event"],
+            )
 
 
 def _apply_permissions(spec: AgentSpec) -> None:

--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -18,6 +18,7 @@ from lionagi.ln._proc import aterminate_process_group
 __all__ = (
     "apply_hooks_from_settings",
     "load_settings",
+    "parse_external_hooks",
 )
 
 import yaml
@@ -73,7 +74,19 @@ def apply_hooks_from_settings(
     *,
     trusted_hook_modules: set[str] | frozenset[str] | None = None,
 ) -> AgentSpec:
-    """Resolve hook specs from settings and register them on the AgentSpec; returns config."""
+    """Resolve hook specs from settings and register them on the AgentSpec; returns config.
+
+    Handles two independent settings blocks: the legacy ``hooks:``
+    ``{pre,post,on_error}`` shape (in-process callables, resolved and
+    attached to ``config.hook_handlers`` right here), and the
+    ``hooks_external:`` block (external commands, parsed and validated here
+    but attached to ``config.external_hooks`` for ``create_agent`` to wire
+    once a ``Branch`` -- and its ``ActionManager``/``HookBus`` -- exists).
+    ``hooks_external:`` here is unrelated to the field of the same name on a
+    plugin manifest (``lionagi.plugins.manifest.Capabilities.hooks_external``),
+    which is parsed as inert data only; this is the block that actually loads
+    and executes.
+    """
     if settings is None:
         settings = load_settings()
 
@@ -98,7 +111,72 @@ def apply_hooks_from_settings(
                 elif phase == "on_error":
                     config.on_error(tool_name, handler)
 
+    external_config = settings.get("hooks_external", {})
+    if external_config:
+        config.external_hooks.extend(parse_external_hooks(external_config))
+
     return config
+
+
+def parse_external_hooks(external_config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse + validate a ``hooks_external:`` block into flat entry dicts.
+
+    Each returned entry is ``{event, matcher, command, timeout, source}``.
+    Raises ``ExternalHookConfigError`` (a ``ValueError`` subtype) at the
+    first unmappable event, non-``command`` type, or invalid argv -- config
+    load fails loud rather than silently dropping a declared guard.
+    """
+    from lionagi.hooks.external import (
+        SUPPORTED_EVENTS,
+        ExternalHookConfigError,
+        validate_argv,
+    )
+
+    if not isinstance(external_config, dict):
+        raise ExternalHookConfigError(
+            f"hooks_external: must be a mapping of event -> matcher groups, got {external_config!r}"
+        )
+
+    entries: list[dict[str, Any]] = []
+    for event, matcher_groups in external_config.items():
+        if event not in SUPPORTED_EVENTS:
+            raise ExternalHookConfigError(
+                f"hooks_external: no seam for event {event!r}; LionAGI has no "
+                f"hook point for it. Supported events: {sorted(SUPPORTED_EVENTS)}"
+            )
+        if not isinstance(matcher_groups, list):
+            matcher_groups = [matcher_groups]
+        for group in matcher_groups:
+            if not isinstance(group, dict):
+                raise ExternalHookConfigError(
+                    f"hooks_external.{event}: entry must be a mapping, got {group!r}"
+                )
+            matcher = group.get("matcher")
+            hook_specs = group.get("hooks", [])
+            if not isinstance(hook_specs, list):
+                hook_specs = [hook_specs]
+            for spec in hook_specs:
+                if not isinstance(spec, dict):
+                    raise ExternalHookConfigError(
+                        f"hooks_external.{event}: hook entry must be a mapping, got {spec!r}"
+                    )
+                hook_type = spec.get("type", "command")
+                if hook_type != "command":
+                    raise ExternalHookConfigError(
+                        f"hooks_external.{event}: unsupported hook type {hook_type!r}; "
+                        "only 'command' is implemented (reserved: http, mcp_tool, prompt)"
+                    )
+                command = validate_argv(spec.get("command"))
+                entries.append(
+                    {
+                        "event": event,
+                        "matcher": matcher,
+                        "command": command,
+                        "timeout": float(spec.get("timeout", 60.0)),
+                        "source": spec.get("source"),
+                    }
+                )
+    return entries
 
 
 def _resolve_hook_spec(

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -71,6 +71,7 @@ class AgentSpec(HooksMixin):
     lion_system: bool = True
     extra_prompt: str | None = None
     hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
+    external_hooks: list[dict[str, Any]] = field(default_factory=list)
     cwd: str | None = None
     yolo: bool = False
     mcp_servers: list[str] | None = None

--- a/lionagi/cli/hooks.py
+++ b/lionagi/cli/hooks.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li hooks` — import Claude Code / Codex hook configs; trust imported hook commands.
+
+``li hooks import claude|codex [path]`` translates a foreign hooks config
+into the project's ``.lionagi/settings.yaml`` ``hooks_external:`` block,
+tagging every entry it writes with ``source: imported:<harness>`` so the
+loader's trust gate (see ``lionagi.hooks.external``) applies to it. This is a
+one-shot import, not a live read: editing the foreign config afterward has no
+effect until ``li hooks import`` runs again.
+
+``li hooks trust`` lists every imported command hook that has no matching
+hash record yet and, on confirmation, records
+``sha256(json.dumps(argv))`` for each into ``~/.lionagi/settings.yaml``'s
+``trusted_hook_commands`` list -- the same file/key the loader reads at
+execution time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+from ._logging import log_error
+
+__all__ = ("add_hooks_subparser", "run_hooks")
+
+# Characters that only have meaning under a shell -- a command string
+# containing any of these cannot be safely tokenized into an argv vector, and
+# is rejected-with-reason rather than reinterpreted (Dv1-3: LionAGI executes
+# argv vectors only, never a shell).
+_SHELL_METACHARACTERS = re.compile(r"""[|&;<>$`\\"'*?\[\]{}~#!\n]""")
+
+_DEFAULT_CONFIG_PATH = {
+    "claude": ".claude/settings.json",
+    "codex": ".codex/hooks.json",
+}
+
+
+def add_hooks_subparser(subparsers: argparse._SubParsersAction) -> None:
+    hooks = subparsers.add_parser(
+        "hooks",
+        help="Import Claude Code / Codex hook configs; trust imported hook commands.",
+        description=(
+            "`li hooks import` translates a foreign hooks config into this "
+            "project's `.lionagi/settings.yaml` `hooks_external:` block. "
+            "`li hooks trust` records approval (content-hashed argv) for the "
+            "imported commands so they are allowed to execute."
+        ),
+    )
+    hooks_sub = hooks.add_subparsers(dest="hooks_command", required=True)
+
+    imp = hooks_sub.add_parser(
+        "import",
+        help="Translate a Claude Code / Codex hooks config into hooks_external:.",
+    )
+    imp.add_argument(
+        "source", choices=("claude", "codex"), help="Which harness's config shape to read."
+    )
+    imp.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help="Path to the config file (defaults to .claude/settings.json or .codex/hooks.json).",
+    )
+    imp.add_argument("--cwd", default=None, help="Project directory (defaults to cwd).")
+
+    trust = hooks_sub.add_parser(
+        "trust",
+        help="List and approve pending imported hook commands (hash-pinned).",
+    )
+    trust.add_argument("--cwd", default=None, help="Project directory (defaults to cwd).")
+    trust.add_argument(
+        "--yes",
+        action="store_true",
+        help="Record trust without an interactive confirmation prompt.",
+    )
+
+
+def _tokenize_command(command: Any) -> tuple[list[str] | None, str | None]:
+    """Return ``(argv, None)`` on success, or ``(None, reason)`` on rejection.
+
+    A list-form command is validated directly (must already be a non-empty
+    argv list of non-empty strings). A string-form command is tokenized with
+    ``shlex.split`` only when it contains no shell metacharacters; anything
+    else is rejected rather than heuristically reinterpreted.
+    """
+    from lionagi.hooks.external import ExternalHookConfigError, validate_argv
+
+    if isinstance(command, list):
+        try:
+            return validate_argv(command), None
+        except ExternalHookConfigError as exc:
+            return None, str(exc)
+    if isinstance(command, str):
+        if _SHELL_METACHARACTERS.search(command):
+            return (
+                None,
+                f"command {command!r} contains shell metacharacters; cannot "
+                "translate to an argv vector without a shell",
+            )
+        tokens = shlex.split(command)
+        if not tokens:
+            return None, f"command {command!r} tokenized to an empty argv"
+        return tokens, None
+    return None, f"command must be a string or an argv list, got {command!r}"
+
+
+def _translate_config(
+    data: dict[str, Any], *, source_label: str
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    """Translate a foreign ``{"hooks": {...}}`` config into ``hooks_external``
+    matcher-group entries, plus a per-entry report line (imported or
+    rejected-with-reason).
+    """
+    from lionagi.hooks.external import SUPPORTED_EVENTS
+
+    hooks_block = data.get("hooks", {}) if isinstance(data, dict) else None
+    if not isinstance(hooks_block, dict):
+        return {}, ["rejected: top-level 'hooks' key is missing or not a mapping; nothing imported"]
+
+    external: dict[str, list[dict[str, Any]]] = {}
+    report: list[str] = []
+
+    for event, matcher_groups in hooks_block.items():
+        if event not in SUPPORTED_EVENTS:
+            report.append(f"rejected [{event}]: no LionAGI seam for this event (unmappable)")
+            continue
+        if not isinstance(matcher_groups, list):
+            matcher_groups = [matcher_groups]
+        for group in matcher_groups:
+            if not isinstance(group, dict):
+                report.append(f"rejected [{event}]: matcher group must be a mapping, got {group!r}")
+                continue
+            matcher = group.get("matcher")
+            hook_specs = group.get("hooks", [])
+            if not isinstance(hook_specs, list):
+                hook_specs = [hook_specs]
+            translated: list[dict[str, Any]] = []
+            for spec in hook_specs:
+                if not isinstance(spec, dict):
+                    report.append(f"rejected [{event}]: hook entry must be a mapping, got {spec!r}")
+                    continue
+                hook_type = spec.get("type", "command")
+                if hook_type != "command":
+                    report.append(
+                        f"rejected [{event}] matcher={matcher!r}: handler type "
+                        f"{hook_type!r} not supported (v1 executes only 'command')"
+                    )
+                    continue
+                argv, reason = _tokenize_command(spec.get("command"))
+                if argv is None:
+                    report.append(f"rejected [{event}] matcher={matcher!r}: {reason}")
+                    continue
+                entry: dict[str, Any] = {
+                    "type": "command",
+                    "command": argv,
+                    "source": f"imported:{source_label}",
+                }
+                if "timeout" in spec:
+                    entry["timeout"] = spec["timeout"]
+                translated.append(entry)
+
+                note = (
+                    f"imported [{event}] matcher={matcher!r} argv={argv}; verify against profile v1"
+                )
+                if event == "UserPromptSubmit" and source_label == "codex":
+                    note += (
+                        " (divergence: Codex's UserPromptSubmit schema requires "
+                        "transcript_path/turn_id, which LionAGI omits when absent)"
+                    )
+                if event in ("PreToolUse", "PostToolUse") and matcher:
+                    note += (
+                        " (divergence: matcher names a harness tool name -- confirm a "
+                        "LionAGI tool is registered under this exact name)"
+                    )
+                if isinstance(spec.get("command"), str):
+                    note += (
+                        " (divergence: translated from a shell-string command to an argv vector)"
+                    )
+                report.append(note)
+            if translated:
+                group_entry: dict[str, Any] = {"hooks": translated}
+                if matcher is not None:
+                    group_entry = {"matcher": matcher, "hooks": translated}
+                external.setdefault(event, []).append(group_entry)
+
+    return external, report
+
+
+def _run_import(source: str, path: str | None, cwd: str | None) -> int:
+    import yaml
+
+    project_dir = Path(cwd) if cwd else Path.cwd()
+    config_path = Path(path) if path else project_dir / _DEFAULT_CONFIG_PATH[source]
+    if not config_path.is_file():
+        log_error(f"no config file found at {config_path}")
+        return 1
+
+    try:
+        data = json.loads(config_path.read_text())
+    except json.JSONDecodeError as exc:
+        log_error(f"could not parse {config_path} as JSON: {exc}")
+        return 1
+    except OSError as exc:
+        log_error(f"could not read {config_path}: {exc}")
+        return 1
+
+    external, report = _translate_config(data, source_label=source)
+
+    settings_path = project_dir / ".lionagi" / "settings.yaml"
+    existing: dict[str, Any] = {}
+    if settings_path.is_file():
+        loaded = yaml.safe_load(settings_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            existing = loaded
+
+    hooks_external = existing.get("hooks_external")
+    if not isinstance(hooks_external, dict):
+        hooks_external = {}
+        existing["hooks_external"] = hooks_external
+
+    imported_count = 0
+    for event, groups in external.items():
+        hooks_external.setdefault(event, [])
+        hooks_external[event].extend(groups)
+        imported_count += sum(len(g["hooks"]) for g in groups)
+
+    if imported_count:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(settings_path, "w") as f:
+            yaml.safe_dump(existing, f, sort_keys=False, allow_unicode=True)
+
+    for line in report:
+        print(line)
+    print(f"\nimported {imported_count} hook(s) from {config_path} -> {settings_path}")
+    if imported_count:
+        print("run `li hooks trust` to approve them before they will execute.")
+    return 0
+
+
+def _iter_untrusted_commands(project_dir: Path) -> list[dict[str, Any]]:
+    import yaml
+
+    from lionagi.hooks.external import compute_command_hash, is_command_trusted
+
+    settings_path = project_dir / ".lionagi" / "settings.yaml"
+    if not settings_path.is_file():
+        return []
+    data = yaml.safe_load(settings_path.read_text()) or {}
+    hooks_external = data.get("hooks_external", {}) if isinstance(data, dict) else {}
+    if not isinstance(hooks_external, dict):
+        return []
+
+    pending: list[dict[str, Any]] = []
+    seen_hashes: set[str] = set()
+    for event, groups in hooks_external.items():
+        if not isinstance(groups, list):
+            groups = [groups]
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            hook_specs = group.get("hooks", [])
+            if not isinstance(hook_specs, list):
+                hook_specs = [hook_specs]
+            for spec in hook_specs:
+                if not isinstance(spec, dict):
+                    continue
+                source = spec.get("source")
+                command = spec.get("command")
+                if not source or not isinstance(command, list):
+                    continue
+                if is_command_trusted(command, source=source):
+                    continue
+                command_hash = compute_command_hash(command)
+                if command_hash in seen_hashes:
+                    continue
+                seen_hashes.add(command_hash)
+                pending.append(
+                    {"event": event, "command": command, "source": source, "hash": command_hash}
+                )
+    return pending
+
+
+def _run_trust(cwd: str | None, *, assume_yes: bool) -> int:
+    from lionagi.plugins._user_settings import read_user_settings, write_user_settings
+
+    project_dir = Path(cwd) if cwd else Path.cwd()
+    pending = _iter_untrusted_commands(project_dir)
+    if not pending:
+        print("(no pending imported hook commands)")
+        return 0
+
+    print("The following imported hook commands are pending trust:")
+    for p in pending:
+        print(f"  [{p['event']}] source={p['source']} argv={p['command']}")
+
+    if not assume_yes:
+        answer = input("\nTrust all of the above (content-hash-pinned)? [y/N] ").strip().lower()
+        if answer not in ("y", "yes"):
+            print("not trusted.")
+            return 1
+
+    settings = read_user_settings()
+    trusted = settings.get("trusted_hook_commands")
+    if not isinstance(trusted, list):
+        trusted = []
+        settings["trusted_hook_commands"] = trusted
+
+    added = 0
+    for p in pending:
+        if p["hash"] not in trusted:
+            trusted.append(p["hash"])
+            added += 1
+    write_user_settings(settings)
+    print(f"trusted {added} command(s).")
+    return 0
+
+
+def run_hooks(args: argparse.Namespace) -> int:
+    if args.hooks_command == "import":
+        return _run_import(args.source, args.path, args.cwd)
+    if args.hooks_command == "trust":
+        return _run_trust(args.cwd, assume_yes=args.yes)
+    log_error(f"unknown hooks subcommand: {args.hooks_command!r}")
+    return 1

--- a/lionagi/cli/hooks.py
+++ b/lionagi/cli/hooks.py
@@ -243,20 +243,33 @@ def _run_import(source: str, path: str | None, cwd: str | None) -> int:
     return 0
 
 
-def _iter_untrusted_commands(project_dir: Path) -> list[dict[str, Any]]:
+def _iter_untrusted_commands(
+    project_dir: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return ``(pending, rejected)``: pending trust candidates plus a report
+    line per malformed candidate that ``validate_argv`` rejected -- a
+    malformed command (empty argv, a blank/non-string entry, ...) is never
+    added to ``pending``, so it can never be hash-recorded as trusted.
+    """
     import yaml
 
-    from lionagi.hooks.external import compute_command_hash, is_command_trusted
+    from lionagi.hooks.external import (
+        ExternalHookConfigError,
+        compute_command_hash,
+        is_command_trusted,
+        validate_argv,
+    )
 
     settings_path = project_dir / ".lionagi" / "settings.yaml"
     if not settings_path.is_file():
-        return []
+        return [], []
     data = yaml.safe_load(settings_path.read_text()) or {}
     hooks_external = data.get("hooks_external", {}) if isinstance(data, dict) else {}
     if not isinstance(hooks_external, dict):
-        return []
+        return [], []
 
     pending: list[dict[str, Any]] = []
+    rejected: list[str] = []
     seen_hashes: set[str] = set()
     for event, groups in hooks_external.items():
         if not isinstance(groups, list):
@@ -272,7 +285,12 @@ def _iter_untrusted_commands(project_dir: Path) -> list[dict[str, Any]]:
                     continue
                 source = spec.get("source")
                 command = spec.get("command")
-                if not source or not isinstance(command, list):
+                if not source:
+                    continue
+                try:
+                    validate_argv(command)
+                except ExternalHookConfigError as exc:
+                    rejected.append(f"[{event}] source={source!r} command={command!r}: {exc}")
                     continue
                 if is_command_trusted(command, source=source):
                     continue
@@ -283,14 +301,16 @@ def _iter_untrusted_commands(project_dir: Path) -> list[dict[str, Any]]:
                 pending.append(
                     {"event": event, "command": command, "source": source, "hash": command_hash}
                 )
-    return pending
+    return pending, rejected
 
 
 def _run_trust(cwd: str | None, *, assume_yes: bool) -> int:
     from lionagi.plugins._user_settings import read_user_settings, write_user_settings
 
     project_dir = Path(cwd) if cwd else Path.cwd()
-    pending = _iter_untrusted_commands(project_dir)
+    pending, rejected = _iter_untrusted_commands(project_dir)
+    for line in rejected:
+        print(f"rejected {line}")
     if not pending:
         print("(no pending imported hook commands)")
         return 0

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -35,6 +35,10 @@ def _load_engine() -> ModuleType:
     return import_module(".engine", __package__)
 
 
+def _load_hooks() -> ModuleType:
+    return import_module(".hooks", __package__)
+
+
 def _load_invoke() -> ModuleType:
     return import_module(".invoke", __package__)
 
@@ -200,6 +204,13 @@ _COMMAND_REGISTRY = (
         "add_plugin_subparser",
         "run_plugin",
     ),
+    _CommandSpec(
+        "hooks",
+        "Import Claude Code / Codex hook configs; trust imported hook commands.",
+        _load_hooks,
+        "add_hooks_subparser",
+        "run_hooks",
+    ),
 )
 _COMMAND_BY_NAME = {
     command_name: spec for spec in _COMMAND_REGISTRY for command_name in (spec.name, *spec.aliases)
@@ -269,6 +280,10 @@ def run_monitor(args: argparse.Namespace) -> int:
 
 def run_orchestrate(args: argparse.Namespace) -> int:
     return _load_orchestrate().run_orchestrate(args)
+
+
+def run_hooks(args: argparse.Namespace) -> int:
+    return _load_hooks().run_hooks(args)
 
 
 def run_plugin(args: argparse.Namespace) -> int:

--- a/lionagi/hooks/external.py
+++ b/lionagi/hooks/external.py
@@ -234,8 +234,15 @@ def _parse_stdout_decision(
 ) -> tuple[str | None, str, dict[str, Any] | None]:
     """Parse exit-0 stdout into ``(permission_decision, reason, updated_input)``.
 
-    Empty stdout, or non-empty stdout that fails to parse as JSON, both
-    return ``(None, "", None)`` -- "no structured output," never a block.
+    Empty stdout, non-empty stdout that fails to parse as JSON, or a JSON
+    body with no recognized decision field all return ``(None, "", None)``
+    -- "no structured output," never a block. A top-level ``decision`` of
+    ``"block"`` normalizes to ``"deny"``; ``"allow"``/``"approve"`` (or an
+    explicit ``null``) normalize to ``None`` (allow); any other explicit
+    value -- including ``"ask"`` or an unrecognized string -- passes through
+    unchanged so the caller's decision switch fails it closed, matching the
+    nested ``hookSpecificOutput.permissionDecision`` shape's handling of
+    unrecognized values.
     """
     text = stdout_bytes.decode(errors="replace").strip()
     if not text:
@@ -259,7 +266,16 @@ def _parse_stdout_decision(
     if "decision" in data:
         decision = data.get("decision")
         reason = data.get("reason") or ""
-        return ("deny" if decision == "block" else None), reason, None
+        if decision is None or decision in ("allow", "approve"):
+            return None, reason, None
+        if decision == "block":
+            return "deny", reason, None
+        # Any other explicit value (e.g. "ask", or an unrecognized string) is
+        # handed through as-is so `_execute_hook`'s decision switch applies
+        # the same fail-closed handling it uses for the nested
+        # `hookSpecificOutput.permissionDecision` shape -- an explicit but
+        # unrecognized top-level decision must never fall through to allow.
+        return decision, reason, None
     return None, "", None
 
 

--- a/lionagi/hooks/external.py
+++ b/lionagi/hooks/external.py
@@ -1,0 +1,433 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""External-hook exec adapter: compatibility profile v1 wire envelope + executor.
+
+Turns one ``hooks_external:`` config entry (an event, an argv command, a
+matcher, and a timeout) into an async callable shaped for whichever internal
+seam that event maps to: the tool pre/post hook chain at
+``ActionManager.invoke`` for ``PreToolUse``/``PostToolUse``, or a
+``HookBus`` handler for ``SessionStart``/``SessionEnd``/``UserPromptSubmit``/
+``PostToolUseFailure``. The callable spawns the configured command as a real
+subprocess, writes the JSON envelope to its stdin, and parses its stdout/exit
+code back into a decision.
+
+This is a different executor from ``lionagi.agent.settings._make_shell_hook``,
+which stays wired to the legacy ``hooks: {pre,post,on_error}`` shape, never
+reads stdout, and collapses every nonzero exit to one ``PermissionError``.
+
+Also distinct from the ``hooks_external`` field on a plugin manifest
+(``lionagi.plugins.manifest.Capabilities.hooks_external``): that field is
+parsed as inert data only, for trust disclosure, and nothing there executes a
+command. This module is the thing that actually runs one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lionagi.ln._proc import aterminate_process_group
+from lionagi.protocols.action.tool_hooks import ToolPostDecision, ToolPreDecision
+
+logger = logging.getLogger(__name__)
+
+__all__ = (
+    "BLOCKING_EVENTS",
+    "PROFILE_VERSION",
+    "SUPPORTED_EVENTS",
+    "ExternalHookConfigError",
+    "HookVerdict",
+    "build_envelope",
+    "compute_command_hash",
+    "external_hook_adapter",
+    "is_command_trusted",
+    "match_hook",
+    "validate_argv",
+)
+
+# Compatibility profile version this adapter implements (see the ADR's Notes
+# section: the loader and import command reference the profile version they
+# implement; a later harness-driven revision gets a new version here).
+PROFILE_VERSION = "v1"
+
+# External event name -> the internal seam it is wired to (fixed mapping;
+# any other name fails config load rather than silently no-op'ing).
+SUPPORTED_EVENTS = frozenset(
+    {
+        "SessionStart",
+        "SessionEnd",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+    }
+)
+
+# Events with a blocking-capable seam: a deny verdict must fail the action
+# closed (raise), not just log and continue.
+BLOCKING_EVENTS = frozenset({"UserPromptSubmit", "PreToolUse"})
+
+_MAX_STDOUT_BYTES = 1_048_576  # 1 MiB cap on hook stdout read-back
+_TERMINATE_GRACE = 2.0
+
+
+class ExternalHookConfigError(ValueError):
+    """A ``hooks_external`` config entry is malformed; fails config load."""
+
+
+class _HookTimeoutError(Exception):
+    """Internal signal: the hook subprocess did not finish within its timeout."""
+
+
+def validate_argv(command: Any) -> list[str]:
+    """Enforce the argv rule: a non-empty list of non-empty, non-whitespace strings.
+
+    A string-form command, an empty list, or a list containing a blank entry
+    all raise -- this is a config error, never a heuristic ``shlex.split``.
+    """
+    if not isinstance(command, list) or not command:
+        raise ExternalHookConfigError(
+            f"hooks_external: command must be a non-empty argv list, got {command!r}"
+        )
+    for part in command:
+        if not isinstance(part, str) or not part.strip():
+            raise ExternalHookConfigError(
+                "hooks_external: command must be a non-empty argv list of "
+                f"non-empty, non-whitespace strings, got {command!r}"
+            )
+    return command
+
+
+def compute_command_hash(command: list[str]) -> str:
+    """``sha256(json.dumps(argv))`` -- the trust-record key for one hook command."""
+    return hashlib.sha256(json.dumps(command).encode()).hexdigest()
+
+
+def is_command_trusted(command: list[str], *, source: str | None) -> bool:
+    """Loader trust rule: an entry with no ``source`` is project/user-authored
+    and trusted as code; any non-empty ``source`` (``imported:claude``,
+    ``imported:codex``, ...) requires the argv hash to already be recorded in
+    ``~/.lionagi/settings.yaml``'s ``trusted_hook_commands``.
+    """
+    if not source:
+        return True
+    from lionagi.plugins._user_settings import read_user_settings
+
+    trusted = read_user_settings().get("trusted_hook_commands", [])
+    if not isinstance(trusted, list):
+        return False
+    return compute_command_hash(command) in trusted
+
+
+def match_hook(matcher: str | None, subject: str) -> bool:
+    """Harness matcher semantics: omitted/``""``/``"*"`` matches all;
+    alphanumeric/``_``/``-``/space/``,``/``|`` strings are exact-or-list
+    matches; anything else is an unanchored regex."""
+    if not matcher or matcher == "*":
+        return True
+    if re.fullmatch(r"[\w \-,|]+", matcher):
+        names = [n.strip() for n in re.split(r"[,|]", matcher) if n.strip()]
+        return subject in names
+    return re.search(matcher, subject) is not None
+
+
+def build_envelope(
+    *,
+    hook_event_name: str,
+    session_id: str,
+    cwd: str,
+    harness: str = "lionagi",
+    tool_name: str | None = None,
+    tool_input: Any = None,
+    tool_response: Any = None,
+    prompt: str | None = None,
+    model: str | None = None,
+    permission_mode: str | None = None,
+) -> dict[str, Any]:
+    """Build the stdin envelope for *hook_event_name*.
+
+    Common fields (``session_id``, ``cwd``, ``hook_event_name``, ``harness``)
+    are always present. Per-event fields follow the field-guarantee table:
+    ``tool_name``/``tool_input`` always present for tool events;
+    ``tool_response`` always present for ``PostToolUse``/``PostToolUseFailure``;
+    ``prompt``/``model``/``permission_mode`` always present for
+    ``UserPromptSubmit`` (``permission_mode`` defaults to ``"default"`` when no
+    policy is attached).
+    """
+    envelope: dict[str, Any] = {
+        "session_id": session_id,
+        "cwd": cwd,
+        "hook_event_name": hook_event_name,
+        "harness": harness,
+    }
+    if hook_event_name in ("PreToolUse", "PostToolUse", "PostToolUseFailure"):
+        envelope["tool_name"] = tool_name
+        envelope["tool_input"] = tool_input
+        if hook_event_name in ("PostToolUse", "PostToolUseFailure"):
+            envelope["tool_response"] = tool_response
+    elif hook_event_name == "UserPromptSubmit":
+        envelope["prompt"] = prompt
+        envelope["model"] = model
+        envelope["permission_mode"] = permission_mode or "default"
+    return envelope
+
+
+@dataclass(frozen=True, slots=True)
+class HookVerdict:
+    """Normalized outcome of one hook process's exit code + stdout.
+
+    ``outcome`` is ``"allow"`` (continue, possibly with ``updated_input``),
+    ``"deny"`` (fails the action closed on a blocking seam, else an advisory
+    note), or ``"error"`` (hook itself misbehaved -- logged, never a block on
+    an advisory seam; treated as deny on a blocking seam, since a guard that
+    cannot run must not silently admit the action it was meant to gate).
+    """
+
+    outcome: str
+    reason: str = ""
+    updated_input: dict[str, Any] | None = None
+
+
+async def _run_hook_process(
+    argv: list[str], envelope: dict[str, Any], timeout: float
+) -> tuple[int, bytes, bytes]:
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(json.dumps(envelope).encode()),
+            timeout=timeout,
+        )
+    except TimeoutError as err:
+        # Kill the whole process group so a hung hook's children cannot
+        # continue side effects after the timeout is declared.
+        await aterminate_process_group(proc, grace=None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE)
+        raise _HookTimeoutError(f"hook timed out after {timeout}s: {argv[0]!r}") from err
+
+    if len(stdout_bytes) > _MAX_STDOUT_BYTES:
+        logger.warning("hook stdout exceeded %d bytes; truncating", _MAX_STDOUT_BYTES)
+        stdout_bytes = stdout_bytes[:_MAX_STDOUT_BYTES]
+    return proc.returncode, stdout_bytes, stderr_bytes
+
+
+def _parse_stdout_decision(
+    stdout_bytes: bytes,
+) -> tuple[str | None, str, dict[str, Any] | None]:
+    """Parse exit-0 stdout into ``(permission_decision, reason, updated_input)``.
+
+    Empty stdout, or non-empty stdout that fails to parse as JSON, both
+    return ``(None, "", None)`` -- "no structured output," never a block.
+    """
+    text = stdout_bytes.decode(errors="replace").strip()
+    if not text:
+        return None, "", None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("hook stdout was non-empty but not valid JSON; treating as no decision")
+        return None, "", None
+    if not isinstance(data, dict):
+        return None, "", None
+
+    hook_specific = data.get("hookSpecificOutput")
+    if isinstance(hook_specific, dict) and "permissionDecision" in hook_specific:
+        updated_input = hook_specific.get("updatedInput")
+        return (
+            hook_specific.get("permissionDecision"),
+            hook_specific.get("permissionDecisionReason") or "",
+            updated_input if isinstance(updated_input, dict) else None,
+        )
+    if "decision" in data:
+        decision = data.get("decision")
+        reason = data.get("reason") or ""
+        return ("deny" if decision == "block" else None), reason, None
+    return None, "", None
+
+
+async def _execute_hook(
+    *,
+    argv: list[str],
+    envelope: dict[str, Any],
+    timeout: float,
+    blocking: bool,
+) -> HookVerdict:
+    """Spawn *argv*, exchange *envelope*, and normalize the exit-code + stdout
+    contract into a :class:`HookVerdict`.
+
+    Exit 0 -- stdout parsed as JSON if non-empty. Exit 2 -- block; stderr is
+    the reason. Any other exit, or a spawn/IO error -- hook failure (deny on
+    a blocking seam, error/log-and-continue on an advisory one). A timeout is
+    treated the same way after the process group is torn down.
+    """
+    try:
+        returncode, stdout_bytes, stderr_bytes = await _run_hook_process(argv, envelope, timeout)
+    except _HookTimeoutError as exc:
+        return HookVerdict(outcome="deny" if blocking else "error", reason=str(exc))
+    except Exception as exc:  # noqa: BLE001 -- subprocess spawn/IO errors
+        return HookVerdict(
+            outcome="deny" if blocking else "error",
+            reason=f"hook execution error: {exc}",
+        )
+
+    if returncode == 2:
+        reason = stderr_bytes.decode(errors="replace").strip() or f"hook blocked: {argv[0]!r}"
+        return HookVerdict(outcome="deny", reason=reason)
+
+    if returncode != 0:
+        reason = (
+            stderr_bytes.decode(errors="replace").strip()
+            or f"hook failed (exit {returncode}): {argv[0]!r}"
+        )
+        return HookVerdict(outcome="deny" if blocking else "error", reason=reason)
+
+    decision, reason, updated_input = _parse_stdout_decision(stdout_bytes)
+    if decision is None or decision == "allow":
+        return HookVerdict(outcome="allow", reason=reason, updated_input=updated_input)
+    if decision == "deny":
+        return HookVerdict(outcome="deny", reason=reason or "denied")
+    if decision == "ask":
+        return HookVerdict(
+            outcome="deny",
+            reason=(
+                "hook requested interactive approval ('ask'); no interactive "
+                "approval surface exists in this runtime -- failing closed"
+            ),
+        )
+    return HookVerdict(outcome="deny", reason=f"unrecognized decision {decision!r}; failing closed")
+
+
+def external_hook_adapter(
+    *,
+    event: str,
+    command: list[str],
+    timeout: float = 60.0,
+    matcher: str | None = None,
+    source: str | None = None,
+    cwd: str | None = None,
+    session_id: str | None = None,
+    harness: str = "lionagi",
+) -> Callable[..., Awaitable[Any]]:
+    """Turn one ``hooks_external`` entry into an async callable for its seam.
+
+    ``event`` selects the shape: ``PreToolUse``/``PostToolUse`` return a
+    :class:`ToolPreHook`/:class:`ToolPostHook`-shaped callable for
+    ``ActionManager``; the remaining supported events return a
+    ``HookBus``-shaped ``**kwargs`` handler. ``source`` carries D6's
+    provenance field (``None`` for project/user-authored entries,
+    ``"imported:claude"``/``"imported:codex"`` for imported ones) -- an
+    untrusted non-empty-``source`` command never executes (see
+    :func:`is_command_trusted`).
+    """
+    if event not in SUPPORTED_EVENTS:
+        raise ExternalHookConfigError(
+            f"hooks_external: no seam for event {event!r}; LionAGI has no hook "
+            f"point for it. Supported events: {sorted(SUPPORTED_EVENTS)}"
+        )
+    command = validate_argv(command)
+    resolved_cwd = cwd or str(Path.cwd())
+    fallback_session_id = session_id or ""
+    blocking = event in BLOCKING_EVENTS
+
+    async def _guarded_execute(envelope: dict[str, Any]) -> HookVerdict:
+        if not is_command_trusted(command, source=source):
+            reason = (
+                f"untrusted hook command {command!r} (source={source!r}); "
+                "run `li hooks trust` to approve it"
+            )
+            return HookVerdict(outcome="deny" if blocking else "error", reason=reason)
+        return await _execute_hook(
+            argv=command, envelope=envelope, timeout=timeout, blocking=blocking
+        )
+
+    if event == "PreToolUse":
+
+        async def pre_hook(tool_name: str, arguments: dict[str, Any]) -> ToolPreDecision | None:
+            if not match_hook(matcher, tool_name):
+                return None
+            envelope = build_envelope(
+                hook_event_name=event,
+                session_id=fallback_session_id,
+                cwd=resolved_cwd,
+                harness=harness,
+                tool_name=tool_name,
+                tool_input=arguments,
+            )
+            verdict = await _guarded_execute(envelope)
+            if verdict.outcome == "allow":
+                return ToolPreDecision(decision="allow", updated_input=verdict.updated_input)
+            return ToolPreDecision(decision="deny", reason=verdict.reason)
+
+        return pre_hook
+
+    if event == "PostToolUse":
+
+        async def post_hook(
+            tool_name: str,
+            arguments: dict[str, Any],
+            result: Any,
+            error: BaseException | None,
+        ) -> ToolPostDecision | None:
+            if not match_hook(matcher, tool_name):
+                return None
+            tool_response = result if error is None else {"error": str(error)}
+            envelope = build_envelope(
+                hook_event_name=event,
+                session_id=fallback_session_id,
+                cwd=resolved_cwd,
+                harness=harness,
+                tool_name=tool_name,
+                tool_input=arguments,
+                tool_response=tool_response,
+            )
+            verdict = await _guarded_execute(envelope)
+            # PostToolUse cannot un-run the call; a deny/error becomes an
+            # advisory note (matches "block on an advisory event" -- the
+            # reason is surfaced, not enforced).
+            if verdict.outcome in ("deny", "error") and verdict.reason:
+                return ToolPostDecision(reason=verdict.reason)
+            return None
+
+        return post_hook
+
+    # Remaining supported events route through HookBus (advisory unless
+    # USER_PROMPT_SUBMIT, which is blocking).
+    async def bus_hook(**kwargs: Any) -> None:
+        tool_response = kwargs.get("tool_response")
+        if event == "PostToolUseFailure" and tool_response is None and "error" in kwargs:
+            tool_response = {"error": str(kwargs.get("error"))}
+        envelope = build_envelope(
+            hook_event_name=event,
+            session_id=str(kwargs.get("session_id") or fallback_session_id),
+            cwd=resolved_cwd,
+            harness=harness,
+            tool_name=kwargs.get("tool_name"),
+            tool_input=kwargs.get("tool_input"),
+            tool_response=tool_response,
+            prompt=kwargs.get("prompt"),
+            model=kwargs.get("model"),
+            permission_mode=kwargs.get("permission_mode"),
+        )
+        verdict = await _guarded_execute(envelope)
+        if verdict.outcome == "deny":
+            if blocking:
+                raise PermissionError(verdict.reason or "denied by external hook")
+            logger.info("external hook %r reported block: %s", command, verdict.reason)
+        elif verdict.outcome == "error":
+            logger.warning("external hook %r failed: %s", command, verdict.reason)
+
+    return bus_hook

--- a/lionagi/hooks/external.py
+++ b/lionagi/hooks/external.py
@@ -211,7 +211,11 @@ async def _run_hook_process(
             proc.communicate(json.dumps(envelope).encode()),
             timeout=timeout,
         )
-    except TimeoutError as err:
+    except (TimeoutError, asyncio.TimeoutError) as err:
+        # asyncio.wait_for raises asyncio.TimeoutError, which is a distinct
+        # class from the builtin TimeoutError before Python 3.11 (they only
+        # became aliases in 3.11) -- catch both so the teardown below runs on
+        # every supported interpreter, not just 3.11+.
         # Kill the whole process group so a hung hook's children cannot
         # continue side effects after the timeout is declared.
         await aterminate_process_group(proc, grace=None)

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import JsonValue
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 async def _emit_user_prompt_submit(
-    branch: "Branch", chat_param: ChatParam, ins: Instruction
+    branch: "Branch", chat_param: ChatParam, ins: Instruction, imodel: Any = None
 ) -> None:
     """Fire USER_PROMPT_SUBMIT exactly once, iff the operation context carries a token."""
     token = consume_turn_origin(chat_param.turn_origin)
@@ -34,6 +34,8 @@ async def _emit_user_prompt_submit(
         session_id=str(branch._owning_session_id or branch.id),
         branch_id=str(branch.id),
         prompt=prompt,
+        model=getattr(imodel, "model_name", None) or "",
+        permission_mode="default",
     )
 
 
@@ -49,9 +51,9 @@ async def chat(
     finally:
         branch._context_injection_slot = None
 
-    await _emit_user_prompt_submit(branch, chat_param, ins)
-
     imodel = chat_param.imodel or branch.chat_model
+    await _emit_user_prompt_submit(branch, chat_param, ins, imodel=imodel)
+
     if not chat_param._is_sentinel(chat_param.include_token_usage_to_model):
         kw["include_token_usage_to_model"] = chat_param.include_token_usage_to_model
     api_call = await imodel.invoke(**kw)

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -335,6 +335,8 @@ async def run(
                     session_id=str(branch._owning_session_id or branch.id),
                     branch_id=str(branch.id),
                     prompt=_prompt,
+                    model=getattr(branch.chat_model, "model_name", None) or "",
+                    permission_mode="default",
                 )
             except GeneratorExit:
                 raise

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -103,6 +103,7 @@ class Branch(Element, Relational):
     _operation_manager: OperationManager | None = PrivateAttr(None)
     _observer: Any = PrivateAttr(None)
     _hooks: Any = PrivateAttr(None)
+    _pending_hook_bus_entries: list = PrivateAttr(default_factory=list)
     _memory: MemoryStore | None = PrivateAttr(None)
     _owning_session_id: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
@@ -338,6 +339,26 @@ class Branch(Element, Relational):
         if self._observer is None:
             return True
         return await self._observer.authorize(action)
+
+    def attach_hook_bus(self, bus: Any) -> None:
+        """Set this branch's :class:`HookBus` and flush any handlers queued
+        while it had none.
+
+        A standalone branch built via ``create_agent`` has no bus yet, so
+        ``hooks_external`` entries bound to bus-only events (``UserPromptSubmit``,
+        ``SessionStart``/``SessionEnd``/``PostToolUseFailure``) cannot attach
+        at config time; ``lionagi.agent.factory._wire_external_hooks`` queues
+        them onto ``_pending_hook_bus_entries`` instead of dropping them.
+        Every seam that later gives this branch a bus -- ``Session.include_branches``
+        and the lazy ``Session.hooks`` property -- must route the assignment
+        through this method so those queued handlers actually attach, rather
+        than a configured guard silently never firing.
+        """
+        self._hooks = bus
+        if bus is not None and self._pending_hook_bus_entries:
+            pending, self._pending_hook_bus_entries = self._pending_hook_bus_entries, []
+            for point, handler in pending:
+                bus.on(point, handler)
 
     async def _persist_via_bus(self, msg: Any) -> None:
         """on_message_added hook: emit MESSAGE_ADD for ordered persistence."""

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -104,6 +104,8 @@ class Branch(Element, Relational):
     _observer: Any = PrivateAttr(None)
     _hooks: Any = PrivateAttr(None)
     _pending_hook_bus_entries: list = PrivateAttr(default_factory=list)
+    _hook_bus_synced_to: Any = PrivateAttr(None)
+    _hook_bus_synced_count: int = PrivateAttr(0)
     _memory: MemoryStore | None = PrivateAttr(None)
     _owning_session_id: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
@@ -341,24 +343,36 @@ class Branch(Element, Relational):
         return await self._observer.authorize(action)
 
     def attach_hook_bus(self, bus: Any) -> None:
-        """Set this branch's :class:`HookBus` and flush any handlers queued
-        while it had none.
+        """Set this branch's :class:`HookBus` and (re)register any external
+        handlers queued for bus attachment.
 
         A standalone branch built via ``create_agent`` has no bus yet, so
         ``hooks_external`` entries bound to bus-only events (``UserPromptSubmit``,
         ``SessionStart``/``SessionEnd``/``PostToolUseFailure``) cannot attach
         at config time; ``lionagi.agent.factory._wire_external_hooks`` queues
         them onto ``_pending_hook_bus_entries`` instead of dropping them.
-        Every seam that later gives this branch a bus -- ``Session.include_branches``
+        That list is retained for the branch's lifetime, not cleared after
+        the first flush, so a branch moved between sessions (``Session.
+        remove_branch`` then ``include_branches``/``new_branch`` elsewhere)
+        re-registers the same external handlers on its new session's bus
+        instead of silently losing them. Re-attaching the same bus is a
+        no-op for entries already registered on it -- only the entries
+        appended since the last sync onto the current bus are flushed.
+        Every seam that gives this branch a bus -- ``Session.include_branches``
         and the lazy ``Session.hooks`` property -- must route the assignment
         through this method so those queued handlers actually attach, rather
         than a configured guard silently never firing.
         """
         self._hooks = bus
-        if bus is not None and self._pending_hook_bus_entries:
-            pending, self._pending_hook_bus_entries = self._pending_hook_bus_entries, []
-            for point, handler in pending:
-                bus.on(point, handler)
+        if bus is None:
+            return
+        if bus is not self._hook_bus_synced_to:
+            self._hook_bus_synced_to = bus
+            self._hook_bus_synced_count = 0
+        unsynced = self._pending_hook_bus_entries[self._hook_bus_synced_count :]
+        for point, handler in unsynced:
+            bus.on(point, handler)
+        self._hook_bus_synced_count = len(self._pending_hook_bus_entries)
 
     async def _persist_via_bus(self, msg: Any) -> None:
         """on_message_added hook: emit MESSAGE_ADD for ordered persistence."""

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -96,7 +96,7 @@ class Session(Node, Relational):
             branch._operation_manager = self._operation_manager
             branch._observer = self.observer
             if self._hooks is not None:
-                branch._hooks = self._hooks
+                branch.attach_hook_bus(self._hooks)
             if branch._memory is None:
                 # First claim wins; reading self.memory lazily creates and
                 # shares one store instance across every branch taken in.
@@ -142,7 +142,7 @@ class Session(Node, Relational):
 
             self._hooks = build_session_bus(observer=self.observer)
             for branch in self.branches:
-                branch._hooks = self._hooks
+                branch.attach_hook_bus(self._hooks)
         return self._hooks
 
     @property

--- a/tests/agent/test_factory_external_hooks.py
+++ b/tests/agent/test_factory_external_hooks.py
@@ -126,9 +126,14 @@ def test_user_prompt_submit_without_hook_bus_is_queued_not_dropped():
     assert branch._hooks is None
     assert len(branch._pending_hook_bus_entries) == 1
 
-    branch.attach_hook_bus(HookBus())
+    bus = HookBus()
+    branch.attach_hook_bus(bus)
     assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
-    assert branch._pending_hook_bus_entries == []
+    # Retained (not cleared) so the branch can re-register onto a later bus
+    # if reparented; re-attaching the same bus must not double-register.
+    assert len(branch._pending_hook_bus_entries) == 1
+    branch.attach_hook_bus(bus)
+    assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
 
 
 def test_session_start_and_error_route_to_hook_bus():
@@ -237,4 +242,49 @@ async def test_user_prompt_submit_hook_fires_after_create_agent_and_session_incl
     with pytest.raises(PermissionError, match="hygiene check failed"):
         await branch._hooks.blocking_emit(
             HookPoint.USER_PROMPT_SUBMIT, session_id=str(session.id), prompt="do a thing"
+        )
+
+
+async def test_user_prompt_submit_hook_survives_reparent_to_another_session(
+    monkeypatch,
+):
+    """A blocking external hook must not silently vanish when its branch is
+    moved between sessions (`Session.remove_branch` then `include_branches`
+    on another session, a supported reparenting op). The handler was queued
+    onto `_pending_hook_bus_entries` while the branch was standalone, then
+    flushed onto session A's bus; it must also flush onto session B's bus."""
+    stdout = json.dumps({"decision": "block", "reason": "hygiene check failed"}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+
+    spec = _spec_with(
+        [
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hygiene"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    branch = await create_agent(spec, load_settings=False)
+
+    session_a = Session()
+    _ = session_a.hooks  # bus exists before the branch joins
+    session_a.include_branches(branch)
+    assert len(session_a.hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+
+    session_a.remove_branch(branch)
+    session_b = Session()
+    _ = session_b.hooks  # bus exists before the reparented branch joins
+    session_b.include_branches(branch)
+
+    assert branch._hooks is session_b.hooks
+    assert len(session_b.hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+
+    with pytest.raises(PermissionError, match="hygiene check failed"):
+        await branch._hooks.blocking_emit(
+            HookPoint.USER_PROMPT_SUBMIT, session_id=str(session_b.id), prompt="do a thing"
         )

--- a/tests/agent/test_factory_external_hooks.py
+++ b/tests/agent/test_factory_external_hooks.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `_wire_external_hooks` (lionagi.agent.factory): attaching parsed
+`hooks_external` entries to the seam their event maps to -- ActionManager's
+tool pre/post hook chain for PreToolUse/PostToolUse, HookBus for the rest."""
+
+from __future__ import annotations
+
+from lionagi.agent.factory import _wire_external_hooks
+from lionagi.agent.spec import AgentSpec
+from lionagi.hooks.bus import HookBus, HookPoint
+from lionagi.session.branch import Branch
+
+
+def _spec_with(entries: list[dict]) -> AgentSpec:
+    spec = AgentSpec.compose("implementer")
+    spec.external_hooks = entries
+    return spec
+
+
+def test_no_external_hooks_is_a_noop():
+    branch = Branch()
+    spec = _spec_with([])
+    _wire_external_hooks(branch, spec)
+    assert branch.acts._tool_pre_hooks == []
+    assert branch.acts._tool_post_hooks == []
+
+
+def test_pre_tool_use_attaches_to_action_manager():
+    branch = Branch()
+    spec = _spec_with(
+        [
+            {
+                "event": "PreToolUse",
+                "matcher": None,
+                "command": ["guard"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert len(branch.acts._tool_pre_hooks) == 1
+    assert branch.acts._tool_post_hooks == []
+
+
+def test_post_tool_use_attaches_to_action_manager():
+    branch = Branch()
+    spec = _spec_with(
+        [
+            {
+                "event": "PostToolUse",
+                "matcher": None,
+                "command": ["notify"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert len(branch.acts._tool_post_hooks) == 1
+    assert branch.acts._tool_pre_hooks == []
+
+
+def test_user_prompt_submit_attaches_to_hook_bus_when_present():
+    branch = Branch()
+    branch._hooks = HookBus()
+    spec = _spec_with(
+        [
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hygiene"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+
+
+def test_user_prompt_submit_skipped_without_hook_bus(caplog):
+    branch = Branch()
+    assert branch._hooks is None
+    spec = _spec_with(
+        [
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hygiene"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    _wire_external_hooks(branch, spec)  # must not raise
+    assert branch._hooks is None
+
+
+def test_session_start_and_error_route_to_hook_bus():
+    branch = Branch()
+    branch._hooks = HookBus()
+    spec = _spec_with(
+        [
+            {
+                "event": "SessionStart",
+                "matcher": None,
+                "command": ["a"],
+                "timeout": 30.0,
+                "source": None,
+            },
+            {
+                "event": "PostToolUseFailure",
+                "matcher": None,
+                "command": ["b"],
+                "timeout": 30.0,
+                "source": None,
+            },
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert len(branch._hooks.handlers_for(HookPoint.SESSION_START)) == 1
+    assert len(branch._hooks.handlers_for(HookPoint.TOOL_ERROR)) == 1
+
+
+def test_multiple_entries_wire_independently():
+    branch = Branch()
+    branch._hooks = HookBus()
+    spec = _spec_with(
+        [
+            {
+                "event": "PreToolUse",
+                "matcher": "bash",
+                "command": ["g1"],
+                "timeout": 30.0,
+                "source": None,
+            },
+            {
+                "event": "PreToolUse",
+                "matcher": "reader",
+                "command": ["g2"],
+                "timeout": 30.0,
+                "source": None,
+            },
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hyg"],
+                "timeout": 30.0,
+                "source": None,
+            },
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert len(branch.acts._tool_pre_hooks) == 2
+    assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1

--- a/tests/agent/test_factory_external_hooks.py
+++ b/tests/agent/test_factory_external_hooks.py
@@ -7,10 +7,17 @@ tool pre/post hook chain for PreToolUse/PostToolUse, HookBus for the rest."""
 
 from __future__ import annotations
 
-from lionagi.agent.factory import _wire_external_hooks
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lionagi.agent.factory import _wire_external_hooks, create_agent
 from lionagi.agent.spec import AgentSpec
 from lionagi.hooks.bus import HookBus, HookPoint
 from lionagi.session.branch import Branch
+from lionagi.session.session import Session
 
 
 def _spec_with(entries: list[dict]) -> AgentSpec:
@@ -99,6 +106,31 @@ def test_user_prompt_submit_skipped_without_hook_bus(caplog):
     assert branch._hooks is None
 
 
+def test_user_prompt_submit_without_hook_bus_is_queued_not_dropped():
+    """A HookBus-only external hook configured before the branch has a bus
+    must not be lost: it queues onto `_pending_hook_bus_entries` so it can
+    still attach once the branch acquires one (`Branch.attach_hook_bus`)."""
+    branch = Branch()
+    spec = _spec_with(
+        [
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hygiene"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    _wire_external_hooks(branch, spec)
+    assert branch._hooks is None
+    assert len(branch._pending_hook_bus_entries) == 1
+
+    branch.attach_hook_bus(HookBus())
+    assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+    assert branch._pending_hook_bus_entries == []
+
+
 def test_session_start_and_error_route_to_hook_bus():
     branch = Branch()
     branch._hooks = HookBus()
@@ -156,3 +188,53 @@ def test_multiple_entries_wire_independently():
     _wire_external_hooks(branch, spec)
     assert len(branch.acts._tool_pre_hooks) == 2
     assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Session-bus wiring: create_agent() always builds a standalone branch with
+# no HookBus yet; a configured UserPromptSubmit hook must still fire once
+# that branch joins a Session (the only thing that ever attaches a bus).
+# ---------------------------------------------------------------------------
+
+
+def _mock_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.pid = 4242
+    return proc
+
+
+async def test_user_prompt_submit_hook_fires_after_create_agent_and_session_inclusion(
+    monkeypatch,
+):
+    stdout = json.dumps({"decision": "block", "reason": "hygiene check failed"}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+
+    spec = _spec_with(
+        [
+            {
+                "event": "UserPromptSubmit",
+                "matcher": None,
+                "command": ["hygiene"],
+                "timeout": 30.0,
+                "source": None,
+            }
+        ]
+    )
+    branch = await create_agent(spec, load_settings=False)
+    assert branch._hooks is None, "standalone branch: no bus exists yet"
+
+    session = Session()
+    session.include_branches(branch)
+    # Session.hooks lazily creates the bus and must flush the queued
+    # UserPromptSubmit handler onto every branch it already owns.
+    assert len(session.hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
+    assert branch._hooks is session.hooks
+
+    with pytest.raises(PermissionError, match="hygiene check failed"):
+        await branch._hooks.blocking_emit(
+            HookPoint.USER_PROMPT_SUBMIT, session_id=str(session.id), prompt="do a thing"
+        )

--- a/tests/agent/test_settings_external_hooks.py
+++ b/tests/agent/test_settings_external_hooks.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the `hooks_external:` settings block (D6): parsing, validation,
+and that it lands on AgentSpec.external_hooks distinct from the legacy
+hook_handlers dict."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.agent.settings import apply_hooks_from_settings, parse_external_hooks
+from lionagi.agent.spec import AgentSpec
+from lionagi.hooks.external import ExternalHookConfigError
+
+
+def test_parse_external_hooks_basic_entry():
+    config = {
+        "PreToolUse": [
+            {
+                "matcher": "bash|shell",
+                "hooks": [{"type": "command", "command": ["uv", "run", "guard.py"], "timeout": 30}],
+            }
+        ]
+    }
+    entries = parse_external_hooks(config)
+    assert entries == [
+        {
+            "event": "PreToolUse",
+            "matcher": "bash|shell",
+            "command": ["uv", "run", "guard.py"],
+            "timeout": 30.0,
+            "source": None,
+        }
+    ]
+
+
+def test_parse_external_hooks_defaults_timeout_to_60():
+    config = {"UserPromptSubmit": [{"hooks": [{"command": ["./hygiene"]}]}]}
+    entries = parse_external_hooks(config)
+    assert entries[0]["timeout"] == 60.0
+    assert entries[0]["matcher"] is None
+
+
+def test_parse_external_hooks_preserves_source_provenance():
+    config = {"PreToolUse": [{"hooks": [{"command": ["guard"], "source": "imported:claude"}]}]}
+    entries = parse_external_hooks(config)
+    assert entries[0]["source"] == "imported:claude"
+
+
+def test_parse_external_hooks_rejects_unmappable_event():
+    config = {"Stop": [{"hooks": [{"command": ["guard"]}]}]}
+    with pytest.raises(ExternalHookConfigError, match="no seam for event 'Stop'"):
+        parse_external_hooks(config)
+
+
+def test_parse_external_hooks_rejects_non_command_type():
+    config = {"PreToolUse": [{"hooks": [{"type": "http", "command": ["guard"]}]}]}
+    with pytest.raises(ExternalHookConfigError, match="unsupported hook type 'http'"):
+        parse_external_hooks(config)
+
+
+def test_parse_external_hooks_rejects_shell_string_command():
+    config = {"PreToolUse": [{"hooks": [{"command": "echo unsafe"}]}]}
+    with pytest.raises(ExternalHookConfigError, match="argv list"):
+        parse_external_hooks(config)
+
+
+def test_parse_external_hooks_rejects_empty_argv():
+    config = {"PreToolUse": [{"hooks": [{"command": []}]}]}
+    with pytest.raises(ExternalHookConfigError):
+        parse_external_hooks(config)
+
+
+def test_parse_external_hooks_multiple_events_and_matchers():
+    config = {
+        "PreToolUse": [
+            {"matcher": "bash", "hooks": [{"command": ["guard1"]}]},
+            {"matcher": "reader", "hooks": [{"command": ["guard2"]}]},
+        ],
+        "SessionStart": [{"hooks": [{"command": ["notify"]}]}],
+    }
+    entries = parse_external_hooks(config)
+    assert len(entries) == 3
+    events = {e["event"] for e in entries}
+    assert events == {"PreToolUse", "SessionStart"}
+
+
+# ---------------------------------------------------------------------------
+# apply_hooks_from_settings: hooks_external lands on config.external_hooks,
+# never on config.hook_handlers (the legacy shape's storage).
+# ---------------------------------------------------------------------------
+
+
+def test_apply_hooks_from_settings_populates_external_hooks_field():
+    settings = {
+        "hooks_external": {
+            "PreToolUse": [{"hooks": [{"command": ["guard"]}]}],
+        }
+    }
+    spec = AgentSpec.compose("implementer")
+    apply_hooks_from_settings(spec, settings)
+
+    assert len(spec.external_hooks) == 1
+    assert spec.external_hooks[0]["event"] == "PreToolUse"
+    # The legacy hook_handlers dict is untouched by the new block.
+    assert spec.hook_handlers == {}
+
+
+def test_apply_hooks_from_settings_legacy_and_external_coexist():
+    settings = {
+        "hooks": {"pre": {"bash": [{"command": ["legacy_guard"]}]}},
+        "hooks_external": {"PreToolUse": [{"hooks": [{"command": ["new_guard"]}]}]},
+    }
+    spec = AgentSpec.compose("implementer")
+    apply_hooks_from_settings(spec, settings)
+
+    assert "pre:bash" in spec.hook_handlers
+    assert len(spec.external_hooks) == 1
+
+
+def test_apply_hooks_from_settings_no_hooks_external_key_is_a_noop():
+    spec = AgentSpec.compose("implementer")
+    apply_hooks_from_settings(spec, {})
+    assert spec.external_hooks == []

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -138,6 +138,7 @@ TOP_LEVEL_COMMANDS = [
     "dispatch",
     "doctor",
     "engine",
+    "hooks",
     "invoke",
     "kill",
     "mirror",

--- a/tests/cli/test_hooks_cli.py
+++ b/tests/cli/test_hooks_cli.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `li hooks import claude|codex` and `li hooks trust`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lionagi.cli.main import main as cli_main
+from lionagi.plugins._user_settings import read_user_settings
+
+pytestmark = pytest.mark.usefixtures("plugin_home")
+
+
+CLAUDE_SETTINGS = {
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {"type": "command", "command": ["uv", "run", "guards/check.py"], "timeout": 20}
+                ],
+            }
+        ],
+        "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "./hooks/hygiene"}]}],
+        "Stop": [{"hooks": [{"type": "command", "command": ["notify-stop"]}]}],
+        "PostToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "rm -rf $HOME"}]}
+        ],
+    }
+}
+
+
+def _write_claude_settings(project_dir: Path, data: dict) -> Path:
+    path = project_dir / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_import_claude_writes_hooks_external_block(capsys, tmp_path):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 0
+
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    assert settings_path.is_file()
+    data = yaml.safe_load(settings_path.read_text())
+    external = data["hooks_external"]
+
+    assert "PreToolUse" in external
+    pre_entry = external["PreToolUse"][0]["hooks"][0]
+    assert pre_entry["command"] == ["uv", "run", "guards/check.py"]
+    assert pre_entry["source"] == "imported:claude"
+    assert pre_entry["timeout"] == 20
+
+    # UserPromptSubmit's shell-string command with no metacharacters tokenizes fine.
+    ups_entry = external["UserPromptSubmit"][0]["hooks"][0]
+    assert ups_entry["command"] == ["./hooks/hygiene"]
+
+
+def test_import_claude_rejects_unmappable_event(capsys, tmp_path):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "rejected [Stop]" in out
+    assert "no LionAGI seam" in out
+
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    data = yaml.safe_load(settings_path.read_text())
+    assert "Stop" not in data["hooks_external"]
+
+
+def test_import_claude_rejects_shell_metacharacter_command(capsys, tmp_path):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "rejected [PostToolUse]" in out
+    assert "shell metacharacters" in out
+
+
+def test_import_missing_config_file_errors(capsys, tmp_path):
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 1
+
+
+def test_import_codex_translates_hooks_json(capsys, tmp_path):
+    codex_config = {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "shell", "hooks": [{"type": "command", "command": ["deny_check"]}]}
+            ]
+        }
+    }
+    path = tmp_path / ".codex" / "hooks.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(codex_config))
+
+    code = cli_main(["hooks", "import", "codex", "--cwd", str(tmp_path)])
+    assert code == 0
+
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    data = yaml.safe_load(settings_path.read_text())
+    entry = data["hooks_external"]["PreToolUse"][0]["hooks"][0]
+    assert entry["source"] == "imported:codex"
+
+
+def test_import_merges_with_existing_hooks_external_block(tmp_path):
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        yaml.safe_dump(
+            {"hooks_external": {"SessionStart": [{"hooks": [{"command": ["existing"]}]}]}}
+        )
+    )
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 0
+
+    data = yaml.safe_load(settings_path.read_text())
+    assert data["hooks_external"]["SessionStart"][0]["hooks"][0]["command"] == ["existing"]
+    assert "PreToolUse" in data["hooks_external"]
+
+
+# ---------------------------------------------------------------------------
+# `li hooks trust`
+# ---------------------------------------------------------------------------
+
+
+def test_trust_lists_and_records_pending_commands(capsys, tmp_path, monkeypatch):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+    code = cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    assert code == 0
+    capsys.readouterr()
+
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path), "--yes"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "trusted" in out
+
+    trusted = read_user_settings().get("trusted_hook_commands", [])
+    assert len(trusted) >= 2  # PreToolUse + UserPromptSubmit imported commands
+
+
+def test_trust_declined_leaves_untrusted(monkeypatch, capsys, tmp_path):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+    cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    capsys.readouterr()
+
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path)])
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "not trusted" in out
+
+
+def test_trust_with_nothing_pending(capsys, tmp_path):
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "no pending" in out
+
+
+def test_trust_is_idempotent_on_rerun(tmp_path):
+    _write_claude_settings(tmp_path, CLAUDE_SETTINGS)
+    cli_main(["hooks", "import", "claude", "--cwd", str(tmp_path)])
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path), "--yes"])
+    assert code == 0
+
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path)])
+    assert code == 0  # nothing left pending -> no prompt needed

--- a/tests/cli/test_hooks_cli.py
+++ b/tests/cli/test_hooks_cli.py
@@ -178,3 +178,72 @@ def test_trust_is_idempotent_on_rerun(tmp_path):
 
     code = cli_main(["hooks", "trust", "--cwd", str(tmp_path)])
     assert code == 0  # nothing left pending -> no prompt needed
+
+
+def test_trust_rejects_malformed_argv_instead_of_recording_it(capsys, tmp_path):
+    """`li hooks trust` must not hash-record a malformed imported command
+    (an empty argv list here) -- it must reject it with a clear message,
+    matching the argv validation the config loader enforces at execution
+    time (ADR-0048 D4)."""
+    from lionagi.hooks.external import compute_command_hash
+
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        yaml.safe_dump(
+            {
+                "hooks_external": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {"command": [], "source": "imported:claude"},
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path), "--yes"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "rejected" in out
+    assert "no pending" in out
+
+    trusted = read_user_settings().get("trusted_hook_commands", [])
+    assert compute_command_hash([]) not in trusted
+
+
+@pytest.mark.parametrize(
+    "bad_command",
+    [
+        [],  # empty argv
+        ["guard", "   "],  # blank entry
+        ["guard", 1],  # non-string entry
+    ],
+    ids=["empty", "blank", "non-string"],
+)
+def test_trust_rejects_various_malformed_argv_shapes(capsys, tmp_path, bad_command):
+    from lionagi.hooks.external import compute_command_hash
+
+    settings_path = tmp_path / ".lionagi" / "settings.yaml"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        yaml.safe_dump(
+            {
+                "hooks_external": {
+                    "PreToolUse": [
+                        {"hooks": [{"command": bad_command, "source": "imported:claude"}]}
+                    ]
+                }
+            }
+        )
+    )
+
+    code = cli_main(["hooks", "trust", "--cwd", str(tmp_path), "--yes"])
+    assert code == 0
+    assert "rejected" in capsys.readouterr().out
+
+    trusted = read_user_settings().get("trusted_hook_commands", [])
+    assert compute_command_hash(bad_command) not in trusted

--- a/tests/hooks/fixtures/claude_settings.json
+++ b/tests/hooks/fixtures/claude_settings.json
@@ -1,0 +1,56 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["uv", "run", "guards/check_cmd.py"],
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rm -rf $HOME/scratch"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["uv", "run", "guards/audit_log.py"]
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/prompt_hygiene"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["notify-stop"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/hooks/fixtures/codex_hooks.json
+++ b/tests/hooks/fixtures/codex_hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "shell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["deny_destructive"],
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["prompt_gate"]
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["compact-notify"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/hooks/test_conformance_matrix.py
+++ b/tests/hooks/test_conformance_matrix.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""External-hook compatibility profile v1 conformance matrix.
+
+Fixture hooks shaped after the Claude Code and Codex hook config schemas
+(``tests/hooks/fixtures/``) are imported and then actually run under the
+LionAGI adapter, asserting: the per-event field-guarantee rows; the
+exit-code/stdout decision contract; and the named divergences Dv1-1..Dv1-4.
+Until this file exists and passes, no LionAGI documentation or `li hooks
+import` output may claim a foreign hook runs "unmodified" -- the import
+report always says "imported; verify against profile v1" (see
+``lionagi/cli/hooks.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from lionagi.agent.settings import parse_external_hooks
+from lionagi.cli.hooks import _translate_config
+from lionagi.hooks.external import build_envelope, external_hook_adapter
+from lionagi.protocols.action.tool_hooks import ToolPreDecision
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _mock_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.pid = 1234
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Claude Code fixture: import report + resulting hooks_external entries
+# ---------------------------------------------------------------------------
+
+
+def test_claude_fixture_imports_mappable_events_and_rejects_the_rest():
+    data = _load("claude_settings.json")
+    external, report = _translate_config(data, source_label="claude")
+
+    # Mappable events with valid argv/shell-string commands import.
+    assert "PreToolUse" in external
+    assert "PostToolUse" in external
+    assert "UserPromptSubmit" in external
+    # Stop has no LionAGI seam (D2 fixed mapping) -- rejected, not silently dropped.
+    assert "Stop" not in external
+    assert any("rejected [Stop]" in line and "no LionAGI seam" in line for line in report)
+
+    # The shell-string command containing `$HOME` (a shell metacharacter) is
+    # rejected rather than reinterpreted (Dv1-3).
+    assert any(
+        "rejected [PreToolUse]" in line and "shell metacharacters" in line for line in report
+    )
+
+    # Every accepted entry's report line says "verify against profile v1" --
+    # never "unmodified" (D1's acceptance-gate language).
+    imported_lines = [line for line in report if line.startswith("imported")]
+    assert imported_lines
+    for line in imported_lines:
+        assert "verify against profile v1" in line
+        assert "unmodified" not in line
+
+
+def test_claude_fixture_entries_parse_and_construct_adapters():
+    data = _load("claude_settings.json")
+    external, _ = _translate_config(data, source_label="claude")
+    entries = parse_external_hooks(external)
+
+    pre_entries = [e for e in entries if e["event"] == "PreToolUse"]
+    assert len(pre_entries) == 1  # only the valid-argv one survived translation
+    assert pre_entries[0]["source"] == "imported:claude"
+
+    for entry in entries:
+        handler = external_hook_adapter(
+            event=entry["event"],
+            command=entry["command"],
+            timeout=entry["timeout"],
+            matcher=entry.get("matcher"),
+            source=entry.get("source"),
+        )
+        assert callable(handler)
+
+
+# ---------------------------------------------------------------------------
+# Codex fixture: PreCompact (out of scope, no runtime seam) is rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_codex_fixture_rejects_precompact_no_seam():
+    data = _load("codex_hooks.json")
+    external, report = _translate_config(data, source_label="codex")
+
+    assert "PreCompact" not in external
+    assert any("rejected [PreCompact]" in line and "no LionAGI seam" in line for line in report)
+    assert "PreToolUse" in external
+    assert "UserPromptSubmit" in external
+
+
+def test_codex_fixture_marks_dv1_1_transcript_divergence_for_user_prompt_submit():
+    data = _load("codex_hooks.json")
+    _, report = _translate_config(data, source_label="codex")
+    ups_lines = [line for line in report if "UserPromptSubmit" in line and "imported" in line]
+    assert ups_lines
+    assert any("transcript_path/turn_id" in line for line in ups_lines)
+
+
+# ---------------------------------------------------------------------------
+# Field-guarantee rows, exercised end to end against a mocked subprocess.
+# ---------------------------------------------------------------------------
+
+
+async def test_pre_tool_use_field_guarantees_reach_the_subprocess(monkeypatch):
+    captured = {}
+
+    async def fake_communicate(data):
+        captured["envelope"] = json.loads(data.decode())
+        return b"", b""
+
+    proc = _mock_proc(0)
+    proc.communicate = AsyncMock(side_effect=fake_communicate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    hook = external_hook_adapter(
+        event="PreToolUse", command=["guard"], session_id="s-42", cwd="/work"
+    )
+    await hook("bash", {"command": ["git", "status"]})
+
+    env = captured["envelope"]
+    assert env["session_id"] == "s-42"
+    assert env["cwd"] == "/work"
+    assert env["hook_event_name"] == "PreToolUse"
+    assert env["harness"] == "lionagi"
+    assert env["tool_name"] == "bash"
+    assert env["tool_input"] == {"command": ["git", "status"]}
+    assert "tool_response" not in env
+
+
+async def test_post_tool_use_field_guarantees_include_tool_response(monkeypatch):
+    captured = {}
+
+    async def fake_communicate(data):
+        captured["envelope"] = json.loads(data.decode())
+        return b"", b""
+
+    proc = _mock_proc(0)
+    proc.communicate = AsyncMock(side_effect=fake_communicate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    hook = external_hook_adapter(event="PostToolUse", command=["notify"], session_id="s-1")
+    await hook("bash", {"command": ["ls"]}, {"stdout": "ok"}, None)
+
+    env = captured["envelope"]
+    assert env["tool_response"] == {"stdout": "ok"}
+
+
+async def test_user_prompt_submit_field_guarantees_include_model_and_permission_mode(
+    monkeypatch,
+):
+    captured = {}
+
+    async def fake_communicate(data):
+        captured["envelope"] = json.loads(data.decode())
+        return b"", b""
+
+    proc = _mock_proc(0)
+    proc.communicate = AsyncMock(side_effect=fake_communicate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    hook = external_hook_adapter(event="UserPromptSubmit", command=["hygiene"])
+    await hook(session_id="s-1", branch_id="b-1", prompt="hello", model="claude-sonnet")
+
+    env = captured["envelope"]
+    assert env["prompt"] == "hello"
+    assert env["model"] == "claude-sonnet"
+    # Dv1-1 in miniature: LionAGI never fabricates transcript_path/turn_id --
+    # they are simply absent, not present-with-a-placeholder.
+    assert "transcript_path" not in env
+    assert "turn_id" not in env
+    # No PermissionPolicy attached at this call -> the ADR's explicit "else
+    # default" fallback, not a missing field.
+    assert env["permission_mode"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# Exit-code protocol, exactly as the ADR states it (D1/D4 acceptance).
+# ---------------------------------------------------------------------------
+
+
+async def test_exit_code_protocol_zero_two_and_other(monkeypatch):
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
+    allow = await hook("bash", {})
+    assert allow.decision == "allow"
+
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(2, stderr=b"blocked reason")),
+    )
+    deny = await hook("bash", {})
+    assert deny.decision == "deny"
+    assert "blocked reason" in deny.reason
+
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(17, stderr=b"unexpected crash")),
+    )
+    error = await hook("bash", {})
+    # Exit 2 (block) is distinguished from every other nonzero exit (hook
+    # failure); on a blocking seam both fail the action closed, but the
+    # reason text must not collapse the two into indistinguishable output.
+    assert error.decision == "deny"
+    assert "unexpected crash" in error.reason
+
+
+# ---------------------------------------------------------------------------
+# Named divergence Dv1-4: LionAGI fails closed on a blocking-event timeout,
+# where Claude Code cancels the hook and lets the prompt proceed (fail open).
+# ---------------------------------------------------------------------------
+
+
+async def test_dv1_4_timeout_fails_closed_unlike_claude_codes_fail_open(monkeypatch):
+    proc = MagicMock()
+    proc.pid = 555
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.wait = AsyncMock(return_value=None)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+    monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda pgid, sig: None)
+
+    hook = external_hook_adapter(event="UserPromptSubmit", command=["slow_hygiene"], timeout=0.01)
+    try:
+        await hook(session_id="s-1", prompt="hi")
+        raised = False
+    except PermissionError:
+        raised = True
+    assert raised, "a timed-out UserPromptSubmit hook must fail closed (deny), not allow the prompt"
+
+
+def test_build_envelope_matches_the_adapters_own_construction():
+    """The envelope schema documented for hand-authored hooks (build_envelope)
+    matches exactly what the adapter sends -- no drift between the two."""
+    manual = build_envelope(
+        hook_event_name="PreToolUse",
+        session_id="s",
+        cwd="/w",
+        tool_name="bash",
+        tool_input={"command": ["ls"]},
+    )
+    assert set(manual) == {
+        "session_id",
+        "cwd",
+        "hook_event_name",
+        "harness",
+        "tool_name",
+        "tool_input",
+    }

--- a/tests/hooks/test_external_adapter.py
+++ b/tests/hooks/test_external_adapter.py
@@ -288,6 +288,31 @@ async def test_pre_tool_use_unrecognized_decision_fails_closed(monkeypatch):
     assert "maybe" in result.reason
 
 
+async def test_pre_tool_use_top_level_unrecognized_decision_fails_closed(monkeypatch):
+    """The top-level `decision` shape must fail closed the same way the nested
+    `hookSpecificOutput.permissionDecision` shape does: an explicit but
+    unrecognized value (e.g. "maybe") must never fall through to allow."""
+    stdout = json.dumps({"decision": "maybe", "reason": "unexpected"}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "maybe" in result.reason
+
+
+@pytest.mark.parametrize("value", ["allow", "approve"])
+async def test_pre_tool_use_top_level_allow_synonyms_allow(monkeypatch, value):
+    stdout = json.dumps({"decision": value}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "allow"
+
+
 async def test_pre_tool_use_nonjson_stdout_is_treated_as_no_decision(monkeypatch):
     monkeypatch.setattr(
         asyncio,

--- a/tests/hooks/test_external_adapter.py
+++ b/tests/hooks/test_external_adapter.py
@@ -1,0 +1,478 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the external-hook exec adapter: envelope construction, the
+exit-code/stdout contract, timeout handling, and the trust gate."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lionagi.hooks.external import (
+    ExternalHookConfigError,
+    build_envelope,
+    compute_command_hash,
+    external_hook_adapter,
+    is_command_trusted,
+    match_hook,
+    validate_argv,
+)
+from lionagi.protocols.action.tool_hooks import ToolPostDecision, ToolPreDecision
+
+# ---------------------------------------------------------------------------
+# validate_argv (D4: non-empty argv of non-empty/non-whitespace strings)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_argv_accepts_nonempty_string_list():
+    assert validate_argv(["uv", "run", "guard.py"]) == ["uv", "run", "guard.py"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "echo unsafe",  # shell string, not a list
+        [],  # empty list
+        ["ok", ""],  # blank entry
+        ["ok", "   "],  # whitespace-only entry
+        ["ok", 1],  # non-string entry
+        None,
+    ],
+)
+def test_validate_argv_rejects(bad):
+    with pytest.raises(ExternalHookConfigError):
+        validate_argv(bad)
+
+
+# ---------------------------------------------------------------------------
+# build_envelope: D1 field guarantees per event
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_common_fields_always_present():
+    env = build_envelope(
+        hook_event_name="PreToolUse",
+        session_id="s-1",
+        cwd="/tmp/proj",
+        tool_name="bash",
+        tool_input={"command": ["git", "status"]},
+    )
+    assert env["session_id"] == "s-1"
+    assert env["cwd"] == "/tmp/proj"
+    assert env["hook_event_name"] == "PreToolUse"
+    assert env["harness"] == "lionagi"
+
+
+def test_envelope_pre_tool_use_guarantees_tool_name_and_input():
+    env = build_envelope(
+        hook_event_name="PreToolUse",
+        session_id="s",
+        cwd="/",
+        tool_name="bash",
+        tool_input={"command": ["ls"]},
+    )
+    assert env["tool_name"] == "bash"
+    assert env["tool_input"] == {"command": ["ls"]}
+    assert "tool_response" not in env
+
+
+def test_envelope_post_tool_use_guarantees_tool_response():
+    env = build_envelope(
+        hook_event_name="PostToolUse",
+        session_id="s",
+        cwd="/",
+        tool_name="bash",
+        tool_input={"command": ["ls"]},
+        tool_response={"stdout": "ok"},
+    )
+    assert env["tool_response"] == {"stdout": "ok"}
+
+
+def test_envelope_user_prompt_submit_guarantees_prompt_model_permission_mode():
+    env = build_envelope(
+        hook_event_name="UserPromptSubmit",
+        session_id="s",
+        cwd="/",
+        prompt="hi there",
+        model="claude-sonnet",
+    )
+    assert env["prompt"] == "hi there"
+    assert env["model"] == "claude-sonnet"
+    # No PermissionPolicy attached at this call site -> "default", per the ADR's
+    # explicit fallback rule (not an omission).
+    assert env["permission_mode"] == "default"
+
+
+def test_envelope_post_tool_use_failure_guarantees_tool_response_as_error():
+    env = build_envelope(
+        hook_event_name="PostToolUseFailure",
+        session_id="s",
+        cwd="/",
+        tool_name="bash",
+        tool_input=None,
+        tool_response={"error": "boom"},
+    )
+    assert env["tool_response"] == {"error": "boom"}
+
+
+# ---------------------------------------------------------------------------
+# match_hook: harness matcher semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("matcher", [None, "", "*"])
+def test_match_hook_empty_or_star_matches_everything(matcher):
+    assert match_hook(matcher, "bash") is True
+    assert match_hook(matcher, "anything") is True
+
+
+def test_match_hook_exact_or_list():
+    assert match_hook("bash", "bash") is True
+    assert match_hook("bash", "reader") is False
+    assert match_hook("bash,reader", "reader") is True
+    assert match_hook("bash|reader", "editor") is False
+
+
+def test_match_hook_unanchored_regex_fallback():
+    assert match_hook("^bash$", "bash") is True
+    assert match_hook("bash.*", "bash_tool") is True
+
+
+# ---------------------------------------------------------------------------
+# Trust gate (D7)
+# ---------------------------------------------------------------------------
+
+
+def test_is_command_trusted_no_source_is_project_authored():
+    assert is_command_trusted(["guard"], source=None) is True
+
+
+def test_is_command_trusted_imported_without_record_is_untrusted(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert is_command_trusted(["guard"], source="imported:claude") is False
+
+
+def test_is_command_trusted_imported_with_matching_hash(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from lionagi.plugins._user_settings import write_user_settings
+
+    command = ["guard", "--check"]
+    write_user_settings({"trusted_hook_commands": [compute_command_hash(command)]})
+    assert is_command_trusted(command, source="imported:claude") is True
+
+
+def test_command_hash_changes_with_argv():
+    assert compute_command_hash(["a", "b"]) != compute_command_hash(["a", "c"])
+
+
+# ---------------------------------------------------------------------------
+# external_hook_adapter: unsupported event fails config load
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_rejects_unmappable_event():
+    with pytest.raises(ExternalHookConfigError, match="no seam"):
+        external_hook_adapter(event="Stop", command=["guard"])
+
+
+def test_adapter_rejects_invalid_argv():
+    with pytest.raises(ExternalHookConfigError):
+        external_hook_adapter(event="PreToolUse", command="echo unsafe")
+
+
+# ---------------------------------------------------------------------------
+# PreToolUse: exit-code contract + stdout decision parsing
+# ---------------------------------------------------------------------------
+
+
+def _mock_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.pid = 4242
+    return proc
+
+
+async def test_pre_tool_use_exit_zero_no_stdout_allows(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result == ToolPreDecision(decision="allow", updated_input=None)
+
+
+async def test_pre_tool_use_exit_zero_with_updated_input(monkeypatch):
+    stdout = json.dumps(
+        {
+            "hookSpecificOutput": {
+                "permissionDecision": "allow",
+                "updatedInput": {"command": ["ls", "-la"]},
+            }
+        }
+    ).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "allow"
+    assert result.updated_input == {"command": ["ls", "-la"]}
+
+
+async def test_pre_tool_use_exit_two_is_deny_with_stderr_reason(monkeypatch):
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(2, stderr=b"blocked: destructive command")),
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["rm", "-rf", "/"]})
+    assert result.decision == "deny"
+    assert "blocked" in result.reason
+
+
+async def test_pre_tool_use_other_nonzero_exit_is_deny_with_diagnostic(monkeypatch):
+    """Distinguishes exit 2 (block) from any other nonzero exit (hook failure) --
+    PreToolUse is a blocking seam, so a hook failure still fails closed."""
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(1, stderr=b"crashed")),
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "crashed" in result.reason
+
+
+async def test_pre_tool_use_stdout_deny_decision(monkeypatch):
+    stdout = json.dumps(
+        {
+            "hookSpecificOutput": {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "not allowed",
+            }
+        }
+    ).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert result.reason == "not allowed"
+
+
+async def test_pre_tool_use_ask_fails_closed(monkeypatch):
+    stdout = json.dumps({"hookSpecificOutput": {"permissionDecision": "ask"}}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "ask" in result.reason
+
+
+async def test_pre_tool_use_unrecognized_decision_fails_closed(monkeypatch):
+    stdout = json.dumps({"hookSpecificOutput": {"permissionDecision": "maybe"}}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "maybe" in result.reason
+
+
+async def test_pre_tool_use_nonjson_stdout_is_treated_as_no_decision(monkeypatch):
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(0, stdout=b"not json at all")),
+    )
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"])
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "allow"
+
+
+async def test_pre_tool_use_matcher_skips_non_matching_tool(monkeypatch):
+    spawn = AsyncMock()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"], matcher="reader")
+    result = await hook("bash", {"command": ["ls"]})
+    assert result is None
+    spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PostToolUse: advisory only -- a deny/error becomes a surfaced note, never
+# a raised exception (the action already happened).
+# ---------------------------------------------------------------------------
+
+
+async def test_post_tool_use_allow_returns_none(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
+    hook = external_hook_adapter(event="PostToolUse", command=["notify"])
+    result = await hook("bash", {"command": ["ls"]}, {"stdout": "ok"}, None)
+    assert result is None
+
+
+async def test_post_tool_use_exit_two_surfaces_reason_not_raise(monkeypatch):
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_mock_proc(2, stderr=b"flagged after the fact")),
+    )
+    hook = external_hook_adapter(event="PostToolUse", command=["notify"])
+    result = await hook("bash", {"command": ["ls"]}, {"stdout": "ok"}, None)
+    assert isinstance(result, ToolPostDecision)
+    assert "flagged" in result.reason
+
+
+async def test_post_tool_use_error_result_maps_tool_response_to_error_dict(monkeypatch):
+    captured = {}
+
+    async def fake_communicate(data):
+        captured["envelope"] = json.loads(data.decode())
+        return b"", b""
+
+    proc = _mock_proc(0)
+    proc.communicate = AsyncMock(side_effect=fake_communicate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    hook = external_hook_adapter(event="PostToolUse", command=["notify"])
+    err = ValueError("kaboom")
+    await hook("bash", {"command": ["ls"]}, None, err)
+    assert captured["envelope"]["tool_response"] == {"error": "kaboom"}
+
+
+# ---------------------------------------------------------------------------
+# Timeout: process group is killed; blocking events fail closed, advisory
+# events are logged and continue.
+# ---------------------------------------------------------------------------
+
+
+async def test_pre_tool_use_timeout_kills_process_group_and_denies(monkeypatch):
+    proc = MagicMock()
+    proc.pid = 9999
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.wait = AsyncMock(return_value=None)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    killed: list[int] = []
+    monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda pgid, sig: killed.append(pgid))
+
+    hook = external_hook_adapter(event="PreToolUse", command=["slow_guard"], timeout=0.01)
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "timed out" in result.reason
+    assert killed, "expected the hook's process group to be killed on timeout"
+
+
+async def test_post_tool_use_timeout_surfaces_reason_not_raise(monkeypatch):
+    proc = MagicMock()
+    proc.pid = 8888
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.wait = AsyncMock(return_value=None)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+    monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda pgid, sig: None)
+
+    hook = external_hook_adapter(event="PostToolUse", command=["slow_notify"], timeout=0.01)
+    result = await hook("bash", {"command": ["ls"]}, {"ok": True}, None)
+    assert isinstance(result, ToolPostDecision)
+    assert "timed out" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# UserPromptSubmit: blocking HookBus seam -- a deny verdict raises.
+# ---------------------------------------------------------------------------
+
+
+async def test_user_prompt_submit_deny_raises_permission_error(monkeypatch):
+    stdout = json.dumps({"decision": "block", "reason": "hygiene check failed"}).encode()
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0, stdout=stdout))
+    )
+    hook = external_hook_adapter(event="UserPromptSubmit", command=["hygiene"])
+    with pytest.raises(PermissionError, match="hygiene check failed"):
+        await hook(session_id="s-1", branch_id="b-1", prompt="do a thing")
+
+
+async def test_user_prompt_submit_allow_does_not_raise(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
+    hook = external_hook_adapter(event="UserPromptSubmit", command=["hygiene"])
+    await hook(session_id="s-1", branch_id="b-1", prompt="do a thing")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# SessionStart/SessionEnd/PostToolUseFailure: advisory -- deny is logged, not raised.
+# ---------------------------------------------------------------------------
+
+
+async def test_session_start_deny_is_logged_not_raised(monkeypatch):
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(2, stderr=b"nope"))
+    )
+    hook = external_hook_adapter(event="SessionStart", command=["notify"])
+    await hook(session_id="s-1", model="sonnet")  # must not raise
+
+
+async def test_post_tool_use_failure_stringifies_error_into_tool_response(monkeypatch):
+    captured = {}
+
+    async def fake_communicate(data):
+        captured["envelope"] = json.loads(data.decode())
+        return b"", b""
+
+    proc = _mock_proc(0)
+    proc.communicate = AsyncMock(side_effect=fake_communicate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+
+    hook = external_hook_adapter(event="PostToolUseFailure", command=["notify"])
+    await hook(session_id="s-1", tool_name="bash", error=RuntimeError("disk full"))
+
+    assert captured["envelope"]["tool_response"] == {"error": "disk full"}
+    assert captured["envelope"]["tool_name"] == "bash"
+
+
+# ---------------------------------------------------------------------------
+# Untrusted command: imported entries never execute without a trust record.
+# ---------------------------------------------------------------------------
+
+
+async def test_untrusted_imported_pre_tool_use_denies_without_spawning(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    spawn = AsyncMock()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+
+    hook = external_hook_adapter(event="PreToolUse", command=["guard"], source="imported:claude")
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "deny"
+    assert "untrusted" in result.reason
+    spawn.assert_not_called()
+
+
+async def test_trusted_imported_pre_tool_use_executes(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from lionagi.plugins._user_settings import write_user_settings
+
+    command = ["guard"]
+    write_user_settings({"trusted_hook_commands": [compute_command_hash(command)]})
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
+    hook = external_hook_adapter(event="PreToolUse", command=command, source="imported:claude")
+    result = await hook("bash", {"command": ["ls"]})
+    assert result.decision == "allow"
+
+
+async def test_untrusted_imported_advisory_event_is_error_not_raise(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    spawn = AsyncMock()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+
+    hook = external_hook_adapter(event="SessionStart", command=["notify"], source="imported:codex")
+    await hook(session_id="s-1")  # advisory: must not raise even though untrusted
+    spawn.assert_not_called()

--- a/tests/hooks/test_external_adapter.py
+++ b/tests/hooks/test_external_adapter.py
@@ -359,7 +359,10 @@ async def test_post_tool_use_error_result_maps_tool_response_to_error_dict(monke
 async def test_pre_tool_use_timeout_kills_process_group_and_denies(monkeypatch):
     proc = MagicMock()
     proc.pid = 9999
-    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    # asyncio.wait_for raises asyncio.TimeoutError, which is NOT the builtin
+    # TimeoutError before 3.11 -- inject the real raised type so this exercises
+    # the pre-3.11 teardown path rather than passing by luck on 3.11+.
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
     proc.wait = AsyncMock(return_value=None)
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
 
@@ -376,7 +379,7 @@ async def test_pre_tool_use_timeout_kills_process_group_and_denies(monkeypatch):
 async def test_post_tool_use_timeout_surfaces_reason_not_raise(monkeypatch):
     proc = MagicMock()
     proc.pid = 8888
-    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
     proc.wait = AsyncMock(return_value=None)
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
     monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda pgid, sig: None)


### PR DESCRIPTION
## What

ADR-0048 external-hook exec layer: run externally-authored hook commands (Claude Code / Codex-shaped) against LionAGI's internal hook seams. A `hooks_external:` config entry (event + argv command + matcher + timeout) becomes an async callable wired to the tool pre/post chain (`PreToolUse`/`PostToolUse` at `ActionManager.invoke`) or the `HookBus` (`SessionStart`/`SessionEnd`/`UserPromptSubmit`/`PostToolUseFailure`). The callable spawns the command as a real subprocess, writes a JSON envelope to stdin, and maps stdout + exit code back to a decision. Adds `li hooks import claude|codex` and `li hooks trust`.

## Compatibility profile v1

- **Envelope (D1)**: common fields (`session_id`, `cwd`, `hook_event_name`, `harness="lionagi"`) always present; per-event additions (`tool_name`/`tool_input`, `tool_response`, `prompt`/`model`/`permission_mode`) per the field-guarantee table. Named divergences from CC/Codex are documented and tested (no fabricated `transcript_path`/`turn_id`; argv-only, no shell reinterpretation; fails closed on blocking-event timeout unlike CC's fail-open).
- **Exit-code contract (D4)**: `0` = success (stdout parsed as JSON if non-empty) · `2` = deny (stderr is the reason) · other nonzero / spawn error = hook failure (deny on a blocking seam, log-and-continue on advisory) · timeout = process-group killed, deny on blocking.
- **Trust (D6)**: a config entry with no `source` is project/user-authored and trusted as code; any `imported:*` source requires the argv's sha256 to be recorded in `trusted_hook_commands` (via `li hooks trust`) before it will execute.

## Safety properties

- **argv-only**: `validate_argv` rejects string-form commands and blank entries — never a heuristic `shlex.split`.
- **Fail-closed**: on a blocking seam (`PreToolUse`/`UserPromptSubmit`), a deny, a hook crash, an unrecognized decision, an `ask` (no interactive surface), and a timeout all fail the action closed.
- **Process-group teardown on timeout**: the subprocess is spawned with `start_new_session=True` and the whole group is killed on timeout so a hung hook's children can't keep running.
- **Bounded stdout** (1 MiB), trust gate evaluated before every exec.

## Owner-review fix included

During owner diff-read I found and fixed a Python-3.10 correctness bug: `asyncio.wait_for` raises `asyncio.TimeoutError`, which is a **distinct class** from the builtin `TimeoutError` before 3.11. The timeout handler only caught the builtin, so on the 3.10 CI floor the process-group teardown was skipped (child leak) and the "timed out" reason was lost. The regression tests had masked it by injecting the builtin `TimeoutError` as a mock side-effect; they now inject `asyncio.TimeoutError` (what `wait_for` actually raises), and the handler catches both.

## Tests

`tests/hooks/` (adapter contract, conformance matrix, fixtures), `tests/agent/test_{factory,settings}_external_hooks.py`, `tests/cli/test_hooks_cli.py`, golden update. Green locally on 3.10; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
