### PR TITLE
fix(cli): batch CLI/orchestration fixes — purge audit, cast-pack continuity, dep normalizer, action-kind vocab, spawn affordance, messenger seam (closes 6)

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -52,6 +52,7 @@ __all__ = (
     "resolve_model_spec",
     "resolve_persisted_effort",
     "AgentProfile",
+    "build_agent_profile_catalog",
     "build_deadline_preamble",
     "list_agents",
     "load_agent_profile",
@@ -371,6 +372,30 @@ def list_agents() -> list[str]:
                 seen.add(p.stem)
     seen.update(_plugin_agent_profiles().keys())
     return sorted(seen)
+
+
+def build_agent_profile_catalog() -> dict[str, dict[str, Any]]:
+    """Index discoverable profiles by name and resolved runtime configuration.
+
+    Prompt bodies are deliberately omitted: the catalog is a discovery surface,
+    not a second path for exposing or copying profile instructions.
+    """
+    catalog: dict[str, dict[str, Any]] = {}
+    for name in list_agents():
+        profile = load_agent_profile(name)
+        catalog[name] = {
+            "model": profile.model,
+            "effort": profile.effort,
+            "role": profile.extra.get("role"),
+            "pack": profile.extra.get("pack"),
+            "yolo": profile.yolo,
+            "bypass": profile.bypass,
+            "fast_mode": profile.fast_mode,
+            "lion_system": profile.lion_system,
+            "timeout": profile.timeout,
+            "resume_on_timeout": profile.resume_on_timeout,
+        }
+    return catalog
 
 
 def _resolve_plugin_profile_path(name: str) -> Path | None:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -661,6 +661,11 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
     agent.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="Print the resolved agent-profile catalog as JSON and exit.",
+    )
+    agent.add_argument(
         "-r",
         "--resume",
         metavar="BRANCH_ID",
@@ -769,6 +774,11 @@ def _resolve_model_and_prompt(args: argparse.Namespace) -> tuple[str | None, str
 
 def run_agent(args: argparse.Namespace) -> int:
     """Dispatch agent command."""
+    if args.list_profiles:
+        from lionagi.cli._providers import build_agent_profile_catalog
+
+        print(json.dumps(build_agent_profile_catalog(), indent=2, sort_keys=True))
+        return 0
     resolved = _resolve_model_and_prompt(args)
     if resolved is None:
         return 1

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -774,7 +774,7 @@ def _resolve_model_and_prompt(args: argparse.Namespace) -> tuple[str | None, str
 
 def run_agent(args: argparse.Namespace) -> int:
     """Dispatch agent command."""
-    if args.list_profiles:
+    if getattr(args, "list_profiles", False):
         from lionagi.cli._providers import build_agent_profile_catalog
 
         print(json.dumps(build_agent_profile_catalog(), indent=2, sort_keys=True))

--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -103,6 +103,17 @@ async def _cmd_purge(dispatch_id: str, *, dry_run: bool = False) -> int:
             if row is None:
                 print(f"dispatch not found: {dispatch_id}")
                 return 1
+            await db.insert_admin_event(
+                action="dispatch_purge",
+                target_id=dispatch_id,
+                details={
+                    "dispatch_id": dispatch_id,
+                    "dry_run": True,
+                    "status": row["status"],
+                    "total": 1,
+                },
+                actor="li_dispatch_purge",
+            )
             print(f"would purge {dispatch_id} (status={row['status']})")
             return 0
         deleted = await purge_dispatch(db, dispatch_id, actor="li_dispatch_purge")

--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -58,10 +58,22 @@ def _format_result_json(
 # ── Default worker system prompt (shared by flow + fanout) ────────────────
 
 
-def _bare_worker_system() -> str:
+def bare_worker_system(*, grant_spawn: bool = False) -> str:
     from lionagi.session.prompts import LION_SYSTEM_MESSAGE
 
-    return LION_SYSTEM_MESSAGE.strip() + "\n\n" + _BARE_WORKER_BODY
+    body = _BARE_WORKER_BODY
+    if grant_spawn:
+        body = body.replace(_LEAF_EXECUTOR_LINE, _SPAWN_AFFORDANCE)
+    return LION_SYSTEM_MESSAGE.strip() + "\n\n" + body
+
+
+_LEAF_EXECUTOR_LINE = "Do NOT spawn sub-agents or delegate further — you are a leaf executor."
+_SPAWN_AFFORDANCE = """\
+## Workflow expansion
+
+You may emit a structured `spawn_request` when necessary adjacent work falls \
+outside this assignment. The request is a signal to the workflow orchestrator, \
+not provider-native delegation; use only the granted capability described below."""
 
 
 _BARE_WORKER_BODY = """\
@@ -81,7 +93,7 @@ BASH QUOTING: Use variable assignment for multi-word CLI args: \
 Q="your query" && command "$Q" (NOT command "your query").\
 """
 
-BARE_WORKER_SYSTEM = _bare_worker_system()
+BARE_WORKER_SYSTEM = bare_worker_system()
 
 
 # ── Team-mode coordination section ────────────────────────────────────────

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -413,7 +413,8 @@ class OrchestrationEnv:
     # mixed-provider teams). None when team messaging isn't active.
     messenger_names: frozenset[str] | None = None
 
-    # None falls through to the default pack for role_config / resolve_modes.
+    # The selected pack is resolved once and retained by identity through
+    # role configuration and AgentSpec prompt construction.
     pack: Pack | None = None
 
     # None = no budget configured; workers skip the BUDGET preamble.
@@ -480,6 +481,13 @@ async def setup_orchestration(
             "Provide a model spec or use -a/--agent to load a profile with a model."
         )
 
+    from lionagi.casts.catalog import _load_packaged_pack
+    from lionagi.casts.pack import Pack as _Pack
+
+    loaded_pack = _Pack.from_file(pack) if pack else _load_packaged_pack(raise_on_error=True)
+    if loaded_pack is None:
+        raise ConfigurationError("The packaged default casts pack could not be loaded.")
+
     orc_imodel = build_imodel_from_spec(
         model_spec,
         yolo=yolo,
@@ -507,7 +515,7 @@ async def setup_orchestration(
         )
     else:
         # Built-in "orchestrator" casts role via AgentSpec.compose + factory.
-        orc_spec = AgentSpec.compose("orchestrator", grant_emissions=False)
+        orc_spec = AgentSpec.compose("orchestrator", pack=loaded_pack, grant_emissions=False)
         orc_branch = await create_agent(
             orc_spec,
             load_settings=False,
@@ -522,12 +530,6 @@ async def setup_orchestration(
         else Session(default_branch=orc_branch)
     )
     builder = OperationGraphBuilder(pattern_name)
-
-    loaded_pack: Pack | None = None
-    if pack:
-        from lionagi.casts.pack import Pack as _Pack
-
-        loaded_pack = _Pack.from_file(pack)
 
     return OrchestrationEnv(
         run=run,
@@ -600,12 +602,13 @@ async def build_worker_branch(
     explicit_name: str | None = None,
     system_prompt_override: str | None = None,
     grant_spawn: bool = False,
+    spawn_assignees: list[str] | tuple[str, ...] | set[str] | None = None,
     modes: list[str] | None = None,
 ) -> tuple[Branch, str, AgentProfile | None, bool]:
     """Resolve model/profile/system and build a worker Branch. The fourth
     return value, ``messenger_bound``, is True when this worker got the
     in-process messenger tool registered — see docs/internals/cli.md."""
-    from ._common import BARE_WORKER_SYSTEM
+    from ._common import bare_worker_system
 
     w_model, w_profile, w_cfg = _resolve_worker_model_spec(env, role, model_override)
 
@@ -670,7 +673,7 @@ async def build_worker_branch(
     elif not env.bare and w_profile and w_profile.system_prompt:
         verbatim_system = w_profile.system_prompt
     elif env.bare or not _is_casts_role(role):
-        verbatim_system = BARE_WORKER_SYSTEM
+        verbatim_system = bare_worker_system(grant_spawn=grant_spawn)
 
     log_config = DataLoggerConfig(auto_save_on_exit=False)
     if verbatim_system is None:
@@ -679,6 +682,7 @@ async def build_worker_branch(
         spec = AgentSpec.compose(
             role,
             modes=resolved_modes,
+            pack=env.pack if env.pack is not None else "default",
             grant_emissions=False,
             system_prompt=team_section,
         )
@@ -703,7 +707,7 @@ async def build_worker_branch(
     if grant_spawn:
         from lionagi.orchestration import grant_spawn as _grant_spawn
 
-        _grant_spawn(wb)
+        _grant_spawn(wb, assignees=spawn_assignees or [role])
 
     if env._live_persist:
         register_branch_hook(env._live_persist, wb)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -18,7 +18,7 @@ from lionagi._errors import LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.casts.emission import SpawnRequest, TaskAssignment
 from lionagi.ln.concurrency import CancelScope, move_on_after
-from lionagi.orchestration import plan, role_node_builder
+from lionagi.orchestration import normalize_dep_indices, plan, role_node_builder
 from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
@@ -348,20 +348,6 @@ def _fallback_notify_reason(status: str) -> str:
     }.get(status, RunReasons.FAILED_EXCEPTION)
 
 
-def _earlier_dep_indices(depends_on: list[str] | None, position: int) -> list[int]:
-    out: list[int] = []
-    for ref in depends_on or []:
-        try:
-            j = int(str(ref).strip()) - 1
-        except (TypeError, ValueError):
-            continue
-        if 0 <= j < position:
-            out.append(j)
-        elif j >= position:
-            logger.warning("Dropped forward dep ref %s (index %d >= position %d)", ref, j, position)
-    return out
-
-
 def _parse_reactive(spec: str | None) -> tuple[bool, set[str] | None]:
     """Parse --reactive into (reactive, spawn_roles)."""
     s = (spec or "all").strip().lower()
@@ -458,6 +444,7 @@ async def _build_dag(
     role_artifact_defaults: dict[str, dict | None] = {}
     worker_branches: dict[str, object] = {}
     worker_messenger_bound: dict[str, bool] = {}
+    spawn_assignees = sorted({ta.assignee for ta in assignments})
 
     for i, ta in enumerate(assignments):
         w_branch, w_model, w_profile, messenger_bound = await build_worker_branch(
@@ -467,6 +454,7 @@ async def _build_dag(
             model_override=pool[i % len(pool)] if pool else None,
             explicit_name=agent_ids[i],
             grant_spawn=_may_spawn(ta.assignee),
+            spawn_assignees=spawn_assignees,
             modes=ta.modes or None,
         )
         worker_branches[agent_ids[i]] = w_branch
@@ -1840,7 +1828,7 @@ async def _run_flow_inner(
     if resume_checkpoint is not None:
         # Resume: replay the persisted plan verbatim — no planner LLM call.
         # dep_indices are already 0-based positions (persisted, not the raw
-        # depends_on ordinal refs), so _earlier_dep_indices is skipped
+        # depends_on ordinal refs), so normalization is skipped
         # entirely, not just its LLM-facing caller.
         plan_entries = resume_checkpoint.get("plan") or []
         if not plan_entries:
@@ -1917,7 +1905,10 @@ async def _run_flow_inner(
 
         agent_ids = [env.assign_name(ta.assignee) for ta in assignments]
 
-        dep_indices = [_earlier_dep_indices(ta.depends_on, i) for i, ta in enumerate(assignments)]
+        try:
+            dep_indices = normalize_dep_indices(assignments)
+        except ValueError as exc:
+            raise FlowPlanError(str(exc)) from exc
 
     # --workers overrides model only; --bare also drops profiles (distinct behaviors).
     pool = [s.strip() for s in workers_str.split(",")] if workers_str else []

--- a/lionagi/orchestration/__init__.py
+++ b/lionagi/orchestration/__init__.py
@@ -10,6 +10,7 @@ from .patterns import (
     build_fanout_graph,
     fanout,
     grant_spawn,
+    normalize_dep_indices,
     plan,
     role_node_builder,
     spawn_roles,
@@ -23,4 +24,5 @@ __all__ = (
     "build_dag_graph",
     "role_node_builder",
     "grant_spawn",
+    "normalize_dep_indices",
 )

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,7 @@ from .prompts import (
     DECOMPOSE_DAG_INSTRUCTION,
     DECOMPOSE_DISCIPLINE,
     DECOMPOSE_INSTRUCTION,
+    SPAWN_GUIDANCE,
     SYNTHESIS_INSTRUCTION,
 )
 
@@ -37,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = (
     "grant_spawn",
+    "normalize_dep_indices",
     "role_node_builder",
     "spawn_roles",
     "plan",
@@ -59,9 +62,43 @@ _MAX_TASKS_CONSTRAINT = (
 )
 
 
-def grant_spawn(branch: Branch, *, prompt: bool = True) -> None:
-    """Let an agent grow the live DAG by emitting a ``SpawnRequest``; grants the capability and, when *prompt*, injects the instruction block."""
-    branch.grant_capabilities(build_emission_operable((SpawnRequest,), name="spawn"), prompt=prompt)
+def grant_spawn(
+    branch: Branch,
+    *,
+    prompt: bool = True,
+    assignees: list[str] | tuple[str, ...] | set[str] | None = None,
+) -> None:
+    """Grant ``SpawnRequest`` emission and render its routing contract."""
+    operable = build_emission_operable((SpawnRequest,), name="spawn")
+    branch.grant_capabilities(operable, prompt=prompt)
+    if not prompt:
+        return
+
+    from lionagi.session.capabilities import CAP_END
+
+    roster = sorted(set(assignees or ()))
+    roster_text = (
+        "Valid assignees: " + ", ".join(roster) + "."
+        if roster
+        else "Valid assignees: omit `assignee` to keep the work on your branch."
+    )
+    operations = ", ".join(sorted(SPAWN_ALLOWED_OPERATIONS))
+    example_request: dict[str, Any] = {
+        "instruction": "Verify the discovered edge case",
+        "independent": False,
+        "reason": "The edge case must be checked before completion",
+        "operation": "operate",
+    }
+    if roster:
+        example_request["assignee"] = roster[0]
+    specialized = (
+        f"## Spawn-request guidance\n\n{SPAWN_GUIDANCE}\n\n"
+        f"{roster_text}\n\nAllowed operations: {operations}.\n\n"
+        f"Example:\n```json\n{json.dumps({'spawn_request': example_request}, indent=2)}\n```"
+    )
+    current = branch._system_text()
+    enhanced = current.replace(CAP_END, f"\n\n{specialized}\n{CAP_END}", 1)
+    branch.msgs.set_system(branch.msgs.create_system(system=enhanced))
 
 
 def role_node_builder(
@@ -137,7 +174,7 @@ async def spawn_roles(
         branch.name = name
         session.include_branches(branch)
         if name in spawn_set:
-            grant_spawn(branch)
+            grant_spawn(branch, assignees=set(specs))
         roles[name] = branch
     return roles
 
@@ -189,9 +226,15 @@ async def plan(
     return valid
 
 
-def _resolve_dep_indices(assignments: list[TaskAssignment]) -> dict[int, list[int]]:
-    """Map assignment index → 0-based predecessor indices; drops invalid/self refs."""
-    deps: dict[int, list[int]] = {}
+def normalize_dep_indices(assignments: list[TaskAssignment]) -> list[list[int]]:
+    """Normalize one-based dependency ordinals into earlier zero-based indices.
+
+    Forward references are dropped after the structurally valid reference graph
+    is checked for cycles. This matches incremental CLI construction, keeps the
+    planner's "earlier assignments" contract, and rejects cyclic input instead
+    of silently repairing it by discarding one of the cycle's forward edges.
+    """
+    candidates: list[list[int]] = []
     n = len(assignments)
     for i, ta in enumerate(assignments):
         preds: list[int] = []
@@ -199,16 +242,42 @@ def _resolve_dep_indices(assignments: list[TaskAssignment]) -> dict[int, list[in
             try:
                 j = int(str(ref).strip()) - 1
             except (TypeError, ValueError):
-                logger.warning("build_dag_graph: non-integer depends_on %r on step %d", ref, i + 1)
+                logger.warning("depends_on: non-integer ref %r on step %d; dropping", ref, i + 1)
                 continue
-            if j == i or not (0 <= j < n):
-                logger.warning(
-                    "build_dag_graph: dropping out-of-range dep %r on step %d", ref, i + 1
-                )
+            if j == i:
+                logger.warning("depends_on: self ref %r on step %d; dropping", ref, i + 1)
+                continue
+            if not (0 <= j < n):
+                logger.warning("depends_on: out-of-range ref %r on step %d; dropping", ref, i + 1)
                 continue
             preds.append(j)
-        deps[i] = preds
-    return deps
+        candidates.append(preds)
+
+    state = [0] * n
+
+    def visit(node: int) -> None:
+        if state[node] == 1:
+            raise ValueError(f"depends_on cycle detected at step {node + 1}")
+        if state[node] == 2:
+            return
+        state[node] = 1
+        for pred in candidates[node]:
+            visit(pred)
+        state[node] = 2
+
+    for node in range(n):
+        visit(node)
+
+    normalized: list[list[int]] = []
+    for i, preds in enumerate(candidates):
+        earlier: list[int] = []
+        for pred in preds:
+            if pred < i:
+                earlier.append(pred)
+            else:
+                logger.warning("depends_on: forward ref %d on step %d; dropping", pred + 1, i + 1)
+        normalized.append(earlier)
+    return normalized
 
 
 def build_fanout_graph(
@@ -269,7 +338,7 @@ def build_dag_graph(
 ) -> tuple[Graph, list[str | None]]:
     """Wire assignments into a dependency DAG honouring depends_on; pure, does not execute."""
     graph = Graph()
-    deps = _resolve_dep_indices(assignments)
+    deps = normalize_dep_indices(assignments)
     nodes: list[Operation | None] = []
 
     for ta in assignments:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -730,10 +730,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
     # recognize the canonical 'github_poll' token.
     trigger_type = "github_poll" if args.trigger_type == "github" else args.trigger_type
 
+    from lionagi.studio.scheduler.subprocess import _ALIAS_ACTION_KINDS
+
+    action_kind = _ALIAS_ACTION_KINDS.get(args.action_kind, args.action_kind)
     body: dict[str, Any] = {
         "name": args.name,
         "trigger_type": trigger_type,
-        "action_kind": args.action_kind,
+        "action_kind": action_kind,
     }
     if args.cron:
         body["cron_expr"] = args.cron
@@ -939,6 +942,11 @@ def suggest_schedule_flag(token: str) -> str | None:
 
 def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     """Register `li schedule` sub-command. Returns the `schedule` parser."""
+    from lionagi.studio.scheduler.subprocess import (
+        _ALIAS_ACTION_KINDS,
+        _VALID_ACTION_KINDS,
+    )
+
     sched = subparsers.add_parser(
         "schedule",
         help="Manage lionagi Studio schedules.",
@@ -1047,13 +1055,13 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         "--action-kind",
         dest="action_kind",
         default="agent",
-        choices=("agent", "playbook", "flow_yaml", "command"),
-        help="Action kind (default: agent).",
+        choices=tuple(sorted(_VALID_ACTION_KINDS | set(_ALIAS_ACTION_KINDS))),
+        help="Stored action kind or accepted alias (default: agent).",
     )
     create_p.add_argument("--prompt", help="Prompt for agent action.")
     create_p.add_argument("--model", help="Model spec for agent action.")
     create_p.add_argument("--agent", help="Agent profile name.")
-    create_p.add_argument("--playbook", help="Playbook name (for action-kind=playbook).")
+    create_p.add_argument("--playbook", help="Playbook name (for action-kind=play/playbook).")
     create_p.add_argument(
         "--flow-yaml",
         dest="flow_yaml",

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -129,6 +129,59 @@ async def test_dry_run_lists_assignments_with_deps(tmp_path):
     assert len(orc.operate_calls) == 1  # no retry needed
 
 
+@pytest.mark.asyncio
+async def test_dry_run_drops_forward_dependency(tmp_path):
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(
+                assignments=[
+                    TaskAssignment(task="first", assignee="researcher", depends_on=["2"]),
+                    TaskAssignment(task="second", assignee="architect"),
+                ]
+            )
+        ]
+    )
+
+    out = await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
+
+    assert "depends_on:" not in out
+
+
+@pytest.mark.asyncio
+async def test_dry_run_drops_self_non_integer_and_out_of_range_dependencies(tmp_path):
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(
+                assignments=[
+                    TaskAssignment(task="first", assignee="researcher", depends_on=["1"]),
+                    TaskAssignment(task="second", assignee="architect", depends_on=["x", "9"]),
+                ]
+            )
+        ]
+    )
+
+    out = await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
+
+    assert "depends_on:" not in out
+
+
+@pytest.mark.asyncio
+async def test_dry_run_rejects_dependency_cycle(tmp_path):
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(
+                assignments=[
+                    TaskAssignment(task="first", assignee="researcher", depends_on=["2"]),
+                    TaskAssignment(task="second", assignee="architect", depends_on=["1"]),
+                ]
+            )
+        ]
+    )
+
+    with pytest.raises(FlowPlanError, match="cycle"):
+        await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
+
+
 class TestParseReactive:
     """--reactive MODE → (reactive, spawn_roles) for grant-gating."""
 

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 from lionagi import iModel
+from lionagi.casts.emission import TaskAssignment
 from lionagi.cli.orchestrate._common import (
     TEAM_COORD_SECTION,
     TEAM_COORD_SECTION_MESSENGER,
@@ -809,3 +810,179 @@ async def test_every_advertised_messenger_recipient_is_actually_reachable(tmp_pa
     # and pre-fix, orchestrator).
     assert checked_reachable > 0
     assert checked_unreachable > 0
+
+
+@pytest.mark.asyncio
+async def test_reactive_worker_prompt_renders_spawn_affordance_and_roster(tmp_path):
+    env = _make_env(tmp_path)
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        branch, *_ = await build_worker_branch(
+            env,
+            agent_id="researcher",
+            role="researcher",
+            explicit_name="researcher",
+            grant_spawn=True,
+            spawn_assignees=["researcher", "reviewer"],
+        )
+
+    prompt = branch.system.rendered
+    assert "Do NOT spawn sub-agents" not in prompt
+    assert "## Workflow expansion" in prompt
+    assert "## Spawn-request guidance" in prompt
+    assert "Valid assignees: researcher, reviewer." in prompt
+    assert "Allowed operations:" in prompt
+    assert '"spawn_request"' in prompt
+
+
+@pytest.mark.asyncio
+async def test_non_reactive_worker_prompt_keeps_leaf_executor_rule(tmp_path):
+    env = _make_env(tmp_path)
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        side_effect=_api_imodel,
+    ):
+        branch, *_ = await build_worker_branch(
+            env,
+            agent_id="researcher",
+            role="researcher",
+            explicit_name="researcher",
+        )
+
+    assert "Do NOT spawn sub-agents or delegate further" in branch.system.rendered
+
+
+class _EntrypointSession(_FakeSession):
+    async def flow(self, _graph, **_kwargs):
+        return {"operation_results": {}}
+
+
+def _entrypoint_env(tmp_path):
+    env = _make_env(tmp_path)
+    env.session = _EntrypointSession()
+    env.builder = OperationGraphBuilder()
+    env.run = SimpleNamespace(
+        artifact_root=tmp_path,
+        dag_image_path=tmp_path / "dag.png",
+        synthesis_path=tmp_path / "synthesis.md",
+        agent_artifact_dir=lambda name: tmp_path / name,
+    )
+    return env
+
+
+def _model_for_mixed_pool(spec, *_args, **_kwargs):
+    if str(spec).startswith("codex/"):
+        return _cli_imodel()
+    return _api_imodel()
+
+
+@pytest.mark.asyncio
+async def test_fanout_entrypoint_prepass_matches_worker_binding(tmp_path, monkeypatch):
+    import lionagi.cli.orchestrate.fanout as fanout_module
+
+    assignments = [
+        TaskAssignment(task="api work", assignee="researcher"),
+        TaskAssignment(task="cli work", assignee="reviewer"),
+    ]
+    worker_names = ["researcher", "reviewer"]
+    env = _entrypoint_env(tmp_path)
+    observed: dict[str, bool] = {}
+
+    async def fake_plan(*_args, **_kwargs):
+        return assignments
+
+    async def tracked_build(env, **kwargs):
+        result = await build_worker_branch(env, **kwargs)
+        name = kwargs["explicit_name"]
+        observed[name] = result[3]
+        assert (name in env.messenger_names) is result[3]
+        return result
+
+    monkeypatch.setattr(fanout_module, "plan", fake_plan)
+    monkeypatch.setattr(fanout_module, "build_worker_branch", tracked_build)
+    monkeypatch.setattr(
+        fanout_module,
+        "_create_fanout_team",
+        lambda name, members: {
+            "id": "team-id",
+            "name": name,
+            "members": ["orchestrator", *members],
+        },
+    )
+    monkeypatch.setattr(fanout_module, "_post_results_to_team", lambda *_a, **_kw: None)
+    monkeypatch.setattr(fanout_module, "finalize_orchestration", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        _model_for_mixed_pool,
+    )
+
+    await fanout_module._run_fanout_inner(
+        "openai/gpt-4o-mini",
+        "mixed work",
+        env=env,
+        workers_str="openai/gpt-4o-mini,codex/gpt-5.5",
+        team_name="mixed",
+    )
+
+    assert env.messenger_names == frozenset({"researcher"})
+    assert observed == dict(zip(worker_names, (True, False), strict=True))
+
+
+@pytest.mark.asyncio
+async def test_flow_entrypoint_prepass_matches_worker_binding(tmp_path, monkeypatch):
+    import lionagi.cli.orchestrate.flow as flow_module
+
+    assignments = [
+        TaskAssignment(task="api work", assignee="researcher"),
+        TaskAssignment(task="cli work", assignee="reviewer"),
+    ]
+    worker_names = ["researcher", "reviewer"]
+    env = _entrypoint_env(tmp_path)
+    observed: dict[str, bool] = {}
+
+    async def fake_plan(*_args, **_kwargs):
+        return assignments
+
+    async def tracked_build(env, **kwargs):
+        result = await build_worker_branch(env, **kwargs)
+        name = kwargs["explicit_name"]
+        observed[name] = result[3]
+        assert (name in env.messenger_names) is result[3]
+        return result
+
+    async def fake_execute(*_args, **_kwargs):
+        return flow_module._ExecResult(agent_results=[], n_spawned=0, t_exec_elapsed=0.0)
+
+    monkeypatch.setattr(flow_module, "plan", fake_plan)
+    monkeypatch.setattr(flow_module, "build_worker_branch", tracked_build)
+    monkeypatch.setattr(flow_module, "_execute_dag", fake_execute)
+    monkeypatch.setattr(flow_module, "_finalize_flow", lambda *_a, **_kw: "")
+    monkeypatch.setattr(
+        flow_module,
+        "_create_fanout_team",
+        lambda name, members: {
+            "id": "team-id",
+            "name": name,
+            "members": ["orchestrator", *members],
+        },
+    )
+    monkeypatch.setattr(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        _model_for_mixed_pool,
+    )
+
+    await flow_module._run_flow_inner(
+        "openai/gpt-4o-mini",
+        "mixed work",
+        env=env,
+        workers_str="openai/gpt-4o-mini,codex/gpt-5.5",
+        team_name="mixed",
+        reactive_spec="off",
+    )
+
+    assert env.messenger_names == frozenset({"researcher"})
+    assert observed == dict(zip(worker_names, (True, False), strict=True))

--- a/tests/cli/orchestrate/test_role_config.py
+++ b/tests/cli/orchestrate/test_role_config.py
@@ -5,11 +5,15 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lionagi.cli.orchestrate._orchestration import (
+    build_worker_branch,
     casts_role_system,
     mode_roster,
     resolve_modes,
     role_config,
+    setup_orchestration,
 )
 
 
@@ -101,3 +105,93 @@ class TestCastsRoleSystem:
 def test_role_config_model_unset_in_default_pack():
     # the shipped pack must not pin a provider
     assert role_config("critic").model is None
+
+
+@pytest.mark.asyncio
+async def test_selected_pack_reaches_worker_prompt(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from lionagi import iModel
+    from lionagi.casts.pack import Pack, RoleConfig, RolePolicy
+
+    class _Session:
+        def __init__(self):
+            self.branches = []
+
+        def include_branches(self, branch):
+            self.branches.append(branch)
+
+    pack = Pack(
+        name="selected",
+        configs={"researcher": RoleConfig()},
+        policies={"researcher": RolePolicy(boundaries=("selected-pack-worker-boundary",))},
+    )
+    env = SimpleNamespace(
+        run=SimpleNamespace(agent_artifact_dir=lambda name: tmp_path / name),
+        session=_Session(),
+        default_model_spec="openai/gpt-4o-mini",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=str(tmp_path),
+        team_data=None,
+        exchange=None,
+        messenger=None,
+        roster=None,
+        messenger_names=None,
+        pack=pack,
+        _live_persist=None,
+        register_name=lambda _name: None,
+    )
+    monkeypatch.setattr(
+        "lionagi.cli.orchestrate._orchestration.build_imodel_from_spec",
+        lambda *_a, **_kw: iModel(provider="openai", model="gpt-4o-mini", api_key="dummy-key"),
+    )
+
+    def missing_profile(_name):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(
+        "lionagi.cli.orchestrate._orchestration.load_agent_profile", missing_profile
+    )
+
+    branch, *_ = await build_worker_branch(
+        env, agent_id="researcher", role="researcher", explicit_name="researcher"
+    )
+
+    assert "selected-pack-worker-boundary" in branch.system.rendered
+
+
+@pytest.mark.asyncio
+async def test_selected_pack_reaches_orchestrator_prompt(tmp_path):
+    pack_path = tmp_path / "selected.yaml"
+    pack_path.write_text(
+        """\
+name: selected
+roles:
+  orchestrator:
+    boundaries:
+      - selected-pack-orchestrator-boundary
+""",
+        encoding="utf-8",
+    )
+
+    env = await setup_orchestration(
+        pattern_name="PackContinuity",
+        model_spec="openai/gpt-4o-mini",
+        agent_name=None,
+        save_dir=str(tmp_path / "run"),
+        cwd=str(tmp_path),
+        yolo=False,
+        verbose=False,
+        effort=None,
+        theme=None,
+        pack=str(pack_path),
+    )
+
+    assert env.pack is not None
+    assert "selected-pack-orchestrator-boundary" in env.orc_branch.system.rendered

--- a/tests/cli/test_agent_arg_ux.py
+++ b/tests/cli/test_agent_arg_ux.py
@@ -75,6 +75,20 @@ class TestSinglePositional:
         assert rc == 1  # model or --agent required
 
 
+def test_list_profiles_prints_catalog_without_requiring_prompt(monkeypatch, capsys):
+    from lionagi.cli import _providers
+    from lionagi.cli.main import main
+
+    monkeypatch.setattr(
+        _providers,
+        "build_agent_profile_catalog",
+        lambda: {"reviewer": {"model": "codex/gpt-5.5", "pack": "review"}},
+    )
+
+    assert main(["agent", "--list-profiles"]) == 0
+    assert '"reviewer"' in capsys.readouterr().out
+
+
 class TestPromptFlagAndFile:
     def test_prompt_flag(self):
         rc = _run(["agent", "codex", "--prompt", "from flag"])

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -231,6 +231,21 @@ class TestFormToContextBlock:
 class TestFormValidationGate:
     """The validation gate must fire before any LLM call is attempted."""
 
+    def test_legacy_namespace_without_list_profiles_reaches_validation(self, tmp_path, monkeypatch):
+        """Namespaces created before newer flags still reach form validation."""
+        spec = tmp_path / "spec.yaml"
+        spec.write_text("fields:\n  repo:\n    type: str\n    required: true\nvalues: {}\n")
+
+        import lionagi.cli.agent as agent_mod
+
+        errors: list[str] = []
+        monkeypatch.setattr(agent_mod, "log_error", lambda msg: errors.append(msg))
+        args = _agent_args(form=str(spec))
+
+        assert not hasattr(args, "list_profiles")
+        assert run_agent(args) == 1
+        assert any("repo" in error for error in errors)
+
     def test_missing_form_file_returns_rc1_without_llm_call(self, tmp_path, monkeypatch):
         """--form pointing to a nonexistent file must exit rc=1 immediately."""
         llm_called = []

--- a/tests/cli/test_agent_profile_plugin.py
+++ b/tests/cli/test_agent_profile_plugin.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pytest
 
-from lionagi.cli._providers import list_agents, load_agent_profile
+from lionagi.cli._providers import build_agent_profile_catalog, list_agents, load_agent_profile
 from lionagi.plugins.discovery import discover_plugins
 from lionagi.plugins.trust import trust_plugin
 
@@ -66,6 +66,40 @@ def test_active_plugin_profile_resolves_by_namespaced_token(write_plugin):
     profile = load_agent_profile("web-research/researcher")
     assert profile.model == "codex/gpt-5.5"
     assert "research body" in profile.system_prompt
+
+
+def test_agent_profile_catalog_indexes_resolved_configuration(write_plugin):
+    _write_plugin_profile(
+        write_plugin,
+        "wr",
+        "web-research",
+        "researcher",
+        """\
+---
+model: codex/gpt-5.5
+effort: high
+role: researcher
+pack: research-pack
+---
+
+research body
+""",
+    )
+
+    catalog = build_agent_profile_catalog()
+
+    assert catalog["web-research/researcher"] == {
+        "bypass": False,
+        "effort": "high",
+        "fast_mode": False,
+        "lion_system": True,
+        "model": "codex/gpt-5.5",
+        "pack": "research-pack",
+        "resume_on_timeout": False,
+        "role": "researcher",
+        "timeout": None,
+        "yolo": False,
+    }
 
 
 def test_unambiguous_bare_name_resolves_to_plugin(write_plugin):

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -101,6 +101,7 @@ AGENT_HELP_FLAGS = [
     "--form",
     "--help",
     "--invocation",
+    "--list-profiles",
     "--preset",
     "--project",
     "--prompt",

--- a/tests/cli/test_dispatch_cli.py
+++ b/tests/cli/test_dispatch_cli.py
@@ -236,9 +236,23 @@ def test_dispatch_purge_single_row_honors_dry_run(monkeypatch, tmp_path, capsys)
         from lionagi.dispatch import get_dispatch
 
         async with StateDB(db_path) as db:
-            return await get_dispatch(db, dispatch_id)
+            row = await get_dispatch(db, dispatch_id)
+            events = await db.list_admin_events(action="dispatch_purge", target_id=dispatch_id)
+            return row, events
 
-    assert asyncio.run(check()) is not None
+    row, events = asyncio.run(check())
+    assert row is not None
+    assert len(events) == 1
+    assert events[0]["actor"] == "li_dispatch_purge"
+    import json
+
+    details = json.loads(events[0]["details"])
+    assert details == {
+        "dispatch_id": dispatch_id,
+        "dry_run": True,
+        "status": "pending",
+        "total": 1,
+    }
 
 
 def test_dispatch_purge_bare_before_leaves_pending_row_alone(monkeypatch, tmp_path, capsys):

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -50,6 +50,59 @@ def test_schedule_create_subcommand_args():
     assert args.prompt == "ping"
 
 
+def test_schedule_action_kind_choices_match_store_vocabulary():
+    from lionagi.studio.cli import add_schedule_subparser
+    from lionagi.studio.scheduler.subprocess import (
+        _ALIAS_ACTION_KINDS,
+        _VALID_ACTION_KINDS,
+    )
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    schedule_parser = sub.choices["schedule"]
+    action_subparsers = next(
+        action
+        for action in schedule_parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    create_parser = action_subparsers.choices["create"]
+    action_kind = next(action for action in create_parser._actions if action.dest == "action_kind")
+
+    assert set(action_kind.choices) == _VALID_ACTION_KINDS | set(_ALIAS_ACTION_KINDS)
+
+
+def test_schedule_create_normalizes_action_kind_alias(monkeypatch):
+    import lionagi.studio.cli as schedule_cli
+
+    captured = {}
+
+    def fake_api(path, method="GET", body=None):
+        captured.update(path=path, method=method, body=body)
+        return {"id": "schedule-id"}
+
+    monkeypatch.setattr(schedule_cli, "_api", fake_api)
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    schedule_cli.add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "create",
+            "nightly",
+            "--cron",
+            "0 0 * * *",
+            "--action-kind",
+            "playbook",
+            "--playbook",
+            "review",
+        ]
+    )
+
+    assert schedule_cli.run_schedule(args) == 0
+    assert captured["body"]["action_kind"] == "play"
+
+
 def test_schedule_enable_disable_trigger_delete_accept_id():
     """enable/disable/trigger/delete all take an id positional arg."""
     from lionagi.studio.cli import add_schedule_subparser

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -22,6 +22,7 @@ from lionagi.orchestration import (
     role_node_builder,
     spawn_roles,
 )
+from lionagi.orchestration.patterns import normalize_dep_indices
 from lionagi.session.branch import Branch
 from lionagi.session.session import Session
 
@@ -249,6 +250,24 @@ class TestBuildDagGraph:
         graph, ids = build_dag_graph(session, assignments, roles)
         assert len(graph.internal_edges) == 0  # all dropped, no crash
 
+    def test_forward_dependencies_are_dropped(self):
+        session, roles = _roles("researcher")
+        assignments = [
+            TaskAssignment(task="a", assignee="researcher", depends_on=["2"]),
+            TaskAssignment(task="b", assignee="researcher"),
+        ]
+        graph, _ = build_dag_graph(session, assignments, roles)
+        assert len(graph.internal_edges) == 0
+
+    def test_dependency_cycle_is_rejected_during_construction(self):
+        session, roles = _roles("researcher")
+        assignments = [
+            TaskAssignment(task="a", assignee="researcher", depends_on=["2"]),
+            TaskAssignment(task="b", assignee="researcher", depends_on=["1"]),
+        ]
+        with pytest.raises(ValueError, match="cycle"):
+            build_dag_graph(session, assignments, roles)
+
     def test_unknown_assignee_becomes_none_and_skips_edges(self):
         session, roles = _roles("researcher")
         assignments = [
@@ -311,6 +330,22 @@ class _FakeOrc:
     async def operate(self, **kw):
         self.calls.append(kw)
         return SimpleNamespace(assignments=self._assignments)
+
+
+class TestNormalizeDepIndices:
+    def test_self_non_integer_and_out_of_range_refs_are_dropped(self):
+        assignments = [
+            TaskAssignment(task="a", assignee="researcher", depends_on=["1"]),
+            TaskAssignment(task="b", assignee="researcher", depends_on=["x", "9"]),
+        ]
+        assert normalize_dep_indices(assignments) == [[], []]
+
+    def test_valid_earlier_refs_are_retained(self):
+        assignments = [
+            TaskAssignment(task="a", assignee="researcher"),
+            TaskAssignment(task="b", assignee="researcher", depends_on=["1"]),
+        ]
+        assert normalize_dep_indices(assignments) == [[], [0]]
 
 
 class TestPlan:


### PR DESCRIPTION
Batch fix of six CLI/orchestration issues, each with regression coverage.

- **Purge dry-run audit** — the single-dispatch dry-run path now records the same `dispatch_purge` administrative event contract as destructive purge paths while leaving the dispatch row intact. Regression asserts the retained row, actor, target, dry-run flag, status, and count.
- **Cast pack continuity + profile catalog** — orchestration setup resolves the selected cast pack once and passes that exact `Pack` to both orchestrator and worker `AgentSpec.compose` calls (one source of truth for role/mode/prompt). Adds a resolved agent-profile catalog and `li agent --list-profiles` JSON discovery surface with pack metadata. Regressions prove custom policy boundaries appear in both rendered prompts.
- **Shared dependency normalization** — one exported `normalize_dep_indices` used by both pattern-graph construction and CLI flow planning; drops non-integer/self/out-of-range/forward refs, validates the structurally valid graph for cycles before dropping forward references (cyclic plans now fail at construction instead of being silently repaired).
- **Schedule action vocabulary** — `--action-kind` accepts every canonical stored kind plus accepted aliases; the `playbook` alias normalizes to canonical `play` before persistence. A parity test derives both vocabularies from the scheduler constants to prevent drift.
- **Reactive spawn affordance** — reactive workers no longer receive the contradictory leaf-executor prohibition; their capability block now includes spawn guidance, the valid-assignee roster, the allowed-operation list, and a concrete JSON request example. Non-reactive workers retain the leaf-executor rule.
- **Messenger pre-pass integration seam** (test-only) — fanout and flow entrypoint tests with a mixed API/CLI worker pool let the real pre-pass compute `env.messenger_names`, invoke the real worker builder, and prove membership matches `messenger_bound` for every worker.

Verification: `uv run pytest tests/cli/ tests/cli/orchestrate/ tests/orchestration/` — all green. ruff check + format clean on touched files.

Closes #1995
Closes #1972
Closes #2027
Closes #1959
Closes #1941
Closes #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
