### PR TITLE
fix(session): Exchange.run() after stop() raises instead of silent no-op

### DIFF
--- a/lionagi/session/exchange.py
+++ b/lionagi/session/exchange.py
@@ -33,6 +33,7 @@ class Exchange(Element):
     flows: Pile[Flow[Message, Progression]] = None  # type: ignore
     _owner_index: dict[UUID, UUID] = PrivateAttr(default_factory=dict)
     _stop: bool = PrivateAttr(default=False)
+    _run_started: bool = PrivateAttr(default=False)
     _in_flight: dict[UUID, list[Message]] = PrivateAttr(default_factory=dict)
     _in_flight_lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
 
@@ -246,7 +247,22 @@ class Exchange(Element):
         return total
 
     async def run(self, interval: float = 1.0) -> None:
-        """Continuous sync loop; call stop() to exit. Does not reset ``_stop`` on entry — a pre-issued stop() must make run() return immediately, not loop forever. Construct a fresh Exchange to reuse."""
+        """Continuous sync loop; call stop() to exit.
+
+        One-shot: raises RuntimeError if called a second time on the same
+        instance, whether or not the first call already exited. Does not
+        reset ``_stop`` on entry — a stop() issued before this coroutine's
+        first turn (e.g. the DAG it watches over failed immediately) must
+        make this first call return right away rather than clearing that
+        signal and looping forever. Construct a fresh Exchange for a new
+        run instead of reusing one that has already been run.
+        """
+        if self._run_started:
+            raise RuntimeError(
+                f"{self!r} has already been run and cannot be restarted; "
+                "construct a fresh Exchange for a new run."
+            )
+        self._run_started = True
         while not self._stop:
             await self.sync()
             await sleep(interval)

--- a/tests/session/test_exchange.py
+++ b/tests/session/test_exchange.py
@@ -422,6 +422,41 @@ class TestExchangeEdgeCases:
         assert exch_task.done()
 
     @pytest.mark.anyio
+    async def test_run_after_stop_raises_instead_of_silent_noop(self):
+        """Regression: calling run() again on an Exchange that has already
+        completed a run/stop cycle must raise loudly instead of silently
+        returning without ever syncing again -- a caller starting a
+        "restart" task would otherwise get no signal that nothing ran."""
+        import asyncio
+
+        from lionagi.ln.concurrency import fail_after
+
+        exchange = Exchange()
+        first_run = asyncio.ensure_future(exchange.run(0.01))
+        await asyncio.sleep(0.05)
+        exchange.stop()
+        with fail_after(2):
+            await first_run
+        assert first_run.done()
+
+        with pytest.raises(RuntimeError, match="already been run"):
+            await exchange.run(0.01)
+
+    @pytest.mark.anyio
+    async def test_stop_before_first_tick_does_not_raise_on_first_call(self):
+        """The stop()-races-ahead-of-run() shape (the fix target of the
+        earlier task-group tests above) is a legitimate first call and must
+        still return promptly without tripping the already-run guard added
+        for the run()-after-stop() regression."""
+        exchange = Exchange()
+        exchange.stop()
+
+        # First-ever call to run(): must return immediately, not raise.
+        await exchange.run(0.01)
+
+        assert exchange._stop is True
+
+    @pytest.mark.anyio
     async def test_collect_empty_outbox(self):
         exchange = Exchange()
         owner_id = uuid4()


### PR DESCRIPTION
## What

`Exchange.run()` silently no-op'd when called again after `stop()` — the caller thought it started, but it was inert with no signal. Fixes regression #2041.

## Contract chosen: raise, not restart

PR #2040 deliberately made `run()` NOT reset `_stop` on entry, so that a `stop()` issued before `run()`'s first event-loop turn makes `run()` return immediately (preventing a hang) instead of clearing the signal and looping. Resetting `_stop` to support "restart" would reopen that exact hang. The class docstring already states the intended contract ("construct a fresh Exchange for a new run rather than reusing one that has already been stopped") — the bug was that a second `run()` was silent instead of loud.

A `_run_started` flag (PrivateAttr) is set at the top of `run()`. The first call proceeds unchanged (including the legitimate stop-before-first-tick case). A second call raises `RuntimeError` — matching stdlib precedent (`threading.Thread.start()` raises `RuntimeError` on a second start), deliberately not the in-class `ValueError` style used for bad-argument cases.

## Verification

- `tests/session/test_exchange.py`: 47/47 passed, including a new test reproducing the issue's repro shape (second `run()` → `RuntimeError`) and a guard test that stop-before-first-tick still does NOT raise on the first call.
- `tests/session/` + affected `tests/cli/orchestrate/` wiring: 490 passed (1 pre-existing `pandas`-not-installed failure, identical on unmodified main).
- Both in-repo call sites (`fanout.py`, `flow.py`) construct a fresh `Exchange()` and call `run()` once, so they're unaffected. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
