### PR TITLE
test: restore timestamp-freshness assertions across 5 protocol test files

### DIFF
--- a/tests/protocols/generic/test_element.py
+++ b/tests/protocols/generic/test_element.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
 
+from lionagi.protocols.generic import element as element_mod
 from lionagi.protocols.generic.element import ID, Element, validate_order
 
 
@@ -28,9 +30,11 @@ def test_element_metadata_validation():
     assert element.metadata == {"key": "value"}
 
 
-def test_element_timestamp():
+def test_element_timestamp(monkeypatch):
+    fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(element_mod, "now_utc", lambda: fixed)
     element = Element()
-    assert element.created_at > 0
+    assert element.created_at == fixed.timestamp()
 
 
 def test_element_equality():

--- a/tests/protocols/generic/test_element.py
+++ b/tests/protocols/generic/test_element.py
@@ -31,10 +31,18 @@ def test_element_metadata_validation():
 
 
 def test_element_timestamp(monkeypatch):
-    fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-    monkeypatch.setattr(element_mod, "now_utc", lambda: fixed)
-    element = Element()
-    assert element.created_at == fixed.timestamp()
+    # A moving clock: created_at must be stamped fresh from the clock at each
+    # construction and advance between instances — the freshness/ordering property,
+    # not merely equality to a chosen value.
+    t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
+    first = Element()
+    monkeypatch.setattr(element_mod, "now_utc", lambda: t1)
+    second = Element()
+    assert first.created_at == t0.timestamp()
+    assert second.created_at == t1.timestamp()
+    assert second.created_at > first.created_at
 
 
 def test_element_equality():

--- a/tests/protocols/generic/test_event.py
+++ b/tests/protocols/generic/test_event.py
@@ -83,10 +83,14 @@ def test_event_with_error():
 
 
 def test_event_duration(monkeypatch):
-    fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-    monkeypatch.setattr(element_mod, "now_utc", lambda: fixed)
-    execution = Execution(duration=1.5)
-    event = Event(execution=execution)
+    t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
+    first = Event(execution=Execution(duration=1.5))
+    monkeypatch.setattr(element_mod, "now_utc", lambda: t1)
+    second = Event(execution=Execution(duration=2.5))
 
-    assert event.execution.duration == 1.5
-    assert event.created_at == fixed.timestamp()
+    assert first.execution.duration == 1.5
+    # created_at is stamped fresh at construction and advances between events.
+    assert first.created_at == t0.timestamp()
+    assert second.created_at > first.created_at

--- a/tests/protocols/generic/test_event.py
+++ b/tests/protocols/generic/test_event.py
@@ -93,4 +93,5 @@ def test_event_duration(monkeypatch):
     assert first.execution.duration == 1.5
     # created_at is stamped fresh at construction and advances between events.
     assert first.created_at == t0.timestamp()
+    assert second.created_at == t1.timestamp()
     assert second.created_at > first.created_at

--- a/tests/protocols/generic/test_event.py
+++ b/tests/protocols/generic/test_event.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timezone
+
 import pytest
 
 from lionagi.ln.types import Unset
+from lionagi.protocols.generic import element as element_mod
 from lionagi.protocols.generic.event import Event, EventStatus, Execution
 
 
@@ -79,8 +82,11 @@ def test_event_with_error():
     assert event.execution.error == "Test error"
 
 
-def test_event_duration():
+def test_event_duration(monkeypatch):
+    fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(element_mod, "now_utc", lambda: fixed)
     execution = Execution(duration=1.5)
     event = Event(execution=execution)
 
     assert event.execution.duration == 1.5
+    assert event.created_at == fixed.timestamp()

--- a/tests/protocols/graph/test_node_config_expanded.py
+++ b/tests/protocols/graph/test_node_config_expanded.py
@@ -290,12 +290,16 @@ class TestTouchRealFields:
         assert v.version == 2
 
     def test_touch_sets_updated_at_field(self, monkeypatch):
