### PR TITLE
fix(operations): context-provider registry coverage, call-local context threading, tokenize containment

### DIFF
--- a/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
+++ b/docs/adr/ADR-0008-pre-turn-context-provider-execution-and-attribution.md
@@ -35,13 +35,14 @@ low-priority block jump ahead merely because it was evaluated later.
 
 **P5 — Injection must be ephemeral.** The active compiler needs the selected text for one call, but
 `Branch.messages` must not acquire retrieved context as a fake user or system turn. The
-implementation uses a private per-turn slot, consumes it during request preparation, and clears it
-in a `finally` block in both chat and run.
+implementation threads selected blocks directly from chat or run into request preparation through
+the keyword-only `context_blocks` argument. No injection block is stored on `Branch`.
 
-**P6 — Attribution exists, but only as last-turn diagnostics.** `ProviderReport` captures retained
-raw blocks, provider names and token counts, skipped names, and failed names. It is overwritten on
-the next provider pass, carries no turn identifier, conflates skip reasons, and is not persisted or
-emitted to run metadata.
+**P6 — Attribution exists, but only as in-memory diagnostics.** `ProviderReport` captures retained
+raw blocks, provider names and token counts, skipped names, and failed names. The calling task keeps
+its most recent report, while the branch also retains the most recently completed provider pass as
+a compatibility fallback with last-writer semantics. Reports carry no turn identifier, conflate
+skip reasons, and are not persisted or emitted to run metadata.
 
 **P7 — The current render target requires a system message.** Provider blocks are inserted into the
 system-guidance fold. A branch without `branch.msgs.system` skips every registered provider without
@@ -63,8 +64,8 @@ or another source, but provider selection and memory lifecycle are not the same 
 | Ownership and registration | D1: Store one lazily-created ordered registry on each Branch. |
 | Retrieval and failure behavior | D2: Invoke providers sequentially, contain provider exceptions, and ignore empty results. |
 | Caps and priority | D3: Apply per-provider and total rendered-token limits after retrieval, select by descending priority, and render retained blocks in registration order. |
-| Turn integration | D4: Gather before chat/run compilation, inject through a private per-turn slot only when a system render target exists, and always clear the slot after preparation. |
-| Attribution | D5: Retain one in-memory `ProviderReport` describing selected, skipped, and failed providers. |
+| Turn integration | D4: Gather before chat/run compilation and pass retained blocks call-locally into request preparation only when a system render target exists. |
+| Attribution | D5: Retain a task-local `ProviderReport` plus a branch-level latest-completed compatibility fallback. |
 | Source independence | D6: Keep the provider protocol independent of `MemoryStore` and concrete adapters. |
 | Post-action writeback | D7: Invoke optional async writeback hooks from the operate action-result path and contain their failures. |
 
@@ -143,8 +144,10 @@ Branch ownership is:
 # lionagi/session/branch.py
 class Branch(...):
     _context_providers: ContextProviderRegistry | None = PrivateAttr(None)
-    _context_injection_slot: list[str] | None = PrivateAttr(None)
-    _last_context_report: Any = PrivateAttr(None)
+    _last_context_report: ContextVar[Any] = PrivateAttr(
+        default_factory=lambda: ContextVar("last_context_report", default=None)
+    )
+    _last_context_report_fallback: Any = PrivateAttr(None)
 
     @property
     def providers(self) -> ContextProviderRegistry:
@@ -154,12 +157,16 @@ class Branch(...):
 
     @property
     def last_context_report(self):
-        return self._last_context_report
+        task_report = self._last_context_report.get()
+        if task_report is not None:
+            return task_report
+        return self._last_context_report_fallback
 ```
 
 Exact ownership and registration semantics:
 
-- a newly constructed branch has no registry, no injection slot, and no report;
+- a newly constructed branch has no registry, its task-local report is `None`, and its branch-level
+  fallback is `None`;
 - the first access to `branch.providers` constructs `ContextProviderRegistry(budget=2000)` and all
   later accesses return the same object;
 - operation code checks `branch._context_providers` directly. It does not touch the property and
@@ -185,15 +192,15 @@ Exact retrieval cases:
 
 - **Empty registry:** returns a new report with four empty lists and imports no tokenizer.
 - **Successful non-empty string:** tokenizes the string and enters it into budget selection.
-- **`None` or any other falsy result:** contributes no block and no fired, skipped, or failed
-  outcome. Empty results are therefore invisible in the report.
-- **Provider raises `Exception`:** logs a warning with traceback, appends the provider name to
-  `report.failed`, and continues to the next entry.
+- **`None` or an empty string:** contributes no block and no fired, skipped, or failed outcome.
+  Empty results are therefore invisible in the report.
+- **Truthy or falsy non-string result:** violates the `str | None` protocol, is rejected before
+  tokenization, appends the provider name to `report.failed`, and does not prevent later providers
+  from contributing blocks.
+- **Provider raises `Exception`, or per-entry validation or token processing raises:** logs a
+  warning with traceback, appends the provider name to `report.failed`, and continues to the next
+  entry.
 - **Provider raises `BaseException` outside `Exception`:** is not contained and propagates.
-- **Protocol violation:** tokenization and later processing occur outside the `provide` try/except.
-  The protocol requires `str | None`; the registry does not promise containment for arbitrary
-  truthy non-string return values, though the current tokenizer returns zero on many encoding
-  errors.
 - **No timeout or retry:** a provider that waits indefinitely delays the turn indefinitely; a
   transient failure is attempted once.
 
@@ -213,10 +220,11 @@ The token measurement is:
 tokens = TokenCalculator.tokenize(text)
 ```
 
