### PR TITLE
fix(context): non-int writeback() return is a successful no-op, not a failure (ADR-0008)

### DIFF
--- a/lionagi/protocols/context_providers.py
+++ b/lionagi/protocols/context_providers.py
@@ -146,9 +146,12 @@ class ContextProviderRegistry:
             if hook is None:
                 continue
             try:
-                self.stats["writeback_records"] += int(await hook(branch, action_responses) or 0)
+                result = await hook(branch, action_responses)
             except Exception:
                 self.stats["writeback_failed"] += 1
                 logger.warning(
                     "context provider %r writeback raised; skipping", entry.name, exc_info=True
                 )
+                continue
+            if isinstance(result, int):
+                self.stats["writeback_records"] += result

--- a/tests/operations/test_context_providers.py
+++ b/tests/operations/test_context_providers.py
@@ -78,6 +78,16 @@ class _RaisingWritebackProvider:
         raise RuntimeError("writeback failed")
 
 
+class _NonIntWritebackProvider:
+    name = "non-int-writer"
+
+    async def provide(self, branch, instruction):
+        return None
+
+    async def writeback(self, branch, action_responses):
+        return {"written": 3}
+
+
 def _chat_param(branch, **overrides):
     kw = dict(
         guidance=None,
@@ -218,6 +228,18 @@ async def test_gather_writeback_warns_and_continues_to_sibling(caplog):
     assert writer.calls == [(None, ["response"])]
     assert "context provider 'raising-writer' writeback raised; skipping" in caplog.text
     assert registry.stats["writeback_failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gather_writeback_non_int_return_is_not_a_failure(caplog):
+    registry = ContextProviderRegistry()
+    registry.register(_NonIntWritebackProvider())
+
+    await registry.gather_writeback(None, ["response"])
+
+    assert registry.stats["writeback_failed"] == 0
+    assert registry.stats["writeback_records"] == 0
+    assert "writeback raised" not in caplog.text
 
 
 def test_registry_is_falsy_when_empty():


### PR DESCRIPTION
`gather_writeback` counted a non-int return from `writeback()` as a failure,
which contradicts the ADR-0008 `-> None` contract (a provider that returns
`None`, or any non-count value, is a successful no-op writeback, not an error).
This treats a non-int return as success and only classifies genuine exceptions
as failures.

Tests: `tests/operations/test_context_providers.py` — 23 passed.

Closes #2269
