### PR TITLE
fix(messages): bypass render cache for content holding untracked-mutable objects

### DIFF
--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -324,8 +324,13 @@ class Message(Node, Sendable):
 
     def _render_cached(self, variant: str, render: Callable[[], Any]) -> Any:
         """Return a rendering cached by content identity and revision (not
-        id(), which could cross-wire non-overlapping objects reusing an address)."""
+        id(), which could cross-wire non-overlapping objects reusing an address).
+        Bypasses the cache entirely when content holds a value the revision
+        tracker cannot observe in-place mutation of."""
         content = self.content
+        if _content_has_untracked_mutable(content):
+            return render()
+
         revision = getattr(content, "_render_revision", 0)
         cached = self._render_cache.get(variant)
         if cached is not None and cached[0] is content and cached[1] == revision:
@@ -371,6 +376,41 @@ class Message(Node, Sendable):
         if isinstance(msg_, dict) and isinstance(msg_["content"], list):
             return [i for i in msg_["content"] if i["type"] == "image_url"]
         return None
+
+
+_JSON_SAFE_LEAF_TYPES = (type(None), bool, int, float, str, bytes)
+
+
+def _has_untracked_mutable(value: Any, _seen: frozenset[int] = frozenset()) -> bool:
+    """True if `value` holds — at any depth — a mutable object whose in-place
+    mutation `_TrackedList`/`_TrackedDict` cannot observe: anything besides
+    JSON-safe primitives and list/dict/tuple/frozenset nesting of them.
+    `type` objects are exempt — content only ever reads their class-level
+    schema, never live instance state (see `_build_structure` in instruction.py).
+    """
+    if isinstance(value, _JSON_SAFE_LEAF_TYPES) or isinstance(value, type):
+        return False
+    if isinstance(value, (list, tuple, frozenset)):
+        if id(value) in _seen:
+            return False
+        seen = _seen | {id(value)}
+        return any(_has_untracked_mutable(v, seen) for v in value)
+    if isinstance(value, dict):
+        if id(value) in _seen:
+            return False
+        seen = _seen | {id(value)}
+        return any(_has_untracked_mutable(v, seen) for v in value.values())
+    return True
+
+
+def _content_has_untracked_mutable(content: Any) -> bool:
+    """True if any render-input field on `content` carries a value the
+    revision tracker cannot observe in-place mutation of — the cache must
+    not trust its revision counter and should re-render on every call."""
+    allowed = getattr(content, "allowed", None)
+    if not callable(allowed):
+        return False
+    return any(_has_untracked_mutable(getattr(content, name, None)) for name in allowed())
 
 
 def _copy_rendered(rendered: Any) -> Any:

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -226,23 +226,31 @@ class Message(Node, Sendable):
 
     content: Any = None
     _render_cache: dict[str, tuple[Any, int, Any]] = PrivateAttr(default_factory=dict)
+    # Memoized "fully JSON-safe" verdict, keyed by (content identity, tracked
+    # revision) — see `_content_is_render_safe`. Only ever holds a *safe*
+    # verdict; an unsafe (untracked-mutable) verdict is never cached.
+    _untracked_mutable_safe: tuple[Any, int] | None = PrivateAttr(default=None)
 
     def __getstate__(self) -> dict[str, Any]:
         # A clone must start uncached: the copied entry would hold the source
         # content/revision pair and never be servable.
         state = super().__getstate__()
         private = state.get("__pydantic_private__")
-        if private and private.get("_render_cache"):
+        if private and (private.get("_render_cache") or private.get("_untracked_mutable_safe")):
             private = dict(private)
             private["_render_cache"] = {}
+            private["_untracked_mutable_safe"] = None
             state = {**state, "__pydantic_private__": private}
         return state
 
     def __deepcopy__(self, memo: dict | None = None) -> "Message":
         clone = super().__deepcopy__(memo)
         private = getattr(clone, "__pydantic_private__", None)
-        if private is not None and private.get("_render_cache"):
-            private["_render_cache"] = {}
+        if private is not None:
+            if private.get("_render_cache"):
+                private["_render_cache"] = {}
+            if private.get("_untracked_mutable_safe"):
+                private["_untracked_mutable_safe"] = None
         return clone
 
     @field_validator("content", mode="before")
@@ -328,7 +336,7 @@ class Message(Node, Sendable):
         Bypasses the cache entirely when content holds a value the revision
         tracker cannot observe in-place mutation of."""
         content = self.content
