### PR TITLE
feat(cli): honor khive_injection on the bare `li agent` path

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -356,6 +356,29 @@ def _register_providers(branch: Branch, spec: AgentSpec) -> None:
     branch.providers.register(KhiveInjectionProvider(policy))
 
 
+def register_profile_injection(branch: Branch, role_name: str, profile: Any) -> None:
+    """Register a CLI agent profile's khive injection provider onto ``branch``.
+
+    Shared by the orchestrate path and the bare ``li agent`` path so both honor a
+    profile's ``khive_injection`` opt-in without routing through the coding preset —
+    injection is a context-provider concern, orthogonal to CodingToolkit/path-guards.
+    The provider is keyed on ``{role_name}-recall-v1`` (role_name is the invoked
+    profile name). None/False disables; the env kill-switch is honored by
+    ``_register_providers``.
+    """
+    configured = getattr(profile, "khive_injection", None)
+    # Only None/False disable — an empty mapping is a valid opt-in (see _register_providers).
+    if configured is None or configured is False:
+        return
+
+    from lionagi.casts.pattern import Role
+    from lionagi.casts.profile import Profile
+
+    identity = Profile(name=role_name, role=Role(name=role_name, description="", body=""))
+    provider_spec = AgentSpec(profile=identity, pack=None, khive_injection=configured)
+    _register_providers(branch, provider_spec)
+
+
 def _register_coding_tools(branch: Branch, spec: AgentSpec) -> None:
     from pathlib import Path
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -380,6 +380,14 @@ async def _run_agent(
                 chat_model=chat_model,
                 log_config=DataLoggerConfig(auto_save_on_exit=False),
             )
