### PR TITLE
fix(engine): bound coding-engine plan/verify stages with a soft watchdog

### DIFF
--- a/docs/reference/engines.md
+++ b/docs/reference/engines.md
@@ -42,7 +42,7 @@ Extends `Engine` with:
 | `turn_timeout_s` | `600.0` | Wall-clock cap for each implementer model turn, including fix turns. A timeout records `turn_timeout` and drives the emission-repair path; `None` disables the cap. |
 | `strict_spec` | `False` | Raise `ValueError` on the first spec-lint warning before creating an agent. When `False`, warnings are emitted and execution continues. |
 | `heartbeat_interval_s` | `30.0` | Seconds between implement-stage `WorkerHeartbeat` checks; file mtime changes also emit `WorkerActivity`. `None` disables heartbeats. |
-| `stage_timeout_s` | `None` | Optional wall-clock cap for implement and fix stages. A timeout emits `WorkAborted` and aborts the run. |
+| `stage_timeout_s` | `None` | Optional wall-clock cap applied to every model stage. A timeout always emits `WorkAborted` (with a `hard` flag). Implement and fix timeouts are hard: the run aborts and concludes failed. Plan and verify timeouts are soft: the stage is bounded but the run recovers — a timed-out planner degrades to the raw task text, and a timed-out verifier omits its advisory verdict while the test result still decides pass/fail. |
 | `worker_extra_tools` | `()` | Additional tool names granted only to the implementer, appended to `coding_tools`. |
 | `worker_mcp_servers` | `None` | Optional MCP server names granted only to the implementer. |
 | `worker_extra_prompt` | `None` | Optional extra prompt text passed only to the implementer. |

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -606,13 +606,17 @@ class CodingEngine(Engine):
                 model=self.model_for("plan"),
                 emits=emits,
             )
-            await run.operate_with_repair(
+            stage_coro = run.operate_with_repair(
                 agent,
                 _plan_instruction(run.task_text, run.workspace),
                 arrived=lambda: bool(run.events_of(WorkPlanned)),
                 emits=emits,
                 retries=self.repair_retries,
             )
+            # Soft watchdog: a hung planner is bounded but not fatal — the
+            # missing-plan branch below degrades to the raw task, so plan
+            # timeout must not poison run._aborted (which would fail the run).
+            await self._run_stage_with_watchdog(run, stage_coro, "plan", hard=False)
         plan = run.last(WorkPlanned)
         if plan is None:
             # Degrade rather than crash: implement against the raw task.
@@ -818,13 +822,17 @@ class CodingEngine(Engine):
                 emits=emits,
                 exempt=True,
             )