-With no explicit encoding or tokenizer, `TokenCalculator` resolves the default through
-`get_encoding_name(None)`, which falls back to `o200k_base`. Tokenization exceptions are contained
-inside `TokenCalculator.tokenize()` and return a count of zero. The budget is therefore a local
-rendered-text estimate, not the exact token count for every eventual model.
+Only a validated string reaches this measurement. With no explicit encoding or tokenizer,
+`TokenCalculator` resolves the default through `get_encoding_name(None)`, which falls back to
+`o200k_base`. Tokenization exceptions are contained inside `TokenCalculator.tokenize()` and return
+a count of zero. The budget is therefore a local rendered-text estimate, not the exact token count
+for every eventual model.
 
 Admission has two stages.
 
@@ -266,7 +274,7 @@ setting.
 Priority is not a relevance score and is not normalized. It is a caller-assigned admission order
 used only under budget pressure.
 
-### D4 — Gather before compilation, inject ephemerally, and clear after preparation
+### D4 — Gather before compilation and thread blocks call-locally
 
 The shared chat/run helper is:
 
@@ -276,7 +284,9 @@ async def _apply_context_providers(
     branch: Branch,
     instruction: JsonValue | Instruction,
     param: ChatParam,
-) -> Instruction | None: ...
+    *,
+    ins: Instruction | None = None,
+) -> tuple[Instruction | None, ProviderReport | None]: ...
 ```
 
 The active call sequence is:
@@ -289,53 +299,54 @@ sequenceDiagram
     participant C as _prepare_run_kwargs
     O->>B: inspect private registry
     alt no registered providers
-        B-->>O: no pre-built instruction
+        B-->>O: (None, None)
     else no system message
-        O->>B: last report = all names skipped
-        B-->>O: no pre-built instruction
+        O->>B: publish skipped report task-locally and branch-wide
+        B-->>O: (None, report)
     else system message present
         O->>R: gather(branch, pre-built instruction)
         R-->>O: ProviderReport
-        O->>B: save report and blocks in per-turn slot
+        O->>B: publish report task-locally and branch-wide
+        B-->>O: (instruction, report)
     end
-    O->>C: prepare request
+    O->>C: prepare request with context_blocks=report.blocks
     C-->>O: instruction and model kwargs
-    O->>B: clear slot in finally
 ```
 
 Exact turn semantics:
 
-- **No registry or empty registry:** `_apply_context_providers()` returns `None` and does not modify
-  `_last_context_report` or `_context_injection_slot`. The ordinary preparation path builds the
-  instruction once.
+- **No registry or empty registry:** `_apply_context_providers()` returns `(None, None)` and does not
+  modify either report view. The ordinary preparation path uses the instruction built by the
+  caller.
 - **Systemless branch:** the helper does not build an instruction and does not call any provider.
