### PR TITLE
fix(plugins): targeted activation rescan + Windows fcntl import guard (closes 2)

### DIFF
--- a/lionagi/plugins/_user_settings.py
+++ b/lionagi/plugins/_user_settings.py
@@ -23,12 +23,23 @@ from __future__ import annotations
 
 import contextlib
 import copy
-import fcntl
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+if sys.platform == "win32":
+    _fcntl = None
+    try:
+        import msvcrt as _msvcrt
+    except ImportError:  # pragma: no cover - only reached by cross-platform import simulation
+        _msvcrt = None
+else:
+    import fcntl as _fcntl
+
+    _msvcrt = None
 
 __all__ = (
     "locked_user_settings",
@@ -47,6 +58,30 @@ def _load_yaml_dict(raw: str) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _lock_file(fp, *, exclusive: bool) -> None:
+    if _fcntl is not None:
+        mode = _fcntl.LOCK_EX if exclusive else _fcntl.LOCK_SH
+        _fcntl.flock(fp.fileno(), mode)
+        return
+    if _msvcrt is not None:
+        position = fp.tell()
+        fp.seek(0)
+        mode = _msvcrt.LK_LOCK if exclusive else _msvcrt.LK_RLCK
+        _msvcrt.locking(fp.fileno(), mode, 1)
+        fp.seek(position)
+
+
+def _unlock_file(fp) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(fp.fileno(), _fcntl.LOCK_UN)
+        return
+    if _msvcrt is not None:
+        position = fp.tell()
+        fp.seek(0)
+        _msvcrt.locking(fp.fileno(), _msvcrt.LK_UNLCK, 1)
+        fp.seek(position)
+
+
 def read_user_settings() -> dict[str, Any]:
     """Snapshot read under a shared lock — safe against a concurrent writer's
     truncate-then-rewrite (see ``locked_user_settings``)."""
@@ -54,11 +89,11 @@ def read_user_settings() -> dict[str, Any]:
     if not path.is_file():
         return {}
     with open(path) as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        _lock_file(f, exclusive=False)
         try:
             raw = f.read()
         finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            _unlock_file(f)
     return _load_yaml_dict(raw)
 
 
@@ -75,7 +110,7 @@ def write_user_settings(data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     mode = "r+" if path.is_file() else "w+"
     with open(path, mode) as fp:
-        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        _lock_file(fp, exclusive=True)
         try:
             fp.seek(0)
             fp.truncate()
@@ -83,7 +118,7 @@ def write_user_settings(data: dict[str, Any]) -> None:
             fp.flush()
             os.fsync(fp.fileno())
         finally:
-            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            _unlock_file(fp)
 
 
 @contextlib.contextmanager
@@ -109,7 +144,7 @@ def locked_user_settings():
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
     with os.fdopen(fd, "r+") as fp:
-        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        _lock_file(fp, exclusive=True)
         try:
             fp.seek(0)
             data = _load_yaml_dict(fp.read())
@@ -123,4 +158,4 @@ def locked_user_settings():
             fp.flush()
             os.fsync(fp.fileno())
         finally:
-            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            _unlock_file(fp)

--- a/lionagi/plugins/registry.py
+++ b/lionagi/plugins/registry.py
@@ -257,8 +257,10 @@ def _build_snapshot() -> list[PluginRecord]:
     for surface, extractor in _NAMED_SURFACES:
         owners: dict[str, list[str]] = {}
         for d in candidates:
-            for cap_name in extractor(d.manifest):
-                owners.setdefault(cap_name, []).append(d.manifest.name)
+            manifest = d.manifest
+            assert manifest is not None
+            for cap_name in extractor(manifest):
+                owners.setdefault(cap_name, []).append(manifest.name)
         for cap_name, owner_names in owners.items():
             if len(owner_names) > 1:
                 msg = (
@@ -560,31 +562,44 @@ class PluginRegistry:
     def activate_target(cls, plugin_name: str, target: str) -> Any:
         """Stage 2: resolve a bundle-relative ``path.py:callable`` (or bare
         ``path.py`` module) reference. Eligibility and trust are revalidated
-        fresh on every call, never from the cached snapshot. See
-        docs/internals/runtime.md for the single-read and cache-key contract.
+        fresh on every call by rescanning only the requested plugin; the
+        cached snapshot supplies its bundle-directory candidate, not a trust
+        verdict. See docs/internals/runtime.md for the single-read and
+        cache-key contract.
         """
-        active, _, by_name = _fresh_active_plugins(cls._ensure_loaded())
-        fresh = active.get(plugin_name)
-        if fresh is None:
-            matches = by_name.get(plugin_name, [])
-            if len(matches) == 1:
-                candidate = matches[0]
-                assert candidate.manifest is not None
-                if (
-                    _is_live_active(candidate.manifest)
-                    and _trust_state(candidate) is not TrustState.TRUSTED
-                ):
-                    msg = (
-                        f"plugin {plugin_name!r} is no longer trusted (the manifest or a "
-                        f"declared file changed since the cached scan) — re-run "
-                        f"`li plugin trust {plugin_name}` or `li plugin list` to refresh"
-                    )
-                    raise PluginActivationError(plugin_name, target, msg)
+        records = cls._ensure_loaded()
+        record = cls.get(plugin_name)
+        if record is None or sum(item.name == plugin_name for item in records) != 1:
             msg = f"plugin {plugin_name!r} is not active (no such plugin, or untrusted/disabled/incompatible)"
+            raise PluginActivationError(plugin_name, target, msg)
+
+        fresh = _rescan(record)
+        if fresh is None:
+            msg = (
+                f"plugin {plugin_name!r} is no longer trusted (the manifest or a "
+                f"declared file changed since the cached scan) — re-run "
+                f"`li plugin trust {plugin_name}` or `li plugin list` to refresh"
+            )
             raise PluginActivationError(plugin_name, target, msg)
         assert fresh.manifest is not None
 
-        resolution = _target_resolution_map(fresh.manifest)
+        manifest = fresh.manifest
+        if not _is_live_active(manifest):
+            msg = f"plugin {plugin_name!r} is not active (no such plugin, or untrusted/disabled/incompatible)"
+            raise PluginActivationError(plugin_name, target, msg)
+        if manifest.name != plugin_name or _trust_state(fresh) is not TrustState.TRUSTED:
+            msg = (
+                f"plugin {plugin_name!r} is no longer trusted (the manifest or a "
+                f"declared file changed since the cached scan) — re-run "
+                f"`li plugin trust {plugin_name}` or `li plugin list` to refresh"
+            )
+            raise PluginActivationError(plugin_name, target, msg)
+        tool_names = _tool_names(manifest)
+        if len(tool_names) != len(set(tool_names)):
+            msg = f"plugin {plugin_name!r} is not active (no such plugin, or untrusted/disabled/incompatible)"
+            raise PluginActivationError(plugin_name, target, msg)
+
+        resolution = _target_resolution_map(manifest)
         if target not in resolution:
             msg = (
                 f"target {target!r} is not declared by plugin {plugin_name!r}'s manifest "

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -235,6 +235,30 @@ capabilities:
 
 
 class TestActivateTarget:
+    def test_activation_rescans_only_the_requested_plugin(self, write_plugin, monkeypatch):
+        import lionagi.plugins.registry as registry_mod
+
+        requested_bundle = _write_tool_plugin(write_plugin, "p1", tool_name="tool1")
+        unrelated_bundle = _write_tool_plugin(write_plugin, "p2", tool_name="tool2")
+        _trust_by_dir_name("p1")
+        _trust_by_dir_name("p2")
+        PluginRegistry.reset()
+
+        real_rescan = registry_mod._rescan
+        rescanned = []
+
+        def recording_rescan(record):
+            rescanned.append(record.bundle_dir)
+            return real_rescan(record)
+
+        monkeypatch.setattr(registry_mod, "_rescan", recording_rescan)
+
+        fn = PluginRegistry.activate_target("p1", "tools/t.py:t")
+
+        assert fn() == 1
+        assert rescanned == [requested_bundle]
+        assert unrelated_bundle not in rescanned
+
     def test_activates_lazily_and_caches(self, write_plugin):
         _write_tool_plugin(write_plugin, "p1", tool_body="def t():\n    return 42\n")
         _trust_by_dir_name("p1")
@@ -425,9 +449,7 @@ class TestActivePlaybookFiles:
         assert "p1/research" in files
         assert "p2/research" in files
 
-    def test_editing_playbook_after_first_access_removes_it_from_active_files(
-        self, write_plugin
-    ):
+    def test_editing_playbook_after_first_access_removes_it_from_active_files(self, write_plugin):
         bundle = _write_playbook_plugin(write_plugin, "p1", playbook="deep-research")
         _trust_by_dir_name("p1")
         PluginRegistry.reset()

--- a/tests/plugins/test_user_settings.py
+++ b/tests/plugins/test_user_settings.py
@@ -14,6 +14,8 @@ interleaving.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -29,7 +31,7 @@ def test_locked_user_settings_serializes_concurrent_writers(plugin_home):
     """Two concurrent read-modify-write sections -- one shaped like GC pruning a
     trust record, one shaped like `li plugin disable` setting `enabled: false` --
     must both land. Neither may be lost to the other's stale read, which is
-    exactly what happened before GC's mutation was locked (finding #2)."""
+    exactly what happened before GC's mutation was locked."""
     barrier = threading.Barrier(2)
     errors: list[BaseException] = []
 
@@ -66,6 +68,34 @@ def test_locked_user_settings_serializes_concurrent_writers(plugin_home):
     settings = read_user_settings()
     assert settings["trusted_plugins"]["web-research"]["manifest"] == "deadbeef"
     assert settings["plugins"]["other-plugin"]["enabled"] is False
+
+
+def test_plugins_imports_on_win32_without_fcntl():
+    script = """
+import importlib
+import sys
+import lionagi.plugins
+
+for module_name in (
+    "lionagi.plugins",
+    "lionagi.plugins.registry",
+    "lionagi.plugins.trust",
+    "lionagi.plugins._user_settings",
+):
+    sys.modules.pop(module_name, None)
+
+sys.platform = "win32"
+sys.modules["fcntl"] = None
+importlib.import_module("lionagi.plugins")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_locked_user_settings_no_op_writes_nothing(plugin_home):


### PR DESCRIPTION
Batch fix of two plugin-guard issues, each with regression coverage.

- **#2146 — targeted activation rescan**: `PluginRegistry.activate_target()` now uses the cached registry only to locate the requested plugin's bundle directory, then rescans and revalidates live eligibility and trust for that plugin alone (preserving the cheap duplicate cached-namespace and duplicate in-manifest tool-name rejections). `resolve_tool_target()` keeps the full fresh scan because it must compare all live tool owners for collisions. A tool miss therefore does one full collision-detection scan during resolution plus one targeted rescan during activation; unrelated plugins are not rescanned twice. Regression `test_activation_rescans_only_the_requested_plugin` records `_rescan()` calls and asserts activation touches only the requested bundle.
- **#2211 — Windows fcntl import guard**: `_user_settings.py` imports `fcntl` only outside `win32`; Windows uses `msvcrt.locking` for shared/exclusive one-byte file locks, with a no-op fallback limited to environments reporting `win32` that cannot import `msvcrt`. Regression `test_plugins_imports_on_win32_without_fcntl` reloads `lionagi.plugins` in a subprocess with `sys.platform == "win32"` and `fcntl` blocked.

Verification: `uv run pytest tests/plugins/` — all green; ruff clean.

Closes #2146
Closes #2211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
