### PR TITLE
fix(studio): Fleet stats — persisted duration bounds, sanitized file stats, honest totals

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.test.ts
+++ b/apps/studio/frontend/src/components/RunStepCard.test.ts
@@ -5,6 +5,7 @@ import {
   stepPropsEqual,
   collapsedTextFor,
   extractFilePaths,
+  pathFromArgs,
 } from "./RunStepCard";
 import type { RunMessage, RunStep } from "@/lib/types";
 
@@ -196,5 +197,33 @@ describe("extractFilePaths — the known file surface behind file links", () => 
 
   it("returns an empty list when there is no file activity", () => {
     expect(extractFilePaths([])).toEqual([]);
+  });
+});
+
+describe("pathFromArgs — shell-derived file paths", () => {
+  it("strips shell separators and dedupes the normalized file path", () => {
+    expect(
+      pathFromArgs(
+        { command: "python /repo/scripts/check.py; sed -n '1p' /repo/scripts/check.py" },
+        "",
+      ),
+    ).toEqual(["/repo/scripts/check.py"]);
+  });
+
+  it("excludes root markers, directory-looking paths, and interpreter binaries", () => {
+    expect(
+      pathFromArgs(
+        { command: "cd //; cd /repo/worktree; /repo/.venv/bin/li run /repo/src/main.py" },
+        "",
+      ),
+    ).toEqual(["/repo/src/main.py"]);
+  });
+
+  it("trusts structured file_path values even when a filename has no extension", () => {
+    expect(pathFromArgs({ file_path: "/repo/Makefile" }, "", "Read")).toEqual(["/repo/Makefile"]);
+  });
+
+  it("does not treat a directory-valued path from a search tool as a file", () => {
+    expect(pathFromArgs({ path: "/repo/src" }, "", "Glob")).toEqual([]);
   });
 });

--- a/apps/studio/frontend/src/components/RunStepCard.test.ts
+++ b/apps/studio/frontend/src/components/RunStepCard.test.ts
@@ -226,4 +226,19 @@ describe("pathFromArgs — shell-derived file paths", () => {
   it("does not treat a directory-valued path from a search tool as a file", () => {
     expect(pathFromArgs({ path: "/repo/src" }, "", "Glob")).toEqual([]);
   });
+
+  it.each([
+    ["cat src/worker.py", ["src/worker.py"]],
+    ["cat ./README", ["README"]],
+    ["cat ./.env", [".env"]],
+    ["cat bin/config.json", ["bin/config.json"]],
+  ])("retains ordinary Bash file operand from %s", (command, expected) => {
+    expect(pathFromArgs({ command }, "", "Bash")).toEqual(expected);
+  });
+
+  it("normalizes lexical aliases before deduplication", () => {
+    expect(
+      pathFromArgs({ command: "cat /repo/src/a.py /repo/src/../src/a.py" }, "", "Bash"),
+    ).toEqual(["/repo/src/a.py"]);
+  });
 });

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -34,6 +34,7 @@ interface StepResult {
   agent?: string;
   model?: string;
   message_count?: number;
+  duration_sec?: number;
   roles?: RolesBreakdown;
   [key: string]: unknown;
 }
