### PR TITLE
fix(run): sum multi-turn codex result deltas within a flush window instead of overwriting

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -267,6 +267,40 @@ async def _stream_with_liveness(
             return
 
 
+# Fields inside a "result" chunk's metadata that CLI providers may emit as a
+# per-turn delta rather than a running total (see codex.py's turn.completed
+# handler). Every provider that only ever emits one "result" chunk per run()
+# call (claude_code, gemini_code) reports these as the final total, which sums
+# correctly here too since there is nothing else to add it to.
+_RESULT_META_DELTA_KEYS = ("total_cost_usd", "num_turns")
+
+
+def _accumulate_result_meta(result_meta: dict, metadata: dict) -> None:
+    """Merge a "result" chunk's metadata into the in-progress accumulator.
+
+    Numeric usage/cost/turn fields are summed (codex emits marginal deltas
+    across multiple turn.completed events within one flush window); every
+    other field (e.g. duration_ms, a point-in-time snapshot rather than a
+    delta) is overwritten with the latest value.
+    """
+    for key, value in metadata.items():
+        if key == "usage" and isinstance(value, dict):
+            usage = result_meta.setdefault("usage", {})
+            for uk, uv in value.items():
+                if isinstance(uv, (int, float)) and not isinstance(uv, bool):
+                    usage[uk] = usage.get(uk, 0) + uv
+                else:
+                    usage[uk] = uv
+        elif (
+            key in _RESULT_META_DELTA_KEYS
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ):
+            result_meta[key] = result_meta.get(key, 0) + value
+        else:
+            result_meta[key] = value
+
+
 async def run(
     branch: Branch,
     instruction: JsonValue | Instruction,
@@ -526,7 +560,7 @@ async def run(
 
                         case "result":
                             if chunk.metadata:
-                                result_meta.update(chunk.metadata)
+                                _accumulate_result_meta(result_meta, chunk.metadata)
 
                         case "error":
                             # A CLI provider marks a resumed-session end-of-stream by

--- a/tests/providers/openai/codex/test_result_usage.py
+++ b/tests/providers/openai/codex/test_result_usage.py
@@ -279,3 +279,80 @@ async def test_end_to_end_run_does_not_double_count_across_multiple_turns():
     usage = _collect_branch_usage(branch)
     assert usage["input_tokens"] == 30
     assert usage["output_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_run_sums_result_chunks_within_a_single_flush_window():
+    """Two turn.completed events with NO tool call (and thus no intervening
+    flush) between them land in the SAME result_meta accumulation window
+    inside run.py. Each event already carries its own marginal delta (per
+    codex.py's turn.completed handler); run.py must SUM those deltas into
+    result_meta rather than dict.update()-replacing them, or the first
+    turn's contribution is silently discarded when the second turn's
+    "usage"/"num_turns" keys overwrite it wholesale."""
+    import types
+    from unittest.mock import AsyncMock
+
+    from lionagi.operations.run.run import RunParam, run
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+    from lionagi.session.signal import _collect_branch_usage
+
+    events = [
+        {"type": "thread.started", "thread_id": "codex-thread-no-intervening-tool"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "turn one"}},
+        {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "turn two"}},
+        {"type": "turn.completed", "usage": {"input_tokens": 20, "output_tokens": 8}},
+        {"type": "done"},
+    ]
+    chunks = await _chunks_from_events(events)
+
+    # Sanity: codex.py already emits marginal (not cumulative) deltas per
+    # event -- {10,5} then {10,3} (20-10, 8-5) -- confirming this test
+    # exercises run.py's accumulation, not codex.py's delta computation.
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 2
+    assert result_chunks[0].metadata["usage"] == {"input_tokens": 10, "output_tokens": 5}
+    assert result_chunks[1].metadata["usage"] == {"input_tokens": 10, "output_tokens": 3}
+
+    m = iModel(provider="openai", model="gpt-5.5-codex", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli"},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+
+    branch = Branch()
+    branch.chat_model = m
+
+    async for _ in run(branch, "hi", RunParam()):
+        pass
+
+    # No tool call fired between the two turn.completed events, so both
+    # deltas land on the SAME (only) flushed AssistantResponse.
+    assistant_messages_with_usage = [
+        msg
+        for msg in branch.msgs.messages
+        if isinstance(msg.metadata.get("model_response"), dict) and msg.metadata["model_response"]
+    ]
+    assert len(assistant_messages_with_usage) == 1
+
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 20
+    assert usage["output_tokens"] == 8
+    assert assistant_messages_with_usage[0].metadata["model_response"]["num_turns"] == 2


### PR DESCRIPTION
Fixes #2123. `run.py`'s `case "result":` handler merged each chunk's metadata via `dict.update()`. codex.py's `turn.completed` emits marginal per-turn deltas for usage/total_cost_usd/num_turns by design; when two turn.completed events land in the same flush window, the second `update()` wholesale-replaced the first turn's usage sub-dict and num_turns — silently under-counting telemetry.

Fix: `_accumulate_result_meta()` numerically sums usage's numeric sub-fields, total_cost_usd, and num_turns across events in a flush window; point-in-time fields (duration_ms) still take the latest value. Safe for claude_code/gemini_code (one result chunk per run → summing a single occurrence == overwrite).

New end-to-end test: two text-only codex turns, no intervening tool call → usage sums correctly (fails against old code). 8/8 + broader sweep passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)