### PR TITLE
fix(cli): codex-warning quiet mode, project-dir ancestor walk, marker backfill, dir-cache memoization, effort clamps, symlink diagnostic

### DIFF
--- a/lionagi/_paths.py
+++ b/lionagi/_paths.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import os
 import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 __all__ = (
     "LIONAGI_HOME",
     "RUNS_ROOT",
+    "clear_lionagi_dirs_cache",
     "find_lionagi_dirs",
 )
 
@@ -35,30 +37,46 @@ def _find_git_root(cwd: Path) -> Path | None:
     return None
 
 
-def find_lionagi_dirs() -> list[Path]:
-    """Find .lionagi/ directories, project-local first then global ~/.lionagi/."""
+@lru_cache(maxsize=32)
+def _find_lionagi_dirs_cached(cwd: Path, home: Path) -> tuple[Path, ...]:
+    """Find .lionagi/ directories for a stable cwd/home pair."""
     dirs: list[Path] = []
 
     # 1. Git root
-    git_root = _find_git_root(Path.cwd())
+    git_root = _find_git_root(cwd)
     if git_root is not None:
         candidate = git_root / ".lionagi"
         if candidate.is_dir():
             dirs.append(candidate)
 
     # 2. Walk up from cwd
-    cwd = Path.cwd()
     for parent in [cwd, *cwd.parents]:
         candidate = parent / ".lionagi"
         if candidate.is_dir() and candidate not in dirs:
             dirs.append(candidate)
 
     # 3. Global ~/.lionagi/ (always check)
-    home_candidate = Path.home() / ".lionagi"
+    home_candidate = home / ".lionagi"
     if home_candidate.is_dir() and home_candidate not in dirs:
         dirs.append(home_candidate)
 
-    return dirs
+    return tuple(dirs)
+
+
+def find_lionagi_dirs() -> list[Path]:
+    """Find .lionagi/ directories, project-local first then global ~/.lionagi/."""
+    return list(_find_lionagi_dirs_cached(Path.cwd(), Path.home()))
+
+
+def clear_lionagi_dirs_cache() -> None:
+    """Clear cached directory discovery after filesystem topology changes."""
+    _find_lionagi_dirs_cached.cache_clear()
+
+
+# Keep the conventional lru_cache hook available on the public finder while
+# caching by cwd/home internally so in-process directory changes cannot reuse
+# stale discovery results.
+find_lionagi_dirs.cache_clear = clear_lionagi_dirs_cache
 
 
 # Private alias for callers that imported the old name.

--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -48,21 +48,14 @@ def load_settings(
     if not include_project:
         return merged
 
-    if project_dir:
-        local_path = Path(project_dir) / ".lionagi" / "settings.yaml"
-        if local_path.is_file():
-            with open(local_path) as f:
+    project_root = Path(project_dir) if project_dir else Path.cwd()
+    for parent in [project_root, *project_root.parents]:
+        candidate = parent / ".lionagi" / "settings.yaml"
+        if candidate.is_file():
+            with open(candidate) as f:
                 local_settings = yaml.safe_load(f) or {}
             _deep_merge(merged, local_settings)
-    else:
-        cwd = Path.cwd()
-        for parent in [cwd, *cwd.parents]:
-            candidate = parent / ".lionagi" / "settings.yaml"
-            if candidate.is_file():
-                with open(candidate) as f:
-                    local_settings = yaml.safe_load(f) or {}
-                _deep_merge(merged, local_settings)
-                break
+            break
 
     return merged
 

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -328,14 +328,30 @@ class AgentProfile:
     extra: dict = field(default_factory=dict)
 
 
-def _resolve_profile_path(agents_dir: Path, name: str) -> Path | None:
-    """Return profile path for NAME: directory layout (<name>/<name>.md) before flat (<name>.md)."""
-    dir_candidate = agents_dir / name / f"{name}.md"
-    if dir_candidate.is_file():
-        return dir_candidate
-    flat_candidate = agents_dir / f"{name}.md"
-    if flat_candidate.is_file():
-        return flat_candidate
+def _unreadable_symlink_target(path: Path) -> str | None:
+    """Return a broken/non-file symlink's declared target, if applicable."""
+    if not path.is_symlink() or path.is_file():
+        return None
+    try:
+        return str(path.readlink())
+    except OSError:
+        return "<unreadable>"
+
+
+def _resolve_profile_path(
+    agents_dir: Path,
+    name: str,
+    *,
+    unreadable_symlinks: list[tuple[Path, str]] | None = None,
+) -> Path | None:
+    """Return profile path for NAME, recording unreadable candidate symlinks."""
+    candidates = (agents_dir / name / f"{name}.md", agents_dir / f"{name}.md")
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+        target = _unreadable_symlink_target(candidate)
+        if target is not None and unreadable_symlinks is not None:
+            unreadable_symlinks.append((candidate, target))
     return None
 
 
@@ -363,10 +379,15 @@ def list_agents() -> list[str]:
             continue
         # Directory layout
         for child in agents_dir.iterdir():
-            if child.is_dir() and (child / f"{child.name}.md").is_file():
+            profile_path = child / f"{child.name}.md"
+            if _unreadable_symlink_target(profile_path) is not None:
+                continue
+            if child.is_dir() and profile_path.is_file():
                 seen.add(child.name)
         # Flat legacy layout
         for p in agents_dir.glob("*.md"):
+            if _unreadable_symlink_target(p) is not None:
+                continue
             if p.is_file():
                 seen.add(p.stem)
     seen.update(_plugin_agent_profiles().keys())
@@ -431,9 +452,14 @@ def load_agent_profile(name: str) -> AgentProfile:
         _validate_bare_name(name)
 
     dirs = _find_lionagi_dirs()
+    unreadable_symlinks: list[tuple[Path, str]] = []
     if not plugin_token:
         for d in dirs:
-            path = _resolve_profile_path(d / "agents", name)
+            path = _resolve_profile_path(
+                d / "agents",
+                name,
+                unreadable_symlinks=unreadable_symlinks,
+            )
             if path is not None:
                 _warn_if_shadowing_plugin_profile(name)
                 text = path.read_text()
@@ -449,8 +475,10 @@ def load_agent_profile(name: str) -> AgentProfile:
             "or ~/.lionagi/agents/ globally."
         )
 
