### PR TITLE
fix(service): rescan plugin endpoints only on cache miss

### DIFF
--- a/lionagi/plugins/registry.py
+++ b/lionagi/plugins/registry.py
@@ -430,6 +430,13 @@ class PluginRegistry:
 
     _snapshot: ClassVar[list[PluginRecord] | None] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
+    # Monotonic counter bumped every time _snapshot is (re)built. id()-based
+    # tokens are reusable once the prior snapshot list is garbage-collected,
+    # so a rebuilt snapshot could get the SAME id() as an earlier one a
+    # caller had cached -- making a stale entry look current and skipping
+    # the post-reset trust/enablement/peer-collision recheck. A counter that
+    # only ever increases cannot repeat.
+    _generation: ClassVar[int] = 0
     # Keyed by (plugin_name, target, content_hash) so re-trusted content is
     # structurally a cache miss, not dependent on prior eviction.
     _activation_cache: ClassVar[dict[tuple[str, str, str], Any]] = {}
@@ -442,6 +449,7 @@ class PluginRegistry:
         with cls._lock:
             if cls._snapshot is None:
                 cls._snapshot = _build_snapshot()
+                cls._generation += 1
             return cls._snapshot
 
     @classmethod
@@ -456,13 +464,17 @@ class PluginRegistry:
     def snapshot_generation(cls) -> int:
         """Cheap process-lifetime token for the cached plugin scan: identical
         across calls until ``reset()`` forces a rebuild, at which point it
-        changes. Lets a caller that already fully validated a plugin against
-        the live snapshot cheaply detect ``nothing has been reset since``
-        without repeating the scan itself; never a substitute for the
-        full, per-target trust/eligibility check ``activate_target()``
-        performs whenever this token *does* change.
+        strictly increases. Lets a caller that already fully validated a
+        plugin against the live snapshot cheaply detect ``nothing has been
+        reset since`` without repeating the scan itself; never a substitute
+        for the full, per-target trust/eligibility check ``activate_target()``
+        performs whenever this token *does* change. A monotonic counter
+        (not ``id()`` of the cached snapshot list) so the token can never
+        repeat across the process lifetime, even after many reset() cycles
+        recycle the same memory address for a new snapshot object.
         """
-        return id(cls._ensure_loaded())
+        cls._ensure_loaded()
+        return cls._generation
 
     @classmethod
     def list_plugins(cls) -> list[PluginRecord]:

--- a/lionagi/plugins/registry.py
+++ b/lionagi/plugins/registry.py
@@ -453,6 +453,18 @@ class PluginRegistry:
             cls._activation_errors = {}
 
     @classmethod
