### PR TITLE
fix(providers): apply codex effort clamp when model kwarg omitted

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -219,13 +219,22 @@ class CodexCodeRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _clamp_effort(cls, values):
-        """Clamp max/ultra down to the target model's supported ceiling (model-dependent: the gpt-5.6 family accepts max, sol/terra also ultra; earlier models top out at xhigh)."""
+        """Clamp max/ultra down to the target model's supported ceiling (model-dependent: the gpt-5.6 family accepts max, sol/terra also ultra; earlier models top out at xhigh).
+
+        `values` is the raw constructor input — a caller who omits `model=`
+        (relying on the field default) leaves the key absent here, since
+        Pydantic v2 applies field defaults after `mode="before"` validators
+        run. Falling back to the field's own default keeps the clamp
+        consistent between an omitted `model` and that same default passed
+        explicitly.
+        """
         from lionagi.service.providers import _clamp_codex_effort
 
+        model = values.get("model", cls.model_fields["model"].default)
         for key in ("reasoning_effort", "plan_mode_reasoning_effort"):
             effort = values.get(key)
             if isinstance(effort, str):
-                values[key] = _clamp_codex_effort(effort, values.get("model"))
+                values[key] = _clamp_codex_effort(effort, model)
         return values
 
     # ── images & config (special-cased) ───────────────────────────

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -50,7 +50,14 @@ def normalize_effort(effort: str | None) -> str | None:
 _CODEX_ULTRA_MODELS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra"})
 _CODEX_MAX_ONLY_MODELS = frozenset({"gpt-5.6-luna"})
 _CODEX_XHIGH_CEILING_MODELS = frozenset(
-    {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "codex-auto-review"}
+    {
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "codex-auto-review",
+    }
 )
 
 

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -341,6 +341,8 @@ def test_build_imodel_from_spec_mixed_case_xhigh_clamps_claude_to_high(monkeypat
         ("gpt-5.4", "ultra", "xhigh"),
         ("gpt-5.4-mini", "max", "xhigh"),
         ("gpt-5.4-mini", "ultra", "xhigh"),
+        ("gpt-5.3-codex", "max", "xhigh"),
+        ("gpt-5.3-codex", "ultra", "xhigh"),
         ("gpt-5.3-codex-spark", "max", "xhigh"),
         ("gpt-5.3-codex-spark", "ultra", "xhigh"),
         ("codex-auto-review", "max", "xhigh"),
@@ -355,6 +357,25 @@ def test_clamp_codex_effort_is_model_aware(model, effort, expected):
     from lionagi.service.providers import _clamp_codex_effort
 
     assert _clamp_codex_effort(effort, model) == expected
+
+
+def test_codex_code_request_clamps_effort_when_model_kwarg_omitted():
+    """CodexCodeRequest(reasoning_effort="max") with no explicit model= kwarg
+    must clamp against the field's own default model, matching the result of
+    passing that same default explicitly. Pydantic v2 `mode="before"`
+    validators only see keys the caller actually supplied — omitting `model`
+    must not silently skip the clamp for the request that will actually be
+    sent against the default model."""
+    from lionagi.providers.openai.codex import CodexCodeRequest
+
+    omitted = CodexCodeRequest(prompt="hello", reasoning_effort="max")
+    explicit_default = CodexCodeRequest(
+        prompt="hello", reasoning_effort="max", model="gpt-5.3-codex"
+    )
+
+    assert omitted.model == "gpt-5.3-codex"
+    assert omitted.reasoning_effort == explicit_default.reasoning_effort
+    assert omitted.reasoning_effort == "xhigh"
 
 
 def test_build_imodel_from_spec_codex_sol_keeps_max(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #2087. `CodexCodeRequest._clamp_effort` is a Pydantic v2 `mode="before"` validator that read `values.get("model")` directly. In Pydantic v2, `mode="before"` validators only see keys the caller actually supplied — field defaults are applied *after* the validator runs. So `CodexCodeRequest(prompt=..., reasoning_effort="max")` (omitting `model=`) saw `model=None` inside the validator and skipped the model-aware effort clamp, even though `model` defaults to `"gpt-5.3-codex"`.

While verifying the reproduction, a second latent defect surfaced: `"gpt-5.3-codex"` (the bare default model, distinct from its listed sibling `"gpt-5.3-codex-spark"`) was itself missing from `_CODEX_XHIGH_CEILING_MODELS`, so even an explicit `model="gpt-5.3-codex"` produced unclamped `"max"`. This contradicts the documented design intent that every earlier model tops out at xhigh.

## Fix

- `_clamp_effort` now defaults `model` to `cls.model_fields["model"].default` when the kwarg is omitted.
- Add `"gpt-5.3-codex"` to `_CODEX_XHIGH_CEILING_MODELS`.

## Tests

- `test_codex_code_request_clamps_effort_when_model_kwarg_omitted` — fails pre-fix (`'max' == 'xhigh'`), passes after.
- Extended `test_clamp_codex_effort_is_model_aware` parametrize table with `("gpt-5.3-codex", "max"/"ultra", "xhigh")`.
- 273 passed (2 pre-existing ollama-optional-dep failures unrelated).
