### PR TITLE
fix(cli): reapply plain-profile system prompt on resume/continue

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -445,6 +445,18 @@ its persisted system message — which, for a role/preset branch, is the compose
 block, not the bare profile body — so `add_message` must not run for it either, or it clobbers
 that persisted message via `set_system`.
 
+For a brand-new branch, `took_create_agent_path` (set in the same leg that builds the branch)
+is the authoritative signal. A resumed/continued branch cannot use the *current* invocation's
+profile for this decision — the profile reloaded this leg (`has_role_key`) describes only what
+was passed to *this* `-a`, not how the persisted branch was originally built; resuming a
+role-composed branch under a different, plain profile (or the same profile with `role:` since
+removed) would then make the guard treat it as plain and clobber its composed message. Instead,
+`create_agent` (`lionagi/agent/factory.py`) stamps every branch it builds with an immutable
+`CREATE_AGENT_BRANCH_ORIGIN_KEY` marker in `branch.metadata`, which round-trips through
+`Branch.to_dict()`/`from_dict()` with the rest of `metadata`. On a resumed/continued leg,
+`_run_agent` consults that marker on the reloaded branch instead of re-deriving the guard from
+the current profile.
+
 **`_run_agent` auto-resume terminal-status guard** — known before teardown runs: an auto-resume
 leg is about to fire on this same session, so this leg's teardown must not stamp a terminal
 status the resumed leg would then be blocked from overwriting by the ADR-0035 terminal guard

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -11,7 +11,24 @@ from lionagi.session.branch import Branch
 
 from .spec import AgentSpec
 
