### PR TITLE
fix(state): lifecycle batch — transition rejection precedence, shared health evaluator, initial-state history, terminal-write chokepoint (closes 4)

### DIFF
--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -43,12 +43,30 @@ async def _start_invocation(
 
 async def _end_invocation(invocation_id: str, *, status: str, metadata: dict | None) -> dict | None:
     from lionagi.state.db import StateDB
+    from lionagi.state.reasons import RunReasons
+
+    reason_by_status = {
+        "completed": RunReasons.COMPLETED_OK,
+        "failed": RunReasons.FAILED_EXCEPTION,
+        "timed_out": RunReasons.TIMED_OUT_DEADLINE,
+        "aborted": RunReasons.ABORTED_USER,
+        "cancelled": RunReasons.CANCELLED_SYSTEM,
+    }
 
     async with StateDB() as db:
         existing = await db.get_invocation(invocation_id)
         if existing is None:
             return None
-        fields: dict = {"status": status, "ended_at": time.time()}
+        await db.update_status(
+            "invocation",
+            invocation_id,
+            new_status=status,
+            reason_code=reason_by_status[status],
+            reason_summary=f"Invocation {status}.",
+            source="executor",
+            actor=invocation_id,
+            extra_fields={"ended_at": time.time()},
+        )
         if metadata is not None:
             # Merge: preserve any metadata the skill wrote during the
             # run, overwrite per-key with the closer's payload.
@@ -58,8 +76,10 @@ async def _end_invocation(invocation_id: str, *, status: str, metadata: dict | N
                     current = json.loads(current)
                 except json.JSONDecodeError:
                     current = {}
-            fields["node_metadata"] = {**current, **metadata}
-        await db.update_invocation(invocation_id, **fields)
+            await db.update_invocation(
+                invocation_id,
+                node_metadata={**current, **metadata},
+            )
         return await db.get_invocation(invocation_id)
 
 

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -54,21 +54,25 @@ async def persist_session_start(
     current_status = row.get("status")
     if current_status in SESSION_TERMINAL_STATUSES:
         return
+    fields = {
+        "model": model,
+        "provider": provider,
+        "effort": effort,
+        "agent_name": agent_name,
+        "agent_hash": agent_hash,
+        "invocation_id": invocation_id,
+        "started_at": time.time(),
+    }
     if row.get("status_reason_code") == RunReasons.STARTED_OK:
+        await db.update_session(session_id, **fields)
         return
     await db.update_session(
         session_id,
         # Explicit reason_code avoids tripping the deprecation shim, which
         # would swallow the transition and silently drop provenance fields.
         reason_code=RunReasons.STARTED_OK,
-        model=model,
-        provider=provider,
-        effort=effort,
-        agent_name=agent_name,
-        agent_hash=agent_hash,
-        invocation_id=invocation_id,
         status="running",
-        started_at=time.time(),
+        **fields,
     )
 
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -29,12 +29,25 @@ from lionagi.state.engine import (
 from lionagi.state.lifecycle import LifecycleNotFoundError as _LifecycleNotFoundError
 from lionagi.state.lifecycle import adapters as _lifecycle_adapters
 from lionagi.state.lifecycle import policy as _lifecycle_policy
+from lionagi.state.lifecycle.models import (
+    ActorRecord as _ActorRecord,
+)
+from lionagi.state.lifecycle.models import (
+    InitialStateCommand as _InitialStateCommand,
+)
+from lionagi.state.lifecycle.models import (
+    ReasonRecord as _ReasonRecord,
+)
 from lionagi.state.lifecycle.service import SQLAlchemyLifecycleService as _LifecycleService
+from lionagi.state.reasons import LEGACY_IMPORTED as _LEGACY_IMPORTED
 from lionagi.state.reasons import (
     PlayReasons as _PlayReasons,
 )
 from lionagi.state.reasons import (
     RunReasons as _RunReasons,
+)
+from lionagi.state.reasons import (
+    ScheduleReasons as _ScheduleReasons,
 )
 from lionagi.state.reasons import (
     ShowReasons as _ShowReasons,
@@ -71,6 +84,18 @@ _PLAY_DEFAULTS: dict[str, str] = {
     "merged": _PlayReasons.MERGED_OK,
     "escalated": _PlayReasons.ESCALATED_GATE_TWICE,
     "gate_failed": _PlayReasons.GATE_FAILED_VERDICT,
+}
+
+_INITIAL_REASON_CODES: dict[tuple[str, str], str] = {
+    ("session", "running"): _RunReasons.STARTED_OK,
+    ("invocation", "running"): _RunReasons.STARTED_OK,
+    ("show", "active"): _ShowReasons.ACTIVE_CREATED,
+    ("show", "imported"): _LEGACY_IMPORTED,
+    ("play", "pending"): _PlayReasons.PENDING_CREATED,
+    ("schedule_run", "queued"): _ScheduleReasons.QUEUED_CREATED,
+    ("schedule_run", "running"): _RunReasons.STARTED_OK,
+    ("schedule_run", "failed"): _RunReasons.FAILED_EXCEPTION,
+    ("schedule_run", "skipped"): _ScheduleReasons.SKIPPED_PRECONDITION,
 }
 
 
@@ -286,6 +311,7 @@ TEAM_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["team"]
 # two transactions that a crash between them could leave inconsistent.
 EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": frozenset({"ended_at"}),
+    "invocation": frozenset({"ended_at"}),
 }
 
 # ── ADR-0035 status vocabulary (valid, not just terminal) ──────────────
@@ -424,6 +450,46 @@ class StateDB:
         if self.__lifecycle_service is None:
             self.__lifecycle_service = _LifecycleService(self)
         return self.__lifecycle_service
+
+    async def _initialize_managed_entity_in_tx(
+        self,
+        conn,
+        *,
+        entity_type: str,
+        entity_id: str,
+        status: str,
+        actor_id: str,
+    ) -> None:
+        reason_code = _INITIAL_REASON_CODES.get((entity_type, status))
+        if reason_code is None:
+            # Compatibility repositories may insert historical terminal rows
+            # directly. Those are not declared lifecycle initial states and
+            # must not receive a fabricated creation event.
+            return
+        policy = _lifecycle_policy.DEFAULT_REGISTRY.get(entity_type)
+        await conn.execute(
+            text(
+                f"UPDATE {policy.table} SET status_reason_code = :reason_code, "  # noqa: S608
+                "status_reason_summary = :reason_summary, "
+                "status_evidence_refs = :evidence_refs WHERE id = :entity_id"
+            ).bindparams(bindparam("evidence_refs", type_=JSON)),
+            {
+                "reason_code": reason_code,
+                "reason_summary": "",
+                "evidence_refs": [],
+                "entity_id": entity_id,
+            },
+        )
+        await self._lifecycle_service().initialize_in_transaction(
+            conn,
+            _InitialStateCommand(
+                entity_type=entity_type,
+                entity_id=entity_id,
+                status=status,
+                reason=_ReasonRecord(code=reason_code),
+                actor=_ActorRecord(type="system", id=actor_id),
+            ),
+        )
 
     # ── backward-compat path property ─────────────────────────────────
 
@@ -1589,6 +1655,14 @@ class StateDB:
                 },
             )
             # Only increment session_count when INSERT actually created a row.
+            if result.rowcount and session.get("status") is not None:
+                await self._initialize_managed_entity_in_tx(
+                    conn,
+                    entity_type="session",
+                    entity_id=session["id"],
+                    status=session["status"],
+                    actor_id="create_session",
+                )
             if session.get("invocation_id") and result.rowcount:
                 await conn.execute(
                     text(
@@ -1827,6 +1901,8 @@ class StateDB:
         status_value = fields.pop("status", None)
         if status_value is None:
             return
+        allowed_extra = EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE.get(entity_type, frozenset())
+        extra_fields = {name: fields.pop(name) for name in allowed_extra if name in fields}
         if reason_code is None:
             from warnings import warn
 
@@ -1856,6 +1932,7 @@ class StateDB:
             evidence_refs=evidence_refs,
             source=reason_source,
             actor=reason_actor,
+            extra_fields=extra_fields or None,
             override=override,
             override_actor=override_actor,
             override_justification=override_justification,
@@ -2435,6 +2512,13 @@ class StateDB:
         stmt, params = self._build_schedule_run_insert_stmt(run)
         async with self._tx() as conn:
             await conn.execute(stmt, params)
+            await self._initialize_managed_entity_in_tx(
+                conn,
+                entity_type="schedule_run",
+                entity_id=params["id"],
+                status=params["status"],
+                actor_id="create_schedule_run",
+            )
 
     @staticmethod
     def _build_schedule_run_insert_stmt(run: dict[str, Any]):
@@ -2492,6 +2576,13 @@ class StateDB:
         sched_stmt, sched_params = self._build_update_schedule_stmt(schedule_id, schedule_fields)
         async with self._tx() as conn:
             await conn.execute(run_stmt, run_params)
+            await self._initialize_managed_entity_in_tx(
+                conn,
+                entity_type="schedule_run",
+                entity_id=run_params["id"],
+                status=run_params["status"],
+                actor_id="create_schedule_run_and_advance",
+            )
             await conn.execute(sched_stmt, sched_params)
 
     async def tombstone_and_replace_schedule_run(
@@ -2528,6 +2619,13 @@ class StateDB:
             if result.rowcount == 0:
                 return False
             await conn.execute(run_stmt, run_params)
+            await self._initialize_managed_entity_in_tx(
+                conn,
+                entity_type="schedule_run",
+                entity_id=run_params["id"],
+                status=run_params["status"],
+                actor_id="tombstone_and_replace_schedule_run",
+            )
         return True
 
     async def update_schedule_run(
@@ -2949,7 +3047,7 @@ class StateDB:
         )
         now = time.time()
         async with self._tx() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 text(
                     """INSERT INTO invocations
                        (id, skill, plugin, prompt, started_at, ended_at, status,
@@ -2972,6 +3070,14 @@ class StateDB:
                     "node_metadata": invocation.get("node_metadata"),
                 },
             )
+            if result.rowcount:
+                await self._initialize_managed_entity_in_tx(
+                    conn,
+                    entity_type="invocation",
+                    entity_id=invocation["id"],
+                    status=status,
+                    actor_id="create_invocation",
+                )
 
     async def update_invocation(
         self,
@@ -3528,7 +3634,7 @@ class StateDB:
         )
         now = time.time()
         async with self._tx() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 text(
                     """INSERT INTO shows (id, topic, goal, repo, base_branch,
                        integration_branch, status, show_dir, status_source,
@@ -3552,6 +3658,14 @@ class StateDB:
                     "updated_at": now,
                 },
             )
+            if result.rowcount:
+                await self._initialize_managed_entity_in_tx(
+                    conn,
+                    entity_type="show",
+                    entity_id=show["id"],
+                    status=show.get("status", "active"),
+                    actor_id="create_show",
+                )
 
     async def get_show(self, show_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:
@@ -3662,7 +3776,7 @@ class StateDB:
         )
         now = time.time()
         async with self._tx() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 text(
                     """INSERT INTO plays (id, show_id, name, playbook, effort,
                        status, attempt, session_id, started_at, ended_at, exit_code,
@@ -3698,6 +3812,14 @@ class StateDB:
                     "updated_at": now,
                 },
             )
+            if result.rowcount:
+                await self._initialize_managed_entity_in_tx(
+                    conn,
+                    entity_type="play",
+                    entity_id=play["id"],
+                    status=play.get("status", "pending"),
+                    actor_id="create_play",
+                )
 
     async def get_play(self, play_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from .staleness import DEFAULT_STALE_THRESHOLD, STALE_THRESHOLDS
+from .staleness import staleness_check
 
 # The 1h "quiet" floor below which a session is HEALTHY regardless of activity.
 IDLE_THRESHOLD: int = 3600
@@ -66,8 +66,7 @@ def classify_session_health(
     )
     idle_seconds = now - last_activity
 
-    kind = session.get("invocation_kind")
-    threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
+    is_stale = staleness_check(session, now=now) is not None
 
     if process_alive is not True:
         # Orphan check first (crashed before any message/artifact) — see docs/internals/runtime.md.
@@ -77,14 +76,14 @@ def classify_session_health(
             # Confirmed dead outranks the activity guard below.
             return SessionHealth.STALE
         # Unknown liveness: activity is the stronger life-evidence here — see docs/internals/runtime.md.
-        if idle_seconds <= threshold:
+        if not is_stale:
             if idle_seconds > IDLE_THRESHOLD:
                 return SessionHealth.IDLE
             return SessionHealth.HEALTHY
         return SessionHealth.STALE
 
     # Process alive — classify by activity gap.
-    if idle_seconds > threshold:
+    if is_stale:
         return SessionHealth.UNRESPONSIVE
     if idle_seconds > IDLE_THRESHOLD:
         return SessionHealth.IDLE

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -275,7 +275,10 @@ class SQLAlchemyLifecycleService:
                 )
             previous_status = row["status"]
 
-            # expected_statuses / expected_version guards.
+            # expected_statuses is a caller precondition. Version conflicts,
+            # by contrast, apply only to writes: policy rejections must retain
+            # their rejection audit even when the caller holds a stale row
+            # version.
             if (
                 command.expected_statuses is not None
                 and previous_status not in command.expected_statuses
@@ -286,17 +289,6 @@ class SQLAlchemyLifecycleService:
                     current_status=previous_status,
                     transition_id=None,
                 )
-            if (
-                command.expected_version is not None
-                and row["updated_at"] != command.expected_version
-            ):
-                return TransitionOutcome(
-                    result="conflict",
-                    previous_status=previous_status,
-                    current_status=previous_status,
-                    transition_id=None,
-                )
-
             same_status = previous_status == command.to_status
             declared_edges = policy.edges.get(previous_status, ()) if enforce_edges else ()
             self_edge = next((e for e in declared_edges if e.to_status == command.to_status), None)
@@ -402,6 +394,17 @@ class SQLAlchemyLifecycleService:
                 )
                 return TransitionOutcome(
                     result="rejected",
+                    previous_status=previous_status,
+                    current_status=previous_status,
+                    transition_id=None,
+                )
+
+            if (
+                command.expected_version is not None
+                and row["updated_at"] != command.expected_version
+            ):
+                return TransitionOutcome(
+                    result="conflict",
                     previous_status=previous_status,
                     current_status=previous_status,
                     transition_id=None,

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -116,6 +116,7 @@ class SessionReasons:
 class PlayReasons:
     """Show-play lifecycle reasons (ADR-0057 play vocabulary)."""
 
+    PENDING_CREATED = "play.pending.created"
     PENDING_WAITING_DEPS = "play.pending.waiting_on_deps"
     PENDING_READY = "play.pending.ready"
     BLOCKED_INVALID_DEPS = "play.blocked.invalid_deps"
@@ -128,6 +129,7 @@ class PlayReasons:
 class ShowReasons:
     """Show-level orchestration reasons."""
 
+    ACTIVE_CREATED = "show.active.created"
     BLOCKED_NO_READY_PLAYS = "show.blocked.no_ready_plays"
     COMPLETED_FINAL_GATE = "show.completed.final_gate"
     ABORTED_OPERATOR = "show.aborted.operator"
@@ -140,7 +142,9 @@ class ShowReasons:
 class ScheduleReasons:
     """ADR-0070 schedule-fire outcomes."""
 
+    QUEUED_CREATED = "schedule.queued.created"
     FIRED_DUE = "schedule.fired.due"
+    SKIPPED_PRECONDITION = "schedule.skipped.precondition"
     SKIPPED_OVERLAP = "schedule.skipped.overlap"
     SKIPPED_MISSED_FIRE = "schedule.skipped.missed_fire"
     DEFERRED_CAPACITY = "schedule.deferred.capacity"

--- a/lionagi/state/staleness.py
+++ b/lionagi/state/staleness.py
@@ -23,8 +23,13 @@ def staleness_check(session: dict[str, Any], *, now: float | None = None) -> str
     """Return "stale" if the running session exceeds its kind-aware threshold; None for terminal sessions."""
     if session.get("status") != "running":
         return None
-    threshold = STALE_THRESHOLDS.get(session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD)
-    last_activity = session.get("last_message_at") or session.get("updated_at") or 0
+    threshold = threshold_for_kind(session.get("invocation_kind"))
+    last_activity = (
+        session.get("last_message_at")
+        or session.get("updated_at")
+        or session.get("started_at")
+        or 0
+    )
     ts = now if now is not None else time.time()
     if ts - last_activity > threshold:
         return "stale"

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -535,7 +535,8 @@ def test_admin_transition_with_reason_code_succeeds(tmp_path, monkeypatch):
             assert row["status_reason_summary"] == "Operator forced failure after alert."
             rows = await db.fetch_all(
                 "SELECT reason_code, previous_status, status, evidence_refs "
-                "FROM status_transitions WHERE entity_id = ?",
+                "FROM status_transitions "
+                "WHERE entity_id = ? AND previous_status = 'running' AND status = 'failed'",
                 (sid,),
             )
             assert len(rows) == 1
@@ -601,7 +602,8 @@ def test_admin_transition_phantom_classifier_override(
             import json as _json
 
             row_t = await db.fetch_one(
-                "SELECT evidence_refs FROM status_transitions WHERE entity_id = ?",
+                "SELECT evidence_refs FROM status_transitions "
+                "WHERE entity_id = ? AND previous_status = 'running' AND status = 'failed'",
                 (sid,),
             )
             refs = _json.loads(row_t["evidence_refs"] or "[]")

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -125,6 +125,20 @@ async def _count_transitions(db_path: Path, entity_id: str) -> int:
         return row["n"] if row else 0
 
 
+async def _count_reaping_transitions(db_path: Path, entity_id: str) -> int:
+    # Count transitions out of a real prior status, excluding the synthetic
+    # initial creation row (previous_status IS NULL). Use this for entities
+    # created through the managed insert path (which now records a creation
+    # row) when asserting that no reaping transition occurred.
+    async with StateDB(db_path) as db:
+        row = await db.fetch_one(
+            "SELECT COUNT(*) AS n FROM status_transitions "
+            "WHERE entity_id = ? AND previous_status IS NOT NULL",
+            (entity_id,),
+        )
+        return row["n"] if row else 0
+
+
 # ── invocation deadline reaper ────────────────────────────────────────────────
 
 
@@ -267,7 +281,7 @@ def test_reap_stale_invocations_per_kind_override(tmp_path, monkeypatch):
     assert agent_inv["status"] == "timed_out", "agent kind exceeded its 1800 s deadline"
     assert flow_inv["status"] == "running", "flow kind within global 7200 s deadline"
     assert run_async(_count_transitions(db_path, agent_iid)) >= 1
-    assert run_async(_count_transitions(db_path, flow_iid)) == 0
+    assert run_async(_count_reaping_transitions(db_path, flow_iid)) == 0
 
 
 # ── null-status session detector ─────────────────────────────────────────────

--- a/tests/cli/test_invoke.py
+++ b/tests/cli/test_invoke.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli.invoke import _end_invocation
+from lionagi.state.reasons import RunReasons
+
+
+async def test_end_invocation_writes_terminal_status_and_ended_at_through_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = {"id": "invocation-1", "status": "running", "node_metadata": {"kept": True}}
+    updated = {**existing, "status": "completed", "ended_at": 123.0}
+
+    class FakeStateDB:
+        instance = None
+
+        def __init__(self):
+            self.get_invocation = AsyncMock(side_effect=[existing, updated])
+            self.update_invocation = AsyncMock()
+            self.update_status = AsyncMock(return_value=True)
+            type(self).instance = self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr("lionagi.state.db.StateDB", FakeStateDB)
+    monkeypatch.setattr("lionagi.cli.invoke.time.time", lambda: 123.0)
+
+    result = await _end_invocation(
+        "invocation-1",
+        status="completed",
+        metadata={"added": "value"},
+    )
+
+    db = FakeStateDB.instance
+    db.update_invocation.assert_awaited_once_with(
+        "invocation-1", node_metadata={"kept": True, "added": "value"}
+    )
+    db.update_status.assert_awaited_once_with(
+        "invocation",
+        "invocation-1",
+        new_status="completed",
+        reason_code=RunReasons.COMPLETED_OK,
+        reason_summary="Invocation completed.",
+        source="executor",
+        actor="invocation-1",
+        extra_fields={"ended_at": 123.0},
+    )
+    assert result == updated

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -583,7 +583,11 @@ async def test_persist_cancel_inserts_status_transition(temp_db_path: Path):
             evidence={"signal": "sigterm", "pid": 99},
         )
 
-        row = await db.fetch_one("SELECT * FROM status_transitions WHERE entity_id = ?", (sid,))
+        row = await db.fetch_one(
+            "SELECT * FROM status_transitions "
+            "WHERE entity_id = ? AND previous_status = 'running' AND status = 'cancelled'",
+            (sid,),
+        )
         assert row is not None
         assert row["reason_code"] == RunReasons.CANCELLED_MANUAL_KILL
         assert row["source"] == "admin"  # CLI kill is an admin action (ADR-0028)
@@ -681,7 +685,9 @@ async def test_kill_one_force_kill_uses_force_kill_reason(
         await _kill_one(db, "session", sid, row, user_reason="")
 
         tr = await db.fetch_one(
-            "SELECT reason_code FROM status_transitions WHERE entity_id = ?", (sid,)
+            "SELECT reason_code FROM status_transitions "
+            "WHERE entity_id = ? AND previous_status = 'running' AND status = 'cancelled'",
+            (sid,),
         )
         assert tr["reason_code"] == RunReasons.CANCELLED_FORCE_KILL
 
@@ -821,7 +827,9 @@ async def test_do_kill_all_stale_uses_stale_auto_reason(
 
     async with StateDB() as db:
         row = await db.fetch_one(
-            "SELECT reason_code FROM status_transitions WHERE entity_id = ?", (sid,)
+            "SELECT reason_code FROM status_transitions "
+            "WHERE entity_id = ? AND previous_status = 'running' AND status = 'cancelled'",
+            (sid,),
         )
         assert row is not None
         assert row["reason_code"] == RunReasons.CANCELLED_STALE_AUTO

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -453,7 +453,10 @@ async def test_conflict_never_writes_status_transitions_row(db: StateDB) -> None
         _command(entity_id=sid, to_status="completed", expected_statuses=frozenset({"failed"}))
     )
 
-    rows = await db.fetch_all("SELECT * FROM status_transitions WHERE entity_id = ?", (sid,))
+    rows = await db.fetch_all(
+        "SELECT * FROM status_transitions WHERE entity_id = ? AND previous_status IS NOT NULL",
+        (sid,),
+    )
     assert rows == []
     row = await db.get_session(sid)
     assert row["status"] == "running"
@@ -469,7 +472,10 @@ async def test_rejection_commits_only_its_admin_event_not_a_status_transitions_r
     outcome = await service.transition(_command(entity_id=sid, to_status="running"))
     assert outcome.result == "rejected"
 
-    transitions = await db.fetch_all("SELECT * FROM status_transitions WHERE entity_id = ?", (sid,))
+    transitions = await db.fetch_all(
+        "SELECT * FROM status_transitions WHERE entity_id = ? AND previous_status IS NOT NULL",
+        (sid,),
+    )
     assert transitions == []
 
     events = await db.list_admin_events(action="status_transition_rejected", target_id=sid)
@@ -529,7 +535,9 @@ async def test_guarded_update_reasserts_expected_version(db: StateDB) -> None:
             expected_version=stale_version,
         )
     )
-    assert outcome.result == "conflict"
+    assert outcome.result == "rejected"
+    events = await db.list_admin_events(action="status_transition_rejected", target_id=sid)
+    assert len(events) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -556,7 +556,8 @@ async def test_transition_store_governs_schedule_run_status(db: StateDB) -> None
     assert row["status"] == "completed"
 
     audit_rows = await db.fetch_all(
-        "SELECT previous_status, status, entity_type FROM status_transitions WHERE entity_id = ?",
+        "SELECT previous_status, status, entity_type FROM status_transitions "
+        "WHERE entity_id = ? AND previous_status IS NOT NULL",
         (run_id,),
     )
     assert len(audit_rows) == 1
@@ -689,7 +690,8 @@ async def test_transition_rejects_unknown_patch_column(db: StateDB) -> None:
 # update_schedule_run through _route_status_change/update_status), on a
 # schema without this change. `id`, `schedule_id`, and `created_at` are
 # caller-generated/wall-clock and excluded from the golden dict; every other
-# column produced by the existing write path must match exactly.
+# column produced by the existing write path must match exactly except the
+# initial lifecycle reason fields, which creation now fills atomically.
 
 _GOLDEN_ROW_AFTER_CREATE = {
     "action_args": '{"prompt": "hello"}',
@@ -702,9 +704,9 @@ _GOLDEN_ROW_AFTER_CREATE = {
     "fired_at": 1700000000.0,
     "invocation_id": None,
     "status": "running",
-    "status_evidence_refs": None,
-    "status_reason_code": None,
-    "status_reason_summary": None,
+    "status_evidence_refs": "[]",
+    "status_reason_code": "run.started.ok",
+    "status_reason_summary": "",
     "trigger_context": '{"trigger": "interval"}',
 }
 
@@ -775,10 +777,8 @@ def _strip(row: dict) -> dict:
 
 async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
     """The schedule_id-populated path (create_schedule_run + update_schedule_run,
-    i.e. an ordinary schedule fire) writes the same rows with the same column
-    values, and produces the same status_transitions sequence, as the
-    pre-ADR-0071 code — this codepath was not touched by the schema
-    generalization; new queue/task columns simply default to NULL.
+    i.e. an ordinary schedule fire) preserves the queue/task column contract
+    while also recording the managed entity's initial lifecycle reason.
     """
     sched_id = _uid()
     await db.create_schedule(
@@ -840,7 +840,7 @@ async def test_schedule_spawned_run_stays_byte_identical(db: StateDB) -> None:
     transitions = await db.fetch_all(
         "SELECT entity_type, entity_id, previous_status, status, reason_code, "
         "reason_summary, source, actor FROM status_transitions "
-        "WHERE entity_id = ? ORDER BY created_at",
+        "WHERE entity_id = ? AND previous_status IS NOT NULL ORDER BY created_at",
         (run_id,),
     )
     stripped_transitions = [

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -14,6 +14,7 @@ import time
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 from lionagi.state.db import StateDB
 
@@ -139,6 +140,125 @@ async def test_context_manager():
         version = await state.schema_version()
         assert version == "1"
     assert state._engine is None
+
+
+async def test_managed_entity_creations_write_initial_lifecycle_history(db: StateDB):
+    progression_id = uid()
+    await db.create_progression(progression_id)
+    session_id = uid()
+    await db.create_session(
+        {"id": session_id, "progression_id": progression_id, "status": "running"}
+    )
+
+    invocation_id = uid()
+    await db.create_invocation({"id": invocation_id, "skill": "test", "started_at": time.time()})
+
+    show_id = uid()
+    await db.create_show({"id": show_id, "topic": "creation-history", "show_dir": "shows/history"})
+    play_id = uid()
+    await db.create_play({"id": play_id, "show_id": show_id, "name": "first"})
+
+    schedule_id = uid()
+    await db.create_schedule(
+        {
+            "id": schedule_id,
+            "name": "creation-history",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    schedule_run_id = uid()
+    await db.create_schedule_run(
+        {
+            "id": schedule_run_id,
+            "schedule_id": schedule_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": "running",
+            "fired_at": time.time(),
+        }
+    )
+    advanced_run_id = uid()
+    advanced_run = {
+        "id": advanced_run_id,
+        "schedule_id": schedule_id,
+        "trigger_context": {},
+        "action_kind": "agent",
+        "action_args": [],
+        "status": "running",
+        "fired_at": time.time(),
+    }
+    await db.create_schedule_run_and_advance(
+        advanced_run,
+        schedule_id=schedule_id,
+        schedule_fields={"last_fired_at": time.time()},
+    )
+    replacement_run_id = uid()
+    replacement_run = {**advanced_run, "id": replacement_run_id}
+    assert await db.tombstone_and_replace_schedule_run(
+        schedule_run_id,
+        replacement_run,
+    )
+
+    # Idempotent creation retries do not append another creation event.
+    await db.create_session(
+        {"id": session_id, "progression_id": progression_id, "status": "running"}
+    )
+
+    expected = {
+        session_id: ("session", "running"),
+        invocation_id: ("invocation", "running"),
+        show_id: ("show", "active"),
+        play_id: ("play", "pending"),
+        schedule_run_id: ("schedule_run", "running"),
+        advanced_run_id: ("schedule_run", "running"),
+        replacement_run_id: ("schedule_run", "running"),
+    }
+    placeholders = ", ".join(f":id{i}" for i in range(len(expected)))
+    params = {f"id{i}": entity_id for i, entity_id in enumerate(expected)}
+    async with db._read() as conn:
+        rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT entity_type, entity_id, previous_status, status "
+                        f"FROM status_transitions WHERE entity_id IN ({placeholders})"
+                    ),
+                    params,
+                )
+            )
+            .mappings()
+            .all()
+        )
+
+    assert len(rows) == len(expected)
+    for row in rows:
+        assert row["previous_status"] is None
+        assert (row["entity_type"], row["status"]) == expected[row["entity_id"]]
+
+
+async def test_creation_history_failure_rolls_back_managed_entity(
+    db: StateDB, monkeypatch: pytest.MonkeyPatch
+):
+    from lionagi.state.lifecycle.service import SQLAlchemyLifecycleService
+
+    async def _fail_initial_history(self, connection, command):
+        raise RuntimeError("forced history failure")
+
+    monkeypatch.setattr(
+        SQLAlchemyLifecycleService,
+        "initialize_in_transaction",
+        _fail_initial_history,
+    )
+    invocation_id = uid()
+    with pytest.raises(RuntimeError, match="forced history failure"):
+        await db.create_invocation(
+            {"id": invocation_id, "skill": "test", "started_at": time.time()}
+        )
+
+    assert await db.get_invocation(invocation_id) is None
 
 
 async def test_engine_is_none_when_closed():

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -125,14 +125,15 @@ async def _run_parity_suite(db: StateDB) -> None:
     assert updated["status"] == "completed"
     assert updated["status_reason_code"] == RunReasons.COMPLETED_OK
 
-    # 4. status_transitions row was written
+    # 4. Creation and transition history were written.
     async with db._read() as conn:
         rows = (
             (
                 await conn.execute(
                     text(
                         "SELECT entity_type, previous_status, status, reason_code "
-                        "FROM status_transitions WHERE entity_id = :id"
+                        "FROM status_transitions WHERE entity_id = :id "
+                        "ORDER BY created_at"
                     ),
                     {"id": session_id},
                 )
@@ -140,8 +141,15 @@ async def _run_parity_suite(db: StateDB) -> None:
             .mappings()
             .all()
         )
-    assert len(rows) == 1
-    t = dict(rows[0])
+    assert len(rows) == 2
+    initial = dict(rows[0])
+    assert initial == {
+        "entity_type": "session",
+        "previous_status": None,
+        "status": "running",
+        "reason_code": RunReasons.STARTED_OK,
+    }
+    t = dict(rows[1])
     assert t["entity_type"] == "session"
     assert t["previous_status"] == "running"
     assert t["status"] == "completed"

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -14,8 +14,54 @@ from lionagi.state.health import (
     classify_session_health,
     worst_health,
 )
+from lionagi.state.staleness import staleness_check, threshold_for_kind
 
 NOW = 1_000_000.0
+
+
+@pytest.mark.parametrize(
+    ("offset", "stale_result", "alive_health", "unknown_health"),
+    [
+        (-1, None, SessionHealth.IDLE, SessionHealth.IDLE),
+        (0, None, SessionHealth.IDLE, SessionHealth.IDLE),
+        (1, "stale", SessionHealth.UNRESPONSIVE, SessionHealth.STALE),
+    ],
+)
+def test_health_and_staleness_entry_points_share_threshold_boundary(
+    offset: int,
+    stale_result: str | None,
+    alive_health: SessionHealth,
+    unknown_health: SessionHealth,
+) -> None:
+    threshold = threshold_for_kind("agent")
+    session = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - threshold - offset,
+        "message_count": 1,
+    }
+
+    assert staleness_check(session, now=NOW) == stale_result
+    assert (
+        classify_session_health(
+            session,
+            now=NOW,
+            process_alive=True,
+            has_artifacts=True,
+            has_stale_locks=False,
+        )
+        == alive_health
+    )
+    assert (
+        classify_session_health(
+            session,
+            now=NOW,
+            process_alive=None,
+            has_artifacts=True,
+            has_stale_locks=False,
+        )
+        == unknown_health
+    )
 
 
 # ── Terminal sessions ────────────────────────────────────────────────────────

--- a/tests/state/test_lifecycle_gate.py
+++ b/tests/state/test_lifecycle_gate.py
@@ -13,9 +13,9 @@ Regression class this module pins, in plain terms:
    ``override=True`` is a completely different case: it raises
    ``TransitionRejectedError``. A caller (or a future refactor) that treats
    one of these as the other is a live bug, not a style choice. The two
-   contracts can also *interact* — a terminal row with a stale guard still
-   returns ``False``, not a raise, because the guard check happens before
-   the terminal-exit check; this file pins that interaction directly.
+   contracts can also *interact* — a terminal row with a stale version guard
+   is still rejected and audited because terminal-exit policy is evaluated
+   before a write-only version conflict; this file pins that interaction.
 
 2. New statuses get added to one vocabulary source (a schema ``CHECK``
    constraint, the ``PolicyRegistry``, or the ``VALID_STATUSES_BY_ENTITY_TYPE``
@@ -439,8 +439,8 @@ async def test_cas_miss_on_expected_statuses_returns_false_silently(db: StateDB)
 
 
 @pytest.mark.asyncio
-async def test_cas_miss_on_expected_updated_at_returns_false_silently(db: StateDB) -> None:
-    """The version guard (`expected_updated_at`) is a distinct CAS channel from `expected_statuses` -- pinned separately because a caller could plausibly drop one and keep the other without any status-only test noticing. A stale version snapshot is also a silent `False`."""
+async def test_terminal_rejection_precedes_expected_updated_at_conflict(db: StateDB) -> None:
+    """A stale version guard does not suppress terminal-exit rejection or its audit."""
     sid = await _make_session(db, status="running")
     stale_snapshot = await db.get_session(sid)
     stale_version = stale_snapshot["updated_at"]
@@ -455,19 +455,21 @@ async def test_cas_miss_on_expected_updated_at_returns_false_silently(db: StateD
         source="executor",
     )
 
-    applied = await db.update_status(
-        "session",
-        sid,
-        new_status="completed",
-        reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
-        source="executor",
-        expected_statuses={"failed"},  # status membership alone would pass...
-        expected_updated_at=stale_version,  # ...but the version guard catches it
-    )
-    assert applied is False
+    with pytest.raises(TransitionRejectedError):
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+            source="executor",
+            expected_statuses={"failed"},
+            expected_updated_at=stale_version,
+        )
 
     row = await db.get_session(sid)
-    assert row["status"] == "failed"  # unchanged by the losing writer
+    assert row["status"] == "failed"
+    events = await db.list_admin_events(action="status_transition_rejected", target_id=sid)
+    assert len(events) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -255,7 +255,8 @@ class TestUpdateStatusAtomic:
                     await conn.execute(
                         text(
                             "SELECT entity_type, entity_id, previous_status, status, "
-                            "       reason_code, source FROM status_transitions WHERE entity_id = :id"
+                            "       reason_code, source FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
                         ),
                         {"id": sid},
                     )
@@ -296,7 +297,10 @@ class TestUpdateStatusAtomic:
             row = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )
@@ -329,7 +333,8 @@ class TestUpdateStatusAtomic:
                     await conn.execute(
                         text(
                             "SELECT entity_type, COUNT(*) AS n FROM status_transitions "
-                            "WHERE entity_id = :id GROUP BY entity_type"
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL "
+                            "GROUP BY entity_type"
                         ),
                         {"id": sid},
                     )
@@ -390,7 +395,7 @@ class TestUpdateStatusValidation:
             )
         row = dict(row)
         assert row["status"] == "running"
-        assert row["status_reason_code"] is None
+        assert row["status_reason_code"] == RunReasons.STARTED_OK
 
     async def test_invalid_entity_type_raises_valueerror(self, db: StateDB):
         with pytest.raises(ValueError, match="invalid entity_type"):
@@ -463,7 +468,10 @@ class TestUpdateStatusValidation:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )
@@ -622,7 +630,8 @@ class TestInvocationTransition:
                     await conn.execute(
                         text(
                             "SELECT entity_type, previous_status, status, reason_code "
-                            "FROM status_transitions WHERE entity_id = :id"
+                            "FROM status_transitions WHERE entity_id = :id "
+                            "AND previous_status IS NOT NULL"
                         ),
                         {"id": inv_id},
                     )
@@ -672,7 +681,10 @@ class TestInvocationTransition:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": inv_id},
                     )
                 )
@@ -680,6 +692,33 @@ class TestInvocationTransition:
                 .first()
             )
         assert count["n"] == 1
+
+    async def test_update_invocation_guards_ended_at_with_terminal_status(
+        self, db: StateDB, monkeypatch: pytest.MonkeyPatch
+    ):
+        from lionagi.state.lifecycle.service import SQLAlchemyLifecycleService
+
+        inv_id = await _create_invocation(db)
+        ended_at = time.time()
+        original_write = SQLAlchemyLifecycleService._write
+
+        async def _write_then_fail(self, conn, table, command, **kwargs):
+            assert command.patch["ended_at"] == ended_at
+            await original_write(self, conn, table, command, **kwargs)
+            raise RuntimeError("forced rollback")
+
+        monkeypatch.setattr(SQLAlchemyLifecycleService, "_write", _write_then_fail)
+        with pytest.raises(RuntimeError, match="forced rollback"):
+            await db.update_invocation(
+                inv_id,
+                status="completed",
+                ended_at=ended_at,
+                reason_code=RunReasons.COMPLETED_OK,
+            )
+
+        row = await db.get_invocation(inv_id)
+        assert row["status"] == "running"
+        assert row["ended_at"] is None
 
     async def test_update_invocation_compat_warns_when_reason_omitted(self, db: StateDB):
         """Legacy callers that pass status without reason_code get a deprecation
@@ -726,13 +765,16 @@ class TestInvocationTransition:
             )
         row = dict(row)
         assert row["status"] == "running"  # unchanged
-        assert row["status_reason_code"] is None  # never touched
+        assert row["status_reason_code"] == RunReasons.STARTED_OK
 
         async with db._read() as conn:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": inv_id},
                     )
                 )
@@ -781,7 +823,8 @@ class TestUpdateSessionRoutesStatusThroughHistory:
                     await conn.execute(
                         text(
                             "SELECT entity_type, previous_status, status, reason_code "
-                            "FROM status_transitions WHERE entity_id = :id"
+                            "FROM status_transitions WHERE entity_id = :id "
+                            "AND previous_status IS NOT NULL"
                         ),
                         {"id": sid},
                     )
@@ -812,7 +855,10 @@ class TestUpdateSessionRoutesStatusThroughHistory:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )
@@ -843,7 +889,10 @@ class TestUpdateSessionRoutesStatusThroughHistory:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )
@@ -898,13 +947,16 @@ class TestUpdateStatusSourceValidation:
             )
         row = dict(row)
         assert row["status"] == "running", "entity row must be unchanged on invalid source"
