### PR TITLE
fix(studio): add show-level lifecycle reaper for phantom active shows

### DIFF
--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -131,6 +131,10 @@ class ShowReasons:
     BLOCKED_NO_READY_PLAYS = "show.blocked.no_ready_plays"
     COMPLETED_FINAL_GATE = "show.completed.final_gate"
     ABORTED_OPERATOR = "show.aborted.operator"
+    # A show reached completion without ever landing a `_final_verdict.json`
+    # (e.g. the last play merged and nothing else ran a final gate); derived
+    # by the lifecycle reaper from every child play's on-disk status.
+    COMPLETED_ALL_PLAYS_MERGED = "show.completed.all_plays_merged"
 
 
 class ScheduleReasons:

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -88,6 +88,14 @@ PLAY_STALE_HOURS: float = float(os.environ.get("LIONAGI_STUDIO_PLAY_STALE_HOURS"
 SCHEDULE_RUN_STALE_HOURS: float = float(
     os.environ.get("LIONAGI_STUDIO_SCHEDULE_RUN_STALE_HOURS", "24.0")
 )
+# Staleness threshold for the show-level reaper. A show's status is derived
+# only once, at mirror-row creation (`shows.import_shows()`); a show
+# mirrored while its plays are still in flight is never re-evaluated once
+# those plays later merge or abort on disk. This reaper re-derives the
+# terminal state from on-disk play/verdict evidence past this staleness
+# window. Liveness-first means a show with any child play whose session
+# process is still alive is never reaped regardless of this value.
+SHOW_STALE_HOURS: float = float(os.environ.get("LIONAGI_STUDIO_SHOW_STALE_HOURS", "6.0"))
 # Minimum seconds between consecutive periodic reaper runs (throttle).
 REAPER_INTERVAL_SECONDS: int = int(os.environ.get("LIONAGI_STUDIO_REAPER_INTERVAL_SECONDS", "300"))
 

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -692,7 +692,23 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                     show_dir_raw = row.get("show_dir")
                     if not show_dir_raw:
                         continue
-                    recomputed = _recompute_show_status_from_disk(Path(show_dir_raw))
+                    show_dir = Path(show_dir_raw)
+                    for play_dir in _play_dirs(show_dir):
+                        try:
+                            play_pid = int((play_dir / ".pid").read_text().strip())
+                        except (OSError, ValueError):
+                            continue
+                        if play_pid <= 1:
+                            continue
+                        session = {"id": "", "node_metadata": {"pid": play_pid}}
+                        if process_liveness(session, None, ps_snapshot) is True:
+                            live = True
+                            break
+                    if live:
+                        # The play PID is written before its session is linked.
+                        continue
+
+                    recomputed = _recompute_show_status_from_disk(show_dir)
                     if recomputed is None:
                         # Still genuinely in flight on disk — nothing to reap.
                         continue

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 import logging
 import os
 import time
+from pathlib import Path
 
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
-from lionagi.state.reasons import RunReasons, SessionReasons
+from lionagi.state.reasons import RunReasons, SessionReasons, ShowReasons
 
 from . import admin as admin_svc
 from .admin import _artifacts_path, _ps_snapshot, process_liveness
+from .shows import _SHOW_TERMINAL_STATUSES, _play_dirs
+from .shows import _read_json as _read_show_json
 
 _log = logging.getLogger(__name__)
 
@@ -555,6 +558,188 @@ async def reap_stale_schedule_runs(*, stale_hours: float | None = None) -> int:
     return reaped
 
 
+# ── show-level staleness reaper ──────────────────────────────────────────────
+
+# Non-terminal show statuses (the complement of `_SHOW_TERMINAL_STATUSES`).
+# Kept as its own curated set — like `_REAPABLE_PLAY_STATUSES` — so the CAS
+# `expected_statuses` guard below only matches the exact statuses this
+# reaper is willing to move out of, rather than importing the full status
+# vocabulary just to subtract the terminal set at call time.
+_REAPABLE_SHOW_STATUSES = frozenset({"active", "imported"})
+
+
+def _recompute_show_status_from_disk(show_dir: Path) -> tuple[str, str, str] | None:
+    """Re-derive a show's terminal status from on-disk play/verdict evidence.
+
+    Mirrors the rules ``shows.import_shows()`` applies once, at mirror-row
+    creation time: an ``_ABORT`` marker means aborted; a passing
+    ``_final_verdict.json`` means completed; every child play reaching
+    ``merged`` (with at least one play) also means completed. Any other
+    on-disk state is still genuinely in flight, so this returns ``None`` and
+    the caller skips the show.
+
+    Returns ``(new_status, reason_code, reason_summary)`` or ``None``.
+    """
+    if (show_dir / "_ABORT").exists():
+        return (
+            "aborted",
+            ShowReasons.ABORTED_OPERATOR,
+            "Show directory carries an operator abort marker.",
+        )
+
+    final_verdict = _read_show_json(show_dir / "_final_verdict.json")
+    if final_verdict and final_verdict.get("show_passed"):
+        return (
+            "completed",
+            ShowReasons.COMPLETED_FINAL_GATE,
+            "Show has a passing final gate verdict.",
+        )
+
+    metas = [_read_show_json(p / "_meta.json") or {} for p in _play_dirs(show_dir)]
+    statuses = [m.get("status", "pending") for m in metas]
+    if statuses and all(s == "merged" for s in statuses):
+        return (
+            "completed",
+            ShowReasons.COMPLETED_ALL_PLAYS_MERGED,
+            "All child plays reached merged status.",
+        )
+
+    return None
+
+
+async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
+    """Recompute a stale non-terminal show's status from its plays' state.
+
+    ``shows.py`` computes ``show_status`` only once, at mirror-row creation
+    time (``import_shows()``): a show mirrored while its plays are still
+    in flight gets ``status="active"`` and the row is never re-evaluated
+    once those plays later merge or abort on disk — there is no periodic
+    re-derivation, unlike sessions/plays/invocations/schedule_runs, which
+    all have their own reapers. This fills that gap using the exact same
+    on-disk rules ``import_shows()`` already applies (see
+    ``_recompute_show_status_from_disk``).
+
+    Liveness-first, like ``reap_stale_plays``: a show with any child play
+    whose session process is still observably alive is never reaped,
+    regardless of the on-disk snapshot or how stale the row looks.
+    """
+    from lionagi.studio.config import SHOW_STALE_HOURS
+
+    if stale_hours is None:
+        stale_hours = SHOW_STALE_HOURS
+    stale_seconds = stale_hours * 3600
+
+    if not DEFAULT_DB_PATH.exists():
+        return 0
+
+    now = time.time()
+    reaped = 0
+
+    try:
+        async with StateDB() as db:
+            placeholders = ",".join("?" * len(_SHOW_TERMINAL_STATUSES))
+            candidates = await db.fetch_all(
+                f"SELECT id FROM shows WHERE status NOT IN ({placeholders})",  # noqa: S608
+                tuple(sorted(_SHOW_TERMINAL_STATUSES)),
+            )
+
+        ps_snapshot: str | None = None
+        for cand in candidates:
+            show_id = cand["id"]
+            try:
+                async with StateDB() as db:
+                    # Re-read fresh immediately before deciding — a show can
+                    # be legitimately re-touched between the scan and here.
+                    row = await db.fetch_one(
+                        "SELECT id, status, show_dir, updated_at FROM shows WHERE id = ?",
+                        (show_id,),
+                    )
+                    if row is None or row["status"] not in _REAPABLE_SHOW_STATUSES:
+                        continue
+
+                    updated_at_raw = row.get("updated_at")
+                    updated_at = updated_at_raw or 0.0
+                    if now - updated_at < stale_seconds:
+                        # Not confirmed alive, but too fresh to reap.
+                        continue
+
+                    play_rows = await db.fetch_all(
+                        "SELECT id, session_id FROM plays WHERE show_id = ?",
+                        (show_id,),
+                    )
+                    live = False
+                    for prow in play_rows:
+                        session_id = prow.get("session_id")
+                        if not session_id:
+                            continue
+                        srow = await db.fetch_one(
+                            "SELECT id, artifacts_path, node_metadata FROM sessions WHERE id = ?",
+                            (session_id,),
+                        )
+                        if srow is None:
+                            continue
+                        if ps_snapshot is None:
+                            ps_snapshot = _ps_snapshot()
+                        session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
+                        if process_liveness(session, _artifacts_path(srow), ps_snapshot) is True:
+                            live = True
+                            break
+                    if live:
+                        # A live child play process is never reaped on
+                        # staleness alone.
+                        continue
+
+                    show_dir_raw = row.get("show_dir")
+                    if not show_dir_raw:
+                        continue
+                    recomputed = _recompute_show_status_from_disk(Path(show_dir_raw))
+                    if recomputed is None:
+                        # Still genuinely in flight on disk — nothing to reap.
+                        continue
+                    new_status, reason_code, reason_summary = recomputed
+
+                    _log.info(
+                        "Reaping stale show %s: status=%s -> %s",
+                        show_id,
+                        row["status"],
+                        new_status,
+                    )
+                    # expected_updated_at pins the transition to the exact row
+                    # version validated above: a claim/re-touch landing
+                    # between this read and the write bumps updated_at, so
+                    # the guarded write loses the race and we skip rather
+                    # than clobber a show that moved.
+                    transitioned = await db.update_status(
+                        "show",
+                        show_id,
+                        new_status=new_status,
+                        reason_code=reason_code,
+                        reason_summary=reason_summary,
+                        evidence_refs=[{"kind": "show", "id": show_id}],
+                        source="system",
+                        actor="studio_lifecycle_reaper",
+                        metadata={
+                            "detector": "stale_show_reaper",
+                            "prior_status": row["status"],
+                            "updated_at": updated_at,
+                        },
+                        expected_statuses=_REAPABLE_SHOW_STATUSES,
+                        expected_updated_at=updated_at_raw,
+                    )
+                    if transitioned:
+                        reaped += 1
+                    else:
+                        _log.debug("Show %s skipped (status changed before CAS lock)", show_id)
+            except LookupError:
+                pass
+            except Exception:
+                _log.exception("Failed to reap stale show %s", show_id)
+    except Exception:
+        _log.exception("reap_stale_shows error")
+
+    return reaped
+
+
 # ── Startup + periodic entry points ──────────────────────────────────────────
 
 
@@ -585,6 +770,11 @@ async def run_startup_reconciliation() -> dict[str, int]:
     except Exception:
         _log.exception("Startup play reaper failed")
         results["stale_plays"] = 0
+    try:
+        results["stale_shows"] = await reap_stale_shows()
+    except Exception:
+        _log.exception("Startup show reaper failed")
+        results["stale_shows"] = 0
     try:
         results["stale_schedule_runs"] = await reap_stale_schedule_runs()
     except Exception:
@@ -623,6 +813,11 @@ async def run_periodic_reapers(now: float | None = None) -> dict[str, int]:
     except Exception:
         _log.exception("Periodic play reaper failed")
         results["stale_plays"] = 0
+    try:
+        results["stale_shows"] = await reap_stale_shows()
+    except Exception:
+        _log.exception("Periodic show reaper failed")
+        results["stale_shows"] = 0
     try:
         results["stale_schedule_runs"] = await reap_stale_schedule_runs()
     except Exception:

--- a/tests/apps_studio_server/test_lifecycle_show_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_show_reaper.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -248,6 +250,54 @@ def test_reap_stale_shows_reaps_dead_child_session(tmp_path, monkeypatch):
 
     show = run_async(_get_show(db_path, show_id))
     assert show["status"] == "completed"
+
+
+def test_reap_stale_shows_skips_live_unlinked_play_pid(tmp_path, monkeypatch):
+    """A child process may be live before its play row is linked to a session."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "live-unlinked-topic"
+    play_id = str(uuid.uuid4())
+    play_name = f"play-{play_id[:8]}"
+    _write_play_meta(show_dir, play_name, status="running")
+    (show_dir / play_name / ".pid").write_text(str(os.getpid()))
+    (show_dir / "_ABORT").write_text("")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+    run_async(_seed_play_row(db_path, show_id, play_id=play_id, session_id=None))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "active"
+
+
+def test_reap_stale_shows_reaps_dead_unlinked_play_pid(tmp_path, monkeypatch):
+    """A dead unlinked play PID does not block an otherwise reapable show."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "dead-unlinked-topic"
+    play_id = str(uuid.uuid4())
+    play_name = f"play-{play_id[:8]}"
+    _write_play_meta(show_dir, play_name, status="running")
+    proc = subprocess.Popen(["/bin/sleep", "0"])  # noqa: S603
+    proc.wait()
+    (show_dir / play_name / ".pid").write_text(str(proc.pid))
+    (show_dir / "_ABORT").write_text("")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+    run_async(_seed_play_row(db_path, show_id, play_id=play_id, session_id=None))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 1
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "aborted"
 
 
 # ── already-terminal: never reaped ────────────────────────────────────────────

--- a/tests/apps_studio_server/test_lifecycle_show_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_show_reaper.py
@@ -1,0 +1,360 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Studio show-level staleness reaper."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+
+from lionagi.state.db import StateDB
+
+from ._helpers import run_async
+
+# ── Fixtures / helpers ────────────────────────────────────────────────────────
+
+
+def _monkey_db(monkeypatch, db_path: Path) -> None:
+    """Point all relevant modules at a temp DB path."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
+    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+
+
+async def _seed_show(
+    db_path: Path,
+    show_dir: Path,
+    *,
+    show_id: str | None = None,
+    status: str = "active",
+    updated_at: float | None = None,
+) -> str:
+    sid = show_id or str(uuid.uuid4())
+    async with StateDB(db_path) as db:
+        await db.create_show(
+            {
+                "id": sid,
+                "topic": f"topic-{sid[:8]}",
+                "show_dir": str(show_dir),
+                "status": status,
+            }
+        )
+        if updated_at is not None:
+            await db.execute(
+                "UPDATE shows SET updated_at = ? WHERE id = ?",
+                (updated_at, sid),
+            )
+    return sid
+
+
+async def _seed_play_row(
+    db_path: Path,
+    show_id: str,
+    *,
+    play_id: str | None = None,
+    status: str = "merged",
+    session_id: str | None = None,
+) -> str:
+    pid = play_id or str(uuid.uuid4())
+    now = time.time()
+    async with StateDB(db_path) as db:
+        await db.create_play(
+            {
+                "id": pid,
+                "show_id": show_id,
+                "name": f"play-{pid[:8]}",
+                "status": status,
+                "session_id": session_id,
+                "started_at": now,
+            }
+        )
+    return pid
+
+
+async def _seed_session(
+    db_path: Path,
+    *,
+    session_id: str | None = None,
+    node_metadata: dict | None = None,
+) -> str:
+    sid = session_id or str(uuid.uuid4())
+    async with StateDB(db_path) as db:
+        prog_id = str(uuid.uuid4())
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog_id,
+                "name": "test-session",
+                "status": "running",
+                "started_at": time.time(),
+                "node_metadata": node_metadata,
+            }
+        )
+    return sid
+
+
+async def _get_show(db_path: Path, show_id: str) -> dict | None:
+    async with StateDB(db_path) as db:
+        return await db.get_show(show_id)
+
+
+async def _count_transitions(db_path: Path, entity_id: str) -> int:
+    async with StateDB(db_path) as db:
+        row = await db.fetch_one(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?", (entity_id,)
+        )
+        return row["n"] if row else 0
+
+
+def _write_play_meta(show_dir: Path, name: str, *, status: str) -> None:
+    play_dir = show_dir / name
+    play_dir.mkdir(parents=True, exist_ok=True)
+    (play_dir / "_meta.json").write_text(json.dumps({"status": status}))
+
+
+_STALE = time.time() - 100 * 3600  # 100h ago, well past any reasonable stale_hours
+
+
+# ── all-merged-on-disk reap ───────────────────────────────────────────────────
+
+
+def test_reap_stale_shows_all_merged_reaped(tmp_path, monkeypatch):
+    """A stale non-terminal show whose every on-disk play reached 'merged' is
+    reaped to 'completed' via the same rule import_shows() uses at creation."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "my-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _write_play_meta(show_dir, "play-two", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 1
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show is not None
+    assert show["status"] == "completed"
+    assert show["status_reason_code"] == "show.completed.all_plays_merged"
+    assert run_async(_count_transitions(db_path, show_id)) >= 1
+
+
+# ── abort marker reap ─────────────────────────────────────────────────────────
+
+
+def test_reap_stale_shows_abort_marker_reaped(tmp_path, monkeypatch):
+    """A stale non-terminal show with an on-disk _ABORT marker is reaped to
+    'aborted', regardless of play state."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "aborted-topic"
+    show_dir.mkdir(parents=True)
+    (show_dir / "_ABORT").write_text("")
+    _write_play_meta(show_dir, "play-one", status="running")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 1
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "aborted"
+    assert show["status_reason_code"] == "show.aborted.operator"
+
+
+# ── still-in-flight-on-disk: nothing to reap ──────────────────────────────────
+
+
+def test_reap_stale_shows_skips_still_in_flight_on_disk(tmp_path, monkeypatch):
+    """A stale show whose on-disk plays are not all merged and carries no abort
+    marker or passing verdict is left alone — genuinely still in flight."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "in-flight-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _write_play_meta(show_dir, "play-two", status="running")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "active"
+
+
+# ── liveness-first ─────────────────────────────────────────────────────────────
+
+
+def test_reap_stale_shows_skips_live_child_session(tmp_path, monkeypatch):
+    """A show with a child play whose session process is still alive is never
+    reaped, even when the on-disk snapshot looks fully merged and ancient."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "live-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    session_id = run_async(_seed_session(db_path, node_metadata={"pid": 1}))
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+    run_async(_seed_play_row(db_path, show_id, status="merged", session_id=session_id))
+
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: True)
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "active"
+
+
+def test_reap_stale_shows_reaps_dead_child_session(tmp_path, monkeypatch):
+    """A show whose linked child session is confirmed dead (not merely absent)
+    is reaped once stale and the on-disk plays are all merged."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "dead-session-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    session_id = run_async(_seed_session(db_path))
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+    run_async(_seed_play_row(db_path, show_id, status="merged", session_id=session_id))
+
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 1
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "completed"
+
+
+# ── already-terminal: never reaped ────────────────────────────────────────────
+
+
+def test_reap_stale_shows_skips_already_terminal(tmp_path, monkeypatch):
+    """A show already in a terminal status is left untouched, regardless of
+    on-disk state — it is outside the reapable status set entirely."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "terminal-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, status="completed", updated_at=_STALE))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "completed"
+
+
+# ── staleness grace ────────────────────────────────────────────────────────────
+
+
+def test_reap_stale_shows_skips_fresh(tmp_path, monkeypatch):
+    """A fresh (recently updated) show is not reaped even if fully merged on
+    disk — the staleness window gives it the benefit of the doubt."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "fresh-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=time.time()))
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "active"
+
+
+# ── CAS / version guard ───────────────────────────────────────────────────────
+
+
+def test_reap_stale_shows_version_guard_skips_claimed_row(tmp_path, monkeypatch):
+    """A stale, reapable show that gets re-touched (re-imported/re-touched
+    updated_at) after the reaper's fresh re-read validated it, but before the
+    guarded write lands, must not be clobbered. The expected_updated_at
+    optimistic-lock guard pins the transition to the exact row version
+    validated, so the bumped updated_at defeats the write."""
+    db_path = tmp_path / "state.db"
+    show_dir = tmp_path / "shows" / "claimed-topic"
+    _write_play_meta(show_dir, "play-one", status="merged")
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
+
+    import lionagi.state.db as state_db_mod
+
+    original_update_status = state_db_mod.StateDB.update_status
+    claimed = {"done": False}
+
+    async def _claim_then_update(self, entity_type, entity_id, **kwargs):
+        if entity_type == "show" and entity_id == show_id and not claimed["done"]:
+            claimed["done"] = True
+            await self.execute(
+                "UPDATE shows SET updated_at = ? WHERE id = ?",
+                (time.time(), show_id),
+            )
+        return await original_update_status(self, entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(state_db_mod.StateDB, "update_status", _claim_then_update)
+
+    from lionagi.studio.services.lifecycle import reap_stale_shows
+
+    count = run_async(reap_stale_shows(stale_hours=6.0))
+    assert count == 0
+
+    show = run_async(_get_show(db_path, show_id))
+    assert show["status"] == "active"
+
+
+# ── wiring ───────────────────────────────────────────────────────────────────────
+
+
+def test_run_startup_reconciliation_includes_stale_shows_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    from lionagi.studio.services.lifecycle import run_startup_reconciliation
+
+    results = run_async(run_startup_reconciliation())
+    assert "stale_shows" in results
+    assert isinstance(results["stale_shows"], int)
+
+
+def test_run_periodic_reapers_includes_stale_shows_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    from lionagi.studio.services.lifecycle import run_periodic_reapers
+
+    results = run_async(run_periodic_reapers())
+    assert "stale_shows" in results
+    assert isinstance(results["stale_shows"], int)


### PR DESCRIPTION
## Summary

Studio "phantom shows": show rows stick at `status="active"` forever. Root cause: show status is computed **only at mirror-row creation** (`shows.py` — the status block sits inside the `else` of `if existing:`), so a show mirrored while its plays are still running gets `active` and is never re-evaluated when the plays later merge/terminate on disk. Sessions, invocations, plays, and schedule_runs all have lifecycle reapers; shows had none.

## Change

- **`lionagi/studio/services/lifecycle.py`** — new `reap_stale_shows()` mirroring `reap_stale_plays()`: for each non-terminal show past the staleness threshold, recompute terminal state from on-disk evidence using the exact rules `import_shows()` applies at creation (`_ABORT` → aborted; `_final_verdict.json` show_passed → completed; all child plays merged → completed; otherwise skip). Liveness-first: if any child play's session process is still alive, the show is never reaped. Wired into `run_startup_reconciliation()` and `run_periodic_reapers()`.
- **CAS discipline**: writes go only through `StateDB.update_status()` with `expected_statuses` (the non-terminal complement of the show terminal set) plus an `expected_updated_at` optimistic-lock guard — a row whose status or version changed under the reaper is skipped, never clobbered.
- **`lionagi/studio/config.py`** — `SHOW_STALE_HOURS` (env `LIONAGI_STUDIO_SHOW_STALE_HOURS`, default 6.0), beside `PLAY_STALE_HOURS`.
- **`lionagi/state/reasons.py`** — `ShowReasons.COMPLETED_ALL_PLAYS_MERGED` for the all-merged completion path (every guarded write requires a reason code).

## Tests

New `tests/apps_studio_server/test_lifecycle_show_reaper.py` (10 tests): all-merged reap, abort-marker reap, in-flight skip, liveness-first skip, dead-session reap, already-terminal skip, staleness-grace skip, CAS/version-guard skip (flips `updated_at` mid-transition and asserts no clobber), plus periodic/startup wiring.

Full reaper + shows suite: **56 passed** (`test_lifecycle_show_reaper.py`, `test_lifecycle_play_reaper.py`, `test_lifecycle_reapers.py`, `test_shows.py`). `ruff` clean.