+    def snapshot_generation(cls) -> int:
+        """Cheap process-lifetime token for the cached plugin scan: identical
+        across calls until ``reset()`` forces a rebuild, at which point it
+        changes. Lets a caller that already fully validated a plugin against
+        the live snapshot cheaply detect ``nothing has been reset since``
+        without repeating the scan itself; never a substitute for the
+        full, per-target trust/eligibility check ``activate_target()``
+        performs whenever this token *does* change.
+        """
+        return id(cls._ensure_loaded())
+
+    @classmethod
     def list_plugins(cls) -> list[PluginRecord]:
         return list(cls._ensure_loaded())
 

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -21,6 +21,9 @@ __all__ = (
 
 logger = logging.getLogger(__name__)
 
+# (mtime_ns, ctime_ns, size, inode) for one file -- see _plugin_entry_stat.
+_FileStat = tuple[int, int, int, int]
+
 
 class EndpointType(Enum):
     API = "api"
@@ -86,10 +89,10 @@ class _RegistryEntry:
         self.plugin_name: str | None = None
         self.plugin_target: str | None = None
         # Fast-path cache for _revalidate_plugin_entry: the PluginRegistry
-        # snapshot generation and (manifest, target) mtimes as of the last
-        # clean activate_target() call. See _revalidate_plugin_entry.
+        # snapshot generation and (manifest, target) stat signatures as of
+        # the last clean activate_target() call. See _revalidate_plugin_entry.
         self._validated_generation: int | None = None
-        self._validated_stat: tuple[int, int] | None = None
+        self._validated_stat: tuple[_FileStat, _FileStat] | None = None
 
 
 class EndpointRegistry:
@@ -203,9 +206,13 @@ class EndpointRegistry:
         rehashes every installed plugin on each call, not just this one --
         too expensive to pay on every ``match()`` hit against an endpoint
         that already activated cleanly. Only re-runs it when the
-        ``PluginRegistry`` snapshot has been reset, or this plugin's
-        manifest or declared target file has been touched on disk since the
-        last clean revalidation; otherwise reuses that prior result.
+        ``PluginRegistry`` snapshot generation has strictly advanced (a
+        ``reset()`` happened), or this plugin's manifest or declared target
+        file's content-pinned stat signature (see ``_plugin_entry_stat``,
+        which is ctime/size/inode-backed, not mtime-only -- mtime alone can
+        be restored via ``os.utime`` after an edit and would let a stale
+        entry be served) no longer matches the last clean revalidation;
+        otherwise reuses that prior result.
         """
         if entry.plugin_name is None or entry.plugin_target is None:
             return True
@@ -235,12 +242,26 @@ class EndpointRegistry:
         return True
 
     @classmethod
-    def _plugin_entry_stat(cls, plugin_name: str, target: str) -> tuple[int, int] | None:
-        """``(manifest_mtime_ns, target_mtime_ns)`` for a plugin-provided
-        endpoint's backing files -- a cheap ``anything on disk moved`` signal
-        for ``_revalidate_plugin_entry``'s fast path. ``None`` (unknown
-        plugin, unresolvable path, either file missing) always forces the
-        caller back onto the full ``activate_target()`` path.
+    def _plugin_entry_stat(
+        cls, plugin_name: str, target: str
+    ) -> tuple[_FileStat, _FileStat] | None:
+        """``(manifest_stat, target_stat)`` for a plugin-provided endpoint's
+        backing files -- a cheap ``has anything on disk changed`` signal for
+        ``_revalidate_plugin_entry``'s fast path.
+
+        Each element is ``(mtime_ns, ctime_ns, size, inode)``. mtime ALONE is
+        not a valid content-pinning signal: ``os.utime()`` lets a caller edit
+        a file's bytes and then restore its original mtime, which would make
+        a stale, unrevalidated entry look unchanged forever. ctime closes
+        that hole -- it records the last *inode metadata* change (which an
+        mtime write, restored or not, always triggers) and cannot be set by
+        any standard API, so it can't be forged back to an old value the way
+        mtime can. size and inode are free extra signal from the same
+        ``stat()`` call (no additional syscall) and catch same-second
+        same-mtime same-ctime edits and delete+recreate respectively.
+
+        ``None`` (unknown plugin, unresolvable path, either file missing)
+        always forces the caller back onto the full ``activate_target()`` path.
         """
         from lionagi.plugins import PluginRegistry
 
@@ -249,11 +270,24 @@ class EndpointRegistry:
             return None
         module_path = target.split(":", 1)[0]
         try:
-            manifest_mtime = record.manifest_path.stat().st_mtime_ns
-            target_mtime = (record.bundle_dir / module_path).stat().st_mtime_ns
+            manifest_stat = record.manifest_path.stat()
+            target_stat = (record.bundle_dir / module_path).stat()
         except OSError:
             return None
-        return (manifest_mtime, target_mtime)
+        return (
+            (
+                manifest_stat.st_mtime_ns,
+                manifest_stat.st_ctime_ns,
+                manifest_stat.st_size,
+                manifest_stat.st_ino,
+            ),
+            (
+                target_stat.st_mtime_ns,
+                target_stat.st_ctime_ns,
+                target_stat.st_size,
+                target_stat.st_ino,
+            ),
+        )
 
     @classmethod
     def _consult_plugin_providers(cls) -> bool:

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -71,13 +71,25 @@ class EndpointMeta:
 
 
 class _RegistryEntry:
-    __slots__ = ("meta", "cls", "plugin_name", "plugin_target")
+    __slots__ = (
+        "meta",
+        "cls",
+        "plugin_name",
+        "plugin_target",
+        "_validated_generation",
+        "_validated_stat",
+    )
 
     def __init__(self, meta: EndpointMeta, cls: type):
         self.meta = meta
         self.cls = cls
         self.plugin_name: str | None = None
         self.plugin_target: str | None = None
+        # Fast-path cache for _revalidate_plugin_entry: the PluginRegistry
+        # snapshot generation and (manifest, target) mtimes as of the last
+        # clean activate_target() call. See _revalidate_plugin_entry.
+        self._validated_generation: int | None = None
+        self._validated_stat: tuple[int, int] | None = None
 
 
 class EndpointRegistry:
