### PR TITLE
fix(orchestrate): translate over-max-tasks plan ValueError into FlowPlanError

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1805,20 +1805,31 @@ async def _run_flow_inner(
         )
 
         progress("Planning DAG...")
-        assignments = await plan(
-            env.orc_branch, prompt, roles=roster, dag=True, guidance=guidance, max_tasks=max_ops
-        )
+        try:
+            assignments = await plan(
+                env.orc_branch, prompt, roles=roster, dag=True, guidance=guidance, max_tasks=max_ops
+            )
+        except ValueError as exc:
+            # plan() raises a bare ValueError when the orchestrator still
+            # overshoots max_tasks after the cap was stated in guidance —
+            # route it through the same clean-failure channel as every
+            # other plan-time failure in this function.
+            raise FlowPlanError(str(exc)) from exc
         if not assignments:
             # Fail loud rather than silently exiting 0 with no work done.
             _warn("Orchestrator returned no assignments; retrying once with a sharper instruction.")
-            assignments = await plan(
-                env.orc_branch,
-                prompt,
-                roles=roster,
-                dag=True,
-                guidance=guidance + " Return ONLY the assignments list — do not perform the task.",
-                max_tasks=max_ops,
-            )
+            try:
+                assignments = await plan(
+                    env.orc_branch,
+                    prompt,
+                    roles=roster,
+                    dag=True,
+                    guidance=guidance
+                    + " Return ONLY the assignments list — do not perform the task.",
+                    max_tasks=max_ops,
+                )
+            except ValueError as exc:
+                raise FlowPlanError(str(exc)) from exc
         if not assignments:
             raise FlowPlanError(
                 "Orchestrator produced no usable plan (an empty TaskAssignment list) after a "

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -80,6 +80,28 @@ async def test_no_plan_after_retry_raises_flow_plan_error(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_over_max_tasks_plan_raises_flow_plan_error(tmp_path):
+    """plan() raises ValueError when the orchestrator overshoots max_tasks even
+    after the cap was stated in guidance — flow.py must translate that into the
+    same FlowPlanError channel as every other plan-time failure, not let a bare
+    ValueError escape uncaught."""
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(
+                assignments=[
+                    TaskAssignment(task="a", assignee="researcher"),
+                    TaskAssignment(task="b", assignee="architect"),
+                ]
+            )
+        ]
+    )
+    with pytest.raises(FlowPlanError, match="exceeding max_tasks"):
+        await _run_flow_inner(
+            "codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True, max_ops=1
+        )
+
+
+@pytest.mark.asyncio
 async def test_unknown_assignees_dropped_then_loud_fail(tmp_path):
     """plan() drops assignees outside the roster; an all-unknown plan is empty."""
     bad = SimpleNamespace(assignments=[TaskAssignment(task="x", assignee="not_a_role")])


### PR DESCRIPTION
## What

Fixes #2165 — an over-`max_tasks` plan raised a bare `ValueError` out of `_run_flow_inner` instead of the `FlowPlanError` that callers wire `extra_handlers` for.

## Fix

Wrapped both `await plan(...)` call sites in `_run_flow_inner` in `try/except ValueError as exc: raise FlowPlanError(str(exc)) from exc` — the same error type the sibling "empty plan" failure already raises a few lines below.

## Scope

Translated at the `flow.py` call site rather than at the shared `plan()` source (`orchestration/patterns.py`), which is used by three call sites and can't import `FlowPlanError` without a circular import. The other two call sites (`engines/planning.py`, `fanout.py`) still have the gap and need separate follow-up.

## Verification

`tests/cli/orchestrate/test_flow_planning.py` → 18 passed (1 new: over-max-tasks → FlowPlanError). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