+            # A bare `li agent -a <profile>` leg (no --preset coding, no role key)
+            # still honors the profile's khive_injection opt-in — injection is a
+            # context-provider concern, independent of the coding preset. Keyed on
+            # `{profile.name}-recall-v1`, matching the orchestrate path.
+            if profile is not None:
+                from lionagi.agent.factory import register_profile_injection
+
+                register_profile_injection(branch, profile.name, profile)
 
         # Fail fast: `li agent` only drives CLI-backed providers (the `run`
         # operation raises this same ValueError deep inside

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -383,11 +383,16 @@ async def _run_agent(
             # A bare `li agent -a <profile>` leg (no --preset coding, no role key)
             # still honors the profile's khive_injection opt-in — injection is a
             # context-provider concern, independent of the coding preset. Keyed on
-            # `{profile.name}-recall-v1`, matching the orchestrate path.
+            # `{agent_name}-recall-v1` (the invoked profile name, which equals
+            # profile.name for a loaded profile), matching the orchestrate path.
+            # Pass agent_name — guaranteed a non-empty str on this path — rather
+            # than profile.name, so a profile object without a `name` attribute
+            # and no injection opt-in does not trip an eager attribute access
+            # before the helper's khive_injection guard can early-return.
             if profile is not None:
                 from lionagi.agent.factory import register_profile_injection
 
-                register_profile_injection(branch, profile.name, profile)
+                register_profile_injection(branch, agent_name, profile)
 
         # Fail fast: `li agent` only drives CLI-backed providers (the `run`
         # operation raises this same ValueError deep inside

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 from lionagi import Branch, Session
 from lionagi._errors import ConfigurationError
 from lionagi.agent import AgentSpec, create_agent
+from lionagi.agent.factory import register_profile_injection
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
@@ -82,33 +83,6 @@ def parse_orchestrator_provider(model_spec: str) -> tuple[str | None, str | None
         return None, None
     provider = ms.model.split("/", 1)[0] if "/" in ms.model else None
     return ms.model, provider
-
-
-def _register_profile_providers(
-    branch: Branch,
-    role_name: str,
-    profile: AgentProfile,
-) -> None:
-    """Register providers from a verbatim CLI profile without changing its prompt."""
-    configured = getattr(profile, "khive_injection", None)
-    # Only None/False disable — an empty mapping is a valid opt-in (see _register_providers).
-    if configured is None or configured is False:
-        return
-
-    from lionagi.agent.factory import _register_providers
-    from lionagi.casts.pattern import Role
-    from lionagi.casts.profile import Profile
-
-    identity = Profile(
-        name=role_name,
-        role=Role(name=role_name, description="", body=""),
-    )
-    provider_spec = AgentSpec(
-        profile=identity,
-        pack=None,
-        khive_injection=configured,
-    )
-    _register_providers(branch, provider_spec)
 
 
 def available_roles() -> list[str]:
@@ -541,7 +515,7 @@ async def setup_orchestration(
             log_config=orc_log_config,
             name="orchestrator",
         )
-        _register_profile_providers(orc_branch, "orchestrator", orc_profile)
+        register_profile_injection(orc_branch, "orchestrator", orc_profile)
     else:
         # Built-in "orchestrator" casts role via AgentSpec.compose + factory.
         orc_spec = AgentSpec.compose("orchestrator", pack=loaded_pack, grant_emissions=False)
@@ -732,7 +706,7 @@ async def build_worker_branch(
             name=wname,
         )
         if w_profile is not None:
-            _register_profile_providers(wb, role, w_profile)
+            register_profile_injection(wb, role, w_profile)
 
     env.session.include_branches(wb)
 

--- a/tests/cli/test_agent_profile_khive_injection.py
+++ b/tests/cli/test_agent_profile_khive_injection.py
@@ -147,3 +147,73 @@ async def test_bare_li_agent_path_registers_injection_from_profile(monkeypatch, 
     await agent_mod._run_agent("codex/model", "do the thing", agent_name="reviewer")
 
     assert seen["providers"] == ["khive_injection:reviewer-recall-v1"]
+
+
+@pytest.mark.asyncio
+async def test_bare_li_agent_path_no_injection_when_profile_lacks_optin(monkeypatch, tmp_path):
+    """A bare-agent profile that does NOT opt into khive_injection must take the
+    else-path without registering any provider — and without tripping an eager
+    attribute access. The minimal profile mocks used across the CLI suite carry
+    no `name` attribute (a profile without an opt-in never needs one), so the
+    else-path must key on the invoked `agent_name`, not `profile.name`."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.service.manager import iModelManager
+
+    # No khive_injection, no name — as real profile mocks vary.
+    profile = SimpleNamespace(
+        model=None,
+        effort=None,
+        yolo=False,
+        fast_mode=False,
+        system_prompt="hi",
+        artifact_defaults=None,
+        timeout=None,
+        bypass=False,
+        resume_on_timeout=False,
+        lion_system=True,
+    )
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda name: profile)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/model")
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", AsyncMock(return_value=None))
+
+    async def fake_teardown(ctx, *, status="completed", **kw):
+        return status
+
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+
+    seen = {}
+
+    async def fake_operate(self, instruction=None, **kw):
+        seen["providers"] = list(self.providers.names)
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+
+    await agent_mod._run_agent("codex/model", "do the thing", agent_name="myprofile")
+
+    assert seen["providers"] == []

--- a/tests/cli/test_agent_profile_khive_injection.py
+++ b/tests/cli/test_agent_profile_khive_injection.py
@@ -3,9 +3,11 @@
 
 """Tests for khive injection configuration in CLI agent profiles."""
 
+import pytest
+
 from lionagi import Branch
+from lionagi.agent.factory import register_profile_injection
 from lionagi.cli._providers import _parse_profile
-from lionagi.cli.orchestrate._orchestration import _register_profile_providers
 
 
 def test_profile_parser_promotes_khive_injection_frontmatter():
@@ -39,8 +41,109 @@ Research carefully.
     )
     branch = Branch(system=profile.system_prompt)
 
-    _register_profile_providers(branch, "researcher", profile)
+    register_profile_injection(branch, "researcher", profile)
 
     assert branch.providers.names == ["khive_injection:researcher-recall-v1"]
     provider = branch.providers._entries[0].provider
     assert provider.policy.profile_id == "researcher-recall-v1"
+
+
+def test_register_profile_injection_keys_on_profile_name():
+    # The bare `li agent -a <name>` path passes profile.name as role_name, so the
+    # provider is keyed on `{profile.name}-recall-v1` — not the create_agent path's
+    # "implementer" default. A reviewer profile derives reviewer-recall-v1.
+    profile = _parse_profile("reviewer", "---\nkhive_injection: true\n---\nReview.\n")
+    branch = Branch()
+
+    register_profile_injection(branch, profile.name, profile)
+
+    assert branch.providers.names == ["khive_injection:reviewer-recall-v1"]
+
+
+@pytest.mark.parametrize("configured", [None, False])
+def test_register_profile_injection_disabled(configured):
+    profile = _parse_profile("reviewer", "---\nkhive_injection: true\n---\nReview.\n")
+    profile.khive_injection = configured
+    branch = Branch()
+
+    register_profile_injection(branch, "reviewer", profile)
+
+    assert branch.providers.names == []
+
+
+def test_register_profile_injection_empty_mapping_is_optin():
+    # An empty mapping is a valid opt-in that receives the fleet defaults.
+    profile = _parse_profile("reviewer", "---\nkhive_injection: true\n---\nReview.\n")
+    profile.khive_injection = {}
+    branch = Branch()
+
+    register_profile_injection(branch, "reviewer", profile)
+
+    assert branch.providers.names == ["khive_injection:reviewer-recall-v1"]
+
+
+def test_register_profile_injection_respects_env_killswitch(monkeypatch):
+    monkeypatch.setenv("LIONAGI_KHIVE_INJECTION", "0")
+    profile = _parse_profile("reviewer", "---\nkhive_injection: true\n---\nReview.\n")
+    branch = Branch()
+
+    register_profile_injection(branch, "reviewer", profile)
+
+    assert branch.providers.names == []
+
+
+@pytest.mark.asyncio
+async def test_bare_li_agent_path_registers_injection_from_profile(monkeypatch, tmp_path):
+    """End-to-end guard for the bare `li agent -a <profile>` path: a profile that
+    opts into khive_injection but has no `role` key (so it takes the plain-Branch
+    else-path, not create_agent) must still register the provider — keyed on
+    `{profile.name}-recall-v1`. Guards against silently dropping the else-path wiring."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.service.manager import iModelManager
+
+    profile = _parse_profile("reviewer", "---\nkhive_injection: true\n---\nReview.\n")
+    monkeypatch.setattr(agent_mod, "load_agent_profile", lambda name: profile)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/model")
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", AsyncMock(return_value=None))
+
+    async def fake_teardown(ctx, *, status="completed", **kw):
+        return status
+
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+
+    seen = {}
+
+    async def fake_operate(self, instruction=None, **kw):
+        seen["providers"] = list(self.providers.names)
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+
+    await agent_mod._run_agent("codex/model", "do the thing", agent_name="reviewer")
+
+    assert seen["providers"] == ["khive_injection:reviewer-recall-v1"]


### PR DESCRIPTION
## Summary

The `KhiveInjectionProvider` (ADR-0008) that auto-recalls khive context before a
turn and writes tool-error resolutions back after was only registered when a run
took the `create_agent` path — that is, `--preset coding` or a profile carrying a
`role` key. A bare `li agent -a <profile>` leg with neither fell through to the
plain-`Branch()` else-path and registered **zero** providers, so a profile's
`khive_injection: true` opt-in was silently ignored on the fleet's most common
path: direct review/fix legs. Injection only ever fired via `li o fanout/play/flow`.

## Change

Decouple injection registration from the coding-preset gate:

- Relocate the profile-injection registration helper into `agent/factory.py` as
  `register_profile_injection`, shared by the orchestrate path and the bare-agent
  path. Injection is a context-provider concern, orthogonal to CodingToolkit /
  path-guards.
- Call it from `cli/agent.py`'s new-`Branch` else-path, keyed on
  `{profile.name}-recall-v1` (matching the orchestrate path's role-token keying).

Preserved unchanged: the `LIONAGI_KHIVE_INJECTION` env kill-switch, `None`/`False`
disabling, and the empty-mapping opt-in (a profile with `khive_injection: {}` gets
the fleet defaults). The `create_agent` and orchestrate paths are untouched.

## Tests

- `register_profile_injection` unit coverage: keys on profile name
  (`reviewer` → `reviewer-recall-v1`), `None`/`False` disable, empty-mapping
  opt-in registers, env kill-switch yields no provider.
- End-to-end guard: `_run_agent(..., agent_name="reviewer")` on the bare-agent
  path registers `khive_injection:reviewer-recall-v1` on the real branch's
  provider registry.

Full sweep across `tests/agent/`, `tests/cli/orchestrate/`, the CLI profile and
preflight suites, `tests/tools/test_khive_injection.py`, import-laziness, and
context-providers — all green. `ruff format`/`check` clean.

Follow-up: #2271 (surface injection stats in the `li monitor` summary table).
