### PR TITLE
fix(state): cc_session_id backfill must not bump updated_at (preserve reconcile CAS)

### DIFF
--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -250,12 +250,17 @@ async def mirror_session(
             }
         )
     else:
-        if existing.get("cc_session_id") is None:
-            await db.update_session(sid, cc_session_id=session_uid)
-        if project and not existing.get("project"):
+        cc_session_id = session_uid if existing.get("cc_session_id") is None else None
+        provenance_project = project if project and not existing.get("project") else None
+        if cc_session_id is not None or provenance_project is not None:
             # Backfill attribution for an already-seen session (INSERT OR IGNORE never
             # updates); writes without disturbing the liveness clock.
-            await db.set_session_provenance(sid, project=project, project_source=project_source)
+            await db.set_session_provenance(
+                sid,
+                cc_session_id=cc_session_id,
+                project=provenance_project,
+                project_source=project_source if provenance_project is not None else None,
+            )
     await db.create_branch(
         {
             "id": branch_id,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1898,6 +1898,7 @@ class StateDB:
         node_metadata: dict[str, Any] | None = None,
         project: str | None = None,
         project_source: str | None = None,
+        cc_session_id: str | None = None,
     ) -> None:
         """Write attribution/provenance fields without touching updated_at.
 
@@ -1918,6 +1919,9 @@ class StateDB:
             params["project"] = project
             sets.append("project_source = :project_source")
             params["project_source"] = project_source
+        if cc_session_id is not None:
+            sets.append("cc_session_id = :cc_session_id")
+            params["cc_session_id"] = cc_session_id
         if not sets:
             return
         params["_id"] = session_id

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -289,6 +289,59 @@ async def test_mirror_session_backfills_cc_session_id_on_existing_row(
 
 
 @pytest.mark.asyncio
+async def test_cc_session_id_backfill_does_not_bump_updated_at(
+    temp_db_path: Path,
+) -> None:
+    # The cc_session_id backfill is not activity: it must not move the liveness
+    # clock, or a concurrent reconcile_session_status CAS (expected_updated_at)
+    # can be silently defeated by this one-time backfill.
+    from lionagi.state.reasons import RunReasons
+
+    sprog = _det(SID, "sprog")
+    sid = session_db_id(SID)
+    async with StateDB() as db:
+        await db.create_progression(sprog)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": sprog,
+                "name": "Legacy Claude Code session",
+                "status": "running",
+                "updated_at": 1000.0,
+                "last_message_at": 1000.0,
+            }
+        )
+        before = await db.get_session(sid)
+        expected_updated_at = before["updated_at"]
+
+        # No new events on this pass -- only the one-time cc_session_id backfill
+        # runs; a real new message would legitimately bump updated_at via
+        # touch_session_activity, which is not what's under test here.
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=[],
+            tool_names={},
+            status="running",
+        )
+        after = await db.get_session(sid)
+        assert after["cc_session_id"] == SID
+        assert after["updated_at"] == expected_updated_at
+
+        # A concurrent reconciler that read updated_at before the backfill must
+        # still win its compare-and-set afterward.
+        written = await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            expected_statuses={"running"},
+            expected_updated_at=expected_updated_at,
+        )
+    assert written is True
+
+
+@pytest.mark.asyncio
 async def test_mirror_session_preserves_empty_cc_session_id(temp_db_path: Path) -> None:
     sprog = _det(SID, "sprog")
     async with StateDB() as db:


### PR DESCRIPTION
The `cc_session_id` backfill bumped `updated_at`, which can defeat the
optimistic-lock (CAS) check in `reconcile_session_status` — a concurrent
reconcile keyed on `updated_at` would spuriously miss. Backfill now goes
through `set_session_provenance`, which writes the provenance columns WITHOUT
bumping `updated_at`, preserving the reconcile CAS guard.

Tests: `tests/cli/test_mirror.py` — 53 passed.

Closes #2270
