### PR TITLE
feat(cli): per-invocation --notify on li agent + li o fanout

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -51,10 +51,14 @@ instead. Which variant applies is decided by `messenger_bound` in
 `team_worker_system()` in `_orchestration.py`.
 
 `_notify.py`: `--notify` is scoped compatibility sugar over the terminal-
-callback registry. After the flow/play run's own entity id is known, it
-registers the legacy payload shape (kind/playbook/save_dir/cwd/exit_class/
-started_at/ended_at/status/invocation_id) as an exec adapter filtered to
-that one entity, and unregisters it once the run's teardown fires. This is
+callback registry. The flag is defined once in `add_common_cli_args`, so
+every spawn-forwarding surface carries it — `li agent`, `li o fanout`, and
+`li o flow` / `li play` — and each wires it identically. After the run's own
+entity id is known (a `li agent` session, an `li o fanout` session, or an
+`li o flow` / `li play` session or invocation), it registers the legacy
+payload shape (kind/playbook/save_dir/cwd/exit_class/started_at/ended_at/
+status/invocation_id) as an exec adapter filtered to that one entity, and
+unregisters it once the run's teardown fires. This is
 deliberately different from the settings-level `notify.on_terminal` handler
 (bootstrapped once per process, unscoped, delivering the new minimal
 envelope) — `--notify` is a per-run override carrying the old payload shape

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -51,14 +51,10 @@ instead. Which variant applies is decided by `messenger_bound` in
 `team_worker_system()` in `_orchestration.py`.
 
 `_notify.py`: `--notify` is scoped compatibility sugar over the terminal-
-callback registry. The flag is defined once in `add_common_cli_args`, so
-every spawn-forwarding surface carries it — `li agent`, `li o fanout`, and
-`li o flow` / `li play` — and each wires it identically. After the run's own
-entity id is known (a `li agent` session, an `li o fanout` session, or an
-`li o flow` / `li play` session or invocation), it registers the legacy
-payload shape (kind/playbook/save_dir/cwd/exit_class/started_at/ended_at/
-status/invocation_id) as an exec adapter filtered to that one entity, and
-unregisters it once the run's teardown fires. This is
+callback registry. `li agent` and `li o fanout` always scope to their
+**session** entity because only their sessions transition to terminal. `li o
+flow` / `li play` additionally finalize and scope to an **invocation** when
+`--invocation` is set, because flow owns that finalization. This is
 deliberately different from the settings-level `notify.on_terminal` handler
 (bootstrapped once per process, unscoped, delivering the new minimal
 envelope) — `--notify` is a per-run override carrying the old payload shape

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -278,6 +278,16 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
             "Same effect as an agent profile's 'resume_on_timeout: once'."
         ),
     )
+    parser.add_argument(
+        "--notify",
+        metavar="CMD",
+        default=None,
+        help=(
+            "Shell command template run once this run reaches its terminal "
+            "status. Overrides .lionagi/settings.yaml notify.on_terminal. "
+            "Substitutes {payload} (full JSON), {status}, {invocation_id}."
+        ),
+    )
 
 
 # ── Agent profile loading (absorbed from _agents.py) ─────────────────────────

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -207,6 +208,7 @@ async def _run_agent(
     resume_on_timeout: bool = False,
     context_from: list[str] | None = None,
     context_budget: int | None = None,
+    notify: str | None = None,
     _auto_resumed: bool = False,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
@@ -504,6 +506,33 @@ async def _run_agent(
         project=project,
     )
 
+    # `--notify` compatibility sugar: register a scoped override on this run's
+    # own terminal entity, unregistered in `finally`. Fires from the guarded
+    # lifecycle transition that persists the terminal status (mirrors _run_flow).
+    # An about-to-auto-resume leg defers its terminal status, so this leg's
+    # scope never fires; the recursed leg re-registers and fires on its own.
+    _notify_scope_name: str | None = None
+    if notify:
+        from lionagi.cli.orchestrate._notify import (
+            register_flow_notify_scope,
+            unregister_flow_notify_scope,
+        )
+
+        _notify_session_id = live.get("session_id") if live else None
+        _notify_entity_id = invocation_id or _notify_session_id
+        if _notify_entity_id is not None:
+            _notify_scope_name = register_flow_notify_scope(
+                override=notify,
+                entity_kind="invocation" if invocation_id else "session",
+                entity_id=_notify_entity_id,
+                invocation_id=invocation_id,
+                flow_kind="agent",
+                playbook=None,
+                save_dir=str(run.artifact_root),
+                cwd=cwd or os.getcwd(),
+                started_at=run_manifest["started_at"],
+            )
+
     _terminal_status = "completed"
     _terminal_exc: BaseException | None = None
 
@@ -591,6 +620,11 @@ async def _run_agent(
                 run_manifest["ended_at"] = time.time()
             if _write_run_manifest is not None:
                 _write_run_manifest(run_manifest)
+            # Unregister after teardown_agent_persist (the notify handler fired
+            # during its terminal transition; a deferred-terminal leg fired
+            # nothing and the recursed leg re-registers its own scope).
+            if _notify_scope_name is not None:
+                unregister_flow_notify_scope(_notify_scope_name)
             await branch.mdls.shutdown()
 
     is_resume = bool(resume or continue_last)
@@ -636,6 +670,7 @@ async def _run_agent(
             project=project,
             bypass=bypass,
             resume_on_timeout=resume_on_timeout,
+            notify=notify,
             _auto_resumed=True,
         )
 
@@ -876,6 +911,7 @@ def run_agent(args: argparse.Namespace) -> int:
                 resume_on_timeout=getattr(args, "resume_on_timeout", False),
                 context_from=getattr(args, "context_from", None),
                 context_budget=getattr(args, "context_budget", None),
+                notify=getattr(args, "notify", None),
             )
         )
     except ContextFromError as exc:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -506,11 +506,9 @@ async def _run_agent(
         project=project,
     )
 
