### PR TITLE
fix(service): case-fold provider routing, plugin consult locking, revalidation signature, hook type conformance

### DIFF
--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -29,6 +29,10 @@ _FileStat = tuple[int, int, int, int]
 # (manifest_digest, target_digest) for one plugin entry -- see _plugin_entry_digest.
 _ContentDigest = tuple[str, str]
 
+# Manifest metadata, every manifest-declared path's metadata, and the user
+# settings source mtime -- see _plugin_entry_stat.
+_PluginStatSignature = tuple[_FileStat, tuple[tuple[str, _FileStat], ...], int | None]
+
 
 class EndpointType(Enum):
     API = "api"
@@ -95,11 +99,11 @@ class _RegistryEntry:
         self.plugin_name: str | None = None
         self.plugin_target: str | None = None
         # Fast-path cache for _revalidate_plugin_entry: the PluginRegistry
-        # snapshot generation, (manifest, target) stat signatures, and
+        # snapshot generation, full plugin stat signature, and the entry's
         # (manifest, target) content digests as of the last clean
         # activate_target() call. See _revalidate_plugin_entry.
         self._validated_generation: int | None = None
-        self._validated_stat: tuple[_FileStat, _FileStat] | None = None
+        self._validated_stat: _PluginStatSignature | None = None
         self._validated_digest: _ContentDigest | None = None
 
 
@@ -179,6 +183,7 @@ class EndpointRegistry:
     @classmethod
     def _match_registered(cls, provider: str, endpoint: str, kwargs: dict[str, Any]) -> Any | None:
         """Scan currently-registered entries (built-in + any plugin-activated). ``None`` = no match."""
+        provider = provider.lower()
         first_for_provider = None
         for entry in tuple(cls._entries):
             m = entry.meta
@@ -195,11 +200,10 @@ class EndpointRegistry:
             # Single-endpoint providers (claude_code, codex, pi) always match; non-empty unmatched falls through.
             if not endpoint:
                 return first_for_provider.cls(None, **kwargs)
-            prov = first_for_provider.meta.provider
             n = sum(
                 1
                 for e in tuple(cls._entries)
-                if e.meta.provider == prov or prov in e.meta.provider_aliases
+                if e.meta.provider == provider or provider in e.meta.provider_aliases
                 if cls._revalidate_plugin_entry(e)
             )
             if n == 1:
@@ -215,12 +219,11 @@ class EndpointRegistry:
         too expensive to pay on every ``match()`` hit against an endpoint
         that already activated cleanly. Only re-runs it when the
         ``PluginRegistry`` snapshot generation has strictly advanced (a
-        ``reset()`` happened), when this plugin's manifest or declared
-        target file's cheap stat signature (see ``_plugin_entry_stat``) no
-        longer matches the last clean revalidation, or -- when that stat
-        signature still matches -- when its content digest (see
-        ``_plugin_entry_digest``) no longer matches either; otherwise reuses
-        that prior result.
+        ``reset()`` happened), when this plugin's manifest, any declared
+        path, or user settings source changed (see ``_plugin_entry_stat``),
+        or -- when that stat signature still matches -- when the entry's own
+        content digest (see ``_plugin_entry_digest``) no longer matches
+        either; otherwise reuses that prior result.
 
         The stat signature alone is not a portable content-change
         guarantee: ``os.utime()`` restores a spoofed mtime after an edit,
@@ -265,20 +268,19 @@ class EndpointRegistry:
         return True
 
     @classmethod
-    def _plugin_entry_stat(
-        cls, plugin_name: str, target: str
-    ) -> tuple[_FileStat, _FileStat] | None:
-        """``(manifest_stat, target_stat)`` for a plugin-provided endpoint's
-        backing files -- a cheap ``has anything on disk changed`` first gate
-        for ``_revalidate_plugin_entry``'s fast path. It is a *probabilistic*
-        signal, not a correctness guarantee; see ``_plugin_entry_digest``
-        for the guarantee this gate feeds into.
+    def _plugin_entry_stat(cls, plugin_name: str, target: str) -> _PluginStatSignature | None:
+        """Metadata for the manifest, every declared path, and user settings.
 
