### PR TITLE
fix(chat): fire USER_PROMPT_SUBMIT guard before context-provider side effects

### DIFF
--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -11,7 +11,7 @@ from lionagi.protocols.messages import AssistantResponse, Instruction
 
 from .._turn_origin import consume_turn_origin
 from ..types import ChatParam
-from ._prepare import _apply_context_providers, _prepare_run_kwargs
+from ._prepare import _apply_context_providers, _build_instruction, _prepare_run_kwargs
 
 if TYPE_CHECKING:
     from lionagi.session.branch import Branch
@@ -43,13 +43,21 @@ async def chat(
     chat_param: ChatParam,
     return_ins_res_message: bool = False,
 ) -> tuple[Instruction, AssistantResponse] | str:
-    pre_ins = await _apply_context_providers(branch, instruction, chat_param)
-    try:
-        ins, kw = _prepare_run_kwargs(branch, instruction, chat_param, ins=pre_ins)
-    finally:
-        branch._context_injection_slot = None
+    # Built synchronously and purely from (instruction, chat_param) — no
+    # context-provider I/O. This is the only thing the guard below needs,
+    # so it happens before any other awaited operation for this turn,
+    # mirroring run()'s ordering (operations/run/run.py): the guard is
+    # evaluated before context providers get a chance to run their
+    # (potentially side-effecting) gather.
+    ins = _build_instruction(branch, instruction, chat_param)
 
     await _emit_user_prompt_submit(branch, chat_param, ins)
+
+    await _apply_context_providers(branch, instruction, chat_param, ins=ins)
+    try:
+        ins, kw = _prepare_run_kwargs(branch, instruction, chat_param, ins=ins)
+    finally:
+        branch._context_injection_slot = None
 
     imodel = chat_param.imodel or branch.chat_model
     if not chat_param._is_sentinel(chat_param.include_token_usage_to_model):

--- a/tests/hooks/test_user_prompt_submit_matrix.py
+++ b/tests/hooks/test_user_prompt_submit_matrix.py
@@ -293,6 +293,32 @@ async def test_run_guard_rejection_no_pre_guard_side_effects():
     assert not any(isinstance(m, Instruction) for m in branch.messages)
 
 
+async def test_chat_guard_rejection_no_pre_guard_side_effects():
+    """Mirrors test_run_guard_rejection_no_pre_guard_side_effects for chat():
+    a rejected prompt must never let a registered context provider run its
+    (potentially side-effecting) gather — the guard is the first awaited
+    operation for chat()'s turn, strictly before context providers run,
+    matching run()'s ordering."""
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello", system="be helpful")
+
+    spy = _SpyContextProvider()
+    branch.providers.register(spy, name="spy")
+
+    bus = HookBus()
+
+    async def reject_submit(**kw):
+        raise PermissionError("blocked")
+
+    bus.on(HookPoint.USER_PROMPT_SUBMIT, reject_submit)
+    branch._hooks = bus
+
+    with pytest.raises(PermissionError):
+        await branch.chat("SECRET=top-secret")
+
+    assert spy.calls == [], "context providers must never run on a rejected prompt"
+    assert not any(isinstance(m, Instruction) for m in branch.messages)
+
+
 async def test_run_yielded_instruction_already_in_branch_messages():
     """A consumer that receives the first yielded Instruction must find it
     already committed to branch.messages at that moment — the guard runs


### PR DESCRIPTION
Fixes #2133. `chat()` ran `_apply_context_providers()` (side-effecting `.provide()` calls) BEFORE evaluating the USER_PROMPT_SUBMIT guard, unlike `run()` which builds the Instruction synchronously, fires the guard, and only runs context providers after it passes. A denying prompt-submit hook could therefore still trigger context-provider side effects.

Fix: reorder `chat()` to mirror `run()` — build `ins` via `_build_instruction` first, emit USER_PROMPT_SUBMIT, then apply context providers + prepare run kwargs.

New test `test_chat_guard_rejection_no_pre_guard_side_effects` (modeled on the run() equivalent): a rejected prompt runs no context-provider side effects — fails against the old ordering. 24 + 67 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)