-            await run.operate_with_repair(
+            stage_coro = run.operate_with_repair(
                 agent,
                 _verify_instruction(plan, change, tests, run.diff),
                 arrived=lambda: bool(run.events_of(VerifyResult)),
                 emits=emits,
                 retries=self.repair_retries,
             )
+            # Soft watchdog: verify is advisory (the pass/fail verdict is the
+            # test result, not this note) and runs after the abort gate, so a
+            # hung verifier is bounded but must not set run._aborted.
+            await self._run_stage_with_watchdog(run, stage_coro, "verify", hard=False)
         return run.last(VerifyResult)
 
     async def _conclude(
@@ -944,20 +952,33 @@ class CodingEngine(Engine):
         return asyncio.ensure_future(_loop())
 
     async def _run_stage_with_watchdog(
-        self, run: CodingRun, stage_coro: Any, stage_name: str
-    ) -> None:
-        """Run *stage_coro* bounded by stage_timeout_s; on timeout emit WorkAborted and set run._aborted."""
+        self, run: CodingRun, stage_coro: Any, stage_name: str, *, hard: bool = True
+    ) -> bool:
+        """Run *stage_coro* bounded by stage_timeout_s.
+
+        On timeout, emit a WorkAborted notification and return True. When
+        *hard* (the default, for implement/fix rounds) the timeout also sets
+        run._aborted, which concludes the run as failed. A *soft* stage
+        (hard=False, for plan/verify) is bounded but recoverable: the caller
+        degrades gracefully (raw-task plan, or a missing advisory verdict)
+        rather than failing the whole run.
+        """
         if self.stage_timeout_s is None:
             await stage_coro
-            return
+            return False
         t0 = monotonic()
         try:
             await asyncio.wait_for(stage_coro, timeout=self.stage_timeout_s)
+            return False
         except asyncio.TimeoutError:
             elapsed = round(monotonic() - t0, 1)
             reason = f"stage '{stage_name}' exceeded {self.stage_timeout_s}s wall-clock limit"
-            run.notify("WorkAborted", stage=stage_name, reason=reason, elapsed_s=elapsed)
-            run._aborted = True
+            run.notify(
+                "WorkAborted", stage=stage_name, reason=reason, elapsed_s=elapsed, hard=hard
+            )
+            if hard:
+                run._aborted = True
+            return True
 
     async def _partial_export(
         self, run: CodingRun, *args: Any, **kwargs: Any

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -973,9 +973,7 @@ class CodingEngine(Engine):
         except asyncio.TimeoutError:
             elapsed = round(monotonic() - t0, 1)
             reason = f"stage '{stage_name}' exceeded {self.stage_timeout_s}s wall-clock limit"
-            run.notify(
-                "WorkAborted", stage=stage_name, reason=reason, elapsed_s=elapsed, hard=hard
-            )
+            run.notify("WorkAborted", stage=stage_name, reason=reason, elapsed_s=elapsed, hard=hard)
             if hard:
                 run._aborted = True
             return True

--- a/tests/engines/test_worker_safety.py
+++ b/tests/engines/test_worker_safety.py
@@ -694,3 +694,107 @@ async def test_hanging_fix_round_aborts_with_caveat(tmp_path, monkeypatch):
     assert "stage aborted by watchdog" in result.caveats
     assert verify_calls == [], "verify must not run after a watchdog abort"
     assert (export_dir / "report.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_hanging_plan_is_bounded_but_does_not_abort_the_run(tmp_path, monkeypatch):
+    """A hung _plan stage must be bounded (soft watchdog) and degrade to the raw-task
+    plan, letting implement/test proceed — it must NOT poison run._aborted and fail the run."""
+    import sys
+
+    eng = CodingEngine(repair_retries=0, max_fix_rounds=0, stage_timeout_s=0.2)
+    run = eng.new_run()
+
+    class _HangingPlanBranch:
+        name = "plan"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(60)  # planner hangs indefinitely
+            return "never"
+
+    implement_branch = _ScriptedBranch(
+        run, [ChangeProposed(summary="did the work")], name="implement"
+    )
+    branches = {"plan": _HangingPlanBranch(), "implement": implement_branch}
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    export_dir = tmp_path / "export"
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "plan hangs but work still happens",
+        test_cmd=[sys.executable, "-c", "exit(0)"],  # tests pass
+        workspace=str(tmp_path),
+        export_dir=export_dir,
+    )
+
+    plan_aborted = [e for e in events if e["type"] == "WorkAborted" and e.get("stage") == "plan"]
+    assert plan_aborted, f"soft plan-abort not found in {[e['type'] for e in events]}"
+    assert plan_aborted[0].get("hard") is False, "plan watchdog must be soft (hard=False)"
+
+    # The run must NOT be failed by the plan timeout: implement ran and tests passed.
+    assert implement_branch.calls, "implement must run despite a hung planner"
+    assert result.passed is True
+    assert "stage aborted by watchdog" not in result.caveats
+
+
+@pytest.mark.asyncio
+async def test_hanging_verify_is_bounded_and_run_still_concludes(tmp_path, monkeypatch):
+    """A hung _verify stage must be bounded (soft watchdog): the advisory verdict is
+    dropped, but the run concludes on the test result rather than hanging or failing."""
+    import sys
+
+    eng = CodingEngine(repair_retries=0, max_fix_rounds=0, stage_timeout_s=0.2)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="implement, then verify hangs")
+
+    class _HangingVerifyBranch:
+        name = "verify"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(60)  # verifier hangs indefinitely
+            return "never"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(
+            run, [ChangeProposed(summary="did the work")], name="implement"
+        ),
+        "verify": _HangingVerifyBranch(),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    export_dir = tmp_path / "export"
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "verify hangs after passing tests",
+        test_cmd=[sys.executable, "-c", "exit(0)"],  # tests pass
+        workspace=str(tmp_path),
+        export_dir=export_dir,
+    )
+
+    verify_aborted = [
+        e for e in events if e["type"] == "WorkAborted" and e.get("stage") == "verify"
+    ]
+    assert verify_aborted, f"soft verify-abort not found in {[e['type'] for e in events]}"
+    assert verify_aborted[0].get("hard") is False, "verify watchdog must be soft (hard=False)"
+
+    # Verdict comes from the tests, not the (dropped) verify note; run concludes.
+    assert result.passed is True
+    assert "stage aborted by watchdog" not in result.caveats
+    assert (export_dir / "report.md").exists()


### PR DESCRIPTION
## Summary

The coding-engine stage watchdog (`_run_stage_with_watchdog`) only wrapped the `implement` and `fix-{n}` stages. A hung `_plan` or `_verify` agent had **no wall-clock bound** and could stall a run indefinitely — the exact failure mode the watchdog exists to prevent, just at two stages it never covered.

## Change

`_run_stage_with_watchdog` gains a `hard: bool` flag so the two stage families get the abort semantics they actually need:

| Stage | Mode | On timeout |
|---|---|---|
| `implement`, `fix-{n}` | **hard** (unchanged) | sets `run._aborted` → run concludes **failed** with the "stage aborted by watchdog" caveat |
| `plan` | **soft** | bounded; degrades to the existing raw-task fallback (the `plan is None` branch) and proceeds |
| `verify` | **soft** | bounded; drops the advisory verdict. The pass/fail result comes from the test run, not verify, so the run still concludes |

A soft timeout must **not** set `run._aborted`, or a stage with a graceful fallback would wrongly fail the whole run. The flag makes that distinction explicit and keeps the existing hard-abort behavior byte-for-byte.

## Tests

Adds two regression tests mirroring the existing implement/fix watchdog tests:
- `test_hanging_plan_is_bounded_but_does_not_abort_the_run` — a hung planner is bounded (`WorkAborted stage=plan hard=False`), implement still runs, tests pass, run is **not** failed.
- `test_hanging_verify_is_bounded_and_run_still_concludes` — a hung verifier is bounded (`WorkAborted stage=verify hard=False`), the run concludes on the test result.

Full `tests/engines/test_worker_safety.py` (21 tests) passes; `ruff` clean.
