### PR TITLE
fix(orchestrate): stamp assignee/spawn_id on wakeup ops; thread team-round context through checkpoint resume

### DIFF
--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -95,6 +95,7 @@ class CheckpointWriter:
         instruction: str | None = None,
         parent_id: str | None = None,
         spawn_id: str | None = None,
+        context: Any | None = None,
     ) -> None:
         """Record one reactively spawned node's outcome, keyed by its own node id.
 
@@ -115,6 +116,12 @@ class CheckpointWriter:
         checkpoint written before this field set existed carries entries
         without `operation`; resume treats those as unreconstructable and
         refuses only for the affected node(s), not the whole run.
+
+        context is the spawned node's `parameters["context"]` payload (e.g. a
+        team round op's `prior_team_messages`) — distinct from `instruction`,
+        which for a team round is generic boilerplate; the actual teammate
+        mail that motivated the round lives only in `context`. None for
+        spawned nodes with no context payload (the common case).
         """
         async with self._lock:
             entry = {
@@ -126,6 +133,7 @@ class CheckpointWriter:
                 "instruction": instruction,
                 "parent_id": parent_id,
                 "spawn_id": spawn_id,
+                "context": context,
             }
             for i, existing in enumerate(self.spawned):
                 if existing.get("node_id") == node_id:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -888,7 +888,16 @@ class TeamLifecycleCoordinator:
                 params["actions"] = True
             node = create_operation("operate", parameters=params)
             node.branch_id = branch.id