-    available = list_agents()
+    available = [] if plugin_token else list_agents()
     msg = f"Agent profile '{name}' not found"
+    for path, target in unreadable_symlinks:
+        msg += f"\n{path} exists but its symlink target is unreadable: {target}"
     if available:
         msg += f"\nAvailable: {', '.join(available)}"
     raise FileNotFoundError(msg)

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -29,12 +29,15 @@ from ._context_from import (
 )
 from ._logging import hint, log_error
 from ._providers import (
+    _CLAUDE_PROVIDER_NAMES,
     BACKENDS,
     PROVIDER_BYPASS_KWARGS,
     PROVIDER_EFFORT_KWARG,
     PROVIDER_FAST_KWARGS,
     PROVIDER_YOLO_KWARGS,
     PROVIDERS_EFFORT_VIA_MODEL_NAME,
+    _clamp_claude_effort,
+    _clamp_codex_effort,
     add_common_cli_args,
     build_chat_model,
     build_deadline_preamble,
@@ -329,9 +332,9 @@ async def _run_agent(
         )
 
     if branch is None:
-        # codex sandbox blocks tool calls without bypass — surface only in
-        # verbose runs now that profiles can carry bypass/yolo themselves.
-        if verbose and provider == "codex" and not yolo and not bypass:
+        # Codex sandbox blocks tool calls without bypass. Surface this even
+        # without verbose output; CLI or profile approval flags suppress it.
+        if provider == "codex" and not yolo and not bypass:
             from lionagi.cli._logging import warn
 
             warn(
@@ -410,6 +413,10 @@ async def _run_agent(
         if effort is not None:
             kwarg = PROVIDER_EFFORT_KWARG.get(provider)
             if kwarg:
+                if provider == "codex":
+                    effort = _clamp_codex_effort(effort, cfg.get("model"))
+                elif provider in _CLAUDE_PROVIDER_NAMES:
+                    effort = _clamp_claude_effort(effort, cfg.get("model") or "")
                 cfg[kwarg] = effort
             elif provider in PROVIDERS_EFFORT_VIA_MODEL_NAME:
                 # agy (Antigravity CLI) has no effort kwarg — fold effort into
@@ -449,6 +456,15 @@ async def _run_agent(
         from lionagi.agent.factory import CREATE_AGENT_BRANCH_ORIGIN_KEY
 
         composed_via_create_agent = bool(branch.metadata.get(CREATE_AGENT_BRANCH_ORIGIN_KEY))
+        if CREATE_AGENT_BRANCH_ORIGIN_KEY not in branch.metadata and has_role_key:
+            from lionagi.protocols.messages.system import System
+
+            has_persisted_system = branch.msgs.system is not None or any(
+                isinstance(message, System) for message in branch.msgs.messages
+            )
+            if has_persisted_system:
+                branch.metadata[CREATE_AGENT_BRANCH_ORIGIN_KEY] = True
+                composed_via_create_agent = True
     else:
         composed_via_create_agent = took_create_agent_path
     if profile and profile.system_prompt and not composed_via_create_agent:

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -221,7 +221,8 @@ BACKENDS: dict[str, str] = {
 # ── Parsing ───────────────────────────────────────────────────────────────
 
 _EFFORT_SUFFIX_RE = re.compile(
-    r"^(.+?)-(" + "|".join(sorted(EFFORT_LEVELS, key=len, reverse=True)) + r")$"
+    r"^(.+?)-(" + "|".join(sorted(EFFORT_LEVELS, key=len, reverse=True)) + r")$",
+    re.IGNORECASE,
 )
 
 
@@ -278,7 +279,7 @@ def parse_model_spec(spec: str) -> ModelSpec:
     m = _EFFORT_SUFFIX_RE.match(spec)
     if m:
         model_clean = m.group(1)
-        effort = m.group(2)
+        effort = normalize_effort(m.group(2))
 
         if provider_raw in PROVIDERS_NO_EFFORT:
             raise ValueError(

--- a/tests/agent/test_settings.py
+++ b/tests/agent/test_settings.py
@@ -100,6 +100,22 @@ def test_load_settings_discovers_parent_project_settings_from_cwd(tmp_path, monk
     assert settings.get("x", {}).get("y") == 1
 
 
+def test_load_settings_discovers_parent_of_explicit_project_dir(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".lionagi").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    project = tmp_path / "project"
+    overridden_cwd = project / "nested" / "worktree"
+    overridden_cwd.mkdir(parents=True)
+    (project / ".lionagi").mkdir(parents=True)
+    (project / ".lionagi" / "settings.yaml").write_text("notifications:\n  enabled: true\n")
+
+    settings = load_settings(project_dir=overridden_cwd, include_project=True)
+
+    assert settings["notifications"]["enabled"] is True
+
+
 # ---------------------------------------------------------------------------
 # A3: untrusted python hook rejected via explicit trusted_hook_modules
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -164,19 +164,15 @@ async def test_run_agent_threads_bypass_to_build_chat_model(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path, capsys):
-    """Naked codex without --bypass or --yolo warns only in verbose runs."""
+async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path):
+    """Naked codex without --bypass or --yolo warns even without verbose output."""
     captured: list = []
     _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured)
 
     warnings_emitted: list[str] = []
 
-    import lionagi.cli.agent as agent_mod
-
-    original_warn = None
     import lionagi.cli._logging as logging_mod
-
-    original_warn = logging_mod.warn
+    import lionagi.cli.agent as agent_mod
 
     def capture_warn(msg):
         warnings_emitted.append(msg)
@@ -188,15 +184,47 @@ async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path, ca
     from lionagi.cli.agent import _run_agent
 
     await _run_agent("codex/gpt-5.3-codex-spark", "do stuff", bypass=False, yolo=False)
-    assert not warnings_emitted, f"Expected silence without verbose, got: {warnings_emitted}"
-
-    await _run_agent(
-        "codex/gpt-5.3-codex-spark", "do stuff", bypass=False, yolo=False, verbose=True
-    )
 
     assert any("--bypass" in w or "bypass" in w.lower() for w in warnings_emitted), (
         f"Expected a bypass warning, got: {warnings_emitted}"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile_flag", ["bypass", "yolo"])
+async def test_run_agent_codex_profile_approval_flag_suppresses_warning(
+    monkeypatch, tmp_path, profile_flag
+):
+    """An approval flag explicitly enabled by a loaded profile suppresses the warning."""
+    captured: list = []
+    _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured)
+
+    warnings_emitted: list[str] = []
+    import lionagi.cli._logging as logging_mod
+
+    monkeypatch.setattr(logging_mod, "warn", lambda msg: warnings_emitted.append(msg))
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli._providers import _parse_profile
+
+    profile = _parse_profile(
+        "approved",
+        "---\n"
+        "model: codex/gpt-5.3-codex-spark\n"
+        f"{profile_flag}: true\n"
+        "lion_system: false\n"
+        "---\n"
+        "Profile body.",
+    )
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda _name: profile)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/gpt-5.3-codex-spark")
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "do stuff", agent_name="approved")
+
+    bypass_warns = [w for w in warnings_emitted if "require" in w.lower() and "bypass" in w.lower()]
+    assert not bypass_warns
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_profile_validation.py
+++ b/tests/cli/test_agent_profile_validation.py
@@ -90,3 +90,21 @@ class TestLoadAgentProfileValidation:
             load_agent_profile("valid-name")
         # Must NOT be the validation error.
         assert not isinstance(exc_info.value, ValueError)
+
+    def test_broken_profile_symlink_reports_unreadable_target(self, monkeypatch, tmp_path):
+        import lionagi.cli._providers as providers
+
+        lionagi_dir = tmp_path / ".lionagi"
+        agents_dir = lionagi_dir / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "broken.md").symlink_to("missing-profile.md")
+
+        monkeypatch.setattr(providers, "_find_lionagi_dirs", lambda: [lionagi_dir])
+        monkeypatch.setattr(providers, "_plugin_agent_profiles", lambda: {})
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            providers.load_agent_profile("broken")
+
+        message = str(exc_info.value)
+        assert "exists but its symlink target is unreadable: missing-profile.md" in message
+        assert "broken" not in providers.list_agents()

--- a/tests/cli/test_agent_resume_model_override.py
+++ b/tests/cli/test_agent_resume_model_override.py
@@ -89,6 +89,24 @@ def _make_branch_json(tmp_path: Path) -> tuple[str, Path]:
     return branch_id, p
 
 
+def _make_cli_branch_json(tmp_path: Path, provider: str, model: str) -> tuple[str, Path]:
+    """Persist a minimal CLI-backed Branch for resume effort tests."""
+    from lionagi import Branch, iModel
+
+    branch = Branch(
+        chat_model=iModel(
+            provider=provider,
+            endpoint="query_cli",
+            model=model,
+            api_key="dummy",
+        )
+    )
+    branch_id = str(branch.id)
+    path = tmp_path / f"{branch_id}.json"
+    path.write_text(json.dumps(branch.to_dict()))
+    return branch_id, path
+
+
 def _reset_channel(name: str) -> logging.Logger:
     """Clear handlers + force propagate=True so caplog captures this channel.
 
@@ -306,3 +324,43 @@ async def test_exact_resume_id_does_not_emit_prefix_hint(monkeypatch, tmp_path, 
     assert terminal_status == "completed"
     prefix_hints = [rec.message for rec in caplog.records if "prefix-matched" in rec.message]
     assert not prefix_hints, f"Unexpected prefix-match hint for an exact id: {prefix_hints}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "requested", "effort_kwarg", "expected"),
+    [
+        ("codex", "gpt-5.4", "max", "reasoning_effort", "xhigh"),
+        ("claude_code", "sonnet", "xhigh", "effort", "high"),
+    ],
+)
+async def test_resume_effort_uses_provider_model_clamp(
+    monkeypatch, tmp_path, provider, model, requested, effort_kwarg, expected
+):
+    branch_id, branch_path = _make_cli_branch_json(tmp_path, provider, model)
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+
+    captured: list[str | None] = []
+
+    async def capture_operate(self, instruction=None, **kw):
+        captured.append(self.chat_model.endpoint.config.kwargs.get(effort_kwarg))
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", capture_operate)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
+        None,
+        "continue",
+        resume=branch_id,
+        effort=requested,
+    )
+
+    assert terminal_status == "completed"
+    assert captured == [expected]

--- a/tests/cli/test_agent_resume_role_branch_origin_marker.py
+++ b/tests/cli/test_agent_resume_role_branch_origin_marker.py
@@ -144,6 +144,24 @@ async def _make_persisted_role_branch(tmp_path: Path) -> tuple[str, str]:
     return branch_id, rendered
 
 
+def _make_markerless_role_branch(tmp_path: Path) -> tuple[str, str]:
+    """Persist a role-composed-looking branch without using the factory marker."""
+    from lionagi import Branch
+
+    rendered = (
+        "# Reviewer\n\nReview the requested work critically.\n\n"
+        "## Authority\n- Inspect and report on the supplied implementation."
+    )
+    branch = Branch(chat_model="claude_code/sonnet")
+    branch.msgs.set_system(branch.msgs.create_system(system=rendered))
+
+    branch_dir = tmp_path / "branches"
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    branch_id = str(branch.id)
+    (branch_dir / f"{branch_id}.json").write_text(json.dumps(branch.to_dict()))
+    return branch_id, rendered
+
+
 @pytest.mark.asyncio
 async def test_resume_with_different_plain_profile_preserves_composed_system_message(
     monkeypatch, tmp_path
@@ -226,3 +244,33 @@ async def test_continue_last_with_different_plain_profile_preserves_composed_sys
         "--continue-last on a role-composed branch under a different plain "
         "profile must not replace its persisted composed system message"
     )
+
+
+@pytest.mark.asyncio
+async def test_resume_markerless_role_branch_backfills_origin_and_preserves_system(
+    monkeypatch, tmp_path
+):
+    """Older role branches with a System message are protected and upgraded on resume."""
+    from lionagi.agent.factory import CREATE_AGENT_BRANCH_ORIGIN_KEY
+
+    branch_id, original_rendered = _make_markerless_role_branch(tmp_path)
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+    _stub_profile(
+        monkeypatch,
+        "reviewer",
+        "---\nmodel: claude_code/sonnet\nrole: reviewer\n---\nUpdated reviewer body.",
+    )
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(
+        agent_mod, "find_branch", lambda bid: ("run-x", tmp_path / "branches" / f"{bid}.json")
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "keep going", resume=branch_id, agent_name="reviewer")
+
+    branch = branches_created[-1]
+    assert _rendered_system(branch) == original_rendered
+    assert branch.metadata[CREATE_AGENT_BRANCH_ORIGIN_KEY] is True

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -18,6 +18,13 @@ def test_parse_model_spec_folds_effort_suffix_for_gemini_code():
     assert ms.effort == "high"
 
 
+def test_parse_model_spec_normalizes_mixed_case_effort_suffix():
+    ms = parse_model_spec("codex/gpt-5.4-Max")
+
+    assert ms.model == "codex/gpt-5.4"
+    assert ms.effort == "max"
+
+
 def test_parse_model_spec_rejects_effort_for_bare_gemini_provider():
     """The bare 'gemini' provider (direct Google API, not the agy CLI) still
     does not support effort levels — ValueError is raised."""
@@ -435,3 +442,44 @@ def test_gemini_ultra_folds_to_high():
     )
     assert isinstance(chat_model, str)
     assert "High" in chat_model
+
+
+def test_find_lionagi_dirs_memoizes_git_probe_per_location(monkeypatch, tmp_path):
+    import lionagi._paths as paths
+
+    calls: list = []
+    paths.clear_lionagi_dirs_cache()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(paths, "_find_git_root", lambda cwd: calls.append(cwd) or None)
+
+    try:
+        first = paths.find_lionagi_dirs()
+        second = paths.find_lionagi_dirs()
+    finally:
+        paths.clear_lionagi_dirs_cache()
+
+    assert first == second
+    assert calls == [tmp_path]
+
+
+def test_slash_profile_miss_skips_available_profile_listing(monkeypatch, tmp_path):
+    import lionagi.cli._providers as providers
+
+    find_calls: list = []
+    monkeypatch.setattr(
+        providers,
+        "_find_lionagi_dirs",
+        lambda: find_calls.append(True) or [tmp_path / ".lionagi"],
+    )
+    monkeypatch.setattr(providers, "_resolve_plugin_profile_path", lambda _name: None)
+    monkeypatch.setattr(
+        providers,
+        "list_agents",
+        lambda: pytest.fail("slash-token misses must not scan profiles for an Available listing"),
+    )
+
+    with pytest.raises(FileNotFoundError, match="Agent profile 'openai/gpt-4o' not found"):
+        providers.load_agent_profile("openai/gpt-4o")
+
+    assert find_calls == [True]


### PR DESCRIPTION
Batch fix of 6 `li agent` CLI issues, each with regression coverage.

- **#1936** — the new-branch Codex approval warning no longer requires `--verbose`; a naked Codex run warns in quiet mode, while effective `--bypass`/`--yolo` (flag OR profile-frontmatter) still suppress it.
- **#1883** — explicit `project_dir` and implicit-cwd resolution unified around one `[start, *parents]` ancestor walk stopping at the nearest `.lionagi/settings.yaml` (nearest-ancestor precedence).
- **#2222** — a resumed role-bearing branch that lacks the durable factory marker but has a persisted System message backfills the marker in branch metadata (compatibility rule, not prompt-text guessing).
- **#2223** — LionAGI directory discovery memoized by `(cwd, home)` with `clear_lionagi_dirs_cache()` / `cache_clear` hooks; slash-token misses skip `list_agents()` (no repeat git probes at a stable location, no stale results after in-process cwd/home change).
- **#1664** — resume-path Codex/Claude effort values pass through the same model-aware clamp helpers as fresh construction; effort-suffix parsing is case-insensitive and normalized before validation.
- **#2059** — profile resolution records candidate symlinks that don't resolve to files, `list_agents()` excludes them, and the not-found error names each unreadable declared target (kept `Path | None` API, added an optional diagnostic collector).

Verification: `uv run pytest` on the cited agent/provider/settings suites — all pass. ruff clean.

Closes #1936
Closes #1883
Closes #2222
Closes #2223
Closes #1664
Closes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