@@ -186,11 +198,28 @@ class EndpointRegistry:
 
     @classmethod
     def _revalidate_plugin_entry(cls, entry: _RegistryEntry) -> bool:
-        """Keep plugin entries available only while their declared target remains trusted."""
+        """Keep plugin entries available only while their declared target
+        remains trusted. ``PluginRegistry.activate_target()`` rescans and
+        rehashes every installed plugin on each call, not just this one --
+        too expensive to pay on every ``match()`` hit against an endpoint
+        that already activated cleanly. Only re-runs it when the
+        ``PluginRegistry`` snapshot has been reset, or this plugin's
+        manifest or declared target file has been touched on disk since the
+        last clean revalidation; otherwise reuses that prior result.
+        """
         if entry.plugin_name is None or entry.plugin_target is None:
             return True
 
         from lionagi.plugins import PluginActivationError, PluginRegistry
+
+        generation = PluginRegistry.snapshot_generation()
+        stat_signature = cls._plugin_entry_stat(entry.plugin_name, entry.plugin_target)
+        if (
+            stat_signature is not None
+            and entry._validated_generation == generation
+            and entry._validated_stat == stat_signature
+        ):
+            return True
 
         try:
             PluginRegistry.activate_target(entry.plugin_name, entry.plugin_target)
@@ -200,7 +229,31 @@ class EndpointRegistry:
             except ValueError:
                 pass
             return False
+
+        entry._validated_generation = generation
+        entry._validated_stat = cls._plugin_entry_stat(entry.plugin_name, entry.plugin_target)
         return True
+
+    @classmethod
+    def _plugin_entry_stat(cls, plugin_name: str, target: str) -> tuple[int, int] | None:
+        """``(manifest_mtime_ns, target_mtime_ns)`` for a plugin-provided
+        endpoint's backing files -- a cheap ``anything on disk moved`` signal
+        for ``_revalidate_plugin_entry``'s fast path. ``None`` (unknown
+        plugin, unresolvable path, either file missing) always forces the
+        caller back onto the full ``activate_target()`` path.
+        """
+        from lionagi.plugins import PluginRegistry
+
+        record = PluginRegistry.get(plugin_name)
+        if record is None:
+            return None
+        module_path = target.split(":", 1)[0]
+        try:
+            manifest_mtime = record.manifest_path.stat().st_mtime_ns
+            target_mtime = (record.bundle_dir / module_path).stat().st_mtime_ns
+        except OSError:
+            return None
+        return (manifest_mtime, target_mtime)
 
     @classmethod
     def _consult_plugin_providers(cls) -> bool:

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 from dataclasses import dataclass
@@ -22,7 +23,11 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 # (mtime_ns, ctime_ns, size, inode) for one file -- see _plugin_entry_stat.
+# A cheap first gate only; see _plugin_entry_digest for the correctness guarantee.
 _FileStat = tuple[int, int, int, int]
+
+# (manifest_digest, target_digest) for one plugin entry -- see _plugin_entry_digest.
+_ContentDigest = tuple[str, str]
 
 
 class EndpointType(Enum):
@@ -81,6 +86,7 @@ class _RegistryEntry:
         "plugin_target",
         "_validated_generation",
         "_validated_stat",
+        "_validated_digest",
     )
 
     def __init__(self, meta: EndpointMeta, cls: type):
@@ -89,10 +95,12 @@ class _RegistryEntry:
         self.plugin_name: str | None = None
         self.plugin_target: str | None = None
         # Fast-path cache for _revalidate_plugin_entry: the PluginRegistry
-        # snapshot generation and (manifest, target) stat signatures as of
-        # the last clean activate_target() call. See _revalidate_plugin_entry.
+        # snapshot generation, (manifest, target) stat signatures, and
+        # (manifest, target) content digests as of the last clean
+        # activate_target() call. See _revalidate_plugin_entry.
         self._validated_generation: int | None = None
         self._validated_stat: tuple[_FileStat, _FileStat] | None = None
+        self._validated_digest: _ContentDigest | None = None
 
 
 class EndpointRegistry:
@@ -207,12 +215,23 @@ class EndpointRegistry:
         too expensive to pay on every ``match()`` hit against an endpoint
         that already activated cleanly. Only re-runs it when the
         ``PluginRegistry`` snapshot generation has strictly advanced (a
-        ``reset()`` happened), or this plugin's manifest or declared target
-        file's content-pinned stat signature (see ``_plugin_entry_stat``,
-        which is ctime/size/inode-backed, not mtime-only -- mtime alone can
-        be restored via ``os.utime`` after an edit and would let a stale
-        entry be served) no longer matches the last clean revalidation;
-        otherwise reuses that prior result.
+        ``reset()`` happened), when this plugin's manifest or declared
+        target file's cheap stat signature (see ``_plugin_entry_stat``) no
+        longer matches the last clean revalidation, or -- when that stat
+        signature still matches -- when its content digest (see
+        ``_plugin_entry_digest``) no longer matches either; otherwise reuses
+        that prior result.
+
+        The stat signature alone is not a portable content-change
+        guarantee: ``os.utime()`` restores a spoofed mtime after an edit,
+        and on platforms where ``st_ctime_ns`` is not a metadata-change
+        token (Windows CPython documents it as file *creation* time, which
+        a content write or ``os.utime()`` never advances), a same-length
+        in-place edit can leave the whole stat tuple looking unchanged. The
+        content digest is only computed on that stat-stable path -- the
+        files plugins declare are small, so paying for the read there is
+        cheap -- and closes that hole on every platform: it always changes
+        when either file's bytes do.
         """
         if entry.plugin_name is None or entry.plugin_target is None:
             return True
@@ -221,12 +240,15 @@ class EndpointRegistry:
 
         generation = PluginRegistry.snapshot_generation()
         stat_signature = cls._plugin_entry_stat(entry.plugin_name, entry.plugin_target)
-        if (
+        stat_unchanged = (
             stat_signature is not None
             and entry._validated_generation == generation
             and entry._validated_stat == stat_signature
-        ):
-            return True
+        )
+        if stat_unchanged:
+            digest = cls._plugin_entry_digest(entry.plugin_name, entry.plugin_target)
+            if digest is not None and entry._validated_digest == digest:
+                return True
 
         try:
             PluginRegistry.activate_target(entry.plugin_name, entry.plugin_target)
@@ -239,6 +261,7 @@ class EndpointRegistry:
 
         entry._validated_generation = generation
         entry._validated_stat = cls._plugin_entry_stat(entry.plugin_name, entry.plugin_target)
+        entry._validated_digest = cls._plugin_entry_digest(entry.plugin_name, entry.plugin_target)
         return True
 
     @classmethod
@@ -246,19 +269,26 @@ class EndpointRegistry:
         cls, plugin_name: str, target: str
     ) -> tuple[_FileStat, _FileStat] | None:
         """``(manifest_stat, target_stat)`` for a plugin-provided endpoint's
-        backing files -- a cheap ``has anything on disk changed`` signal for
-        ``_revalidate_plugin_entry``'s fast path.
+        backing files -- a cheap ``has anything on disk changed`` first gate
+        for ``_revalidate_plugin_entry``'s fast path. It is a *probabilistic*
+        signal, not a correctness guarantee; see ``_plugin_entry_digest``
+        for the guarantee this gate feeds into.
 
         Each element is ``(mtime_ns, ctime_ns, size, inode)``. mtime ALONE is
         not a valid content-pinning signal: ``os.utime()`` lets a caller edit
-        a file's bytes and then restore its original mtime, which would make
-        a stale, unrevalidated entry look unchanged forever. ctime closes
-        that hole -- it records the last *inode metadata* change (which an
-        mtime write, restored or not, always triggers) and cannot be set by
-        any standard API, so it can't be forged back to an old value the way
-        mtime can. size and inode are free extra signal from the same
-        ``stat()`` call (no additional syscall) and catch same-second
-        same-mtime same-ctime edits and delete+recreate respectively.
+        a file's bytes and then restore its original mtime. ctime narrows
+        that hole on filesystems where it tracks inode metadata changes, but
+        it is not portable: current CPython documents ``st_ctime``/
+        ``st_ctime_ns`` as file *creation* time on Windows, so neither a
+        content write nor ``os.utime()`` advances it there, and timestamp
+        resolution is filesystem-dependent in general. size and inode are
+        free extra signal from the same ``stat()`` call (no additional
+        syscall) and catch same-second same-mtime same-ctime edits and
+        delete+recreate respectively, but a same-length in-place edit
+        defeats size too. Whenever this whole tuple compares unchanged,
+        ``_revalidate_plugin_entry`` confirms with ``_plugin_entry_digest``
+        before trusting it -- that confirmation, not this stat tuple, is
+        what makes the fast path safe to serve from cache.
 
         ``None`` (unknown plugin, unresolvable path, either file missing)
         always forces the caller back onto the full ``activate_target()`` path.
