### PR TITLE
fix(studio,vscode): mirror NodeEscalated route=notify as non-terminal

### DIFF
--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -273,6 +273,58 @@ describe("runFiles union logic (mirrors the useMemo body) — file outside the l
   });
 });
 
+// ─── NodeEscalated route=notify badge ──────────────────────────────────────────
+// A soft ("fyi" urgency) EscalationRequest resolves to route="notify" and
+// fires NodeEscalated purely for observability — the node itself keeps
+// working. The per-event timeline badge must not label that "escalated"
+// (error tone) the same as a real, terminal escalation.
+
+describe("history/RunDetail.tsx — badgeForEvent (NodeEscalated route=notify)", () => {
+  it("labels a route=notify NodeEscalated as notify, not escalated", async () => {
+    const { badgeForEvent } = await import("./RunDetail");
+    const badge = badgeForEvent({
+      id: "1",
+      session_id: "s1",
+      seq: 0,
+      kind: "NodeEscalated",
+      op_id: "op-a",
+      ts: 1,
+      payload: { route: "notify" },
+    });
+    expect(badge.label).toBe("notify");
+    expect(badge.tone).not.toMatch(/error/);
+  });
+
+  it("still labels a route=higher_tier NodeEscalated as escalated", async () => {
+    const { badgeForEvent } = await import("./RunDetail");
+    const badge = badgeForEvent({
+      id: "1",
+      session_id: "s1",
+      seq: 0,
+      kind: "NodeEscalated",
+      op_id: "op-a",
+      ts: 1,
+      payload: { route: "higher_tier" },
+    });
+    expect(badge.label).toBe("escalated");
+    expect(badge.tone).toMatch(/error/);
+  });
+
+  it("still labels a bare NodeEscalated (no route) as escalated — back-compat", async () => {
+    const { badgeForEvent } = await import("./RunDetail");
+    const badge = badgeForEvent({
+      id: "1",
+      session_id: "s1",
+      seq: 0,
+      kind: "NodeEscalated",
+      op_id: "op-a",
+      ts: 1,
+      payload: {},
+    });
+    expect(badge.label).toBe("escalated");
+  });
+});
+
 describe("stale-write guard predicate (mirrors the done handler's merge condition)", () => {
   function mergeIfSameSession(
     prev: { id: string; status: string } | null,

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -17,7 +17,7 @@ import { IconChevronDown, IconChevronRight } from "@/components/ui/icons";
 import { getSession, streamSession, streamSignals, SESSION_MESSAGE_PAGE } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage, SignalEvent } from "@/lib/api";
 import { buildNodeStatusesByName, buildOperationGraph, laneFor } from "@/lib/operationGraph";
-import type { OperationStatus } from "@/lib/operationGraph";
+import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
 import { deriveDisplayStatus } from "@/lib/runStatus";
 import type { RunMessage, RunStep, WorkerGraph } from "@/lib/types";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
@@ -531,6 +531,18 @@ const KIND_BADGE: Record<string, { label: string; tone: string }> = {
   StructuredOutput: { label: "output", tone: "bg-surface-overlay text-content-secondary" },
 };
 
+// A NodeEscalated with route="notify" is a soft ("fyi") help signal, not a
+// real escalation — badge it distinctly (warning tone, like an approval
+// request) instead of the unconditional error-toned "escalated" label.
+export function badgeForEvent(ev: SignalEvent): { label: string; tone: string } {
+  if (ev.kind === "NodeEscalated" && ev.payload?.route === "notify") {
+    return { label: "notify", tone: "bg-status-warning-bg text-status-warning" };
+  }
+  return (
+    KIND_BADGE[ev.kind] ?? { label: ev.kind, tone: "bg-surface-overlay text-content-muted" }
+  );
+}
+
 type LaneState = OperationStatus;
 
 const LANE_TONE: Record<LaneState, string> = {
@@ -552,11 +564,12 @@ interface LaneSummary {
 function EventsSection({ events, live }: { events: SignalEvent[]; live: boolean }) {
   const t = useTranslations("history.detail");
   const laneSummaries = useMemo((): LaneSummary[] => {
-    const byOp = new Map<string, string[]>();
+    const byOp = new Map<string, LaneSignal[]>();
     for (const ev of events) {
       if (!ev.op_id) continue;
       const list = byOp.get(ev.op_id) ?? [];
-      list.push(ev.kind);
+      const route = ev.payload?.route;
+      list.push(typeof route === "string" ? { kind: ev.kind, route } : ev.kind);
       byOp.set(ev.op_id, list);
     }
     return Array.from(byOp.entries()).map(([op_id, kinds]) => ({
@@ -611,10 +624,7 @@ function EventsSection({ events, live }: { events: SignalEvent[]; live: boolean 
         <div className="max-h-72 overflow-y-auto rounded border border-edge bg-surface-raised">
           <div className="flex flex-col divide-y divide-edge-subtle">
             {events.map((ev) => {
-              const badge = KIND_BADGE[ev.kind] ?? {
-                label: ev.kind,
-                tone: "bg-surface-overlay text-content-muted",
-              };
+              const badge = badgeForEvent(ev);
               const hasPayload = ev.payload && Object.keys(ev.payload).length > 0;
               return (
                 <div

--- a/apps/studio/frontend/src/lib/operationGraph.test.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.test.ts
@@ -99,6 +99,42 @@ describe("laneFor — status projection", () => {
   });
 });
 
+// A soft ("fyi" urgency) EscalationRequest resolves to route="notify"
+// (lionagi/operations/flow.py::_schedule_escalation) and fires NodeEscalated
+// purely for observability — the node keeps working toward its own terminal
+// state. laneFor must not map every "NodeEscalated" kind straight to the
+// terminal "escalated" lane regardless of route — that pins the op into
+// "escalated" forever even after a later NodeCompleted.
+describe("laneFor — NodeEscalated route handling", () => {
+  it("route=notify (soft help signal) does not move the lane off running", () => {
+    expect(
+      laneFor(["NodeStarted", { kind: "NodeEscalated", route: "notify" }]),
+    ).toBe("running");
+  });
+
+  it("route=notify does not block a later NodeCompleted from landing", () => {
+    expect(
+      laneFor(["NodeStarted", { kind: "NodeEscalated", route: "notify" }, "NodeCompleted"]),
+    ).toBe("succeeded");
+  });
+
+  it("route=higher_tier (blocked urgency) still escalates", () => {
+    expect(
+      laneFor(["NodeStarted", { kind: "NodeEscalated", route: "higher_tier" }]),
+    ).toBe("escalated");
+  });
+
+  it("route=give_up (blocked urgency) still escalates", () => {
+    expect(laneFor(["NodeStarted", { kind: "NodeEscalated", route: "give_up" }])).toBe(
+      "escalated",
+    );
+  });
+
+  it("a bare NodeEscalated string (no route) still escalates — back-compat", () => {
+    expect(laneFor(["NodeStarted", "NodeEscalated"])).toBe("escalated");
+  });
+});
+
 // ── buildOperationGraph — core fold ──────────────────────────────────────────
 
 describe("buildOperationGraph — empty-op_id exclusion", () => {
@@ -154,6 +190,27 @@ describe("buildOperationGraph — status fold", () => {
     const events = [ev("1", "NodeStarted", "op-a", {}, 1), ev("2", "NodePaused", "op-a", {}, 2)];
     const g = buildOperationGraph(events);
     expect(g.nodes[0]!.status).toBe("paused");
+  });
+});
+
+describe("buildOperationGraph — NodeEscalated route handling", () => {
+  it("a route=notify NodeEscalated does not pin the op into the escalated status", () => {
+    const events = [
+      ev("1", "NodeStarted", "op-a", {}, 1),
+      ev("2", "NodeEscalated", "op-a", { route: "notify" }, 2),
+      ev("3", "NodeCompleted", "op-a", {}, 3),
+    ];
+    const g = buildOperationGraph(events);
+    expect(g.nodes[0]!.status).toBe("succeeded");
+  });
+
+  it("a route=higher_tier NodeEscalated still reports escalated", () => {
+    const events = [
+      ev("1", "NodeStarted", "op-a", {}, 1),
+      ev("2", "NodeEscalated", "op-a", { route: "higher_tier" }, 2),
+    ];
+    const g = buildOperationGraph(events);
+    expect(g.nodes[0]!.status).toBe("escalated");
   });
 });
 

--- a/apps/studio/frontend/src/lib/operationGraph.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.ts
@@ -35,10 +35,25 @@ const KIND_TO_STATE: Record<string, OperationStatus | undefined> = {
   NodeEscalated: "escalated",
 };
 
-export function laneFor(kinds: string[]): OperationStatus {
+// A lane-projection input: either a bare kind string (back-compat; an
+// unaccompanied "NodeEscalated" with no route info still projects to
+// "escalated", matching an EscalationRequest-less signal on the backend) or
+// a {kind, route} pair carrying the NodeEscalated route so a soft ("fyi")
+// help signal (route="notify") can be told apart from a real escalation.
+export type LaneSignal = string | { kind: string; route?: string };
+
+export function laneFor(kinds: LaneSignal[]): OperationStatus {
   let state: OperationStatus = "queued";
   let inTerminal = false;
-  for (const k of kinds) {
+  for (const entry of kinds) {
+    const k = typeof entry === "string" ? entry : entry.kind;
+    const route = typeof entry === "string" ? undefined : entry.route;
+    // Soft ("fyi") help signal: NodeEscalated fires for observability but
+    // the emitting node keeps working toward its own terminal state — must
+    // not get pinned into the terminal "escalated" lane. Mirrors
+    // _signal_to_state returning None for urgency="fyi" in
+    // lionagi/session/signal.py.
+    if (k === "NodeEscalated" && route === "notify") continue;
     const newState = KIND_TO_STATE[k];
     if (!newState) continue;
     if (inTerminal && newState !== "queued" && newState !== "running") continue;
@@ -46,6 +61,14 @@ export function laneFor(kinds: string[]): OperationStatus {
     inTerminal = TERMINAL.has(state);
   }
   return state;
+}
+
+// Build the laneFor() input for one signal event, carrying its route when
+// present (currently only NodeEscalated sets it) so laneFor can tell a soft
+// help signal apart from a real escalation.
+function toLaneSignal(ev: SignalEvent): LaneSignal {
+  const route = ev.payload?.route;
+  return typeof route === "string" ? { kind: ev.kind, route } : ev.kind;
 }
 
 // ── Transitive reduction ──────────────────────────────────────────────────────
@@ -95,7 +118,7 @@ export function transitiveReduce<E extends { source: string; target: string }>(e
 
 export function buildOperationGraph(events: SignalEvent[]): OperationGraphState {
   const order: string[] = [];
-  const kindsByOp = new Map<string, string[]>();
+  const kindsByOp = new Map<string, LaneSignal[]>();
   const nameByOp = new Map<string, string>();
   const elapsedByOp = new Map<string, number>();
   const firstTsByOp = new Map<string, number>();
@@ -113,7 +136,7 @@ export function buildOperationGraph(events: SignalEvent[]): OperationGraphState 
       causeOpIdByOp.set(ev.op_id, null);
     }
 
-    kindsByOp.get(ev.op_id)!.push(ev.kind);
+    kindsByOp.get(ev.op_id)!.push(toLaneSignal(ev));
 
     const ts = ev.ts;
     if (!firstTsByOp.has(ev.op_id) || ts < firstTsByOp.get(ev.op_id)!) {
@@ -194,7 +217,7 @@ export interface NodeSignalStatus {
 }
 
 export function buildNodeStatusesByName(events: SignalEvent[]): Map<string, NodeSignalStatus> {
-  const kindsByName = new Map<string, string[]>();
+  const kindsByName = new Map<string, LaneSignal[]>();
   const elapsedByName = new Map<string, number>();
 
   for (const ev of events) {
@@ -203,7 +226,7 @@ export function buildNodeStatusesByName(events: SignalEvent[]): Map<string, Node
     const name = payload && typeof payload.name === "string" ? payload.name : "";
     if (!name) continue;
 
-    (kindsByName.get(name) ?? kindsByName.set(name, []).get(name)!).push(ev.kind);
+    (kindsByName.get(name) ?? kindsByName.set(name, []).get(name)!).push(toLaneSignal(ev));
 
     const elapsed = payload?.elapsed;
     if (typeof elapsed === "number") {

--- a/apps/vscode/src/runs/runTreeModel.ts
+++ b/apps/vscode/src/runs/runTreeModel.ts
@@ -108,6 +108,16 @@ export function applySignalRow(state: RunTreeState, row: SignalRow): void {
       newState = "failed";
       break;
     case "NodeEscalated":
+      // A soft ("fyi") help signal (route="notify") is informational only —
+      // the emitting node keeps working toward its own terminal state, so it
+      // must not get pinned into the terminal "escalated" lane. Mirrors
+      // _signal_to_state returning None for urgency="fyi" in
+      // lionagi/session/signal.py. Only a "blocked"-urgency escalation
+      // (route "higher_tier"/"give_up") or a bare route (no request
+      // attached) is treated as escalated.
+      if (p["route"] === "notify") {
+        return;
+      }
       newState = "escalated";
       break;
     case "NodeSpawned":

--- a/apps/vscode/test/runTreeModel.test.ts
+++ b/apps/vscode/test/runTreeModel.test.ts
@@ -50,3 +50,38 @@ describe("runTreeModel paused lane", () => {
     expect(state.order).toContain("op9");
   });
 });
+
+// A soft ("fyi" urgency) EscalationRequest resolves to route="notify"
+// (lionagi/operations/flow.py::_schedule_escalation) and fires NodeEscalated
+// purely for observability — the node keeps working toward its own terminal
+// state. applySignalRow must not treat every NodeEscalated as an
+// unconditional, terminal "escalated" transition (no route check) — that
+// pins the op into displaying "escalated" forever even after it later
+// emits NodeCompleted.
+describe("runTreeModel NodeEscalated route handling", () => {
+  it("route=notify (soft help signal) does not change the node's lane", () => {
+    const state = createRunTreeState();
+    applySignalRow(state, row("NodeStarted", "op1", { name: "worker" }));
+    expect(state.nodes.get("op1")?.state).toBe("running");
+
+    applySignalRow(state, row("NodeEscalated", "op1", { route: "notify" }));
+    expect(state.nodes.get("op1")?.state).toBe("running");
+
+    applySignalRow(state, row("NodeCompleted", "op1"));
+    expect(state.nodes.get("op1")?.state).toBe("succeeded");
+  });
+
+  it("route=higher_tier (blocked urgency) still marks the node escalated", () => {
+    const state = createRunTreeState();
+    applySignalRow(state, row("NodeStarted", "op1", { name: "worker" }));
+    applySignalRow(state, row("NodeEscalated", "op1", { route: "higher_tier" }));
+    expect(state.nodes.get("op1")?.state).toBe("escalated");
+  });
+
+  it("a bare NodeEscalated with no route still marks the node escalated", () => {
+    const state = createRunTreeState();
+    applySignalRow(state, row("NodeStarted", "op1", { name: "worker" }));
+    applySignalRow(state, row("NodeEscalated", "op1"));
+    expect(state.nodes.get("op1")?.state).toBe("escalated");
+  });
+});


### PR DESCRIPTION
## Summary

A soft (`urgency="fyi"`) `EscalationRequest` resolves to `route="notify"` on the backend (`_schedule_escalation` / `_signal_to_state`): `NodeEscalated` still fires for observability, but the emitting node keeps working toward its own terminal state instead of being pinned into the escalated lane. Three frontend/extension consumers still treated every `NodeEscalated` as an unconditional, terminal `escalated` state with no route check, so an op that sent a soft help signal got stuck displaying red "escalated" forever, silently dropping the `NodeCompleted` that followed.

## Fix
- `apps/studio/frontend/src/lib/operationGraph.ts` — `laneFor()` accepts the route and skips the lane update when `route="notify"`; graph builders thread `payload.route` through.
- `apps/studio/frontend/src/components/history/RunDetail.tsx` — same route-aware fix for the events-section lane summary, plus a distinct warning-toned "notify" badge for `route=notify` timeline events.
- `apps/vscode/src/runs/runTreeModel.ts` — `applySignalRow()` skips the lifecycle transition for `route="notify"`, mirroring `_signal_to_state` returning `None` for `urgency="fyi"`.

A bare `NodeEscalated` (no route) still projects to `escalated` in all three call sites — back-compat with the pre-soft-escalation contract.

## Tests
Regression tests added to all three suites, verified failing pre-fix (stash-free) and passing post-fix. Studio frontend 866/866 + vscode 62/62 vitest pass; `tsc --noEmit` and eslint clean on touched files.

Closes #2061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)