-    # `--notify` compatibility sugar: register a scoped override on this run's
-    # own terminal entity, unregistered in `finally`. Fires from the guarded
-    # lifecycle transition that persists the terminal status (mirrors _run_flow).
-    # An about-to-auto-resume leg defers its terminal status, so this leg's
-    # scope never fires; the recursed leg re-registers and fires on its own.
+    # Session-scoped: teardown_agent_persist terminalizes only the session;
+    # invocation records are finalized externally and would never fire. Deferred
+    # auto-resume legs unregister without firing; the recursed leg registers anew.
     _notify_scope_name: str | None = None
     if notify:
         from lionagi.cli.orchestrate._notify import (
@@ -519,12 +517,11 @@ async def _run_agent(
         )
 
         _notify_session_id = live.get("session_id") if live else None
-        _notify_entity_id = invocation_id or _notify_session_id
-        if _notify_entity_id is not None:
+        if _notify_session_id is not None:
             _notify_scope_name = register_flow_notify_scope(
                 override=notify,
-                entity_kind="invocation" if invocation_id else "session",
-                entity_id=_notify_entity_id,
+                entity_kind="session",
+                entity_id=_notify_session_id,
                 invocation_id=invocation_id,
                 flow_kind="agent",
                 playbook=None,
@@ -620,9 +617,7 @@ async def _run_agent(
                 run_manifest["ended_at"] = time.time()
             if _write_run_manifest is not None:
                 _write_run_manifest(run_manifest)
-            # Unregister after teardown_agent_persist (the notify handler fired
-            # during its terminal transition; a deferred-terminal leg fired
-            # nothing and the recursed leg re-registers its own scope).
+            # Unregister after teardown fires the terminal transition.
             if _notify_scope_name is not None:
                 unregister_flow_notify_scope(_notify_scope_name)
             await branch.mdls.shutdown()

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -805,16 +805,6 @@ def add_orchestrate_subparser(
             "restore. Without this flag such ops refuse loudly, naming them."
         ),
     )
-    fl.add_argument(
-        "--notify",
-        metavar="CMD",
-        default=None,
-        help=(
-            "Shell command template run once this run reaches its terminal "
-            "status. Overrides .lionagi/settings.yaml notify.on_terminal. "
-            "Substitutes {payload} (full JSON), {status}, {invocation_id}."
-        ),
-    )
     add_common_cli_args(fl)
 
     # `li o ctl status <id>` aliases the same status renderer as `li agent
@@ -959,6 +949,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                 invocation_id=getattr(args, "invocation", None),
                 project=getattr(args, "project", None),
                 pack=getattr(args, "pack", None),
+                notify=getattr(args, "notify", None),
             ),
             verbose=args.verbose,
         )

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 
 from lionagi._errors import TimeoutError as LionTimeoutError
@@ -23,6 +24,7 @@ from ._common import (
     _format_result_text,
     _post_results_to_team,
 )