-        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
+        t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("T", track_updated_at=True)
         t = cls()
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         t.touch()
-        assert t.updated_at == fixed.isoformat()
+        # updated_at reflects the touch() time, not construction, and orders after it.
+        assert t.updated_at == t1.isoformat()
+        assert datetime.fromisoformat(t.updated_at) > t0
 
     def test_touch_sets_created_by_field_first_time(self):
         cls = create_node("CB", track_created_by=True)
@@ -379,12 +383,16 @@ class TestSoftDeleteRealFields:
         assert d.is_deleted is True
 
     def test_soft_delete_sets_real_deleted_at(self, monkeypatch):
-        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
+        t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Del", soft_delete=True)
         d = cls()
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         d.soft_delete()
-        assert d.deleted_at == fixed.isoformat()
+        # deleted_at reflects the soft_delete() time, not construction, and orders after it.
+        assert d.deleted_at == t1.isoformat()
+        assert datetime.fromisoformat(d.deleted_at) > t0
 
     def test_restore_clears_real_is_deleted(self):
         cls = create_node("Rest", soft_delete=True)

--- a/tests/protocols/graph/test_node_config_expanded.py
+++ b/tests/protocols/graph/test_node_config_expanded.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import NodeConfig, create_node
 
@@ -18,6 +19,17 @@ from lionagi.protocols.graph.node_factory import NodeConfig, create_node
 def _content_hash(content):
     """Wrapper for compute_hash matching the rehash() calling convention."""
     return compute_hash(content, none_as_valid=True)
+
+
+def _frozen_datetime(fixed):
+    """A datetime subclass whose now() always returns `fixed`."""
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    return _Frozen
 
 
 class TestNodeConfigNewFields:
@@ -277,12 +289,13 @@ class TestTouchRealFields:
         v.touch()
         assert v.version == 2
 
-    def test_touch_sets_updated_at_field(self):
+    def test_touch_sets_updated_at_field(self, monkeypatch):
+        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
         cls = create_node("T", track_updated_at=True)
         t = cls()
         t.touch()
-        assert t.updated_at is not None
-        assert datetime.fromisoformat(t.updated_at).tzinfo == timezone.utc
+        assert t.updated_at == fixed.isoformat()
 
     def test_touch_sets_created_by_field_first_time(self):
         cls = create_node("CB", track_created_by=True)
@@ -365,12 +378,13 @@ class TestSoftDeleteRealFields:
         d.soft_delete()
         assert d.is_deleted is True
 
-    def test_soft_delete_sets_real_deleted_at(self):
+    def test_soft_delete_sets_real_deleted_at(self, monkeypatch):
+        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
         cls = create_node("Del", soft_delete=True)
         d = cls()
         d.soft_delete()
-        assert d.deleted_at is not None
-        assert datetime.fromisoformat(d.deleted_at).tzinfo == timezone.utc
+        assert d.deleted_at == fixed.isoformat()
 
     def test_restore_clears_real_is_deleted(self):
         cls = create_node("Rest", soft_delete=True)

--- a/tests/protocols/graph/test_node_config_expanded.py
+++ b/tests/protocols/graph/test_node_config_expanded.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.generic import element as element_mod
 from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import NodeConfig, create_node
@@ -292,14 +293,19 @@ class TestTouchRealFields:
     def test_touch_sets_updated_at_field(self, monkeypatch):
         t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("T", track_updated_at=True)
         t = cls()
+        assert t.created_at == t0.timestamp()
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         t.touch()
-        # updated_at reflects the touch() time, not construction, and orders after it.
+        # updated_at reflects the touch() clock (t1) and orders strictly after the
+        # node's actual construction time (created_at), not an arbitrary constant.
         assert t.updated_at == t1.isoformat()
-        assert datetime.fromisoformat(t.updated_at) > t0
+        updated_at = datetime.fromisoformat(t.updated_at)
+        assert updated_at == t1
+        assert updated_at > datetime.fromtimestamp(t.created_at, tz=timezone.utc)
 
     def test_touch_sets_created_by_field_first_time(self):
         cls = create_node("CB", track_created_by=True)
