### PR TITLE
fix(orchestrate): fire terminal notify even when invocation finalize raises

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -331,6 +331,23 @@ async def _resolve_invocation_terminal_flow(
         return "failed", RunReasons.FAILED_EXCEPTION, "Flow failed.", evidence_refs, metadata
 
 
+def _fallback_notify_reason(status: str) -> str:
+    """Reason code for a best-effort terminal-notify envelope emitted when
+    invocation finalization itself raised (see `_run_flow`'s finally block)
+    -- *status* here is the flow's own already-computed terminal status, not
+    a value read back from the (never-committed) invocation row."""
+    from lionagi.state.reasons import RunReasons
+
+    return {
+        "completed": RunReasons.COMPLETED_OK,
+        "completed_empty": RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+        "failed": RunReasons.FAILED_EXCEPTION,
+        "timed_out": RunReasons.TIMED_OUT_DEADLINE,
+        "aborted": RunReasons.ABORTED_USER,
+        "cancelled": RunReasons.CANCELLED_SYSTEM,
+    }.get(status, RunReasons.FAILED_EXCEPTION)
+
+
 def _earlier_dep_indices(depends_on: list[str] | None, position: int) -> list[int]:
     out: list[int] = []
     for ref in depends_on or []:
@@ -1737,6 +1754,42 @@ async def _run_flow(
                     _logging.getLogger("lionagi.cli").exception(
                         "Failed to finalize invocation %s", invocation_id
                     )
+                    # The guarded update_status() above never committed, so
+                    # the terminal-callback registry never emitted for this
+                    # invocation's entity -- any --notify / notify.on_terminal
+                    # handler scoped to it would otherwise be silently
+                    # dropped exactly when a notification is most needed.
+                    # Emit a best-effort envelope directly, using the flow's
+                    # own already-computed terminal status as a fallback
+                    # (mirrors the unconditional fire_terminal_notify() call
+                    # this code path replaced).
+                    try:
+                        import uuid as _uuid
+
+                        from lionagi.state.lifecycle.callbacks import (
+                            DEFAULT_TERMINAL_CALLBACKS,
+                            Correlation,
+                            EntityRef,
+                            RunTerminalEnvelope,
+                        )
+
+                        await DEFAULT_TERMINAL_CALLBACKS.emit(
+                            RunTerminalEnvelope(
+                                event_id=str(_uuid.uuid4()),
+                                entity=EntityRef(kind="invocation", id=invocation_id),
+                                previous_status=None,
+                                terminal_status=_terminal_status,
+                                reason_code=_fallback_notify_reason(_terminal_status),
+                                occurred_at=_ended_at,
+                                correlation=Correlation(invocation_id=invocation_id),
+                                durable=False,
+                            )
+                        )
+                    except Exception:
+                        _logging.getLogger("lionagi.cli").exception(
+                            "Failed to emit fallback terminal notify for invocation %s",
+                            invocation_id,
+                        )
 
             unregister_flow_notify_scope(_notify_scope_name)
             for _br in env.session.branches:

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -385,6 +385,52 @@ async def test_run_flow_no_hook_configured_is_a_noop(
     spawn_shell.assert_not_called()
 
 
+async def test_run_flow_notify_still_fires_when_invocation_finalize_raises(
+    temp_db_path: Path, tmp_path: Path
+):
+    """Regression: when `_resolve_invocation_terminal_flow` (or the
+    subsequent `update_status('invocation', ...)` write) raises, the guarded
+    lifecycle transition never commits and so never pushes a terminal
+    envelope through the registry for this invocation's entity -- but the
+    `--notify` hook explicitly scoped to that entity must still fire,
+    reporting the flow's own already-computed terminal status, not be
+    silently dropped."""
+    env = _make_env(tmp_path)
+    invocation_id = str(uuid4())
+    await _make_invocation(temp_db_path, invocation_id)
+    out_file = tmp_path / "captured.json"
+
+    with (
+        patch(
+            "lionagi.cli.orchestrate.flow.setup_orchestration",
+            AsyncMock(return_value=env),
+        ),
+        patch(
+            "lionagi.cli.orchestrate.flow._run_flow_inner",
+            AsyncMock(return_value="ok result"),
+        ),
+        patch(
+            "lionagi.cli.orchestrate.flow._resolve_invocation_terminal_flow",
+            AsyncMock(side_effect=RuntimeError("db hiccup during invocation finalize")),
+        ),
+    ):
+        result, terminal_status = await _run_flow(
+            "claude",
+            "do the thing",
+            invocation_id=invocation_id,
+            notify=_capture_command(out_file),
+        )
+
+    # The run's own outcome must be unaffected by the finalize failure.
+    assert result == "ok result"
+    assert terminal_status == "completed"
+
+    assert out_file.exists(), "notify hook never fired despite invocation finalize raising"
+    payload = json.loads(out_file.read_text())
+    assert payload["invocation_id"] == invocation_id
+    assert payload["status"] == "completed"
+
+
 async def test_run_flow_fires_hook_without_invocation_id(temp_db_path: Path, tmp_path: Path):
     """A `--notify` run with no --invocation scopes to the session id
     instead, and the payload's own invocation_id field stays null; no


### PR DESCRIPTION
Fixes #2158. `_run_flow`'s notify handler fires only when the guarded `update_status("invocation", ...)` transition commits and pushes an envelope. If `_resolve_invocation_terminal_flow`/`update_status` raised, the exception was logged and swallowed but NO envelope was emitted — so the terminal-notify signal (which callers rely on for CI/paging/on-call reaction) silently never fired, exactly when something had already gone wrong.

Fix: in the finalize `except`, after logging (still surfaced), construct a `RunTerminalEnvelope` from the flow's already-computed terminal status and call `DEFAULT_TERMINAL_CALLBACKS.emit()` as a best-effort fallback (mirrors the pre-PR-2119 unconditional fire_terminal_notify). The fallback emit is itself try/except-wrapped so it can't skip scope-unregister/branch shutdown. Added `_fallback_notify_reason` mapping terminal status → RunReasons.

New test: a finalize that raises still writes the --notify capture with the right invocation_id + terminal_status (fails against old code). 9 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)