-            node.metadata["reference_id"] = f"{worker}-round{self.rounds_run + 1}"
+            round_id = f"{worker}-round{self.rounds_run + 1}"
+            node.metadata["reference_id"] = round_id
+            # Stamp the same assignee/spawn_id pair role_node_builder stamps
+            # on every reactively-injected node (patterns.py) — flow.py's
+            # finalize-time result scan and checkpoint capture both key off
+            # these two fields to attribute a spawned node back to its
+            # worker/round instead of falling through to a generic
+            # "spawned"/"spawn-N" entry.
+            node.metadata["assignee"] = worker
+            node.metadata["spawn_id"] = round_id
             with contextlib.suppress(FileNotFoundError):
                 team.post_wakeup_signal(self.team_id, target=worker, content="follow-up round")
             ops.append(node)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -666,9 +666,15 @@ def _reconstruct_spawned_nodes(
         if spawn_id:
             metadata["spawn_id"] = spawn_id
             metadata["reference_id"] = spawn_id
+        parameters: dict[str, Any] = {"instruction": entry.get("instruction") or ""}
+        # context (e.g. a team round op's prior_team_messages) is optional —
+        # only checkpoints written after CHECKPOINT_VERSION 2's context
+        # capture carry it; older entries simply have none to restore.
+        if entry.get("context") is not None:
+            parameters["context"] = entry["context"]
         node = create_operation(
             entry["operation"],
-            parameters={"instruction": entry.get("instruction") or ""},
+            parameters=parameters,
             id=_UUID(node_id),
             metadata=metadata,
         )
@@ -931,6 +937,15 @@ async def _execute_dag(
                     # role_node_builder stamps spawn_id unconditionally, so
                     # it's captured the same way regardless of assignee.
                     spawn_fields["spawn_id"] = spawned_node.metadata.get("spawn_id")
+                    # context carries payload the generic `instruction` text
+                    # doesn't (e.g. a team round op's prior_team_messages) —
+                    # without it, resume reconstructs the node with only the
+                    # boilerplate instruction and silently loses that data.
+                    spawn_fields["context"] = (
+                        params.get("context")
+                        if isinstance(params, dict)
+                        else getattr(params, "context", None)
+                    )
             _checkpoint_tasks.append(
                 _asyncio.ensure_future(
                     _checkpoint_writer.record_spawned(

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -315,8 +315,37 @@ async def test_checkpoint_writer_record_spawned_keeps_separate_from_ops_and_dedu
             "instruction": "critique the draft",
             "parent_id": "node-0",
             "spawn_id": "spawn-3",
+            "context": None,
         }
     ]
+
+
+async def test_checkpoint_writer_record_spawned_captures_context_payload(tmp_path: Path):
+    """context (added alongside CHECKPOINT_VERSION 2's other reconstruction
+    fields) round-trips independently of instruction — a team round op's
+    prior_team_messages lives in context, not instruction, so it must be
+    captured the same way the other reconstruction fields are."""
+    path = tmp_path / "checkpoint.json"
+    writer = CheckpointWriter(path=path, session_id="s", prompt="p", plan=[], config={})
+
+    context_payload = [
+        {"original_task": "t"},
+        {"prior_team_messages": {"total_count": 1, "messages": [{"from": "bob", "content": "hi"}]}},
+    ]
+    await writer.record_spawned(
+        "spawned-2",
+        status="completed",
+        response="child-result",
+        operation="operate",
+        assignee="alice",
+        instruction="Team follow-up round: teammates left you new message(s)...",
+        parent_id="node-0",
+        spawn_id="alice-round1",
+        context=context_payload,
+    )
+
+    data = load_checkpoint(path)
+    assert data["spawned"][0]["context"] == context_payload
 
 
 # ── _apply_checkpoint_precompletion ──────────────────────────────────────────
@@ -557,6 +586,89 @@ def test_reconstruct_spawned_nodes_precompletes_completed_child_with_edge_and_br
     assert child.metadata["reference_id"] == "spawn-1"
     incoming_heads = list(graph.node_edge_mapping[UUID(child_id)]["in"].values())
     assert parent_id in incoming_heads
+
+
+def test_reconstruct_spawned_nodes_restores_context_into_rebuilt_parameters():
+    """Checkpoint/resume round-trip for a team round op: the checkpointed
+    entry's `context` (prior_team_messages — the actual teammate mail, never
+    present in the generic `instruction` boilerplate) must land back in the
+    rebuilt node's `parameters["context"]`, or a resumed round op loses that
+    payload silently."""
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    plan_result, checkpoint_ops = _terminal_plan_and_ops("worker", parent_id)
+    child_id = str(uuid4())
+    context_payload = [
+        {"original_task": "t"},
+        {"prior_team_messages": {"total_count": 1, "messages": [{"from": "bob", "content": "hi"}]}},
+    ]
+    checkpoint_spawned = [
+        {
+            "node_id": child_id,
+            "status": "completed",
+            "response": "child result",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "Team follow-up round: ...",
+            "parent_id": str(parent_id),
+            "spawn_id": "spawn-1",
+            "context": context_payload,
+        }
+    ]
+
+    _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
+
+    graph = builder.get_graph()
+    child = graph.internal_nodes[UUID(child_id)]
+    assert child.parameters["instruction"] == "Team follow-up round: ..."
+    assert child.parameters["context"] == context_payload
+
+
+def test_reconstruct_spawned_nodes_omits_context_key_when_checkpoint_has_none():
+    """A checkpoint entry with no context payload (the common case, and
+    every pre-context-capture checkpoint) must rebuild parameters without a
+    `context` key at all -- not clobber it with an explicit None, which
+    would differ from a live-built node that never had the key either."""
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = SimpleNamespace(builder=builder)
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=[],
+    )
+    plan_result, checkpoint_ops = _terminal_plan_and_ops("worker", parent_id)
+    child_id = str(uuid4())
+    checkpoint_spawned = [
+        {
+            "node_id": child_id,
+            "status": "completed",
+            "response": "child result",
+            "operation": "operate",
+            "assignee": "worker",
+            "instruction": "follow-up task",
+            "parent_id": str(parent_id),
+            "spawn_id": "spawn-1",
+            "context": None,
+        }
+    ]
+
+    _reconstruct_spawned_nodes(env, plan_result, dag_state, checkpoint_ops, checkpoint_spawned)
+
+    child = builder.get_graph().internal_nodes[UUID(child_id)]
+    assert "context" not in child.parameters
 
 
 def test_reconstruct_spawned_nodes_marks_failed_child_terminal_not_rerun():
@@ -997,6 +1109,7 @@ async def test_checkpoint_spawned_node_name_collision_does_not_overwrite_planned
             "instruction": None,
             "parent_id": "node-critic",
             "spawn_id": None,
+            "context": None,
         }
     ]
 