-        if _content_has_untracked_mutable(content):
+        if not self._content_is_render_safe(content):
             return render()
 
         revision = getattr(content, "_render_revision", 0)
@@ -339,6 +347,30 @@ class Message(Node, Sendable):
         rendered = render()
         self._render_cache[variant] = (content, revision, _copy_rendered(rendered))
         return rendered
+
+    def _content_is_render_safe(self, content: Any) -> bool:
+        """True if `content` is fully JSON-safe (no untracked-mutable value
+        reachable at any depth, including dict keys) — memoized per
+        (content identity, tracked revision) so a warm JSON-safe content is
+        walked at most once per revision instead of on every render.
+
+        Only the *safe* verdict is ever cached. An untracked-mutable object
+        can mutate without bumping the tracked revision (that is the whole
+        reason the render cache must bypass for it), so a cached *unsafe*
+        verdict has no revision to reliably invalidate on; recomputing it
+        every call is the only way to keep it honest. Content that never
+        clears the walk is presumably rare, so re-walking it is cheap in
+        practice.
+        """
+        revision = getattr(content, "_render_revision", 0)
+        verdict = self._untracked_mutable_safe
+        if verdict is not None and verdict[0] is content and verdict[1] == revision:
+            return True
+
+        safe = not _content_has_untracked_mutable(content)
+        if safe:
+            self._untracked_mutable_safe = (content, revision)
+        return safe
 
     @property
     def rendered(self) -> str:
@@ -379,28 +411,68 @@ class Message(Node, Sendable):
 
 
 _JSON_SAFE_LEAF_TYPES = (type(None), bool, int, float, str, bytes)
