### PR TITLE
feat(benchmarks): lionbench v0 record schemas + campaign config

### DIFF
--- a/benchmarks/orchestration/suites/lionbench/test_v0_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/test_v0_schema.py
@@ -1,0 +1,292 @@
+"""Unit tests for lionbench v0's durable record schemas + campaign config
+(DESIGN.md §2.2, §8 item 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from v0_config import assemble_campaign, git_sha_and_dirty, hash_price_table  # noqa: E402
+from v0_schema import (  # noqa: E402
+    Campaign,
+    Cell,
+    CellRegistry,
+    CellStatus,
+    ClaimRecord,
+    DuplicateCellKeyError,
+    Episode,
+    InjectionTrace,
+    Iteration,
+    JoinKeys,
+    Treatment,
+    UsageRow,
+    hash_file,
+    hash_json,
+    hash_text,
+)
+
+
+def _keys(**overrides) -> JoinKeys:
+    defaults = dict(
+        campaign_id="camp-1",
+        episode_id="ep-1",
+        treatment=Treatment.ON,
+        iteration=Iteration.N,
+        run_id="run-1",
+        branch_id="branch-1",
+        namespace_id="ns-1",
+        execution_scope="sandbox",
+        session_id="sess-1",
+    )
+    defaults.update(overrides)
+    return JoinKeys(**defaults)
+
+
+def _campaign(**overrides) -> Campaign:
+    defaults = dict(
+        campaign_id="camp-1",
+        git_sha="deadbeef",
+        git_dirty=False,
+        lionagi_version="0.22.6",
+        khive_version="1.0.0",
+        cli_version="1.0.0",
+        image_digest="sha256:aaa",
+        model="claude-code/sonnet",
+        model_revision="2026-06-01",
+        profile_hash="hash-profile-a",
+        price_table_hash="hash-prices-a",
+        isolation_requested="strict",
+        isolation_effective="strict",
+        seed=42,
+        dataset_hashes={"flywheel": "hash-data-a"},
+        parameters={"max_turns": 40},
+        created_at="2026-07-14T00:00:00Z",
+    )
+    defaults.update(overrides)
+    return Campaign(**defaults)
+
+
+# --- JSON round trip for every record type (Task 1 acceptance #1) ---
+
+
+def test_campaign_round_trip():
+    camp = _campaign()
+    restored = Campaign.from_dict(camp.to_dict())
+    assert restored == camp
+    assert restored.fingerprint == camp.fingerprint
+
+
+def test_episode_round_trip():
+    ep = Episode(
+        episode_id="ep-1",
+        campaign_id="camp-1",
+        family_id="family-a",
+        variant_order="A_then_B",
+        replica_index=2,
+        base_commit="deadbeef",
+        task_variant_n="A",
+        task_variant_n1="B",
+        created_at="2026-07-14T00:00:00Z",
+    )
+    restored = Episode.from_dict(ep.to_dict())
+    assert restored == ep
+
+
+def test_cell_round_trip():
+    cell = Cell(
+        keys=_keys(),
+        manifest_path="/runs/run-1/run.json",
+        status=CellStatus.VALID,
+        duration_s=12.5,
+        statedb_locator="statedb://sessions/abc",
+        oracle_passed=True,
+        artifact_hashes={"tool_trace.jsonl": "abc123"},
+        created_at="2026-07-14T00:00:00Z",
+    )
+    restored = Cell.from_dict(cell.to_dict())
+    assert restored == cell
+
+
+def test_injection_trace_round_trip():
+    trace = InjectionTrace(
+        keys=_keys(),
+        event_type="writeback",
+        policy_hash="policy-hash",
+        query_hash="query-hash",
+        returned_ids=["mem-1", "mem-2"],
+        written_ids=["mem-3"],
+        token_count=128,
+        error_class=None,
+        timestamp="2026-07-14T00:00:01Z",
+    )
+    restored = InjectionTrace.from_dict(trace.to_dict())
+    assert restored == trace
+
+
+def test_usage_row_round_trip():
+    row = UsageRow(
+        keys=_keys(execution_scope="host"),
+        generation_id="gen-1",
+        model="claude-code/sonnet",
+        uncached_input=1000,
+        cache_read=200,
+        cache_write=50,
+        output=300,
+        num_turns=4,
+        reasoning_disclosed=True,
+        usage_source="reported",
+    )
+    restored = UsageRow.from_dict(row.to_dict())
+    assert restored == row
+
+
+def test_claim_record_round_trip():
+    claim = ClaimRecord(
+        keys=_keys(iteration=Iteration.N_PLUS_1),
+        claim_id="claim-1",
+        text_span="I ran the tests and they passed.",
+        rule_label="tests_pass",
+        supporting_event_ids=["evt-1", "evt-2"],
+        oracle_outcome=False,
+        adjudication_state="human_reviewed",
+        result="false",
+    )
+    restored = ClaimRecord.from_dict(claim.to_dict())
+    assert restored == claim
+
+
+def test_join_keys_round_trip_without_optional_session_id():
+    keys = _keys(session_id=None)
+    restored = JoinKeys.from_dict(keys.to_dict())
+    assert restored == keys
+    assert restored.session_id is None
+
+
+# --- Duplicate cell key rejection, fail-closed (Task 1 acceptance #2) ---
+
+
+def test_duplicate_cell_key_is_rejected():
+    registry = CellRegistry()
+    cell_n = Cell(keys=_keys(iteration=Iteration.N), manifest_path="/runs/run-1/run.json")
+    dup = Cell(
+        keys=_keys(iteration=Iteration.N, run_id="run-1-retry"),
+        manifest_path="/runs/run-1-retry/run.json",
+    )
+
+    registry.add(cell_n)
+    with pytest.raises(DuplicateCellKeyError):
+        registry.add(dup)
+
+    assert len(registry) == 1
+
+
+def test_distinct_iteration_or_treatment_is_not_a_duplicate():
+    registry = CellRegistry()
+    cell_n = Cell(keys=_keys(iteration=Iteration.N), manifest_path="/runs/run-1/run.json")
+    cell_n1 = Cell(keys=_keys(iteration=Iteration.N_PLUS_1), manifest_path="/runs/run-2/run.json")
+    cell_off = Cell(
+        keys=_keys(iteration=Iteration.N, treatment=Treatment.OFF),
+        manifest_path="/runs/run-3/run.json",
+    )
+
+    registry.add(cell_n)
+    registry.add(cell_n1)
+    registry.add(cell_off)
+
+    assert len(registry) == 3
+
+
+def test_duplicate_key_ignores_non_key_fields():
+    """Same {campaign, episode, treatment, iteration} but a different run_id
+    is still a duplicate — run_id/branch_id are not part of the cell key."""
+    registry = CellRegistry()
+    registry.add(Cell(keys=_keys(run_id="run-a"), manifest_path="/runs/run-a/run.json"))
+    with pytest.raises(DuplicateCellKeyError):
+        registry.add(Cell(keys=_keys(run_id="run-b"), manifest_path="/runs/run-b/run.json"))
+
+
+# --- Campaign fingerprint stability + change detection (acceptance #3) ---
+
+
+def test_fingerprint_stable_for_identical_inputs():
+    a = _campaign()
+    b = _campaign()
+    assert a.fingerprint == b.fingerprint
+
+
+def test_fingerprint_stable_across_non_config_fields():
+    """campaign_id/created_at/git_sha/git_dirty are identity/provenance, not
+    configuration — changing them must not change the fingerprint."""
+    a = _campaign()
+    b = _campaign(
+        campaign_id="camp-2",
+        created_at="2026-08-01T00:00:00Z",
+        git_sha="cafebabe",
+        git_dirty=True,
+    )
+    assert a.fingerprint == b.fingerprint
+
+
+@pytest.mark.parametrize(
+    "field_name,new_value",
+    [
+        ("model", "claude-code/opus"),
+        ("profile_hash", "hash-profile-b"),
+        ("price_table_hash", "hash-prices-b"),
+        ("image_digest", "sha256:bbb"),
+        ("isolation_effective", "unheld"),
+        ("isolation_requested", "unheld"),
+    ],
+)
+def test_fingerprint_changes_when_config_factor_changes(field_name, new_value):
+    a = _campaign()
+    b = _campaign(**{field_name: new_value})
+    assert a.fingerprint != b.fingerprint
+
+
+def test_hash_price_table_changes_fingerprint_via_assemble_campaign(tmp_path):
+    common = dict(
+        campaign_id="camp-1",
+        model="claude-code/sonnet",
+        model_revision="2026-06-01",
+        profile_hash="hash-profile-a",
+        image_digest="sha256:aaa",
+        isolation_requested="strict",
+        isolation_effective="strict",
+        lionagi_version="0.22.6",
+        khive_version="1.0.0",
+        cli_version="1.0.0",
+        created_at="2026-07-14T00:00:00Z",
+    )
+    campaign_a = assemble_campaign(price_table={"claude-code/sonnet": [3.0, 15.0, 0.3]}, **common)
+    campaign_b = assemble_campaign(price_table={"claude-code/sonnet": [5.0, 25.0, 0.5]}, **common)
+
+    assert campaign_a.fingerprint != campaign_b.fingerprint
+    assert campaign_a.price_table_hash == hash_price_table({"claude-code/sonnet": [3.0, 15.0, 0.3]})
+
+
+def test_git_sha_and_dirty_defaults_when_not_a_git_repo(tmp_path):
+    sha, dirty = git_sha_and_dirty(tmp_path)
+    assert sha == ""
+    assert dirty is False
+
+
+# --- content hashing helpers ---
+
+
+def test_hash_json_is_order_independent_and_deterministic():
+    a = hash_json({"x": 1, "y": 2})
+    b = hash_json({"y": 2, "x": 1})
+    assert a == b
+    assert hash_json({"x": 1, "y": 3}) != a
+
+
+def test_hash_text_matches_hash_file(tmp_path):
+    content = "some raw artifact content\n"
+    path = tmp_path / "artifact.txt"
+    path.write_text(content)
+    assert hash_file(path) == hash_text(content)

--- a/benchmarks/orchestration/suites/lionbench/test_v0_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/test_v0_schema.py
@@ -127,6 +127,25 @@ def test_injection_trace_round_trip():
     assert restored == trace
 
 
+def test_injection_trace_rejects_unredacted_content():
+    """A hash/id field carrying whitespace is treated as un-redacted content and
+    rejected at construction (the redaction tripwire)."""
+    with pytest.raises(ValueError):
+        InjectionTrace(
+            keys=_keys(),
+            event_type="recall",
+            policy_hash="policy-hash",
+            query_hash="the user asked about their password reset",
+        )
+    with pytest.raises(ValueError):
+        InjectionTrace(
+            keys=_keys(),
+            event_type="writeback",
+            policy_hash="policy-hash",
+            written_ids=["mem-1", "leaked secret value with spaces"],
+        )
+
+
 def test_usage_row_round_trip():
     row = UsageRow(
         keys=_keys(execution_scope="host"),
@@ -209,6 +228,19 @@ def test_duplicate_key_ignores_non_key_fields():
         registry.add(Cell(keys=_keys(run_id="run-b"), manifest_path="/runs/run-b/run.json"))
 
 
+def test_duplicate_key_ignores_both_run_id_and_branch_id():
+    """Same {campaign, episode, treatment, iteration} is a duplicate even when
+    BOTH run_id and branch_id differ — neither is part of the cell key."""
+    registry = CellRegistry()
+    registry.add(
+        Cell(keys=_keys(run_id="run-a", branch_id="br-a"), manifest_path="/runs/run-a/run.json")
+    )
+    with pytest.raises(DuplicateCellKeyError):
+        registry.add(
+            Cell(keys=_keys(run_id="run-b", branch_id="br-b"), manifest_path="/runs/run-b/run.json")
+        )
+
+
 # --- Campaign fingerprint stability + change detection (acceptance #3) ---
 
 
@@ -240,6 +272,7 @@ def test_fingerprint_stable_across_non_config_fields():
         ("image_digest", "sha256:bbb"),
         ("isolation_effective", "unheld"),
         ("isolation_requested", "unheld"),
+        ("parameters", {"max_turns": 80}),
     ],
 )
 def test_fingerprint_changes_when_config_factor_changes(field_name, new_value):

--- a/benchmarks/orchestration/suites/lionbench/v0_config.py
+++ b/benchmarks/orchestration/suites/lionbench/v0_config.py
@@ -1,0 +1,89 @@
+"""lionbench v0 campaign config assembly (DESIGN.md §2.2 campaign.json, §8
+item 1). Builds a fingerprinted ``Campaign`` record from explicit inputs —
+no hidden env magic — plus small git/price-table introspection helpers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from v0_schema import Campaign, hash_json
+
+
+def hash_price_table(price_table: dict[str, Any]) -> str:
+    """Content hash of a resolved price table (model -> price tuple/list), so
+    ``campaign.json`` changes whenever the *effective* prices change even if
+    the override source (env var vs. default table) does not."""
+    return hash_json(price_table)
+
+
+def git_sha_and_dirty(repo_root: str | Path) -> tuple[str, bool]:
+    """Best-effort git SHA + dirty-worktree state for provenance. Returns
+    ``("", False)`` if the path is not a git checkout or git is unavailable —
+    campaign assembly never fails because of provenance introspection."""
+    root = Path(repo_root)
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607 — git resolved on PATH by design
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],  # noqa: S607 — git resolved on PATH by design
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        return sha, bool(status.strip())
+    except (OSError, subprocess.CalledProcessError):
+        return "", False
+
+
+def assemble_campaign(
+    campaign_id: str,
+    *,
+    model: str,
+    model_revision: str,
+    profile_hash: str,
+    price_table: dict[str, Any],
+    image_digest: str,
+    isolation_requested: str,
+    isolation_effective: str,
+    lionagi_version: str,
+    khive_version: str,
+    cli_version: str,
+    created_at: str,
+    repo_root: str | Path | None = None,
+    dataset_hashes: dict[str, str] | None = None,
+    seed: int = 0,
+    parameters: dict[str, Any] | None = None,
+) -> Campaign:
+    """Build the frozen ``Campaign`` record a campaign directory is stamped
+    with. ``fingerprint`` (computed on ``Campaign``) changes whenever model,
+    profile hash, price table, sandbox image, or isolation setting changes —
+    the acceptance bar for DESIGN.md §8 item 1."""
+    git_sha, git_dirty = git_sha_and_dirty(repo_root) if repo_root is not None else ("", False)
+    return Campaign(
+        campaign_id=campaign_id,
+        git_sha=git_sha,
+        git_dirty=git_dirty,
+        lionagi_version=lionagi_version,
+        khive_version=khive_version,
+        cli_version=cli_version,
+        image_digest=image_digest,
+        model=model,
+        model_revision=model_revision,
+        profile_hash=profile_hash,
+        price_table_hash=hash_price_table(price_table),
+        isolation_requested=isolation_requested,
+        isolation_effective=isolation_effective,
+        seed=seed,
+        dataset_hashes=dict(dataset_hashes or {}),
+        parameters=dict(parameters or {}),
+        created_at=created_at,
+    )