@@ -1086,8 +1199,100 @@ async def test_checkpoint_record_captures_spawn_id_from_live_role_routed_graph_n
             "instruction": "follow-up",
             "parent_id": str(parent_id),
             "spawn_id": "spawn-7",
+            "context": None,
         }
     ]
+
+
+async def test_checkpoint_record_captures_context_from_live_graph_node_parameters(
+    tmp_path: Path,
+):
+    """Write-side counterpart for context: a team round op's params are
+    {"instruction": <boilerplate>, "context": [...prior_team_messages...]}
+    — _checkpoint_record must capture context off the live graph node's
+    parameters the same way it captures instruction, or resume rebuilds the
+    node with the boilerplate instruction and silently drops the teammate
+    mail that motivated the round."""
+    builder, parent_id, worker_branch = _real_planned_node("worker")
+    env = _make_resume_env(tmp_path)
+    env.builder = builder
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    assignments = [TaskAssignment(task="write the brief", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[parent_id],
+        known_nodes={parent_id},
+        deps_by_node={parent_id: []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker_branch},
+        worker_models=["claude"],
+    )
+
+    from lionagi.operations.node import create_operation
+
+    context_payload = [
+        {"original_task": "write the brief"},
+        {"prior_team_messages": {"total_count": 1, "messages": [{"from": "bob", "content": "hi"}]}},
+    ]
+    spawned_node = create_operation(
+        "operate",
+        parameters={"instruction": "Team follow-up round: ...", "context": context_payload},
+    )
+    spawned_node.metadata["assignee"] = "worker"
+    spawned_node.metadata["spawn_id"] = "worker-round1"
+    spawned_node.metadata["reference_id"] = "worker-round1"
+    builder.get_graph().add_node(spawned_node)
+    spawned_id_str = str(spawned_node.id)
+
+    async def _run_dag_result(*args, executor_ref=None, **_kw):
+        executor_ref["executor"] = SimpleNamespace(
+            context=SimpleNamespace(content={}),
+            results={spawned_node.id: "spawned-result"},
+        )
+        await env.session.emit(
+            NodeCompleted(
+                op_id=spawned_id_str,
+                name="worker-clone",
+                elapsed=0.1,
+                parent_id=str(parent_id),
+                depends_on=[str(parent_id)],
+            )
+        )
+        return {
+            "operation_results": {spawned_id_str: "spawned-result"},
+            "spawned_operations": 1,
+            "escalated_operations": [],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = _run_dag_result
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+        )
+
+    data = load_checkpoint(env.run.checkpoint_path)
+    assert data["spawned"][0]["context"] == context_payload
+    assert data["spawned"][0]["instruction"] == "Team follow-up round: ..."
 
 
 async def test_execute_dag_seeds_fresh_checkpoint_with_already_reconstructed_spawned_entries(

--- a/tests/cli/orchestrate/test_team_lifecycle_wiring.py
+++ b/tests/cli/orchestrate/test_team_lifecycle_wiring.py
@@ -150,6 +150,44 @@ class TestTeamLifecycleCoordinatorBuildRoundOperations:
         assert prior["total_count"] == 1
         assert prior["messages"] == [{"from": "bob", "content": "come back"}]
 
+    def test_build_round_operations_stamps_assignee_and_spawn_id_for_attribution(self):
+        """role_node_builder (patterns.py) stamps assignee+spawn_id on every
+        reactively-injected node; flow.py's finalize-time result scan and
+        checkpoint capture both key off those two fields. A round op that
+        skips this stamping surfaces in agent_results as an anonymous
+        "spawned"/"spawn-N" entry instead of being attributed to its worker
+        and round (regression watch)."""
+        _make_team("t4b", ["orchestrator", "alice"])
+        alice_branch = _FakeBranch("alice")
+        coord = make_team_lifecycle_coordinator(
+            "t4b", ["alice"], {"alice": alice_branch}, messenger_bound={"alice": True}
+        )
+        coord.on_done(name="alice", sender_id=uuid4(), reason="")
+        with team._locked_team("t4b") as data:
+            data["messages"].append(
+                {
+                    "id": "m1",
+                    "from": "bob",
+                    "to": ["alice"],
+                    "content": "come back",
+                    "kind": "message",
+                    "read_by": {},
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            )
+
+        state = coord.check_round()
+        ops = coord.build_round_operations(state, prompt="original task")
+
+        assert len(ops) == 1
+        op = ops[0]
+        assert op.metadata["assignee"] == "alice"
+        assert op.metadata["spawn_id"] == "alice-round1"
+        assert op.metadata["reference_id"] == "alice-round1"
+        # assignee/spawn_id must agree with reference_id, matching
+        # role_node_builder's unconditional stamp-together invariant.
+        assert op.metadata["spawn_id"] == op.metadata["reference_id"]
+
     def test_build_round_operations_omits_actions_for_non_messenger_worker(self):
         _make_team("t5", ["orchestrator", "cli-worker"])
         branch = _FakeBranch("cli-worker")
@@ -499,6 +537,18 @@ async def test_execute_dag_real_executor_wakes_alice_before_task_group_closes(tm
     # The round-injected op actually ran — proves inject() was not rejected.
     assert len(calls) == 2
     assert exec_result.agent_results[0]["response"] == "first pass done"
+
+    # The round op's result must be attributed to alice/round1, not surface
+    # as a generic anonymous "spawned"/"spawn-N" entry (regression watch:
+    # build_round_operations must stamp assignee+spawn_id like every other
+    # reactively-injected node).
+    assert len(exec_result.agent_results) == 2
+    round_result = exec_result.agent_results[1]
+    assert round_result["spawned"] is True
+    assert round_result["assignee"] == "alice"
+    assert round_result["name"] == "alice"
+    assert round_result["id"] == "alice-round1"
+    assert round_result["response"] == "all clear now"
 
 
 async def test_execute_dag_real_executor_respects_team_max_rounds_bound(tmp_path):


### PR DESCRIPTION
## What

Fixes #2156 (round-2 team-wakeup nodes lost their result attribution) and #2157 (team-round context payload was dropped on checkpoint resume).

## #2156 — wakeup ops missing assignee/spawn_id stamps

`build_round_operations` stamped only `node.metadata["reference_id"]` on round-2 wakeup ops, skipping the `assignee`/`spawn_id` stamps that `role_node_builder` applies to every other reactively-injected node. `flow.py`'s finalize-time result scan reads `assignee`/`spawn_id` off graph-node metadata to attribute a spawned result; without them it fell through to a synthesized `spawn-N` id and `name="spawned"`. Fix: stamp `assignee` and `spawn_id` (reusing the `<worker>-round<N>` reference_id as spawn_id so both fields agree with the finalize scan's assignee-implies-spawn_id invariant, which otherwise raises).

## #2157 — checkpoint dropped the team-round context

The checkpoint writer captured a spawned node's `instruction` but never its `context`, and a team round op's real payload (`prior_team_messages`) lives only in `context`. Added a `context` param to `CheckpointWriter.record_spawned`, captured it at the live-graph-node checkpoint site, and restored it into the rebuilt node's `parameters["context"]` on resume (only when present, so pre-fix checkpoints don't get a spurious `None` context key).

## Verification

`tests/cli/orchestrate/test_team_lifecycle_wiring.py test_flow_checkpoint_resume.py test_team_lifecycle.py` → 94 passed. Broader `tests/cli/ -k "team or wakeup or fanout or flow"` → 288 passed, 1 skipped. 6 new tests; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
