### PR TITLE
docs(adr): fix ADR-0094 cross-ref, ADR-0095 no-shell + verification item, numbering exception (closes 5)

### DIFF
--- a/docs/adr/ADR-0094-automated-pr-review-pipeline.md
+++ b/docs/adr/ADR-0094-automated-pr-review-pipeline.md
@@ -4,7 +4,7 @@
 - **Kind**: Aspirational
 - **Area**: scheduling-control-plane
 - **Date**: 2026-07-10
-- **Relations**: extends ADR-0027
+- **Relations**: extends ADR-0070
 
 ## Decisions
 
@@ -29,7 +29,7 @@ Each step is a human-latency stall and a forgettable action — stale branches s
 blocking merges and reviews firing against superseded heads are both observed failure
 modes, not hypotheticals.
 
-The scheduler (ADR-0027) already provides the heartbeat: `github_poll` maintains an
+The scheduler (ADR-0070) already provides the heartbeat: `github_poll` maintains an
 `updated_at` cursor over a repo's open PRs with state/base/draft filters and per-poll
 health columns. Because both `opened` and `synchronize` bump `updated_at`, round-chaining
 falls out of the existing trigger — a fix commit re-surfaces the PR on the next poll.

--- a/docs/adr/ADR-0095-run-terminal-callbacks-and-orphan-recovery.md
+++ b/docs/adr/ADR-0095-run-terminal-callbacks-and-orphan-recovery.md
@@ -338,7 +338,7 @@ wrapper makes the resume decision against the recovery projection.
 | Durable callback fact | Status audit exists, no terminal-event reader | Anti-join reconciliation over `status_transitions` plus `terminal_deliveries` ack table | M |
 | Settings-level handler | Flow-only `notify.on_terminal` string command | Same key, generic: exec/python adapter shapes, precedence, snapshot resolution, explicit disabled state | S |
 | Payload | Flow-specific environment payload | Versioned minimal terminal envelope; legacy adapter preserves old payload | S |
-| Delivery | Flow shell hook, 10 s, swallowed failures | Direct bounded registry; shell/executable only as adapter; external retry | M |
+| Delivery | Flow shell hook, 10 s, swallowed failures | Direct bounded registry; executable/python adapter only, no shell; external retry | M |
 | Flow `--notify` | Direct teardown call | Scoped sugar over the registry, same legacy payload/timeout | S |
 | Session liveness | PID/create-time on CLI sessions, several predicates | Shared conservative identity classifier used by all reaper/read paths | M |
 | Studio/scheduler child identity | Child PID not persisted on invocation/schedule run | `spawn_and_wait(on_spawn=...)` persists identity on the linked invocation | M |
@@ -371,6 +371,10 @@ wrapper makes the resume decision against the recovery projection.
    run reconciliation for that consumer, and assert zero redelivered events — pruning
    eligibility must have excluded every ack whose transition row remains in the
    reconciliation-queryable set.
+1b-iv. Consumer retirement atomicity: retire a registered consumer holding a nonempty
+   unacknowledged set; assert registration removal and unacknowledged-set disposition occur
+   in one transaction, with neither intermediate state observable (registration absent while
+   the set remains owed, or registration present after the set is released).
 1c. Settings contract: string form, mapping form, invalid value (warns, disabled, run
    unaffected), per-run override replacing the settings handler for its scope only, and the
    explicit `enabled: false` state. No-shell path: assert no executable adapter invocation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,11 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 | orchestration | 0033-0040 | agent-roles | 0041-0046 |
 | hooks | 0047-0049 | utilities | 0050-0054 |
 
+ADR-0094 and ADR-0095 are documented numbering exceptions: both retain numbers from the
+substrates block (0090-0095) despite declaring `scheduling-control-plane` as their area.
+They landed in that range before the area mismatch was identified; retaining the numbers
+avoids collisions with other ADR work and preserves existing inbound references.
+
 ## Index
 
 ### core-data-model (0001-0005)
@@ -220,9 +225,10 @@ collisions. Unused numbers inside a block are intentional gaps, not missing docu
 - [ADR-0093](ADR-0093-external-memory-adapter-fidelity-contract.md) — External memory adapter
   fidelity contract
 - [ADR-0094](ADR-0094-automated-pr-review-pipeline.md) — Automated PR-review pipeline over
-  github-poll schedules
+  github-poll schedules (area: scheduling-control-plane; numbering exception)
 - [ADR-0095](ADR-0095-run-terminal-callbacks-and-orphan-recovery.md) — Run-terminal
-  callbacks and orphan recovery (supersedes ADR-0060)
+  callbacks and orphan recovery (area: scheduling-control-plane; numbering exception;
+  supersedes ADR-0060)
 - [ADR-0088](ADR-0088-plugin-system.md) — Plugin system (directory-bundle manifest with
   lazy activation; number from the adjacent free gap — the substrates block is exhausted)
 


### PR DESCRIPTION
Batch fix of 5 ADR documentation issues (docs-only, no source/test changes).

- **#2004** — ADR-0094 cited unrelated ADR-0027 for the scheduler; corrected both refs to ADR-0070 (verified target defines the scheduling-control-plane heartbeat + github_poll trigger).
- **#2095** — ADR-0095 delta table listed `shell` as a Delivery adapter, contradicting the no-shell decision; now reads "executable/python adapter only, no shell".
- **#2096** — added verification item 1b-iv to ADR-0095: atomic consumer retirement with a nonempty unacked set, asserting no observable intermediate state.
- **#2005** / **#2092** — ADR-0094 and ADR-0095 declare `Area: scheduling-control-plane` but sit in the substrates number range; documented this as an intentional numbering exception in docs/adr/README.md rather than renumbering (avoids colliding with in-flight ADR work and inbound references).

Closes #2004
Closes #2005
Closes #2092
Closes #2095
Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
