### PR TITLE
feat(cli): li kill reaps detached-play workers transitively (ADR-0104)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,7 +25,7 @@ worker.
 | `li monitor run ID...` | Wait for scheduled runs and their chains; optionally keep watching |
 | `li agent status [ID]` | Read stable session/invocation status, optionally as JSON |
 | `li o ctl {status,pause,resume,msg}` | Inspect or steer a live flow by ID |
-| `li kill ID` | Terminate one running entity or sweep stale processes |
+| `li kill ID` | Terminate one running entity or sweep stale processes; play kills also reap the linked worker chain |
 
 ### Reuse, coordination, and operation
 

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -216,7 +216,7 @@ async def _list_running_children(
 async def _walk_running_children(
     db: Any, entity_type: str, entity_id: str
 ) -> list[tuple[str, str, dict[str, Any]]]:
-    """Breadth-first running descendants, bounded against malformed cycles."""
+    """Discover running descendants breadth-first and return them deepest-first."""
     frontier = deque(await _list_running_children(db, entity_type, entity_id))
     seen = {(entity_type, entity_id)}
     children: list[tuple[str, str, dict[str, Any]]] = []
@@ -238,6 +238,7 @@ async def _walk_running_children(
         children.append((table, child_type, child_row))
         frontier.extend(await _list_running_children(db, child_type, child_id))
 
+    children.reverse()
     return children
 
 
@@ -416,8 +417,14 @@ async def _do_kill(
         results = []
         blocked = []
 
-        if recursive or entity_type == "play":
+        if entity_type == "play":
             children = await _walk_running_children(db, entity_type, row["id"])
+        elif recursive:
+            children = await _list_running_children(db, entity_type, row["id"])
+        else:
+            children = []
+
+        if children:
             for _child_table, child_type, child_row in children:
                 r = await _kill_one(
                     db,
@@ -676,7 +683,7 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
             "  li kill abc123                        # kill by id prefix\n"
             "  li kill <play-id>                     # also reap linked workers\n"
             "  li kill abc123 --reason 'stuck'\n"
-            "  li kill abc123 --recursive            # kill + transitive descendants\n"
+            "  li kill abc123 --recursive            # kill + direct children\n"
             "  li kill --all-stale                   # sweep dead-PID rows\n"
             "  li kill --all-stale --threshold 3600  # only rows older than 1h\n"
             "  li kill --all-stale --dry-run\n"
@@ -701,7 +708,7 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--recursive",
         action="store_true",
         help=(
-            "Also kill transitive child entities (e.g. invocations spawned by a session). "
+            "Also kill direct child entities (e.g. invocations spawned by a session). "
             "Play kills always reap their linked workers."
         ),
     )

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import signal
 import time
+from collections import deque
 from typing import Any
 
 import psutil
@@ -159,6 +160,7 @@ def _terminate_pid(
 
 # Only sessions/invocations carry PIDs; plays/shows are orchestrators.
 _STALE_SWEEP_ORDER = ("sessions", "invocations")
+_MAX_RECURSIVE_CHILDREN = 100
 
 
 async def _list_running_children(
@@ -173,6 +175,20 @@ async def _list_running_children(
         )
         for row in rows:
             children.append(("plays", "play", db._row_to_dict(row)))
+
+    if entity_type == "play":
+        rows = await db.fetch_all(
+            "SELECT sessions.* FROM plays "
+            "JOIN sessions ON sessions.id = plays.session_id "
+            "WHERE plays.id = ? AND sessions.status = 'running'",
+            (entity_id,),
+        )
+        if not rows:
+            warn(f"play {entity_id[:12]} has no running worker session to reap")
+        for row in rows:
+            session_row = db._row_to_dict(row)
+            children.append(("sessions", "session", session_row))
+            children.extend(await _list_running_children(db, "session", session_row["id"]))
 
     if entity_type == "session":
         rows = await db.fetch_all(
@@ -193,6 +209,34 @@ async def _list_running_children(
         )
         for row in rows:
             children.append(("sessions", "session", db._row_to_dict(row)))
+
+    return children
+
+
+async def _walk_running_children(
+    db: Any, entity_type: str, entity_id: str
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """Breadth-first running descendants, bounded against malformed cycles."""
+    frontier = deque(await _list_running_children(db, entity_type, entity_id))
+    seen = {(entity_type, entity_id)}
+    children: list[tuple[str, str, dict[str, Any]]] = []
+
+    while frontier:
+        table, child_type, child_row = frontier.popleft()
+        child_id = child_row["id"]
+        child_key = (child_type, child_id)
+        if child_key in seen:
+            continue
+        if len(children) >= _MAX_RECURSIVE_CHILDREN:
+            warn(
+                f"recursive kill stopped after {_MAX_RECURSIVE_CHILDREN} children; "
+                "remaining descendants were not reaped"
+            )
+            break
+
+        seen.add(child_key)
+        children.append((table, child_type, child_row))
+        frontier.extend(await _list_running_children(db, child_type, child_id))
 
     return children
 
@@ -372,8 +416,8 @@ async def _do_kill(
         results = []
         blocked = []
 
-        if recursive:
-            children = await _list_running_children(db, entity_type, row["id"])
+        if recursive or entity_type == "play":
+            children = await _walk_running_children(db, entity_type, row["id"])
             for _child_table, child_type, child_row in children:
                 r = await _kill_one(
                     db,
@@ -630,8 +674,9 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
             "or 'aborted' (shows) with reason tracking per ADR-0028.\n\n"
             "Examples:\n"
             "  li kill abc123                        # kill by id prefix\n"
+            "  li kill <play-id>                     # also reap linked workers\n"
             "  li kill abc123 --reason 'stuck'\n"
-            "  li kill abc123 --recursive            # kill + child invocations\n"
+            "  li kill abc123 --recursive            # kill + transitive descendants\n"
             "  li kill --all-stale                   # sweep dead-PID rows\n"
             "  li kill --all-stale --threshold 3600  # only rows older than 1h\n"
             "  li kill --all-stale --dry-run\n"
@@ -655,7 +700,10 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
     kill.add_argument(
         "--recursive",
         action="store_true",
-        help="Also kill child entities (e.g. invocations spawned by a session).",
+        help=(
+            "Also kill transitive child entities (e.g. invocations spawned by a session). "
+            "Play kills always reap their linked workers."
+        ),
     )
     kill.add_argument(
         "--all-stale",
@@ -663,7 +711,7 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Sweep stale sessions and invocations with dead PIDs older than --threshold. "
             "Plays and shows are not swept (they are orchestrators without direct PIDs; "
-            "use --recursive with an explicit ID instead)."
+            "use an explicit ID instead; play kills reap linked workers automatically)."
         ),
     )
     kill.add_argument(

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -11,6 +13,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from lionagi.cli.kill import (
     _check_pid_identity,
@@ -96,7 +99,13 @@ async def _seed_show(db: StateDB, *, status: str = "active") -> str:
     return show_id
 
 
-async def _seed_play(db: StateDB, show_id: str, *, status: str = "running") -> str:
+async def _seed_play(
+    db: StateDB,
+    show_id: str,
+    *,
+    status: str = "running",
+    session_id: str | None = None,
+) -> str:
     play_id = str(uuid.uuid4())
     await db.create_play(
         {
@@ -104,6 +113,7 @@ async def _seed_play(db: StateDB, show_id: str, *, status: str = "running") -> s
             "show_id": show_id,
             "name": f"play-{play_id[:8]}",
             "status": status,
+            "session_id": session_id,
         }
     )
     return play_id
@@ -818,6 +828,146 @@ async def test_do_kill_all_stale_uses_stale_auto_reason(
 
 
 # ── cascade kill ───────────────────────────────────────────────────────────────
+
+
+async def test_list_running_children_show_behavior_is_unchanged(temp_db_path: Path):
+    """The existing show branch continues to return only running direct plays."""
+    async with StateDB() as db:
+        show_id = await _seed_show(db)
+        running_play_id = await _seed_play(db, show_id, status="running")
+        await _seed_play(db, show_id, status="blocked")
+
+        children = await _list_running_children(db, "show", show_id)
+
+    assert [(kind, row["id"]) for _, kind, row in children] == [("play", running_play_id)]
+
+
+async def test_walk_running_children_stops_at_safety_cap(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The transitive walk terminates and warns if malformed links exceed its cap."""
+    import lionagi.cli.kill as kill_mod
+
+    async def fake_children(db: Any, entity_type: str, entity_id: str):
+        next_id = str(int(entity_id) + 1)
+        return [("sessions", "session", {"id": next_id})]
+
+    warnings: list[str] = []
+    monkeypatch.setattr(kill_mod, "_MAX_RECURSIVE_CHILDREN", 2)
+    monkeypatch.setattr(kill_mod, "_list_running_children", fake_children)
+    monkeypatch.setattr(kill_mod, "warn", warnings.append)
+
+    children = await kill_mod._walk_running_children(object(), "play", "0")
+
+    assert [row["id"] for _, _, row in children] == ["1", "2"]
+    assert warnings == [
+        "recursive kill stopped after 2 children; remaining descendants were not reaped"
+    ]
+
+
+async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A bare play kill reaps its linked session and invocation before the play."""
+    signalled_pids: list[int] = []
+
+    def fake_terminate(pid: int, **kwargs: Any) -> str:
+        assert pid > 1
+        signalled_pids.append(pid)
+        return "sigterm"
+
+    monkeypatch.setattr("lionagi.cli.kill._terminate_pid", fake_terminate)
+
+    async with StateDB() as db:
+        invocation_id = await _seed_invocation(db, status="running", pid=42002)
+        session_id = await _seed_session(db, status="running", pid=42001)
+        await db.update_session(session_id, invocation_id=invocation_id)
+        show_id = await _seed_show(db)
+        play_id = await _seed_play(db, show_id, session_id=session_id)
+
+    rc = await _do_kill(play_id)
+
+    assert rc == 0
+    assert signalled_pids == [42001, 42002]
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (session_id,)))[
+            "status"
+        ] == "cancelled"
+        assert (
+            await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (invocation_id,))
+        )["status"] == "cancelled"
+        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
+            "status"
+        ] == "blocked"
+
+
+async def test_do_kill_emits_settings_terminal_notification(temp_db_path: Path, tmp_path: Path):
+    """The kill transition still reaches the settings notify handler exactly once."""
+    async with StateDB() as db:
+        session_id = await _seed_session(db, status="running")
+
+    output_path = tmp_path / "kill-notify.jsonl"
+    project_dir = tmp_path / "project"
+    settings_dir = project_dir / ".lionagi"
+    settings_dir.mkdir(parents=True)
+    capture_script = (
+        "import pathlib, sys; pathlib.Path(sys.argv[1]).open('a').write(sys.stdin.read() + '\\n')"
+    )
+    (settings_dir / "settings.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "notify": {
+                    "on_terminal": {
+                        "enabled": True,
+                        "adapter": {
+                            "kind": "exec",
+                            "argv": [sys.executable, "-c", capture_script, str(output_path)],
+                        },
+                        "filter": {"ids": [session_id]},
+                    }
+                }
+            }
+        )
+    )
+
+    from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+    from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
+
+    callback_name = "notify.settings.on_terminal"
+    DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+    assert register_settings_terminal_callback(project_dir=str(project_dir)) is True
+    try:
+        assert await _do_kill(session_id) == 0
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+
+    payloads = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert len(payloads) == 1
+    assert payloads[0]["entity"] == {"kind": "session", "id": session_id}
+    assert payloads[0]["terminal_status"] == "cancelled"
+    assert payloads[0]["reason_code"] == RunReasons.CANCELLED_MANUAL_KILL
+
+
+async def test_do_kill_play_without_session_warns_and_continues(
+    temp_db_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A NULL play session link is status-only but never silently misleading."""
+    from lionagi.cli._logging import configure_cli_logging
+
+    configure_cli_logging(verbose=False)
+    async with StateDB() as db:
+        show_id = await _seed_show(db)
+        play_id = await _seed_play(db, show_id, session_id=None)
+
+    capsys.readouterr()
+    rc = await _do_kill(play_id)
+
+    assert rc == 0
+    assert f"play {play_id[:12]} has no running worker session to reap" in capsys.readouterr().err
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
+            "status"
+        ] == "blocked"
 
 
 async def test_do_kill_recursive_kills_child_invocations(

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -859,24 +859,70 @@ async def test_walk_running_children_stops_at_safety_cap(
 
     children = await kill_mod._walk_running_children(object(), "play", "0")
 
-    assert [row["id"] for _, _, row in children] == ["1", "2"]
+    assert [row["id"] for _, _, row in children] == ["2", "1"]
     assert warnings == [
         "recursive kill stopped after 2 children; remaining descendants were not reaped"
     ]
+
+
+async def test_walk_running_children_cycle_terminates_without_cap_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A finite session/invocation cycle is deduplicated before the cap check."""
+    import lionagi.cli.kill as kill_mod
+
+    session = ("sessions", "session", {"id": "session-a"})
+    invocation = ("invocations", "invocation", {"id": "invocation-b"})
+    graph = {
+        ("play", "play-root"): [session],
+        ("session", "session-a"): [invocation],
+        ("invocation", "invocation-b"): [session],
+    }
+    calls: list[tuple[str, str]] = []
+
+    async def fake_children(db: Any, entity_type: str, entity_id: str):
+        calls.append((entity_type, entity_id))
+        return graph.get((entity_type, entity_id), [])
+
+    warnings: list[str] = []
+    monkeypatch.setattr(kill_mod, "_MAX_RECURSIVE_CHILDREN", 2)
+    monkeypatch.setattr(kill_mod, "_list_running_children", fake_children)
+    monkeypatch.setattr(kill_mod, "warn", warnings.append)
+
+    children = await kill_mod._walk_running_children(object(), "play", "play-root")
+
+    assert [row["id"] for _, _, row in children] == ["invocation-b", "session-a"]
+    assert calls == [
+        ("play", "play-root"),
+        ("session", "session-a"),
+        ("invocation", "invocation-b"),
+    ]
+    assert warnings == []
 
 
 async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """A bare play kill reaps its linked session and invocation before the play."""
+    import lionagi.cli.kill as kill_mod
+
     signalled_pids: list[int] = []
+    persisted_entities: list[tuple[str, str]] = []
+    original_persist_cancel = kill_mod._persist_cancel
 
     def fake_terminate(pid: int, **kwargs: Any) -> str:
         assert pid > 1
         signalled_pids.append(pid)
         return "sigterm"
 
-    monkeypatch.setattr("lionagi.cli.kill._terminate_pid", fake_terminate)
+    async def record_persist_cancel(
+        db: Any, entity_type: str, entity_id: str, **kwargs: Any
+    ) -> None:
+        persisted_entities.append((entity_type, entity_id))
+        await original_persist_cancel(db, entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(kill_mod, "_terminate_pid", fake_terminate)
+    monkeypatch.setattr(kill_mod, "_persist_cancel", record_persist_cancel)
 
     async with StateDB() as db:
         invocation_id = await _seed_invocation(db, status="running", pid=42002)
@@ -888,7 +934,12 @@ async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
     rc = await _do_kill(play_id)
 
     assert rc == 0
-    assert signalled_pids == [42001, 42002]
+    assert signalled_pids == [42002, 42001]
+    assert persisted_entities == [
+        ("invocation", invocation_id),
+        ("session", session_id),
+        ("play", play_id),
+    ]
     async with StateDB() as db:
         assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (session_id,)))[
             "status"
@@ -899,6 +950,51 @@ async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
             "status"
         ] == "blocked"
+
+
+async def test_do_kill_recursive_show_does_not_reap_play_workers(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A recursive show kill remains limited to its direct running plays."""
+    signalled_pids: list[int] = []
+
+    def fake_terminate(pid: int, **kwargs: Any) -> str:
+        signalled_pids.append(pid)
+        return "sigterm"
+
+    async with StateDB() as db:
+        invocation_id = await _seed_invocation(db, status="running", pid=43002)
+        session_id = await _seed_session(db, status="running", pid=43001)
+        await db.update_session(session_id, invocation_id=invocation_id)
+        show_id = await _seed_show(db)
+        play_id = await _seed_play(db, show_id, session_id=session_id)
+
+    async def resolve_running_show(db: StateDB, id_or_short: str):
+        assert id_or_short == show_id
+        show_row = await db.fetch_one("SELECT * FROM shows WHERE id = ?", (show_id,))
+        assert show_row is not None
+        show_row["status"] = "running"
+        return "shows", "show", show_row
+
+    monkeypatch.setattr("lionagi.cli.kill._resolve_entity", resolve_running_show)
+    monkeypatch.setattr("lionagi.cli.kill._terminate_pid", fake_terminate)
+
+    assert await _do_kill(show_id, recursive=True) == 0
+    assert signalled_pids == []
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM shows WHERE id = ?", (show_id,)))[
+            "status"
+        ] == "aborted"
+        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
+            "status"
+        ] == "blocked"
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (session_id,)))[
+            "status"
+        ] == "running"
+        assert (
+            await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (invocation_id,))
+        )["status"] == "running"
 
 
 async def test_do_kill_emits_settings_terminal_notification(temp_db_path: Path, tmp_path: Path):
@@ -948,6 +1044,44 @@ async def test_do_kill_emits_settings_terminal_notification(temp_db_path: Path, 
     assert payloads[0]["reason_code"] == RunReasons.CANCELLED_MANUAL_KILL
 
 
+async def test_do_kill_play_emits_blocked_terminal_envelope(temp_db_path: Path):
+    """A play kill emits its blocked envelope through the lifecycle callback seam."""
+    from lionagi.state.lifecycle.callbacks import (
+        DEFAULT_TERMINAL_CALLBACKS,
+        RunTerminalEnvelope,
+    )
+
+    async with StateDB() as db:
+        session_id = await _seed_session(db, status="running")
+        show_id = await _seed_show(db)
+        play_id = await _seed_play(db, show_id, session_id=session_id)
+
+    received: list[RunTerminalEnvelope] = []
+
+    async def collect(envelope: RunTerminalEnvelope) -> None:
+        received.append(envelope)
+
+    callback_name = "test.kill.play-terminal"
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        callback_name,
+        collect,
+        kinds=["play"],
+        ids=[play_id],
+    )
+    try:
+        assert await _do_kill(play_id) == 0
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+
+    assert len(received) == 1
+    envelope = received[0]
+    assert envelope.entity.kind == "play"
+    assert envelope.entity.id == play_id
+    assert envelope.previous_status == "running"
+    assert envelope.terminal_status == "blocked"
+    assert envelope.reason_code == RunReasons.CANCELLED_MANUAL_KILL
+
+
 async def test_do_kill_play_without_session_warns_and_continues(
     temp_db_path: Path, capsys: pytest.CaptureFixture[str]
 ):
@@ -963,6 +1097,36 @@ async def test_do_kill_play_without_session_warns_and_continues(
     rc = await _do_kill(play_id)
 
     assert rc == 0
+    assert f"play {play_id[:12]} has no running worker session to reap" in capsys.readouterr().err
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
+            "status"
+        ] == "blocked"
+
+
+async def test_do_kill_play_with_dangling_session_warns_and_continues(
+    temp_db_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A non-NULL play link with no session row warns and still blocks the play."""
+    import sqlite3
+
+    from lionagi.cli._logging import configure_cli_logging
+
+    configure_cli_logging(verbose=False)
+    dangling_session_id = str(uuid.uuid4())
+    async with StateDB() as db:
+        show_id = await _seed_show(db)
+        play_id = await _seed_play(db, show_id)
+
+    with sqlite3.connect(temp_db_path) as conn:
+        conn.execute(
+            "UPDATE plays SET session_id = ? WHERE id = ?",
+            (dangling_session_id, play_id),
+        )
+
+    capsys.readouterr()
+    assert await _do_kill(play_id) == 0
+
     assert f"play {play_id[:12]} has no running worker session to reap" in capsys.readouterr().err
     async with StateDB() as db:
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[


### PR DESCRIPTION
## Summary

Implements **ADR-0104** (D1/D2/D5): `li kill <play_id>` now actually stops a detached play's workers.

Previously `_list_running_children` had no play branch, so `li kill <play_id> --recursive` found zero children; plays carry no PID, so the kill was a status-only row write and the play's spawned session/invocation OS processes survived.

## Changes (`lionagi/cli/kill.py`)

- **D1** — play → session resolution via the `plays.session_id` linkage (the schema's singular play-worker link), then session → invocations; wrapped in a new `_walk_running_children` bounded breadth-first walk (cycle-guarded via a seen-set, capped at 100 descendants with an explicit warning when the cap truncates).
- **D2** — a play kill implies worker recursion: `recursive or entity_type == "play"`. A row-only play kill was a footgun (reads as success, terminates nothing).
- Dangling/NULL `session_id`: warns `play <id> has no running worker session to reap` and continues.
- CLI help updated; `docs/cli-reference.md` now documents that play kills reap the linked worker chain.
- **D4 (per the ADR) remains deferred** — no per-run notify persistence in this PR.

## Tests (D5, `tests/cli/test_kill.py`)

- play kill reaps the PID-bearing child session and its invocations (OS-signal path via the existing mock pattern; killpg guard respected)
- kill → terminal lifecycle notification still fires (settings-notify path)
- NULL `session_id`: asserts the exact warning text, not just no-crash
- recursion safety cap + unchanged show child-list behavior

Full file: **53 passed**. `tests/state/ -k lifecycle` green. `ruff` clean.

Implements the accepted `docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md`.
