### PR TITLE
fix(scheduler): backfill dispatched_at for pre-migration running rows

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -657,6 +657,43 @@ class StateDB:
                 if name not in existing:
                     async with self._engine.begin() as conn:
                         await conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {name} {defn}"))
+                        if table == "schedule_runs" and name == "dispatched_at":
+                            await self._backfill_dispatched_at(conn)
+
+    async def _backfill_dispatched_at(self, conn) -> None:
+        """One-time migration backfill for the ``dispatched_at`` column just
+        added to ``schedule_runs``.
+
+        ``dispatched_at`` is only stamped going forward, by
+        ``SchedulerEngine._mark_dispatched()``. Without a backfill, every row
+        left at ``status = 'running'`` from before this column existed would
+        have ``dispatched_at IS NULL`` -- indistinguishable from a row whose
+        launch genuinely never got confirmed. ``list_undispatched_schedule_
+        runs()`` (consumed by ``SchedulerEngine._recover_undispatched_
+        fires()`` on the next daemon startup) would then treat every such row
+        as crashed-before-dispatch and re-fire it, even one that is still
+        genuinely executing across the upgrade restart.
+
+        Stamping ``dispatched_at`` to the row's own ``fired_at`` (NOT NULL by
+        schema) excludes these pre-existing rows from that scan -- the same
+        "no signal to distinguish, so don't auto-retry" resolution
+        ``_backfill_action_cwd()`` applies to ``action_cwd``. A still-running
+        row is left alone (nothing re-fires it); a row that actually crashed
+        pre-migration falls through to ``reap_stale_schedule_runs()``'s
+        wall-clock deadline instead of being auto-retried on ambiguous
+        evidence. Scoped to ``schedule_id IS NOT NULL`` to match
+        ``list_undispatched_schedule_runs()`` and leave the leased ad-hoc
+        task queue (its own dispatch/lease model) untouched. Runs inside the
+        same transaction as the ``ALTER TABLE`` that adds the column, so it
+        only ever executes once, the moment the column is created.
+        """
+        await conn.execute(
+            text(
+                "UPDATE schedule_runs SET dispatched_at = fired_at "
+                "WHERE status = 'running' AND dispatched_at IS NULL "
+                "AND schedule_id IS NOT NULL"
+            )
+        )
 
     _LEGACY_SESSION_STATUS_CHECK_MARKER = "'running', 'completed', 'failed', 'aborted'"
 

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -653,3 +653,133 @@ async def test_update_schedule_run_rejects_unknown_field():
         await state.update_schedule_run("run-resume-3", not_a_real_field="x")
 
     await state.close()
