### PR TITLE
fix(lndl): batch LNDL fixes — round-outcome policy, per-round-shape rule, numeric coercion helper, multi-block extraction (closes 4)

### DIFF
--- a/lionagi/lndl/__init__.py
+++ b/lionagi/lndl/__init__.py
@@ -34,7 +34,7 @@ from .lexer import Lexer, Token, TokenType
 from .normalize import normalize_lndl_text
 from .parser import ParseError, Parser
 from .prompt import LNDL_SYSTEM_PROMPT, get_lndl_system_prompt
-from .round_outcome import Continue, Exhausted, Failed, Retry, RoundOutcome, Success
+from .round_outcome import Continue, Retry, RoundOutcome, Success
 from .types import (
     ActionCall,
     LactMetadata,
@@ -53,8 +53,6 @@ __all__ = (
     "NOTE_NAMESPACE",
     "ActionCall",
     "Continue",
-    "Exhausted",
-    "Failed",
     "Identifier",
     "InvalidConstructorError",
     "LNDLError",

--- a/lionagi/lndl/assembler.py
+++ b/lionagi/lndl/assembler.py
@@ -10,7 +10,12 @@ import types as _types
 from typing import Any, Union, get_args, get_origin
 
 from .ast import Lact, Lvar, Program, RLvar
-from .errors import InvalidConstructorError, MissingFieldError, MissingLvarError
+from .errors import (
+    InvalidConstructorError,
+    MissingFieldError,
+    MissingLvarError,
+    TypeMismatchError,
+)
 from .types import ActionCall
 
 NOTE_NAMESPACE = "note"
@@ -128,6 +133,17 @@ def _alias_field(node: Lvar | RLvar | Lact) -> str | None:
     return None
 
 
+def _target_model_name(target_type: Any) -> str | None:
+    """Return the nested model class name expected by a spec, if any."""
+    target_type = _unwrap_optional(target_type)
+    if get_origin(target_type) is list:
+        args = get_args(target_type)
+        target_type = _unwrap_optional(args[0]) if args else Any
+    if _is_model_cls(target_type):
+        return target_type.__name__
+    return None
+
+
 def build_action_call(alias: str, node: Lact) -> ActionCall:
     """Parse a lact node's call text into an ``ActionCall`` placeholder.
     Raises ``InvalidConstructorError`` if the call text isn't a parseable ``fn(args)`` expression."""
@@ -183,6 +199,7 @@ def assemble_spec_value(
     scratchpad: dict[str, Any] | None = None,
 ) -> Any:
     """Resolve OUT{}-listed aliases into a value matching ``target_type``."""
+    expected_model = _target_model_name(target_type)
     parts: list[tuple[str | None, Any]] = []
     for alias in refs:
         # Defensive: aliases must be hashable strings. Skip nested structures
@@ -195,6 +212,12 @@ def assemble_spec_value(
         if not found:
             continue
         node = lacts_by_alias.get(alias) or lvars_by_alias.get(alias)
+        declared_model = getattr(node, "model", None)
+        if expected_model and declared_model and declared_model != expected_model:
+            raise TypeMismatchError(
+                f"alias '{alias}' declares model '{declared_model}', "
+                f"but the target spec expects '{expected_model}'"
+            )
         field = _alias_field(node) if node else None
         parts.append((field, value))
 

--- a/lionagi/lndl/parser.py
+++ b/lionagi/lndl/parser.py
@@ -73,6 +73,20 @@ class ParseError(LNDLError):
         super().__init__(f"Parse error at line {token.line}, column {token.column}: {message}")
 
 
+def _coerce_num_token(token: Token) -> int | float:
+    """Convert one NUM token to its finite Python numeric value."""
+    num_str = token.value
+    try:
+        if any(c in num_str for c in ".eE"):
+            parsed = float(num_str)
+            if not math.isfinite(parsed):
+                raise ValueError("non-finite number literal")
+            return parsed
+        return int(num_str)
+    except ValueError as e:
+        raise ParseError(f"Invalid number literal '{num_str}'", token) from e
+
+
 class Parser:
     """Recursive descent parser for LNDL. Not thread-safe."""
 
@@ -347,9 +361,13 @@ class Parser:
                     name = f"{name}.{self.current_token().value}"
                     self.advance()
                 items.append(name)
-            elif self.match(TokenType.STR) or self.match(TokenType.NUM):
+            elif self.match(TokenType.STR):
                 items.append(self.current_token().value)
                 self.advance()
+            elif self.match(TokenType.NUM):
+                token = self.current_token()
+                self.advance()
+                items.append(_coerce_num_token(token))
             else:
                 self.advance()
             self.skip_newlines()
@@ -454,20 +472,8 @@ class Parser:
 
             elif self.match(TokenType.NUM):
                 num_token = self.current_token()
-                num_str = num_token.value
                 self.advance()
-                try:
-                    is_float = any(c in num_str for c in ".eE")
-                    if is_float:
-                        parsed = float(num_str)
-                        # Overflow-to-inf (e.g. 1e400) serializes to invalid JSON downstream.
-                        if not math.isfinite(parsed):
-                            raise ValueError("non-finite number literal")
-                        fields[field_name] = parsed
-                    else:
-                        fields[field_name] = int(num_str)
-                except ValueError as e:
-                    raise ParseError(f"Invalid number literal '{num_str}'", num_token) from e
+                fields[field_name] = _coerce_num_token(num_token)
 
             elif self.match(TokenType.ID):
                 value = self.current_token().value

--- a/lionagi/lndl/prompt.py
+++ b/lionagi/lndl/prompt.py
@@ -41,9 +41,8 @@ Use the shortest form that's unambiguous.
 RULES
 
 1. Tags are SIBLINGS — never nest <lvar> inside <lact> or vice versa.
-2. ONLY aliases listed in OUT{} are committed to the final result.
-   Lacts NOT in OUT{} are scratch (zero-cost planning, never executed
-   in single-round mode).
+2. Per-round action rule: if OUT{} is present, only its referenced lacts execute; if OUT{} is absent, every declared lact executes.
+   With OUT{} present, unreferenced lacts are scratch and never execute.
 3. Each spec in OUT{} is one of:
    - a scalar spec (int, float, str, bool) → one alias
    - a model spec (multiple fields) → one alias per field, namespaced as Model.field
@@ -130,8 +129,9 @@ OUT{scores: [p, r]}     # → {"precision": 0.92, "recall": 0.81}
 
 EXAMPLE 6 — choosing among candidate tool calls
 
-You can sketch several tool calls in scratch and commit only the best
-one. Lacts NOT in OUT{} never run — they're zero-cost planning.
+Per-round action rule: if OUT{} is present, only its referenced lacts execute; if OUT{} is absent, every declared lact executes.
+Here OUT{} is present, so you can sketch several tool calls in scratch and
+commit only the best one.
 
 Specs: results(list[str])
 Tools: search_web(query, limit)
@@ -176,8 +176,10 @@ MULTI-ROUND MODE
 If the runtime tells you "Round N of M" in a continuation message, you are
 in MULTI-ROUND mode. Each round is one chat turn:
 
+  Per-round action rule: if OUT{} is present, only its referenced lacts execute; if OUT{} is absent, every declared lact executes.
+
   - In intermediate rounds, you can issue tool calls (<lact>) WITHOUT an
-    OUT{} block to gather information. Tools execute every round; their
+    OUT{} block to gather information. Every declared lact executes; their
     results appear as tool messages in the chat history before your next
     turn — you can read and reason over them.
   - Commit OUT{} when (and only when) you have enough information to fill

--- a/lionagi/lndl/round_outcome.py
+++ b/lionagi/lndl/round_outcome.py
@@ -11,8 +11,6 @@ from typing import Any
 
 __all__ = (
     "Continue",
-    "Exhausted",
-    "Failed",
     "Retry",
     "RoundOutcome",
     "Success",
@@ -43,19 +41,4 @@ class Retry:
     note_keys: tuple[str, ...] = ()
 
 
-@dataclass(slots=True, frozen=True)
-class Exhausted:
-    """Hit the round budget without a Success. Carries the most recent
-    error so the caller can surface something useful."""
-
-    last_error: str | None = None
-
-
-@dataclass(slots=True, frozen=True)
-class Failed:
-    """Unrecoverable error — no point retrying. Caller should raise."""
-
-    error: BaseException
-
-
-RoundOutcome = Success | Continue | Retry | Exhausted | Failed
+RoundOutcome = Success | Continue | Retry

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -192,7 +192,7 @@ def _extract_lndl(text: str, operable: "Operable") -> Any:
 
     blocks = extract_lndl_blocks(text)
     if blocks:
-        return blocks[0]
+        return "\n\n".join(blocks)
     return text
 
 

--- a/tests/lndl/test_assembler.py
+++ b/tests/lndl/test_assembler.py
@@ -16,7 +16,12 @@ from lionagi.lndl.assembler import (
     collect_actions,
     replace_actions,
 )
-from lionagi.lndl.errors import InvalidConstructorError, MissingFieldError, MissingLvarError
+from lionagi.lndl.errors import (
+    InvalidConstructorError,
+    MissingFieldError,
+    MissingLvarError,
+    TypeMismatchError,
+)
 from lionagi.lndl.lexer import Lexer
 from lionagi.lndl.parser import Parser
 from lionagi.lndl.types import ActionCall
@@ -230,6 +235,20 @@ class TestOptionalFieldUnwrap:
         )
         result = assemble(prog, Wrapper, action_results={"s": "done"})
         assert result["report"] == {"title": "Analysis", "summary": "done"}
+
+
+class TestTypeMismatchError:
+    def test_namespaced_alias_model_must_match_target_model(self):
+        class Report(BaseModel):
+            title: str
+
+        class Wrapper(BaseModel):
+            report: Report
+
+        prog = _parse("<lvar Summary.title t>Analysis</lvar>\nOUT{report: [t]}")
+
+        with pytest.raises(TypeMismatchError, match="Summary.*Report"):
+            assemble(prog, Wrapper)
 
 
 class TestMissingFieldError:

--- a/tests/lndl/test_parser.py
+++ b/tests/lndl/test_parser.py
@@ -176,6 +176,16 @@ class TestOutBlockForms:
         assert prog.out_block.fields["a"] == 3.5
         assert isinstance(prog.out_block.fields["a"], float)
 
+    def test_list_number_literals_preserve_numeric_types(self):
+        prog = _parse("OUT{a: [5, -2, 3.5, 1e10]}")
+        values = prog.out_block.fields["a"]
+        assert values == [5, -2, 3.5, 1e10]
+        assert [type(value) for value in values] == [int, int, float, float]
+
+    def test_nested_list_number_literals_preserve_numeric_types(self):
+        prog = _parse("OUT{a: [[1, 2.5], [3e2]]}")
+        assert prog.out_block.fields["a"] == [[1, 2.5], [300.0]]
+
     def test_bool_true(self):
         prog = _parse("OUT{a: true}")
         assert prog.out_block.fields["a"] is True

--- a/tests/lndl/test_prompt.py
+++ b/tests/lndl/test_prompt.py
@@ -12,7 +12,7 @@ from lionagi.lndl.prompt import get_lndl_system_prompt
 # SHA-256 of the prompt as of the tests being written. Any accidental edit to
 # LNDL_SYSTEM_PROMPT (whitespace, typo, truncation, marker removal) will flip
 # this hash and make test_prompt_snapshot fail immediately.
-_EXPECTED_SHA256 = "d03ae99735fbfcbbf4ebd76bf0d9b86edaf5aa5c656ffbf796a9d96ce5e7adb8"
+_EXPECTED_SHA256 = "463c703f2f32431db647b81d456bf952bb101aa67c088fa3bfa619740ad152b6"
 
 
 class TestGetLndlSystemPrompt:

--- a/tests/lndl/test_round_outcome.py
+++ b/tests/lndl/test_round_outcome.py
@@ -7,7 +7,7 @@ import dataclasses
 
 import pytest
 
-from lionagi.lndl.round_outcome import Continue, Exhausted, Failed, Retry, Success
+from lionagi.lndl.round_outcome import Continue, Retry, Success
 
 
 class TestSuccess:
@@ -52,36 +52,9 @@ class TestRetry:
             outcome.error = "other"
 
 
-class TestExhausted:
-    def test_default_last_error_is_none(self):
-        outcome = Exhausted()
-        assert outcome.last_error is None
-
-    def test_last_error_accepts_string(self):
-        outcome = Exhausted(last_error="undeclared alias 'x'")
-        assert outcome.last_error == "undeclared alias 'x'"
-
-    def test_frozen(self):
-        outcome = Exhausted()
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            outcome.last_error = "x"
-
-
-class TestFailed:
-    def test_construction_carries_exception(self):
-        exc = RuntimeError("boom")
-        outcome = Failed(error=exc)
-        assert outcome.error is exc
-
-    def test_frozen(self):
-        outcome = Failed(error=RuntimeError("boom"))
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            outcome.error = ValueError("other")
-
-
 class TestRoundOutcomeDispatch:
     """RoundOutcome is a plain union type alias, not a base class — callers
-    dispatch via isinstance() against the five variants directly."""
+    dispatch via isinstance() against the three variants directly."""
 
     @pytest.mark.parametrize(
         "outcome,expected_type",
@@ -89,11 +62,9 @@ class TestRoundOutcomeDispatch:
             (Success(output=1), Success),
             (Continue(), Continue),
             (Retry(error="e"), Retry),
-            (Exhausted(), Exhausted),
-            (Failed(error=RuntimeError()), Failed),
         ],
     )
     def test_isinstance_matches_exactly_one_variant(self, outcome, expected_type):
-        variants = (Success, Continue, Retry, Exhausted, Failed)
+        variants = (Success, Continue, Retry)
         matches = [v for v in variants if isinstance(outcome, v)]
         assert matches == [expected_type]

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import BaseModel
 
+import lionagi.lndl as lndl
 from lionagi.hooks.bus import HookBus, HookPoint
 from lionagi.lndl import Continue, LNDLError, Retry, Success, get_lndl_system_prompt
 from lionagi.operations.lndl_middle import (
@@ -133,6 +134,29 @@ class TestClassifyRound:
         )
         assert isinstance(outcome, Success)
         assert assembled == {"answer": "from an earlier round"}
+
+    def test_prompt_action_rule_matches_both_round_shapes(self):
+        rule = (
+            "Per-round action rule: if OUT{} is present, only its referenced lacts "
+            "execute; if OUT{} is absent, every declared lact executes."
+        )
+        assert get_lndl_system_prompt().count(rule) == 3
+
+        with_out = (
+            "```lndl\n"
+            '<lact a>lookup(query="broad")</lact>\n'
+            '<lact b>lookup(query="narrow")</lact>\n'
+            "OUT{answer: [b]}\n"
+            "```"
+        )
+        outcome, pending, _assembled = _classify_round(with_out, AnswerModel, {})
+        assert isinstance(outcome, Success)
+        assert [call.name for call in pending] == ["b"]
+
+        without_out = with_out.replace("OUT{answer: [b]}\n", "")
+        outcome, pending, _assembled = _classify_round(without_out, AnswerModel, {})
+        assert isinstance(outcome, Continue)
+        assert [call.name for call in pending] == ["a", "b"]
 
 
 # ---------------------------------------------------------------------------
@@ -314,10 +338,9 @@ class TestRetryAndRepair:
         assert result.answer == "fixed"
 
 
-class TestExhausted:
-    """Exhaustion is a terminal RoundOutcome with no value to return — the
-    Middle raises LNDLError rather than leaking a raw last_error str (or
-    None, for an all-Continue run) through operate()'s return type."""
+class TestRoundBudgetExhaustion:
+    """The Middle raises LNDLError rather than leaking a raw last_error str
+    (or None, for an all-Continue run) through operate()'s return type."""
 
     @pytest.mark.asyncio
     async def test_exhausted_raises_with_last_error(self):
@@ -348,6 +371,8 @@ class TestExhausted:
     async def test_operate_integration_exhaustion_raises(self):
         """branch.operate(..., response_format=...) must not silently hand a
         structured caller a bare string or None on exhaustion."""
+        assert not hasattr(lndl, "Exhausted")
+        assert not hasattr(lndl, "Failed")
         custom_middle = build_lndl_middle(round_budget=1)
         branch = TestBranch.from_text("```lndl\nOUT{answer: [missing]}\n```")
         with pytest.raises(LNDLError):

--- a/tests/operations/test_parse.py
+++ b/tests/operations/test_parse.py
@@ -7,7 +7,9 @@ import pytest
 from pydantic import BaseModel
 
 from lionagi.ln.fuzzy import FuzzyMatchKeysParams
+from lionagi.ln.types import Operable
 from lionagi.operations.parse.parse import (
+    _extract_lndl,
     _validate_dict_or_model,
     get_default_call,
     prepare_parse_kws,
@@ -325,6 +327,22 @@ class TestAdvancedFeatures:
         # Second call returns same instance
         call2 = get_default_call()
         assert call1 is call2  # Same object
+
+
+class TestLndlExtraction:
+    def test_multiple_blocks_are_joined_in_source_order(self):
+        text = (
+            "reasoning\n"
+            "```lndl\n<lvar answer a>first</lvar>\n```\n"
+            "more reasoning\n"
+            "```lndl\nOUT{answer: [a]}\n```"
+        )
+
+        result = _extract_lndl(text, Operable())
+
+        assert result.index("<lvar") < result.index("OUT{")
+        assert "<lvar answer a>first</lvar>" in result
+        assert "OUT{answer: [a]}" in result
 
 
 # ============================================================================

--- a/tests/operations/test_parse.py
+++ b/tests/operations/test_parse.py
@@ -340,9 +340,7 @@ class TestLndlExtraction:
 
         result = _extract_lndl(text, Operable())
 
-        assert result.index("<lvar") < result.index("OUT{")
-        assert "<lvar answer a>first</lvar>" in result
-        assert "OUT{answer: [a]}" in result
+        assert result == "<lvar answer a>first</lvar>\n\n\nOUT{answer: [a]}\n"
 
 
 # ============================================================================


### PR DESCRIPTION
Batch fix of four LNDL issues, each with regression coverage.

- **#2025 — round-outcome public policy**: the adapter already raises `LNDLError` on round-budget exhaustion and propagates unexpected exceptions, so the unused `Exhausted`/`Failed` dataclasses were removed from `round_outcome.py`, the `RoundOutcome` union, and the `lionagi.lndl` public exports. The adapter-boundary regression asserts the dead variants are absent and `branch.operate(...)` raises on exhaustion.
- **#2024 — per-round-shape action rule**: the rules section, candidate-tool example, and multi-round section now state the same rule verbatim — rounds containing `OUT{}` execute only referenced lacts; rounds without `OUT{}` execute every declared lact. The doc-check regression counts all three statements and verifies both shapes through `_classify_round`.
- **#1668 — numeric list-literal coercion**: the scalar number conversion was extracted into `_coerce_num_token`, now used by both scalar and list parsing (nested lists, integer/float/scientific-notation typing, invalid-literal rejection, finite-number enforcement).
- **#1635 — multi-block extraction + typed mismatch**: multiple fenced LNDL blocks are joined in source order with a blank-line separator instead of silently discarding blocks after the first; `TypeMismatchError` remains public and is now raised by the assembler when a namespaced alias declares a model differing from the target nested model type.

Verification: `uv run pytest tests/lndl/ tests/operations/test_lndl_middle.py` — all green (the pandas log-dump diagnostic is a pre-existing optional-extra warning, exit status 0). ruff clean.

Closes #2025
Closes #2024
Closes #1668
Closes #1635

🤖 Generated with [Claude Code](https://claude.com/claude-code)