-        Each element is ``(mtime_ns, ctime_ns, size, inode)``. mtime ALONE is
-        not a valid content-pinning signal: ``os.utime()`` lets a caller edit
-        a file's bytes and then restore its original mtime. ctime narrows
-        that hole on filesystems where it tracks inode metadata changes, but
-        it is not portable: current CPython documents ``st_ctime``/
+        This is the cheap ``has anything relevant changed`` first gate for
+        ``_revalidate_plugin_entry``. It is a *probabilistic* signal, not a
+        correctness guarantee; see ``_plugin_entry_digest`` for the content
+        guarantee this gate feeds into for the entry's own executable files.
+
+        Each file metadata value is ``(mtime_ns, ctime_ns, size, inode)``.
+        mtime ALONE is not a valid content-pinning signal: ``os.utime()`` lets
+        a caller edit a file's bytes and then restore its original mtime.
+        ctime narrows that hole on filesystems where it tracks inode metadata
+        changes, but it is not portable: current CPython documents ``st_ctime``/
         ``st_ctime_ns`` as file *creation* time on Windows, so neither a
         content write nor ``os.utime()`` advances it there, and timestamp
         resolution is filesystem-dependent in general. size and inode are
@@ -290,20 +292,46 @@ class EndpointRegistry:
         before trusting it -- that confirmation, not this stat tuple, is
         what makes the fast path safe to serve from cache.
 
-        ``None`` (unknown plugin, unresolvable path, either file missing)
-        always forces the caller back onto the full ``activate_target()`` path.
+        ``None`` (unknown plugin, invalid manifest, unresolvable path, or a
+        declared file missing) always forces the caller back onto the full
+        ``activate_target()`` path.
         """
         from lionagi.plugins import PluginRegistry
+        from lionagi.plugins._user_settings import user_settings_path
+        from lionagi.plugins.discovery import _collect_declared_paths
 
         record = PluginRegistry.get(plugin_name)
-        if record is None:
+        if record is None or record.manifest is None:
             return None
-        module_path = target.split(":", 1)[0]
+        declared_paths = set(_collect_declared_paths(record.manifest))
+        if target.split(":", 1)[0] not in declared_paths:
+            return None
         try:
             manifest_stat = record.manifest_path.stat()
-            target_stat = (record.bundle_dir / module_path).stat()
+            declared_stats = []
+            for relative_path in sorted(declared_paths):
+                path_stat = (record.bundle_dir / relative_path).stat()
+                declared_stats.append(
+                    (
+                        relative_path,
+                        (
+                            path_stat.st_mtime_ns,
+                            path_stat.st_ctime_ns,
+                            path_stat.st_size,
+                            path_stat.st_ino,
+                        ),
+                    )
+                )
         except OSError:
             return None
+
+        try:
+            settings_mtime_ns = user_settings_path().stat().st_mtime_ns
+        except FileNotFoundError:
+            settings_mtime_ns = None
+        except OSError:
+            return None
+
         return (
             (
                 manifest_stat.st_mtime_ns,
@@ -311,29 +339,21 @@ class EndpointRegistry:
                 manifest_stat.st_size,
                 manifest_stat.st_ino,
             ),
-            (
-                target_stat.st_mtime_ns,
-                target_stat.st_ctime_ns,
-                target_stat.st_size,
-                target_stat.st_ino,
-            ),
+            tuple(declared_stats),
+            settings_mtime_ns,
         )
 
     @classmethod
     def _plugin_entry_digest(cls, plugin_name: str, target: str) -> _ContentDigest | None:
-        """``(manifest_digest, target_digest)`` -- a content hash of the same
-        two files ``_plugin_entry_stat`` stats, and the correctness
-        guarantee ``_revalidate_plugin_entry``'s fast path actually relies
-        on. Unlike any timestamp/size/inode signature, a hash of the file's
-        bytes always changes when the bytes do, on every platform and
-        filesystem -- there is no metadata field to spoof or leave static.
-        Only computed on the stat-stable path (see ``_plugin_entry_stat``):
-        plugin manifest and target files are small, so the extra read here
-        is cheap, and an entry whose stat signature already looks different
-        skips straight to ``activate_target()`` without paying for it.
+        """Content hashes for an entry's manifest and active target.
 
-        ``None`` under the same conditions ``_plugin_entry_stat`` returns
-        ``None`` for (unknown plugin, unresolvable path, either file missing).
+        Unlike any timestamp/size/inode signature, these hashes always
+        change when either entry file's bytes do. They are only computed on
+        ``_plugin_entry_stat``'s stat-stable path; a signature that already
+        looks different skips straight to ``activate_target()``.
+
+        ``None`` means the plugin is unknown or either entry file could not
+        be read.
         """
         from lionagi.plugins import PluginRegistry
 
