### PR TITLE
fix(studio): correct README state.db env var to LIONAGI_HOME, drop dead DATA_ROOT

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -30,7 +30,7 @@ All variables are optional; defaults are shown.
 | `LIONAGI_STUDIO_PORT` | `8765` | FastAPI bind port |
 | `LIONAGI_STUDIO_AUTH_TOKEN` | *(unset)* | Bearer token for `/api/*` routes |
 | `LIONAGI_STUDIO_FRONTEND_DIST` | `apps/studio/frontend/dist` | Path to built SPA dist/ |
-| `LIONAGI_DATA_ROOT` | `~/.lionagi` | Base LionAGI data directory |
+| `LIONAGI_HOME` | `~/.lionagi` | Base LionAGI data directory (holds `state.db`) |
 | `LIONAGI_SHOWS_ROOT` | `~/khive-work/shows` | Show artifact root |
 | `CORS_ORIGINS` | `localhost:5173,localhost:3000` | Comma-separated allowed browser origins |
 
@@ -84,7 +84,7 @@ Authorization: Bearer <token>
 
 ## Database
 
-Studio uses the LionAGI state database at `$LIONAGI_DATA_ROOT/state.db`
+Studio uses the LionAGI state database at `$LIONAGI_HOME/state.db`
 (default `~/.lionagi/state.db`).
 
 ## Testing

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -29,7 +29,6 @@ def _system_local_tz_name() -> str:
 
 STUDIO_PORT: int = int(os.environ.get("LIONAGI_STUDIO_PORT", "8765"))
 HOST: str = os.environ.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
-DATA_ROOT: Path = Path(os.environ.get("LIONAGI_DATA_ROOT", "~/.lionagi")).expanduser()
 SHOWS_ROOT: Path = Path(os.environ.get("LIONAGI_SHOWS_ROOT", "~/khive-work/shows")).expanduser()
 
 _raw_origins = os.environ.get("CORS_ORIGINS", "")


### PR DESCRIPTION
## Summary

The studio README documented `$LIONAGI_DATA_ROOT` as the base directory for the state database, but the state DB actually resolves its path from `LIONAGI_HOME`:

```python
# lionagi/state/db.py
DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"   # LIONAGI_HOME from _paths.py
```

Setting `LIONAGI_DATA_ROOT` had no effect on where `state.db` lives. `lionagi/studio/config.py` defined a `DATA_ROOT` attribute reading that variable, but it had **zero consumers** (repo-wide grep found only the definition line) — a phantom knob that could only mislead operators.

## Changes

- `apps/studio/README.md` — env table + Database section now reference `$LIONAGI_HOME` (the variable that actually controls the DB path).
- `lionagi/studio/config.py` — remove the orphan `DATA_ROOT` attribute.

## Verification

- `grep -rn DATA_ROOT` across `lionagi/ apps/ tests/` → no references remain.
- `import lionagi.studio.config` succeeds; `SHOWS_ROOT` intact.

Docs + dead-code removal only; no behavior change.