+_UNTRACKED_MUTABLE_MAX_DEPTH = 1000
 
 
-def _has_untracked_mutable(value: Any, _seen: frozenset[int] = frozenset()) -> bool:
-    """True if `value` holds — at any depth — a mutable object whose in-place
-    mutation `_TrackedList`/`_TrackedDict` cannot observe: anything besides
-    JSON-safe primitives and list/dict/tuple/frozenset nesting of them.
-    `type` objects are exempt — content only ever reads their class-level
-    schema, never live instance state (see `_build_structure` in instruction.py).
+class _ExitFrame:
+    """Stack marker: pops `obj_id` off `on_path` once all of its children
+    have been visited, so a later *sibling* reference to the same container
+    is not mistaken for a cycle back through an ancestor."""
+
+    __slots__ = ("obj_id",)
+
+    def __init__(self, obj_id: int) -> None:
+        self.obj_id = obj_id
+
+
+def _has_untracked_mutable(root: Any) -> bool:
+    """True if `root` holds — at any depth, including dict keys — a mutable
+    object whose in-place mutation `_TrackedList`/`_TrackedDict` cannot
+    observe: anything besides JSON-safe primitives and list/dict/tuple/
+    frozenset nesting of them. `type` objects are exempt — content only
+    ever reads their class-level schema, never live instance state (see
+    `_build_structure` in instruction.py).
+
+    Iterative (explicit stack, not recursion) so deeply nested-but-safe
+    input cannot raise `RecursionError`. Fails safe — returns True without
+    raising — for a self-referential (cyclic) container or once traversal
+    exceeds a bounded depth, since neither can be proven safe to cache.
     """
-    if isinstance(value, _JSON_SAFE_LEAF_TYPES) or isinstance(value, type):
-        return False
-    if isinstance(value, (list, tuple, frozenset)):
-        if id(value) in _seen:
-            return False
-        seen = _seen | {id(value)}
-        return any(_has_untracked_mutable(v, seen) for v in value)
-    if isinstance(value, dict):
-        if id(value) in _seen:
-            return False
-        seen = _seen | {id(value)}
-        return any(_has_untracked_mutable(v, seen) for v in value.values())
-    return True
+    stack: list[tuple[Any, int]] = [(root, 0)]
+    on_path: set[int] = set()
+
+    while stack:
+        value, depth = stack.pop()
+
+        if isinstance(value, _ExitFrame):
+            on_path.discard(value.obj_id)
+            continue
+
+        if isinstance(value, _JSON_SAFE_LEAF_TYPES) or isinstance(value, type):
+            continue
+
+        if isinstance(value, (list, tuple, frozenset, dict)):
+            if depth > _UNTRACKED_MUTABLE_MAX_DEPTH:
+                return True
+
+            obj_id = id(value)
+            if obj_id in on_path:
+                return True  # cyclic reference: cannot prove safe
+
+            on_path.add(obj_id)
+            stack.append((_ExitFrame(obj_id), depth))
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    stack.append((key, depth + 1))
+                    stack.append((item, depth + 1))
+            else:
+                for item in value:
+                    stack.append((item, depth + 1))
+            continue
+
+        return True
+
+    return False
 
 
 def _content_has_untracked_mutable(content: Any) -> bool:

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -133,6 +133,32 @@ def test_response_format_structure_derives_from_tracked_copy():
     )
 
 
+def test_response_format_nested_object_mutated_in_place_invalidates_cache():
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        note: str
+
+    answer = Answer(note="draft")
+    branch = Branch()
+    branch.msgs.add_message(instruction="historic", response_format={"answer": answer})
+
+    first = branch.msgs.to_chat_msgs()[0]["content"]
+    assert "draft" in first
+
+    # `answer` is a live object nested inside a tracked dict value; mutating
+    # its own field in place advances no `_TrackedDict`/`_TrackedList`
+    # revision, so a naive revision-keyed cache would keep serving the
+    # pre-mutation rendering.
+    answer.note = "final"
+
+    cached = branch.msgs.to_chat_msgs()[0]["content"]
+    uncached = branch.msgs.to_chat_msgs(_use_render_cache=False)[0]["content"]
+    assert "final" in cached
+    assert "draft" not in cached
+    assert cached == uncached
+
+
 def test_message_deepcopy_pickle_and_prepare_roundtrip():
     import copy
     import pickle

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -159,6 +159,94 @@ def test_response_format_nested_object_mutated_in_place_invalidates_cache():
     assert cached == uncached
 
 
+def test_response_format_mutable_dict_key_mutation_invalidates_cache():
+    class Key:
+        """A hashable, mutable key whose repr changes with its state — used
+        as a `response_format` dict key, not a value."""
+
+        def __init__(self, value: str):
+            self.value = value
+
+        def __repr__(self) -> str:
+            return f"Key({self.value!r})"
+
+    key = Key("draft")
+    branch = Branch()
+    branch.msgs.add_message(instruction="historic", response_format={key: "string"})
+
+    first = branch.msgs.to_chat_msgs()[0]["content"]
+    assert "draft" in first
+
+    # `key` is a live object used as a dict KEY (not a value) inside a
+    # tracked `response_format` dict; the untracked-mutable walk must
+    # inspect keys too, or this mutation goes undetected and the cache
+    # keeps serving the pre-mutation rendering.
+    key.value = "final"
+
+    cached = branch.msgs.to_chat_msgs()[0]["content"]
+    uncached = branch.msgs.to_chat_msgs(_use_render_cache=False)[0]["content"]
+    assert "final" in cached
+    assert "draft" not in cached
+    assert cached == uncached
+
+
+def test_cyclic_prompt_context_does_not_raise_recursion_error():
+    branch = Branch()
+
+    # A tuple/list cycle: `_track_mutable` only wraps list/dict values into
+    # revision-tracking containers (not tuples), so a cycle that closes
+    # through a tuple boundary reaches the untracked-mutable guard intact
+    # instead of blowing the stack earlier, in unrelated tracked-container
+    # construction (list/dict cycles recurse infinitely there — a
+    # separate, pre-existing limitation of `_TrackedList`/`_TrackedDict`,
+    # not the guard under test here).
+    inner_list: list = []
+    cyclic_tuple = (inner_list,)
+    inner_list.append(cyclic_tuple)
+
+    # `plain_content` short-circuits rendering before `prompt_context` is
+    # ever read (InstructionContent._format_text_content), so this isolates
+    # the untracked-mutable guard itself: the guard still walks every
+    # allowed() field, including `prompt_context`, regardless of what the
+    # renderer actually uses.
+    message = branch.msgs.add_message(
+        instruction="ignored",
+        plain_content="stable",
+        context=[cyclic_tuple],
+    )
+
+    chat = message.chat_msg
+    assert chat is not None
+    assert chat["content"] == "stable"
+    assert branch.msgs.to_chat_msgs()[0]["content"] == "stable"
+
+
+def test_json_safe_content_untracked_mutable_walk_runs_once_per_revision(monkeypatch):
+    import lionagi.protocols.messages.message as message_module
+
+    branch = Branch()
+    branch.msgs.add_message(instruction="historic", context=[{"a": 1, "b": [1, 2, 3]}])
+
+    calls: list = []
+    original = message_module._content_has_untracked_mutable
+
+    def counting(content):
+        calls.append(content)
+        return original(content)
+
+    monkeypatch.setattr(message_module, "_content_has_untracked_mutable", counting)
+
+    branch.msgs.to_chat_msgs()
+    assert len(calls) == 1
+
+    # Two more warm, revision-unchanged renders: the walk verdict is
+    # memoized per (content identity, tracked revision), so the fast path
+    # must not re-run the full traversal on either hit.
+    branch.msgs.to_chat_msgs()
+    branch.msgs.to_chat_msgs()
+    assert len(calls) == 1
+
+
 def test_message_deepcopy_pickle_and_prepare_roundtrip():
     import copy
     import pickle

--- a/tests/operations/test_message_render_cache.py
+++ b/tests/operations/test_message_render_cache.py
@@ -218,6 +218,12 @@ def test_cyclic_prompt_context_does_not_raise_recursion_error():
     chat = message.chat_msg
     assert chat is not None
     assert chat["content"] == "stable"
+    # The untracked-mutable guard must REFUSE to cache content it cannot
+    # safely fingerprint: a cyclic structure trips the fail-safe path, so the
+    # render cache stays empty rather than pinning a value that can silently
+    # go stale. (Pre-fix this test passed on "no exception" alone, which did
+    # not prove the bypass — assert the bypass directly.)
+    assert message._render_cache == {}
     assert branch.msgs.to_chat_msgs()[0]["content"] == "stable"
 
 


### PR DESCRIPTION
Fixes #2101. The render cache (PR #2088) keys on `_render_revision`, which only advances when mutation goes through `_TrackedList`/`_TrackedDict`. A BaseModel/dataclass/custom object held inside `prompt_context` or a `response_format` dict can be mutated in place with zero signal, so a stale rendering is served indefinitely (concretely observable with a BaseModel nested as a response_format value).

Fix: `_content_has_untracked_mutable()` walks the content's render-input fields (via `content.allowed()`) and flags any value that isn't a JSON-safe primitive or a list/dict/tuple/frozenset nesting thereof; `type` objects are exempt (only class-level schema is read, never live instance state). When flagged, `_render_cached` bypasses the cache and renders live; the fast path stays intact for fully JSON-safe content (the common case).

New test: mutate a BaseModel nested in response_format in place → second render reflects the mutation (fails against old code). 425 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)