@@ -368,24 +388,32 @@ class EndpointRegistry:
 
         imported = False
         for plugin_name, module in targets:
-            previous = getattr(cls._plugin_registration, "provenance", None)
-            cls._plugin_registration.provenance = (plugin_name, module)
-            try:
-                activated = PluginRegistry.activate_target(plugin_name, module)
-                module_name = getattr(activated, "__name__", None)
-                for entry in cls._entries:
-                    if module_name is not None and entry.cls.__module__ == module_name:
-                        entry.plugin_name = plugin_name
-                        entry.plugin_target = module
-                cls._reject_builtin_collisions(plugin_name, module, module_name)
-                imported = True
-            except PluginActivationError:
-                continue
-            finally:
-                if previous is None:
-                    del cls._plugin_registration.provenance
-                else:
-                    cls._plugin_registration.provenance = previous
+            with cls._lock:
+                if any(
+                    entry.plugin_name == plugin_name and entry.plugin_target == module
+                    for entry in cls._entries
+                ):
+                    imported = True
+                    continue
+
+                previous = getattr(cls._plugin_registration, "provenance", None)
+                cls._plugin_registration.provenance = (plugin_name, module)
+                try:
+                    activated = PluginRegistry.activate_target(plugin_name, module)
+                    module_name = getattr(activated, "__name__", None)
+                    for entry in cls._entries:
+                        if module_name is not None and entry.cls.__module__ == module_name:
+                            entry.plugin_name = plugin_name
+                            entry.plugin_target = module
+                    cls._reject_builtin_collisions(plugin_name, module, module_name)
+                    imported = True
+                except PluginActivationError:
+                    continue
+                finally:
+                    if previous is None:
+                        del cls._plugin_registration.provenance
+                    else:
+                        cls._plugin_registration.provenance = previous
         return imported
 
     @classmethod

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -26,8 +26,9 @@ logger = logging.getLogger(__name__)
 # A cheap first gate only; see _plugin_entry_digest for the correctness guarantee.
 _FileStat = tuple[int, int, int, int]
 
-# (manifest_digest, target_digest) for one plugin entry -- see _plugin_entry_digest.
-_ContentDigest = tuple[str, str]
+# The manifest digest and every declared path's digest for one plugin entry --
+# see _plugin_entry_digest.
+_ContentDigest = tuple[str, tuple[tuple[str, str], ...]]
 
 # Manifest metadata, every manifest-declared path's metadata, and the user
 # settings source mtime -- see _plugin_entry_stat.
@@ -100,7 +101,7 @@ class _RegistryEntry:
         self.plugin_target: str | None = None
         # Fast-path cache for _revalidate_plugin_entry: the PluginRegistry
         # snapshot generation, full plugin stat signature, and the entry's
-        # (manifest, target) content digests as of the last clean
+        # manifest + all-declared-path content digests as of the last clean
         # activate_target() call. See _revalidate_plugin_entry.
         self._validated_generation: int | None = None
         self._validated_stat: _PluginStatSignature | None = None
@@ -110,7 +111,7 @@ class _RegistryEntry:
 class EndpointRegistry:
     _entries: ClassVar[list[_RegistryEntry]] = []
     _loaded: ClassVar[bool] = False
-    _lock: ClassVar[threading.Lock] = threading.Lock()
+    _lock: ClassVar[threading.RLock] = threading.RLock()
     _plugin_registration: ClassVar[threading.local] = threading.local()
 
     @classmethod