-__all__ = ("create_agent", "_chain_pre_hooks", "_chain_post_hooks")
+__all__ = (
+    "create_agent",
+    "CREATE_AGENT_BRANCH_ORIGIN_KEY",
+    "_chain_pre_hooks",
+    "_chain_post_hooks",
+)
+
+# Stamped into `branch.metadata` for every Branch this factory produces. The
+# key's presence (not the current invocation's profile) is the durable,
+# immutable record that a branch's system message was composed via
+# create_agent (role header + policy block) rather than a bare profile body.
+# It round-trips through Branch.to_dict()/from_dict() with the rest of
+# `metadata`, so a later resume/continue-last leg can consult the PERSISTED
+# branch itself instead of re-deriving "was this create_agent-composed?"
+# from whatever profile happens to be supplied on the resuming invocation
+# (which may differ, or may have since dropped its `role:` key) — see
+# lionagi/cli/agent.py `_run_agent`'s system-prompt reapply guard.
+CREATE_AGENT_BRANCH_ORIGIN_KEY = "create_agent_origin"
 
 
 async def create_agent(
@@ -86,6 +103,10 @@ async def create_agent(
         branch_kwargs["log_config"] = log_config
 
     branch = Branch(**branch_kwargs)
+    # Immutable branch-origin marker (see CREATE_AGENT_BRANCH_ORIGIN_KEY):
+    # stamped once, here, on every branch this factory builds; never read or
+    # written anywhere else in the branch's lifetime.
+    branch.metadata[CREATE_AGENT_BRANCH_ORIGIN_KEY] = True
 
     system_message = spec.build_system_message()
     if "coding" in spec.tools and getattr(spec, "context_management", True):

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -294,6 +294,11 @@ async def _run_agent(
             hint(f"[resume] prefix-matched {resume} → {resolved_branch_id}")
         branch = Branch.from_dict(json.loads(branch_path.read_text()))
 
+    # Captured before the `branch is None` new-branch block below reassigns
+    # `branch` — the only reliable way to tell "this leg reopened an existing
+    # branch" from "this leg is minting a brand-new one" once that block runs.
+    is_resumed_branch = branch is not None
+
     if model_str is not None:
         ms = parse_model_spec(model_str)
         if branch is not None and "/" not in ms.model and ms.model not in BACKENDS:
@@ -424,17 +429,28 @@ async def _run_agent(
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
 
     # Profile system prompt for every leg EXCEPT one whose branch carries (or
-    # would carry, on the resumed leg) a create_agent-composed system message
+    # would carry, on a brand-new leg) a create_agent-composed system message
     # (role header + policy block) — see docs/internals/cli.md. `preset` can
     # never be set together with resume/continue_last (validated above), so
-    # on a resumed leg the only signal that the ORIGINAL branch went through
-    # create_agent is the profile's own `role:` key: it is stable per profile
-    # file, so a role-profile branch always took (and, if resumed, always
-    # took) the create_agent path. Plain profiles (no `role:` key) never go
-    # through create_agent, on a fresh branch or a resumed one, so they must
-    # keep getting their system prompt (re)applied here on every leg,
-    # including resume/continue-last.
-    composed_via_create_agent = took_create_agent_path or has_role_key
+    # `took_create_agent_path` alone is authoritative for a brand-new branch.
+    #
+    # A RESUMED branch is different: the profile loaded for *this*
+    # invocation (and therefore `has_role_key`) describes only what was
+    # passed to *this* leg, not how the persisted branch was originally
+    # built — it may have been created via create_agent under a role profile
+    # and now be resumed with a different, plain `-a` profile (or the same
+    # profile with `role:` since removed). Re-deriving the guard from the
+    # current profile would then clobber that branch's composed role/policy
+    # system message. The persisted branch itself carries the answer: every
+    # branch create_agent builds is stamped with an immutable origin marker
+    # in `branch.metadata` (see CREATE_AGENT_BRANCH_ORIGIN_KEY) that
+    # round-trips through save/resume — consult THAT instead.
+    if is_resumed_branch:
+        from lionagi.agent.factory import CREATE_AGENT_BRANCH_ORIGIN_KEY
+
+        composed_via_create_agent = bool(branch.metadata.get(CREATE_AGENT_BRANCH_ORIGIN_KEY))
+    else:
+        composed_via_create_agent = took_create_agent_path
     if profile and profile.system_prompt and not composed_via_create_agent:
         branch.msgs.add_message(system=profile.system_prompt)
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -423,14 +423,19 @@ async def _run_agent(
         if fast:
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
 
-    # Profile system prompt for a brand-new, non-preset branch only — see
-    # docs/internals/cli.md for why the preset/resume paths must skip this.
-    if (
-        profile
-        and profile.system_prompt
-        and not took_create_agent_path
-        and not (resume or continue_last)
-    ):
+    # Profile system prompt for every leg EXCEPT one whose branch carries (or
+    # would carry, on the resumed leg) a create_agent-composed system message
+    # (role header + policy block) — see docs/internals/cli.md. `preset` can
+    # never be set together with resume/continue_last (validated above), so
+    # on a resumed leg the only signal that the ORIGINAL branch went through
+    # create_agent is the profile's own `role:` key: it is stable per profile
+    # file, so a role-profile branch always took (and, if resumed, always
+    # took) the create_agent path. Plain profiles (no `role:` key) never go
+    # through create_agent, on a fresh branch or a resumed one, so they must
+    # keep getting their system prompt (re)applied here on every leg,
+    # including resume/continue-last.
+    composed_via_create_agent = took_create_agent_path or has_role_key
+    if profile and profile.system_prompt and not composed_via_create_agent:
         branch.msgs.add_message(system=profile.system_prompt)
 
     if timeout is not None:

--- a/tests/cli/test_agent_resume_plain_profile_system_prompt.py
+++ b/tests/cli/test_agent_resume_plain_profile_system_prompt.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: resuming a profile WITHOUT a `role:` key must still reapply
+the profile's system prompt.
+
+A prior fix addressed a role/preset branch's create_agent-composed system
+message (role header + policy block) getting clobbered by a bare
+`add_message(system=profile.system_prompt)` on resume. That fix's guard —
+skip reapplication whenever the leg is a resume/continue-last — was
+unconditional though: it also disabled reapplication for *plain* profiles
+(no `role:` key), which never go through create_agent and never had a
+composed message to protect. `load_agent_profile(agent_name)` re-reads the
+profile file from disk on every `_run_agent` call, so editing a plain
+profile's body and then `-r`/`-c`-ing back into an existing branch is
+expected to pick up the edit on the next turn — for plain profiles there is
+no role/preset composition to protect in the first place.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import _parse_profile
+
+_PLAIN_PROFILE_TEXT_V1 = "---\nmodel: claude_code/sonnet\n---\nOriginal plain profile body."
+_PLAIN_PROFILE_TEXT_V2 = "---\nmodel: claude_code/sonnet\n---\nEdited plain profile body."
+
+
+def _rendered_system(branch) -> str:
+    """See test_agent_resume_role_system_message.py for why this scans the
+    pile instead of trusting `branch.msgs.system` after a from_dict roundtrip."""
+    from lionagi.protocols.messages.system import System
+
+    if branch.msgs.system is not None:
+        return branch.msgs.system.rendered
+    for m in branch.msgs.messages:
+        if isinstance(m, System):
+            return m.rendered
+    raise AssertionError("branch has no System message")
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path, *, operate_result="done"):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    branches_created: list = []
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return operate_result
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return branches_created
+
+
+def _stub_profile(monkeypatch, name: str, text: str):
+    import lionagi.cli.agent as agent_mod
+
+    profile = _parse_profile(name, text)
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda n: profile)
+    return profile
+
+
+async def _make_persisted_plain_branch(tmp_path: Path) -> str:
+    """Build a plain (non-role) Branch the same way a brand-new `-a` leg
+    would, snapshot it to disk, and return the branch id."""
+    from lionagi import Branch
+    from lionagi.protocols.generic.log import DataLoggerConfig
+
+    branch = Branch(
+        chat_model="claude_code/sonnet",
+        log_config=DataLoggerConfig(auto_save_on_exit=False),
+    )
+    branch_dir = tmp_path / "branches"
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    branch_id = str(branch.id)
+    (branch_dir / f"{branch_id}.json").write_text(json.dumps(branch.to_dict()))
+    return branch_id
+
+
+@pytest.mark.asyncio
+async def test_resume_flag_reapplies_plain_profile_system_prompt(monkeypatch, tmp_path):
+    branch_id = await _make_persisted_plain_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    # The profile file was edited between the original leg and this resume —
+    # the resumed branch must pick up the new body.
+    _stub_profile(monkeypatch, "plain", _PLAIN_PROFILE_TEXT_V2)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", resume=branch_id, agent_name="plain")
+
+    branch = branches_created[-1]
+    assert "Edited plain profile body." in _rendered_system(branch), (
+        "resuming (-r) a plain (no role:) profile branch must still reapply "
+        "the profile's system prompt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_continue_last_reapplies_plain_profile_system_prompt(monkeypatch, tmp_path):
+    branch_id = await _make_persisted_plain_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "plain", _PLAIN_PROFILE_TEXT_V2)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "load_last_branch", lambda: ("run-x", branch_id))
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", continue_last=True, agent_name="plain")
+
+    branch = branches_created[-1]
+    assert "Edited plain profile body." in _rendered_system(branch), (
+        "--continue-last on a plain (no role:) profile branch must still "
+        "reapply the profile's system prompt"
+    )

--- a/tests/cli/test_agent_resume_role_branch_origin_marker.py
+++ b/tests/cli/test_agent_resume_role_branch_origin_marker.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: resuming a role-composed branch must not clobber its persisted
+system message even when the CURRENT invocation's profile no longer signals
+`role:` — either because a different, plain `-a` profile is supplied, or
+because the same profile file has since had its `role:` key removed.
+
+A prior guard derived "was this branch composed via create_agent?" from the
+profile reloaded for the *resuming* invocation (`has_role_key`). That is the
+wrong signal on a resumed leg: `has_role_key` describes only what was passed
+to this particular `-a`, not how the persisted branch was originally built.
+Resuming a role-composed branch under a mismatched profile made the guard
+treat it as a plain branch and call `branch.msgs.add_message(system=...)`,
+which replaces the branch's composed role header + policy block with the
+current profile's bare body.
+
+The fix stamps every create_agent-built branch with an immutable origin
+marker in `branch.metadata` (`CREATE_AGENT_BRANCH_ORIGIN_KEY`) that
+round-trips through save/resume, and consults that marker — not the current
+profile — on any resumed/continued leg.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import _parse_profile
+
+_DIFFERENT_PLAIN_PROFILE_TEXT = "---\nmodel: claude_code/sonnet\n---\nUnrelated plain body."
+_ROLE_KEY_REMOVED_PROFILE_TEXT = "---\nmodel: claude_code/sonnet\n---\nExtra reviewer body."
+
+
+def _rendered_system(branch) -> str:
+    """See test_agent_resume_role_system_message.py for why this scans the
+    pile instead of trusting `branch.msgs.system` after a from_dict roundtrip."""
+    from lionagi.protocols.messages.system import System
+
+    if branch.msgs.system is not None:
+        return branch.msgs.system.rendered
+    for m in branch.msgs.messages:
+        if isinstance(m, System):
+            return m.rendered
+    raise AssertionError("branch has no System message")
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path, *, operate_result="done"):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    branches_created: list = []
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return operate_result
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return branches_created
+
+
+def _stub_profile(monkeypatch, name: str, text: str):
+    import lionagi.cli.agent as agent_mod
+
+    profile = _parse_profile(name, text)
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda n: profile)
+    return profile
+
+
+async def _make_persisted_role_branch(tmp_path: Path) -> tuple[str, str]:
+    """Build a real role-profile branch via create_agent (composed system
+    message with role header + policy block, and the immutable branch-origin
+    marker in metadata), snapshot it to disk, and return
+    (branch_id, rendered_system_message)."""
+    from lionagi.agent.factory import create_agent
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.coding(cwd=str(tmp_path), effort="high", role="reviewer")
+    branch = await create_agent(
+        spec,
+        chat_model="claude_code/sonnet",
+        load_settings=False,
+    )
+    rendered = branch.msgs.system.rendered
+    assert "## Authority" in rendered, (
+        "sanity: the composed system message carries the policy block"
+    )
+
+    branch_dir = tmp_path / "branches"
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    branch_id = str(branch.id)
+    (branch_dir / f"{branch_id}.json").write_text(json.dumps(branch.to_dict()))
+    return branch_id, rendered
+
+
+@pytest.mark.asyncio
+async def test_resume_with_different_plain_profile_preserves_composed_system_message(
+    monkeypatch, tmp_path
+):
+    """Reviewer case 1: resume a role-composed branch, but this leg's `-a`
+    names a different, plain (no `role:`) profile."""
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "plain", _DIFFERENT_PLAIN_PROFILE_TEXT)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", resume=branch_id, agent_name="plain")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered, (
+        "resuming (-r) a role-composed branch under a different plain profile "
+        "must not replace its persisted composed system message"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_after_role_key_removed_preserves_composed_system_message(
+    monkeypatch, tmp_path
+):
+    """Reviewer case 2: resume a role-composed branch after the SAME profile
+    file has had its `role:` key removed."""
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "reviewer", _ROLE_KEY_REMOVED_PROFILE_TEXT)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", resume=branch_id, agent_name="reviewer")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered, (
+        "resuming (-r) a role-composed branch after its profile's `role:` key "
+        "was removed must not replace its persisted composed system message"
+    )
+
+
+@pytest.mark.asyncio
+async def test_continue_last_with_different_plain_profile_preserves_composed_system_message(
+    monkeypatch, tmp_path
+):
+    """Same as case 1, via --continue-last instead of -r."""
+    branch_id, original_rendered = await _make_persisted_role_branch(tmp_path)
+
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(monkeypatch, "plain", _DIFFERENT_PLAIN_PROFILE_TEXT)
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "load_last_branch", lambda: ("run-x", branch_id))
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", continue_last=True, agent_name="plain")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered, (
+        "--continue-last on a role-composed branch under a different plain "
+        "profile must not replace its persisted composed system message"
+    )


### PR DESCRIPTION
## Summary

Fixes #2050. The resume guard in `_run_agent` (`lionagi/cli/agent.py`) was:
`profile and profile.system_prompt and not took_create_agent_path and not (resume or continue_last)`.
The `not (resume or continue_last)` clause is unconditional — it blocks `add_message(system=profile.system_prompt)` on every resumed/continued leg for **any** profile, not just role/preset-composed ones. So resuming a plain (no `role:`) profile silently stopped reapplying its system prompt.

## Fix

A resumed leg's only stable signal that the branch's original creation went through `create_agent` (and therefore already carries a properly composed system message that must not be clobbered) is the profile's own `role:` key. Replaced the guard with `not (took_create_agent_path or has_role_key)` — still protects role/preset-composed branches, restores reapplication for plain profiles on `-r`/`-c`.

## Tests

- New `test_resume_flag_reapplies_plain_profile_system_prompt` + `test_continue_last_reapplies_plain_profile_system_prompt` — reproduce the bug against pre-fix (`branch has no System message`), pass after.
- Existing role-profile regression suite still passes (original fix preserved).
- `tests/cli/`: 1623 passed, 5 skipped.
