### PR TITLE
fix(studio): distinguish boundary-split UTF-8 from binary in get_run_file

### DIFF
--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -769,6 +769,34 @@ def _open_regular_file_no_follow(root: Path, resolved: Path) -> int:
         raise
 
 
+def _decode_capped_utf8(raw_slice: bytes) -> str | None:
+    """Decode a byte-capped file read, tolerating only a multibyte UTF-8
+    sequence that was split by the cap boundary itself.
+
+    Returns the decoded text, or ``None`` if the slice is not valid UTF-8
+    even once any boundary-truncated trailing sequence is set aside — i.e.
+    the content is genuinely non-text/binary and should still 415,
+    regardless of whether it happens to exceed the read cap.
+    """
+    try:
+        return raw_slice.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # Only tolerate an incomplete multibyte sequence cut off exactly at
+        # the end of the slice (the cap boundary). Any other decode failure
+        # -- an invalid start/continuation byte anywhere else in the slice --
+        # means the content itself is not valid UTF-8.
+        if exc.reason != "unexpected end of data" or exc.end != len(raw_slice):
+            return None
+        try:
+            raw_slice[: exc.start].decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        # Everything before the cut-off tail is confirmed valid UTF-8, so the
+        # only thing being masked here is the boundary-truncated trailing
+        # character itself -- safe to render it as a replacement character.
+        return raw_slice.decode("utf-8", errors="replace")
+
+
 async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
     """Read-only content fetch for a file inside a run's artifact root;
     always re-validates against the live artifact root rather than trusting the caller."""
@@ -814,8 +842,11 @@ async def get_run_file(run_id: str, path: str) -> dict[str, Any]:
     truncated = len(raw) > _MAX_FILE_READ_BYTES
     if truncated:
         # A split multibyte UTF-8 sequence at the cap boundary must read as
-        # truncation, not a binary file — only the untruncated branch gets a 415.
-        content = raw[:_MAX_FILE_READ_BYTES].decode("utf-8", errors="replace")
+        # truncation, not a binary file -- but a genuinely non-text file that
+        # happens to exceed the cap must still 415, the same as a small one.
+        content = _decode_capped_utf8(raw[:_MAX_FILE_READ_BYTES])
+        if content is None:
+            raise HTTPException(status_code=415, detail="File is not text/UTF-8") from None
     else:
         try:
             content = raw.decode("utf-8")

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -201,6 +201,29 @@ async def test_untruncated_binary_file_still_returns_415(patched_runs_svc, tmp_p
     assert exc_info.value.status_code == 415
 
 
+async def test_truncated_binary_file_over_cap_still_returns_415(
+    patched_runs_svc, tmp_path, monkeypatch
+):
+    """A genuinely non-text file that exceeds the read cap must still 415 --
+    the boundary-truncation leniency is only for otherwise-valid UTF-8 whose
+    trailing multibyte character was split by the cap, not a blanket pass
+    for any file that happens to be larger than the cap."""
+    svc, db_path = patched_runs_svc
+    monkeypatch.setattr(svc, "_MAX_FILE_READ_BYTES", 10)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    target = artifact_root / "blob.bin"
+    # Invalid UTF-8 start bytes scattered through a slice well over the cap --
+    # nothing here is a boundary-split multibyte character, it is simply not
+    # text.
+    target.write_bytes(b"\xff\xfe\x00\x01binary-blob-that-is-not-utf8-text")
+    await seed_session(db_path, session_id="run-14", artifacts_path=str(artifact_root))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_run_file("run-14", str(target))
+    assert exc_info.value.status_code == 415
+
+
 # ---------------------------------------------------------------------------
 # Bounded read: the cap must be enforced by the read itself, not by slicing
 # an already-materialized full read (Path.read_bytes() then [:cap] would
@@ -469,6 +492,22 @@ def test_route_non_utf8_returns_415(tmp_path, monkeypatch):
     _run_async(_seed(db_path, session_id="route-7", artifacts_path=str(artifact_root)))
 
     resp = client.get("/api/runs/route-7/file", params={"path": str(binary)})
+    assert resp.status_code == 415
+
+
+def test_route_binary_file_over_cap_returns_415(tmp_path, monkeypatch):
+    import lionagi.studio.services.runs as runs_svc
+
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    monkeypatch.setattr(runs_svc, "_MAX_FILE_READ_BYTES", 16)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    binary = artifact_root / "big.bin"
+    binary.write_bytes(b"\xff\xfe\x00\x01" + b"binary-blob-well-over-the-cap" * 4)
+    _run_async(_seed(db_path, session_id="route-10", artifacts_path=str(artifact_root)))
+
+    resp = client.get("/api/runs/route-10/file", params={"path": str(binary)})
     assert resp.status_code == 415
 
 


### PR DESCRIPTION
## Summary

Fixes #2062 and #2064 (coupled — same function, opposite failure modes). The prior fix for #2062 correctly handled a large valid-UTF-8 file whose trailing multibyte character is split by the `_MAX_FILE_READ_BYTES` cap, but it applied `decode("utf-8", errors="replace")` to **any** oversized file — so a genuinely binary artifact over the 2MB cap silently decoded to U+FFFD garbage and returned 200, dropping the 415 safety net (#2064).

## Fix

New `_decode_capped_utf8` attempts a strict decode first, and falls back to lenient replace-decode **only** when the `UnicodeDecodeError` is specifically an incomplete multibyte sequence cut off at the exact end of the capped slice (`reason == "unexpected end of data"` and `end == len(slice)`) **and** the preceding bytes decode cleanly on their own — confirming the file really is valid UTF-8 with only the boundary character to mask. Any other decode failure returns `None`, and the route still raises 415 regardless of file size.

## Tests

- `test_truncated_binary_file_over_cap_still_returns_415` (service) + `test_route_binary_file_over_cap_returns_415` (route) — both fail pre-fix (`DID NOT RAISE` / `200 != 415`), pass after.
- Pre-existing `test_multibyte_char_split_at_cap_is_truncation_not_415` still passes (boundary-split contract preserved).
- `tests/apps_studio_server/`: 994/994 passed.