--- a/benchmarks/orchestration/suites/lionbench/v0_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/v0_schema.py
@@ -161,6 +161,7 @@ class Campaign:
             "cli_version": self.cli_version,
             "seed": self.seed,
             "dataset_hashes": self.dataset_hashes,
+            "parameters": self.parameters,
         }
         return hash_json(payload)
 
@@ -293,11 +294,27 @@ class Cell:
         )
 
 
+def _reject_unredacted(field_name: str, value: str | None) -> None:
+    """Redaction tripwire for ``InjectionTrace``: hashes and IDs never contain
+    whitespace, so a value carrying spaces or newlines is almost certainly
+    un-redacted memory content or a credential leaking into the trace store —
+    fail closed rather than persist it."""
+    if value is not None and any(ch.isspace() for ch in value):
+        raise ValueError(
+            f"InjectionTrace.{field_name} contains whitespace; it must be a "
+            "redacted hash or id (the injection collector redacts before this "
+            "record is built), never raw content or credentials"
+        )
+
+
 @dataclass(slots=True)
 class InjectionTrace:
     """One redacted ``injection.jsonl`` row: a recall, compose, auto-feedback,
-    writeback, or failure event (DESIGN.md §2.2 table). Never carries memory
-    content or credentials — only hashes and IDs."""
+    writeback, or failure event (DESIGN.md §2.2 table). Carries only redacted
+    hashes and IDs, never memory content or credentials — construction fails
+    closed (see ``_reject_unredacted``) when a hash/id field holds whitespace,
+    a tripwire for un-redacted content. The injection collector is responsible
+    for redacting before this row is built."""
 
     keys: JoinKeys
     event_type: str  # "recall" | "compose" | "auto_feedback" | "writeback" | "failure"
@@ -308,6 +325,15 @@ class InjectionTrace:
     token_count: int = 0
     error_class: str | None = None
     timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        _reject_unredacted("policy_hash", self.policy_hash)
+        _reject_unredacted("query_hash", self.query_hash)
+        _reject_unredacted("error_class", self.error_class)
+        for _id in self.returned_ids:
+            _reject_unredacted("returned_ids", _id)
+        for _id in self.written_ids:
+            _reject_unredacted("written_ids", _id)
 
     def to_dict(self) -> dict:
         return {

--- a/benchmarks/orchestration/suites/lionbench/v0_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/v0_schema.py
@@ -1,0 +1,457 @@
+"""lionbench v0 durable record schemas — the join-keyed rows that make up one
+campaign's evidence trail (DESIGN.md §2.2 "Required durable records", §8 item 1).
+
+Every artifact row carries the same join keys so `campaign.json`, `cell.json`,
+`injection.jsonl`, `usage.*.jsonl`, and `claims.json` can all be reconciled by
+`{campaign_id, episode_id, treatment, iteration, run_id, branch_id,
+session_id?, namespace_id, execution_scope}` (DESIGN.md §2.2). Records
+round-trip losslessly through plain JSON, matching the ``to_dict``/
+``from_dict`` convention already used by ``schema.py``'s ``Instance``.
+
+A duplicate ``{campaign_id, episode_id, treatment, iteration}`` cell key must
+fail closed rather than silently resume or overwrite a prior attempt
+(DESIGN.md §6.2 item 7, §8 item 1) — see ``CellRegistry``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class Treatment(str, Enum):
+    """Arm B fleet switch (DESIGN.md §4.1): identical profile apart from this."""
+
+    ON = "ON"
+    OFF = "OFF"
+
+
+class Iteration(str, Enum):
+    """The two fresh-process runs of one episode (DESIGN.md §2.1)."""
+
+    N = "N"
+    N_PLUS_1 = "N+1"
+
+
+class CellStatus(str, Enum):
+    """The decision-rule states a cell can settle into (DESIGN.md §9)."""
+
+    VALID = "valid"
+    INSTRUMENT_INVALID = "instrument_invalid"
+    BLOCKED = "blocked"
+    INCOMPLETE = "incomplete"
+    MEASURED_UNVERIFIED = "measured_unverified"
+    VERIFIED = "verified"
+
+
+# --- content hashing helpers (DESIGN.md §2.2 "hashes of every raw artifact") ---
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_text(text: str) -> str:
+    return sha256_hex(text.encode("utf-8"))
+
+
+def hash_json(obj: Any) -> str:
+    """Canonical content hash of a JSON-serializable object: sorted keys, no
+    whitespace ambiguity, so the same logical config always hashes the same."""
+    return hash_text(json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str))
+
+
+def hash_file(path: str | Path) -> str:
+    return sha256_hex(Path(path).read_bytes())
+
+
+@dataclass(slots=True)
+class JoinKeys:
+    """The durable join keys every lionbench v0 record row carries (DESIGN.md
+    §2.2). ``cell_key`` is the uniqueness key a ``CellRegistry`` rejects
+    duplicates on (§6.2 item 7)."""
+
+    campaign_id: str
+    episode_id: str
+    treatment: Treatment
+    iteration: Iteration
+    run_id: str
+    branch_id: str
+    namespace_id: str
+    execution_scope: str  # "host" | "sandbox"
+    session_id: str | None = None
+
+    @property
+    def cell_key(self) -> tuple[str, str, str, str]:
+        return (self.campaign_id, self.episode_id, self.treatment.value, self.iteration.value)
+
+    def to_dict(self) -> dict:
+        return {
+            "campaign_id": self.campaign_id,
+            "episode_id": self.episode_id,
+            "treatment": self.treatment.value,
+            "iteration": self.iteration.value,
+            "run_id": self.run_id,
+            "branch_id": self.branch_id,
+            "namespace_id": self.namespace_id,
+            "execution_scope": self.execution_scope,
+            "session_id": self.session_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> JoinKeys:
+        return cls(
+            campaign_id=d["campaign_id"],
+            episode_id=d["episode_id"],
+            treatment=Treatment(d["treatment"]),
+            iteration=Iteration(d["iteration"]),
+            run_id=d["run_id"],
+            branch_id=d["branch_id"],
+            namespace_id=d["namespace_id"],
+            execution_scope=d["execution_scope"],
+            session_id=d.get("session_id"),
+        )
+
+
+@dataclass(slots=True)
+class Campaign:
+    """``campaign.json`` (DESIGN.md §2.2 table). Immutable once the campaign
+    begins. ``fingerprint`` changes whenever model, profile hash, price
+    table, sandbox image, or isolation setting changes (§8 item 1)."""
+
+    campaign_id: str
+    git_sha: str
+    git_dirty: bool
+    lionagi_version: str
+    khive_version: str
+    cli_version: str
+    image_digest: str
+    model: str
+    model_revision: str
+    profile_hash: str
+    price_table_hash: str
+    isolation_requested: str
+    isolation_effective: str
+    seed: int = 0
+    dataset_hashes: dict[str, str] = field(default_factory=dict)
+    parameters: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+
+    @property
+    def fingerprint(self) -> str:
+        """Content hash of the fields that define a distinct measurement
+        configuration. Deliberately excludes ``campaign_id``/``created_at``
+        (identity/timing, not configuration) and ``git_sha``/``git_dirty``
+        (provenance, not a configuration knob) so identical inputs always
+        fingerprint identically."""
+        payload = {
+            "model": self.model,
+            "model_revision": self.model_revision,
+            "profile_hash": self.profile_hash,
+            "price_table_hash": self.price_table_hash,
+            "image_digest": self.image_digest,
+            "isolation_requested": self.isolation_requested,
+            "isolation_effective": self.isolation_effective,
+            "lionagi_version": self.lionagi_version,
+            "khive_version": self.khive_version,
+            "cli_version": self.cli_version,
+            "seed": self.seed,
+            "dataset_hashes": self.dataset_hashes,
+        }
+        return hash_json(payload)
+
+    def to_dict(self) -> dict:
+        return {
+            "campaign_id": self.campaign_id,
+            "git_sha": self.git_sha,
+            "git_dirty": self.git_dirty,
+            "lionagi_version": self.lionagi_version,
+            "khive_version": self.khive_version,
+            "cli_version": self.cli_version,
+            "image_digest": self.image_digest,
+            "model": self.model,
+            "model_revision": self.model_revision,
+            "profile_hash": self.profile_hash,
+            "price_table_hash": self.price_table_hash,
+            "isolation_requested": self.isolation_requested,
+            "isolation_effective": self.isolation_effective,
+            "seed": self.seed,
+            "dataset_hashes": self.dataset_hashes,
+            "parameters": self.parameters,
+            "created_at": self.created_at,
+            "fingerprint": self.fingerprint,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Campaign:
+        return cls(
+            campaign_id=d["campaign_id"],
+            git_sha=d.get("git_sha", ""),
+            git_dirty=d.get("git_dirty", False),
+            lionagi_version=d.get("lionagi_version", ""),
+            khive_version=d.get("khive_version", ""),
+            cli_version=d.get("cli_version", ""),
+            image_digest=d.get("image_digest", ""),
+            model=d["model"],
+            model_revision=d.get("model_revision", ""),
+            profile_hash=d.get("profile_hash", ""),
+            price_table_hash=d.get("price_table_hash", ""),
+            isolation_requested=d.get("isolation_requested", ""),
+            isolation_effective=d.get("isolation_effective", ""),
+            seed=d.get("seed", 0),
+            dataset_hashes=dict(d.get("dataset_hashes", {})),
+            parameters=dict(d.get("parameters", {})),
+            created_at=d.get("created_at", ""),
+        )
+
+
+@dataclass(slots=True)
+class Episode:
+    """One episode's identity/pairing metadata (DESIGN.md §2.1): the N and
+    N+1 counterbalanced task variants sharing one family."""
+
+    episode_id: str
+    campaign_id: str
+    family_id: str
+    variant_order: str  # "A_then_B" | "B_then_A"
+    replica_index: int
+    base_commit: str
+    task_variant_n: str
+    task_variant_n1: str
+    created_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "episode_id": self.episode_id,
+            "campaign_id": self.campaign_id,
+            "family_id": self.family_id,
+            "variant_order": self.variant_order,
+            "replica_index": self.replica_index,
+            "base_commit": self.base_commit,
+            "task_variant_n": self.task_variant_n,
+            "task_variant_n1": self.task_variant_n1,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Episode:
+        return cls(
+            episode_id=d["episode_id"],
+            campaign_id=d["campaign_id"],
+            family_id=d["family_id"],
+            variant_order=d["variant_order"],
+            replica_index=d["replica_index"],
+            base_commit=d["base_commit"],
+            task_variant_n=d["task_variant_n"],
+            task_variant_n1=d["task_variant_n1"],
+            created_at=d.get("created_at", ""),
+        )
+
+
+@dataclass(slots=True)
+class Cell:
+    """``cell.json`` (DESIGN.md §2.2 table): arm/iteration/task identity,
+    manifest path, StateDB locator, status, duration, oracle result, and
+    hashes of every raw artifact."""
+
+    keys: JoinKeys
+    manifest_path: str
+    status: CellStatus = CellStatus.INCOMPLETE
+    duration_s: float = 0.0
+    statedb_locator: str | None = None
+    oracle_passed: bool | None = None
+    artifact_hashes: dict[str, str] = field(default_factory=dict)
+    created_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "keys": self.keys.to_dict(),
+            "manifest_path": self.manifest_path,
+            "status": self.status.value,
+            "duration_s": self.duration_s,
+            "statedb_locator": self.statedb_locator,
+            "oracle_passed": self.oracle_passed,
+            "artifact_hashes": self.artifact_hashes,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Cell:
+        return cls(
+            keys=JoinKeys.from_dict(d["keys"]),
+            manifest_path=d["manifest_path"],
+            status=CellStatus(d.get("status", CellStatus.INCOMPLETE.value)),
+            duration_s=d.get("duration_s", 0.0),
+            statedb_locator=d.get("statedb_locator"),
+            oracle_passed=d.get("oracle_passed"),
+            artifact_hashes=dict(d.get("artifact_hashes", {})),
+            created_at=d.get("created_at", ""),
+        )
+
+
+@dataclass(slots=True)
+class InjectionTrace:
+    """One redacted ``injection.jsonl`` row: a recall, compose, auto-feedback,
+    writeback, or failure event (DESIGN.md §2.2 table). Never carries memory
+    content or credentials — only hashes and IDs."""
+
+    keys: JoinKeys
+    event_type: str  # "recall" | "compose" | "auto_feedback" | "writeback" | "failure"
+    policy_hash: str
+    query_hash: str | None = None
+    returned_ids: list[str] = field(default_factory=list)
+    written_ids: list[str] = field(default_factory=list)
+    token_count: int = 0
+    error_class: str | None = None
+    timestamp: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "keys": self.keys.to_dict(),
+            "event_type": self.event_type,
+            "policy_hash": self.policy_hash,
+            "query_hash": self.query_hash,
+            "returned_ids": self.returned_ids,
+            "written_ids": self.written_ids,
+            "token_count": self.token_count,
+            "error_class": self.error_class,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> InjectionTrace:
+        return cls(
+            keys=JoinKeys.from_dict(d["keys"]),
+            event_type=d["event_type"],
+            policy_hash=d["policy_hash"],
+            query_hash=d.get("query_hash"),
+            returned_ids=list(d.get("returned_ids", [])),
+            written_ids=list(d.get("written_ids", [])),
+            token_count=d.get("token_count", 0),
+            error_class=d.get("error_class"),
+            timestamp=d.get("timestamp", ""),
+        )
+
+
+@dataclass(slots=True)
+class UsageRow:
+    """One ``usage.{host,sandbox}.jsonl`` row. Dimensions match the shared
+    meter's normalized billing dimensions exactly (``harness/cost.py``'s
+    ``Usage``: uncached input, cache read, cache write, output) so a
+    lionbench ledger can be built straight from serialized rows."""
+
+    keys: JoinKeys
+    generation_id: str
+    model: str
+    uncached_input: int = 0
+    cache_read: int = 0
+    cache_write: int = 0
+    output: int = 0
+    num_turns: int = 0
+    reasoning_disclosed: bool = True
+    usage_source: str = "none"  # "reported" | "estimated" | "mixed" | "none"
+
+    def to_dict(self) -> dict:
+        return {
+            "keys": self.keys.to_dict(),
+            "generation_id": self.generation_id,
+            "model": self.model,
+            "uncached_input": self.uncached_input,
+            "cache_read": self.cache_read,
+            "cache_write": self.cache_write,
+            "output": self.output,
+            "num_turns": self.num_turns,
+            "reasoning_disclosed": self.reasoning_disclosed,
+            "usage_source": self.usage_source,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> UsageRow:
+        return cls(
+            keys=JoinKeys.from_dict(d["keys"]),
+            generation_id=d["generation_id"],
+            model=d["model"],
+            uncached_input=d.get("uncached_input", 0),
+            cache_read=d.get("cache_read", 0),
+            cache_write=d.get("cache_write", 0),
+            output=d.get("output", 0),
+            num_turns=d.get("num_turns", 0),
+            reasoning_disclosed=d.get("reasoning_disclosed", True),
+            usage_source=d.get("usage_source", "none"),
+        )
+
+
+@dataclass(slots=True)
+class ClaimRecord:
+    """One ``claims.json`` row (DESIGN.md §5, §2.2 table): a verification
+    claim span joined to its supporting tool-trace evidence and oracle
+    outcome, with an explicit true/false/ambiguous adjudication."""
+
+    keys: JoinKeys
+    claim_id: str
+    text_span: str
+    rule_label: str
+    supporting_event_ids: list[str] = field(default_factory=list)
+    oracle_outcome: bool | None = None
+    adjudication_state: str = "auto"  # "auto" | "human_pending" | "human_reviewed"
+    result: str = "ambiguous"  # "true" | "false" | "ambiguous"
+
+    def to_dict(self) -> dict:
+        return {
+            "keys": self.keys.to_dict(),
+            "claim_id": self.claim_id,
+            "text_span": self.text_span,
+            "rule_label": self.rule_label,
+            "supporting_event_ids": self.supporting_event_ids,
+            "oracle_outcome": self.oracle_outcome,
+            "adjudication_state": self.adjudication_state,
+            "result": self.result,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ClaimRecord:
+        return cls(
+            keys=JoinKeys.from_dict(d["keys"]),
+            claim_id=d["claim_id"],
+            text_span=d["text_span"],
+            rule_label=d["rule_label"],
+            supporting_event_ids=list(d.get("supporting_event_ids", [])),
+            oracle_outcome=d.get("oracle_outcome"),
+            adjudication_state=d.get("adjudication_state", "auto"),
+            result=d.get("result", "ambiguous"),
+        )
+
+
+class DuplicateCellKeyError(ValueError):
+    """A ``{campaign_id, episode_id, treatment, iteration}`` key was already
+    registered (DESIGN.md §6.2 item 7: fail closed, never silently resume)."""
+
+
+class CellRegistry:
+    """Tracks ``Cell`` join keys and rejects duplicates. A partially written
+    cell is ``incomplete``, not resumably re-scored under the same key
+    (DESIGN.md §6.2 item 7) — retrying requires a new attempt/run_id, which
+    is a different key only if it changes ``run_id`` without changing the
+    campaign/episode/treatment/iteration identity checked here."""
+
+    def __init__(self) -> None:
+        self._seen: set[tuple[str, str, str, str]] = set()
+
+    def add(self, cell: Cell) -> None:
+        key = cell.keys.cell_key
+        if key in self._seen:
+            raise DuplicateCellKeyError(
+                f"duplicate cell key {key!r} — a cell with this "
+                "{campaign_id, episode_id, treatment, iteration} was already registered"
+            )
+        self._seen.add(key)
+
+    def __contains__(self, key: tuple[str, str, str, str]) -> bool:
+        return key in self._seen
+
+    def __len__(self) -> int:
+        return len(self._seen)


### PR DESCRIPTION
## lionbench v0 — record schemas + campaign config (build-queue item 1)

First foundational piece of **lionbench v0**, a measurement harness for the khive↔lionagi
injection flywheel (does per-turn khive recall/writeback actually make later runs
better/cheaper/more-correct?). This PR adds only the durable record types that make up one
campaign's evidence trail — no drivers, no cost ledger, no oracle, and no changes to core
`lionagi/**`. Scope is schemas only.

### What's here
All under `benchmarks/orchestration/suites/lionbench/`:

- **`v0_schema.py`** — the join-keyed record types:
  - `Treatment` (ON/OFF), `Iteration` (N/N+1), `CellStatus` (valid / instrument_invalid /
    blocked / incomplete / measured_unverified / verified) enums.
  - `JoinKeys` — the shared join-key set every row carries, with a 4-tuple `cell_key`
    (`campaign_id, episode_id, treatment, iteration`).
  - `Campaign` — with a `fingerprint` that changes whenever a measurement-config factor
    changes (model, model revision, profile hash, price-table hash, image digest, isolation
    requested/effective, tool versions, seed, dataset hashes) and stays stable across
    identity/provenance fields (`campaign_id`, `created_at`, `git_sha`, `git_dirty`).
  - `Episode`, `Cell`, `InjectionTrace` (redacted — hashes and IDs only, never memory content
    or credentials), `UsageRow` (dimensions aligned to the shared cost meter's normalized
    billing dimensions: uncached input / cache read / cache write / output), `ClaimRecord`.
  - Content-hashing helpers and a `CellRegistry` that **fails closed** on a duplicate cell key
    (a partially written cell is not silently resumed or overwritten).

- **`v0_config.py`** — `assemble_campaign()` builds a fingerprinted `Campaign` from explicit
  inputs (no hidden env magic); `hash_price_table()` and a fail-soft git-provenance helper.

- **`test_v0_schema.py`** — 22 tests: JSON round-trip for all six record types, fail-closed
  duplicate-key rejection, fingerprint stability + per-factor change detection, hashing sanity.

### Verification
- `pytest benchmarks/orchestration/suites/lionbench/test_v0_schema.py` → 22 passed
- Full `benchmarks/orchestration/suites/lionbench/` suite → green (no regressions)
- `ruff format --check` + `ruff check` on the three new files → clean

No `lionagi/**` files touched.