@@ -287,6 +317,38 @@ class EndpointRegistry:
                 target_stat.st_size,
                 target_stat.st_ino,
             ),
+        )
+
+    @classmethod
+    def _plugin_entry_digest(cls, plugin_name: str, target: str) -> _ContentDigest | None:
+        """``(manifest_digest, target_digest)`` -- a content hash of the same
+        two files ``_plugin_entry_stat`` stats, and the correctness
+        guarantee ``_revalidate_plugin_entry``'s fast path actually relies
+        on. Unlike any timestamp/size/inode signature, a hash of the file's
+        bytes always changes when the bytes do, on every platform and
+        filesystem -- there is no metadata field to spoof or leave static.
+        Only computed on the stat-stable path (see ``_plugin_entry_stat``):
+        plugin manifest and target files are small, so the extra read here
+        is cheap, and an entry whose stat signature already looks different
+        skips straight to ``activate_target()`` without paying for it.
+
+        ``None`` under the same conditions ``_plugin_entry_stat`` returns
+        ``None`` for (unknown plugin, unresolvable path, either file missing).
+        """
+        from lionagi.plugins import PluginRegistry
+
+        record = PluginRegistry.get(plugin_name)
+        if record is None:
+            return None
+        module_path = target.split(":", 1)[0]
+        try:
+            manifest_bytes = record.manifest_path.read_bytes()
+            target_bytes = (record.bundle_dir / module_path).read_bytes()
+        except OSError:
+            return None
+        return (
+            hashlib.blake2b(manifest_bytes).hexdigest(),
+            hashlib.blake2b(target_bytes).hexdigest(),
         )
 
     @classmethod

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -608,3 +608,46 @@ class TestMultiColonTargetBypass:
 
         fn = PluginRegistry.activate_target("p1", "tools/t.py:t")
         assert fn() == 7
+
+
+class TestSnapshotGenerationMonotonicity:
+    """``snapshot_generation()`` is a trust token: a consumer that already
+    fully revalidated a plugin entry treats an unchanged token as ``nothing
+    was reset since`` and skips the expensive full recheck. An ``id()``-based
+    token is unsound for this: ``id()`` is a memory address, reusable once
+    the prior snapshot list is garbage-collected, so a rebuilt snapshot can
+    land at the SAME address as an earlier one a caller cached -- making a
+    stale, no-longer-eligible entry look current. A monotonic counter that
+    only ever increases cannot repeat.
+    """
+
+    def test_generation_strictly_increases_across_many_resets(self, write_plugin):
+        _write_tool_plugin(write_plugin, "p1")
+        _trust_by_dir_name("p1")
+
+        seen: list[int] = []
+        for _ in range(40):
+            PluginRegistry.reset()
+            seen.append(PluginRegistry.snapshot_generation())
+
+        assert seen == sorted(seen), "generation must never decrease across resets"
+        assert len(set(seen)) == len(seen), (
+            "generation token repeated across resets -- a rebuilt snapshot "
+            "must never be able to masquerade as an earlier one"
+        )
+        assert all(b > a for a, b in zip(seen, seen[1:])), (
+            "generation must strictly increase on every rebuild, not merely stay non-decreasing"
+        )
+
+    def test_generation_is_stable_between_resets(self, write_plugin):
+        _write_tool_plugin(write_plugin, "p1")
+        _trust_by_dir_name("p1")
+        PluginRegistry.reset()
+
+        first = PluginRegistry.snapshot_generation()
+        # Repeat reads (and touching the cached snapshot via list_plugins())
+        # without an intervening reset() must not bump the token.
+        PluginRegistry.list_plugins()
+        second = PluginRegistry.snapshot_generation()
+
+        assert first == second

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -151,6 +151,82 @@ class TestPluginProviderHit:
         assert second.config.provider == "acme-llm"
 
 
