### PR TITLE
fix(action): tool-pre-hook deny captures as FAILED; skip post-hooks during cancellation

### DIFF
--- a/lionagi/operations/act/act.py
+++ b/lionagi/operations/act/act.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from lionagi._errors import ConfigurationError
 from lionagi.ln import AlcallParams
+from lionagi.protocols.action.tool_hooks import ActionGovernanceDeniedError
 from lionagi.protocols.generic.event import EventStatus
 from lionagi.protocols.messages import ActionRequest, ActionResponse
 
@@ -95,17 +96,18 @@ async def _act(
         # ActionManager.invoke() is total: a pre-hook denial, a schema-
         # revalidation failure, or an ordinary tool exception is captured as
         # FAILED status + execution.error rather than raised. A denial
-        # (ToolHookDeniedError) or a schema-revalidation failure (a plain
-        # PermissionError raised in FunctionCalling._invoke()) is a
-        # governance/policy outcome, not a business result -- it must be
-        # visibly distinguishable from a tool that legitimately returned
-        # `None`, so route it through the same except-block error path
-        # below instead of the success path. An ordinary tool exception
-        # (any other error type) keeps the historical degrade-to-`None`
-        # contract under suppress_errors=True (test_invoke_action_suppress_errors) --
-        # only the two governance-denial error shapes changed behavior here.
+        # (ToolHookDeniedError) or a schema-revalidation failure
+        # (RevalidationDeniedError) is a governance/policy outcome, not a
+        # business result -- it must be visibly distinguishable from a tool
+        # that legitimately returned `None`, so route it through the same
+        # except-block error path below instead of the success path.
+        # Matching is on ActionGovernanceDeniedError specifically (not the
+        # broader PermissionError) so an ordinary tool exception -- including
+        # a tool body that itself raises a plain PermissionError for its own
+        # business reasons -- keeps the historical degrade-to-`None` contract
+        # under suppress_errors=True (test_invoke_action_suppress_errors).
         if func_call.status == EventStatus.FAILED and isinstance(
-            func_call.execution.error, PermissionError
+            func_call.execution.error, ActionGovernanceDeniedError
         ):
             raise func_call.execution.error
 

--- a/lionagi/operations/act/act.py
+++ b/lionagi/operations/act/act.py
@@ -94,13 +94,20 @@ async def _act(
 
         # ActionManager.invoke() is total: a pre-hook denial, a schema-
         # revalidation failure, or an ordinary tool exception is captured as
-        # FAILED status + execution.error rather than raised. Route it
-        # through the same except-block error path below instead of letting
-        # a `None` response read as a silent successful result.
-        if func_call.status == EventStatus.FAILED:
-            raise func_call.execution.error or RuntimeError(
-                f"action {_request['function']!r} failed with no captured error"
-            )
+        # FAILED status + execution.error rather than raised. A denial
+        # (ToolHookDeniedError) or a schema-revalidation failure (a plain
+        # PermissionError raised in FunctionCalling._invoke()) is a
+        # governance/policy outcome, not a business result -- it must be
+        # visibly distinguishable from a tool that legitimately returned
+        # `None`, so route it through the same except-block error path
+        # below instead of the success path. An ordinary tool exception
+        # (any other error type) keeps the historical degrade-to-`None`
+        # contract under suppress_errors=True (test_invoke_action_suppress_errors) --
+        # only the two governance-denial error shapes changed behavior here.
+        if func_call.status == EventStatus.FAILED and isinstance(
+            func_call.execution.error, PermissionError
+        ):
+            raise func_call.execution.error
 
         if _hooks is not None:
             from lionagi.hooks.bus import HookPoint

--- a/lionagi/operations/act/act.py
+++ b/lionagi/operations/act/act.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from lionagi._errors import ConfigurationError
 from lionagi.ln import AlcallParams
+from lionagi.protocols.generic.event import EventStatus
 from lionagi.protocols.messages import ActionRequest, ActionResponse
 
 from .._defaults import get_default_action_call as _get_default_call_params
@@ -90,6 +91,16 @@ async def _act(
         func_call = await branch._action_manager.invoke(_request)
         if verbose_action:
             logger.debug("Action %s invoked, status: %s.", _request["function"], func_call.status)
+
+        # ActionManager.invoke() is total: a pre-hook denial, a schema-
+        # revalidation failure, or an ordinary tool exception is captured as
+        # FAILED status + execution.error rather than raised. Route it
+        # through the same except-block error path below instead of letting
+        # a `None` response read as a silent successful result.
+        if func_call.status == EventStatus.FAILED:
+            raise func_call.execution.error or RuntimeError(
+                f"action {_request['function']!r} failed with no captured error"
+            )
 
         if _hooks is not None:
             from lionagi.hooks.bus import HookPoint

--- a/lionagi/protocols/action/function_calling.py
+++ b/lionagi/protocols/action/function_calling.py
@@ -10,6 +10,15 @@ from lionagi.ln.concurrency import is_coro_func
 
 from ..generic.event import Event
 from .tool import Tool
+from .tool_hooks import ActionGovernanceDeniedError
+
+
+class RevalidationDeniedError(ActionGovernanceDeniedError):
+    """Raised when rewritten tool arguments fail schema revalidation after a
+    hook or preprocessor rewrite. A governance denial, not an ordinary tool
+    exception -- distinct from a tool body raising ``PermissionError`` for
+    its own business reasons.
+    """
 
 
 class FunctionCalling(Event):
@@ -69,7 +78,7 @@ class FunctionCalling(Event):
             try:
                 validated = self.func_tool.request_options(**self.arguments)
             except Exception as e:
-                raise PermissionError(
+                raise RevalidationDeniedError(
                     f"rewritten arguments failed validation for {self.func_tool.function!r}: {e}"
                 ) from e
             self.arguments = validated.model_dump(exclude_unset=True)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -17,6 +17,7 @@ from lionagi.utils import to_list
 from .function_calling import FunctionCalling
 from .tool import FuncTool, FuncToolRef, Tool, ToolRef
 from .tool_hooks import (
+    ToolHookDeniedError,
     ToolPostHook,
     ToolPreHook,
     run_tool_post_hooks,
@@ -186,28 +187,45 @@ class ActionManager(Manager):
         Bypassing this manager (constructing ``FunctionCalling`` directly)
         skips the hook layer entirely. See docs/internals/core.md.
 
+        A denying tool-pre hook fails the call closed the same way every
+        other denial/validation-failure path in this module does: the
+        returned ``FunctionCalling`` ends up ``FAILED`` with the denial
+        captured as its error, never raised out of ``invoke()``.
+
         Non-empty tool-post-hook reasons are attached to the returned event
         at ``metadata["tool_post_hook_notes"]`` and logged, on success and
-        failure paths alike.
+        failure paths alike. Tool-post hooks are skipped while a
+        cancellation (or other non-``Exception`` ``BaseException``) is
+        unwinding, so a slow or hanging hook can never delay that propagation.
         """
         function_calling = self.match_tool(func_call)
         tool_name = function_calling.function
 
-        if self._tool_pre_hooks:
-            function_calling.arguments = await run_tool_pre_hooks(
-                self._tool_pre_hooks, tool_name, function_calling.arguments
-            )
-
         error: BaseException | None = None
+        denied = False
+        if self._tool_pre_hooks:
+            try:
+                function_calling.arguments = await run_tool_pre_hooks(
+                    self._tool_pre_hooks, tool_name, function_calling.arguments
+                )
+            except ToolHookDeniedError as exc:
+                denied = True
+                error = exc
+                function_calling.status = EventStatus.FAILED
+                function_calling.execution.add_error(exc)
+
+        cancelling = False
         try:
-            await function_calling.invoke()
-            if function_calling.status == EventStatus.FAILED:
-                error = function_calling.execution.error
+            if not denied:
+                await function_calling.invoke()
+                if function_calling.status == EventStatus.FAILED:
+                    error = function_calling.execution.error
         except BaseException as exc:
             error = exc
+            cancelling = True
             raise
         finally:
-            if self._tool_post_hooks:
+            if self._tool_post_hooks and not cancelling:
                 notes = await run_tool_post_hooks(
                     self._tool_post_hooks,
                     tool_name,

--- a/lionagi/protocols/action/tool_hooks.py
+++ b/lionagi/protocols/action/tool_hooks.py
@@ -19,6 +19,7 @@ from typing import Any
 from lionagi.ln.concurrency import maybe_await
 
 __all__ = (
+    "ActionGovernanceDeniedError",
     "ToolHookDeniedError",
     "ToolPostDecision",
     "ToolPostHook",
@@ -64,7 +65,17 @@ ToolPostHook = Callable[
 ]
 
 
-class ToolHookDeniedError(PermissionError):
+class ActionGovernanceDeniedError(PermissionError):
+    """Base for governance/policy denials raised at the tool-invocation
+    boundary (hook deny, schema-rewrite revalidation). A plain
+    ``PermissionError`` raised by a tool's own body is NOT an instance of
+    this class -- callers that need to distinguish "this call was denied by
+    governance" from "the tool raised its own permission error" should match
+    on this type, not on ``PermissionError`` directly.
+    """
+
+
+class ToolHookDeniedError(ActionGovernanceDeniedError):
     """Raised when a tool-pre hook denies (or fails closed on) a call."""
 
     def __init__(self, hook_name: str, reason: str) -> None:

--- a/lionagi/protocols/action/tool_hooks.py
+++ b/lionagi/protocols/action/tool_hooks.py
@@ -72,6 +72,15 @@ class ToolHookDeniedError(PermissionError):
         self.hook_name = hook_name
         self.reason = reason
 
+    def __reduce__(self):
+        # BaseException's default __reduce__ replays via `self.args`, which
+        # here is the single formatted message string -- not the two
+        # positional args this __init__ requires. That mismatch makes
+        # deepcopy() (used by run_tool_post_hooks' evidence isolation) raise
+        # and silently skip post hooks on the deny path. Reconstruct from
+        # the named fields instead so deepcopy/pickle round-trip correctly.
+        return (self.__class__, (self.hook_name, self.reason))
+
 
 def _hook_name(hook: Callable) -> str:
     return getattr(hook, "__name__", None) or type(hook).__name__

--- a/tests/operations/test_act.py
+++ b/tests/operations/test_act.py
@@ -201,6 +201,87 @@ async def test_act_suppress_errors_false_reraises():
 
 
 @pytest.mark.asyncio
+async def test_act_pre_hook_denial_surfaces_as_observable_error_not_silent_none():
+    """A denied tool-pre hook must not read as a silent successful `None`
+    result -- ActionManager.invoke() captures the denial as FAILED status
+    instead of raising it, and _act() must route that through the same
+    error-response path used for any other action failure."""
+    from lionagi.protocols.action.tool_hooks import ToolPreDecision
+
+    branch = _make_branch_with_tool()
+
+    async def denier(name: str, arguments: dict):
+        return ToolPreDecision(decision="deny", reason="not today")
+
+    branch._action_manager.add_tool_pre_hook(denier)
+
+    req = {"function": "add", "arguments": {"a": 1, "b": 2}}
+    result = await _act(branch, req, suppress_errors=True)
+
+    assert isinstance(result, ActionResponseModel)
+    assert result.output is not None, "a denial must never surface as a bare `None` result"
+    assert "error" in result.output
+    assert "not today" in str(result.output["error"])
+
+    from lionagi.protocols.messages import ActionResponse
+
+    responses = [m for m in branch.messages if isinstance(m, ActionResponse)]
+    assert len(responses) == 1
+    assert "error" in responses[0].output
+    assert "not today" in str(responses[0].output["error"])
+
+
+@pytest.mark.asyncio
+async def test_act_pre_hook_denial_suppress_errors_false_reraises():
+    """suppress_errors=False must re-raise the denial (matching the
+    pre-existing re-raise contract for every other action failure), not
+    swallow it into a successful response."""
+    from lionagi.protocols.action.tool_hooks import ToolHookDeniedError, ToolPreDecision
+
+    branch = _make_branch_with_tool()
+
+    async def denier(name: str, arguments: dict):
+        return ToolPreDecision(decision="deny", reason="not today")
+
+    branch._action_manager.add_tool_pre_hook(denier)
+
+    req = {"function": "add", "arguments": {"a": 1, "b": 2}}
+    with pytest.raises(ToolHookDeniedError, match="not today"):
+        await _act(branch, req, suppress_errors=False)
+
+
+@pytest.mark.asyncio
+async def test_act_pre_hook_denial_fires_tool_error_not_tool_post():
+    """A denial must be routed through the TOOL_ERROR hook point, not
+    TOOL_POST -- the model/consumer-facing hook layer must see it as a
+    failure, never as a completed call."""
+    from lionagi.hooks.bus import HookBus, HookPoint
+    from lionagi.protocols.action.tool_hooks import ToolPreDecision
+
+    branch = _make_branch_with_tool()
+
+    async def denier(name: str, arguments: dict):
+        return ToolPreDecision(decision="deny", reason="not today")
+
+    branch._action_manager.add_tool_pre_hook(denier)
+
+    bus = HookBus()
+    tool_post_calls: list = []
+    tool_error_calls: list = []
+    bus.on(HookPoint.TOOL_POST, lambda **kw: tool_post_calls.append(kw))
+    bus.on(HookPoint.TOOL_ERROR, lambda **kw: tool_error_calls.append(kw))
+    branch._hooks = bus
+
+    req = {"function": "add", "arguments": {"a": 1, "b": 2}}
+    await _act(branch, req, suppress_errors=True)
+
+    assert tool_post_calls == []
+    assert len(tool_error_calls) == 1
+    assert tool_error_calls[0]["tool_name"] == "add"
+    assert "not today" in str(tool_error_calls[0]["error"])
+
+
+@pytest.mark.asyncio
 async def test_act_verbose_logging(caplog):
     """verbose_action=True emits debug log lines (lines 52-54, 57-60)."""
     import logging

--- a/tests/protocols/action/test_tool_invoke_hooks.py
+++ b/tests/protocols/action/test_tool_invoke_hooks.py
@@ -112,7 +112,10 @@ async def test_security_pre_sees_external_rewrite_with_no_user_hook():
 # ── Deny / ask / unrecognized (D5) ──────────────────────────────────────────
 
 
-async def test_deny_short_circuits_before_invoke_and_post():
+async def test_deny_short_circuits_before_invoke_and_captures_as_failed():
+    """A denying pre-hook must fail the call closed the same way every other
+    denial path in this module does: FAILED status with the denial captured
+    as the error, never raised out of ActionManager.invoke."""
     order: list[str] = []
     calls: list[tuple[int, int]] = []
     manager, tool_name = _build_manager(order, calls, with_security=True)
@@ -129,12 +132,18 @@ async def test_deny_short_circuits_before_invoke_and_post():
     manager.add_tool_pre_hook(denier)
     manager.add_tool_post_hook(external_post)
 
-    with pytest.raises(ToolHookDeniedError, match="not today"):
-        await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
 
     assert order == ["pre-deny"], "security_pre and the tool callable must never run"
     assert calls == [], "the tool callable must never run on deny"
-    assert post_calls == [], "post hooks must not fire when pre denies"
+    assert fc.status == EventStatus.FAILED
+    assert isinstance(fc.execution.error, ToolHookDeniedError)
+    assert "not today" in str(fc.execution.error)
+    # ToolHookDeniedError isn't deepcopy-able (its __init__ signature doesn't
+    # match the args exception __reduce__ replays), so evidence isolation
+    # fails and post hooks are safely skipped rather than fired on live
+    # execution state -- see run_tool_post_hooks' isolation contract.
+    assert post_calls == []
 
 
 async def test_ask_fails_closed():
@@ -147,10 +156,12 @@ async def test_ask_fails_closed():
 
     manager.add_tool_pre_hook(asker)
 
-    with pytest.raises(ToolHookDeniedError, match="failing closed"):
-        await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
 
     assert calls == []
+    assert fc.status == EventStatus.FAILED
+    assert isinstance(fc.execution.error, ToolHookDeniedError)
+    assert "failing closed" in str(fc.execution.error)
 
 
 async def test_unrecognized_decision_fails_closed_with_diagnostic():
@@ -163,10 +174,12 @@ async def test_unrecognized_decision_fails_closed_with_diagnostic():
 
     manager.add_tool_pre_hook(confused)
 
-    with pytest.raises(ToolHookDeniedError, match="unrecognized decision 'warn'"):
-        await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
 
     assert calls == []
+    assert fc.status == EventStatus.FAILED
+    assert isinstance(fc.execution.error, ToolHookDeniedError)
+    assert "unrecognized decision 'warn'" in str(fc.execution.error)
 
 
 async def test_pre_hook_raising_permission_error_denies():
@@ -180,10 +193,12 @@ async def test_pre_hook_raising_permission_error_denies():
 
     manager.add_tool_pre_hook(legacy_guard)
 
-    with pytest.raises(ToolHookDeniedError, match="blocked by legacy guard"):
-        await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
+    fc = await manager.invoke({"function": tool_name, "arguments": {"a": 1, "b": 2}})
 
     assert calls == []
+    assert fc.status == EventStatus.FAILED
+    assert isinstance(fc.execution.error, ToolHookDeniedError)
+    assert "blocked by legacy guard" in str(fc.execution.error)
 
 
 # ── Rewrite + revalidation ──────────────────────────────────────────────────
@@ -512,6 +527,38 @@ async def test_post_hook_cannot_rewrite_completed_error():
     assert fc.execution.error is failure
     assert fc.execution.error.args == ("original",)
     assert fc.execution.error.details == {"source": "tool"}
+
+
+async def test_cancellation_propagates_promptly_despite_slow_post_hook():
+    """A cancellation delivered while the tool call is in flight must not be
+    held up by an in-flight tool-post hook -- otherwise wait_for/cancel-based
+    timeouts silently inherit the hook's latency."""
+    import asyncio
+    import time
+
+    tool_started = asyncio.Event()
+
+    async def slow_tool() -> None:
+        tool_started.set()
+        await asyncio.sleep(10)
+
+    manager = ActionManager(Tool(func_callable=slow_tool))
+
+    async def slow_post_hook(name, arguments, result, error) -> None:
+        await asyncio.sleep(2)
+
+    manager.add_tool_post_hook(slow_post_hook)
+
+    task = asyncio.create_task(manager.invoke({"function": "slow_tool", "arguments": {}}))
+    await tool_started.wait()
+
+    task.cancel()
+    start = time.monotonic()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, "cancellation must not be delayed by a slow tool-post hook"
 
 
 # ── No hooks registered: unchanged behavior ─────────────────────────────────

--- a/tests/protocols/action/test_tool_invoke_hooks.py
+++ b/tests/protocols/action/test_tool_invoke_hooks.py
@@ -115,7 +115,11 @@ async def test_security_pre_sees_external_rewrite_with_no_user_hook():
 async def test_deny_short_circuits_before_invoke_and_captures_as_failed():
     """A denying pre-hook must fail the call closed the same way every other
     denial path in this module does: FAILED status with the denial captured
-    as the error, never raised out of ActionManager.invoke."""
+    as the error, never raised out of ActionManager.invoke. Post hooks still
+    run on the deny path (matching the "failures run post hooks too"
+    contract that already holds for ordinary tool exceptions and
+    schema-revalidation failures), receiving an isolated snapshot that a
+    mutating hook cannot leak back into the live event."""
     order: list[str] = []
     calls: list[tuple[int, int]] = []
     manager, tool_name = _build_manager(order, calls, with_security=True)
@@ -127,6 +131,8 @@ async def test_deny_short_circuits_before_invoke_and_captures_as_failed():
     post_calls: list = []
 
     async def external_post(name: str, arguments: dict, result, error) -> None:
+        if error is not None:
+            error.reason = "forged"
         post_calls.append((name, result, error))
 
     manager.add_tool_pre_hook(denier)
@@ -139,11 +145,18 @@ async def test_deny_short_circuits_before_invoke_and_captures_as_failed():
     assert fc.status == EventStatus.FAILED
     assert isinstance(fc.execution.error, ToolHookDeniedError)
     assert "not today" in str(fc.execution.error)
-    # ToolHookDeniedError isn't deepcopy-able (its __init__ signature doesn't
-    # match the args exception __reduce__ replays), so evidence isolation
-    # fails and post hooks are safely skipped rather than fired on live
-    # execution state -- see run_tool_post_hooks' isolation contract.
-    assert post_calls == []
+    # ToolHookDeniedError is reconstructable via __reduce__ (hook_name,
+    # reason), so evidence isolation succeeds and the post hook observes the
+    # denial instead of being silently skipped.
+    assert len(post_calls) == 1
+    name, result, observed_error = post_calls[0]
+    assert name == tool_name
+    assert result is None
+    assert isinstance(observed_error, ToolHookDeniedError)
+    # The hook mutated its snapshot ("forged") -- confirm that never leaks
+    # back into the live event's error, which must still read "not today".
+    assert observed_error.reason == "forged"
+    assert fc.execution.error.reason == "not today"
 
 
 async def test_ask_fails_closed():

--- a/tests/session/test_branch.py
+++ b/tests/session/test_branch.py
@@ -208,6 +208,94 @@ async def test_invoke_action_suppress_errors(branch_with_mock_imodel: Branch):
     assert logs[-1].content["execution"]["response"] is None
 
 
+@pytest.mark.asyncio
+async def test_invoke_action_suppress_errors_plain_permission_error_from_tool_body(
+    branch_with_mock_imodel: Branch,
+):
+    """A tool body that raises a plain `PermissionError` for its own business
+    reasons (e.g. filesystem access denied) is an ORDINARY tool exception --
+    it must keep the same historical degrade-to-`None` contract as any other
+    exception type, not be promoted to a visible error just because its
+    type happens to be `PermissionError`. Only governance denials
+    (`ToolHookDeniedError`, schema-revalidation denial) surface."""
+
+    def fail_tool(**kwargs):
+        raise PermissionError("filesystem denied by the tool")
+
+    branch_with_mock_imodel.acts.register_tool(fail_tool)
+    req = ActionRequest(content={"function": "fail_tool", "arguments": {}})
+
+    result = await branch_with_mock_imodel.act(req, suppress_errors=True)
+    assert result == [ActionResponseModel(function="fail_tool", arguments={}, output=None)]
+    logs = branch_with_mock_imodel.logs
+    assert len(logs) == 1
+    assert logs[-1].content["execution"]["response"] is None
+
+
+@pytest.mark.asyncio
+async def test_invoke_action_suppress_errors_hook_denial_surfaces(
+    branch_with_mock_imodel: Branch,
+):
+    """A tool-pre hook denial is a governance outcome, not an ordinary tool
+    exception -- unlike a plain `PermissionError` from a tool body, it must
+    surface as a visible error even though `ToolHookDeniedError` is itself a
+    `PermissionError` subclass."""
+    from lionagi.protocols.action.tool_hooks import ToolPreDecision
+
+    def ok_tool(**kwargs):
+        return "should never run"
+
+    branch_with_mock_imodel.acts.register_tool(ok_tool)
+
+    async def denier(name: str, arguments: dict):
+        return ToolPreDecision(decision="deny", reason="policy denied")
+
+    branch_with_mock_imodel._action_manager.add_tool_pre_hook(denier)
+
+    req = ActionRequest(content={"function": "ok_tool", "arguments": {}})
+    result = await branch_with_mock_imodel.act(req, suppress_errors=True)
+
+    assert len(result) == 1
+    assert result[0].output is not None
+    assert "error" in result[0].output
+    assert "policy denied" in str(result[0].output["error"])
+
+
+@pytest.mark.asyncio
+async def test_invoke_action_suppress_errors_revalidation_denial_surfaces(
+    branch_with_mock_imodel: Branch,
+):
+    """A hook rewrite that fails schema revalidation is a governance denial
+    (`RevalidationDeniedError`) -- it must surface as a visible error, not
+    degrade to `output=None` like an ordinary tool exception."""
+    from lionagi.protocols.action.tool import Tool
+    from lionagi.protocols.action.tool_hooks import ToolPreDecision
+
+    class AddArgs(BaseModel):
+        a: int
+        b: int
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    tool = Tool(func_callable=add, request_options=AddArgs)
+    branch_with_mock_imodel.acts.register_tool(tool)
+
+    async def bad_rewriter(name: str, arguments: dict):
+        # Drops the required 'b' field -- fails AddArgs validation.
+        return ToolPreDecision(decision="allow", updated_input={"a": 999})
+
+    branch_with_mock_imodel._action_manager.add_tool_pre_hook(bad_rewriter)
+
+    req = ActionRequest(content={"function": "add", "arguments": {"a": 1, "b": 2}})
+    result = await branch_with_mock_imodel.act(req, suppress_errors=True)
+
+    assert len(result) == 1
+    assert result[0].output is not None
+    assert "error" in result[0].output
+    assert "rewritten arguments failed validation" in str(result[0].output["error"])
+
+
 def test_clone_with_id_sender(branch_with_mock_imodel: Branch):
     msg = Instruction(
         content={"instruction": "Hello original"},


### PR DESCRIPTION
Fixes #2153 and #2155 in ActionManager.invoke().

**#2153** — the tool-pre-hook deny path RAISED `ToolHookDeniedError` before `invoke()`, unlike every other denial path (security-gate deny, revalidation failure) which capture as a FAILED-status FunctionCalling. Now wraps the pre-hook call and, on denial, sets status=FAILED + records the error instead of propagating; post-hooks still run in the finally for the denial case.

**#2155** — the finally block unconditionally awaited tool-post-hooks even while unwinding a cancellation, so a slow post-hook added unbounded latency before CancelledError could leave invoke(). Now a `cancelling` flag (set in the `except BaseException` clause) skips post-hooks during cancellation so it propagates immediately.

Tests: 4 existing deny tests updated (raise → FAILED-status assertion), new cancellation-propagates-promptly test (<1s vs ~2s). `tests/protocols/action/` + event-lifecycle + act + cancelled-status → 165 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)