### PR TITLE
fix(tools): restore operational content dropped from LLM-facing tool docstrings

### DIFF
--- a/lionagi/tools/code/ast_search.py
+++ b/lionagi/tools/code/ast_search.py
@@ -186,8 +186,21 @@ class AstSearchTool(LionTool):
         if self._tool is None:
 
             async def ast_search(**kwargs):
-                """Search source code by AST shape using ast-grep (structural patterns, not text — e.g. 'except: pass' regardless of whitespace).
-                Requires the 'sg'/'ast-grep' binary in PATH; returns status='unavailable' if absent, not an error.
+                """
+                Search source code by AST shape using ast-grep (sg binary) —
+                structural patterns rather than text (e.g. 'except: pass'
+                regardless of whitespace, or all calls with a None first arg).
+
+                Requires the 'sg' or 'ast-grep' binary in PATH; returns
+                status='unavailable' if absent (not an error).
+
+                Pattern syntax: https://ast-grep.github.io/reference/pattern.html
+                  '$X'    — matches any single AST node, captured as X
+                  '$$$'   — matches zero or more nodes (variadic)
+                  '...'   — elides sub-patterns (wildcard for bodies)
+
+                Result status: 'ok' (no matches) | 'matches' (see matches list)
+                | 'unavailable' (sg not installed) | 'error' (tool failed)
                 """
                 return (await self.handle_request(AstSearchRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -130,9 +130,22 @@ class BashTool(LionTool):
         if self._tool is None:
 
             async def bash_tool(**kwargs):
-                """Execute a single shell command (no shell interpretation) and return stdout, stderr, and return code.
-                Shell operators (;, &&, ||, |, redirects, backticks) are rejected — one command per call; use cwd= instead of `cd dir && cmd`.
-                Recovery: 'command not found' → check PATH; timed out → raise timeout= or split into steps.
+                """Execute a single shell command and return its output.
+
+                Runs the command safely without shell interpretation. Shell operators
+                (;, &&, ||, |, redirects, backticks, $(...)) are rejected — run one
+                command per call. Use cwd= to set the working directory instead of
+                `cd dir && cmd`. For file search/read/edit, prefer the dedicated
+                reader/editor/search tools.
+
+                Enforces a configurable timeout (default 30 s, max 5 min). Output
+                exceeding 100 KB per stream is truncated — redirect to a file and
+                use the reader tool for large outputs.
+
+                Recovery hints:
+                - 'command not found': check the executable is installed and in PATH
+                - 'timed out': increase timeout= or split into smaller steps
+                - 'operators not supported': use cwd= and separate calls
                 """
                 return (await self.handle_request(BashRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -542,7 +542,7 @@ class CodingToolkit(LionTool):
             cwd: str = None,
         ) -> dict:
             """Execute a single shell command and return stdout, stderr, and return code.
-            One command per call — shell operators (&&, ||, |, ;, redirects, backticks) are rejected; pass cwd= to run in a directory.
+            One command per call — shell operators (&&, ||, |, ;, redirects, backticks, $(...)) are rejected; pass cwd= to run in a directory. Output is truncated if it exceeds 100 KB per stream.
             """
             timeout_ms = max(1, min(timeout or 30000, 300000))
             timeout_s = timeout_ms / 1000.0

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -132,9 +132,13 @@ class LionMessenger(LionTool):
             content: str = None,
             urgency: str = None,
         ) -> str:
-            """Send/receive teammate messages, signal done/finished, wake a teammate, or send a help signal.
-            action in {'send','receive','done','finished','wakeup','help'}; 'to'+'content' required for send/wakeup, 'content' required for help.
-            """
+            """Send messages to teammates, receive pending ones, signal
+            done/finished, wake a teammate, or send a help signal. action in
+            {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to
+            (name or list of names) and content are required for
+            send/wakeup, neither is required for receive; content (the
+            reason) is required for help, urgency is optional (defaults to
+            'fyi')."""
             if action == "receive":
                 pending = exchange.receive(sender_id)
                 if not pending:

--- a/lionagi/tools/file/editor.py
+++ b/lionagi/tools/file/editor.py
@@ -241,9 +241,22 @@ class EditorTool(LionTool):
         if self._tool is None:
 
             async def editor_tool(**kwargs):