+
+
+async def test_dispatched_at_migration_backfills_preexisting_running_rows(tmp_path):
+    """A ``schedule_runs`` row already at ``status='running'`` when the
+    ``dispatched_at`` column is first added must have it backfilled to its
+    ``fired_at`` — not left ``NULL``.
+
+    Without the backfill, ``dispatched_at IS NULL`` is indistinguishable
+    between "genuinely never dispatched" and "predates the column
+    entirely", so ``list_undispatched_schedule_runs()`` (consumed by
+    ``SchedulerEngine._recover_undispatched_fires()`` on the next daemon
+    startup) would treat every pre-existing running row as crashed and
+    duplicate-fire a replacement for it — including one that is still
+    genuinely executing across the upgrade restart.
+    """
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "legacy_no_dispatched_at.db"
+
+    async with aiosqlite.connect(str(db_path)) as raw:
+        await raw.execute(
+            """
+            CREATE TABLE schedules (
+              id           TEXT    PRIMARY KEY,
+              name         TEXT    NOT NULL UNIQUE,
+              enabled      INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+              trigger_type TEXT    NOT NULL CHECK(trigger_type IN ('cron', 'interval', 'github_poll')),
+              action_kind  TEXT    NOT NULL CHECK(action_kind IN ('agent', 'flow', 'fanout', 'play', 'flow_yaml')),
+              created_at   REAL    NOT NULL,
+              updated_at   REAL    NOT NULL
+            )
+            """
+        )
+        # schedule_runs at ADR-0071 D4 shape (lease_attempts present) but
+        # pre-dating the dispatched_at / resume_packet columns entirely.
+        await raw.execute(
+            """
+            CREATE TABLE schedule_runs (
+              id                  TEXT    PRIMARY KEY,
+              schedule_id         TEXT    REFERENCES schedules(id) ON DELETE CASCADE,
+              invocation_id       TEXT,
+              trigger_context     JSON    NOT NULL,
+              action_kind         TEXT    NOT NULL,
+              action_args         JSON    NOT NULL,
+              status              TEXT    NOT NULL DEFAULT 'running'
+                                  CHECK(status IN ('queued', 'waiting_dependency', 'running',
+                                                   'retry_wait', 'completed', 'failed',
+                                                   'timed_out', 'skipped', 'cancelled')),
+              exit_code           INTEGER,
+              chain_parent_id     TEXT    REFERENCES schedule_runs(id),
+              chain_depth         INTEGER NOT NULL DEFAULT 0,
+              fired_at            REAL    NOT NULL,
+              ended_at            REAL,
+              error_detail        TEXT,
+              created_at          REAL    NOT NULL,
+              updated_at          REAL,
+              status_reason_code     TEXT,
+              status_reason_summary  TEXT,
+              status_evidence_refs   JSON,
+              queued_at           REAL,
+              leased_by           TEXT,
+              lease_expires_at    REAL,
+              concurrency_key     TEXT,
+              lease_attempts      INTEGER NOT NULL DEFAULT 0,
+              required_capabilities  JSON,
+              execution_target       TEXT,
+              library_ref             TEXT,
+              library_content_hash    TEXT
+            )
+            """
+        )
+        await raw.execute(
+            "INSERT INTO schedules (id, name, trigger_type, action_kind, created_at, updated_at) "
+            "VALUES ('sched-da', 'sched-da', 'interval', 'agent', 1.0, 1.0)"
+        )
+        # A row still genuinely running (or orphaned by an unrelated earlier
+        # crash) at the moment of the upgrade -- fired_at is deliberately
+        # far in the past so a naive "treat as undispatched" scan would be
+        # the only thing standing between it and a duplicate re-fire.
+        await raw.execute(
+            "INSERT INTO schedule_runs "
+            "(id, schedule_id, trigger_context, action_kind, action_args, status, "
+            " chain_depth, fired_at, created_at) "
+            "VALUES ('run-da-running', 'sched-da', '{}', 'agent', '{}', 'running', 0, 100.0, 100.0)"
+        )
+        # A row already terminal before the upgrade -- must NOT be touched
+        # by the backfill (it was never a candidate for the recovery scan).
+        await raw.execute(
+            "INSERT INTO schedule_runs "
+            "(id, schedule_id, trigger_context, action_kind, action_args, status, "
+            " chain_depth, fired_at, created_at) "
+            "VALUES ('run-da-completed', 'sched-da', '{}', 'agent', '{}', 'completed', 0, 50.0, 50.0)"
+        )
+        await raw.commit()
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        async with state._read() as conn:
+            running_row = (
+                (
+                    await conn.execute(
+                        text("SELECT * FROM schedule_runs WHERE id = :id"),
+                        {"id": "run-da-running"},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+            completed_row = (
+                (
+                    await conn.execute(
+                        text("SELECT * FROM schedule_runs WHERE id = :id"),
+                        {"id": "run-da-completed"},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        assert running_row["dispatched_at"] == running_row["fired_at"] == 100.0
+        assert completed_row["dispatched_at"] is None
+
+        # The whole point of the backfill: the recovery scan must no longer
+        # pick up the pre-existing running row as an undispatched orphan.
+        orphans = await state.list_undispatched_schedule_runs()
+        assert orphans == []
+    finally:
+        await state.close()


### PR DESCRIPTION
## Summary

Fixes #2142. `SchedulerEngine._recover_undispatched_fires()` runs on daemon startup and treats any `schedule_runs` row with `status='running' AND dispatched_at IS NULL` as "crashed before the external process launched," tombstoning it and firing a duplicate. `dispatched_at` is a new nullable column with **no backfill migration**, so any row already `status='running'` when a site upgrades and restarts has `dispatched_at IS NULL` simply because the column didn't exist yet — including genuinely still-executing long-running actions, which get duplicate-fired on the first restart after upgrade.

## Fix

`StateDB._reconcile_columns()` now special-cases the moment `schedule_runs.dispatched_at` is first added via `ALTER TABLE`: a one-time `_backfill_dispatched_at` runs `UPDATE schedule_runs SET dispatched_at = fired_at WHERE status='running' AND dispatched_at IS NULL AND schedule_id IS NOT NULL` inside the same transaction. Because it executes only at column-creation time, it is inherently one-shot and idempotent — genuine future crash-recovery signal is preserved. Mirrors the existing `_backfill_action_cwd()` precedent.

## Tests

- `test_dispatched_at_migration_backfills_preexisting_running_rows` — fails pre-fix (`None == 100.0`), passes after.
- Targeted schema-migration + scheduler-recovery + reaper suite: 219/219 passed.
