### PR TITLE
test/ci: conformance + CI batch — cast-pack consistency, scanner alias, bench cost columns, provenance tests, docs-job guard (closes 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
   docs:
     needs: changes
+    if: ${{ always() && needs.changes.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/benchmarks/orchestration/score.py
+++ b/benchmarks/orchestration/score.py
@@ -103,11 +103,11 @@ def report(scored: list[ScoredResult], kinds: dict[str, str]) -> None:
 
     # ---- Compute / cost table (the matched-compute view) --------------------
     print("\nCOMPUTE & COST  (lift is meaningless unless it holds per-dollar)")
-    print("-" * 118)
+    print("-" * 125)
     print(
-        f"{'config':<26}{'in tok':<10}{'out tok':<10}{'$/run':<11}{'$/defect-found':<16}{'wall':<8}{'usage':<10}{'reasoning':<10}"
+        f"{'config':<26}{'in tok':<10}{'cached read':<12}{'cache write':<12}{'out tok':<10}{'$/run':<11}{'$/defect-found':<16}{'wall':<8}{'usage':<10}{'reasoning':<10}"
     )
-    print("-" * 118)
+    print("-" * 125)
     costs = {}
     for cfg in sorted(by_cfg):
         runs = _valid(by_cfg[cfg]["defect"]) + _valid(by_cfg[cfg]["intended"])
@@ -115,6 +115,8 @@ def report(scored: list[ScoredResult], kinds: dict[str, str]) -> None:
             print(f"{cfg:<26}{'— no valid runs —'}")
             continue
         mean_in = statistics.mean([s.input_tokens for s in runs])
+        mean_cached = statistics.mean([s.cached_tokens for s in runs])
+        mean_cache_write = statistics.mean([s.cache_write_tokens for s in runs])
         mean_out = statistics.mean([s.output_tokens for s in runs])
         mean_cost = statistics.mean([s.est_cost_usd for s in runs])
         tp = sum(s.found_defect for s in _valid(by_cfg[cfg]["defect"]))
@@ -125,9 +127,9 @@ def report(scored: list[ScoredResult], kinds: dict[str, str]) -> None:
         reasoning = "full" if all(s.reasoning_disclosed for s in runs) else "FLOOR*"
         costs[cfg] = mean_cost
         print(
-            f"{cfg:<26}{mean_in:<10.0f}{mean_out:<10.0f}{f'${mean_cost:.4f}':<11}{per_found:<16}{f'{mean_wall:.0f}s':<8}{src:<10}{reasoning:<10}"
+            f"{cfg:<26}{mean_in:<10.0f}{mean_cached:<12.0f}{mean_cache_write:<12.0f}{mean_out:<10.0f}{f'${mean_cost:.4f}':<11}{per_found:<16}{f'{mean_wall:.0f}s':<8}{src:<10}{reasoning:<10}"
         )
-    print("=" * 118)
+    print("=" * 125)
     print("recall = P(flag planted defect | mutant)   FP-avoid = P(not flag intended | clean)")
     print(
         "engaged = P(examined the baited path | clean)  — low engaged ⇒ FP-avoid is laziness, not skill"

--- a/benchmarks/orchestration/test_score.py
+++ b/benchmarks/orchestration/test_score.py
@@ -1,0 +1,58 @@
+"""Tests for the orchestration benchmark aggregate report."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harness.task import ScoredResult  # noqa: E402
+from score import report  # noqa: E402
+
+
+def test_compute_table_reports_mean_cache_read_and_write_tokens(capsys):
+    scored = [
+        ScoredResult(
+            task_id="task-a",
+            config_key="single__first",
+            trial=1,
+            found_defect=True,
+            false_positive=False,
+            engaged=True,
+            reported_severity="high",
+            severity_error=0,
+            input_tokens=80,
+            cached_tokens=200,
+            cache_write_tokens=400,
+            output_tokens=160,
+            est_cost_usd=0.01,
+            usage_source="reported",
+        ),
+        ScoredResult(
+            task_id="task-b",
+            config_key="single__second",
+            trial=2,
+            found_defect=True,
+            false_positive=False,
+            engaged=True,
+            reported_severity="high",
+            severity_error=0,
+            input_tokens=120,
+            cached_tokens=400,
+            cache_write_tokens=600,
+            output_tokens=240,
+            est_cost_usd=0.02,
+            usage_source="reported",
+        ),
+    ]
+
+    report(scored, {"task-a": "defect", "task-b": "defect"})
+
+    output = capsys.readouterr().out
+    assert "cached read" in output
+    assert "cache write" in output
+    compute_output = output.split("COMPUTE & COST", 1)[1]
+    row = next(line for line in compute_output.splitlines() if line.startswith("single"))
+    assert re.match(r"single\s+100\s+300\s+500\s+200\s+", row)

--- a/tests/benchmarks/test_ci_check_provenance.py
+++ b/tests/benchmarks/test_ci_check_provenance.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "benchmarks"))
+
+from ci_check_provenance import PYTHON_IDENTITY_META_KEYS, check  # noqa: E402
+
+SUITE = "concurrency-asyncio"
+PYTHON_IDENTITY = {
+    "python_full_version": "3.12.1 (stable)",
+    "python_build": "main build",
+    "python_compiler": "Clang 16",
+}
+
+
+def _write_result(
+    directory: Path,
+    *,
+    lionagi_file: str,
+    scenarios: set[str],
+    meta_overrides: dict[str, str] | None = None,
+) -> None:
+    directory.mkdir()
+    meta = {
+        "lionagi_file": lionagi_file,
+        "anyio": "4.9.0",
+        **PYTHON_IDENTITY,
+        **(meta_overrides or {}),
+    }
+    payload = {"meta": meta, "results": {name: {} for name in scenarios}}
+    (directory / f"{SUITE}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _check_pair(
+    tmp_path: Path,
+    *,
+    baseline_scenarios: set[str] | None = None,
+    current_scenarios: set[str] | None = None,
+    same_install: bool = False,
+    current_meta: dict[str, str] | None = None,
+) -> bool:
+    baseline_dir = tmp_path / "baseline"
+    current_dir = tmp_path / "current"
+    baseline_file = "baseline/site-packages/lionagi/__init__.py"
+    current_file = baseline_file if same_install else "current/site-packages/lionagi/__init__.py"
+    _write_result(
+        baseline_dir,
+        lionagi_file=baseline_file,
+        scenarios=baseline_scenarios if baseline_scenarios is not None else {"shared"},
+    )
+    _write_result(
+        current_dir,
+        lionagi_file=current_file,
+        scenarios=current_scenarios if current_scenarios is not None else {"shared"},
+        meta_overrides=current_meta,
+    )
+    return check(baseline_dir, current_dir, [SUITE])
+
+
+def test_check_rejects_same_install_path(tmp_path, capsys):
+    assert not _check_pair(tmp_path, same_install=True)
+    assert "SAME path" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("baseline_scenarios", "current_scenarios", "message"),
+    [
+        (set(), {"shared"}, "baseline reported zero overlapping scenarios"),
+        ({"shared"}, set(), "current reported zero overlapping scenarios"),
+        ({"baseline-only"}, {"current-only"}, "disjoint sets"),
+        ({"shared", "dropped"}, {"shared"}, "MISSING from current"),
+    ],
+)
+def test_check_rejects_invalid_scenario_coverage(
+    tmp_path, capsys, baseline_scenarios, current_scenarios, message
+):
+    assert not _check_pair(
+        tmp_path,
+        baseline_scenarios=baseline_scenarios,
+        current_scenarios=current_scenarios,
+    )
+    assert message in capsys.readouterr().err
+
+
+def test_check_rejects_dependency_version_mismatch(tmp_path, capsys):
+    assert not _check_pair(tmp_path, current_meta={"anyio": "4.10.0"})
+    assert "anyio version differs" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("identity_key", PYTHON_IDENTITY_META_KEYS)
+def test_check_rejects_python_identity_mismatch(tmp_path, capsys, identity_key):
+    assert not _check_pair(tmp_path, current_meta={identity_key: "different"})
+    assert f"{identity_key} differs" in capsys.readouterr().err
+
+
+def test_check_accepts_distinct_installs_with_matching_provenance(tmp_path, capsys):
+    assert _check_pair(tmp_path, current_scenarios={"shared", "current-only"})
+    captured = capsys.readouterr()
+    assert "OK -- baseline=" in captured.out
+    assert captured.err == ""

--- a/tests/casts/test_catalog.py
+++ b/tests/casts/test_catalog.py
@@ -6,6 +6,9 @@
 from __future__ import annotations
 
 import json
+from importlib.resources import as_file, files
+
+import yaml
 
 from lionagi.casts.catalog import build_catalog
 from lionagi.casts.emission import EscalationRequest, field_name_for
@@ -24,6 +27,40 @@ class TestBuildCatalog:
     def test_modes_count_matches_list_modes(self):
         cat = build_catalog()
         assert len(cat["modes"]) == len(list_modes())
+
+    def test_default_pack_resolves_catalog_keys_and_covers_role_files(self):
+        packaged = files("lionagi.casts").joinpath("packs", "default.yaml")
+        with as_file(packaged) as path:
+            pack_data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+        catalog = build_catalog()
+        catalog_role_entries = {entry["name"]: entry for entry in catalog["roles"]}
+        catalog_roles = set(catalog_role_entries)
+        catalog_modes = {entry["name"] for entry in catalog["modes"]}
+        pack_roles = set(pack_data.get("roles") or {})
+        top_level_modes = set(pack_data.get("modes") or {})
+        referenced_modes = {
+            mode
+            for role_spec in (pack_data.get("roles") or {}).values()
+            for field in ("default_modes", "modes_allow")
+            for mode in role_spec.get(field, ())
+        }
+
+        problems = []
+        if unknown_roles := pack_roles - catalog_roles:
+            problems.append(f"unknown default-pack roles: {sorted(unknown_roles)}")
+        if unresolved_roles := {
+            role
+            for role in pack_roles & catalog_roles
+            if catalog_role_entries[role]["config"] is None
+        }:
+            problems.append(f"unresolved default-pack roles: {sorted(unresolved_roles)}")
+        if unknown_modes := (top_level_modes | referenced_modes) - catalog_modes:
+            problems.append(f"unknown default-pack modes: {sorted(unknown_modes)}")
+        if uncovered_roles := catalog_roles - pack_roles:
+            problems.append(f"uncovered role files: {sorted(uncovered_roles)}")
+
+        assert not problems, "; ".join(problems)
 
     def test_role_entry_shape(self):
         cat = build_catalog()

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -512,6 +512,7 @@ def _collect_kernel_import_bindings(tree: ast.AST) -> set[str]:
 
 
 _FLOW_MODULE_PATH = "lionagi.operations.flow"
+_FLOW_MODULE_SUFFIX = "operations.flow"
 
 
 def _dotted_name(expr: ast.expr) -> str | None:
@@ -593,9 +594,9 @@ def _is_flow_module_expr(expr: ast.expr, env: _FlowModuleEnv) -> bool:
         return True
     if isinstance(expr, ast.Attribute):
         dotted = _dotted_name(expr)
-        if dotted == _FLOW_MODULE_PATH:
-            root = dotted.split(".", 1)[0]
-            return root in env.lionagi_roots
+        if dotted is not None:
+            root, separator, suffix = dotted.partition(".")
+            return bool(separator) and suffix == _FLOW_MODULE_SUFFIX and root in env.lionagi_roots
     if isinstance(expr, ast.Call) and len(expr.args) == 1:
         callee = expr.func
         callee_ok = (isinstance(callee, ast.Name) and callee.id in env.import_module_funcs) or (
@@ -953,7 +954,9 @@ def _replay_binding_events(
             for alias in node.names:
                 if alias.name == _FLOW_MODULE_PATH and alias.asname:
                     env.names.add(alias.asname)
-                elif alias.name.split(".", 1)[0] == "lionagi" and not alias.asname:
+                elif alias.name == "lionagi":
+                    env.lionagi_roots.add(alias.asname or "lionagi")
+                elif alias.name.startswith("lionagi.") and not alias.asname:
                     env.lionagi_roots.add("lionagi")
                 elif alias.name == "importlib":
                     env.importlib_mods.add(alias.asname or "importlib")
@@ -1827,6 +1830,39 @@ def test_shadowed_lionagi_name_dotted_getattr_is_not_misreported(tmp_path):
         f"{sorted(discovery.executor_sites)}"
     )
     assert ("shadowed_root.py", "run") not in discovery.call_sites
+
+
+def test_aliased_lionagi_root_dotted_getattr_discovers_executor_construction(tmp_path):
+    rogue = tmp_path / "aliased_root.py"
+    rogue.write_text(
+        "import lionagi as SDK\n\n\n"
+        "async def run(session, graph):\n"
+        '    return await getattr(SDK.operations.flow, "DependencyAwareExecutor")(\n'
+        "        session, graph\n"
+        "    ).execute()\n"
+    )
+
+    discovery = discover_call_and_construct_sites(tmp_path, base=tmp_path)
+
+    key = ("aliased_root.py", "run")
+    assert discovery.executor_sites == {key}
+    assert key in discovery.call_sites
+
+
+def test_aliased_lionagi_root_only_matches_the_flow_module_suffix(tmp_path):
+    benign = tmp_path / "aliased_non_flow.py"
+    benign.write_text(
+        "import lionagi as SDK\n\n\n"
+        "async def run(session, graph):\n"
+        '    return await getattr(SDK.operations.flow.helpers, "DependencyAwareExecutor")(\n'
+        "        session, graph\n"
+        "    ).execute()\n"
+    )
+
+    discovery = discover_call_and_construct_sites(tmp_path, base=tmp_path)
+
+    assert discovery.executor_sites == set()
+    assert ("aliased_non_flow.py", "run") not in discovery.call_sites
 
 
 def test_arbitrary_import_module_named_callee_is_not_misreported(tmp_path):


### PR DESCRIPTION
Batch fix of five conformance/CI issues, each with regression coverage.

- **#2028 — default cast-pack consistency** (test-only invariant): a new test loads the shipped default pack and the catalog, rejects unknown/unresolved pack roles and unknown top-level or role-referenced modes, and reports built-in role files not covered by the default pack. Current data resolves 40 pack roles against 40 catalog roles with no uncovered files.
- **#2083 — aliased lionagi root in the conformance scanner**: `ast.Import` replay now records `import lionagi as <alias>` as a package-root binding, and dotted flow-module recognition validates the imported root token and compares only the exact `operations.flow` suffix. Adds a positive aliased-root self-test and a suffix-boundary negative self-test; dotted submodule aliases stay distinct from package-root aliases.
- **#1933 — cache-token means in the compute/cost table**: added `cached read` and `cache write` columns populated with per-configuration means from `cached_tokens`/`cache_write_tokens`, preserving the fixed-width report. An output regression checks the headers and exact averaged values.
- **#2145 — CI provenance-check tests**: added executable coverage for the benchmark provenance checker (previously untested).
- **#2039 (partial, not closed)**: adds an `always()`+result guard to the `docs` job in `.github/workflows/ci.yml`, but `ci-gate` still hard-gates the docs result, so a skipped docs job is not yet tolerated. This is a placeholder that does not achieve #2039's goal; #2039 stays open for a proper `ci-gate` change (which will also remove the now-inert guard).

Verification: `uv run pytest tests/casts/ tests/operations/test_graph_entrypoint_conformance.py tests/benchmarks/`, and `benchmarks/orchestration/ --import-mode=importlib` — all green (import-mode set to avoid the pre-existing `test_arms.py` collection collision). ruff clean.

Closes #2028
Closes #2083
Closes #1933
Closes #2145
Refs #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