-                """Write or edit files on disk within the configured workspace root; you must read a file (reader action='read') before editing it.
-                action='write' creates/overwrites; action='edit' does exact-string replacement — strip the `<number>\\t` reader prefix from old_string.
-                On 'not found': re-read the file and copy the exact text, then retry.
+                """
+                Write or edit files on disk within the configured workspace root.
+
+                IMPORTANT: Always read the file first (reader action='read') before editing.
+                The reader returns lines as `<number>\\t<code>` — do NOT copy the leading
+                `<number>\\t` prefix into old_string; use only the actual code text.
+
+                Use action='write' to create or fully replace a file. Use action='edit'
+                for targeted exact-string replacement — safer than full rewrites.
+                Parent directories are created automatically on write.
+
+                If an edit fails with 'not found': re-read the file, copy the exact text
+                including all whitespace, and retry.
+                If an edit fails with 'appears N times': expand old_string with more
+                surrounding context to make it unique, or set replace_all=True.
+                Paths outside the workspace root and symlinks are rejected.
                 """
                 return (await self.handle_request(EditorRequest(**kwargs))).model_dump()
 

--- a/lionagi/tools/file/reader.py
+++ b/lionagi/tools/file/reader.py
@@ -344,7 +344,20 @@ class ReaderTool(LionTool):
 
             async def reader_tool(**kwargs):
                 """Read files, convert documents (PDF/PPTX/DOCX/HTML via docling), or list directories.
-                action='read' returns `<number>\\t<code>` lines (strip the prefix before using as editor old_string); action='open' converts then caches by path for a follow-up 'read'.
+
+                Use action='read' for text files. Output format is `<number>\\t<code>` per line;
+                the number prefix is for reference only — strip the leading `<digits>\\t` before
+                using any line as an editor old_string. Use offset+limit to read large files in
+                windows (e.g. offset=200, limit=200 to get lines 200-400).
+
+                Use action='open' for documents needing conversion (PDF, PPTX, HTML) —
+                result is cached by path, then use 'read' with offset/limit on the same path.
+                Chain them in one turn: [open(path="report.pdf"), read(path="report.pdf", offset=0, limit=100)]
+
+                Use action='list_dir' for directory listings.
+
+                All paths are restricted to the configured workspace root. URL conversion
+                requires explicit host allowlisting.
                 """
                 return (await self.handle_request(ReaderRequest(**kwargs))).model_dump()
 


### PR DESCRIPTION
## What

Restore operational content that a docstring-trim pass (PR #2141) silently dropped from six LLM-facing tool docstrings. These docstrings are extracted by `function_to_schema()` into the live OpenAI-format `"description"` field the model reads at inference time — not internal documentation — so the trim degraded the guidance the model depends on to call the tools correctly. The trim's "AST-identical" check couldn't catch it because it only diffs docstring string content, and no test asserts on the extracted schema description.

## Restored (verified against current source, not a blind revert)

- **`tools/code/bash.py`** (`bash_tool`): `$(...)` back in the rejected shell-operator list, default/max timeout (30s/5min), the 100KB-per-stream truncation + remediation note, three recovery hints.
- **`tools/coding.py`** (`CodingToolkit.bind` inner `bash`): `$(...)` operator + 100KB truncation note.
- **`tools/file/reader.py`** (`reader_tool`): workspace-root/URL-allowlist security disclosure, windowed-read example, open→read chaining example.
- **`tools/file/editor.py`** (`editor_tool`): auto-created-parent-dirs note, the `'appears N times'` recovery hint, workspace-root/symlink-rejection disclosure.
- **`tools/code/ast_search.py`** (`ast_search`): ast-grep pattern-syntax mini-reference (`$X`, `$$$`, `...`) + doc link, result-status enumeration.
- **`tools/communication/messenger.py`** (`messenger`): the `urgency` defaults-to-`'fyi'` disclosure.

Each restored claim was confirmed against current source before restoring (e.g. `$(...)` is in `_SHELL_CONTROL`, `_MAX_OUTPUT_BYTES = 100_000`, the 30s/300s timeout defaults, `urgency or "fyi"`).

## Tests

Ran the tools + schema-extraction suites in the foreground: 222 passed, 6 skipped (missing `ast-grep` binary, pre-existing), 2 pre-existing `docling`-not-installed failures unrelated to this change (identical on unmodified main). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