+class TestPluginProviderRevalidationCaching:
+    """``_revalidate_plugin_entry`` must rescan (via
+    ``PluginRegistry.activate_target``) on a genuine miss -- first
+    resolution, or after the plugin's files changed -- but reuse that result
+    on repeat ``match_endpoint`` hits, not re-run the full plugin-directory
+    rescan + hash pass on every call for an endpoint that already activated
+    cleanly."""
+
+    def test_repeated_hits_do_not_rescan_after_first_revalidation(self, write_plugin, monkeypatch):
+        _write_provider_plugin(write_plugin, "wr", name="web-research", provider="acme-llm")
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == "PluginProviderEndpoint"
+        calls_after_first_resolution = call_count
+        assert calls_after_first_resolution > 0
+
+        for _ in range(5):
+            repeat = match_endpoint(provider="acme-llm", endpoint="chat")
+            assert type(repeat).__name__ == "PluginProviderEndpoint"
+
+        assert call_count == calls_after_first_resolution, (
+            "repeated match_endpoint() hits against an unchanged plugin "
+            "endpoint must reuse the cached revalidation, not re-trigger "
+            "PluginRegistry.activate_target's full rescan on every call"
+        )
+
+    def test_edited_target_after_a_cached_hit_forces_a_fresh_rescan(
+        self, write_plugin, monkeypatch
+    ):
+        """A cache hit must never outlive an actual on-disk change: editing the
+        declared target file after it was already cached as valid must still
+        trigger a fresh activate_target() call on the very next match()."""
+        bundle = _write_provider_plugin(
+            write_plugin, "wr", name="web-research", provider="acme-llm"
+        )
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == "PluginProviderEndpoint"
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_edit = call_count
+
+        (bundle / "providers" / "endpoint.py").write_text(
+            PROVIDER_MODULE.format(provider="acme-llm") + "\n# changed after activation\n"
+        )
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_edit
+        assert type(second).__name__ == "Endpoint"
+
+
 class TestPluginProviderMiss:
     def test_genuinely_unknown_provider_falls_back_identically(self, write_plugin):
         # An active plugin exists but declares an unrelated provider -- a miss

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -12,6 +12,7 @@ identical to today's behavior.
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -225,6 +226,58 @@ class TestPluginProviderRevalidationCaching:
 
         assert call_count > calls_before_edit
         assert type(second).__name__ == "Endpoint"