@@ -301,7 +302,12 @@ function RunStepCard({
       if (firstTs == null) firstTs = m.timestamp;
       lastTs = m.timestamp;
     }
-    const durationSec = firstTs != null && lastTs != null ? Math.round(lastTs - firstTs) : null;
+    const durationSec =
+      typeof result.duration_sec === "number"
+        ? result.duration_sec
+        : firstTs != null && lastTs != null
+          ? Math.round(lastTs - firstTs)
+          : null;
 
     return {
       toolCount: toolMessages.length,
@@ -649,6 +655,8 @@ export function stepPropsEqual(prev: RunStepCardProps, next: RunStepCardProps): 
     prev.step.timestamp === next.step.timestamp &&
     prevResult.agent === nextResult.agent &&
     prevResult.model === nextResult.model &&
+    prevResult.message_count === nextResult.message_count &&
+    prevResult.duration_sec === nextResult.duration_sec &&
     prev.runId === next.runId &&
     prev.artifactRoot === next.artifactRoot &&
     prev.runFiles === next.runFiles &&

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -538,7 +538,7 @@ function RunStepCard({
               active={tab}
               onSelect={setTab}
               label={t("tabConversation")}
-              count={messages.length}
+              count={Math.max(result.message_count ?? 0, messages.length)}
               panelId={`step-${step.step}-panel-conversation`}
               buttonId={`step-${step.step}-tab-conversation`}
               tabIndex={tab === "conversation" ? 0 : -1}

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -33,7 +33,7 @@ interface RolesBreakdown {
 interface StepResult {
   agent?: string;
   model?: string;
-  message_count?: number;
+  message_count?: number | null;
   duration_sec?: number;
   roles?: RolesBreakdown;
   [key: string]: unknown;
@@ -166,28 +166,71 @@ const SHELL_FILE_NAMES = new Set([
   "Procfile",
   "Rakefile",
 ]);
-const SHELL_NON_FILE_SEGMENTS = new Set(["bin", "sbin", ".venv", "venv", "node_modules"]);
+const SHELL_INTERPRETER_NAMES = new Set([
+  "bash",
+  "bun",
+  "deno",
+  "li",
+  "node",
+  "perl",
+  "php",
+  "python",
+  "python2",
+  "python3",
+  "ruby",
+  "sh",
+  "zsh",
+]);
+
+function normalizeShellPath(path: string): string {
+  const absolute = path.startsWith("/");
+  const normalized: string[] = [];
+  for (const segment of path.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      const previous = normalized.at(-1);
+      if (previous && previous !== "..") normalized.pop();
+      else if (!absolute) normalized.push(segment);
+      continue;
+    }
+    normalized.push(segment);
+  }
+  return `${absolute ? "/" : ""}${normalized.join("/")}`;
+}
 
 function shellFilePath(token: string): string | null {
   const path = token.replace(/[,:]+$/, "");
-  if (!path || path === "/" || path.replace(/\//g, "") === "") return null;
-  if (path.endsWith("/")) return null;
-  const segments = path.split("/").filter(Boolean);
-  if (segments.some((segment) => SHELL_NON_FILE_SEGMENTS.has(segment))) return null;
+  if (!path || path.startsWith("-") || path.endsWith("/")) return null;
+  const normalized = normalizeShellPath(path);
+  if (!normalized || normalized === "/") return null;
+  const segments = normalized.split("/").filter(Boolean);
   const basename = segments.at(-1);
   if (!basename || basename === "." || basename === "..") return null;
+  if (SHELL_INTERPRETER_NAMES.has(basename.toLowerCase())) return null;
+  if (/(?:^|\/)\.?venv\/bin\/[^/]+$/.test(normalized)) return null;
   const looksLikeFile =
     SHELL_FILE_NAMES.has(basename) ||
-    (basename.includes(".") && !basename.endsWith(".") && !basename.startsWith("."));
-  return looksLikeFile ? path : null;
+    path.includes("/") ||
+    (basename.includes(".") && !basename.endsWith("."));
+  return looksLikeFile ? normalized : null;
 }
 
 function shellFilePaths(command: string): string[] {
   const paths = new Set<string>();
-  const pattern = /(?:^|[\s"'`])((?:\/|\.{1,2}\/)[^\s"'`|&;<>()[\]{}]+)/g;
-  for (const match of command.matchAll(pattern)) {
-    const path = shellFilePath(match[1]);
-    if (path) paths.add(path);
+  for (const segment of command.split(/(?:&&|\|\||[;|<>\n])/)) {
+    const words = Array.from(segment.matchAll(/"([^"]*)"|'([^']*)'|`([^`]*)`|([^\s]+)/g)).map(
+      (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+    );
+    let commandIndex = 0;
+    while (commandIndex < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[commandIndex])) {
+      commandIndex += 1;
+    }
+    const commandName = words[commandIndex]?.split("/").at(-1)?.toLowerCase();
+    if (commandName === "cd" || commandName === "pushd" || commandName === "popd") continue;
+    for (const word of words.slice(commandIndex + 1)) {
+      const path = shellFilePath(word);
+      if (path) paths.add(path);
+    }
   }
   return Array.from(paths);
 }
@@ -376,7 +419,7 @@ function RunStepCard({
       firstTs,
       lastTs,
     };
-  }, [messages]);
+  }, [messages, result.duration_sec]);
 
   // File-link resolution context (shared by the overview + conversation
   // Markdown renderers): agent dir first, then the run-wide file surface.
@@ -538,7 +581,11 @@ function RunStepCard({
               active={tab}
               onSelect={setTab}
               label={t("tabConversation")}
-              count={Math.max(result.message_count ?? 0, messages.length)}
+              count={
+                result.message_count === null
+                  ? undefined
+                  : Math.max(result.message_count ?? 0, messages.length)
+              }
               panelId={`step-${step.step}-panel-conversation`}
               buttonId={`step-${step.step}-tab-conversation`}
               tabIndex={tab === "conversation" ? 0 : -1}

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -158,24 +158,77 @@ function isEditTool(fn: string): boolean {
   return /Edit|patch/i.test(fn);
 }
 
-export function pathFromArgs(args: Record<string, unknown>, summary: string): string[] {
+const SHELL_FILE_NAMES = new Set([
+  "Dockerfile",
+  "Gemfile",
+  "Justfile",
+  "Makefile",
+  "Procfile",
+  "Rakefile",
+]);
+const SHELL_NON_FILE_SEGMENTS = new Set(["bin", "sbin", ".venv", "venv", "node_modules"]);
+
+function shellFilePath(token: string): string | null {
+  const path = token.replace(/[,:]+$/, "");
+  if (!path || path === "/" || path.replace(/\//g, "") === "") return null;
+  if (path.endsWith("/")) return null;
+  const segments = path.split("/").filter(Boolean);
+  if (segments.some((segment) => SHELL_NON_FILE_SEGMENTS.has(segment))) return null;
+  const basename = segments.at(-1);
+  if (!basename || basename === "." || basename === "..") return null;
+  const looksLikeFile =
+    SHELL_FILE_NAMES.has(basename) ||
+    (basename.includes(".") && !basename.endsWith(".") && !basename.startsWith("."));
+  return looksLikeFile ? path : null;
+}
+
+function shellFilePaths(command: string): string[] {
+  const paths = new Set<string>();
+  const pattern = /(?:^|[\s"'`])((?:\/|\.{1,2}\/)[^\s"'`|&;<>()[\]{}]+)/g;
+  for (const match of command.matchAll(pattern)) {
+    const path = shellFilePath(match[1]);
+    if (path) paths.add(path);
+  }
+  return Array.from(paths);
+}
+
+function isStructuredFileTool(fn: string): boolean {
+  if (!fn) return true;
+  const name = fn.toLowerCase().replaceAll("-", "_").split("__").at(-1)?.split(".").at(-1);
+  return (
+    name != null &&
+    [
+      "read",
+      "read_file",
+      "write",
+      "write_file",
+      "edit",
+      "edit_file",
+      "multiedit",
+      "notebookedit",
+    ].includes(name)
+  );
+}
+
+export function pathFromArgs(
+  args: Record<string, unknown>,
+  _summary: string,
+  functionName = "",
+): string[] {
   const out: string[] = [];
-  if (args.file_path) out.push(String(args.file_path));
-  if (args.path) out.push(String(args.path));
-  if (args.changes && Array.isArray(args.changes)) {
+  if (isStructuredFileTool(functionName)) {
+    if (args.file_path) out.push(String(args.file_path));
+    if (args.path) out.push(String(args.path));
+  }
+  if ((!functionName || /patch|edit/i.test(functionName)) && Array.isArray(args.changes)) {
     for (const c of args.changes) {
       if (c && typeof c === "object" && "path" in c) out.push(String((c as { path: string }).path));
     }
   }
-  // Try to extract paths from `cmd`/`command` like `sed -n '1,220p' /path/to/file`
-  if (out.length === 0 && (args.cmd || args.command || summary)) {
-    const text = String(args.cmd || args.command || summary);
-    const pathMatch = text.match(/(?:^|\s)(\/[^\s'"`)]+(?:\.\w+)?)/g);
-    if (pathMatch) {
-      for (const p of pathMatch) out.push(p.trim());
-    }
+  if (out.length === 0 && (args.cmd || args.command)) {
+    out.push(...shellFilePaths(String(args.cmd || args.command)));
   }
-  return out;
+  return Array.from(new Set(out));
 }
 
 /** The run's known file surface for one branch's messages — same source
@@ -186,7 +239,7 @@ export function extractFilePaths(messages: RunMessage[]): string[] {
   const paths = new Set<string>();
   for (const t of toolMessages) {
     const args = (t.arguments as Record<string, unknown>) ?? {};
-    for (const p of pathFromArgs(args, t.summary || "")) paths.add(p);
+    for (const p of pathFromArgs(args, t.summary || "", t.function || "")) paths.add(p);
   }
   return Array.from(paths);
 }
@@ -268,7 +321,7 @@ function RunStepCard({
     for (const t of toolMessages) {
       const args = (t.arguments as Record<string, unknown>) ?? {};
       const fn = t.function || "";
-      const paths = pathFromArgs(args, t.summary || "");
+      const paths = pathFromArgs(args, t.summary || "", fn);
       for (const p of paths) {
         if (!fileMap.has(p)) {
           fileMap.set(p, { path: p, ops: { read: 0, write: 0, edit: 0, other: 0 } });
@@ -847,7 +900,6 @@ function OverviewPanel({
 
 function FileRow({ file }: { file: FileChange }) {
   const ops = file.ops;
-  const total = ops.read + ops.write + ops.edit + ops.other;
   return (
     <li className="flex items-center justify-between gap-2 text-body">
       <span className="truncate font-mono text-content-secondary" title={file.path}>
@@ -858,7 +910,6 @@ function FileRow({ file }: { file: FileChange }) {
         {ops.edit > 0 && <span className="text-status-warning">e{ops.edit}</span>}
         {ops.write > 0 && <span className="text-status-success">w{ops.write}</span>}
         {ops.other > 0 && <span className="text-content-muted">·{ops.other}</span>}
-        <span className="ml-1 text-content-muted">({total})</span>
       </span>
     </li>
   );

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -6,11 +6,55 @@
  * - It does not import Drawer (master-detail doctrine)
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import RunStepCard from "@/components/RunStepCard";
+import enMessages from "@/messages/en.json";
+import type { RunStep } from "@/lib/types";
+
+vi.mock("@/components/ui/Markdown", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
 const HISTORY_DIR = path.resolve(__dirname);
+const mountedCards: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(() => {
+  for (const { container, root } of mountedCards) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  mountedCards.length = 0;
+});
+
+function renderRunStepCards(steps: RunStep[], defaultExpanded = false) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedCards.push({ container, root });
+
+  const rerender = (nextSteps: RunStep[]) => {
+    act(() => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          {nextSteps.map((step, index) => (
+            <div key={`${step.step}-${index}`} data-segment-index={index}>
+              <RunStepCard step={step} defaultExpanded={defaultExpanded} />
+            </div>
+          ))}
+        </IntlProvider>,
+      );
+    });
+  };
+
+  rerender(steps);
+  return { container, rerender };
+}
 
 // ─── File existence ───────────────────────────────────────────────────────────
 
@@ -312,6 +356,37 @@ describe("history/RunDetail.tsx — persisted branch totals survive message pagi
 });
 
 describe("history/RunDetail.tsx — live branch aggregates", () => {
+  it("refreshes the rendered memoized card duration after a terminal refetch", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: "finished",
+        sender: "worker",
+        timestamp: 20,
+      },
+    ];
+    const runningStep: RunStep = {
+      step: "worker",
+      status: "completed",
+      timestamp: 10,
+      messages,
+      result: { agent: "worker", message_count: 1, duration_sec: 10 },
+    };
+    const terminalStep: RunStep = {
+      ...runningStep,
+      messages,
+      result: { ...runningStep.result, duration_sec: 50 },
+    };
+    const { container, rerender } = renderRunStepCards([runningStep]);
+
+    expect(container.textContent).toContain("10s");
+
+    rerender([terminalStep]);
+
+    expect(container.textContent).not.toContain("10s");
+    expect(container.textContent).toContain("50s");
+  });
+
   it("advances duration through a streamed message and terminal refetch without dropping loaded history", async () => {
     const { appendStreamedMessage, branchToRunStep, mergeCompletedSession } =
       await import("./RunDetail");
@@ -360,11 +435,24 @@ describe("history/RunDetail.tsx — live branch aggregates", () => {
       lion_class: "AssistantResponse",
     };
 
-    const streamed = appendStreamedMessage(initial, "branch-1", streamedMessage);
-    expect(branchToRunStep(streamed.branches[0], "running").result?.duration_sec).toBe(40);
-    expect(streamed.branches[0].message_total).toBe(3);
+    const afterFirstEvent = appendStreamedMessage(initial, "branch-1", streamedMessage);
+    const afterDuplicateEvent = appendStreamedMessage(afterFirstEvent, "branch-1", streamedMessage);
+    const firstDuration = branchToRunStep(afterFirstEvent.branches[0], "running").result
+      ?.duration_sec;
 
-    const completed = mergeCompletedSession(streamed, {
+    expect(afterDuplicateEvent.branches[0].messages.map((message) => message.id)).toEqual(
+      afterFirstEvent.branches[0].messages.map((message) => message.id),
+    );
+    expect(afterDuplicateEvent.branches[0].message_total).toBe(
+      afterFirstEvent.branches[0].message_total,
+    );
+    expect(branchToRunStep(afterDuplicateEvent.branches[0], "running").result?.duration_sec).toBe(
+      firstDuration,
+    );
+    expect(firstDuration).toBe(40);
+    expect(afterDuplicateEvent.branches[0].message_total).toBe(3);
+
+    const completed = mergeCompletedSession(afterDuplicateEvent, {
       ...initial,
       status: "completed",
       updated_at: 60,
@@ -464,6 +552,14 @@ describe("history/RunDetail.tsx — segmented branch totals", () => {
     expect(steps[0].result?.message_count).toBeNull();
     expect(steps[1].messages).toHaveLength(1);
     expect(steps[1].result?.message_count).toBe(6);
+
+    const { container } = renderRunStepCards(steps, true);
+    const cards = container.querySelectorAll<HTMLElement>("[data-segment-index]");
+    const intermediateBadge = cards[0]?.querySelector('[id$="-tab-conversation"] span');
+    const finalBadge = cards[1]?.querySelector('[id$="-tab-conversation"] span');
+
+    expect(intermediateBadge).toBeNull();
+    expect(finalBadge?.textContent).toBe("6");
   });
 });
 

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -311,6 +311,162 @@ describe("history/RunDetail.tsx — persisted branch totals survive message pagi
   });
 });
 
+describe("history/RunDetail.tsx — live branch aggregates", () => {
+  it("advances duration through a streamed message and terminal refetch without dropping loaded history", async () => {
+    const { appendStreamedMessage, branchToRunStep, mergeCompletedSession } =
+      await import("./RunDetail");
+    const initial = {
+      id: "run-1",
+      name: "run",
+      created_at: 10,
+      updated_at: 20,
+      status: "running",
+      branches: [
+        {
+          id: "branch-1",
+          name: "worker",
+          created_at: 10,
+          first_message_at: 10,
+          last_message_at: 20,
+          message_total: 2,
+          messages: [
+            {
+              id: "older-1",
+              role: "assistant",
+              content: { assistant_response: "oldest loaded" },
+              sender: "worker",
+              timestamp: 10,
+              lion_class: "AssistantResponse",
+            },
+            {
+              id: "initial-tail",
+              role: "assistant",
+              content: { assistant_response: "initial tail" },
+              sender: "worker",
+              timestamp: 20,
+              lion_class: "AssistantResponse",
+            },
+          ],
+        },
+      ],
+    };
+    const streamedMessage = {
+      id: "streamed-later",
+      role: "assistant",
+      branch_id: "branch-1",
+      content: { assistant_response: "live" },
+      sender: "worker",
+      timestamp: 50,
+      lion_class: "AssistantResponse",
+    };
+
+    const streamed = appendStreamedMessage(initial, "branch-1", streamedMessage);
+    expect(branchToRunStep(streamed.branches[0], "running").result?.duration_sec).toBe(40);
+    expect(streamed.branches[0].message_total).toBe(3);
+
+    const completed = mergeCompletedSession(streamed, {
+      ...initial,
+      status: "completed",
+      updated_at: 60,
+      ended_at: 60,
+      branches: [
+        {
+          ...initial.branches[0],
+          last_message_at: 60,
+          message_total: 4,
+          messages: [
+            {
+              id: "terminal-tail",
+              role: "assistant",
+              content: { assistant_response: "done" },
+              sender: "worker",
+              timestamp: 60,
+              lion_class: "AssistantResponse",
+            },
+          ],
+        },
+      ],
+    });
+    const completedStep = branchToRunStep(completed.branches[0], "completed");
+
+    expect(completedStep.result?.duration_sec).toBe(50);
+    expect(completedStep.result?.message_count).toBe(4);
+    expect(completed.branches[0].messages.map((message) => message.id)).toEqual([
+      "older-1",
+      "initial-tail",
+      "streamed-later",
+      "terminal-tail",
+    ]);
+  });
+});
+
+describe("history/RunDetail.tsx — segmented branch totals", () => {
+  it("omits intermediate window counts and shows the persisted branch total only on the final segment", async () => {
+    const { buildRunSteps } = await import("./RunDetail");
+    const steps = buildRunSteps(
+      {
+        id: "run-1",
+        name: "run",
+        created_at: 0,
+        updated_at: 200,
+        branches: [
+          {
+            id: "branch-1",
+            name: "worker",
+            created_at: 0,
+            first_message_at: 10,
+            last_message_at: 190,
+            message_total: 6,
+            messages: [
+              {
+                id: "loaded-from-first-segment",
+                role: "assistant",
+                content: { assistant_response: "first segment tail" },
+                sender: "worker",
+                timestamp: 90,
+                lion_class: "AssistantResponse",
+              },
+              {
+                id: "loaded-from-final-segment",
+                role: "assistant",
+                content: { assistant_response: "final segment tail" },
+                sender: "worker",
+                timestamp: 190,
+                lion_class: "AssistantResponse",
+              },
+            ],
+          },
+        ],
+      },
+      "completed",
+      [
+        {
+          op_id: "op-1",
+          branch_id: "branch-1",
+          branch_name: "worker",
+          status: "completed",
+          started_at: 0,
+          ended_at: 99,
+        },
+        {
+          op_id: "op-2",
+          branch_id: "branch-1",
+          branch_name: "worker",
+          status: "completed",
+          started_at: 100,
+          ended_at: 200,
+        },
+      ],
+    );
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0].messages).toHaveLength(1);
+    expect(steps[0].result?.message_count).toBeNull();
+    expect(steps[1].messages).toHaveLength(1);
+    expect(steps[1].result?.message_count).toBe(6);
+  });
+});
+
 describe("history/RunDetail.tsx — overview aggregates are lifetime totals", () => {
   it("prefers full-session aggregate counts to the loaded message window", async () => {
     const { resolveOverviewCounts } = await import("./RunDetail");

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -273,6 +273,70 @@ describe("runFiles union logic (mirrors the useMemo body) — file outside the l
   });
 });
 
+describe("history/RunDetail.tsx — persisted branch totals survive message pagination", () => {
+  it("uses full-progression timestamps and message totals instead of the loaded tail", async () => {
+    const { branchToRunStep } = await import("./RunDetail");
+    const runStep = branchToRunStep(
+      {
+        id: "branch-1",
+        name: "worker",
+        created_at: 10,
+        first_message_at: 10,
+        last_message_at: 610,
+        message_total: 30_525,
+        messages: [
+          {
+            id: "recent-1",
+            role: "assistant",
+            content: { assistant_response: "tail" },
+            sender: "worker",
+            timestamp: 600,
+            lion_class: "AssistantResponse",
+          },
+          {
+            id: "recent-2",
+            role: "assistant",
+            content: { assistant_response: "tail end" },
+            sender: "worker",
+            timestamp: 610,
+            lion_class: "AssistantResponse",
+          },
+        ],
+      },
+      "completed",
+    );
+
+    expect(runStep.result?.duration_sec).toBe(600);
+    expect(runStep.result?.message_count).toBe(30_525);
+  });
+});
+
+describe("history/RunDetail.tsx — overview aggregates are lifetime totals", () => {
+  it("prefers full-session aggregate counts to the loaded message window", async () => {
+    const { resolveOverviewCounts } = await import("./RunDetail");
+    expect(
+      resolveOverviewCounts(
+        {
+          message_count: 30_525,
+          roles: {},
+          tool_call_count: 21_741,
+          error_count: 42,
+          files: [],
+        },
+        { toolCallCount: 2, errorCount: 1 },
+      ),
+    ).toEqual({ toolCallCount: 21_741, errorCount: 42 });
+  });
+
+  it("does not select recent-qualified labels for partial message windows", () => {
+    const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+    const start = src.indexOf("function OverviewSection");
+    const end = src.indexOf("// ── Branches section", start);
+    const overview = src.slice(start, end);
+    expect(overview).not.toMatch(/statToolCallsRecent|statErrorsRecent/);
+  });
+});
+
 // ─── NodeEscalated route=notify badge ──────────────────────────────────────────
 // A soft ("fyi" urgency) EscalationRequest resolves to route="notify" and
 // fires NodeEscalated purely for observability — the node itself keeps

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -387,7 +387,7 @@ describe("history/RunDetail.tsx — live branch aggregates", () => {
     expect(container.textContent).toContain("50s");
   });
 
-  it("advances duration through a streamed message and terminal refetch without dropping loaded history", async () => {
+  it("renders a streamed message once and advances duration through the terminal refetch", async () => {
     const { appendStreamedMessage, branchToRunStep, mergeCompletedSession } =
       await import("./RunDetail");
     const initial = {
@@ -437,20 +437,37 @@ describe("history/RunDetail.tsx — live branch aggregates", () => {
 
     const afterFirstEvent = appendStreamedMessage(initial, "branch-1", streamedMessage);
     const afterDuplicateEvent = appendStreamedMessage(afterFirstEvent, "branch-1", streamedMessage);
-    const firstDuration = branchToRunStep(afterFirstEvent.branches[0], "running").result
-      ?.duration_sec;
+    const firstStep = branchToRunStep(afterFirstEvent.branches[0], "running");
+    const duplicateStep = branchToRunStep(afterDuplicateEvent.branches[0], "running");
+    const { container, rerender } = renderRunStepCards([firstStep], true);
+    const conversationBadge = () =>
+      container.querySelector('[id$="-tab-conversation"] span')?.textContent;
+    const renderedDuration = () =>
+      Array.from(container.querySelectorAll<HTMLElement>("#step-worker > button span"))
+        .map((element) => element.textContent)
+        .find((text) => /^(?:\d+m )?\d+s$/.test(text ?? ""));
+    const renderedLiveResponses = () =>
+      Array.from(container.querySelectorAll<HTMLElement>('[id^="step-worker-r"]')).filter(
+        (response) => response.textContent?.includes("live"),
+      );
+    const conversationTab = container.querySelector<HTMLButtonElement>(
+      '[role="tab"][id$="-tab-conversation"]',
+    );
 
-    expect(afterDuplicateEvent.branches[0].messages.map((message) => message.id)).toEqual(
-      afterFirstEvent.branches[0].messages.map((message) => message.id),
-    );
-    expect(afterDuplicateEvent.branches[0].message_total).toBe(
-      afterFirstEvent.branches[0].message_total,
-    );
-    expect(branchToRunStep(afterDuplicateEvent.branches[0], "running").result?.duration_sec).toBe(
-      firstDuration,
-    );
-    expect(firstDuration).toBe(40);
-    expect(afterDuplicateEvent.branches[0].message_total).toBe(3);
+    expect(conversationTab).not.toBeNull();
+    await act(async () => conversationTab?.click());
+
+    const firstBadge = conversationBadge();
+    const firstDuration = renderedDuration();
+    expect(renderedLiveResponses()).toHaveLength(1);
+    expect(firstBadge).toBe("3");
+    expect(firstDuration).toBe("40s");
+
+    rerender([duplicateStep]);
+
+    expect(renderedLiveResponses()).toHaveLength(1);
+    expect(conversationBadge()).toBe(firstBadge);
+    expect(renderedDuration()).toBe(firstDuration);
 
     const completed = mergeCompletedSession(afterDuplicateEvent, {
       ...initial,

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -184,7 +184,7 @@ export function branchToRunStep(branch: SessionBranch, status: string): RunStep 
     result: {
       agent: branch.agent_name ?? branch.name ?? branch.id.slice(0, 8),
       model: branch.model ?? branch.provider ?? null,
-      message_count: runMessages.length,
+      message_count: Math.max(branch.message_total ?? 0, runMessages.length),
       roles: rolesCounts,
       duration_sec: durationSec,
     },
@@ -231,7 +231,6 @@ interface OverviewData {
   messageCount: number;
   toolCallCount: number;
   errorCount: number;
-  partialWindow: boolean;
   showTopic?: string | null;
   showPlayName?: string | null;
   playbookName?: string | null;
@@ -247,11 +246,11 @@ function OverviewSection({ data }: { data: OverviewData }) {
     { label: t("statBranches"), value: String(data.branchCount) },
     { label: t("statMessages"), value: String(data.messageCount) },
     {
-      label: data.partialWindow ? t("statToolCallsRecent") : t("statToolCalls"),
+      label: t("statToolCalls"),
       value: String(data.toolCallCount),
     },
     {
-      label: data.partialWindow ? t("statErrorsRecent") : t("statErrors"),
+      label: t("statErrors"),
       value: String(data.errorCount),
       tone: data.errorCount > 0 ? ("error" as const) : ("ok" as const),
     },
@@ -302,6 +301,16 @@ function OverviewSection({ data }: { data: OverviewData }) {
       </div>
     </div>
   );
+}
+
+export function resolveOverviewCounts(
+  messageStats: SessionDetail["message_stats"],
+  loaded: { toolCallCount: number; errorCount: number },
+): { toolCallCount: number; errorCount: number } {
+  return {
+    toolCallCount: messageStats?.tool_call_count ?? loaded.toolCallCount,
+    errorCount: messageStats?.error_count ?? loaded.errorCount,
+  };
 }
 
 // ── Branches section ──────────────────────────────────────────────────────────
@@ -1079,9 +1088,13 @@ export default function RunDetail({ id }: RunDetailProps) {
   const partialWindow = session.branches.some((b) => (b.message_total ?? 0) > b.messages.length);
   const durationSec =
     startRef != null && endRef != null ? Math.max(0, Math.round(endRef - startRef)) : null;
-  const toolCallCount = steps.reduce((n, s) => {
+  const loadedToolCallCount = steps.reduce((n, s) => {
     return n + (s.messages ?? []).filter((m) => m.role === "tool_call").length;
   }, 0);
+  const { toolCallCount, errorCount } = resolveOverviewCounts(session.message_stats, {
+    toolCallCount: loadedToolCallCount,
+    errorCount: errors.length,
+  });
 
   // DESIGN-BRIEF §0: derive from the real status_reason fields, not the
   // done/live booleans — those conflate every terminal status (including
@@ -1099,8 +1112,7 @@ export default function RunDetail({ id }: RunDetailProps) {
     branchCount: session.branches.length,
     messageCount: totalMessages,
     toolCallCount,
-    errorCount: errors.length,
-    partialWindow,
+    errorCount,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
       | string
       | null

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -73,7 +73,7 @@ export function shouldRenderAuthoredGraph(
   return !(isEdgeless && opGraph.edges.length > 0);
 }
 
-function branchToRunStep(branch: SessionBranch, status: string): RunStep {
+export function branchToRunStep(branch: SessionBranch, status: string): RunStep {
   const msgs = branch.messages;
   const runMessages: RunMessage[] = [];
 
@@ -171,6 +171,13 @@ function branchToRunStep(branch: SessionBranch, status: string): RunStep {
     rolesCounts[rm.role] = (rolesCounts[rm.role] ?? 0) + 1;
   }
 
+  const firstMessageAt = branch.first_message_at ?? branch.started_at ?? null;
+  const lastMessageAt = branch.last_message_at ?? branch.ended_at ?? null;
+  const durationSec =
+    firstMessageAt != null && lastMessageAt != null
+      ? Math.max(0, Math.round(lastMessageAt - firstMessageAt))
+      : undefined;
+
   return {
     step: branch.name || branch.id.slice(0, 8),
     status,
@@ -179,6 +186,7 @@ function branchToRunStep(branch: SessionBranch, status: string): RunStep {
       model: branch.model ?? branch.provider ?? null,
       message_count: runMessages.length,
       roles: rolesCounts,
+      duration_sec: durationSec,
     },
     messages: runMessages,
     timestamp: branch.created_at,
@@ -934,6 +942,9 @@ export default function RunDetail({ id }: RunDetailProps) {
             ...b,
             messages: segMsgs,
             name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]`,
+            message_total: segMsgs.length,
+            first_message_at: seg.started_at,
+            last_message_at: seg.ended_at,
           };
           result.push(branchToRunStep(segBranch, seg.status || bStatus || sessionStatus));
         }

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -73,7 +73,81 @@ export function shouldRenderAuthoredGraph(
   return !(isEdgeless && opGraph.edges.length > 0);
 }
 
-export function branchToRunStep(branch: SessionBranch, status: string): RunStep {
+export function appendStreamedMessage(
+  session: SessionDetail,
+  branchId: string,
+  message: SessionMessage,
+): SessionDetail {
+  const existing = session.branches.find((branch) => branch.id === branchId);
+  if (!existing) {
+    return {
+      ...session,
+      branches: [
+        ...session.branches,
+        {
+          id: branchId,
+          name: branchId.slice(0, 8),
+          created_at: message.timestamp,
+          first_message_at: message.timestamp,
+          last_message_at: message.timestamp,
+          message_total: 1,
+          messages: [message],
+        },
+      ],
+    };
+  }
+  if (existing.messages.some((candidate) => candidate.id === message.id)) return session;
+
+  return {
+    ...session,
+    branches: session.branches.map((branch) => {
+      if (branch.id !== branchId) return branch;
+      const firstMessageAt = branch.first_message_at ?? branch.started_at;
+      const lastMessageAt = branch.last_message_at ?? branch.ended_at;
+      return {
+        ...branch,
+        messages: [...branch.messages, message],
+        message_total:
+          Math.max(branch.message_total ?? branch.messages.length, branch.messages.length) + 1,
+        first_message_at:
+          firstMessageAt == null ? message.timestamp : Math.min(firstMessageAt, message.timestamp),
+        last_message_at:
+          lastMessageAt == null ? message.timestamp : Math.max(lastMessageAt, message.timestamp),
+      };
+    }),
+  };
+}
+
+export function mergeCompletedSession(
+  previous: SessionDetail,
+  fresh: SessionDetail,
+): SessionDetail {
+  const freshById = new Map(fresh.branches.map((branch) => [branch.id, branch]));
+  const previousIds = new Set(previous.branches.map((branch) => branch.id));
+  const branches = previous.branches.map((branch) => {
+    const freshBranch = freshById.get(branch.id);
+    if (!freshBranch) return branch;
+    const seen = new Set(branch.messages.map((message) => message.id));
+    return {
+      ...branch,
+      ...freshBranch,
+      messages: [
+        ...branch.messages,
+        ...freshBranch.messages.filter((message) => !seen.has(message.id)),
+      ],
+    };
+  });
+  for (const freshBranch of fresh.branches) {
+    if (!previousIds.has(freshBranch.id)) branches.push(freshBranch);
+  }
+  return { ...previous, ...fresh, branches };
+}
+
+export function branchToRunStep(
+  branch: SessionBranch,
+  status: string,
+  options?: { messageCount: number | null },
+): RunStep {
   const msgs = branch.messages;
   const runMessages: RunMessage[] = [];
 
@@ -177,6 +251,9 @@ export function branchToRunStep(branch: SessionBranch, status: string): RunStep 
     firstMessageAt != null && lastMessageAt != null
       ? Math.max(0, Math.round(lastMessageAt - firstMessageAt))
       : undefined;
+  const messageCount =
+    options?.messageCount ??
+    (options ? null : Math.max(branch.message_total ?? 0, runMessages.length));
 
   return {
     step: branch.name || branch.id.slice(0, 8),
@@ -184,13 +261,64 @@ export function branchToRunStep(branch: SessionBranch, status: string): RunStep 
     result: {
       agent: branch.agent_name ?? branch.name ?? branch.id.slice(0, 8),
       model: branch.model ?? branch.provider ?? null,
-      message_count: Math.max(branch.message_total ?? 0, runMessages.length),
+      message_count: messageCount,
       roles: rolesCounts,
       duration_sec: durationSec,
     },
     messages: runMessages,
     timestamp: branch.created_at,
   };
+}
+
+export interface SessionSegment {
+  op_id: string;
+  branch_id: string;
+  branch_name: string;
+  status: string;
+  started_at: number | null;
+  ended_at: number | null;
+}
+
+export function buildRunSteps(
+  session: SessionDetail,
+  sessionStatus: string,
+  segments: SessionSegment[],
+): RunStep[] {
+  const result: RunStep[] = [];
+  for (const branch of session.branches) {
+    const branchStatus = (branch as unknown as Record<string, unknown>).status as string | null;
+    const branchSegments = segments.filter((segment) => segment.branch_id === branch.id);
+    if (branchSegments.length <= 1) {
+      result.push(branchToRunStep(branch, branchStatus || sessionStatus));
+      continue;
+    }
+
+    branchSegments.forEach((segment, index) => {
+      const segmentMessages = branch.messages.filter((message) => {
+        const timestamp = message.timestamp;
+        const after = segment.started_at == null || timestamp >= segment.started_at;
+        const before = segment.ended_at == null || timestamp <= segment.ended_at + 1;
+        return after && before;
+      });
+      result.push(
+        branchToRunStep(
+          {
+            ...branch,
+            messages: segmentMessages,
+            name: `${branch.name || branch.id.slice(0, 8)} [${segment.op_id}]`,
+            first_message_at: segment.started_at,
+            last_message_at: segment.ended_at,
+          },
+          segment.status || branchStatus || sessionStatus,
+          {
+            messageCount:
+              index === branchSegments.length - 1 ? (branch.message_total ?? null) : null,
+          },
+        ),
+      );
+    });
+  }
+  return result;
 }
 
 // ── Section shared header ─────────────────────────────────────────────────────
@@ -555,9 +683,7 @@ export function badgeForEvent(ev: SignalEvent): { label: string; tone: string } 
   if (ev.kind === "NodeEscalated" && ev.payload?.route === "notify") {
     return { label: "notify", tone: "bg-status-warning-bg text-status-warning" };
   }
-  return (
-    KIND_BADGE[ev.kind] ?? { label: ev.kind, tone: "bg-surface-overlay text-content-muted" }
-  );
+  return KIND_BADGE[ev.kind] ?? { label: ev.kind, tone: "bg-surface-overlay text-content-muted" };
 }
 
 type LaneState = OperationStatus;
@@ -778,15 +904,7 @@ export default function RunDetail({ id }: RunDetailProps) {
           .then((fresh) => {
             if (cancelled) return;
             setSession((prev) =>
-              prev && prev.id === fresh.id
-                ? {
-                    ...prev,
-                    status: fresh.status,
-                    status_reason_code: fresh.status_reason_code,
-                    status_reason_summary: fresh.status_reason_summary,
-                    ended_at: fresh.ended_at,
-                  }
-                : prev,
+              prev && prev.id === fresh.id ? mergeCompletedSession(prev, fresh) : prev,
             );
           })
           .catch(() => {});
@@ -798,28 +916,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         setSession((prev) => {
           if (!prev) return prev;
           const branchId = String(event.branch_id);
-          const existing = prev.branches.find((b) => b.id === branchId);
-          if (existing) {
-            if (existing.messages.some((m) => m.id === msg.id)) return prev;
-            return {
-              ...prev,
-              branches: prev.branches.map((b) =>
-                b.id === branchId ? { ...b, messages: [...b.messages, msg] } : b,
-              ),
-            };
-          }
-          return {
-            ...prev,
-            branches: [
-              ...prev.branches,
-              {
-                id: branchId,
-                name: branchId.slice(0, 8),
-                created_at: msg.timestamp,
-                messages: [msg],
-              },
-            ],
-          };
+          return appendStreamedMessage(prev, branchId, msg);
         });
       }
     });
@@ -910,57 +1007,15 @@ export default function RunDetail({ id }: RunDetailProps) {
   const sessionStatus = done ? "completed" : live ? "running" : "completed";
 
   const segments = useMemo(() => {
-    if (!session)
-      return [] as Array<{
-        op_id: string;
-        branch_id: string;
-        branch_name: string;
-        status: string;
-        started_at: number | null;
-        ended_at: number | null;
-      }>;
+    if (!session) return [] as SessionSegment[];
     const raw = (session as unknown as Record<string, unknown>).segments;
-    return (Array.isArray(raw) ? raw : []) as Array<{
-      op_id: string;
-      branch_id: string;
-      branch_name: string;
-      status: string;
-      started_at: number | null;
-      ended_at: number | null;
-    }>;
+    return (Array.isArray(raw) ? raw : []) as SessionSegment[];
   }, [session]);
 
-  const steps = useMemo(() => {
-    if (!session) return [];
-    const result: RunStep[] = [];
-    for (const b of session.branches) {
-      const bStatus = (b as unknown as Record<string, unknown>).status as string | null;
-      const branchSegs = segments.filter((s) => s.branch_id === b.id);
-      if (branchSegs.length <= 1) {
-        result.push(branchToRunStep(b, bStatus || sessionStatus));
-      } else {
-        for (const seg of branchSegs) {
-          const segMsgs = b.messages.filter((m) => {
-            const ts = m.timestamp;
-            if (ts == null) return false;
-            const after = seg.started_at == null || ts >= seg.started_at;
-            const before = seg.ended_at == null || ts <= seg.ended_at + 1;
-            return after && before;
-          });
-          const segBranch = {
-            ...b,
-            messages: segMsgs,
-            name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]`,
-            message_total: segMsgs.length,
-            first_message_at: seg.started_at,
-            last_message_at: seg.ended_at,
-          };
-          result.push(branchToRunStep(segBranch, seg.status || bStatus || sessionStatus));
-        }
-      }
-    }
-    return result;
-  }, [session, sessionStatus, segments]);
+  const steps = useMemo(
+    () => (session ? buildRunSteps(session, sessionStatus, segments) : []),
+    [session, sessionStatus, segments],
+  );
 
   // Run-wide known file surface (union across every step/agent branch) —
   // the file-link resolver's save-root fallback when a bare filename isn't

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -601,6 +601,11 @@ export interface SessionBranch {
   id: string;
   name: string;
   created_at: number;
+  /** Persisted full-progression bounds, independent of the messages window. */
+  first_message_at?: number | null;
+  last_message_at?: number | null;
+  started_at?: number | null;
+  ended_at?: number | null;
   messages: SessionMessage[];
   /** Full progression length; messages is a tail window of it. */
   message_total?: number;

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -345,6 +345,25 @@ async def _fetch_role_counts(db: aiosqlite.Connection, msg_ids: list[str]) -> di
     return counts
 
 
+async def _fetch_message_bounds(
+    db: aiosqlite.Connection, msg_ids: list[str]
+) -> tuple[float | None, float | None]:
+    """Return persisted timestamp bounds without hydrating message content."""
+    if not msg_ids:
+        return None, None
+    cur = await db.execute(
+        """SELECT MIN(m.created_at) AS first_message_at,
+                  MAX(m.created_at) AS last_message_at
+           FROM json_each(?) AS ids
+           JOIN messages m ON m.id = ids.value""",
+        (json.dumps(msg_ids),),
+    )
+    row = await cur.fetchone()
+    if row is None:
+        return None, None
+    return row["first_message_at"], row["last_message_at"]
+
+
 async def _fetch_action_messages(
     db: aiosqlite.Connection, msg_ids: list[str]
 ) -> list[dict[str, Any]]:
@@ -544,6 +563,7 @@ async def get_session(
             messages = [by_id[mid] for mid in window_ids if mid in by_id]
 
             role_counts = await _fetch_role_counts(db, full_msg_ids)
+            first_message_at, last_message_at = await _fetch_message_bounds(db, full_msg_ids)
             action_messages = await _fetch_action_messages(db, full_msg_ids)
             # message_count is the DB role-aggregate, not message_total: a
             # progression can reference ids whose row was pruned, so the two can diverge.
@@ -576,6 +596,8 @@ async def get_session(
                     "messages_truncated": message_total > len(messages),
                     "message_has_older": has_older,
                     "message_stats": full_stats["branches"][branch_id],
+                    "first_message_at": first_message_at,
+                    "last_message_at": last_message_at,
                     "model": br["model"],
                     "provider": br["provider"],
                     "agent_name": br["agent_name"],

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -431,9 +431,20 @@ def _branch_message_stats(
         function = content.get("function") or ""
         arguments = content.get("arguments")
         arguments = arguments if isinstance(arguments, dict) else {}
-        file_path = arguments.get("file_path") or arguments.get("path")
-        if isinstance(file_path, str) and file_path:
-            files.add(file_path)
+        tool_name = str(function).lower().replace("-", "_").rsplit("__", 1)[-1].rsplit(".", 1)[-1]
+        if tool_name in {
+            "read",
+            "read_file",
+            "write",
+            "write_file",
+            "edit",
+            "edit_file",
+            "multiedit",
+            "notebookedit",
+        }:
+            file_path = arguments.get("file_path") or arguments.get("path")
+            if isinstance(file_path, str) and file_path:
+                files.add(file_path)
 
         response_id = content.get("action_response_id")
         response_msg = response_by_id.get(response_id) if response_id else None

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -1056,6 +1056,37 @@ async def test_get_session_action_stats_match_canonical_fully_qualified_lion_cla
     assert "/tmp/canonical.txt" in stats["files"]
 
 
+def test_branch_file_stats_only_accept_structured_file_tool_paths():
+    from lionagi.studio.services.sessions import _branch_message_stats
+
+    action_messages = [
+        {
+            "id": "read",
+            "lion_class": "ActionRequest",
+            "content": {"function": "Read", "arguments": {"file_path": "/repo/src/main.py"}},
+        },
+        {
+            "id": "edit",
+            "lion_class": "ActionRequest",
+            "content": {"function": "Edit", "arguments": {"path": "/repo/Makefile"}},
+        },
+        {
+            "id": "glob",
+            "lion_class": "ActionRequest",
+            "content": {"function": "Glob", "arguments": {"path": "/repo/src"}},
+        },
+        {
+            "id": "bash",
+            "lion_class": "ActionRequest",
+            "content": {"function": "Bash", "arguments": {"path": "//"}},
+        },
+    ]
+
+    stats = _branch_message_stats(4, {"action": 4}, action_messages)
+
+    assert stats["files"] == ["/repo/Makefile", "/repo/src/main.py"]
+
+
 async def test_get_session_message_count_is_db_aggregate_not_progression_length(
     patched_sessions_db,
 ):

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -834,6 +834,20 @@ async def test_get_session_windows_newest_messages_by_default(patched_sessions_d
     assert branch["message_offset"] == 0
 
 
+async def test_get_session_branch_bounds_cover_full_progression_when_messages_are_windowed(
+    patched_sessions_db,
+):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    result = await svc.get_session("sess-paged", message_limit=3)
+
+    branch = result["branches"][0]
+    assert [m["timestamp"] for m in branch["messages"]] == [107.0, 108.0, 109.0]
+    assert branch["first_message_at"] == 100.0
+    assert branch["last_message_at"] == 109.0
+
+
 async def test_get_session_offset_pages_older_history(patched_sessions_db):
     svc, db_path = patched_sessions_db
     await seed_paginated_session(db_path, count=10)


### PR DESCRIPTION
## Summary

Fixes the three Fleet stats bugs observed live on a production session (closes #2229, closes #2230, closes #2231). One commit per bug.

## 1. Branch DURATION from persisted bounds (#2229)

A 7-day session displayed `32m 19s` because duration derived from the *loaded* message window. The sessions service now returns first/last persisted message timestamps from the full branch progression (pagination-independent); the frontend prefers those bounds. Regression tests at both layers: backend asserts full-progression bounds with only the newest page loaded; frontend pins the card against a 10-second loaded tail.

## 2. TOP FILES / FILES TOUCHED sanitized (#2230)

File stats counted `path;`, `//`, directories, and interpreter binaries because they were regex-scraped from Bash command strings. Now: structured file-operation tool inputs are the primary source; Bash-derived operands are normalized and deduplicated with separators stripped and `//`/directories/venv-interpreter tokens excluded. Row counts render once (drops the `·460 (460)` duplication). Tests cover separator stripping, dedupe, `//`, directory and interpreter exclusion.

## 3. Honest totals (#2231)

- `(RECENT)` header stats showed all-time totals. The API exposes lifetime aggregates and no bounded window, so the labels drop the recency qualifier and show persisted lifetime counts (the honest presentation of the data that exists).
- Conversation tab badge now shows the persisted branch message total instead of the loaded-array length under pagination.

## Verification

- Backend: `tests/apps_studio_server/test_sessions_detail.py` — 40 passed.
- Frontend: vitest — 873 passed; `npm run build` succeeds.
- `ruff` clean.
