### PR TITLE
fix(protocols): Node admission, pile UUID list, Graph/Edge round-trip, processor capacity/queue bounds

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -937,7 +937,7 @@ def to_list_type(value: Any, /) -> list[Any]:
     if isinstance(value, UUID):
         return [value]
     if isinstance(value, str):
-        return ID.get_id(value) if ID.is_id(value) else []
+        return [ID.get_id(value)] if ID.is_id(value) else []
     if isinstance(value, Element):
         return [value]
     if hasattr(value, "values") and callable(value.values):

--- a/lionagi/protocols/generic/processor.py
+++ b/lionagi/protocols/generic/processor.py
@@ -37,6 +37,8 @@ class Processor(Observer):
             raise ValueError("Queue capacity must be greater than 0.")
         if capacity_refresh_time <= 0:
             raise ValueError("Capacity refresh time must be larger than 0.")
+        if max_queue_size < 0:
+            raise ValueError("Queue size must be non-negative.")
 
         self.queue_capacity = queue_capacity
         self.capacity_refresh_time = capacity_refresh_time
@@ -112,6 +114,7 @@ class Processor(Observer):
 
                 if not await self.request_permission(**next_event.request):
                     if await self.handle_denied(next_event):
+                        events_processed += 1
                         self._available_capacity -= 1
                     else:
                         # Deferred: re-enqueue for retry, don't consume capacity.

--- a/lionagi/protocols/graph/edge.py
+++ b/lionagi/protocols/graph/edge.py
@@ -52,6 +52,15 @@ class Edge(Element):
         **kwargs,
     ):
         """Link head to tail with optional condition and labels; extra kwargs go into properties."""
+        element_kwargs = {
+            key: kwargs.pop(key) for key in ("id", "created_at", "metadata") if key in kwargs
+        }
+        properties = kwargs.pop("properties", None)
+        if properties is not None:
+            if not isinstance(properties, dict):
+                raise ValueError("Properties must be a dictionary.")
+            kwargs = {**properties, **kwargs}
+
         head = ID.get_id(head)
         tail = ID.get_id(tail)
         if condition:
@@ -69,7 +78,7 @@ class Edge(Element):
             else:
                 raise ValueError("Label must be a string or a list of strings.")
 
-        super().__init__(head=head, tail=tail, properties=kwargs)
+        super().__init__(head=head, tail=tail, properties=kwargs, **element_kwargs)
 
     @field_serializer("head", "tail")
     def _serialize_id(self, value: UUID) -> str:

--- a/lionagi/protocols/graph/graph.py
+++ b/lionagi/protocols/graph/graph.py
@@ -71,7 +71,15 @@ class Graph(Element, Relational, Generic[T]):
 
     @field_validator("internal_nodes", "internal_edges", mode="before")
     def _deserialize_nodes_edges(cls, value: Any):
-        return Pile.from_dict(value)
+        if isinstance(value, Pile):
+            return value
+        if isinstance(value, dict):
+            value = dict(value)
+            metadata = dict(value.get("metadata") or {})
+            metadata.pop("lion_class", None)
+            value["metadata"] = metadata
+            return Pile.from_dict(value)
+        return value
 
     @_graph_synchronized
     def _invalidate_adjacency(self, *node_ids: Any) -> None:
@@ -90,9 +98,9 @@ class Graph(Element, Relational, Generic[T]):
         self._successor_cache = successor_cache
 
     @_graph_synchronized
-    def add_node(self, node: Relational) -> None:
-        if not isinstance(node, Relational):
-            raise RelationError("Failed to add node: Invalid node type: not a <Relational> entity.")
+    def add_node(self, node: Node) -> None:
+        if not isinstance(node, Node):
+            raise RelationError("Failed to add node: Invalid node type: not a <Node> entity.")
         _id = ID.get_id(node)
         try:
             self.internal_nodes.insert(len(self.internal_nodes), node)

--- a/tests/protocols/generic/test_pile_indexing.py
+++ b/tests/protocols/generic/test_pile_indexing.py
@@ -6,12 +6,13 @@
 from __future__ import annotations
 
 import importlib
+from uuid import UUID
 
 import pytest
 
 from lionagi._errors import ItemNotFoundError
 from lionagi.protocols.generic.element import Element
-from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.generic.pile import Pile, to_list_type
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -24,6 +25,40 @@ class Item(Element):
 
 class OtherItem(Element):
     name: str = ""
+
+
+@pytest.mark.parametrize("reference_type", ["uuid", "uuid_string", "element"])
+def test_to_list_type_returns_list_for_single_reference(reference_type):
+    item = Item(value=1)
+    reference = {
+        "uuid": item.id,
+        "uuid_string": str(item.id),
+        "element": item,
+    }[reference_type]
+
+    result = to_list_type(reference)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    if reference_type == "element":
+        assert result == [item]
+    else:
+        assert result == [item.id]
+        assert isinstance(result[0], UUID)
+
+
+def test_uuid_string_reference_access_paths():
+    item = Item(value=1)
+    item_id = str(item.id)
+
+    pile = Pile(collections=[item], order=item_id)
+    assert pile[item_id] is item
+
+    inserted = Pile()
+    inserted[item_id] = item
+    assert inserted[item_id] is item
+    inserted.exclude(item_id)
+    assert len(inserted) == 0
 
 
 @pytest.fixture