@@ -385,14 +391,19 @@ class TestSoftDeleteRealFields:
     def test_soft_delete_sets_real_deleted_at(self, monkeypatch):
         t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Del", soft_delete=True)
         d = cls()
+        assert d.created_at == t0.timestamp()
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         d.soft_delete()
-        # deleted_at reflects the soft_delete() time, not construction, and orders after it.
+        # deleted_at reflects the soft_delete() clock (t1) and orders strictly after
+        # the node's actual construction time (created_at), not an arbitrary constant.
         assert d.deleted_at == t1.isoformat()
-        assert datetime.fromisoformat(d.deleted_at) > t0
+        deleted_at = datetime.fromisoformat(d.deleted_at)
+        assert deleted_at == t1
+        assert deleted_at > datetime.fromtimestamp(d.created_at, tz=timezone.utc)
 
     def test_restore_clears_real_is_deleted(self):
         cls = create_node("Rest", soft_delete=True)

--- a/tests/protocols/graph/test_node_lifecycle.py
+++ b/tests/protocols/graph/test_node_lifecycle.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import NodeConfig, create_node
 
@@ -19,6 +20,17 @@ from lionagi.protocols.graph.node_factory import NodeConfig, create_node
 def _content_hash(content):
     """Wrapper for compute_hash matching the old rehash() calling convention."""
     return compute_hash(content, none_as_valid=True)
+
+
+def _frozen_datetime(fixed):
+    """A datetime subclass whose now() always returns `fixed`."""
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    return _Frozen
 
 
 class TestNodeConfigDefaults:
@@ -357,12 +369,13 @@ class TestNodeTouch:
         b.touch()
         assert "version" not in b.metadata
 
-    def test_touch_track_updated_at(self):
+    def test_touch_track_updated_at(self, monkeypatch):
+        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
         cls = create_node("Tracked", track_updated_at=True)
         t = cls(content="x")
         t.touch()
-        ts = t.updated_at
-        assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+        assert t.updated_at == fixed.isoformat()
 
     def test_touch_versioning_starts_at_one(self):
         cls = create_node("V", versioning=True)

--- a/tests/protocols/graph/test_node_lifecycle.py
+++ b/tests/protocols/graph/test_node_lifecycle.py
@@ -370,12 +370,16 @@ class TestNodeTouch:
         assert "version" not in b.metadata
 
     def test_touch_track_updated_at(self, monkeypatch):
-        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
+        t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Tracked", track_updated_at=True)
         t = cls(content="x")
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         t.touch()
-        assert t.updated_at == fixed.isoformat()
+        # updated_at reflects the touch() time, not construction, and orders after it.
+        assert t.updated_at == t1.isoformat()
+        assert datetime.fromisoformat(t.updated_at) > t0
 
     def test_touch_versioning_starts_at_one(self):
         cls = create_node("V", versioning=True)

--- a/tests/protocols/graph/test_node_lifecycle.py
+++ b/tests/protocols/graph/test_node_lifecycle.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.generic import element as element_mod
 from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import NodeConfig, create_node
@@ -372,14 +373,19 @@ class TestNodeTouch:
     def test_touch_track_updated_at(self, monkeypatch):
         t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Tracked", track_updated_at=True)
         t = cls(content="x")
+        assert t.created_at == t0.timestamp()
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         t.touch()
-        # updated_at reflects the touch() time, not construction, and orders after it.
+        # updated_at reflects the touch() clock (t1) and orders strictly after the
+        # node's actual construction time (created_at), not an arbitrary constant.
         assert t.updated_at == t1.isoformat()
-        assert datetime.fromisoformat(t.updated_at) > t0
+        updated_at = datetime.fromisoformat(t.updated_at)
+        assert updated_at == t1
+        assert updated_at > datetime.fromtimestamp(t.created_at, tz=timezone.utc)
 
     def test_touch_versioning_starts_at_one(self):
         cls = create_node("V", versioning=True)

