### PR TITLE
fix(plugins): restore cross-plugin tool-name collision check in activate_target (ADR-0088 D6)

### DIFF
--- a/lionagi/plugins/registry.py
+++ b/lionagi/plugins/registry.py
@@ -599,6 +599,32 @@ class PluginRegistry:
             msg = f"plugin {plugin_name!r} is not active (no such plugin, or untrusted/disabled/incompatible)"
             raise PluginActivationError(plugin_name, target, msg)
 
+        # ADR-0088 D6: a tool name shared with another live-eligible plugin is a
+        # hard error, not a shadow. Only the requested plugin is rescanned above;
+        # other plugins' tool ownership comes from their cached manifests, but
+        # enabled/compatible is still re-derived live (via _is_live_active) so
+        # disabling the other plugin resolves the collision without a reset().
+        other_tool_owners: dict[str, list[str]] = {}
+        for other in records:
+            if other.name == plugin_name or other.manifest is None:
+                continue
+            if other.state not in (PluginState.ACTIVE, PluginState.COLLISION):
+                continue
+            if not _is_live_active(other.manifest):
+                continue
+            for other_tool_name in _tool_names(other.manifest):
+                other_tool_owners.setdefault(other_tool_name, []).append(other.name)
+
+        for tool_name in tool_names:
+            colliding_owners = list(dict.fromkeys(other_tool_owners.get(tool_name, [])))
+            if colliding_owners:
+                names = ", ".join([plugin_name, *colliding_owners])
+                msg = (
+                    f"tool {tool_name!r} is declared by multiple enabled plugins "
+                    f"({names}) — disable one with `li plugin disable <name>`"
+                )
+                raise PluginActivationError(plugin_name, target, msg)
+
         resolution = _target_resolution_map(manifest)
         if target not in resolution:
             msg = (

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -164,6 +164,22 @@ class TestCollisions:
         assert "shared_tool" in r1.error
         assert "tools" in r1.error
 
+    def test_activate_target_rejects_cross_plugin_tool_name_collision(self, write_plugin):
+        """A plugin's own manifest can be internally consistent (unique name,
+        no duplicate tool within itself) while still being in PluginState.COLLISION
+        because another enabled plugin declares the same tool name. activate_target()
+        must reject it rather than only checking the target plugin in isolation."""
+        _write_tool_plugin(write_plugin, "p1", tool_name="shared_tool", agent_name="a1")
+        _write_tool_plugin(write_plugin, "p2", tool_name="shared_tool", agent_name="a2")
+        _trust_by_dir_name("p1")
+        _trust_by_dir_name("p2")
+
+        PluginRegistry.reset()
+        assert PluginRegistry.get("p1").state is PluginState.COLLISION
+
+        with pytest.raises(PluginActivationError, match="shared_tool"):
+            PluginRegistry.activate_target("p1", "tools/t.py:t")
+
     def test_two_active_plugins_same_agent_name_is_not_a_collision(self, write_plugin):
         """Agent profiles are namespaced (<plugin>/<name>) — same local name across two
         plugins is not a hard error, only the bare name becomes ambiguous (resolver's job)."""


### PR DESCRIPTION
`activate_target()` stopped rejecting a plugin whose tool name collides with a
tool already contributed by another active plugin (ADR-0088 D6). This restores
the cross-plugin collision check so two plugins cannot silently register the
same tool name; the second activation now raises with both plugin identities in
the message.

Tests: `tests/plugins/test_registry.py` — 180 passed.

Closes #2263