+from ._notify import register_flow_notify_scope, unregister_flow_notify_scope
 from ._orchestration import (
     OrchestrationEnv,
     available_roles,
@@ -64,6 +66,7 @@ async def _run_fanout(
     invocation_id: str | None = None,
     project: str | None = None,
     pack: str | None = None,
+    notify: str | None = None,
 ) -> tuple[str, str]:
     """Three-phase fan-out: decompose → fan out → synthesize.
 
@@ -72,6 +75,7 @@ async def _run_fanout(
     teardown path settles on) reaches the caller's exit code instead of being
     silently dropped in favour of a hardcoded success.
     """
+    _started_at = time.time()
     env = await setup_orchestration(
         pattern_name="Fanout",
         model_spec=model_spec,
@@ -104,6 +108,25 @@ async def _run_fanout(
         effort=env.effort,
         project=project,
     )
+
+    # `--notify` compatibility sugar: register a scoped override on this run's
+    # own terminal entity, unregistered in `finally`. Fires from the guarded
+    # lifecycle transition that persists the terminal status (mirrors _run_flow).
+    _notify_scope_name: str | None = None
+    if notify:
+        _notify_entity_kind = "invocation" if invocation_id else "session"
+        _notify_entity_id = invocation_id if invocation_id else str(env.session.id)
+        _notify_scope_name = register_flow_notify_scope(
+            override=notify,
+            entity_kind=_notify_entity_kind,
+            entity_id=_notify_entity_id,
+            invocation_id=invocation_id,
+            flow_kind="fanout",
+            playbook=playbook_name,
+            save_dir=save_dir,
+            cwd=cwd or os.getcwd(),
+            started_at=_started_at,
+        )
 
     inner_kw = dict(
         env=env,
@@ -145,6 +168,9 @@ async def _run_fanout(
             effective_status = await stop_live_persist(env, status=_terminal_status)
             if effective_status != _terminal_status:
                 _terminal_status = effective_status
+            # Unregister after the terminal status is persisted (the notify
+            # handler fired during stop_live_persist's terminal transition).
+            unregister_flow_notify_scope(_notify_scope_name)
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
 

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -109,17 +109,14 @@ async def _run_fanout(
         project=project,
     )
 
-    # `--notify` compatibility sugar: register a scoped override on this run's
-    # own terminal entity, unregistered in `finally`. Fires from the guarded
-    # lifecycle transition that persists the terminal status (mirrors _run_flow).
+    # Session-scoped: stop_live_persist terminalizes only the session; invocation
+    # records are finalized externally and would never fire.
     _notify_scope_name: str | None = None
     if notify:
-        _notify_entity_kind = "invocation" if invocation_id else "session"
-        _notify_entity_id = invocation_id if invocation_id else str(env.session.id)
         _notify_scope_name = register_flow_notify_scope(
             override=notify,
-            entity_kind=_notify_entity_kind,
-            entity_id=_notify_entity_id,
+            entity_kind="session",
+            entity_id=str(env.session.id),
             invocation_id=invocation_id,
             flow_kind="fanout",
             playbook=playbook_name,
@@ -168,8 +165,7 @@ async def _run_fanout(
             effective_status = await stop_live_persist(env, status=_terminal_status)
             if effective_status != _terminal_status:
                 _terminal_status = effective_status
-            # Unregister after the terminal status is persisted (the notify
-            # handler fired during stop_live_persist's terminal transition).
+            # Unregister after stop_live_persist fires the terminal transition.
             unregister_flow_notify_scope(_notify_scope_name)
             for _br in env.session.branches:
                 await _br.mdls.shutdown()

--- a/tests/cli/orchestrate/test_fanout_notify_entity_scope.py
+++ b/tests/cli/orchestrate/test_fanout_notify_entity_scope.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o fanout --notify` remains session-scoped with `--invocation`."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from lionagi.cli.orchestrate import fanout as fanout_module
+
+from .test_fanout_artifacts import _fanout_env
+
+
+async def test_notify_scope_is_session_even_with_invocation_id(tmp_path, monkeypatch):
+    env, _run, _session = _fanout_env(tmp_path)
+
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    # Empty assignments short-circuits _run_fanout_inner before any worker/DAG
+    # machinery runs — the minimal path to a clean "completed" terminal status.
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=[]))
+
+    captured: dict[str, Any] = {}
+
+    def fake_register(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "scope-name"
+
+    monkeypatch.setattr(fanout_module, "register_flow_notify_scope", fake_register)
+    monkeypatch.setattr(fanout_module, "unregister_flow_notify_scope", lambda *a, **kw: None)
+
+    result, status = await fanout_module._run_fanout(
+        "codex/model",
+        "prompt",
+        invocation_id="parent-inv-456",
+        notify="fan-hook {status}",
+    )
+
+    assert status == "completed"
+    assert captured["entity_kind"] == "session"
+    assert captured["entity_id"] == str(env.session.id)
+    assert captured["invocation_id"] == "parent-inv-456"

--- a/tests/cli/orchestrate/test_notify_flag_wiring.py
+++ b/tests/cli/orchestrate/test_notify_flag_wiring.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""`--notify` CLI flag: parses on `li o flow` / `li play`, defaults to None, and
-threads through to _run_flow / _resume_flow, overriding whatever settings resolve."""
+"""`--notify` CLI flag: parses on `li o flow` / `li play` / `li o fanout`, defaults
+to None, and threads through to _run_flow / _resume_flow / _run_fanout, overriding
+whatever settings resolve. The flag is defined once in ``add_common_cli_args`` so
+every spawn-forwarding surface carries it."""
 
 from __future__ import annotations
 
@@ -23,6 +25,13 @@ def _parse_flow_args(argv: list[str]) -> argparse.Namespace:
     full_argv = ["o", "flow", *argv]
     inject_playbook_schema_into_parser(orch_parsers["flow"], full_argv)
     return parser.parse_args(full_argv)
+
+
+def _parse_fanout_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="li")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_orchestrate_subparser(subparsers)
+    return parser.parse_args(["o", "fanout", *argv])
 
 
 def test_notify_flag_parses_and_defaults_to_none():
@@ -70,3 +79,37 @@ def test_notify_flag_threads_into_resume_flow_call():
 
     assert code == 0
     assert resume_mock.call_args.kwargs["notify"] == "resume-hook {invocation_id}"
+
+
+def test_notify_flag_parses_on_fanout_and_defaults_to_none():
+    args = _parse_fanout_args(["claude", "do the thing"])
+    assert args.notify is None
+
+    args = _parse_fanout_args(["--notify", "fan-hook {payload}", "claude", "do the thing"])
+    assert args.notify == "fan-hook {payload}"
+
+
+def test_notify_flag_threads_into_run_fanout_call():
+    args = _parse_fanout_args(["--notify", "fan-hook {status}", "claude", "do the thing"])
+
+    with patch(
+        "lionagi.cli.orchestrate._run_fanout",
+        AsyncMock(return_value=("done", "completed")),
+    ) as fanout_mock:
+        code = run_orchestrate(args)
+
+    assert code == 0
+    assert fanout_mock.call_args.kwargs["notify"] == "fan-hook {status}"
+
+
+def test_notify_flag_defaults_to_none_on_fanout_when_absent():
+    args = _parse_fanout_args(["claude", "do the thing"])
+
+    with patch(
+        "lionagi.cli.orchestrate._run_fanout",
+        AsyncMock(return_value=("done", "completed")),
+    ) as fanout_mock:
+        code = run_orchestrate(args)
+
+    assert code == 0
+    assert fanout_mock.call_args.kwargs["notify"] is None

--- a/tests/cli/test_agent_notify_flag.py
+++ b/tests/cli/test_agent_notify_flag.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li agent --notify`: parses via the shared common args, defaults to None, and
+threads through to _run_agent so a per-invocation terminal-notify override reaches
+the run scope (mirrors the `li o flow` / `li o fanout` wiring)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+_CAPTURED: dict[str, Any] = {}
+
+
+async def _fake_run_agent(
+    model_str: str | None,
+    prompt: str,
+    **kwargs: Any,
+) -> tuple[str, str, str, str, str | None]:
+    _CAPTURED["agent"] = {"model_str": model_str, "prompt": prompt, **kwargs}
+    return "output", "provider", "branch-id", "completed", "sess-001"
+
+
+def _run(argv: list[str]) -> int:
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli.main import main
+
+    _CAPTURED.clear()
+    with patch.object(agent_mod, "_run_agent", _fake_run_agent):
+        return main(argv)
+
+
+def test_agent_notify_flag_threads_into_run_agent():
+    rc = _run(["agent", "claude", "do the thing", "--notify", "my-hook {payload}"])
+    assert rc == 0
+    assert _CAPTURED["agent"]["notify"] == "my-hook {payload}"
+
+
+def test_agent_notify_flag_defaults_to_none_when_absent():
+    rc = _run(["agent", "claude", "do the thing"])
+    assert rc == 0
+    assert _CAPTURED["agent"]["notify"] is None

--- a/tests/cli/test_agent_notify_flag.py
+++ b/tests/cli/test_agent_notify_flag.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
+from tests.cli.test_agent_resume_on_timeout import _wire_agent_stubs
+
 _CAPTURED: dict[str, Any] = {}
 
 
@@ -41,3 +45,38 @@ def test_agent_notify_flag_defaults_to_none_when_absent():
     rc = _run(["agent", "claude", "do the thing"])
     assert rc == 0
     assert _CAPTURED["agent"]["notify"] is None
+
+
+@pytest.mark.asyncio
+async def test_notify_scope_is_session_even_with_invocation_id(monkeypatch, tmp_path):
+    """Notification remains session-scoped when `--invocation` is set."""
+    _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=lambda i: "done",
+        session_ids=["sess-notify-1"],
+    )
+
+    from lionagi.cli.orchestrate import _notify as notify_mod
+
+    captured: dict[str, Any] = {}
+
+    def fake_register(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "scope-name"
+
+    monkeypatch.setattr(notify_mod, "register_flow_notify_scope", fake_register)
+    monkeypatch.setattr(notify_mod, "unregister_flow_notify_scope", lambda *a, **kw: None)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude_code/sonnet",
+        "hello",
+        invocation_id="parent-inv-123",
+        notify="my-hook {status}",
+    )
+
+    assert captured["entity_kind"] == "session"
+    assert captured["entity_id"] == "sess-notify-1"
+    assert captured["invocation_id"] == "parent-inv-123"

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -102,6 +102,7 @@ AGENT_HELP_FLAGS = [
     "--help",
     "--invocation",
     "--list-profiles",
+    "--notify",
     "--preset",
     "--project",
     "--prompt",

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -162,6 +162,7 @@ ORCHESTRATE_FANOUT_FLAGS = [
     "--help",
     "--invocation",
     "--max-concurrent",
+    "--notify",
     "--num-workers",
     "--output",
     "--pack",


### PR DESCRIPTION
## What

Adds a per-invocation `--notify CMD` flag to `li agent` and `li o fanout`,
mirroring the existing `li o flow` / `li play` wiring. `--notify` is now
defined once in `add_common_cli_args`, so every spawn-forwarding surface
(`li agent`, `li o fanout`, `li o flow` / `li play`) carries it from a single
definition instead of a per-surface copy.

Each surface registers a scoped terminal-notify override on its own run
entity (a session, or an invocation when `--invocation` groups the run) via
the generic `register_flow_notify_scope` in `_notify.py`, and unregisters it
in the run's teardown.

## Why

`--notify` was flow/play-only. Agent and fanout callers who wanted a
terminal callback had to fall back on the process-global
`.lionagi/settings.yaml` `notify.on_terminal` handler or wrap the command in
a shell self-report. This gives them the same per-run override the flow
surface already has: a command template run once the run reaches its terminal
status, substituting `{payload}` (full JSON), `{status}`, `{invocation_id}`
and exporting the matching `LIONAGI_NOTIFY_*` env vars.

## How

- `_providers.py`: `--notify` added to `add_common_cli_args` (single
  definition → agent + fanout + flow). Flow's duplicate `--notify` add is
  removed to avoid an argparse conflict; flow's dispatch is unchanged.
- `agent.py` / `fanout.py`: register the scope right after live persistence
  starts (entity = the run's session, or its invocation id when set),
  unregister in the existing `finally` after the terminal status is persisted.
  The handler fires from the same guarded lifecycle transition
  (`db.update_status` → terminal callback emit) that flow relies on, so there
  is no second delivery path. The agent auto-resume leg defers its terminal
  status, so the first leg's scope never fires and the recursed leg
  re-registers its own — no lost or double notify.

## Verification

- New wiring tests: `--notify` parses on `li o fanout` and `li agent`,
  defaults to `None`, and threads through to `_run_fanout` / `_run_agent`
  (mirrors the existing flow wiring tests).
- CLI surface goldens updated: `--notify` now pinned in the `li agent` and
  `li o fanout` flag sets.
- `tests/cli/` + `tests/state/lifecycle/` → 2012 passed, 2 skipped.
- `ruff check` + `ruff format --check` clean.