-  It overwrites `_last_context_report` with `ProviderReport(skipped=registry.names)` and returns
-  `None`.
-- **Systemful branch:** the helper builds the current `Instruction` once, passes that exact object
-  to every provider, saves the returned report, and assigns `report.blocks` to the private slot.
-  `_prepare_run_kwargs()` reuses the pre-built instruction instead of constructing another.
-- **Rendering:** `_prepare_run_kwargs()` joins blocks with exactly one newline, then computes
-  `branch.msgs.system.rendered + injected + guidance`. It adds no guaranteed delimiter between the
-  system string and first block or between the last block and guidance. Non-string guidance first
-  renders through minimal YAML.
+  It publishes `ProviderReport(skipped=registry.names)` to both report views and returns
+  `(None, report)`.
+- **Systemful branch:** chat and run build the current `Instruction` once before gathering and pass
+  that exact object to every provider. The helper publishes the returned report and returns
+  `(instruction, report)`.
+- **Call-local threading:** chat (`lionagi/operations/chat/chat.py`) and run
+  (`lionagi/operations/run/run.py`) pass `report.blocks` directly to the keyword-only
+  `context_blocks` parameter of `_prepare_run_kwargs()`. Concurrent calls therefore do not share,
+  overwrite, or clear an injection slot on the branch.
+- **Rendering:** `_prepare_run_kwargs()` joins `context_blocks` with exactly one newline, then
+  computes `branch.msgs.system.rendered + injected + guidance`. It adds no guaranteed delimiter
+  between the system string and first block or between the last block and guidance. Non-string
+  guidance first renders through minimal YAML.
 - **History placement:** with retained history, that system/injection/guidance value becomes the
   guidance of the first historical instruction; with no retained history, it becomes guidance on
   the current instruction.
-- **Clear on preparation success or failure:** chat and run wrap `_prepare_run_kwargs()` in
-  `try/finally` and set `_context_injection_slot = None`. The slot is cleared before provider
-  invocation/streaming begins.
 - **Gather failure outside normal containment:** `_apply_context_providers()` is awaited before the
-  `try/finally` in both callers. An unexpected error escaping `gather()` prevents compilation; the
-  helper assigns the slot only after gather succeeds.
+  request is prepared in both callers. An unexpected error escaping `gather()` prevents compilation
+  and does not publish a report for that pass.
 - **Durability:** direct `chat()` does not auto-record any messages; `communicate()` records its
   instruction and assistant response after invocation; `run()` records the instruction before
-  streaming. None receives the private block list in its durable content. The injected text exists
-  only in the ephemeral content copy rendered into model kwargs.
+  streaming. None receives the call-local block list in its durable content. The injected text
+  exists only in the ephemeral content copy rendered into model kwargs.
 
 The budget therefore limits injected text sent to the model, not the stored history and not the
 cost of calling providers.
 
-### D5 — `ProviderReport` is a mutable-list, last-turn diagnostic
+### D5 — `ProviderReport` is a mutable-list, task-local diagnostic with a compatibility fallback
 
 The shipped report contract is:
 
@@ -359,18 +370,25 @@ Exact attribution semantics:
 - each fired entry has only `provider_name` and integer `tokens` keys;
 - `skipped` combines per-provider overflow and total-budget exclusion without a reason code or
   token count;
-- `failed` contains names whose `provide()` raised `Exception`, without the exception value in the
-  report; the warning log carries traceback details;
-- empty/falsy provider results have no outcome row;
+- `failed` contains names whose `provide()` raised `Exception` or returned a non-string, without the
+  exception value in the report; the warning log carries traceback details;
+- `None` and empty-string provider results have no outcome row;
 - duplicate provider names make correlation ambiguous because entries have no stable entry ID;
 - a systemless turn lists every registered name in `skipped`, also without a distinct reason;
-- `branch.last_context_report` stores one reference, overwritten by the next provider-bearing or
-  systemless provider pass; turns with no registry leave the previous value unchanged; and
+- every completed provider-bearing or systemless provider pass publishes the same report to a
+  `ContextVar` for its calling task and to a branch-level compatibility fallback;
+- `branch.last_context_report` returns the current task's report when present, preserving attribution
+  for overlapping callers. If the current task has no report, it returns the branch-level fallback,
+  which makes a child-task pass visible to its awaiting parent;
+- overlapping passes update the branch-level fallback with explicit last-writer semantics. A pass
+  publishes only after provider gathering completes, and turns with no registry leave both views
+  unchanged; and
 - the report has no timestamp, turn/message ID, duration, budget total, redaction marker, or durable
   sink.
 
-Raw selected blocks remain in memory through the report even after the private injection slot is
-cleared. Clearing the slot is therefore not a privacy or erasure guarantee.
+Raw selected blocks remain in memory through the task-local and branch-level report references even
+after the call-local `context_blocks` argument falls out of scope. Call-local threading is therefore
+not a privacy or erasure guarantee.
 
 ### D6 — Provider selection is independent of memory storage
 
@@ -439,7 +457,8 @@ non-empty action responses and a registry are present.
 - Priority-based selection bounds retained rendered text while preserving deterministic display
   order.
 - Retrieved blocks reach chat and run without becoming durable messages.
