### PR TITLE
feat(state): store and resolve mirrored sessions by cc_session_id

### DIFF
--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -250,7 +250,7 @@ async def mirror_session(
             }
         )
     else:
-        if not existing.get("cc_session_id"):
+        if existing.get("cc_session_id") is None:
             await db.update_session(sid, cc_session_id=session_uid)
         if project and not existing.get("project"):
             # Backfill attribution for an already-seen session (INSERT OR IGNORE never

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -234,6 +234,7 @@ async def mirror_session(
         await db.create_session(
             {
                 "id": sid,
+                "cc_session_id": session_uid,
                 "created_at": created_at,
                 "progression_id": sprog,
                 "name": name or "Claude Code session",
@@ -248,10 +249,13 @@ async def mirror_session(
                 "updated_at": last_ts,
             }
         )
-    elif project and not existing.get("project"):
-        # Backfill attribution for an already-seen session (INSERT OR IGNORE never
-        # updates); writes without disturbing the liveness clock.
-        await db.set_session_provenance(sid, project=project, project_source=project_source)
+    else:
+        if not existing.get("cc_session_id"):
+            await db.update_session(sid, cc_session_id=session_uid)
+        if project and not existing.get("project"):
+            # Backfill attribution for an already-seen session (INSERT OR IGNORE never
+            # updates); writes without disturbing the liveness clock.
+            await db.set_session_provenance(sid, project=project, project_source=project_source)
     await db.create_branch(
         {
             "id": branch_id,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import JSON, MetaData, bindparam, event, inspect, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.schema import CreateTable
 
 from lionagi._paths import LIONAGI_HOME
@@ -51,6 +51,7 @@ from lionagi.state.reasons import (
 from lionagi.state.schema_meta import metadata
 from lionagi.state.schema_meta import schedules as _schedules_table
 from lionagi.state.schema_migrations import MIGRATION_COLUMNS as _MIGRATION_COLUMNS
+from lionagi.state.schema_migrations import MIGRATION_INDEXES as _MIGRATION_INDEXES
 
 _RUN_DEFAULTS: dict[str, str] = {
     "running": _RunReasons.STARTED_OK,
@@ -612,6 +613,7 @@ class StateDB:
             await self._drop_legacy_schedule_runs_check()
         async with self._engine.begin() as conn:
             await conn.run_sync(metadata.create_all)
+            await self._reconcile_indexes(conn)
             # Seed immutable reference rows; ON CONFLICT DO NOTHING is safe to
             # re-run on every open() because the rows are identity-stable.
             await conn.execute(
@@ -641,6 +643,7 @@ class StateDB:
             )
 
     _MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = _MIGRATION_COLUMNS
+    _MIGRATION_INDEXES: dict[str, tuple[str, ...]] = _MIGRATION_INDEXES
 
     async def _reconcile_columns(self) -> None:
         for table, columns in self._MIGRATION_COLUMNS.items():
@@ -656,10 +659,35 @@ class StateDB:
                 continue
             for name, defn in columns:
                 if name not in existing:
-                    async with self._engine.begin() as conn:
-                        await conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {name} {defn}"))
-                        if table == "schedule_runs" and name == "dispatched_at":
-                            await self._backfill_dispatched_at(conn)
+                    add_column = f"ALTER TABLE {table} ADD COLUMN {name} {defn}"
+                    if self.dialect == "postgresql":
+                        add_column = f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {name} {defn}"
+                    try:
+                        async with self._engine.begin() as conn:
+                            await conn.execute(text(add_column))
+                            if table == "schedule_runs" and name == "dispatched_at":
+                                await self._backfill_dispatched_at(conn)
+                    except OperationalError:
+                        # SQLite has no ADD COLUMN IF NOT EXISTS. Another process
+                        # may commit the same migration after our inspection but
+                        # before our ALTER obtains the WAL write lock. Only
+                        # suppress the error when a fresh inspection proves that
+                        # the requested column now exists.
+                        if self.dialect != "sqlite":
+                            raise
+                        async with self._engine.connect() as conn:
+                            reconciled = await conn.run_sync(
+                                lambda c, t=table, n=name: (
+                                    n in {col["name"] for col in inspect(c).get_columns(t)}
+                                )
+                            )
+                        if not reconciled:
+                            raise
+
+    async def _reconcile_indexes(self, conn) -> None:
+        """Create indexes that ``metadata.create_all`` cannot add to existing tables."""
+        for statement in self._MIGRATION_INDEXES.get(self.dialect, ()):
+            await conn.execute(text(statement))
 
     async def _backfill_dispatched_at(self, conn) -> None:
         """One-time migration backfill for the ``dispatched_at`` column just

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -92,6 +92,7 @@ _VALID_STATUS_SOURCES: frozenset[str] = frozenset({"executor", "agent", "admin",
 
 _SESSION_COLUMNS = frozenset(
     {
+        "cc_session_id",
         "name",
         "user",
         "node_metadata",
@@ -750,6 +751,7 @@ class StateDB:
                         """
                         CREATE TABLE sessions_new (
                           id              TEXT    PRIMARY KEY,
+                          cc_session_id   TEXT,
                           created_at      REAL    NOT NULL,
                           node_metadata   JSON,
                           name            TEXT,
@@ -1532,7 +1534,7 @@ class StateDB:
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
-                    """INSERT INTO sessions (id, created_at, node_metadata, name, "user",
+                    """INSERT INTO sessions (id, cc_session_id, created_at, node_metadata, name, "user",
                        progression_id, first_msg_id, last_msg_id, updated_at,
                        playbook_name, agent_name, invocation_kind, show_topic,
                        show_play_name, artifacts_path, artifact_contract_json,
@@ -1540,7 +1542,7 @@ class StateDB:
                        status, started_at, ended_at, last_message_at, invocation_id,
                        model, provider, effort, agent_hash,
                        project, project_source)
-                       VALUES (:id, :created_at, :node_metadata, :name, :user,
+                       VALUES (:id, :cc_session_id, :created_at, :node_metadata, :name, :user,
                                :progression_id, :first_msg_id, :last_msg_id, :updated_at,
                                :playbook_name, :agent_name, :invocation_kind, :show_topic,
                                :show_play_name, :artifacts_path, :artifact_contract_json,
@@ -1556,6 +1558,7 @@ class StateDB:
                 ),
                 {
                     "id": session["id"],
+                    "cc_session_id": session.get("cc_session_id"),
                     "created_at": session.get("created_at", now),
                     "node_metadata": session.get("node_metadata"),
                     "name": session.get("name"),
@@ -1612,6 +1615,20 @@ class StateDB:
                     await conn.execute(
                         text("SELECT * FROM sessions WHERE id = :id"),
                         {"id": session_id},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        return self._row_to_dict(row) if row else None
+
+    async def get_session_by_cc_id(self, cc_session_id: str) -> dict[str, Any] | None:
+        async with self._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text("SELECT * FROM sessions WHERE cc_session_id = :cc_session_id LIMIT 1"),
+                        {"cc_session_id": cc_session_id},
                     )
                 )
                 .mappings()

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -106,6 +106,7 @@ CREATE INDEX IF NOT EXISTS idx_run_tags_tag ON run_tags(tag);
 
 CREATE TABLE IF NOT EXISTS sessions (
   id              TEXT    PRIMARY KEY,
+  cc_session_id   TEXT,
   created_at      REAL    NOT NULL,
   node_metadata   JSON,
   name            TEXT,
@@ -206,6 +207,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_invocation
 -- Project-scoped session listing in Studio.
 CREATE INDEX IF NOT EXISTS idx_sessions_project
   ON sessions(project) WHERE project IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_cc_session
+  ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL;
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -150,6 +150,7 @@ sessions = Table(
     "sessions",
     metadata,
     Column("id", Text, primary_key=True),
+    Column("cc_session_id", Text),
     Column("created_at", Float, nullable=False),
     Column("node_metadata", JSON),
     Column("name", Text),
@@ -234,6 +235,12 @@ Index(
     sessions.c.project,
     sqlite_where=text("project IS NOT NULL"),
     postgresql_where=text("project IS NOT NULL"),
+)
+Index(
+    "idx_sessions_cc_session",
+    sessions.c.cc_session_id,
+    sqlite_where=text("cc_session_id IS NOT NULL"),
+    postgresql_where=text("cc_session_id IS NOT NULL"),
 )
 
 # ── branches ──────────────────────────────────────────────────────────────────

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""ALTER TABLE column definitions consumed by StateDB._reconcile_columns for schema migrations."""
+"""Additive schema definitions consumed by StateDB's runtime migrations."""
 
 from __future__ import annotations
 
@@ -176,4 +176,17 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("expires_at", "REAL"),
         ("updated_at", "REAL"),
     ],
+}
+
+# metadata.create_all() skips indexes when their table already exists. Keep
+# dialect-specific, idempotent DDL here for indexes introduced after deployment.
+MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
+    "sqlite": (
+        "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
+        "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
+    ),
+    "postgresql": (
+        "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
+        "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
+    ),
 }

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
     "sessions": [
         ("updated_at", "REAL"),
+        ("cc_session_id", "TEXT"),
         ("playbook_name", "TEXT"),
         ("agent_name", "TEXT"),
         ("invocation_kind", "TEXT"),

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -10,6 +10,7 @@ import aiosqlite
 from fastapi import HTTPException
 
 from lionagi._errors import NotFoundError
+from lionagi.state.claude_mirror import session_db_id
 from lionagi.state.db import DEFAULT_DB_PATH, SESSION_TERMINAL_STATUSES
 
 from ..registry import studio_route
@@ -643,6 +644,21 @@ async def get_session(
         # get_run()'s liveness check can find the recorded pid.
         "node_metadata": session_row["node_metadata"],
     }
+
+
+async def get_session_by_cc_id(cc_uid: str) -> dict[str, Any] | None:
+    """Return a mirrored Claude Code session, including legacy unbackfilled rows."""
+    if not DEFAULT_DB_PATH.exists():
+        return None
+
+    async with _open_db(_DB) as db:
+        cur = await db.execute(
+            "SELECT id FROM sessions WHERE cc_session_id = ? LIMIT 1",
+            (cc_uid,),
+        )
+        row = await cur.fetchone()
+
+    return await get_session(row["id"] if row else session_db_id(cc_uid))
 
 
 async def get_session_messages_after(session_id: str, after_ts: float) -> list[dict[str, Any]]:

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -12,6 +12,7 @@ import pytest
 
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
+from lionagi.state.claude_mirror import session_db_id  # noqa: E402
 from lionagi.state.db import StateDB  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -285,6 +286,24 @@ async def test_get_session_returns_none_graph_for_null_node_metadata(patched_ses
     assert result["branches"] == []
     assert result["duration_ms"] is None
     assert result["source_kind"] == "live"
+
+
+# ---------------------------------------------------------------------------
+# Test 1.8a — get_session_by_cc_id: legacy rows fall back to deterministic id
+# ---------------------------------------------------------------------------
+
+
+async def test_get_session_by_cc_id_falls_back_for_legacy_row(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    cc_uid = "11111111-2222-3333-4444-555555555555"
+    legacy_session_id = session_db_id(cc_uid)
+    await seed_session(db_path, session_id=legacy_session_id)
+
+    result = await svc.get_session_by_cc_id(cc_uid)
+
+    assert result is not None
+    assert result["id"] == legacy_session_id
+    assert result["name"] == "Test Session"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -289,6 +289,34 @@ async def test_mirror_session_backfills_cc_session_id_on_existing_row(
 
 
 @pytest.mark.asyncio
+async def test_mirror_session_preserves_empty_cc_session_id(temp_db_path: Path) -> None:
+    sprog = _det(SID, "sprog")
+    async with StateDB() as db:
+        await db.create_progression(sprog)
+        await db.create_session(
+            {
+                "id": session_db_id(SID),
+                "cc_session_id": "",
+                "progression_id": sprog,
+                "name": "Claude Code session with an empty external id",
+                "status": "running",
+            }
+        )
+
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            status="running",
+        )
+        after = await db.get_session(session_db_id(SID))
+
+    assert after is not None
+    assert after["cc_session_id"] == ""
+
+
+@pytest.mark.asyncio
 async def test_mirror_session_is_idempotent(temp_db_path: Path) -> None:
     events = _conversation()
     async with StateDB() as db:

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -238,6 +238,57 @@ async def test_mirror_session_creates_rich_session_row(temp_db_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_mirror_session_persists_and_queries_cc_session_id(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            status="running",
+        )
+        row = await db.get_session_by_cc_id(SID)
+        missing = await db.get_session_by_cc_id("missing-session")
+
+    assert row is not None
+    assert row["id"] == session_db_id(SID)
+    assert row["cc_session_id"] == SID
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_backfills_cc_session_id_on_existing_row(
+    temp_db_path: Path,
+) -> None:
+    sprog = _det(SID, "sprog")
+    async with StateDB() as db:
+        await db.create_progression(sprog)
+        await db.create_session(
+            {
+                "id": session_db_id(SID),
+                "progression_id": sprog,
+                "name": "Legacy Claude Code session",
+                "status": "running",
+            }
+        )
+        before = await db.get_session(session_db_id(SID))
+
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            status="running",
+        )
+        after = await db.get_session_by_cc_id(SID)
+
+    assert before is not None
+    assert before["cc_session_id"] is None
+    assert after is not None
+    assert after["cc_session_id"] == SID
+
+
+@pytest.mark.asyncio
 async def test_mirror_session_is_idempotent(temp_db_path: Path) -> None:
     events = _conversation()
     async with StateDB() as db:

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -10,12 +10,16 @@ import multiprocessing
 import queue
 import sqlite3
 import traceback
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import aiosqlite
 import pytest
 
 from lionagi.state.schema_migrations import MIGRATION_COLUMNS
+
+_NUM_CONCURRENT_WORKERS = 4
+_BARRIER_TIMEOUT_SECONDS = 15
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -36,17 +40,53 @@ def _create_pre_cc_session_db(db_path: Path) -> None:
         conn.execute("ALTER TABLE sessions RENAME COLUMN cc_session_id TO legacy_cc_session_id")
 
 
-def _open_state_db_worker(db_path: str, start_gate, result_queue) -> None:
+def _open_state_db_worker(
+    db_path: str,
+    start_barrier,
+    inspection_barrier,
+    result_queue,
+) -> None:
     """Open and close one StateDB in a spawned process."""
+    import lionagi.state.db as state_db_module
     from lionagi.state.db import StateDB
+
+    original_make_engine = state_db_module.make_engine
+
+    class _SynchronizedEngine:
+        def __init__(self, engine) -> None:
+            self._engine = engine
+            self._alter_synchronized = False
+
+        def begin(self):
+            if not self._alter_synchronized:
+                self._alter_synchronized = True
+
+                @asynccontextmanager
+                async def synchronized_begin():
+                    inspection_barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
+                    async with self._engine.begin() as connection:
+                        yield connection
+
+                return synchronized_begin()
+            return self._engine.begin()
+
+        def __getattr__(self, name: str):
+            return getattr(self._engine, name)
+
+    def synchronized_make_engine(*args, **kwargs):
+        return _SynchronizedEngine(original_make_engine(*args, **kwargs))
+
+    # This fixture is missing only cc_session_id, so the first begin() follows
+    # its missing-column inspection and immediately precedes its ALTER.
+    state_db_module.make_engine = synchronized_make_engine
 
     async def _open() -> None:
         state = StateDB(db_path)
         await state.open()
         await state.close()
 
-    start_gate.wait(timeout=30)
     try:
+        start_barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
         asyncio.run(_open())
     except Exception:  # noqa: BLE001
         result_queue.put(traceback.format_exc())
@@ -275,21 +315,27 @@ def test_concurrent_statedb_opens_reconcile_cc_session_column(tmp_path: Path) ->
     _create_pre_cc_session_db(db_path)
 
     context = multiprocessing.get_context("spawn")
-    start_gate = context.Event()
+    start_barrier = context.Barrier(_NUM_CONCURRENT_WORKERS + 1)
+    inspection_barrier = context.Barrier(_NUM_CONCURRENT_WORKERS)
     result_queue = context.Queue()
     processes = [
         context.Process(
             target=_open_state_db_worker,
-            args=(str(db_path), start_gate, result_queue),
+            args=(
+                str(db_path),
+                start_barrier,
+                inspection_barrier,
+                result_queue,
+            ),
         )
-        for _ in range(4)
+        for _ in range(_NUM_CONCURRENT_WORKERS)
     ]
 
     results: list[str | None] = []
     try:
         for process in processes:
             process.start()
-        start_gate.set()
+        start_barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
         for process in processes:
             process.join(timeout=30)
         for _ in processes:

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -5,6 +5,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import multiprocessing
+import queue
+import sqlite3
+import traceback
+from pathlib import Path
+
 import aiosqlite
 import pytest
 
@@ -17,6 +24,34 @@ async def _column_names(db: aiosqlite.Connection, table: str) -> set[str]:
     cur = await db.execute(f"PRAGMA table_info({table})")
     rows = await cur.fetchall()
     return {row["name"] for row in rows}
+
+
+def _create_pre_cc_session_db(db_path: Path) -> None:
+    """Create a current SQLite schema whose sessions table predates cc_session_id."""
+    from lionagi.state.db import _SCHEMA_PATH
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_SCHEMA_PATH.read_text())
+        conn.execute("DROP INDEX idx_sessions_cc_session")
+        conn.execute("ALTER TABLE sessions RENAME COLUMN cc_session_id TO legacy_cc_session_id")
+
+
+def _open_state_db_worker(db_path: str, start_gate, result_queue) -> None:
+    """Open and close one StateDB in a spawned process."""
+    from lionagi.state.db import StateDB
+
+    async def _open() -> None:
+        state = StateDB(db_path)
+        await state.open()
+        await state.close()
+
+    start_gate.wait(timeout=30)
+    try:
+        asyncio.run(_open())
+    except Exception:  # noqa: BLE001
+        result_queue.put(traceback.format_exc())
+    else:
+        result_queue.put(None)
 
 
 # ── Old-schema fixture ────────────────────────────────────────────────────────
@@ -183,6 +218,100 @@ async def test_reconcile_is_idempotent(old_schema_db):
             continue  # new table not in old_schema_db — skip
         for col_name, _ in columns:
             assert col_name in actual
+
+
+async def test_statedb_upgrade_adds_cc_session_lookup_index(tmp_path: Path) -> None:
+    """Existing databases gain the partial lookup index after the column migration."""
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "pre-cc-session.db"
+    _create_pre_cc_session_db(db_path)
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        await state.create_progression("progression-1")
+        await state.execute(
+            "INSERT INTO sessions "
+            "(id, cc_session_id, created_at, progression_id, updated_at) "
+            "VALUES (:id, :cc_session_id, :created_at, :progression_id, :updated_at)",
+            {
+                "id": "session-1",
+                "cc_session_id": "cc-session-1",
+                "created_at": 1.0,
+                "progression_id": "progression-1",
+                "updated_at": 1.0,
+            },
+        )
+        async with state._read() as conn:
+            indexes = (await conn.execute(text("PRAGMA index_list(sessions)"))).mappings().all()
+            plan = (
+                (
+                    await conn.execute(
+                        text(
+                            "EXPLAIN QUERY PLAN SELECT * FROM sessions "
+                            "WHERE cc_session_id = :cc_session_id LIMIT 1"
+                        ),
+                        {"cc_session_id": "cc-session-1"},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        await state.close()
+
+    assert "idx_sessions_cc_session" in {row["name"] for row in indexes}
+    details = [row["detail"] for row in plan]
+    assert any("SEARCH sessions" in detail for detail in details), details
+    assert any("idx_sessions_cc_session" in detail for detail in details), details
+
+
+def test_concurrent_statedb_opens_reconcile_cc_session_column(tmp_path: Path) -> None:
+    """Concurrent first opens tolerate another process winning the ALTER race."""
+    db_path = tmp_path / "concurrent-pre-cc-session.db"
+    _create_pre_cc_session_db(db_path)
+
+    context = multiprocessing.get_context("spawn")
+    start_gate = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_open_state_db_worker,
+            args=(str(db_path), start_gate, result_queue),
+        )
+        for _ in range(4)
+    ]
+
+    results: list[str | None] = []
+    try:
+        for process in processes:
+            process.start()
+        start_gate.set()
+        for process in processes:
+            process.join(timeout=30)
+        for _ in processes:
+            try:
+                results.append(result_queue.get(timeout=2))
+            except queue.Empty:
+                results.append("worker exited without reporting a result")
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        result_queue.close()
+        result_queue.join_thread()
+
+    exit_codes = [process.exitcode for process in processes]
+    assert all(code == 0 for code in exit_codes), exit_codes
+    assert results == [None] * len(processes), results
+
+    with sqlite3.connect(db_path) as conn:
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(sessions)")]
+    assert columns.count("cc_session_id") == 1
 
 
 async def test_sessions_upgrade_path_populates_adr0028_columns(old_schema_db):


### PR DESCRIPTION
## Summary

Mirrored Claude Code sessions were not browsable by their CC session id: the mirror uses the CC uid only to *derive* the sessions-row PK (`uuid5` in `claude_mirror.session_db_id`) and never stores the raw uid — no column, no index, no resolver. Listing or reverse-mapping required re-deriving the hash.

## Change

- **`lionagi/state/schema.sql`** — `sessions.cc_session_id TEXT` + partial index `idx_sessions_cc_session` (`WHERE cc_session_id IS NOT NULL`).
- **`lionagi/state/schema_migrations.py` / `schema_meta.py`** — additive migration entry + SQLAlchemy metadata parity (parity test green).
- **`lionagi/state/db.py`** — `create_session` accepts the column; new `get_session_by_cc_id`.
- **`lionagi/state/claude_mirror.py`** — mirror writes `cc_session_id` at session creation and backfills it on re-mirror of pre-existing rows.
- **`lionagi/studio/services/sessions.py`** — `get_session_by_cc_id(cc_uid)` service entry: resolves via the indexed column with a derivation fallback for legacy unbackfilled rows, then reuses the existing session/messages read path.

No new tables; messages need no change (already ordered via progressions + `created_at`).

## Tests

- mirroring persists `cc_session_id`; queryable via the new resolver
- legacy row without the value resolves via the derivation fallback
- re-mirror backfills existing rows

`tests/state/` + `tests/cli/test_mirror.py`: **768 passed** (6 environmental skips). `tests/apps_studio_server/test_sessions_detail.py`: 39 passed. `ruff` clean.
