### PR TITLE
feat(studio): schedule observability — RunView join, enriched runs/status CLI, trigger --wait

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -902,7 +902,6 @@ def _watch_loop(
 # ── Wait-for-terminal primitive (li monitor run / li monitor --run) ───────────
 # Scripting primitive; see docs/internals/cli.md for the full contract.
 
-_TERMINAL_SCHEDULE_RUN_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
 # Default wait bound so a stuck run can't hang forever; pass max_wait=0 to opt
 # into unbounded waiting explicitly.
 _DEFAULT_MAX_WAIT_SECONDS = 900.0
@@ -1096,6 +1095,10 @@ async def _poll_pending_once(
 ) -> None:
     """Check every still-pending run once; print, record, and drop terminal
     ones. See docs/internals/cli.md for the cancellation-atomicity contract."""
+    # Shared schema vocabulary — a hand-listed subset here once omitted
+    # timed_out, leaving timed-out occurrences waiting forever.
+    from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES
+
     from ._logging import log_error
 
     for run_id in list(pending):
@@ -1105,7 +1108,7 @@ async def _poll_pending_once(
             # resolve as failure so the wait can't hang on state that never returns.
             row = {**pending[run_id], "status": "failed", "exit_code": None}
             log_error(f"schedule_run {run_id!r} disappeared from state.db while waiting")
-        elif row["status"] not in _TERMINAL_SCHEDULE_RUN_STATUSES:
+        elif row["status"] not in SCHEDULE_RUN_TERMINAL_STATUSES:
             continue
         name = await _schedule_name(db, row["schedule_id"], cache=schedule_names)
         # Resolved before the print/append/delete trio below (not between

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1030,25 +1030,46 @@ async def _poll_pending_sessions_once(
         del pending[run_id]
 
 
+# fire_now() hands the run_id back to its HTTP/CLI caller before the fired
+# occurrence row is durably written (_fire runs as a background task) -- an
+# id resolved immediately after a manual trigger can race that insert. Retry
+# unresolved ids within this bounded grace period instead of giving up on a
+# single up-front lookup.
+_RESOLVE_GRACE_SECONDS = 1.0
+_RESOLVE_GRACE_POLL_SECONDS = 0.2
+
+
 async def _resolve_watched_runs(
-    db: Any, ids: list[str]
+    db: Any, ids: list[str], *, grace_seconds: float | None = None
 ) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
-    """Resolve every requested id once, up front. Ids that aren't schedule_runs
-    are also tried against sessions (`li monitor run <session_id>` support)."""
+    """Resolve every requested id, retrying not-yet-found ones for a bounded
+    grace period. Ids that aren't schedule_runs are also tried against
+    sessions (`li monitor run <session_id>` support)."""
+    import asyncio
+
+    if grace_seconds is None:
+        grace_seconds = _RESOLVE_GRACE_SECONDS
     pending: dict[str, dict[str, Any]] = {}
     session_pending: dict[str, dict[str, Any]] = {}
-    unresolved: list[str] = []
-    for raw_id in ids:
-        row = await _resolve_schedule_run(db, raw_id)
-        if row is not None:
-            pending[row["id"]] = row  # canonical id as key: dedupes prefix collisions
-            continue
-        session_row = await _resolve_session_run(db, raw_id)
-        if session_row is not None:
-            session_pending[session_row["id"]] = session_row
-        else:
-            unresolved.append(raw_id)
-    return pending, session_pending, unresolved
+    remaining = list(ids)
+    deadline = time.monotonic() + grace_seconds if grace_seconds > 0 else None
+    while remaining:
+        still_missing: list[str] = []
+        for raw_id in remaining:
+            row = await _resolve_schedule_run(db, raw_id)
+            if row is not None:
+                pending[row["id"]] = row  # canonical id as key: dedupes prefix collisions
+                continue
+            session_row = await _resolve_session_run(db, raw_id)
+            if session_row is not None:
+                session_pending[session_row["id"]] = session_row
+            else:
+                still_missing.append(raw_id)
+        remaining = still_missing
+        if not remaining or deadline is None or time.monotonic() >= deadline:
+            break
+        await asyncio.sleep(_RESOLVE_GRACE_POLL_SECONDS)
+    return pending, session_pending, remaining
 
 
 async def _schedule_name(db: Any, schedule_id: str, *, cache: dict[str, str]) -> str:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2755,15 +2755,17 @@ class StateDB:
         self,
         schedule_id: str,
         *,
-        status: str | None = None,
+        status: str | list[str] | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         conds: list[str] = ["schedule_id = :schedule_id"]
         params: dict[str, Any] = {"schedule_id": schedule_id}
-        if status:
-            conds.append("status = :status")
-            params["status"] = status
+        statuses = [status] if isinstance(status, str) else (status or [])
+        if statuses:
+            placeholders = ", ".join(f":status{i}" for i in range(len(statuses)))
+            conds.append(f"status IN ({placeholders})")
+            params.update({f"status{i}": s for i, s in enumerate(statuses)})
         query = "SELECT * FROM schedule_runs WHERE " + " AND ".join(conds)  # noqa: S608
         query += " ORDER BY fired_at DESC LIMIT :limit OFFSET :offset"
         params["limit"] = limit

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi.cli._logging import warn
+from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES
 
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
 _HOSTED_URL = "https://lion-studio.khive.ai"
@@ -883,8 +884,6 @@ def _cmd_disable(args: argparse.Namespace) -> int:
     return 0
 
 
-_SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
-
 # fire_now() hands the run_id back to the HTTP caller before its occurrence
 # row is durably written (the fire runs as a background task) -- a lookup
 # immediately after trigger can race that insert. Retry within this bounded
@@ -970,7 +969,7 @@ def _wait_for_run(run_id: str) -> int:
         return 1
 
     deadline = _time.monotonic() + _TRIGGER_WAIT_MAX_SECONDS
-    while run.get("status") not in _SCHEDULE_RUN_TERMINAL_STATUSES and _time.monotonic() < deadline:
+    while run.get("status") not in SCHEDULE_RUN_TERMINAL_STATUSES and _time.monotonic() < deadline:
         _time.sleep(_TRIGGER_WAIT_POLL_SECONDS)
         run = _api(f"/runs/{run_id}")
         if run is None:
@@ -1021,7 +1020,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
 def _status_still_running(result: dict[str, Any] | None) -> bool:
     latest = (result or {}).get("latest_run") or {}
     status = latest.get("status")
-    return status is not None and status not in _SCHEDULE_RUN_TERMINAL_STATUSES
+    return status is not None and status not in SCHEDULE_RUN_TERMINAL_STATUSES
 
 
 def _cmd_status(args: argparse.Namespace) -> int:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -883,14 +883,102 @@ def _cmd_disable(args: argparse.Namespace) -> int:
     return 0
 
 
+_SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
+
+# fire_now() hands the run_id back to the HTTP caller before its occurrence
+# row is durably written (the fire runs as a background task) -- a lookup
+# immediately after trigger can race that insert. Retry within this bounded
+# grace period instead of a single up-front lookup.
+_TRIGGER_WAIT_GRACE_SECONDS = 5.0
+_TRIGGER_WAIT_GRACE_POLL_SECONDS = 0.2
+_TRIGGER_WAIT_POLL_SECONDS = 2.0
+_TRIGGER_WAIT_MAX_SECONDS = 600.0
+
+
+def _fmt_rfc3339(ts: float | None) -> str:
+    if ts is None:
+        return "-"
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ts, tz=timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def _fmt_duration_ms(ms: int | None) -> str:
+    if ms is None:
+        return "-"
+    secs = ms // 1000
+    if secs < 60:
+        return f"{secs}s"
+    mins, secs = divmod(secs, 60)
+    if mins < 60:
+        return f"{mins}m{secs:02d}s"
+    hrs, mins = divmod(mins, 60)
+    return f"{hrs}h{mins:02d}m"
+
+
+def _fmt_outcome(outcome: dict[str, Any] | None) -> str:
+    if not outcome:
+        return "-"
+    code, summary = outcome.get("code", "?"), outcome.get("summary")
+    return f"{code}: {summary}" if summary and summary != code else code
+
+
+def _fmt_artifacts(artifacts: list[str] | None) -> str:
+    if not artifacts:
+        return "-"
+    return artifacts[0] if len(artifacts) == 1 else f"{artifacts[0]} (+{len(artifacts) - 1} more)"
+
+
+def _print_run_table(runs: list[dict[str, Any]]) -> None:
+    header = f"{'RUN':<14}{'STATUS':<11}{'FIRED':<26}{'DURATION':<10}{'OUTCOME':<32}{'INVOCATION':<14}ARTIFACTS"
+    print(header)
+    for r in runs:
+        outcome = _fmt_outcome(r.get("outcome"))
+        print(
+            f"{r.get('id', '?'):<14}{r.get('status', '?'):<11}{_fmt_rfc3339(r.get('fired_at')):<26}"
+            f"{_fmt_duration_ms(r.get('duration_ms')):<10}{outcome[:30]:<32}"
+            f"{r.get('invocation_id') or '-':<14}{_fmt_artifacts(r.get('artifacts'))}"
+        )
+
+
 def _cmd_trigger(args: argparse.Namespace) -> int:
     result = _api(f"/{args.id}/trigger", method="POST")
     if result is None:
         return 1
     print(f"Triggered: {args.id}")
-    if isinstance(result, dict) and result.get("run_id"):
-        print(f"Run: {result['run_id']}")
-    return 0
+    run_id = result.get("run_id") if isinstance(result, dict) else None
+    if not run_id:
+        return 0
+    print(f"Run: {run_id}")
+    if not getattr(args, "wait", False):
+        return 0
+    return _wait_for_run(run_id)
+
+
+def _wait_for_run(run_id: str) -> int:
+    """Poll `/schedules/runs/{run_id}` for the occurrence, tolerating the
+    grace-period race, then for a terminal status."""
+    import time as _time
+
+    deadline_grace = _time.monotonic() + _TRIGGER_WAIT_GRACE_SECONDS
+    run = _api(f"/runs/{run_id}")
+    while run is None and _time.monotonic() < deadline_grace:
+        _time.sleep(_TRIGGER_WAIT_GRACE_POLL_SECONDS)
+        run = _api(f"/runs/{run_id}")
+    if run is None:
+        print(f"Error: run {run_id!r} never appeared", file=sys.stderr)
+        return 1
+
+    deadline = _time.monotonic() + _TRIGGER_WAIT_MAX_SECONDS
+    while run.get("status") not in _SCHEDULE_RUN_TERMINAL_STATUSES and _time.monotonic() < deadline:
+        _time.sleep(_TRIGGER_WAIT_POLL_SECONDS)
+        run = _api(f"/runs/{run_id}")
+        if run is None:
+            print(f"Error: run {run_id!r} disappeared while waiting", file=sys.stderr)
+            return 1
+
+    print(f"status: {run.get('status', '?')}  outcome: {_fmt_outcome(run.get('outcome'))}")
+    return 0 if run.get("status") == "completed" else 1
 
 
 def _cmd_delete(args: argparse.Namespace) -> int:
@@ -902,16 +990,89 @@ def _cmd_delete(args: argparse.Namespace) -> int:
 
 
 def _cmd_runs(args: argparse.Namespace) -> int:
-    result = _api(f"/{args.id}/runs")
+    path = f"/{args.id}/runs?limit={args.limit}"
+    for status in getattr(args, "status", None) or ():
+        path += f"&status={status}"
+    result = _api(path)
     if result is None:
         return 1
     runs = result.get("runs", [])
+    if getattr(args, "as_json", False):
+        print(json.dumps(result))
+        return 0
     if not runs:
         print("(no runs)")
         return 0
-    for r in runs:
-        print(f"  {r['id']}  [{r.get('status', '?')}]  {r.get('started_at', '?')}")
+    _print_run_table(runs)
     return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    result = _api(f"/runs/{args.id}")
+    if result is None:
+        return 1
+    if getattr(args, "as_json", False):
+        print(json.dumps(result))
+    else:
+        _print_run_table([result])
+    return 0
+
+
+def _status_still_running(result: dict[str, Any] | None) -> bool:
+    latest = (result or {}).get("latest_run") or {}
+    status = latest.get("status")
+    return status is not None and status not in _SCHEDULE_RUN_TERMINAL_STATUSES
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    import time as _time
+
+    result = _api(f"/{args.id}/status")
+    if getattr(args, "wait", False):
+        deadline = _time.monotonic() + _TRIGGER_WAIT_MAX_SECONDS
+        while result is not None and _status_still_running(result) and _time.monotonic() < deadline:
+            _time.sleep(_TRIGGER_WAIT_POLL_SECONDS)
+            result = _api(f"/{args.id}/status")
+    if result is None:
+        return 1
+
+    if getattr(args, "as_json", False):
+        print(json.dumps(result))
+        return int(result.get("exit_code", 2))
+
+    schedule = result.get("schedule") or {}
+    latest = result.get("latest_run")
+    trigger = (
+        f'cron "{schedule["cron_expr"]}"'
+        if schedule.get("cron_expr")
+        else (f"every {schedule['interval_sec']}s" if schedule.get("interval_sec") else "-")
+    )
+    print(
+        f"{schedule.get('id', args.id)}  {'enabled' if schedule.get('enabled') else 'disabled'}  {trigger}"
+    )
+    print(f"next:        {_fmt_rfc3339(schedule.get('next_fire_at'))}")
+    if latest is None:
+        print("last run:    (none)")
+        return int(result.get("exit_code", 2))
+    print(f"last run:    {latest.get('id')}")
+    exit_code_str = f" (exit {latest['exit_code']})" if latest.get("exit_code") is not None else ""
+    print(f"status:      {latest.get('status', '?')}{exit_code_str}")
+    print(f"fired:       {_fmt_rfc3339(latest.get('fired_at'))}")
+    if latest.get("ended_at") is not None:
+        print(
+            f"ended:       {_fmt_rfc3339(latest.get('ended_at'))}  ({_fmt_duration_ms(latest.get('duration_ms'))})"
+        )
+    outcome = latest.get("outcome") or {}
+    print(f"outcome:     {outcome.get('code', '-')} — {outcome.get('summary', '-')}")
+    if latest.get("invocation_id"):
+        print(f"invocation:  {latest['invocation_id']}")
+    for sid in latest.get("session_ids") or ():
+        print(f"session:     {sid}")
+    for path in latest.get("artifacts") or ():
+        print(f"artifacts:   {path}")
+    if latest.get("invocation_id"):
+        print(f"inspect:     li monitor {latest['invocation_id']}")
+    return int(result.get("exit_code", 2))
 
 
 # Common wrong spellings mapped to the real flag, checked before the fuzzy
@@ -1170,11 +1331,10 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         ),
     )
 
-    # enable / disable / trigger / delete
+    # enable / disable / delete
     for sub_name, sub_help, example in (
         ("enable", "Enable a schedule.", "li schedule enable sched-abc123"),
         ("disable", "Disable a schedule.", "li schedule disable sched-abc123"),
-        ("trigger", "Fire a schedule immediately.", "li schedule trigger sched-abc123"),
         ("delete", "Delete a schedule.", "li schedule delete sched-abc123"),
     ):
         p = sched_sub.add_parser(
@@ -1185,14 +1345,70 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         )
         p.add_argument("id", help="Schedule ID.")
 
+    # trigger
+    trigger_p = sched_sub.add_parser(
+        "trigger",
+        help="Fire a schedule immediately.",
+        epilog="Example: li schedule trigger sched-abc123 --wait",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    trigger_p.add_argument("id", help="Schedule ID.")
+    trigger_p.add_argument(
+        "--wait",
+        action="store_true",
+        help=(
+            "Block until the fired occurrence reaches a terminal status "
+            "(retries a short grace period first, since the occurrence row "
+            "isn't durably written until just after this returns a run id), "
+            "then print its outcome and exit non-zero on failure."
+        ),
+    )
+
     # runs
     runs_p = sched_sub.add_parser(
         "runs",
         help="List runs for a schedule.",
-        epilog="Example: li schedule runs sched-abc123",
+        epilog="Example: li schedule runs sched-abc123 --status failed --limit 5",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     runs_p.add_argument("id", help="Schedule ID.")
+    runs_p.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Max runs to return, 1-200 (default: 20).",
+    )
+    runs_p.add_argument(
+        "--status",
+        action="append",
+        metavar="STATUS",
+        help="Filter by run status; repeatable (e.g. --status failed --status timed_out).",
+    )
+    runs_p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON.")
+
+    # run (singular)
+    run_p = sched_sub.add_parser(
+        "run",
+        help="Show one schedule run.",
+        epilog="Example: li schedule run 9c8f4d5a2b10 --json",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    run_p.add_argument("id", help="Schedule run ID.")
+    run_p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON.")
+
+    # status
+    status_p = sched_sub.add_parser(
+        "status",
+        help='"Did it work?" summary for a schedule.',
+        epilog="Example: li schedule status sched-abc123 --wait",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    status_p.add_argument("id", help="Schedule ID.")
+    status_p.add_argument(
+        "--wait", action="store_true", help="Wait for the latest in-flight run to finish first."
+    )
+    status_p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON.")
 
     _ALL_SCHEDULE_FLAGS.clear()
     for action_parser in sched_sub.choices.values():
@@ -1215,6 +1431,8 @@ _ACTION_MAP = {
     "trigger": _cmd_trigger,
     "delete": _cmd_delete,
     "runs": _cmd_runs,
+    "run": _cmd_run,
+    "status": _cmd_status,
 }
 
 
@@ -1223,8 +1441,11 @@ def run_schedule(args: argparse.Namespace) -> int:
     fn = _ACTION_MAP.get(action)
     if fn is None:
         print(
-            "Usage: li schedule <subcommand>  "
-            "(list|get|limits|create|enable|disable|trigger|delete|runs)"
+            "Usage: li schedule <subcommand>  (list|get|limits|create|enable|disable|"
+            "trigger|delete|runs|run|status)"
         )
+        return 1
+    if action == "runs" and not (1 <= args.limit <= 200):
+        print(f"Error: --limit must be between 1 and 200, got {args.limit}.", file=sys.stderr)
         return 1
     return fn(args)

--- a/lionagi/studio/services/run_view.py
+++ b/lionagi/studio/services/run_view.py
@@ -79,12 +79,14 @@ def _fallback_outcome(run: dict[str, Any]) -> dict[str, Any]:
             "summary": run.get("error_detail") or "skipped",
             "source": "occurrence",
         }
-    if exit_code == 0:
+    if status == "completed":
         code = "completed"
-    elif exit_code is not None:
-        code = "failed_exit_nonzero"
-    else:
+    elif exit_code is None:
         code = f"{status}_no_exit_code"
+    elif exit_code != 0:
+        code = f"{status}_exit_nonzero"
+    else:
+        code = status
     summary = f"{status} (exit {exit_code})" if exit_code is not None else status
     return {"code": code, "summary": summary, "source": "fallback"}
 
@@ -164,6 +166,8 @@ def exit_code_for_view(
         return EXIT_RUNNING
     if status not in SCHEDULE_RUN_TERMINAL_STATUSES:
         return EXIT_UNKNOWN
+    if status in EXIT_CODE_BY_STATUS:
+        return EXIT_CODE_BY_STATUS[status]
     return 0 if status == "completed" else 1
 
 
@@ -182,8 +186,11 @@ async def _linked(
 
 
 async def _run_view_for_run(db: Any, run: dict[str, Any]) -> dict[str, Any]:
+    """Full schedule_runs row with RunView fields layered on top, additively —
+    never a replacement projection."""
     invocation, sessions = await _linked(db, run)
-    return build_run_view(run, invocation, sessions)
+    view = build_run_view(run, invocation, sessions)
+    return {**run, **view}
 
 
 async def get_run_view(db: Any, run_id: str) -> dict[str, Any] | None:

--- a/lionagi/studio/services/run_view.py
+++ b/lionagi/studio/services/run_view.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Shared ``RunView`` joining schedule_runs, invocations,
+and sessions behind one outcome-precedence reducer. Every schedule list/detail/
+status surface (and eventually `li monitor`) reads through this, not a second
+ad hoc reducer.
+
+Precedence: session terminal reason > invocation terminal reason > occurrence
+``error_detail`` > status+exit_code fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.state.db import (
+    INVOCATION_TERMINAL_STATUSES,
+    SCHEDULE_RUN_TERMINAL_STATUSES,
+    SESSION_TERMINAL_STATUSES,
+)
+
+
+def _primary_session(sessions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Deterministic pick among 0+ sessions linked to one invocation — the
+    most recently created wins, id as a stable tiebreak."""
+    if not sessions:
+        return None
+    return max(sessions, key=lambda s: (s.get("created_at") or 0, s.get("id") or ""))
+
+
+def _artifact_paths(sessions: list[dict[str, Any]]) -> list[str]:
+    seen: dict[str, None] = {}
+    for s in sessions:
+        path = s.get("artifacts_path")
+        if path:
+            seen.setdefault(path, None)
+    return list(seen)
+
+
+def _session_outcome(session: dict[str, Any], artifacts: list[str]) -> dict[str, Any]:
+    status = session.get("status") or ""
+    code = session.get("status_reason_code")
+    summary = session.get("status_reason_summary")
+    if status == "completed":
+        code = code or "run.completed.ok"
+        summary = summary or (
+            f"completed: {len(artifacts)} artifact(s)" if artifacts else "completed: no artifacts"
+        )
+    elif status == "completed_empty":
+        code = code or "run.completed_empty.no_evidence"
+        summary = summary or "completed_empty: no artifacts produced"
+    else:
+        code = code or f"run.failed.{status or 'unknown'}"
+        summary = summary or (status or "failed")
+    return {"code": code, "summary": summary, "source": "session"}
+
+
+def _invocation_outcome(invocation: dict[str, Any]) -> dict[str, Any]:
+    status = invocation.get("status") or ""
+    if status == "completed":
+        default_code = "run.completed.ok"
+    elif status == "completed_empty":
+        default_code = "run.completed_empty.no_evidence"
+    else:
+        default_code = f"run.failed.{status or 'unknown'}"
+    code = invocation.get("status_reason_code") or default_code
+    summary = invocation.get("status_reason_summary") or (status or "unknown")
+    return {"code": code, "summary": summary, "source": "invocation"}
+
+
+def _fallback_outcome(run: dict[str, Any]) -> dict[str, Any]:
+    status = run.get("status") or "unknown"
+    exit_code = run.get("exit_code")
+    if status == "running":
+        return {"code": "running", "summary": "running", "source": "occurrence"}
+    if status == "skipped":
+        return {
+            "code": "skipped",
+            "summary": run.get("error_detail") or "skipped",
+            "source": "occurrence",
+        }
+    if exit_code == 0:
+        code = "completed"
+    elif exit_code is not None:
+        code = "failed_exit_nonzero"
+    else:
+        code = f"{status}_no_exit_code"
+    summary = f"{status} (exit {exit_code})" if exit_code is not None else status
+    return {"code": code, "summary": summary, "source": "fallback"}
+
+
+def _occurrence_outcome(run: dict[str, Any]) -> dict[str, Any]:
+    error_detail = run.get("error_detail")
+    status = run.get("status") or "dispatch"
+    if not error_detail or status in ("running", "skipped"):
+        return _fallback_outcome(run)
+    return {"code": f"failed_{status}", "summary": error_detail, "source": "occurrence"}
+
+
+def build_outcome(
+    run: dict[str, Any],
+    invocation: dict[str, Any] | None,
+    sessions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Outcome precedence: session > invocation > occurrence error_detail > fallback."""
+    primary = _primary_session(sessions)
+    if primary is not None and primary.get("status") in SESSION_TERMINAL_STATUSES:
+        return _session_outcome(primary, _artifact_paths(sessions))
+    if invocation is not None and invocation.get("status") in INVOCATION_TERMINAL_STATUSES:
+        return _invocation_outcome(invocation)
+    if run.get("error_detail"):
+        return _occurrence_outcome(run)
+    return _fallback_outcome(run)
+
+
+def build_run_view(
+    run: dict[str, Any],
+    invocation: dict[str, Any] | None,
+    sessions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """One joined, reconciled view of a schedule occurrence."""
+    fired_at = run.get("fired_at")
+    ended_at = run.get("ended_at")
+    duration_ms = (
+        int((ended_at - fired_at) * 1000) if fired_at is not None and ended_at is not None else None
+    )
+    return {
+        "id": run.get("id"),
+        "schedule_id": run.get("schedule_id"),
+        "status": run.get("status"),
+        "exit_code": run.get("exit_code"),
+        "fired_at": fired_at,
+        "ended_at": ended_at,
+        "duration_ms": duration_ms,
+        "outcome": build_outcome(run, invocation, sessions),
+        "invocation_id": run.get("invocation_id"),
+        "session_ids": [s["id"] for s in sessions if s.get("id")],
+        "artifacts": _artifact_paths(sessions),
+    }
+
+
+def exit_code_for_view(
+    run: dict[str, Any] | None,
+    invocation: dict[str, Any] | None,
+    sessions: list[dict[str, Any]],
+) -> int:
+    """Reuses the existing shared status vocabulary (cli/_util.py,
+    cli/status.py) rather than inventing a second exit-code table: 0 trusted
+    completion, 1 ordinary failure/completed_empty/skip, 2 unknown/no run, 3
+    running, and the existing timeout/abort/cancel codes where a session or
+    invocation status carries one."""
+    from lionagi.cli._util import EXIT_CODE_BY_STATUS
+    from lionagi.cli.status import EXIT_RUNNING, EXIT_UNKNOWN
+
+    if run is None:
+        return EXIT_UNKNOWN
+    primary = _primary_session(sessions)
+    if primary is not None and primary.get("status") in SESSION_TERMINAL_STATUSES:
+        return EXIT_CODE_BY_STATUS.get(primary["status"], 1)
+    if invocation is not None and invocation.get("status") in INVOCATION_TERMINAL_STATUSES:
+        return EXIT_CODE_BY_STATUS.get(invocation["status"], 1)
+    status = run.get("status")
+    if status == "running":
+        return EXIT_RUNNING
+    if status not in SCHEDULE_RUN_TERMINAL_STATUSES:
+        return EXIT_UNKNOWN
+    return 0 if status == "completed" else 1
+
+
+# ── DB-backed assembly ──────────────────────────────────────────────────────
+
+
+async def _linked(
+    db: Any, run: dict[str, Any]
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    invocation_id = run.get("invocation_id")
+    if not invocation_id:
+        return None, []
+    invocation = await db.get_invocation(invocation_id)
+    sessions = await db.list_sessions_for_invocation(invocation_id)
+    return invocation, sessions
+
+
+async def _run_view_for_run(db: Any, run: dict[str, Any]) -> dict[str, Any]:
+    invocation, sessions = await _linked(db, run)
+    return build_run_view(run, invocation, sessions)
+
+
+async def get_run_view(db: Any, run_id: str) -> dict[str, Any] | None:
+    run = await db.get_schedule_run(run_id)
+    if run is None:
+        return None
+    return await _run_view_for_run(db, run)
+
+
+async def list_run_views(
+    db: Any,
+    schedule_id: str,
+    *,
+    status: str | list[str] | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    runs = await db.list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
+    return [await _run_view_for_run(db, run) for run in runs]
+
+
+async def get_schedule_status_view(db: Any, schedule_id: str) -> dict[str, Any] | None:
+    schedule = await db.get_schedule(schedule_id)
+    if schedule is None:
+        return None
+    runs = await db.list_schedule_runs(schedule_id, limit=1)
+    latest_run: dict[str, Any] | None = None
+    exit_code = 2  # EXIT_UNKNOWN — no run recorded yet
+    if runs:
+        run = runs[0]
+        invocation, sessions = await _linked(db, run)
+        latest_run = build_run_view(run, invocation, sessions)
+        exit_code = exit_code_for_view(run, invocation, sessions)
+    return {
+        "schedule": {
+            "id": schedule["id"],
+            "name": schedule.get("name"),
+            "enabled": bool(schedule.get("enabled")),
+            "trigger_type": schedule.get("trigger_type"),
+            "cron_expr": schedule.get("cron_expr"),
+            "interval_sec": schedule.get("interval_sec"),
+            "next_fire_at": schedule.get("next_fire_at"),
+        },
+        "latest_run": latest_run,
+        "exit_code": exit_code,
+    }

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -18,6 +18,7 @@ from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
+from . import run_view
 
 _log = logging.getLogger(__name__)
 
@@ -631,7 +632,7 @@ async def disable_schedule(schedule_id: str) -> bool:
 async def list_schedule_runs(
     schedule_id: str,
     *,
-    status: str | None = None,
+    status: str | list[str] | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -639,6 +640,22 @@ async def list_schedule_runs(
         return []
     async with StateDB() as db:
         return await db.list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
+
+
+async def list_schedule_run_views(
+    schedule_id: str,
+    *,
+    status: str | list[str] | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """RunView list — each row additionally carries a reconciled ``outcome``."""
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    async with StateDB() as db:
+        return await run_view.list_run_views(
+            db, schedule_id, status=status, limit=limit, offset=offset
+        )
 
 
 async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
@@ -655,7 +672,20 @@ async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
                 (run_id,),
             )
             run["chain_children"] = rows
+        # Layer the RunView-reconciled fields on top, additively —
+        # chain_children (legacy) and outcome/duration_ms/... coexist.
+        view = await run_view.get_run_view(db, run_id)
+        if view is not None:
+            run = {**run, **view}
     return run
+
+
+async def get_schedule_status(schedule_id: str) -> dict[str, Any] | None:
+    """'Did it work?' view: schedule header + latest RunView + shared exit code."""
+    if not DEFAULT_DB_PATH.exists():
+        return None
+    async with StateDB() as db:
+        return await run_view.get_schedule_status_view(db, schedule_id)
 
 
 # ---------------------------------------------------------------------------
@@ -866,11 +896,13 @@ async def trigger_schedule_route(schedule_id: str) -> dict[str, Any]:
 )
 async def list_schedule_runs_route(
     schedule_id: str,
-    status: str | None = Query(default=None),
-    limit: int = Query(default=50, ge=1, le=200),
+    status: list[str] | None = Query(default=None),  # noqa: B008
+    limit: int = Query(default=20, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
-    rows = await list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
+    # RunView-enriched rows (adds outcome/duration_ms/session_ids/artifacts
+    # additively) — status is repeatable (?status=failed&status=timed_out).
+    rows = await list_schedule_run_views(schedule_id, status=status, limit=limit, offset=offset)
     return {"runs": rows, "limit": limit, "offset": offset, "has_next": len(rows) == limit}
 
 
@@ -886,4 +918,17 @@ async def get_schedule_run_route(run_id: str) -> dict[str, Any]:
     data = await get_schedule_run(run_id)
     if data is None:
         raise HTTPException(status_code=404, detail=f"Schedule run '{run_id}' not found")
+    return data
+
+
+@studio_route(
+    "/schedules/{schedule_id}/status",
+    method="GET",
+    area="schedules",
+    name="get_schedule_status",
+)
+async def get_schedule_status_route(schedule_id: str) -> dict[str, Any]:
+    data = await get_schedule_status(schedule_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
     return data

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -103,6 +103,7 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/schedules/runs/{run_id}"),
     ("GET", "/api/schedules/{schedule_id}"),
     ("GET", "/api/schedules/{schedule_id}/runs"),
+    ("GET", "/api/schedules/{schedule_id}/status"),
     ("GET", "/api/sessions/"),
     ("GET", "/api/sessions/{session_id}"),
     ("GET", "/api/sessions/{session_id}/signals"),
@@ -234,7 +235,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 98
+    assert len(_GOLDEN_ROUTES) == 99
 
 
 def _compiled_match_shape(path_template: str) -> str:

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -132,6 +132,8 @@ SCHEDULE_SUBCOMMANDS = [
     "trigger",
     "delete",
     "runs",
+    "run",
+    "status",
 ]
 
 SCHEDULE_CREATE_HELP_FLAGS = [

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -236,9 +236,16 @@ SCHEDULE_SIMPLE_SUBCOMMAND_POSITIONALS = {
     "get": ["id"],
     "enable": ["id"],
     "disable": ["id"],
-    "trigger": ["id"],
     "delete": ["id"],
-    "runs": ["id"],
+}
+
+# Phase 1 observability subcommands (RunView): carry extra flags beyond
+# --help/-h, so they get their own golden rather than the "simple" shape.
+SCHEDULE_OBSERVABILITY_SUBCOMMAND_SHAPES = {
+    "trigger": (["--help", "--wait", "-h"], ["id"]),
+    "runs": (["--help", "--json", "--limit", "--status", "-h"], ["id"]),
+    "run": (["--help", "--json", "-h"], ["id"]),
+    "status": (["--help", "--json", "--wait", "-h"], ["id"]),
 }
 
 
@@ -280,6 +287,12 @@ class TestScheduleSubcommandShapeGoldens:
     def test_simple_subcommand_shape(self, name):
         assert _flag_set("schedule", name) == ["--help", "-h"]
         assert _positional_dests("schedule", name) == SCHEDULE_SIMPLE_SUBCOMMAND_POSITIONALS[name]
+
+    @pytest.mark.parametrize("name", sorted(SCHEDULE_OBSERVABILITY_SUBCOMMAND_SHAPES))
+    def test_observability_subcommand_shape(self, name):
+        flags, positionals = SCHEDULE_OBSERVABILITY_SUBCOMMAND_SHAPES[name]
+        assert _flag_set("schedule", name) == flags
+        assert _positional_dests("schedule", name) == positionals
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -6,6 +6,7 @@ dashboard, not a replacement)."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
@@ -25,6 +26,7 @@ from lionagi.cli.monitor import (
     _query_schedule_runs_since,
     _resolve_schedule_run,
     _resolve_session_run,
+    _resolve_watched_runs,
     _split_watched_ids,
     add_monitor_subparser,
     run_monitor_wait,
@@ -186,6 +188,66 @@ async def test_resolve_schedule_run_not_found_returns_none(temp_db_path: Path) -
     async with StateDB() as db:
         row = await _resolve_schedule_run(db, "totally-unknown-id")
         assert row is None
+
+
+# ── _resolve_watched_runs: bounded creation-grace retry ─────────────────────
+#
+# fire_now() hands a run_id to its caller before the fired occurrence row is
+# durably written (the fire itself runs as a background task) — resolving
+# that id immediately can race the insert. _resolve_watched_runs must retry
+# within a bounded grace period instead of giving up on one lookup.
+
+
+@pytest.mark.asyncio
+async def test_resolve_watched_runs_retries_until_row_appears(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = uuid.uuid4().hex[:12]
+
+        # Insert with the pre-chosen id after a short delay, simulating the
+        # background _fire task's race window against the caller's lookup.
+        async def _insert_directly() -> None:
+            await asyncio.sleep(0.05)
+            async with StateDB() as inner_db:
+                await inner_db.create_schedule_run(
+                    {
+                        "id": run_id,
+                        "schedule_id": sched_id,
+                        "invocation_id": None,
+                        "trigger_context": {},
+                        "action_kind": "agent",
+                        "action_args": [],
+                        "status": "running",
+                        "exit_code": None,
+                        "chain_depth": 0,
+                        "chain_parent_id": None,
+                        "fired_at": time.time(),
+                    }
+                )
+
+        task = asyncio.ensure_future(_insert_directly())
+        try:
+            pending, session_pending, unresolved = await _resolve_watched_runs(
+                db, [run_id], grace_seconds=2.0
+            )
+        finally:
+            await task
+
+    assert unresolved == []
+    assert run_id in pending
+    assert session_pending == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_watched_runs_gives_up_after_grace_period(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        pending, session_pending, unresolved = await _resolve_watched_runs(
+            db, ["never-created"], grace_seconds=0.1
+        )
+
+    assert pending == {}
+    assert session_pending == {}
+    assert unresolved == ["never-created"]
 
 
 # ── _poll_pending_once (the testable inner tick — no real sleeps needed) ────
@@ -649,13 +711,18 @@ async def test_dispatch_wait_multi_id_one_nonzero_exit_fails_aggregate(temp_db_p
 
 @pytest.mark.asyncio
 async def test_dispatch_wait_unknown_id_returns_exit_unknown_without_blocking(
-    temp_db_path: Path, caplog: pytest.LogCaptureFixture, sleep_probe: list[float]
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture, sleep_probe: list[float], monkeypatch
 ) -> None:
     # Open+close once so state.db actually exists on disk — this test is
     # about an id that isn't among the (existing) schedule_runs, not about
     # a missing state.db file entirely (see test_dispatch_wait_no_db_file).
     async with StateDB():
         pass
+
+    # A genuinely unknown id still exhausts the bounded resolution grace
+    # period (see _resolve_watched_runs) before giving up — zero it out so
+    # this test stays fast without asserting away that retry.
+    monkeypatch.setattr("lionagi.cli.monitor._RESOLVE_GRACE_SECONDS", 0.0)
 
     with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
         exit_code = _dispatch_wait(["nonexistent-id"], interval=5.0, follow=False)

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -32,7 +32,7 @@ from lionagi.cli.monitor import (
     run_monitor_wait,
 )
 from lionagi.cli.status import EXIT_RUNNING, EXIT_UNKNOWN
-from lionagi.state.db import StateDB
+from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES, StateDB
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -270,6 +270,26 @@ async def test_poll_pending_once_reports_immediately_terminal_run(
     assert run_id in out
     assert "nightly-build" in out
     assert "status=completed" in out
+
+
+@pytest.mark.parametrize("status", sorted(SCHEDULE_RUN_TERMINAL_STATUSES))
+@pytest.mark.asyncio
+async def test_poll_pending_once_treats_every_terminal_status_as_done(
+    temp_db_path: Path, capsys: pytest.CaptureFixture, status: str
+) -> None:
+    """Every shared-vocabulary terminal status ends the wait on the first
+    tick — a hand-listed subset here once omitted timed_out, leaving
+    timed-out occurrences pending forever."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name=f"term-{status}")
+        run_id = await _make_schedule_run(db, sched_id, status=status)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
+
+    assert [r["id"] for r in done] == [run_id]
+    assert run_id not in pending
+    assert f"status={status}" in capsys.readouterr().out
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -200,6 +200,478 @@ def test_schedule_runs_subcommand():
     args = parser.parse_args(["schedule", "runs", "sched-abc"])
     assert args.schedule_action == "runs"
     assert args.id == "sched-abc"
+    assert args.limit == 20
+    assert args.status is None
+    assert args.as_json is False
+
+
+def test_schedule_runs_subcommand_limit_status_json_flags():
+    """--limit/--status (repeatable)/--json all parse onto `runs`."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "runs",
+            "sched-abc",
+            "--limit",
+            "5",
+            "--status",
+            "failed",
+            "--status",
+            "timed_out",
+            "--json",
+        ]
+    )
+    assert args.limit == 5
+    assert args.status == ["failed", "timed_out"]
+    assert args.as_json is True
+
+
+def test_schedule_run_singular_subcommand():
+    """li schedule run <run-id> [--json] parses correctly."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "run", "9c8f4d5a2b10", "--json"])
+    assert args.schedule_action == "run"
+    assert args.id == "9c8f4d5a2b10"
+    assert args.as_json is True
+
+
+def test_schedule_status_subcommand_wait_and_json():
+    """li schedule status <id> [--wait] [--json] parses correctly."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc", "--wait", "--json"])
+    assert args.schedule_action == "status"
+    assert args.id == "sched-abc"
+    assert args.wait is True
+    assert args.as_json is True
+
+
+def test_schedule_trigger_wait_flag_parses():
+    """li schedule trigger <id> --wait parses correctly, default False."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc"])
+    assert args.wait is False
+    args = parser.parse_args(["schedule", "trigger", "sched-abc", "--wait"])
+    assert args.wait is True
+
+
+# ---------------------------------------------------------------------------
+# run_schedule dispatch: runs/run/status/trigger --wait
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_runs_limit_out_of_range_rejected(monkeypatch, capsys):
+    """--limit outside [1, 200] is rejected before any API call."""
+    import lionagi.studio.cli as sched_mod
+
+    api_called = []
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "runs", "sched-abc", "--limit", "500"])
+    result = run_schedule(args)
+
+    assert result == 1
+    assert not api_called
+    assert "--limit" in capsys.readouterr().err
+
+
+def test_schedule_runs_dispatches_with_limit_and_status_query(monkeypatch):
+    """run_schedule runs builds the query string from --limit/--status."""
+    import lionagi.studio.cli as sched_mod
+
+    captured = {}
+
+    def _fake_api(path, method="GET", body=None):
+        captured["path"] = path
+        return {"runs": [], "limit": 5, "offset": 0, "has_next": False}
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "runs", "sched-abc", "--limit", "5", "--status", "failed"]
+    )
+    result = run_schedule(args)
+
+    assert result == 0
+    assert captured["path"] == "/sched-abc/runs?limit=5&status=failed"
+
+
+def test_schedule_runs_empty_prints_no_runs(monkeypatch, capsys):
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: {"runs": []})
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "runs", "sched-abc"])
+    result = run_schedule(args)
+
+    assert result == 0
+    assert "(no runs)" in capsys.readouterr().out
+
+
+def test_schedule_runs_human_table_uses_fired_at_not_started_at(monkeypatch, capsys):
+    """Regression: the human table must render `fired_at` (the real schedule_runs
+    column), not the nonexistent `started_at` that used to print as '?'."""
+    import lionagi.studio.cli as sched_mod
+
+    fake_run = {
+        "id": "run1",
+        "status": "completed",
+        "fired_at": 1_752_000_000.0,
+        "ended_at": 1_752_000_010.0,
+        "duration_ms": 10000,
+        "outcome": {"code": "run.completed.ok", "summary": "completed: 1 artifact(s)"},
+        "invocation_id": "inv1",
+        "artifacts": ["/runs/inv1/artifacts"],
+    }
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: {"runs": [fake_run]})
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "runs", "sched-abc"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "?" not in out.replace("(no runs)", "")
+    assert "run1" in out
+    assert "inv1" in out
+
+
+def test_schedule_runs_json_emits_raw_api_response(monkeypatch, capsys):
+    import lionagi.studio.cli as sched_mod
+
+    api_response = {"runs": [{"id": "run1", "status": "completed"}], "limit": 20, "offset": 0}
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_response)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "runs", "sched-abc", "--json"])
+    result = run_schedule(args)
+
+    assert result == 0
+    import json as _json
+
+    assert _json.loads(capsys.readouterr().out) == api_response
+
+
+def test_schedule_run_singular_dispatches_and_prints_table(monkeypatch, capsys):
+    import lionagi.studio.cli as sched_mod
+
+    fake_run = {
+        "id": "run1",
+        "status": "failed",
+        "fired_at": 1_752_000_000.0,
+        "ended_at": 1_752_000_010.0,
+        "duration_ms": 10000,
+        "outcome": {"code": "run.failed.failed", "summary": "tests failed"},
+        "invocation_id": "inv1",
+        "artifacts": [],
+    }
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: fake_run)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "run", "run1"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "run1" in out and "tests faile" in out
+
+
+def test_schedule_run_singular_not_found_returns_1(monkeypatch):
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: None)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "run", "nonexistent"])
+    result = run_schedule(args)
+
+    assert result == 1
+
+
+def _status_response(**overrides) -> dict:
+    base = {
+        "schedule": {
+            "id": "sched-abc",
+            "name": "nightly",
+            "enabled": True,
+            "trigger_type": "cron",
+            "cron_expr": "0 2 * * *",
+            "interval_sec": None,
+            "next_fire_at": 1_752_100_000.0,
+        },
+        "latest_run": {
+            "id": "run1",
+            "status": "failed",
+            "exit_code": 1,
+            "fired_at": 1_752_000_000.0,
+            "ended_at": 1_752_000_010.0,
+            "duration_ms": 10000,
+            "outcome": {"code": "run.failed.failed", "summary": "tests failed"},
+            "invocation_id": "inv1",
+            "session_ids": ["sess1"],
+            "artifacts": ["/runs/inv1/artifacts"],
+        },
+        "exit_code": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_schedule_status_human_output_includes_inspect_line(monkeypatch, capsys):
+    """The status block must route to `li monitor <invocation>` for drill-in."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: _status_response())
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 1  # exit_code from the response, ordinary failure
+    assert "inspect:     li monitor inv1" in out
+    assert "outcome:     run.failed.failed" in out
+    assert "session:     sess1" in out
+
+
+def test_schedule_status_json_matches_human_fields(monkeypatch, capsys):
+    """Human and JSON views must agree on the same underlying data."""
+    import json as _json
+
+    import lionagi.studio.cli as sched_mod
+
+    response = _status_response()
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: response)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc", "--json"])
+    result = run_schedule(args)
+
+    parsed = _json.loads(capsys.readouterr().out)
+    assert result == response["exit_code"]
+    assert parsed == response
+
+
+def test_schedule_status_no_runs_yet(monkeypatch, capsys):
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(
+        sched_mod, "_api", lambda *a, **kw: _status_response(latest_run=None, exit_code=2)
+    )
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 2
+    assert "last run:    (none)" in out
+
+
+def test_schedule_status_not_found_returns_1(monkeypatch):
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: None)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc"])
+    result = run_schedule(args)
+
+    assert result == 1
+
+
+def test_schedule_status_wait_polls_until_terminal(monkeypatch):
+    """--wait must keep polling while the latest run is still 'running'."""
+    import lionagi.studio.cli as sched_mod
+
+    responses = [
+        _status_response(latest_run={"status": "running"}, exit_code=3),
+        _status_response(latest_run={"status": "running"}, exit_code=3),
+        _status_response(),
+    ]
+    calls = []
+
+    def _fake_api(path, **kw):
+        calls.append(path)
+        return responses.pop(0)
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+    monkeypatch.setattr("time.sleep", lambda secs: None)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    assert result == 1
+    assert len(calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# trigger --wait: grace-period retry across the fire-now-before-insert race
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_trigger_without_wait_unchanged(monkeypatch, capsys):
+    """No --wait: trigger returns as soon as the run id comes back (existing behavior)."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: {"ok": True, "run_id": "run1"})
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "Run: run1" in out
+
+
+def test_schedule_trigger_wait_retries_through_the_creation_race(monkeypatch, capsys):
+    """The occurrence lookup 404s (returns None) a couple of times right after
+    trigger — --wait must retry through the grace period rather than failing."""
+    import lionagi.studio.cli as sched_mod
+
+    calls = []
+
+    def _fake_api(path, method="GET", body=None):
+        calls.append(path)
+        if path == "/sched-abc/trigger":
+            return {"ok": True, "run_id": "run1"}
+        assert path == "/runs/run1"
+        # First two lookups race the not-yet-written row; third finds it running,
+        # fourth finds it terminal.
+        if len(calls) <= 3:
+            return None if len(calls) <= 2 else {"status": "running", "outcome": None}
+        return {"status": "completed", "outcome": {"code": "run.completed.ok", "summary": "ok"}}
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+    monkeypatch.setattr("time.sleep", lambda secs: None)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "status: completed" in out
+
+
+def test_schedule_trigger_wait_never_appears_errors(monkeypatch, capsys):
+    """The occurrence never shows up within the grace period: a clear error, not a hang."""
+    import lionagi.studio.cli as sched_mod
+
+    def _fake_api(path, method="GET", body=None):
+        if path == "/sched-abc/trigger":
+            return {"ok": True, "run_id": "run1"}
+        return None
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+    monkeypatch.setattr("time.sleep", lambda secs: None)
+    monkeypatch.setattr(sched_mod, "_TRIGGER_WAIT_GRACE_SECONDS", 0.01)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    assert result == 1
+    assert "never appeared" in capsys.readouterr().err
+
+
+def test_schedule_trigger_no_run_id_skips_wait(monkeypatch, capsys):
+    """A trigger response without a run_id (shouldn't normally happen) must not
+    crash --wait — it just returns after printing 'Triggered'."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: {"ok": True})
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    assert result == 0
 
 
 def test_schedule_list_dispatches_to_api(monkeypatch):

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -656,6 +656,64 @@ def test_schedule_trigger_wait_never_appears_errors(monkeypatch, capsys):
     assert "never appeared" in capsys.readouterr().err
 
 
+def test_schedule_trigger_wait_treats_timed_out_as_terminal(monkeypatch, capsys):
+    """A timed-out occurrence must stop the poll loop like any other terminal
+    status, not spin until the wait deadline."""
+    import lionagi.studio.cli as sched_mod
+
+    calls = []
+
+    def _fake_api(path, method="GET", body=None):
+        calls.append(path)
+        if path == "/sched-abc/trigger":
+            return {"ok": True, "run_id": "run1"}
+        return {"status": "timed_out", "outcome": {"code": "timed_out", "summary": "timed out"}}
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+    monkeypatch.setattr("time.sleep", lambda secs: None)
+    monkeypatch.setattr(sched_mod, "_TRIGGER_WAIT_MAX_SECONDS", 0.05)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "trigger", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    assert result == 1
+    assert "status: timed_out" in out
+    assert calls.count("/runs/run1") == 1
+
+
+def test_schedule_status_wait_treats_timed_out_as_terminal(monkeypatch):
+    """--wait must stop polling once the latest run reaches 'timed_out', not
+    just the completed/failed/cancelled/skipped subset it used to check."""
+    import lionagi.studio.cli as sched_mod
+
+    calls = []
+
+    def _fake_api(path, **kw):
+        calls.append(path)
+        return _status_response(latest_run={"status": "timed_out"}, exit_code=124)
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+    monkeypatch.setattr("time.sleep", lambda secs: None)
+    monkeypatch.setattr(sched_mod, "_TRIGGER_WAIT_MAX_SECONDS", 0.05)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "status", "sched-abc", "--wait"])
+    result = run_schedule(args)
+
+    assert result == 124
+    assert len(calls) == 1
+
+
 def test_schedule_trigger_no_run_id_skips_wait(monkeypatch, capsys):
     """A trigger response without a run_id (shouldn't normally happen) must not
     crash --wait — it just returns after printing 'Triggered'."""

--- a/tests/studio/test_run_view.py
+++ b/tests/studio/test_run_view.py
@@ -185,6 +185,16 @@ def test_fallback_outcome_success_by_exit_code():
     assert outcome["code"] == "completed"
 
 
+def test_fallback_outcome_status_dominates_over_exit_code_zero():
+    """A terminal non-completed status with exit_code 0 (e.g. crashed before
+    any exit code was ever meaningfully set) must never read as 'completed'."""
+    run = _run(status="failed", exit_code=0, error_detail=None)
+    outcome = build_outcome(run, None, [])
+    assert outcome["source"] == "fallback"
+    assert outcome["code"] == "failed"
+    assert outcome["code"] != "completed"
+
+
 # ── exit_code_for_view: reuses the existing shared status vocabulary ───────
 
 
@@ -229,3 +239,19 @@ def test_exit_code_skipped_is_ordinary_failure_bucket():
 def test_exit_code_pre_invocation_failure_no_session_or_invocation():
     run = _run(status="failed", exit_code=1)
     assert exit_code_for_view(run, None, []) == 1
+
+
+@pytest.mark.parametrize(
+    "occurrence_status, expected",
+    [
+        ("timed_out", 124),
+        ("cancelled", 143),
+    ],
+)
+def test_exit_code_occurrence_only_terminal_status_uses_shared_vocabulary(
+    occurrence_status, expected
+):
+    """No session or invocation reached terminal — the occurrence status
+    itself must still map through EXIT_CODE_BY_STATUS, not collapse to 1."""
+    run = _run(status=occurrence_status, exit_code=None)
+    assert exit_code_for_view(run, None, []) == expected

--- a/tests/studio/test_run_view.py
+++ b/tests/studio/test_run_view.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the RunView reducer: outcome precedence over schedule_runs,
+invocations, and sessions."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.studio.services.run_view import (
+    build_outcome,
+    build_run_view,
+    exit_code_for_view,
+)
+
+_BASE_RUN = {
+    "id": "run1",
+    "schedule_id": "sched1",
+    "status": "completed",
+    "exit_code": 0,
+    "fired_at": 1000.0,
+    "ended_at": 1002.5,
+    "error_detail": None,
+    "invocation_id": None,
+}
+
+
+def _run(**overrides):
+    return {**_BASE_RUN, **overrides}
+
+
+def test_duration_ms_computed_when_both_timestamps_present():
+    view = build_run_view(_run(), None, [])
+    assert view["duration_ms"] == 2500
+
+
+def test_duration_ms_none_when_still_running():
+    view = build_run_view(_run(status="running", ended_at=None), None, [])
+    assert view["duration_ms"] is None
+
+
+def test_pre_invocation_failure_uses_occurrence_error_detail():
+    """Dispatch/pre-session failure: no invocation exists yet, only error_detail."""
+    run = _run(status="failed", exit_code=None, error_detail="dispatch failed: missing cwd")
+    view = build_run_view(run, None, [])
+    assert view["outcome"]["source"] == "occurrence"
+    assert view["outcome"]["summary"] == "dispatch failed: missing cwd"
+
+
+def test_running_outcome_is_not_terminal():
+    run = _run(status="running", ended_at=None)
+    view = build_run_view(run, None, [])
+    assert view["outcome"] == {"code": "running", "summary": "running", "source": "occurrence"}
+
+
+def test_trusted_completion_prefers_session_reason():
+    run = _run(invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "completed", "status_reason_summary": "invocation ok"}
+    session = {
+        "id": "sess1",
+        "status": "completed",
+        "created_at": 1.0,
+        "status_reason_summary": "3 commits landed",
+        "artifacts_path": "/runs/inv1/artifacts",
+    }
+    view = build_run_view(run, invocation, [session])
+    assert view["outcome"] == {
+        "code": "run.completed.ok",
+        "summary": "3 commits landed",
+        "source": "session",
+    }
+    assert view["artifacts"] == ["/runs/inv1/artifacts"]
+    assert view["session_ids"] == ["sess1"]
+
+
+def test_completed_empty_distinct_from_unqualified_success():
+    run = _run(invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "completed_empty"}
+    session = {"id": "sess1", "status": "completed_empty", "created_at": 1.0}
+    outcome = build_outcome(run, invocation, [session])
+    assert outcome["code"] == "run.completed_empty.no_evidence"
+    assert "no_evidence" in outcome["code"] or "no artifacts" in outcome["summary"]
+
+
+def test_failure_outcome_from_session():
+    run = _run(status="failed", exit_code=1, invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "failed"}
+    session = {
+        "id": "sess1",
+        "status": "failed",
+        "created_at": 1.0,
+        "status_reason_summary": "tests failed",
+    }
+    outcome = build_outcome(run, invocation, [session])
+    assert outcome["source"] == "session"
+    assert outcome["summary"] == "tests failed"
+
+
+def test_timeout_outcome_from_session():
+    run = _run(status="failed", exit_code=124, invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "timed_out"}
+    session = {"id": "sess1", "status": "timed_out", "created_at": 1.0}
+    outcome = build_outcome(run, invocation, [session])
+    assert outcome["source"] == "session"
+    assert "timed_out" in outcome["summary"] or "timed_out" in outcome["code"]
+
+
+def test_skip_outcome_from_occurrence():
+    run = _run(status="skipped", exit_code=None, error_detail="overlap policy: prior running")
+    outcome = build_outcome(run, None, [])
+    assert outcome == {
+        "code": "skipped",
+        "summary": "overlap policy: prior running",
+        "source": "occurrence",
+    }
+
+
+def test_missing_session_falls_back_to_invocation():
+    """Invocation is terminal but no session rows exist at all (e.g. a
+    command target with no session concept)."""
+    run = _run(status="completed", invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "completed", "status_reason_summary": "argv exited 0"}
+    outcome = build_outcome(run, invocation, [])
+    assert outcome == {
+        "code": "run.completed.ok",
+        "summary": "argv exited 0",
+        "source": "invocation",
+    }
+
+
+def test_multiple_sessions_picks_most_recently_created_as_primary():
+    run = _run(status="completed", invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "completed"}
+    older = {"id": "sess-old", "status": "completed", "created_at": 1.0}
+    newer = {
+        "id": "sess-new",
+        "status": "failed",
+        "created_at": 5.0,
+        "status_reason_summary": "retry attempt failed",
+    }
+    view = build_run_view(run, invocation, [older, newer])
+    assert view["outcome"]["source"] == "session"
+    assert view["outcome"]["summary"] == "retry attempt failed"
+    assert set(view["session_ids"]) == {"sess-old", "sess-new"}
+
+
+def test_artifact_paths_deduped_and_ordered():
+    run = _run(invocation_id="inv1")
+    sessions = [
+        {"id": "a", "status": "completed", "created_at": 1.0, "artifacts_path": "/p/1"},
+        {"id": "b", "status": "completed", "created_at": 2.0, "artifacts_path": "/p/1"},
+        {"id": "c", "status": "completed", "created_at": 3.0, "artifacts_path": "/p/2"},
+    ]
+    view = build_run_view(run, {"id": "inv1", "status": "completed"}, sessions)
+    assert view["artifacts"] == ["/p/1", "/p/2"]
+
+
+def test_crash_state_disagreement_session_wins_over_invocation_and_occurrence():
+    """schedule_run says 'failed', invocation says 'running' (crashed before
+    update), session is the freshest terminal truth — session must win."""
+    run = _run(status="failed", exit_code=1, error_detail="orphan tombstoned", invocation_id="inv1")
+    invocation = {"id": "inv1", "status": "running"}
+    session = {
+        "id": "sess1",
+        "status": "completed",
+        "created_at": 1.0,
+        "status_reason_summary": "actually finished before the crash",
+    }
+    outcome = build_outcome(run, invocation, [session])
+    assert outcome["source"] == "session"
+    assert outcome["summary"] == "actually finished before the crash"
+
+
+def test_fallback_outcome_when_no_invocation_or_session_and_no_error_detail():
+    run = _run(status="failed", exit_code=1, error_detail=None)
+    outcome = build_outcome(run, None, [])
+    assert outcome["source"] == "fallback"
+    assert outcome["code"] == "failed_exit_nonzero"
+
+
+def test_fallback_outcome_success_by_exit_code():
+    run = _run(status="completed", exit_code=0, error_detail=None)
+    outcome = build_outcome(run, None, [])
+    assert outcome["source"] == "fallback"
+    assert outcome["code"] == "completed"
+
+
+# ── exit_code_for_view: reuses the existing shared status vocabulary ───────
+
+
+@pytest.mark.parametrize(
+    "session_status, expected",
+    [
+        ("completed", 0),
+        ("completed_empty", 1),
+        ("failed", 1),
+        ("timed_out", 124),
+        ("aborted", 130),
+        ("cancelled", 143),
+    ],
+)
+def test_exit_code_reflects_session_terminal_status(session_status, expected):
+    run = _run(
+        status="completed" if session_status == "completed" else "failed", invocation_id="inv1"
+    )
+    invocation = {"id": "inv1", "status": "completed"}
+    session = {"id": "sess1", "status": session_status, "created_at": 1.0}
+    assert exit_code_for_view(run, invocation, [session]) == expected
+
+
+def test_exit_code_running_is_exit_running():
+    from lionagi.cli.status import EXIT_RUNNING
+
+    run = _run(status="running", ended_at=None)
+    assert exit_code_for_view(run, None, []) == EXIT_RUNNING
+
+
+def test_exit_code_no_run_is_exit_unknown():
+    from lionagi.cli.status import EXIT_UNKNOWN
+
+    assert exit_code_for_view(None, None, []) == EXIT_UNKNOWN
+
+
+def test_exit_code_skipped_is_ordinary_failure_bucket():
+    run = _run(status="skipped", exit_code=None)
+    assert exit_code_for_view(run, None, []) == 1
+
+
+def test_exit_code_pre_invocation_failure_no_session_or_invocation():
+    run = _run(status="failed", exit_code=1)
+    assert exit_code_for_view(run, None, []) == 1

--- a/tests/studio/test_schedule_run_view_service.py
+++ b/tests/studio/test_schedule_run_view_service.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""DB-backed integration tests for the RunView service surface: the
+schedule_runs/invocations/sessions join actually resolves against a real
+StateDB, and repeatable ``status`` filtering works end to end."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.studio.services.schedules import (
+    get_schedule_run,
+    get_schedule_status,
+    list_schedule_run_views,
+)
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _seed(db: StateDB) -> tuple[str, str, str, str]:
+    """One schedule with a terminal run wired to an invocation + session."""
+    sched_id = uuid.uuid4().hex[:12]
+    await db.create_schedule(
+        {
+            "id": sched_id,
+            "name": "nightly",
+            "trigger_type": "cron",
+            "cron_expr": "0 2 * * *",
+            "action_kind": "agent",
+            "next_fire_at": time.time() + 3600,
+        }
+    )
+    inv_id = uuid.uuid4().hex[:12]
+    await db.create_invocation(
+        {"id": inv_id, "skill": "agent", "started_at": time.time(), "status": "completed"}
+    )
+    sess_id = str(uuid.uuid4())
+    prog_id = f"{sess_id}-prog"
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sess_id,
+            "progression_id": prog_id,
+            "invocation_id": inv_id,
+            "status": "completed",
+            "artifacts_path": f"/runs/{inv_id}/artifacts",
+        }
+    )
+    await db.update_status(
+        "session",
+        sess_id,
+        new_status="completed",
+        reason_code="run.completed.ok",
+        reason_summary="3 commits landed",
+        expected_statuses={"completed"},
+    )
+    run_id = uuid.uuid4().hex[:12]
+    fired_at = time.time()
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sched_id,
+            "invocation_id": inv_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": "completed",
+            "exit_code": 0,
+            "fired_at": fired_at,
+            "ended_at": fired_at + 5,
+        }
+    )
+    return sched_id, run_id, inv_id, sess_id
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_run_carries_reconciled_outcome_and_chain_children(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        _sched_id, run_id, inv_id, sess_id = await _seed(db)
+
+    view = await get_schedule_run(run_id)
+
+    assert view is not None
+    assert view["chain_children"] == []  # legacy field preserved (additive layering)
+    assert view["outcome"]["source"] == "session"
+    assert view["outcome"]["summary"] == "3 commits landed"
+    assert view["session_ids"] == [sess_id]
+    assert view["artifacts"] == [f"/runs/{inv_id}/artifacts"]
+    assert view["duration_ms"] == 5000
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_status_reports_latest_run_and_exit_code(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id, run_id, _inv_id, _sess_id = await _seed(db)
+
+    status = await get_schedule_status(sched_id)
+
+    assert status is not None
+    assert status["schedule"]["id"] == sched_id
+    assert status["schedule"]["cron_expr"] == "0 2 * * *"
+    assert status["latest_run"]["id"] == run_id
+    assert status["exit_code"] == 0  # trusted completion
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_status_unknown_schedule_returns_none(temp_db_path: Path) -> None:
+    async with StateDB():
+        pass
+    assert await get_schedule_status("no-such-schedule") is None
+
+
+@pytest.mark.asyncio
+async def test_list_schedule_run_views_repeatable_status_filter(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id, completed_run_id, _inv_id, _sess_id = await _seed(db)
+        failed_run_id = uuid.uuid4().hex[:12]
+        await db.create_schedule_run(
+            {
+                "id": failed_run_id,
+                "schedule_id": sched_id,
+                "invocation_id": None,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": "failed",
+                "exit_code": None,
+                "error_detail": "dispatch failed: missing cwd",
+                "fired_at": time.time(),
+            }
+        )
+        skipped_run_id = uuid.uuid4().hex[:12]
+        await db.create_schedule_run(
+            {
+                "id": skipped_run_id,
+                "schedule_id": sched_id,
+                "invocation_id": None,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": "skipped",
+                "exit_code": None,
+                "error_detail": "overlap policy: prior running",
+                "fired_at": time.time(),
+            }
+        )
+
+    views = await list_schedule_run_views(sched_id, status=["failed", "skipped"], limit=20)
+
+    assert {v["id"] for v in views} == {failed_run_id, skipped_run_id}
+    assert {v["outcome"]["source"] for v in views} == {"occurrence"}
+    assert completed_run_id not in {v["id"] for v in views}

--- a/tests/studio/test_schedule_run_view_service.py
+++ b/tests/studio/test_schedule_run_view_service.py
@@ -163,3 +163,35 @@ async def test_list_schedule_run_views_repeatable_status_filter(temp_db_path: Pa
     assert {v["id"] for v in views} == {failed_run_id, skipped_run_id}
     assert {v["outcome"]["source"] for v in views} == {"occurrence"}
     assert completed_run_id not in {v["id"] for v in views}
+
+
+@pytest.mark.asyncio
+async def test_list_schedule_run_views_keeps_full_row_fields(temp_db_path: Path) -> None:
+    """RunView fields layer on top additively — pre-existing schedule_runs
+    columns (error_detail, trigger_context, action_args, ...) must survive."""
+    async with StateDB() as db:
+        sched_id, _completed_run_id, _inv_id, _sess_id = await _seed(db)
+        failed_run_id = uuid.uuid4().hex[:12]
+        await db.create_schedule_run(
+            {
+                "id": failed_run_id,
+                "schedule_id": sched_id,
+                "invocation_id": None,
+                "trigger_context": {"source": "manual"},
+                "action_kind": "agent",
+                "action_args": {"prompt": "ping"},
+                "status": "failed",
+                "exit_code": None,
+                "error_detail": "dispatch failed: missing cwd",
+                "fired_at": time.time(),
+            }
+        )
+
+    views = await list_schedule_run_views(sched_id, status=["failed"], limit=20)
+
+    view = next(v for v in views if v["id"] == failed_run_id)
+    assert view["error_detail"] == "dispatch failed: missing cwd"
+    assert view["trigger_context"] == {"source": "manual"}
+    assert view["action_args"] == {"prompt": "ping"}
+    # RunView-additive fields are still present alongside the raw row.
+    assert view["outcome"]["source"] == "occurrence"


### PR DESCRIPTION
Makes scheduled-run outcomes visible. Closes #2285, closes #2286.

**Problem.** `li schedule runs <id>` rendered `id [status-or-?] ?` — it printed a `started_at` key that does not exist in the `schedule_runs` schema (the column is `fired_at`), and never surfaced `ended_at`/`exit_code`/`error_detail`, which were already persisted. A user could not tell whether a scheduled run worked or where its output went.

**Changes.**
- New `run_view.py` service: one joined `RunView` over `schedule_runs` + `invocations` + linked sessions, with explicit outcome precedence (session terminal reason > invocation terminal reason > occurrence `error_detail` > status+exit_code fallback) and an `outcome.source` field so reconciliation is explainable.
- `li schedule runs <id>`: renders fired/duration/outcome/invocation/artifacts, adds `--limit` (default 20, max 200), repeatable `--status`, `--json`; fixes the `started_at`→`fired_at` bug.
- New `li schedule run <run-id> [--json]` and `li schedule status <id> [--wait] [--json]` — the one-command "did it work" view, exiting with the existing shared status-code mapping.
- `li schedule trigger <id> --wait`: bounded creation-grace retry on the returned occurrence id (closes the fire-now-before-insert race); same retry where monitor resolves schedule-run ids.
- Schedule detail output links invocation drill-in to the existing `li monitor` renderer.

Additive only: no declaration-surface changes, no schema migration (reads existing columns), legacy chain rows render through the same view.

**Tests.** RunView reducer over the full state matrix (pre-invocation failure, running, completed, completed_empty, failure, timeout, skip, missing session, multi-session, artifacts), DB-backed service integration, CLI contract/golden coverage for new flags + human/JSON agreement, trigger-wait grace retry. Focused scope: 267 passed, 1 skipped.