@@ -222,8 +223,8 @@ class EndpointRegistry:
         ``reset()`` happened), when this plugin's manifest, any declared
         path, or user settings source changed (see ``_plugin_entry_stat``),
         or -- when that stat signature still matches -- when the entry's own
-        content digest (see ``_plugin_entry_digest``) no longer matches
-        either; otherwise reuses that prior result.
+        content digest (see ``_plugin_entry_digest``) no longer matches;
+        otherwise reuses that prior result.
 
         The stat signature alone is not a portable content-change
         guarantee: ``os.utime()`` restores a spoofed mtime after an edit,
@@ -234,7 +235,7 @@ class EndpointRegistry:
         content digest is only computed on that stat-stable path -- the
         files plugins declare are small, so paying for the read there is
         cheap -- and closes that hole on every platform: it always changes
-        when either file's bytes do.
+        when the manifest or any declared capability file's bytes do.
         """
         if entry.plugin_name is None or entry.plugin_target is None:
             return True
@@ -274,7 +275,7 @@ class EndpointRegistry:
         This is the cheap ``has anything relevant changed`` first gate for
         ``_revalidate_plugin_entry``. It is a *probabilistic* signal, not a
         correctness guarantee; see ``_plugin_entry_digest`` for the content
-        guarantee this gate feeds into for the entry's own executable files.
+        guarantee this gate feeds into for every declared capability file.
 
         Each file metadata value is ``(mtime_ns, ctime_ns, size, inode)``.
         mtime ALONE is not a valid content-pinning signal: ``os.utime()`` lets
@@ -345,37 +346,50 @@ class EndpointRegistry:
 
     @classmethod
     def _plugin_entry_digest(cls, plugin_name: str, target: str) -> _ContentDigest | None:
-        """Content hashes for an entry's manifest and active target.
+        """Content hashes for an entry's manifest and every declared path.
 
         Unlike any timestamp/size/inode signature, these hashes always
-        change when either entry file's bytes do. They are only computed on
-        ``_plugin_entry_stat``'s stat-stable path; a signature that already
-        looks different skips straight to ``activate_target()``.
+        change when any file covered by the plugin's trust record changes.
+        They are only computed on ``_plugin_entry_stat``'s stat-stable path;
+        a signature that already looks different skips straight to
+        ``activate_target()``.
 
-        ``None`` means the plugin is unknown or either entry file could not
-        be read.
+        ``None`` means the plugin is unknown, the target is undeclared, or a
+        covered file could not be read.
         """
         from lionagi.plugins import PluginRegistry
+        from lionagi.plugins.discovery import _collect_declared_paths
 
         record = PluginRegistry.get(plugin_name)
-        if record is None:
+        if record is None or record.manifest is None:
             return None
         module_path = target.split(":", 1)[0]
+        declared_paths = set(_collect_declared_paths(record.manifest))
+        if module_path not in declared_paths:
+            return None
         try:
             manifest_bytes = record.manifest_path.read_bytes()
-            target_bytes = (record.bundle_dir / module_path).read_bytes()
+            declared_digests = tuple(
+                (
+                    relative_path,
+                    hashlib.blake2b((record.bundle_dir / relative_path).read_bytes()).hexdigest(),
+                )
+                for relative_path in sorted(declared_paths)
+            )
         except OSError:
             return None
         return (
             hashlib.blake2b(manifest_bytes).hexdigest(),
-            hashlib.blake2b(target_bytes).hexdigest(),
+            declared_digests,
         )
 
     @classmethod
     def _consult_plugin_providers(cls) -> bool:
         """Import every ACTIVE plugin's declared provider module (ADR-0088
         D3), lazily, only from ``match()`` after a registered-entry miss —
-        never at import time. Returns whether any import succeeded.
+        never at import time. The reentrant lock keeps activation atomic
+        across threads while allowing activated code to perform a nested
+        endpoint lookup. Returns whether any import succeeded.
         """
         try:
             from lionagi.plugins import PluginActivationError, PluginRegistry