+
+    def test_target_edited_then_mtime_restored_forces_a_fresh_rescan(
+        self, write_plugin, monkeypatch
+    ):
+        """mtime alone cannot pin content: editing a target's bytes and then
+        restoring its ORIGINAL mtime (e.g. ``os.utime`` after a backup
+        restore, or a deliberate attempt to dodge an mtime-only staleness
+        check) must not let the fast path keep serving the entry cached as
+        valid before the edit. The very next match() must still revalidate
+        and observe the edit, exactly as the live-edit case above does."""
+        bundle = _write_provider_plugin(
+            write_plugin, "wr", name="web-research", provider="acme-llm"
+        )
+        target_path = bundle / "providers" / "endpoint.py"
+        original_stat = target_path.stat()
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == "PluginProviderEndpoint"
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_attack = call_count
+
+        target_path.write_text(
+            PROVIDER_MODULE.format(provider="acme-llm") + "\n# changed after activation\n"
+        )
+        os.utime(target_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        assert target_path.stat().st_mtime_ns == original_stat.st_mtime_ns, (
+            "test setup must actually restore the original mtime"
+        )
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_attack, (
+            "restoring a target file's mtime after editing its content must "
+            "still force a fresh activate_target() revalidation on the next "
+            "match() -- mtime alone is not a valid content-pinning signal"
+        )
+        assert type(second).__name__ == "Endpoint", (
+            "the stale, edited-but-mtime-restored plugin entry must not be served after the edit"
+        )
 
 
 class TestPluginProviderMiss:

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -13,7 +13,9 @@ identical to today's behavior.
 from __future__ import annotations
 
 import os
+import pathlib
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -277,6 +279,98 @@ class TestPluginProviderRevalidationCaching:
         )
         assert type(second).__name__ == "Endpoint", (
             "the stale, edited-but-mtime-restored plugin entry must not be served after the edit"
+        )
+
+    def test_equal_length_edit_with_static_ctime_still_forces_a_fresh_rescan(
+        self, write_plugin, monkeypatch
+    ):
+        """Neither mtime nor ctime alone is a portable content-pinning
+        signal. mtime can be restored with ``os.utime()``; ctime is not even
+        a metadata-change token everywhere -- current CPython documents
+        ``st_ctime``/``st_ctime_ns`` as file *creation* time on Windows, so a
+        content write or ``os.utime()`` never advances it there. An attacker
+        (or a naive backup/restore tool) that performs a same-length
+        in-place edit, restores the original mtime, and leaves ctime static
+        must still be detected: the fast path must fall back to a content
+        digest whenever its stat signature claims nothing changed, not trust
+        the stat tuple by itself. This reproduces the Windows/static-ctime
+        case on any host by freezing the ctime this test observes back to
+        its pre-edit value after performing the edit.
+        """
+        bundle = _write_provider_plugin(
+            write_plugin, "wr", name="web-research", provider="acme-llm"
+        )
+        target_path = bundle / "providers" / "endpoint.py"
+        original_stat = target_path.stat()
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == "PluginProviderEndpoint"
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_attack = call_count
+
+        original_bytes = target_path.read_bytes()
+        edited_bytes = original_bytes.replace(b"pass", b"PASS", 1)
+        assert edited_bytes != original_bytes
+        assert len(edited_bytes) == len(original_bytes), (
+            "test setup must keep the edit equal-length so size cannot betray it"
+        )
+        target_path.write_bytes(edited_bytes)
+        os.utime(target_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        edited_stat = target_path.stat()
+        assert edited_stat.st_size == original_stat.st_size, (
+            "test setup must actually preserve the original size"
+        )
+        assert edited_stat.st_mtime_ns == original_stat.st_mtime_ns, (
+            "test setup must actually restore the original mtime"
+        )
+        assert edited_stat.st_ino == original_stat.st_ino, (
+            "test setup must actually preserve the original inode"
+        )
+
+        # Freeze what this file reports for st_ctime_ns back to its pre-edit
+        # value from here on, so this test reproduces the Windows/
+        # static-ctime case regardless of what the host filesystem actually
+        # does to ctime for an in-place write + os.utime().
+        real_stat = pathlib.Path.stat
+        frozen_ctime_ns = original_stat.st_ctime_ns
+
+        def frozen_ctime_stat(self, *args, **kwargs):
+            result = real_stat(self, *args, **kwargs)
+            if self == target_path:
+                return SimpleNamespace(
+                    st_mtime_ns=result.st_mtime_ns,
+                    st_ctime_ns=frozen_ctime_ns,
+                    st_size=result.st_size,
+                    st_ino=result.st_ino,
+                )
+            return result
+
+        monkeypatch.setattr(pathlib.Path, "stat", frozen_ctime_stat)
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_attack, (
+            "a same-length in-place edit whose mtime is restored and whose "
+            "ctime never advances (the Windows case) must still force a "
+            "fresh activate_target() revalidation on the next match() -- "
+            "the fast path must confirm with a content digest whenever "
+            "its stat signature alone claims nothing changed"
+        )
+        assert type(second).__name__ == "Endpoint", (
+            "the stale, edited-but-signature-preserved plugin entry must not be served after the edit"
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #2151. `EndpointRegistry._match_registered()` called `_revalidate_plugin_entry()` — which triggers a full O(N-installed-plugins) filesystem rescan+rehash via `PluginRegistry.activate_target()` — on **every** `match()` for a plugin-provided endpoint, including plain in-memory hits, not just the miss/fallback path. Every `iModel` construction paid a filesystem pass proportional to the number of installed plugins.

## Fix

Cheap "still valid" fast path that preserves the live-edit-caught-on-next-call correctness guarantee:

- `PluginRegistry.snapshot_generation()` — `id()`-based token that only changes when the cached plugin scan is rebuilt (after `reset()`).
- Per-entry cache on `_RegistryEntry` (`_validated_generation`, `_validated_stat`) storing the generation + `(manifest_mtime_ns, target_mtime_ns)` from the last clean `activate_target()`.
- `_revalidate_plugin_entry()` now calls the expensive `activate_target()` only when the generation changed or either file's mtime moved (2 `stat()` syscalls, no manifest parse/hash); otherwise reuses the prior result.

## Tests

`TestPluginProviderRevalidationCaching`:
- `test_repeated_hits_do_not_rescan_after_first_revalidation` — 5 repeat `match_endpoint()` calls trigger zero additional `activate_target` invocations (fails against pre-fix: call count kept growing).
- `test_edited_target_after_a_cached_hit_forces_a_fresh_rescan` — a file edit after caching still forces a fresh call + correct fallback.

`tests/service/connections/test_plugin_provider_consumer.py` + `tests/plugins/test_registry.py`: 50 passed.