-        assert row["status_reason_code"] is None
+        assert row["status_reason_code"] == RunReasons.STARTED_OK
 
         async with db._read() as conn:
             count = (
                 (
                     await conn.execute(
-                        text("SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT COUNT(*) AS n FROM status_transitions "
+                            "WHERE entity_id = :id AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )
@@ -927,7 +979,10 @@ class TestUpdateStatusSourceValidation:
             row = (
                 (
                     await conn.execute(
-                        text("SELECT source FROM status_transitions WHERE entity_id = :id"),
+                        text(
+                            "SELECT source FROM status_transitions WHERE entity_id = :id "
+                            "AND previous_status IS NOT NULL"
+                        ),
                         {"id": sid},
                     )
                 )


### PR DESCRIPTION
Batch fix of four state-lifecycle issues, each with regression coverage.

- **#2009 — transition rejection precedence**: `SQLAlchemyLifecycleService._transition()` now evaluates policy/terminal-status rejection (and writes the `status_transition_rejected` admin-events audit row) BEFORE the optimistic version-guard conflict branch. Only the version guard moved after the rejection branch, restoring the pre-merge semantics where a rejected transition is recorded rather than masked by a version conflict.
- **#2080 — shared health/staleness evaluator**: `classify_session_health()` now delegates the kind-aware stale boundary to a single consolidated predicate, so `health.py` and `staleness.py` no longer classify independently against the shared thresholds. Both entry points keep their public return types.
- **#2079 — initial managed-entity lifecycle history**: every managed insert surface in `StateDB` now emits a creation history row (`previous_status=NULL`) for policy-declared initial states, so entity creation is represented in lifecycle history. Compatibility paths that are not policy-declared initial states do not emit spurious rows.
- **#2078 — terminal-write chokepoint**: `_end_invocation` now writes terminal status + `ended_at` through the guarded status transaction (via `EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE`) instead of a generic update outside it, closing the wrapper-path crash window between the terminal write and the guarded transition.

Verification: `uv run pytest tests/state/` — all green; ruff clean on touched files.

Closes #2009
Closes #2080
Closes #2079
Closes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
