### PR TITLE
fix(cli): restore Available-profiles hint on load_agent_profile not-found

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -502,7 +502,7 @@ def load_agent_profile(name: str) -> AgentProfile:
             "or ~/.lionagi/agents/ globally."
         )
 
-    available = [] if plugin_token else list_agents()
+    available = sorted(_plugin_agent_profiles().keys()) if plugin_token else list_agents()
     msg = f"Agent profile '{name}' not found"
     for path, target in unreadable_symlinks:
         msg += f"\n{path} exists but its symlink target is unreadable: {target}"

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -463,7 +463,9 @@ def test_find_lionagi_dirs_memoizes_git_probe_per_location(monkeypatch, tmp_path
     assert calls == [tmp_path]
 
 
-def test_slash_profile_miss_skips_available_profile_listing(monkeypatch, tmp_path):
+def test_slash_profile_miss_skips_directory_scan(monkeypatch, tmp_path):
+    """A slash-token miss must not trigger the list_agents() directory scan (still expensive),
+    but must still populate the Available listing from the already-computed plugin profiles."""
     import lionagi.cli._providers as providers
 
     find_calls: list = []
@@ -473,6 +475,7 @@ def test_slash_profile_miss_skips_available_profile_listing(monkeypatch, tmp_pat
         lambda: find_calls.append(True) or [tmp_path / ".lionagi"],
     )
     monkeypatch.setattr(providers, "_resolve_plugin_profile_path", lambda _name: None)
+    monkeypatch.setattr(providers, "_plugin_agent_profiles", lambda: {})
     monkeypatch.setattr(
         providers,
         "list_agents",
@@ -483,3 +486,29 @@ def test_slash_profile_miss_skips_available_profile_listing(monkeypatch, tmp_pat
         providers.load_agent_profile("openai/gpt-4o")
 
     assert find_calls == [True]
+
+
+def test_slash_profile_miss_includes_available_plugin_profiles(monkeypatch, tmp_path):
+    """A typo'd '<plugin>/<name>' token still gets an 'Available:' hint listing the
+    resolvable plugin-namespaced profiles, without paying for a directory scan."""
+    import lionagi.cli._providers as providers
+
+    monkeypatch.setattr(providers, "_find_lionagi_dirs", lambda: [tmp_path / ".lionagi"])
+    monkeypatch.setattr(providers, "_resolve_plugin_profile_path", lambda _name: None)
+    monkeypatch.setattr(
+        providers,
+        "_plugin_agent_profiles",
+        lambda: {"myplugin/reviewer": ("myplugin", tmp_path / "reviewer.md")},
+    )
+    monkeypatch.setattr(
+        providers,
+        "list_agents",
+        lambda: pytest.fail("slash-token misses must not scan profiles for an Available listing"),
+    )
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        providers.load_agent_profile("myplugin/reviewr")
+
+    message = str(exc_info.value)
+    assert "Agent profile 'myplugin/reviewr' not found" in message
+    assert "Available: myplugin/reviewer" in message


### PR DESCRIPTION
`load_agent_profile` dropped the "Available profiles: ..." hint on a
slash-token not-found error. This restores the hint so a mistyped profile name
surfaces the known profiles again. The list is sourced from
`_plugin_agent_profiles()` (the registered-plugin profiles) rather than a
filesystem scan, so it stays correct under the plugin model and does not touch
disk on the error path.

Tests: `tests/cli/test_providers.py` — 52 passed.

Closes #2259
