### PR TITLE
fix(orchestrate): resolve plugin-namespaced roles in worker spec resolution

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -357,15 +357,26 @@ def team_history_context(
 def resolve_worker_spec(
     token: str,
 ) -> tuple[str, AgentProfile | None]:
-    """Resolve a worker token to (model_spec, profile_or_None)."""
-    if "/" in token:
-        return token, None
+    """Resolve a worker token to (model_spec, profile_or_None).
+
+    A token containing '/' is ambiguous: it may be a plugin-namespaced agent
+    profile (``<plugin>/<name>``) or a literal ``provider/model`` spec (e.g.
+    ``openai/gpt-4.1``, predating plugin-namespaced profiles). Always attempt
+    profile resolution first — ``load_agent_profile`` only succeeds for a
+    real ``<plugin>/<name>`` match — and fall back to treating the token as a
+    raw model spec on a miss (FileNotFoundError) or on a shape that can't be
+    a profile name at all (ValueError, e.g. a dotted model version).
+    """
     try:
         profile = load_agent_profile(token)
         # No hardcoded fallback — callers apply their own default so it doesn't rot.
         return profile.model or token, profile
     except FileNotFoundError:
         return token, None
+    except ValueError:
+        if "/" in token:
+            return token, None
+        raise
 
 
 @dataclass

--- a/tests/cli/test_agent_profile_plugin.py
+++ b/tests/cli/test_agent_profile_plugin.py
@@ -153,6 +153,31 @@ def test_resolve_worker_spec_falls_back_to_raw_model_spec_for_unknown_slash_toke
     assert profile is None
 
 
+def test_resolve_worker_spec_falls_back_to_raw_model_spec_for_nonexistent_bare_token(write_plugin):
+    """A `<namespace>/<name>` token with no dots (a valid profile-name shape) that matches no
+    real plugin or local profile misses via `FileNotFoundError`, not `ValueError` — a distinct
+    fallback branch from the dotted-model-version case below and must be exercised separately.
+    """
+    from lionagi.cli.orchestrate._orchestration import resolve_worker_spec
+
+    model, profile = resolve_worker_spec("unknown/role")
+
+    assert model == "unknown/role"
+    assert profile is None
+
+
+def test_resolve_worker_spec_falls_back_to_raw_model_spec_for_codex_token(write_plugin):
+    """`codex/gpt-5.5` (a dotted model version, matching no plugin profile) is a real-world
+    raw-spec token used by the orchestrator's own worker defaults and must resolve as such.
+    """
+    from lionagi.cli.orchestrate._orchestration import resolve_worker_spec
+
+    model, profile = resolve_worker_spec("codex/gpt-5.5")
+
+    assert model == "codex/gpt-5.5"
+    assert profile is None
+
+
 def test_resolve_worker_spec_falls_back_for_dotted_model_version(write_plugin):
     """A dotted model version (invalid as a bare profile-name component) must still fall back
     to a raw model spec instead of raising.

--- a/tests/cli/test_agent_profile_plugin.py
+++ b/tests/cli/test_agent_profile_plugin.py
@@ -120,6 +120,59 @@ def test_local_shadow_logs_a_warning(write_plugin, plugin_home, caplog):
     assert any("web-research" in rec.message for rec in caplog.records)
 
 
+def test_resolve_worker_spec_resolves_plugin_namespaced_role(write_plugin):
+    """A `<plugin>/<name>` role assigned by the orchestrator's planner must resolve to the
+    plugin's declared profile, not silently fall back to a bare model spec.
+    """
+    from lionagi.cli.orchestrate._orchestration import resolve_worker_spec
+
+    _write_plugin_profile(
+        write_plugin,
+        "wr",
+        "web-research",
+        "researcher",
+        "---\nmodel: codex/gpt-5.5\n---\n\nresearch body\n",
+    )
+
+    model, profile = resolve_worker_spec("web-research/researcher")
+
+    assert model == "codex/gpt-5.5"
+    assert profile is not None
+    assert profile.name == "web-research/researcher"
+
+
+def test_resolve_worker_spec_falls_back_to_raw_model_spec_for_unknown_slash_token(write_plugin):
+    """A literal `provider/model` token (no matching plugin profile) still resolves as a raw
+    model spec, unaffected by the plugin-namespaced-role fix.
+    """
+    from lionagi.cli.orchestrate._orchestration import resolve_worker_spec
+
+    model, profile = resolve_worker_spec("openai/gpt-4.1")
+
+    assert model == "openai/gpt-4.1"
+    assert profile is None
+
+
+def test_resolve_worker_spec_falls_back_for_dotted_model_version(write_plugin):
+    """A dotted model version (invalid as a bare profile-name component) must still fall back
+    to a raw model spec instead of raising.
+    """
+    from lionagi.cli.orchestrate._orchestration import resolve_worker_spec
+
+    _write_plugin_profile(
+        write_plugin,
+        "wr",
+        "web-research",
+        "researcher",
+        "---\nmodel: codex/gpt-5.5\n---\n\nresearch body\n",
+    )
+
+    model, profile = resolve_worker_spec("anthropic/claude-3.7")
+
+    assert model == "anthropic/claude-3.7"
+    assert profile is None
+
+
 def test_disabled_plugin_profile_is_unreachable(write_plugin):
     from lionagi.plugins._user_settings import read_user_settings, write_user_settings
     from lionagi.plugins.registry import PluginRegistry


### PR DESCRIPTION
## Summary

Fixes #2130. `resolve_worker_spec()` in `lionagi/cli/orchestrate/_orchestration.py` had `if "/" in token: return token, None` — a guard predating plugin-namespaced agent-profile tokens (`<plugin>/<name>`). When the orchestrator's planner assigned a role like `web-research/researcher`, this guard intercepted it before `load_agent_profile()` ran, so the worker silently fell back to the default model with none of the plugin profile's settings — no error surfaced. Both consumers (`build_worker_branch` and the assignee-resolution preview in `flow.py`) were affected.

## Fix

Always attempt `load_agent_profile(token)` first, regardless of `/`. Fall back to a raw model spec only on `FileNotFoundError` (no matching profile) or `ValueError` (token shape can't be a valid profile name — e.g. `openai/gpt-4.1` fails the no-dots rule). This resolves plugin tokens while leaving legitimate raw `provider/model` specs (including dotted) unaffected.

## Tests

3 regression tests: plugin-namespaced role resolves to profile; unknown slash-token falls back to raw spec; dotted-version token falls back without raising. Primary test fails pre-fix (`'web-research/researcher' == 'codex/gpt-5.5'`), passes after.

`tests/cli/`, `tests/agent/`, `tests/orchestration/`, integration: 2133 passed.