--- a/tests/protocols/generic/test_processor_edge_cases.py
+++ b/tests/protocols/generic/test_processor_edge_cases.py
@@ -49,6 +49,15 @@ class TestProcessorInit:
         p = _proc(max_queue_size=5)
         assert p.max_queue_size == 5
 
+    @pytest.mark.parametrize("max_queue_size", [0, 3])
+    def test_nonnegative_max_queue_size(self, max_queue_size):
+        p = _proc(max_queue_size=max_queue_size)
+        assert p.queue.maxsize == max_queue_size
+
+    def test_negative_max_queue_size_raises(self):
+        with pytest.raises(ValueError, match="Queue size"):
+            _proc(max_queue_size=-1)
+
     def test_zero_concurrency_limit_no_semaphore(self):
         p = _proc(concurrency_limit=0)
         assert p._concurrency_sem is None
@@ -349,6 +358,30 @@ class TestProcessorJoin:
         await asyncio.wait_for(p.join(), timeout=1.0)
         assert p.queue.empty()
         assert all(e.status == EventStatus.SKIPPED for e in events)
+
+    @pytest.mark.parametrize("operation", ["join", "execute"])
+    async def test_terminal_denials_beyond_capacity_drain(self, operation):
+        p = _RejectProc(queue_capacity=2, capacity_refresh_time=0.001, concurrency_limit=2)
+        events = [_OkEvent() for _ in range(5)]
+        for event in events:
+            await p.enqueue(event)
+
+        if operation == "join":
+            await asyncio.wait_for(p.join(), timeout=1.0)
+        else:
+
+            async def stop_when_drained():
+                while not p.queue.empty():
+                    await asyncio.sleep(0)
+                await p.stop()
+
+            await asyncio.wait_for(
+                asyncio.gather(p.execute(), stop_when_drained()),
+                timeout=1.0,
+            )
+
+        assert p.queue.empty()
+        assert all(event.status == EventStatus.SKIPPED for event in events)
 
     async def test_join_completes_deferred_then_granted(self):
         # Event is deferred on the first lap, then granted: join() loops past

--- a/tests/protocols/graph/test_graph_basic.py
+++ b/tests/protocols/graph/test_graph_basic.py
@@ -73,6 +73,10 @@ class TestGraphBasics:
         with pytest.raises(RelationError):
             empty_graph.add_node("not a node")
 
+    def test_add_relational_non_node(self, empty_graph):
+        with pytest.raises(RelationError):
+            empty_graph.add_node(Graph())
+
     def test_add_duplicate_node(self, empty_graph):
         node = create_test_node("TestNode")
         empty_graph.add_node(node)
@@ -95,6 +99,37 @@ class TestGraphBasics:
         edge = Edge(head=node1, tail=node2)
         with pytest.raises(RelationError):
             empty_graph.add_edge(edge)
+
+    def test_graph_dict_round_trip(self, simple_graph):
+        graph, node1, node2, edge = simple_graph
+        graph.metadata["marker"] = "graph"
+        edge.metadata["marker"] = "edge"
+
+        restored = Graph.from_dict(graph.to_dict())
+
+        assert restored.id == graph.id
+        assert restored.created_at == graph.created_at
+        assert restored.metadata["marker"] == "graph"
+        assert set(restored.internal_nodes.keys()) == {node1.id, node2.id}
+        assert set(restored.internal_edges.keys()) == {edge.id}
+        assert restored.node_edge_mapping[node1.id]["out"][edge.id] == node2.id
+
+
+class TestEdgeRoundTrip:
+    def test_edge_dict_round_trip_preserves_element_fields(self):
+        node1 = create_test_node("Node1")
+        node2 = create_test_node("Node2")
+        edge = Edge(head=node1, tail=node2, weight=3)
+        edge.metadata["marker"] = "edge"
+
+        restored = Edge.from_dict(edge.to_dict())
+
+        assert restored.id == edge.id
+        assert restored.created_at == edge.created_at
+        assert restored.metadata["marker"] == "edge"
+        assert restored.head == edge.head
+        assert restored.tail == edge.tail
+        assert restored.properties == edge.properties
 
 
 class TestGraphModification:


### PR DESCRIPTION
Batch fix of 6 protocols/graph + protocols/generic issues, each with regression coverage.

- **#2019** — `Graph.add_node` accepts only `Node` instances and raises `RelationError` before `Pile` admission for any other value (including relational non-`Node` values).
- **#2012** — `to_list_type` normalizes a valid UUID string to `[ID.get_id(value)]`, so UUID-string references work across getitem/setitem/exclude paths.
- **#1921** — Graph dictionary round-trip: field validation accepts existing `Pile` values and routes dict values through `Pile.from_dict` after stripping the serialized `lion_class` discriminator from nested Pile metadata.
- **#1920** — Edge dictionary round-trip: `Edge.__init__` separates serialized `Element` fields (`id`, `created_at`, `metadata`) from edge properties and merges serialized `properties`, so inherited `from_dict` validation restores identity and state.
- **#2018** — Processor terminal-denial capacity refresh: terminal denials increment cycle progress before consuming capacity, so capacity resets after a denied batch and queued events keep processing.
- **#2013** — `Processor.__init__` raises `ValueError` when `max_queue_size < 0`.

Verification: `uv run pytest tests/protocols/graph/ tests/protocols/generic/` — all pass. ruff check + format clean on touched files.

Closes #2019
Closes #2012
Closes #1921
Closes #1920
Closes #2018
Closes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
