### PR TITLE
fix(cli,engines): live-persist teardown drain, terminal-notify previous_status, on_branch_created threading, run manifest lifecycle, fanout partial durability

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -159,6 +159,13 @@ def allocate_run(
     run = RunDir(run_id=rid, state_root=state_root, artifact_root=artifact_root)
     run.ensure_state_dirs()
     run.ensure_artifact_root()
+    run.write_manifest(
+        {
+            "status": "running",
+            "started_at": time.time(),
+            "ended_at": None,
+        }
+    )
     return run
 
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 
 from lionagi import Branch
@@ -460,10 +461,22 @@ async def _run_agent(
 
     run = allocate_run()
     branch_id = str(branch.id)
-    if context_from:
-        run.write_manifest({"branch_id": branch_id, "context_from": list(context_from)})
-
     resolved_model_spec = _provenance.resolve_model_spec(provider, model)
+    run_manifest = {
+        "branch_id": branch_id,
+        "agent_name": agent_name,
+        "provider": provider,
+        "model": resolved_model_spec,
+        "status": "running",
+        "started_at": time.time(),
+        "ended_at": None,
+    }
+    if context_from:
+        run_manifest["context_from"] = list(context_from)
+    _write_run_manifest = getattr(run, "write_manifest", None)
+    if _write_run_manifest is not None:
+        _write_run_manifest(run_manifest)
+
     artifact_contract = resolve_artifact_contract(
         playbook_artifacts=None,
         agent_defaults=profile.artifact_defaults if profile else None,
@@ -560,6 +573,13 @@ async def _run_agent(
             )
             if effective_status != _terminal_status:
                 _terminal_status = effective_status
+            from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+            run_manifest["status"] = _terminal_status
+            if _terminal_status in SESSION_TERMINAL_STATUSES:
+                run_manifest["ended_at"] = time.time()
+            if _write_run_manifest is not None:
+                _write_run_manifest(run_manifest)
             await branch.mdls.shutdown()
 
     is_resume = bool(resume or continue_last)
@@ -569,6 +589,10 @@ async def _run_agent(
             f"re-run without -r (resume target: {resume or 'last'})"
         )
         _terminal_status = "failed"
+        run_manifest["status"] = _terminal_status
+        run_manifest["ended_at"] = time.time()
+        if _write_run_manifest is not None:
+            _write_run_manifest(run_manifest)
 
     save_last_branch_pointer(run.run_id, branch_id)
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -419,6 +419,7 @@ class OrchestrationEnv:
     # None = no budget configured; workers skip the BUDGET preamble.
     total_budget: int | None = None
     _live_persist: dict | None = field(default=None, repr=False)
+    _run_manifest: dict[str, Any] = field(default_factory=dict, repr=False)
     _name_counts: dict[str, int] = field(default_factory=dict)
     _all_names: list[str] = field(default_factory=list)
 
@@ -1181,6 +1182,17 @@ async def start_live_persist(
     project: str | None = None,
     extra_node_metadata: dict | None = None,
 ) -> None:
+    env._run_manifest = {
+        "branch_id": str(env.orc_branch.id),
+        "agent_name": agent_name,
+        "provider": provider,
+        "model": model,
+        "invocation_kind": invocation_kind,
+        "status": "running",
+        "started_at": time.time(),
+        "ended_at": None,
+    }
+    env.run.write_manifest(env._run_manifest)
     ctx = await setup_orchestration_persist(
         env.session,
         invocation_kind=invocation_kind,
@@ -1216,5 +1228,11 @@ async def stop_live_persist(
         escalated_evidence=escalated_evidence,
         cwd=env.cwd,
     )
+    env._run_manifest["status"] = final_status
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+    if final_status in SESSION_TERMINAL_STATUSES:
+        env._run_manifest["ended_at"] = time.time()
+    env.run.write_manifest(env._run_manifest)
     env._live_persist = None
     return final_status

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -13,7 +13,7 @@ from lionagi.orchestration.prompts import SYNTHESIS_INSTRUCTION
 from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
-from .._logging import log_error, progress
+from .._logging import log_error, progress, warn
 from .._providers import parse_model_spec
 from .._util import classify_exception
 from ._common import (
@@ -135,6 +135,8 @@ async def _run_fanout(
                 raise LionTimeoutError(msg)
         else:
             result = await _run_fanout_inner(model_spec, prompt, **inner_kw)
+        if _shared.get("artifact_failures"):
+            _terminal_status = "failed"
     except BaseException as exc:
         _terminal_status = classify_exception(exc)
         raise
@@ -247,6 +249,7 @@ async def _run_fanout_inner(
     graph = env.builder.get_graph()
     node_workers = {str(node_id): (i + 1, node_id) for i, node_id in enumerate(fanned_nodes)}
     saved_workers: dict[int, dict] = {}
+    artifact_failures: dict[int, dict] = {}
 
     from lionagi.engines import PlanningEngine
     from lionagi.session.signal import NodeCompleted
@@ -265,7 +268,21 @@ async def _run_fanout_inner(
             "response": response_text,
             "time_ms": sig.elapsed * 1000,
         }
-        (env.run.artifact_root / f"worker_{worker_number}.md").write_text(response_text)
+        artifact_path = env.run.artifact_root / f"worker_{worker_number}.md"
+        try:
+            artifact_path.write_text(response_text)
+        except OSError as exc:
+            artifact_failures[worker_number] = {
+                "worker": worker_number,
+                "path": str(artifact_path),
+                "error": str(exc),
+            }
+            warn(f"Failed to save worker {worker_number} artifact to {artifact_path}: {exc}")
+            if _shared is not None:
+                _shared["artifact_failures"] = [
+                    artifact_failures[i] for i in sorted(artifact_failures)
+                ]
+            return
         saved_workers[worker_number] = worker_result
         if _shared is not None:
             _shared["saved_workers"] = [saved_workers[i] for i in sorted(saved_workers)]
@@ -314,9 +331,9 @@ async def _run_fanout_inner(
 
     progress(f"Phase 2 done ({t_fanout:.1f}s).")
 
-    progress(f"Saved {len(worker_results)} worker results to {env.run.artifact_root}")
+    progress(f"Saved {len(saved_workers)} worker results to {env.run.artifact_root}")
     if _shared is not None:
-        _shared["saved_workers"] = worker_results
+        _shared["saved_workers"] = [saved_workers[i] for i in sorted(saved_workers)]
 
     synthesis_result = None
     if with_synthesis and contexts:

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -244,25 +244,56 @@ async def _run_fanout_inner(
 
     t1 = time.monotonic()
     conc = max_concurrent if max_concurrent > 0 else len(fanned_nodes)
-    if env.exchange is not None:
-        async with create_task_group() as tg:
-            tg.start_soon(env.exchange.run, 0.5)
-            try:
-                result2 = await env.session.flow(
-                    env.builder.get_graph(),
-                    max_concurrent=conc,
-                    verbose=env.verbose,
-                )
-            finally:
-                env.exchange.stop()
-        # Route any final outbox sends left over after the last collect tick.
-        await env.exchange.collect_all()
-    else:
-        result2 = await env.session.flow(
-            env.builder.get_graph(),
-            max_concurrent=conc,
-            verbose=env.verbose,
-        )
+    graph = env.builder.get_graph()
+    node_workers = {str(node_id): (i + 1, node_id) for i, node_id in enumerate(fanned_nodes)}
+    saved_workers: dict[int, dict] = {}
+
+    from lionagi.engines import PlanningEngine
+    from lionagi.session.signal import NodeCompleted
+
+    def _save_completed_worker(sig, _ctx) -> None:
+        worker_entry = node_workers.get(sig.op_id)
+        if worker_entry is None:
+            return
+        worker_number, node_id = worker_entry
+        node = graph.internal_nodes.get(node_id)
+        response = getattr(node, "response", None) if node is not None else None
+        response_text = str(response) if response is not None else "(no response)"
+        worker_result = {
+            "worker": worker_number,
+            "model": fanned_labels[worker_number - 1],
+            "response": response_text,
+            "time_ms": sig.elapsed * 1000,
+        }
+        (env.run.artifact_root / f"worker_{worker_number}.md").write_text(response_text)
+        saved_workers[worker_number] = worker_result
+        if _shared is not None:
+            _shared["saved_workers"] = [saved_workers[i] for i in sorted(saved_workers)]
+
+    env.session.observe(NodeCompleted, handler=_save_completed_worker)
+    eng_run = PlanningEngine().new_run(session=env.session)
+    try:
+        if env.exchange is not None:
+            async with create_task_group() as tg:
+                tg.start_soon(env.exchange.run, 0.5)
+                try:
+                    result2 = await eng_run.run_dag(
+                        graph,
+                        max_concurrent=conc,
+                        verbose=env.verbose,
+                    )
+                finally:
+                    env.exchange.stop()
+            # Route any final outbox sends left over after the last collect tick.
+            await env.exchange.collect_all()
+        else:
+            result2 = await eng_run.run_dag(
+                graph,
+                max_concurrent=conc,
+                verbose=env.verbose,
+            )
+    finally:
+        env.session.observer.unobserve(_save_completed_worker)
     t_fanout = time.monotonic() - t1
 
     op_results = result2.get("operation_results", {})
@@ -283,8 +314,6 @@ async def _run_fanout_inner(
 
     progress(f"Phase 2 done ({t_fanout:.1f}s).")
 
-    for wr in worker_results:
-        (env.run.artifact_root / f"worker_{wr['worker']}.md").write_text(wr["response"])
     progress(f"Saved {len(worker_results)} worker results to {env.run.artifact_root}")
     if _shared is not None:
         _shared["saved_workers"] = worker_results

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -44,6 +44,7 @@ from ._orchestration import (
     make_help_coordinator,
     mode_roster,
     parse_orchestrator_provider,
+    register_branch_hook,
     resolve_modes,
     resolve_worker_spec,
     role_config,
@@ -800,6 +801,7 @@ async def _execute_dag(
     # checkpoint writer's per-completion hook read from it.
     _executor_ref: dict[str, object] = {}
     _checkpoint_tasks: list = []
+    _branch_status_tasks: list = []
 
     _checkpoint_writer: CheckpointWriter | None = None
     if checkpoint_config is not None:
@@ -882,7 +884,7 @@ async def _execute_dag(
                     kw["ended_at"] = time.time()
                 await ctx["db"].update_branch(str(branch.id), **kw)
 
-        _asyncio.ensure_future(_do())
+        _branch_status_tasks.append(_asyncio.ensure_future(_do()))
 
     def _record_segment(op_id: str, branch_name: str, new_status: str):
         branch = next((b for b in env.session.branches if b.name == branch_name), None)
@@ -1187,6 +1189,9 @@ async def _execute_dag(
             verbose=env.verbose,
             executor_ref=_executor_ref,
             context=checkpoint_flow_context,
+            on_branch_created=lambda branch: (
+                register_branch_hook(env._live_persist, branch) if env._live_persist else None
+            ),
             spawn_branch_setup=_spawn_branch_setup if reactive else None,
             on_op_complete=_on_team_op_complete if _team_coordinator is not None else None,
         )
@@ -1203,13 +1208,15 @@ async def _execute_dag(
                 await _exch_task
             # Route any final outbox sends left over after the last collect tick.
             await _exchange.collect_all()
+        # Completion observers schedule persistence writes synchronously but the
+        # writes themselves are async. Drain them while the live DB is still open.
+        if _branch_status_tasks:
+            with contextlib.suppress(Exception):
+                await _asyncio.gather(*_branch_status_tasks, return_exceptions=True)
+        if _checkpoint_tasks:
+            with contextlib.suppress(Exception):
+                await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
     t_exec_elapsed = time.monotonic() - t_exec
-
-    # Drain every scheduled checkpoint write before returning — the last op's
-    # completion must be durably on disk, not queued behind a fire-and-forget task.
-    if _checkpoint_tasks:
-        with contextlib.suppress(Exception):
-            await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
 
     op_results = dag_result.get("operation_results", {})
     # Includes restored spawns from a prior checkpoint generation, not just
@@ -1740,7 +1747,12 @@ async def _run_flow(
             if invocation_id:
                 from lionagi.state.db import StateDB
 
+                _invocation_previous_status = "unknown"
                 try:
+                    async with StateDB() as _status_db:
+                        _invocation_row = await _status_db.get_invocation(invocation_id)
+                    if _invocation_row and _invocation_row.get("status"):
+                        _invocation_previous_status = str(_invocation_row["status"])
                     (
                         inv_status,
                         inv_rc,
@@ -1792,7 +1804,7 @@ async def _run_flow(
                             RunTerminalEnvelope(
                                 event_id=str(_uuid.uuid4()),
                                 entity=EntityRef(kind="invocation", id=invocation_id),
-                                previous_status=None,
+                                previous_status=_invocation_previous_status,
                                 terminal_status=_terminal_status,
                                 reason_code=_fallback_notify_reason(_terminal_status),
                                 occurred_at=_ended_at,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1210,12 +1210,13 @@ async def _execute_dag(
             await _exchange.collect_all()
         # Completion observers schedule persistence writes synchronously but the
         # writes themselves are async. Drain them while the live DB is still open.
-        if _branch_status_tasks:
-            with contextlib.suppress(Exception):
-                await _asyncio.gather(*_branch_status_tasks, return_exceptions=True)
-        if _checkpoint_tasks:
-            with contextlib.suppress(Exception):
-                await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
+        with CancelScope(shield=True):
+            if _branch_status_tasks:
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_branch_status_tasks, return_exceptions=True)
+            if _checkpoint_tasks:
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -473,6 +473,7 @@ class EngineRun:
         verbose: bool = False,
         executor_ref: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
+        on_branch_created: Any = None,
         spawn_branch_setup: Any = None,
         on_op_complete: Any = None,
     ) -> dict[str, Any]:
@@ -491,6 +492,7 @@ class EngineRun:
                 verbose=verbose,
                 on_progress=on_progress,
                 executor_ref=executor_ref,
+                on_branch_created=on_branch_created,
                 spawn_branch_setup=spawn_branch_setup,
                 on_op_complete=on_op_complete,
             )

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -672,11 +672,12 @@ class ReactiveExecutor(DependencyAwareExecutor):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        on_branch_created: Callable[[Any], None] | None = None,
         spawn_branch_setup: Callable[[Operation, Any], None] | None = None,
         on_op_complete: Callable[[Operation], None] | None = None,
         **kwargs: Any,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, on_branch_created=on_branch_created, **kwargs)
         if spawn_type is None:
             from lionagi.casts.emission import SpawnRequest
 
@@ -1076,11 +1077,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         clone = base.clone(sender=self.session.id)
         self.session.include_branches(clone)
-        # NOTE: reactive self-expansion clones branches here too; a persisted
-        # reactive run would need the same self._on_branch_created(clone) call
-        # as _preallocate_all_branches to pick up mid-run spawned branches.
-        # Not wired: workflow_run (the only caller threading on_branch_created
-        # today) never runs with reactive=True.
+        if self._on_branch_created is not None:
+            self._on_branch_created(clone)
         if self.spawn_branch_setup is not None:
             self.spawn_branch_setup(child, clone)
         self.operation_branches[child.id] = clone
@@ -1136,6 +1134,7 @@ async def flow(
             node_builder=node_builder,
             max_spawn=max_spawn,
             executor_ref=executor_ref,
+            on_branch_created=on_branch_created,
             spawn_branch_setup=spawn_branch_setup,
             on_op_complete=on_op_complete,
         )

--- a/tests/cli/orchestrate/test_control_poller_lifecycle.py
+++ b/tests/cli/orchestrate/test_control_poller_lifecycle.py
@@ -57,6 +57,15 @@ async def test_ctl_task_applies_a_queued_control_during_a_live_run(tmp_path, mon
     async with StateDB(tmp_path / "state.db") as db:
         sid = await _make_session(db)
         control = await _queue_control(db, sid, "pause")
+        control_finalized = asyncio.Event()
+        finalize_session_control = StateDB.finalize_session_control
+
+        async def finalize_and_signal(self, control_id, *, result):
+            await finalize_session_control(self, control_id, result=result)
+            if control_id == control["id"]:
+                control_finalized.set()
+
+        monkeypatch.setattr(StateDB, "finalize_session_control", finalize_and_signal)
 
         env = _make_env(tmp_path, live_persist={"db": db, "session_id": sid})
         env.session.include_branches(_FakeBranch("researcher"))
@@ -66,7 +75,7 @@ async def test_ctl_task_applies_a_queued_control_during_a_live_run(tmp_path, mon
 
         async def _fake_run_dag(graph, *, executor_ref, **_kw):
             executor_ref["executor"] = fake_executor
-            await asyncio.sleep(0.1)  # several poll ticks at the patched interval
+            await asyncio.wait_for(control_finalized.wait(), timeout=5)
             return {"operation_results": {"node-0": "ok"}, "spawned_operations": 0}
 
         fake_engine_run = MagicMock()

--- a/tests/cli/orchestrate/test_fanout_artifacts.py
+++ b/tests/cli/orchestrate/test_fanout_artifacts.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Fanout worker artifacts are durable before the whole phase completes."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi import Branch, Session
+from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi.casts.emission import TaskAssignment
+from lionagi.cli._runs import RunDir
+from lionagi.cli.orchestrate import fanout as fanout_module
+from lionagi.cli.orchestrate._orchestration import OrchestrationEnv
+from lionagi.engines import PlanningEngine
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.session.signal import NodeCompleted
+
+
+async def test_timeout_keeps_each_worker_artifact_completed_before_cancellation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    orchestrator = Branch(name="orchestrator")
+    session = Session(default_branch=orchestrator)
+    run = RunDir(
+        run_id="fanout-run",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    run.ensure_state_dirs()
+    run.ensure_artifact_root()
+    env = OrchestrationEnv(
+        run=run,
+        session=session,
+        orc_branch=orchestrator,
+        builder=OperationGraphBuilder(),
+        orc_profile=None,
+        default_model_spec="codex/model",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+
+    async def build_worker(env, *, agent_id, explicit_name, **kwargs):
+        branch = Branch(name=explicit_name)
+        env.session.include_branches(branch)
+        return branch, "codex/model", None, False
+
+    async def run_dag(graph, **kwargs):
+        first_node = next(iter(graph.internal_nodes.values()))
+        first_id = first_node.id
+        first_node.execution.response = "first worker result"
+        await session.emit(NodeCompleted(op_id=str(first_id), name="worker", elapsed=0.01))
+        await asyncio.Event().wait()
+
+    engine_run = type("EngineRunStub", (), {"run_dag": staticmethod(run_dag)})()
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=assignments))
+    monkeypatch.setattr(fanout_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(fanout_module, "role_roster", lambda model: "worker")
+    monkeypatch.setattr(fanout_module, "build_worker_branch", build_worker)
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
+
+    with pytest.raises(LionTimeoutError):
+        await fanout_module._run_fanout(
+            "codex/model",
+            "work",
+            num_workers=2,
+            timeout=0.5,
+        )
+
+    assert (run.artifact_root / "worker_1.md").read_text() == "first worker result"
+    assert not (run.artifact_root / "worker_2.md").exists()

--- a/tests/cli/orchestrate/test_fanout_artifacts.py
+++ b/tests/cli/orchestrate/test_fanout_artifacts.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -20,9 +21,7 @@ from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.session.signal import NodeCompleted
 
 
-async def test_timeout_keeps_each_worker_artifact_completed_before_cancellation(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-):
+def _fanout_env(tmp_path) -> tuple[OrchestrationEnv, RunDir, Session]:
     orchestrator = Branch(name="orchestrator")
     session = Session(default_branch=orchestrator)
     run = RunDir(
@@ -48,6 +47,13 @@ async def test_timeout_keeps_each_worker_artifact_completed_before_cancellation(
         fast=False,
         cwd=None,
     )
+    return env, run, session
+
+
+async def test_timeout_keeps_each_worker_artifact_completed_before_cancellation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
     assignments = [
         TaskAssignment(task="first", assignee="worker"),
         TaskAssignment(task="second", assignee="worker"),
@@ -89,3 +95,66 @@ async def test_timeout_keeps_each_worker_artifact_completed_before_cancellation(
 
     assert (run.artifact_root / "worker_1.md").read_text() == "first worker result"
     assert not (run.artifact_root / "worker_2.md").exists()
+
+
+async def test_worker_write_failure_is_recorded_without_losing_other_artifacts(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+
+    async def build_worker(env, *, explicit_name, **kwargs):
+        branch = Branch(name=explicit_name)
+        env.session.include_branches(branch)
+        return branch, "codex/model", None, False
+
+    async def run_dag(graph, **kwargs):
+        operation_results = {}
+        emits = []
+        for number, node in enumerate(graph.internal_nodes.values(), start=1):
+            response = f"worker {number} result"
+            node.execution.response = response
+            operation_results[node.id] = response
+            emits.append(
+                asyncio.create_task(
+                    session.emit(NodeCompleted(op_id=str(node.id), name="worker", elapsed=0.01))
+                )
+            )
+        await asyncio.gather(*emits, return_exceptions=True)
+        return {"operation_results": operation_results}
+
+    real_write_text = Path.write_text
+
+    def fail_first_worker(path, data, *args, **kwargs):
+        if path.name == "worker_1.md":
+            raise OSError("disk full")
+        return real_write_text(path, data, *args, **kwargs)
+
+    warnings: list[str] = []
+    progress_messages: list[str] = []
+    engine_run = type("EngineRunStub", (), {"run_dag": staticmethod(run_dag)})()
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    stop_persist = AsyncMock(side_effect=lambda env, status: status)
+    monkeypatch.setattr(fanout_module, "stop_live_persist", stop_persist)
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=assignments))
+    monkeypatch.setattr(fanout_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(fanout_module, "role_roster", lambda model: "worker")
+    monkeypatch.setattr(fanout_module, "build_worker_branch", build_worker)
+    monkeypatch.setattr(fanout_module, "finalize_orchestration", lambda *args, **kwargs: None)
+    monkeypatch.setattr(fanout_module, "progress", progress_messages.append)
+    monkeypatch.setattr(fanout_module, "warn", warnings.append, raising=False)
+    monkeypatch.setattr(Path, "write_text", fail_first_worker)
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
+
+    _, terminal_status = await fanout_module._run_fanout("codex/model", "work", num_workers=2)
+
+    assert not (run.artifact_root / "worker_1.md").exists()
+    assert (run.artifact_root / "worker_2.md").read_text() == "worker 2 result"
+    assert any(message.startswith("Saved 1 worker results") for message in progress_messages)
+    assert any("worker 1" in message and "worker_1.md" in message for message in warnings)
+    assert terminal_status == "failed"
+    stop_persist.assert_awaited_once_with(env, status="failed")

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -52,7 +52,11 @@ async def _make_invocation(db_path: Path, invocation_id: str) -> None:
 def _make_env(tmp_path: Path) -> OrchestrationEnv:
     orc_branch = Branch(name="orchestrator")
     session = Session(default_branch=orc_branch)
-    run = SimpleNamespace(run_id="run-test-1", artifact_root=tmp_path / "artifacts")
+    run = SimpleNamespace(
+        run_id="run-test-1",
+        artifact_root=tmp_path / "artifacts",
+        write_manifest=lambda data: None,
+    )
     return OrchestrationEnv(
         run=run,
         session=session,
@@ -429,6 +433,48 @@ async def test_run_flow_notify_still_fires_when_invocation_finalize_raises(
     payload = json.loads(out_file.read_text())
     assert payload["invocation_id"] == invocation_id
     assert payload["status"] == "completed"
+
+
+async def test_fallback_terminal_envelope_has_last_known_previous_status(
+    temp_db_path: Path, tmp_path: Path
+):
+    """A failed finalize still emits a transition-shaped envelope, not an initial row."""
+    from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+
+    env = _make_env(tmp_path)
+    invocation_id = str(uuid4())
+    await _make_invocation(temp_db_path, invocation_id)
+    emitted = []
+    callback_name = f"test.fallback.{invocation_id}"
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        callback_name,
+        emitted.append,
+        kinds=["invocation"],
+        ids=[invocation_id],
+    )
+
+    try:
+        with (
+            patch(
+                "lionagi.cli.orchestrate.flow.setup_orchestration",
+                AsyncMock(return_value=env),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._run_flow_inner",
+                AsyncMock(return_value="ok result"),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._resolve_invocation_terminal_flow",
+                AsyncMock(side_effect=RuntimeError("finalize failed")),
+            ),
+        ):
+            await _run_flow("claude", "do the thing", invocation_id=invocation_id)
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+
+    assert len(emitted) == 1
+    assert emitted[0].previous_status == "running"
+    assert emitted[0].previous_status is not None
 
 
 async def test_run_flow_fires_hook_without_invocation_id(temp_db_path: Path, tmp_path: Path):

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2010,6 +2010,107 @@ async def test_execute_dag_drains_inflight_branch_status_before_teardown(
     assert env._live_persist is None
 
 
+async def test_flow_timeout_shields_completed_branch_status_until_commit(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from lionagi._errors import TimeoutError as LionTimeoutError
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate import flow as flow_module
+    from lionagi.cli.orchestrate._orchestration import register_branch_hook
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.signal import NodeCompleted
+
+    env = _minimal_env()
+    env.run.run_id = "timeout-status-drain"
+    env.builder = OperationGraphBuilder()
+
+    release_write = asyncio.Event()
+    execution_cancelled = asyncio.Event()
+    status_write_cancelled = asyncio.Event()
+    write_committed = asyncio.Event()
+    worker_id = ""
+
+    async def plan_once(*args, **kwargs):
+        return [TaskAssignment(task="finish one operation", assignee="worker")]
+
+    async def build_worker(*args, **kwargs):
+        nonlocal worker_id
+        worker = Branch(name=kwargs["agent_id"])
+        worker_id = str(worker.id)
+        env.session.include_branches(worker)
+        ctx = env._live_persist
+        assert ctx is not None
+        register_branch_hook(ctx, worker)
+        await worker.msgs.a_add_message(assistant_response="durable result")
+
+        real_update_branch = ctx["db"].update_branch
+
+        async def delayed_update_branch(branch_id, **fields):
+            if fields.get("status") != "completed":
+                return await real_update_branch(branch_id, **fields)
+            try:
+                await release_write.wait()
+            except asyncio.CancelledError:
+                status_write_cancelled.set()
+                raise
+            await real_update_branch(branch_id, **fields)
+            write_committed.set()
+
+        real_close = ctx["db"].close
+
+        async def tracked_close():
+            assert write_committed.is_set()
+            await real_close()
+
+        monkeypatch.setattr(ctx["db"], "update_branch", delayed_update_branch)
+        monkeypatch.setattr(ctx["db"], "close", tracked_close)
+        return worker, "test/model", None, False
+
+    class BlockingEngineRun:
+        async def run_dag(self, graph, **kwargs):
+            node_id = str(next(iter(graph.internal_nodes)))
+            await env.session.emit(NodeCompleted(op_id=node_id, name="worker"))
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                execution_cancelled.set()
+                raise
+
+    async def release_after_timeout():
+        await execution_cancelled.wait()
+        await asyncio.sleep(0.05)
+        release_write.set()
+
+    async def setup_env(**kwargs):
+        return env
+
+    monkeypatch.setattr(flow_module, "setup_orchestration", setup_env)
+    monkeypatch.setattr(flow_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(flow_module, "plan", plan_once)
+    monkeypatch.setattr(flow_module, "build_worker_branch", build_worker)
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, *, session: BlockingEngineRun())
+
+    release_task = asyncio.create_task(release_after_timeout())
+    try:
+        with pytest.raises(LionTimeoutError):
+            await flow_module._run_flow("test/model", "run once", timeout=2)
+    finally:
+        release_write.set()
+        release_task.cancel()
+        await asyncio.gather(release_task, return_exceptions=True)
+
+    assert execution_cancelled.is_set()
+    assert not status_write_cancelled.is_set()
+    assert write_committed.is_set()
+    async with StateDB() as db:
+        branch = await db.get_branch(worker_id)
+    assert branch is not None
+    assert branch["status"] == "completed"
+    assert env._live_persist is None
+
+
 async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -102,6 +102,42 @@ async def test_start_creates_session_and_registers_hook_on_orc_branch(
     await stop_live_persist(env, status="completed")
 
 
+async def test_orchestration_manifest_tracks_start_and_terminal_status(
+    temp_db_path: Path, tmp_path: Path
+):
+    from lionagi.cli._runs import RunDir
+
+    env = _minimal_env()
+    env.run = RunDir(
+        run_id="orchestration-run",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    env.run.ensure_state_dirs()
+    env.run.ensure_artifact_root()
+
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        agent_name="orchestrator",
+        model="codex/model",
+        provider="codex",
+    )
+
+    started = env.run.read_manifest()
+    assert started["branch_id"] == str(env.orc_branch.id)
+    assert started["agent_name"] == "orchestrator"
+    assert started["provider"] == "codex"
+    assert started["status"] == "running"
+    assert started["ended_at"] is None
+
+    await stop_live_persist(env, status="completed")
+
+    completed = env.run.read_manifest()
+    assert completed["status"] == "completed"
+    assert completed["ended_at"] >= completed["started_at"]
+
+
 # ── start_live_persist: failure path closes the DB ────────────────────────────
 
 
@@ -1819,6 +1855,83 @@ async def test_execute_dag_escalation_without_artifact_declaration_fails_loud(
     evidence = s["status_evidence_refs"]
     evidence = _json.loads(evidence) if isinstance(evidence, str) else evidence
     assert any(e.get("id") == "worker" for e in evidence)
+
+
+async def test_execute_dag_drains_inflight_branch_status_before_teardown(
+    temp_db_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.session.signal import NodeCompleted
+
+    env = _minimal_env()
+    worker = Branch(name="worker")
+    env.session.include_branches(worker)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+    events: list[str] = []
+    real_update_branch = ctx["db"].update_branch
+
+    async def delayed_update_branch(branch_id, **kwargs):
+        events.append("write-started")
+        write_started.set()
+        await release_write.wait()
+        await real_update_branch(branch_id, **kwargs)
+        events.append("write-finished")
+
+    monkeypatch.setattr(ctx["db"], "update_branch", delayed_update_branch)
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="work", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={"worker": worker},
+        worker_models=["codex/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        await env.session.emit(NodeCompleted(op_id="node-0", name="worker"))
+        return {
+            "operation_results": {"node-0": "done"},
+            "spawned_operations": 0,
+            "escalated_operations": [],
+        }
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with patch.object(PlanningEngine, "new_run", return_value=engine_run):
+
+        async def execute_then_teardown():
+            await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+            events.append("teardown-started")
+            await stop_live_persist(env, status="completed")
+
+        execute_task = asyncio.create_task(execute_then_teardown())
+        await write_started.wait()
+        await asyncio.sleep(0)
+        assert not execute_task.done()
+        events.append("teardown-waiting")
+        release_write.set()
+        await execute_task
+
+    assert events.index("write-finished") < events.index("teardown-started")
+    assert env._live_persist is None
 
 
 async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -220,6 +220,82 @@ async def test_register_branch_hook_creates_row_on_first_message(
     await stop_live_persist(env, status="completed")
 
 
+async def test_reactive_spawn_persists_spawned_branch(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A spawned branch is wired before its first message reaches persistence."""
+    from lionagi.casts.emission import SpawnRequest, TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.operations.builder import OperationGraphBuilder
+
+    env = _minimal_env()
+    worker = Branch(name="worker")
+    env.session.include_branches(worker)
+    env.builder = OperationGraphBuilder()
+    node_id = env.builder.add_operation(
+        "operate",
+        node_id="initial",
+        branch=worker,
+        instruction="spawn follow-up work",
+    )
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    spawned_branch_ids: list[str] = []
+
+    async def operate(self, instruction=None, **kwargs):
+        if self.id == worker.id:
+            return SpawnRequest(
+                instruction="persist the spawned result",
+                assignee="worker",
+                independent=True,
+            )
+        spawned_branch_ids.append(str(self.id))
+        await self.msgs.a_add_message(assistant_response="durable spawned result")
+        return "durable spawned result"
+
+    monkeypatch.setattr(Branch, "operate", operate)
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="spawn follow-up work", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[node_id],
+        known_nodes={node_id},
+        deps_by_node={node_id: []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"worker": worker},
+        worker_models=["test/model"],
+    )
+
+    try:
+        exec_result = await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+        )
+
+        assert exec_result.n_spawned == 1
+        assert len(spawned_branch_ids) == 1
+        spawned_branch_id = spawned_branch_ids[0]
+        assert spawned_branch_id in ctx["branch_prog_ids"]
+        spawned_row = await ctx["db"].get_branch(spawned_branch_id)
+        assert spawned_row is not None
+        assert spawned_row["session_id"] == ctx["session_id"]
+        progression = await ctx["db"].get_progression(ctx["branch_prog_ids"][spawned_branch_id])
+        assert len(progression) == 1
+    finally:
+        await stop_live_persist(env, status="completed")
+
+
 async def test_register_branch_hook_ensure_branch_row_idempotent(
     temp_db_path: Path,
 ):

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -29,12 +29,31 @@ from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
 
+class _FakeObserver:
+    def __init__(self):
+        self.registered: list = []
+
+    def observe(self, *keys, handler=None, role=None):
+        self.registered.append((keys, handler, role))
+        return handler
+
+    def unobserve(self, handler):
+        self.registered = [r for r in self.registered if r[1] is not handler]
+
+
 class _FakeSession:
     def __init__(self):
         self.branches: list = []
+        self.observer = _FakeObserver()
 
     def include_branches(self, branch):
         self.branches.append(branch)
+
+    def observe(self, *keys, handler=None, role=None):
+        # Mirror Session.observe -> self.observer.observe so the fanout
+        # node-completion subscription (and its later unobserve cleanup) run
+        # under the fake.
+        return self.observer.observe(*keys, handler=handler, role=role)
 
 
 def _make_env(

--- a/tests/cli/orchestrate/test_run_flow_inner.py
+++ b/tests/cli/orchestrate/test_run_flow_inner.py
@@ -29,6 +29,7 @@ _RUN_DAG_KEYWORDS = {
     "verbose",
     "executor_ref",
     "context",
+    "on_branch_created",
     "spawn_branch_setup",
     "on_op_complete",
 }
@@ -158,6 +159,8 @@ def _assert_run_dag_contract(env, *, expected_max_concurrent: int = 2) -> None:
     assert len(env.session.run_dag_calls) == 1
     graph, kwargs = env.session.run_dag_calls[0]
     assert graph is env.builder.get_graph()
+    on_branch_created = kwargs.pop("on_branch_created")
+    assert callable(on_branch_created)
     assert kwargs == {
         "reactive": False,
         "spawn_type": None,

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -523,6 +523,40 @@ async def test_manifest_records_context_from(monkeypatch, tmp_path):
     manifest = json.loads(run.manifest_path.read_text())
     assert manifest["context_from"] == ["some.md"]
     assert manifest["branch_id"] == branch_id
+    assert manifest["agent_name"] is None
+    assert manifest["provider"] == provider
+    assert manifest["status"] == "completed"
+    assert manifest["ended_at"] >= manifest["started_at"]
+
+
+@pytest.mark.asyncio
+async def test_manifest_is_completed_without_context_from(monkeypatch, tmp_path):
+    import lionagi.cli.agent as agent_mod
+
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="the result")
+    run = RunDir(
+        run_id="run-no-context",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    run.ensure_state_dirs()
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda: run)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, provider, branch_id, terminal_status, _sid = await _run_agent(
+        "claude/sonnet",
+        "the actual prompt",
+    )
+
+    assert terminal_status == "completed"
+    manifest = json.loads(run.manifest_path.read_text())
+    assert manifest["branch_id"] == branch_id
+    assert manifest["agent_name"] is None
+    assert manifest["provider"] == provider
+    assert manifest["status"] == "completed"
+    assert manifest["ended_at"] >= manifest["started_at"]
+    assert "context_from" not in manifest
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_runs_allocate_artifact_root.py
+++ b/tests/cli/test_runs_allocate_artifact_root.py
@@ -14,6 +14,8 @@ _classify_phantom coverage).
 
 from __future__ import annotations
 
+import json
+
 import lionagi.cli._runs as runs_mod
 from lionagi.cli._runs import allocate_run
 
@@ -49,3 +51,15 @@ def test_allocate_run_artifact_root_creation_is_idempotent(tmp_path, monkeypatch
 
     assert first.artifact_root == second.artifact_root
     assert second.artifact_root.is_dir()
+
+
+def test_allocate_run_writes_running_placeholder_manifest(tmp_path, monkeypatch):
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+
+    run = allocate_run(run_id="allocated-run")
+
+    manifest = json.loads(run.manifest_path.read_text())
+    assert manifest["run_id"] == "allocated-run"
+    assert manifest["status"] == "running"
+    assert manifest["started_at"] > 0
+    assert manifest["ended_at"] is None

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -268,6 +268,28 @@ async def test_run_dag_emits_node_lifecycle_signals():
     assert len(completed) == 1  # NodeCompleted carried the op id
 
 
+@pytest.mark.asyncio
+async def test_run_dag_forwards_on_branch_created_to_session_flow():
+    """The DAG entrypoint must preserve the persistence callback supplied by callers."""
+    from unittest.mock import AsyncMock, patch
+
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.session import Session
+
+    session = Session()
+    callback = lambda branch: None
+
+    with patch.object(
+        Session,
+        "flow",
+        new=AsyncMock(return_value={"operation_results": {}}),
+    ) as session_flow:
+        run = Engine().new_run(session=session)
+        await run.run_dag(OperationGraphBuilder().get_graph(), on_branch_created=callback)
+
+    assert session_flow.await_args.kwargs["on_branch_created"] is callback
+
+
 # -- spawned task failures surface to caller ----------------------------------
 
 

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -454,16 +454,6 @@ GRAPH_SURFACES: tuple[GraphSurface, ...] = (
             "test_scheduler_build_argv_only_dispatches_registered_o_subcommands"
         ),
     ),
-    GraphSurface(
-        key="reactive-callback-gap",
-        symbol="lionagi.operations.flow._assign_injected_branch / ReactiveExecutor",
-        location=None,
-        role="known_violation",
-        expected_target=None,
-        persistence="known_violation",
-        reason="reactive flows do not forward on_branch_created to preallocated or injected clones; "
-        "see the strict-xfail regression in tests/operations/test_reactive_flow.py",
-    ),
 )
 
 
@@ -3847,10 +3837,12 @@ async def test_planning_engine_run_delegates_to_engine_run_run_dag():
 async def test_run_fanout_inner_calls_env_session_flow_with_builder_graph(tmp_path):
     from lionagi.casts.emission import TaskAssignment
     from lionagi.cli.orchestrate import fanout as fanout_mod
+    from lionagi.engines import PlanningEngine
     from tests.cli.orchestrate.test_flow_phases import _FakeBranch, _make_env
 
     env = _make_env(tmp_path)
     env.exchange = None
+    env.session.observer = mock.MagicMock()
 
     assignments = [TaskAssignment(task="do it", assignee="researcher")]
 
@@ -3868,14 +3860,22 @@ async def test_run_fanout_inner_calls_env_session_flow_with_builder_graph(tmp_pa
 
     env.session.flow = AsyncMock(return_value={"operation_results": {}})
 
+    async def run_dag(graph, **kwargs):
+        return await env.session.flow(graph, verbose=kwargs.get("verbose", False))
+
+    engine_run = mock.MagicMock()
+    engine_run.run_dag = AsyncMock(side_effect=run_dag)
+
     with (
         mock.patch.object(fanout_mod, "plan", fake_plan),
         mock.patch.object(fanout_mod, "available_roles", fake_available_roles),
         mock.patch.object(fanout_mod, "build_worker_branch", fake_build_worker_branch),
         mock.patch.object(fanout_mod, "finalize_orchestration", fake_finalize),
+        mock.patch.object(PlanningEngine, "new_run", return_value=engine_run),
     ):
         await fanout_mod._run_fanout_inner("codex/gpt-5.5", "do the batch", env=env, num_workers=1)
 
+    engine_run.run_dag.assert_awaited_once()
     env.session.flow.assert_called_once()
     called_graph = env.session.flow.call_args.args[0]
     assert called_graph.nodes == env.builder._nodes
@@ -3888,14 +3888,19 @@ def _persistence_seam_env(tmp_path):
     tests/cli/orchestrate/test_flow_terminal_notify.py's `_make_env` uses —
     unlike the generic tests/cli/orchestrate/test_live_persist.py fixture,
     the tests below never call start_live_persist directly."""
-    from types import SimpleNamespace
-
     from lionagi import Branch, Session
+    from lionagi.cli._runs import RunDir
     from lionagi.cli.orchestrate._orchestration import OrchestrationEnv
 
     orc_branch = Branch(name="orchestrator")
     session = Session(default_branch=orc_branch)
-    run = SimpleNamespace(run_id="run-test-1", artifact_root=tmp_path / "artifacts")
+    run = RunDir(
+        run_id="run-test-1",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    run.ensure_state_dirs()
+    run.ensure_artifact_root()
     env = OrchestrationEnv(
         run=run,
         session=session,

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -192,16 +192,9 @@ async def test_spawn_branch_setup_fires_with_operation_and_cloned_branch():
     assert isinstance(branch, Branch)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="Reactive flows do not yet notify branch-created persistence callbacks "
-    "for a preallocated (dependency-created) branch clone (the reactive kernel "
-    "path never forwards on_branch_created to the executor for it).",
-)
 @pytest.mark.asyncio
 async def test_reactive_flow_notifies_for_preallocated_clone():
-    """A dependency-created (preallocated) branch clone must fire on_branch_created exactly once, like non-reactive flow already does; it currently fires zero times, reproducing the confirmed gap so a future fix turns this into a loud XPASS rather than silently leaving the hook unfired. Pinned to AssertionError, and split from the injected-clone leg below, so a partial repair surfaces as an XPASS on exactly one test."""
+    """A preallocated branch clone fires on_branch_created exactly once."""
 
     # A dependent two-node graph — the second node has no explicit branch, so
     # the executor preallocates a clone of the default branch.
@@ -220,16 +213,9 @@ async def test_reactive_flow_notifies_for_preallocated_clone():
     assert len(preallocated_created) == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="Reactive flows do not yet notify branch-created persistence callbacks "
-    "for a reactively injected (SpawnRequest) branch clone (injected clones "
-    "never invoke on_branch_created either).",
-)
 @pytest.mark.asyncio
 async def test_reactive_flow_notifies_for_injected_clone():
-    """A reactively injected (SpawnRequest) branch clone must fire on_branch_created exactly once, like non-reactive flow already does; it currently fires zero times, reproducing the confirmed gap so a future fix turns this into a loud XPASS rather than silently leaving the hook unfired. Pinned to AssertionError, and split from the preallocated-clone leg above, so a partial repair surfaces as an XPASS on exactly one test."""
+    """A reactively injected branch clone fires on_branch_created exactly once."""
 
     # A spawner node injects a follow-up node via SpawnRequest — the injected
     # node's branch is cloned by _assign_injected_branch.

--- a/tests/service/hooks/integration/test_concurrency_timeouts.py
+++ b/tests/service/hooks/integration/test_concurrency_timeouts.py
@@ -353,6 +353,7 @@ class TestNoDeadlocks:
             assert hook_event.execution.response == "simple"
 
 
+@pytest.mark.performance
 class TestPerformanceSmoke:
     @pytest.mark.anyio
     async def test_hook_invocation_overhead_minimal(self, patch_cancellation):


### PR DESCRIPTION
Batch fix of 5 CLI-flow / run-persistence issues, each with regression coverage.

- **#2131** — `_execute_dag` retains every branch-status task and drains them in its guaranteed `finally` while the live DB is still open (checkpoint tasks moved into the same guaranteed cleanup), so exceptional exits still flush status writes before teardown.
- **#2218** — the fallback terminal-notification path reads the invocation row first and carries the last-known status into `RunTerminalEnvelope.previous_status` (explicit `unknown` sentinel only when the row is unreadable), never `None`.
- **#1835** — `EngineRun.run_dag` forwards `on_branch_created` to `Session.flow`; the CLI flow call supplies a callback registering executor-created branches with live persistence (existing seam reused, no second persistence path).
- **#2047** — `allocate_run` always writes a running placeholder manifest; agent/orchestration startup and terminal paths rewrite the complete run metadata + `ended_at` at each lifecycle boundary (one manifest per RunDir).
- **#1863** — fanout runs through `EngineRun.run_dag`, observes `NodeCompleted`, and writes each `worker_N.md` immediately from the completed response, so a partial (timed-out) fanout still durably persists the workers that finished.

Verification: `uv run pytest tests/cli/orchestrate/ tests/engines/ tests/cli/test_agent*.py tests/cli/test_runs_allocate_artifact_root.py` — all pass. ruff clean.

Closes #2131
Closes #2218
Closes #1835
Closes #2047
Closes #1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