--- a/tests/protocols/graph/test_node_soft_delete.py
+++ b/tests/protocols/graph/test_node_soft_delete.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import create_node
 
@@ -17,6 +18,17 @@ from lionagi.protocols.graph.node_factory import create_node
 def _content_hash(content):
     """Wrapper for compute_hash matching the old rehash() calling convention."""
     return compute_hash(content, none_as_valid=True)
+
+
+def _frozen_datetime(fixed):
+    """A datetime subclass whose now() always returns `fixed`."""
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    return _Frozen
 
 
 class TestNodeSoftDelete:
@@ -39,12 +51,13 @@ class TestNodeSoftDelete:
         d.soft_delete()
         assert d.is_deleted is True
 
-    def test_soft_delete_sets_deleted_at(self):
+    def test_soft_delete_sets_deleted_at(self, monkeypatch):
+        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
         cls = create_node("Del", soft_delete=True)
         d = cls()
         d.soft_delete()
-        ts = d.deleted_at
-        assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+        assert d.deleted_at == fixed.isoformat()
 
     def test_soft_delete_with_by_param(self):
         cls = create_node("Del", soft_delete=True)

--- a/tests/protocols/graph/test_node_soft_delete.py
+++ b/tests/protocols/graph/test_node_soft_delete.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lionagi.ln import compute_hash
+from lionagi.protocols.generic import element as element_mod
 from lionagi.protocols.graph import node as node_mod
 from lionagi.protocols.graph.node import Node
 from lionagi.protocols.graph.node_factory import create_node
@@ -54,14 +55,19 @@ class TestNodeSoftDelete:
     def test_soft_delete_sets_deleted_at(self, monkeypatch):
         t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(element_mod, "now_utc", lambda: t0)
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Del", soft_delete=True)
         d = cls()
+        assert d.created_at == t0.timestamp()
         monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         d.soft_delete()
-        # deleted_at reflects the soft_delete() time, not construction, and orders after it.
+        # deleted_at reflects the soft_delete() clock (t1) and orders strictly after
+        # the node's actual construction time (created_at), not an arbitrary constant.
         assert d.deleted_at == t1.isoformat()
-        assert datetime.fromisoformat(d.deleted_at) > t0
+        deleted_at = datetime.fromisoformat(d.deleted_at)
+        assert deleted_at == t1
+        assert deleted_at > datetime.fromtimestamp(d.created_at, tz=timezone.utc)
 
     def test_soft_delete_with_by_param(self):
         cls = create_node("Del", soft_delete=True)

--- a/tests/protocols/graph/test_node_soft_delete.py
+++ b/tests/protocols/graph/test_node_soft_delete.py
@@ -52,12 +52,16 @@ class TestNodeSoftDelete:
         assert d.is_deleted is True
 
     def test_soft_delete_sets_deleted_at(self, monkeypatch):
-        fixed = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(fixed))
+        t0 = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t1 = datetime(2024, 6, 1, 12, 0, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t0))
         cls = create_node("Del", soft_delete=True)
         d = cls()
+        monkeypatch.setattr(node_mod, "datetime", _frozen_datetime(t1))
         d.soft_delete()
-        assert d.deleted_at == fixed.isoformat()
+        # deleted_at reflects the soft_delete() time, not construction, and orders after it.
+        assert d.deleted_at == t1.isoformat()
+        assert datetime.fromisoformat(d.deleted_at) > t0
 
     def test_soft_delete_with_by_param(self):
         cls = create_node("Del", soft_delete=True)


### PR DESCRIPTION
Restores the timestamp-freshness assertions that a prior refactor weakened or
dropped across 5 test files. Each affected test now injects a controlled clock
and asserts that `created_at`/`updated_at` advance monotonically on mutation
(rather than asserting only equality or nothing at all), so a regression that
freezes or reorders timestamps fails the suite again.

No production code changed — this is test-hardening only.

Tests: `tests/protocols/generic/` + `tests/protocols/graph/` — 177 passed.

Closes #2273