-- Immediate source names and token counts are inspectable without requiring a persistence backend.
+- Immediate source names and token counts are inspectable by the calling task and, through the
+  compatibility fallback, by a parent after an awaited child-task turn.
 - Providers can use memory, search, composition, or external sources behind one structural
   protocol.
 - Post-action writeback failures cannot replace an otherwise successful operate result.
@@ -455,7 +474,8 @@ non-empty action responses and a registry are present.
   called.
 - Direct concatenation provides neither guaranteed section separators nor source names in the
   model-visible text.
-- Last-turn reports lose history, conflate outcomes, and retain raw selected text in mutable lists.
+- Task-local and latest-pass reports lose history, conflate outcomes, and retain raw selected text
+  in mutable lists.
 - Writeback has a narrower lifecycle than its “post-turn” label suggests and no idempotency or
   outcome record.
 
@@ -534,7 +554,7 @@ This would make providers work uniformly and avoid system presence as an eligibi
 was not taken because the current injection point is specifically the system-guidance fold; adding
 another provider-visible role or guidance shape changes prompt semantics. The choice remains
 explicitly open in delta 5 and ADR-0007 provides a target compiler capable of carrying blocks
-without relying on the private slot.
+without relying on that fold.
 
 ### Invoke writeback after every chat and run turn
 

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -246,12 +246,14 @@ async def _apply_context_providers(
     if not branch.msgs.system:
         report = ProviderReport(skipped=list(branch._context_providers.names))
         branch._last_context_report.set(report)
+        branch._last_context_report_fallback = report
         return None, report
 
     if ins is None:
         ins = _build_instruction(branch, instruction, param)
     report = await branch._context_providers.gather(branch, ins)
     branch._last_context_report.set(report)
+    branch._last_context_report_fallback = report
     return ins, report
 
 

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,7 @@ from lionagi.protocols.messages.message import Message, MessageContent
 from ..types import ChatParam, RunParam
 
 if TYPE_CHECKING:
+    from lionagi.protocols.context_providers import ProviderReport
     from lionagi.session.branch import Branch
 
 
@@ -92,6 +94,7 @@ def _prepare_run_kwargs(
     param: ChatParam,
     *,
     ins: Instruction | None = None,
+    context_blocks: Sequence[str] | None = None,
     _use_render_cache: bool = True,
 ) -> tuple[Instruction, dict]:
     if ins is None:
@@ -168,8 +171,7 @@ def _prepare_run_kwargs(
                 from lionagi.libs.schema.minimal_yaml import minimal_yaml
 
                 g = minimal_yaml(g).strip()
-            turn_injections = branch._context_injection_slot
-            injected = "\n".join(turn_injections) if turn_injections else ""
+            injected = "\n".join(context_blocks) if context_blocks else ""
             return branch.msgs.system.rendered + injected + g
 
         if len(_contents) == 0:
@@ -224,31 +226,33 @@ async def _apply_context_providers(
     param: ChatParam,
     *,
     ins: Instruction | None = None,
-) -> Instruction | None:
-    """Gather registered ContextProviders into the branch's per-turn injection
-    slot; returns the (pre-)built Instruction, or None when no providers are
-    registered (zero-overhead path). A branch with no system message has no
-    render target — providers are skipped, not invoked; see `branch.last_context_report`.
+) -> tuple[Instruction | None, "ProviderReport | None"]:
+    """Gather registered ContextProviders for call-local prompt rendering.
+
+    Returns the (pre-)built Instruction and its report, or ``(None, None)``
+    when no providers are registered (zero-overhead path). A branch with no
+    system message has no render target — providers are skipped, not invoked;
+    see ``branch.last_context_report``.
 
     ``ins``, when given, is reused as-is instead of building a second
     Instruction — for callers that already constructed one before this
     async, potentially side-effecting gather runs.
     """
     if not branch._context_providers:
-        return None
+        return None, None
 
     from lionagi.protocols.context_providers import ProviderReport
 
     if not branch.msgs.system:
-        branch._last_context_report = ProviderReport(skipped=list(branch._context_providers.names))
-        return None
+        report = ProviderReport(skipped=list(branch._context_providers.names))
+        branch._last_context_report.set(report)
+        return None, report
 
     if ins is None:
         ins = _build_instruction(branch, instruction, param)
     report = await branch._context_providers.gather(branch, ins)
-    branch._last_context_report = report
-    branch._context_injection_slot = report.blocks
-    return ins
+    branch._last_context_report.set(report)
+    return ins, report
 
 
 def _collect_action_dicts(act_res_msgs):

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -53,11 +53,16 @@ async def chat(
 
     await _emit_user_prompt_submit(branch, chat_param, ins)
 
-    await _apply_context_providers(branch, instruction, chat_param, ins=ins)
-    try:
-        ins, kw = _prepare_run_kwargs(branch, instruction, chat_param, ins=ins)
-    finally:
-        branch._context_injection_slot = None
+    provider_ins, context_report = await _apply_context_providers(
+        branch, instruction, chat_param, ins=ins
+    )
+    ins, kw = _prepare_run_kwargs(
+        branch,
+        instruction,
+        chat_param,
+        ins=provider_ins or ins,
+        context_blocks=context_report.blocks if context_report else None,
+    )
 
     imodel = chat_param.imodel or branch.chat_model
     if not chat_param._is_sentinel(chat_param.include_token_usage_to_model):

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -386,11 +386,16 @@ async def run(
                     "run: observer raised during RunStart emission; run proceeds normally"
                 )
 
-        await _apply_context_providers(branch, instruction, param, ins=ins)
-        try:
-            ins, kw = _prepare_run_kwargs(branch, instruction, param, ins=ins)
-        finally:
-            branch._context_injection_slot = None
+        provider_ins, context_report = await _apply_context_providers(
+            branch, instruction, param, ins=ins
+        )
+        ins, kw = _prepare_run_kwargs(
+            branch,
+            instruction,
+            param,
+            ins=provider_ins or ins,
+            context_blocks=context_report.blocks if context_report else None,
+        )
 
         # Committed before the yield below: any consumer that receives this
         # Instruction from the generator must find it already present in

--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -35,7 +35,7 @@ class ContextProvider(Protocol):
 @dataclass(frozen=True)
 class ProviderReport:
     """Per-turn observability: rendered blocks plus which providers fired,
-    were skipped (budget) or failed (exception)."""
+    were skipped (budget) or failed (exception or invalid output)."""
 
     blocks: list[str] = field(default_factory=list)
     fired: list[dict] = field(default_factory=list)
@@ -93,6 +93,8 @@ class ContextProviderRegistry:
         for entry in self._entries:
             try:
                 text = await entry.provider.provide(branch, instruction)
+                if text is not None and not isinstance(text, str):
+                    raise TypeError("context provider output must be a string or None")
                 if not text:
                     continue
                 tokens = TokenCalculator.tokenize(text)

--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -93,17 +93,16 @@ class ContextProviderRegistry:
         for entry in self._entries:
             try:
                 text = await entry.provider.provide(branch, instruction)
+                if not text:
+                    continue
+                tokens = TokenCalculator.tokenize(text)
+                if entry.max_tokens and tokens > entry.max_tokens:
+                    report.skipped.append(entry.name)
+                    continue
+                successes.append((entry, text, tokens))
             except Exception:
                 logger.warning("context provider %r raised; skipping", entry.name, exc_info=True)
                 report.failed.append(entry.name)
-                continue
-            if not text:
-                continue
-            tokens = TokenCalculator.tokenize(text)
-            if entry.max_tokens and tokens > entry.max_tokens:
-                report.skipped.append(entry.name)
-                continue
-            successes.append((entry, text, tokens))
 
         # Drop lowest-priority first over budget; stable sort preserves
         # registration order among equal priorities.

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import AsyncGenerator, Callable
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, JsonValue, PrivateAttr, field_serializer
@@ -109,8 +110,9 @@ class Branch(Element, Relational):
     _loop_control: "LoopControl | None" = PrivateAttr(None)
     _signal_tasks: list = PrivateAttr(default_factory=list)
     _context_providers: "ContextProviderRegistry | None" = PrivateAttr(None)
-    _context_injection_slot: list[str] | None = PrivateAttr(None)
-    _last_context_report: Any = PrivateAttr(None)
+    _last_context_report: ContextVar[Any] = PrivateAttr(
+        default_factory=lambda: ContextVar("last_context_report", default=None)
+    )
 
     def __init__(
         self,
@@ -283,11 +285,13 @@ class Branch(Element, Relational):
 
     @property
     def last_context_report(self):
-        """ProviderReport from the most recent turn's provider pass, or None
-        when no providers are registered. When the branch has no system
-        message there is no render target, so providers are not invoked and
-        the report lists every registered provider under `skipped`."""
-        return self._last_context_report
+        """ProviderReport from this task's most recent provider pass, or None.
+
+        When the branch has no system message there is no render target, so
+        providers are not invoked and the report lists every registered
+        provider under ``skipped``.
+        """
+        return self._last_context_report.get()
 
     @property
     def chat_model(self) -> iModel:

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -113,6 +113,7 @@ class Branch(Element, Relational):
     _last_context_report: ContextVar[Any] = PrivateAttr(
         default_factory=lambda: ContextVar("last_context_report", default=None)
     )
+    _last_context_report_fallback: Any = PrivateAttr(None)
 
     def __init__(
         self,
@@ -285,13 +286,20 @@ class Branch(Element, Relational):
 
     @property
     def last_context_report(self):
-        """ProviderReport from this task's most recent provider pass, or None.
+        """ProviderReport from this task's latest provider pass, when present.
+
+        Otherwise returns the branch's most recently completed provider pass
+        for backward compatibility. Concurrent passes use last-writer semantics
+        for that branch-level fallback.
 
         When the branch has no system message there is no render target, so
         providers are not invoked and the report lists every registered
         provider under ``skipped``.
         """
-        return self._last_context_report.get()
+        task_report = self._last_context_report.get()
+        if task_report is not None:
+            return task_report
+        return self._last_context_report_fallback
 
     @property
     def chat_model(self) -> iModel:

--- a/tests/operations/operate/test_context_provider_writeback.py
+++ b/tests/operations/operate/test_context_provider_writeback.py
@@ -1,0 +1,40 @@
+from lionagi.testing import LionAGIMockFactory
+
+
+class _RecordingProvider:
+    name = "recorder"
+
+    def __init__(self):
+        self.writebacks = []
+
+    async def provide(self, branch, instruction):
+        return None
+
+    async def writeback(self, branch, action_responses):
+        self.writebacks.append((branch, action_responses))
+
+
+async def test_operate_runs_context_provider_writeback_after_actions():
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    branch = LionAGIMockFactory.create_mocked_branch(
+        response=(
+            '{"action_required": true, "action_requests": '
+            '[{"function": "add", "arguments": {"a": 1, "b": 2}}]}'
+        ),
+        tools=[add],
+    )
+    provider = _RecordingProvider()
+    branch.providers.register(provider)
+
+    result = await branch.operate(instruction="add", actions=True)
+
+    assert len(provider.writebacks) == 1
+    writeback_branch, action_responses = provider.writebacks[0]
+    assert writeback_branch is branch
+    assert len(action_responses) == 1
+    assert action_responses[0].function == "add"
+    assert action_responses[0].output == 3
+    assert result.action_responses == action_responses

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -117,6 +117,21 @@ async def test_run_passes_resume_from_provider_session_id_and_updates_endpoint_s
     assert text_msgs[0].response == "ok"
 
 
+async def test_run_threads_context_provider_blocks_into_first_prompt():
+    class _Provider:
+        async def provide(self, branch, instruction):
+            return "stream-context"
+
+    model, captured = _make_fake_cli_model([StreamChunk(type="text", content="ok")])
+    branch = Branch(system="You are helpful")
+    branch.chat_model = model
+    branch.providers.register(_Provider())
+
+    await _collect(run(branch, "hi", RunParam()))
+
+    assert "stream-context" in captured["messages"][0]["content"]
+
+
 async def test_run_flushes_text_before_tool_use_and_links_tool_result():
     """Text is flushed before tool_use; tool_result is linked to the request."""
     model, _ = _make_fake_cli_model(

--- a/tests/operations/test_context_providers.py
+++ b/tests/operations/test_context_providers.py
@@ -308,6 +308,24 @@ async def test_raising_provider_skipped_others_still_render(make_mocked_branch):
 
 
 @pytest.mark.asyncio
+async def test_non_string_provider_output_fails_open_end_to_end(make_mocked_branch):
+    branch = make_mocked_branch(system="You are helpful", response="ok")
+    invalid_output = object()
+    branch.providers.register(_StubProvider(invalid_output, name="invalid"))
+    branch.providers.register(_StubProvider("valid context", name="valid"))
+
+    result = await branch.communicate(instruction="hello", skip_validation=True)
+
+    sent_messages = branch.chat_model.invoke.call_args.kwargs["messages"]
+    first_content = sent_messages[0]["content"]
+    assert result == "ok"
+    assert "valid context" in first_content
+    assert str(invalid_output) not in first_content
+    assert branch.last_context_report.blocks == ["valid context"]
+    assert branch.last_context_report.failed == ["invalid"]
+
+
+@pytest.mark.asyncio
 async def test_chat_only_branch_no_tools_works_with_providers(make_mocked_branch):
     """Knowledge injection must work for chat-only branches with zero tools (gate Q1)."""
     branch = make_mocked_branch(system="You are helpful", response="ok")
@@ -369,6 +387,22 @@ async def test_last_context_report_populated_on_systemful_turn(make_mocked_branc
     assert isinstance(report, ProviderReport)
     assert [f["provider_name"] for f in report.fired] == ["kp"]
     assert report.fired[0]["tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_last_context_report_visible_after_child_task_turn(make_mocked_branch):
+    branch = make_mocked_branch(system="You are helpful", response="ok")
+    branch.providers.register(_StubProvider("child context"), name="child")
+    assert branch.last_context_report is None
+
+    turn = asyncio.create_task(branch.communicate(instruction="hello", skip_validation=True))
+    result = await turn
+
+    report = branch.last_context_report
+    assert result == "ok"
+    assert isinstance(report, ProviderReport)
+    assert report.blocks == ["child context"]
+    assert [entry["provider_name"] for entry in report.fired] == ["child"]
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_context_providers.py
+++ b/tests/operations/test_context_providers.py
@@ -5,6 +5,8 @@
 budget/failure semantics, and the pre-turn fold that renders provider
 blocks into the first message without ever touching the durable record."""
 
+import asyncio
+
 import pytest
 
 from lionagi.operations.chat._prepare import _prepare_run_kwargs
@@ -38,6 +40,40 @@ class _RaisingProvider:
 
     async def provide(self, branch, instruction):
         raise RuntimeError("boom")
+
+
+class _BadOutput:
+    def __bool__(self):
+        raise TypeError("provider output cannot be inspected")
+
+
+class _BadOutputProvider:
+    name = "bad-output"
+
+    async def provide(self, branch, instruction):
+        return _BadOutput()
+
+
+class _WritebackProvider:
+    def __init__(self, name="writer"):
+        self.name = name
+        self.calls = []
+
+    async def provide(self, branch, instruction):
+        return None
+
+    async def writeback(self, branch, action_responses):
+        self.calls.append((branch, action_responses))
+
+
+class _RaisingWritebackProvider:
+    name = "raising-writer"
+
+    async def provide(self, branch, instruction):
+        return None
+
+    async def writeback(self, branch, action_responses):
+        raise RuntimeError("writeback failed")
 
 
 def _chat_param(branch, **overrides):
@@ -127,6 +163,56 @@ async def test_gather_contains_raising_provider_and_still_renders_others():
     assert report.fired[0]["provider_name"] == "survivor"
 
 
+@pytest.mark.asyncio
+async def test_gather_contains_bad_provider_output_and_still_renders_others():
+    registry = ContextProviderRegistry()
+    registry.register(_BadOutputProvider())
+    registry.register(_StubProvider("survivor", name="survivor"))
+
+    report = await registry.gather(branch=None, instruction=None)
+
+    assert report.failed == ["bad-output"]
+    assert report.blocks == ["survivor"]
+
+
+@pytest.mark.asyncio
+async def test_gather_writeback_calls_registered_hook():
+    registry = ContextProviderRegistry()
+    writer = _WritebackProvider()
+    registry.register(writer)
+    branch = object()
+    action_responses = [object()]
+
+    await registry.gather_writeback(branch, action_responses)
+
+    assert writer.calls == [(branch, action_responses)]
+
+
+@pytest.mark.asyncio
+async def test_gather_writeback_skips_provider_without_hook():
+    registry = ContextProviderRegistry()
+    registry.register(_StubProvider("context", name="reader"))
+    writer = _WritebackProvider()
+    registry.register(writer)
+
+    await registry.gather_writeback(None, ["response"])
+
+    assert writer.calls == [(None, ["response"])]
+
+
+@pytest.mark.asyncio
+async def test_gather_writeback_warns_and_continues_to_sibling(caplog):
+    registry = ContextProviderRegistry()
+    registry.register(_RaisingWritebackProvider())
+    writer = _WritebackProvider(name="survivor")
+    registry.register(writer)
+
+    await registry.gather_writeback(None, ["response"])
+
+    assert writer.calls == [(None, ["response"])]
+    assert "context provider 'raising-writer' writeback raised; skipping" in caplog.text
+
+
 def test_registry_is_falsy_when_empty():
     registry = ContextProviderRegistry()
     assert not registry
@@ -148,15 +234,28 @@ def test_branch_providers_lazily_created_and_zero_cost_when_unused():
 
 
 @pytest.mark.asyncio
-async def test_zero_providers_path_leaves_slot_untouched_and_fold_unchanged(make_mocked_branch):
+async def test_zero_providers_path_leaves_fold_unchanged(make_mocked_branch):
     branch = make_mocked_branch(system="You are helpful", response="ok")
     chat_param = _chat_param(branch)
 
     ins, kw = _prepare_run_kwargs(branch, "hello", chat_param)
 
-    assert branch._context_injection_slot is None
     first = kw["messages"][0]["content"]
     assert branch.msgs.system.rendered in first
+
+
+def test_prepare_run_kwargs_renders_explicit_context_blocks(make_mocked_branch):
+    branch = make_mocked_branch(system="You are helpful", response="ok")
+    chat_param = _chat_param(branch)
+
+    _, kw = _prepare_run_kwargs(
+        branch,
+        "hello",
+        chat_param,
+        context_blocks=["call-local-knowledge"],
+    )
+
+    assert "call-local-knowledge" in kw["messages"][0]["content"]
 
 
 # ---------------------------------------------------------------------------
@@ -177,9 +276,6 @@ async def test_provider_text_rendered_but_never_persisted(make_mocked_branch):
 
     for msg in branch.msgs.messages:
         assert "INJECTED-KNOWLEDGE-BLOCK" not in str(msg.content)
-
-    # slot cleared after the turn
-    assert branch._context_injection_slot is None
 
 
 @pytest.mark.asyncio
@@ -260,7 +356,6 @@ async def test_systemless_branch_skips_providers_with_observable_report(
     assert report.blocks == [] and report.fired == []
     sent_messages = branch.chat_model.invoke.call_args.kwargs["messages"]
     assert all("should never render" not in m["content"] for m in sent_messages)
-    assert branch._context_injection_slot is None
 
 
 @pytest.mark.asyncio
@@ -274,3 +369,50 @@ async def test_last_context_report_populated_on_systemful_turn(make_mocked_branc
     assert isinstance(report, ProviderReport)
     assert [f["provider_name"] for f in report.fired] == ["kp"]
     assert report.fired[0]["tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_turn_reports_are_task_scoped_and_prompts_are_isolated(
+    make_mocked_branch,
+):
+    branch = make_mocked_branch(system="You are helpful", response="ok")
+
+    class _InstructionProvider:
+        name = "instruction-context"
+
+        async def provide(self, branch, instruction):
+            return f"CTX-{instruction.content.instruction}"
+
+    branch.providers.register(_InstructionProvider())
+
+    first_invoke_started = asyncio.Event()
+    release_first_invoke = asyncio.Event()
+    original_invoke = branch.chat_model.invoke.side_effect
+    rendered_prompts = {}
+
+    async def invoke(**kwargs):
+        prompt = kwargs["messages"][0]["content"]
+        turn = "first" if "CTX-first" in prompt else "second"
+        rendered_prompts[turn] = prompt
+        if turn == "first":
+            first_invoke_started.set()
+            await release_first_invoke.wait()
+        return await original_invoke(**kwargs)
+
+    branch.chat_model.invoke.side_effect = invoke
+
+    async def communicate_and_read_report(turn):
+        result = await branch.communicate(instruction=turn, skip_validation=True)
+        return result, branch.last_context_report
+
+    first_task = asyncio.create_task(communicate_and_read_report("first"))
+    await first_invoke_started.wait()
+    second_result, second_report = await communicate_and_read_report("second")
+    release_first_invoke.set()
+    first_result, first_report = await first_task
+
+    assert first_result == second_result == "ok"
+    assert first_report.blocks == ["CTX-first"]
+    assert second_report.blocks == ["CTX-second"]
+    assert "CTX-second" not in rendered_prompts["first"]
+    assert "CTX-first" not in rendered_prompts["second"]


### PR DESCRIPTION
Batch fix of 3 operations/context issues, each with regression coverage.

- **#1891** — added registry-level coverage for writeback fan-out: successful fan-out, providers without a `writeback` hook, and warning-plus-continuation when one provider raises; plus an `operate()` integration test executing a real registered tool and asserting the provider receives the action response while the operation result is unchanged (no production change needed — the truthiness guard, execution, fan-out, and merge are covered together).
- **#1889** — `_apply_context_providers` returns `(instruction, report)`; `chat()` and streaming `run()` thread `report.blocks` into a keyword-only `context_blocks` arg of `_prepare_run_kwargs`. The branch-level injection slot was removed; `last_context_report` stays backward-compatible via a per-Branch `ContextVar`, so concurrent same-branch turns see their own task-scoped report with no lock introduced.
- **#1888** — tokenize containment fix (see report for the specific boundary).

Verification: `uv run pytest tests/operations/` (operate + context suites) — all pass. ruff clean.

Closes #1891
Closes #1889
Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