--- a/lionagi/service/hooks/_types.py
+++ b/lionagi/service/hooks/_types.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from typing_extensions import TypedDict
 
@@ -36,7 +36,7 @@ class HookDict(TypedDict):
     post_invocation: Callable | None
 
 
-StreamHandlers = dict[str, Callable[[SC], Awaitable[None]]]
+StreamHandlers = dict[str, Callable[[Any, str | type, SC], Awaitable[None]]]
 """Mapping of chunk type names to their respective asynchronous handler functions."""
 
 

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -121,7 +121,7 @@ class iModel:  # noqa: N801
         post_invoke_event_hook_timeout: float = 30.0,
         post_invoke_event_hook_params: dict = None,
         **kwargs,
-    ) -> tuple[HookEvent | None, APICalling]:
+    ) -> APICalling:
         h_ev = None
         if self.hook_registry._can_handle(ht_=HookEventTypes.PreEventCreate):
             h_ev = HookEvent(

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -150,26 +150,16 @@ class TestMatchEndpoint:
 
         assert isinstance(endpoint, OpenaiChatEndpoint)
 
-    def test_provider_case_sensitive_routing(self):
+    def test_provider_case_insensitive_routing(self):
         from lionagi.providers.openai.chat import OpenaiChatEndpoint
 
         endpoint_lower = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")
 
         endpoint_upper = match_endpoint(provider="OPENAI", endpoint="chat", model="gpt-4.1-mini")
 
-        # EndpointRegistry.match compares provider strings exactly, so an
-        # exact-case "openai" routes to the concrete registered endpoint
-        # while a differently-cased "OPENAI" misses the registry entry and
-        # falls through to the generic fallback Endpoint. `EndpointConfig`
-        # separately lower-cases `config.provider` on validation, so both
-        # instances still report `config.provider == "openai"` — asserting
-        # only that string equality is too weak, because it stays true even
-        # when the uppercase input silently misses registered routing. The
-        # class-identity checks below are what actually distinguish
-        # registered routing from the generic fallback.
         assert isinstance(endpoint_lower, OpenaiChatEndpoint)
-        assert type(endpoint_upper).__name__ == "Endpoint"
-        assert type(endpoint_lower) is not type(endpoint_upper)
+        assert isinstance(endpoint_upper, OpenaiChatEndpoint)
+        assert type(endpoint_lower) is type(endpoint_upper)
         assert endpoint_lower.config.provider == endpoint_upper.config.provider == "openai"
 
     def test_multiple_providers_isolation(self):

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -423,6 +423,77 @@ class TestPluginProviderRevalidationCaching:
         assert call_count > calls_before_edit
         assert type(second).__name__ == "Endpoint"
 
+    def test_spoofed_metadata_on_inactive_declared_sibling_forces_rescan(
+        self, write_plugin, monkeypatch
+    ):
+        bundle = write_plugin(
+            "wr",
+            (
+                "name: web-research\n"
+                'version: "0.1.0"\n'
+                'lionagi: ">=0.0,<100.0"\n\n'
+                "capabilities:\n"
+                "  agents: [agents/research.md]\n"
+                "  providers:\n"
+                "    - module: providers/endpoint.py\n"
+            ),
+            files={
+                "agents/research.md": "trusted profile\n",
+                "providers/endpoint.py": PROVIDER_MODULE.format(provider="acme-llm"),
+            },
+        )
+        _trust("wr")
+        sibling_path = bundle / "agents" / "research.md"
+        original_stat = sibling_path.stat()
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_attack = call_count
+
+        sibling_path.write_text("changed profile\n")
+        os.utime(sibling_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        edited_stat = sibling_path.stat()
+        assert edited_stat.st_size == original_stat.st_size
+        assert edited_stat.st_mtime_ns == original_stat.st_mtime_ns
+        assert edited_stat.st_ino == original_stat.st_ino
+
+        real_stat = pathlib.Path.stat
+        frozen_ctime_ns = original_stat.st_ctime_ns
+
+        def frozen_ctime_stat(self, *args, **kwargs):
+            result = real_stat(self, *args, **kwargs)
+            if self == sibling_path:
+                return SimpleNamespace(
+                    st_mtime_ns=result.st_mtime_ns,
+                    st_ctime_ns=frozen_ctime_ns,
+                    st_size=result.st_size,
+                    st_ino=result.st_ino,
+                )
+            return result
+
+        monkeypatch.setattr(pathlib.Path, "stat", frozen_ctime_stat)
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_attack, (
+            "an equal-length edit to any declared sibling must force a fresh "
+            "activate_target() revalidation even when its stat signature is unchanged"
+        )
+        assert type(second).__name__ == "Endpoint"
+
     def test_edited_settings_forces_a_fresh_rescan(self, write_plugin, monkeypatch):
         _write_provider_plugin(write_plugin, "wr", name="web-research", provider="acme-llm")
 
@@ -461,6 +532,50 @@ class TestPluginProviderRevalidationCaching:
 
 
 class TestPluginProviderConsultConcurrency:
+    def test_activation_can_issue_nested_unmatched_lookup(self, monkeypatch):
+        nested_results = []
+        thread_results = []
+        errors: list[BaseException] = []
+        activation_calls = 0
+
+        monkeypatch.setattr(
+            PluginRegistry,
+            "active_provider_targets",
+            classmethod(lambda cls: [("plugin-outer", "providers/outer.py")]),
+        )
+
+        def activate_target(cls, plugin_name, module):
+            nonlocal activation_calls
+            activation_calls += 1
+            module_name = "_registry_nested_plugin"
+            if activation_calls == 1:
+                nested_results.append(match_endpoint(provider="nested-missing", endpoint="chat"))
+                endpoint_cls = type("PluginProviderEndpoint", (), {"__module__": module_name})
+                EndpointRegistry.register(provider="outer-provider", endpoint="chat")(endpoint_cls)
+            return SimpleNamespace(__name__=module_name)
+
+        monkeypatch.setattr(PluginRegistry, "activate_target", classmethod(activate_target))
+
+        def consult():
+            try:
+                thread_results.append(EndpointRegistry._consult_plugin_providers())
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=consult, daemon=True)
+        thread.start()
+        thread.join(timeout=0.75)
+
+        assert not thread.is_alive(), (
+            "provider activation deadlocked while a nested unmatched lookup "
+            "re-entered plugin consultation"
+        )
+        assert errors == []
+        assert thread_results == [True]
+        assert activation_calls == 2
+        assert len(nested_results) == 1
+        assert nested_results[0].config.provider == "nested-missing"
+
     def test_activation_and_collision_filtering_are_serialized(self, monkeypatch):
         first_inside_activation = threading.Event()
         release_first = threading.Event()

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -15,11 +15,16 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
+import threading
 from types import SimpleNamespace
 
 import pytest
 
-from lionagi.plugins._user_settings import read_user_settings, write_user_settings
+from lionagi.plugins._user_settings import (
+    read_user_settings,
+    user_settings_path,
+    write_user_settings,
+)
 from lionagi.plugins.discovery import discover_plugins
 from lionagi.plugins.registry import PluginActivationError, PluginRegistry, PluginState
 from lionagi.plugins.trust import trust_plugin
@@ -372,6 +377,160 @@ class TestPluginProviderRevalidationCaching:
         assert type(second).__name__ == "Endpoint", (
             "the stale, edited-but-signature-preserved plugin entry must not be served after the edit"
         )
+
+    def test_edited_sibling_declared_file_forces_a_fresh_rescan(self, write_plugin, monkeypatch):
+        bundle = write_plugin(
+            "wr",
+            (
+                "name: web-research\n"
+                'version: "0.1.0"\n'
+                'lionagi: ">=0.0,<100.0"\n\n'
+                "capabilities:\n"
+                "  providers:\n"
+                "    - module: providers/endpoint.py\n"
+                "    - module: providers/sibling.py\n"
+            ),
+            files={
+                "providers/endpoint.py": PROVIDER_MODULE.format(provider="acme-llm"),
+                "providers/sibling.py": PROVIDER_MODULE.format(provider="acme-sibling"),
+            },
+        )
+        _trust("wr")
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_edit = call_count
+
+        (bundle / "providers" / "sibling.py").write_text(
+            PROVIDER_MODULE.format(provider="acme-sibling") + "\n# changed after activation\n"
+        )
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_edit
+        assert type(second).__name__ == "Endpoint"
+
+    def test_edited_settings_forces_a_fresh_rescan(self, write_plugin, monkeypatch):
+        _write_provider_plugin(write_plugin, "wr", name="web-research", provider="acme-llm")
+
+        call_count = 0
+        original_activate_target = PluginRegistry.activate_target.__func__
+
+        def counting_activate_target(cls, plugin_name, target):
+            nonlocal call_count
+            call_count += 1
+            return original_activate_target(cls, plugin_name, target)
+
+        monkeypatch.setattr(
+            PluginRegistry, "activate_target", classmethod(counting_activate_target)
+        )
+
+        first = match_endpoint(provider="acme-llm", endpoint="chat")
+        cached_hit = match_endpoint(provider="acme-llm", endpoint="chat")
+        assert type(first).__name__ == type(cached_hit).__name__ == "PluginProviderEndpoint"
+        calls_before_edit = call_count
+
+        settings_path = user_settings_path()
+        previous_stat = settings_path.stat()
+        settings = read_user_settings()
+        settings.setdefault("plugins", {})["web-research"] = {"enabled": False}
+        write_user_settings(settings)
+        if settings_path.stat().st_mtime_ns == previous_stat.st_mtime_ns:
+            os.utime(
+                settings_path,
+                ns=(previous_stat.st_atime_ns, previous_stat.st_mtime_ns + 1_000_000_000),
+            )
+
+        second = match_endpoint(provider="acme-llm", endpoint="chat")
+
+        assert call_count > calls_before_edit
+        assert type(second).__name__ == "Endpoint"
+
+
+class TestPluginProviderConsultConcurrency:
+    def test_activation_and_collision_filtering_are_serialized(self, monkeypatch):
+        first_inside_activation = threading.Event()
+        release_first = threading.Event()
+        second_attempting_consult = threading.Event()
+        second_inside_activation = threading.Event()
+        errors: list[BaseException] = []
+        targets = {
+            "registry-first": ("plugin-first", "providers/first.py", "thread-first-provider"),
+            "registry-second": (
+                "plugin-second",
+                "providers/second.py",
+                "thread-second-provider",
+            ),
+        }
+
+        def active_provider_targets(cls):
+            plugin_name, module, _ = targets[threading.current_thread().name]
+            return [(plugin_name, module)]
+
+        def activate_target(cls, plugin_name, module):
+            _, _, provider = targets[threading.current_thread().name]
+            module_name = f"_registry_concurrency_{plugin_name}"
+            endpoint_cls = type("PluginProviderEndpoint", (), {"__module__": module_name})
+            EndpointRegistry.register(provider=provider, endpoint="chat")(endpoint_cls)
+            if threading.current_thread().name == "registry-first":
+                first_inside_activation.set()
+                if not release_first.wait(timeout=5):
+                    raise TimeoutError("timed out waiting to finish the first activation")
+            else:
+                second_inside_activation.set()
+            return SimpleNamespace(__name__=module_name)
+
+        monkeypatch.setattr(
+            PluginRegistry, "active_provider_targets", classmethod(active_provider_targets)
+        )
+        monkeypatch.setattr(PluginRegistry, "activate_target", classmethod(activate_target))
+
+        def consult(*, mark_attempt: bool = False):
+            try:
+                if mark_attempt:
+                    second_attempting_consult.set()
+                EndpointRegistry._consult_plugin_providers()
+            except BaseException as exc:
+                errors.append(exc)
+
+        first = threading.Thread(target=consult, name="registry-first", daemon=True)
+        second = threading.Thread(
+            target=consult,
+            kwargs={"mark_attempt": True},
+            name="registry-second",
+            daemon=True,
+        )
+        first.start()
+        assert first_inside_activation.wait(timeout=5)
+        second.start()
+        assert second_attempting_consult.wait(timeout=5)
+        try:
+            assert not second_inside_activation.wait(timeout=0.5), (
+                "a second consultation entered activation before the first mutation completed"
+            )
+        finally:
+            release_first.set()
+            first.join(timeout=5)
+            second.join(timeout=5)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        registered = {entry.meta.provider for entry in EndpointRegistry._entries}
+        assert {"thread-first-provider", "thread-second-provider"} <= registered
 
 
 class TestPluginProviderMiss:

--- a/tests/service/hooks/unit/test_types_contracts.py
+++ b/tests/service/hooks/unit/test_types_contracts.py
@@ -3,12 +3,21 @@
 
 """Test contracts for hook types and enums."""
 
+from collections.abc import Callable
+from typing import Any, get_args, get_origin, get_type_hints
+
+import pytest
+
+from lionagi.service.connections.api_calling import APICalling
 from lionagi.service.hooks._types import (
     ALLOWED_HOOKS_TYPES,
     AssociatedEventInfo,
     HookDict,
     HookEventTypes,
+    StreamHandlers,
 )
+from lionagi.service.hooks.hook_registry import HookRegistry
+from lionagi.service.imodel import iModel
 
 
 class TestHookEventTypes:
@@ -72,3 +81,45 @@ class TestHookDict:
         assert hook_dict["pre_event_create"] is None
         assert callable(hook_dict["pre_invocation"])
         assert hook_dict["post_invocation"] is None
+
+
+class TestRuntimeTypeConformance:
+    @pytest.mark.anyio
+    async def test_stream_handler_type_matches_runtime_arguments(self):
+        _, handler_type = get_args(StreamHandlers)
+        assert get_origin(handler_type) is Callable
+        positional, _ = get_args(handler_type)
+        assert len(positional) == 3
+        assert positional[0] is Any
+        assert positional[1] == str | type
+
+        captured = {}
+
+        async def handler(event, chunk_type, chunk, **kwargs):
+            captured.update(
+                event=event,
+                chunk_type=chunk_type,
+                chunk=chunk,
+                kwargs=kwargs,
+            )
+
+        handlers: StreamHandlers = {"text": handler}
+        registry = HookRegistry(stream_handlers=handlers)
+
+        await registry.handle_streaming_chunk("text", "payload", marker="value")
+
+        assert captured == {
+            "event": None,
+            "chunk_type": "text",
+            "chunk": "payload",
+            "kwargs": {"exit": False, "marker": "value"},
+        }
+
+    @pytest.mark.anyio
+    async def test_create_event_annotation_matches_runtime_value(self):
+        assert get_type_hints(iModel.create_event)["return"] is APICalling
+
+        model = iModel(provider="openai", model="gpt-4.1-mini", api_key="test-key")
+        event = await model.create_event(messages=[{"role": "user", "content": "hello"}])
+
+        assert isinstance(event, APICalling)


### PR DESCRIPTION
Batch fix of 4 service-layer registry/hooks issues, each with a regression test.

- **#1998** — `EndpointRegistry._match_registered()` lowercases the provider input once and uses that normalized key for both the entry scan and the single-endpoint-provider count, so `OPENAI` and `openai` resolve to the same endpoint class without mutating registered metadata.
- **#2190** — plugin activation, provenance assignment, entry annotation, and built-in collision filtering now run under `EndpointRegistry._lock`, re-reading `_entries` after acquiring the lock and skipping activation when a competing thread already registered the same target. Deterministic two-thread interleaving regression.
- **#2224** — the cached plugin revalidation signature now covers the manifest, every path from `_collect_declared_paths()`, and the user-settings mtime; editing a sibling declared provider file or disabling via settings invalidates the cached entry without a registry reset.
- **#1968** — `StreamHandlers` documents its three positional runtime args `(event, chunk_type, chunk)` and `iModel.create_event()` is annotated with its actual `APICalling` return type; typing-introspection + runtime regression.

Verification: `uv run pytest tests/service/connections/ tests/service/hooks/ tests/service/imodel/ tests/service/test_imodel_hooks.py` — all pass. ruff check + format clean on touched files.

Closes #1998
Closes #2190
Closes #2224
Closes #1968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
