### PR TITLE
feat(cli): inherited agent-depth env marker (LIONAGI_AGENT_DEPTH)

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -462,6 +462,24 @@ leg is about to fire on this same session, so this leg's teardown must not stamp
 status the resumed leg would then be blocked from overwriting by the ADR-0035 terminal guard
 (see `_runs.py` `_teardown_common` defer_terminal, below).
 
+## `_agent_depth.py` — inherited agent-depth env marker
+
+`LIONAGI_AGENT_DEPTH` (integer string; unset/`0` = top-level, `>=1` = spawned worker) lets an
+external policy hook distinguish a seat session from a worker it spawned, using process
+ancestry-independent env inheritance — ancestry breaks under `nohup`/`setsid` detachment and
+launchd reparenting, but env inheritance survives it. `LIONAGI_SEAT_PROFILES` is an
+operator-configured, comma-separated set of `-a` profile names that reset depth to 0 instead of
+incrementing it; the set is empty by default and no profile name is hardcoded in source.
+
+`stamp_agent_depth(agent_name)` (called from `_run_agent`) and `stamp_worker_depth()` (called
+from `_run_fanout` and `_run_flow`, which also covers `li play`) both set
+`os.environ["LIONAGI_AGENT_DEPTH"]` before any engine spawn. `_cli_subprocess.py`'s
+`ndjson_from_cli` passes `env=None` to `create_subprocess_exec` for all three CLI-backed engines
+(`claude_code`, `codex`, `gemini_code`), so the child inherits this process's `os.environ`
+verbatim — the stamp propagates with zero endpoint changes. `inherited_depth()` is captured once
+at import as a module constant rather than read live, so `_run_agent`'s in-process auto-resume
+recursion re-stamps to the same depth instead of double-incrementing.
+
 ## `kill.py`
 
 No standalone entries beyond the general ADR-0035 CAS-guard pattern documented under

--- a/lionagi/cli/_agent_depth.py
+++ b/lionagi/cli/_agent_depth.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Inherited agent-depth env marker — see docs/internals/cli.md."""
+
+from __future__ import annotations
+
+import os
+
+DEPTH_ENV = "LIONAGI_AGENT_DEPTH"
+SEAT_PROFILES_ENV = "LIONAGI_SEAT_PROFILES"
+
+
+def _parse_depth(raw: str | None) -> int:
+    if raw is None:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return value if value >= 0 else 0
+
+
+# Captured once at import, not re-read live: _run_agent recurses in-process on
+# auto-resume, and a live re-read after the first stamp would double-increment.
+_INHERITED_DEPTH = _parse_depth(os.environ.get(DEPTH_ENV))
+
+
+def inherited_depth() -> int:
+    """Depth this process inherited from its parent (import-time snapshot)."""
+    return _INHERITED_DEPTH
+
+
+def _seat_profiles() -> set[str]:
+    raw = os.environ.get(SEAT_PROFILES_ENV, "")
+    return {name.strip() for name in raw.split(",") if name.strip()}
+
+
+def stamp_agent_depth(agent_name: str | None) -> int:
+    """Set LIONAGI_AGENT_DEPTH for `li agent -a NAME`: 0 if NAME is a seat profile, else parent+1."""
+    is_seat = bool(agent_name) and agent_name in _seat_profiles()
+    depth = 0 if is_seat else inherited_depth() + 1
+    os.environ[DEPTH_ENV] = str(depth)
+    return depth
+
+
+def stamp_worker_depth() -> int:
+    """Set LIONAGI_AGENT_DEPTH for fanout/flow/play workers — never seats, always parent+1."""
+    depth = inherited_depth() + 1
+    os.environ[DEPTH_ENV] = str(depth)
+    return depth

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -23,6 +23,7 @@ from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
 from lionagi.state.artifact_verifier import resolve_artifact_contract
 
+from ._agent_depth import stamp_agent_depth
 from ._context_from import (
     DEFAULT_CONTEXT_BUDGET_TOKENS,
     ContextFromError,
@@ -280,6 +281,8 @@ async def _run_agent(
             "string; set it to a valid role name, or remove the key to keep "
             "the plain profile path (no role/policy composition)."
         )
+
+    stamp_agent_depth(agent_name)
 
     # True only when a NEW branch took the create_agent path (--preset coding
     # or an opted-in profile `role:` key) — see the add_message guard below.

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -13,6 +13,7 @@ from lionagi.orchestration.prompts import SYNTHESIS_INSTRUCTION
 from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
+from .._agent_depth import stamp_worker_depth
 from .._logging import log_error, progress, warn
 from .._providers import parse_model_spec
 from .._util import classify_exception
@@ -72,6 +73,8 @@ async def _run_fanout(
     teardown path settles on) reaches the caller's exit code instead of being
     silently dropped in favour of a hardcoded success.
     """
+    stamp_worker_depth()
+
     env = await setup_orchestration(
         pattern_name="Fanout",
         model_spec=model_spec,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -22,6 +22,7 @@ from lionagi.orchestration import normalize_dep_indices, plan, role_node_builder
 from lionagi.session.exchange import Exchange
 from lionagi.tools.communication.messenger import LionMessenger
 
+from .._agent_depth import stamp_worker_depth
 from .._logging import progress
 from .._logging import warn as _warn
 from .._providers import parse_model_spec
@@ -1572,6 +1573,8 @@ async def _run_flow(
     **legacy_kwargs,
 ) -> tuple[str, str]:
     """Returns (output, terminal_status)."""
+    stamp_worker_depth()
+
     if "max_agents" in legacy_kwargs and max_ops == 0:
         max_ops = legacy_kwargs.pop("max_agents")
     elif "max_agents" in legacy_kwargs:

--- a/tests/cli/test_agent_depth.py
+++ b/tests/cli/test_agent_depth.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`lionagi.cli._agent_depth` — the inherited LIONAGI_AGENT_DEPTH env marker.
+
+See docs/internals/cli.md for the mechanism (env inheritance survives
+nohup/setsid/launchd reparenting; process ancestry does not).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli import _agent_depth as depth_mod
+from lionagi.cli._agent_depth import (
+    DEPTH_ENV,
+    SEAT_PROFILES_ENV,
+    _parse_depth,
+    inherited_depth,
+    stamp_agent_depth,
+    stamp_worker_depth,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_depth_env(monkeypatch):
+    # Register cleanup for a key the production code writes directly via
+    # os.environ (bypassing monkeypatch's own setenv tracking).
+    monkeypatch.delenv(DEPTH_ENV, raising=False)
+    monkeypatch.delenv(SEAT_PROFILES_ENV, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _parse_depth
+# ---------------------------------------------------------------------------
+
+
+class TestParseDepth:
+    def test_none_is_zero(self):
+        assert _parse_depth(None) == 0
+
+    def test_unset_string_is_zero(self):
+        assert _parse_depth("") == 0
+
+    def test_garbage_is_zero(self):
+        assert _parse_depth("not-a-number") == 0
+
+    def test_negative_is_zero(self):
+        assert _parse_depth("-3") == 0
+
+    def test_valid_positive(self):
+        assert _parse_depth("3") == 3
+
+    def test_valid_zero(self):
+        assert _parse_depth("0") == 0
+
+
+# ---------------------------------------------------------------------------
+# inherited_depth — import-captured, not a live re-read
+# ---------------------------------------------------------------------------
+
+
+class TestInheritedDepth:
+    def test_returns_captured_module_constant(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 5)
+        assert inherited_depth() == 5
+
+    def test_ignores_live_env_changes(self, monkeypatch):
+        """A live re-read after the module's already captured a value would
+        double-increment the in-process auto-resume recursion — must not
+        happen."""
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 2)
+        monkeypatch.setenv(DEPTH_ENV, "99")
+        assert inherited_depth() == 2
+
+
+# ---------------------------------------------------------------------------
+# stamp_agent_depth — seat vs non-seat vs no-profile
+# ---------------------------------------------------------------------------
+
+
+class TestStampAgentDepth:
+    def test_seat_profile_resets_to_zero(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 5)
+        monkeypatch.setenv(SEAT_PROFILES_ENV, "reviewer,tester")
+        assert stamp_agent_depth("reviewer") == 0
+
+    def test_non_seat_profile_increments(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 2)
+        monkeypatch.setenv(SEAT_PROFILES_ENV, "reviewer")
+        assert stamp_agent_depth("implementer") == 3
+
+    def test_no_profile_treated_as_non_seat(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+        assert stamp_agent_depth(None) == 1
+
+    def test_empty_seat_set_by_default(self, monkeypatch):
+        """No LIONAGI_SEAT_PROFILES configured -> empty set -> every name
+        is non-seat, per contract (operators must opt in explicitly)."""
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+        assert stamp_agent_depth("implementer") == 1
+
+    def test_seat_names_are_stripped_and_empty_entries_ignored(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+        monkeypatch.setenv(SEAT_PROFILES_ENV, " reviewer , , tester ")
+        assert stamp_agent_depth("reviewer") == 0
+        assert stamp_agent_depth("tester") == 0
+
+    def test_sets_env_var(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+        depth = stamp_agent_depth("implementer")
+        import os
+
+        assert os.environ[DEPTH_ENV] == str(depth)
+
+
+# ---------------------------------------------------------------------------
+# stamp_worker_depth — always parent+1, never a seat
+# ---------------------------------------------------------------------------
+
+
+class TestStampWorkerDepth:
+    def test_always_increments_even_with_seat_profiles_configured(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+        monkeypatch.setenv(SEAT_PROFILES_ENV, "anything")
+        assert stamp_worker_depth() == 1
+
+    def test_increments_from_nonzero_inherited_depth(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 3)
+        assert stamp_worker_depth() == 4
+
+    def test_sets_env_var(self, monkeypatch):
+        monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 1)
+        depth = stamp_worker_depth()
+        import os
+
+        assert os.environ[DEPTH_ENV] == str(depth)
+
+
+# ---------------------------------------------------------------------------
+# Auto-resume recursion must not double-increment
+# ---------------------------------------------------------------------------
+
+
+def test_double_stamp_in_one_process_does_not_double_increment(monkeypatch):
+    """Simulates `_run_agent`'s in-process auto-resume recursion: calling
+    stamp_agent_depth twice in the same process (same captured
+    _INHERITED_DEPTH) must yield the same depth both times, not depth+2."""
+    monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+
+    first = stamp_agent_depth("implementer")
+    second = stamp_agent_depth("implementer")
+
+    assert first == 1
+    assert second == 1

--- a/tests/cli/test_agent_depth_wiring.py
+++ b/tests/cli/test_agent_depth_wiring.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wiring of LIONAGI_AGENT_DEPTH stamping into `_run_agent`, `_run_fanout`,
+`_run_flow`, and the engine subprocess spawn (`ndjson_from_cli`).
+
+The stamp must land in os.environ BEFORE any provider/engine spawn — the
+mechanism (see docs/internals/cli.md) relies on `ndjson_from_cli` passing
+env=None to create_subprocess_exec so the spawned engine inherits this
+process's os.environ verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from lionagi.cli import _agent_depth as depth_mod
+from lionagi.cli._agent_depth import DEPTH_ENV
+
+
+@pytest.fixture(autouse=True)
+def _clean_depth_env(monkeypatch):
+    monkeypatch.delenv(DEPTH_ENV, raising=False)
+
+
+class _StopEarly(Exception):
+    """Sentinel raised to abort a function right after the stamp point."""
+
+
+@pytest.mark.asyncio
+async def test_run_agent_stamps_depth_before_any_spawn(monkeypatch):
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+
+    def _boom_build_chat_model(*a, **kw):
+        raise _StopEarly("build_chat_model must not be reached before the stamp")
+
+    monkeypatch.setattr(agent_mod, "build_chat_model", _boom_build_chat_model)
+
+    with pytest.raises(_StopEarly):
+        await agent_mod._run_agent("claude", "do the thing", agent_name=None)
+
+    # No seat set configured, no -a profile -> non-seat -> parent(0) + 1.
+    assert os.environ[DEPTH_ENV] == "1"
+
+
+@pytest.mark.asyncio
+async def test_run_fanout_stamps_depth_before_setup(monkeypatch):
+    import lionagi.cli.orchestrate.fanout as fanout_mod
+
+    monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 2)
+
+    async def _boom_setup_orchestration(*a, **kw):
+        raise _StopEarly("setup_orchestration must not be reached before the stamp")
+
+    monkeypatch.setattr(fanout_mod, "setup_orchestration", _boom_setup_orchestration)
+
+    with pytest.raises(_StopEarly):
+        await fanout_mod._run_fanout("claude", "do the thing")
+
+    # Fanout workers are never seats: unconditional parent(2) + 1.
+    assert os.environ[DEPTH_ENV] == "3"
+
+
+@pytest.mark.asyncio
+async def test_run_flow_stamps_depth_before_setup(monkeypatch):
+    import lionagi.cli.orchestrate.flow as flow_mod
+
+    monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 1)
+
+    async def _boom_setup_orchestration(*a, **kw):
+        raise _StopEarly("setup_orchestration must not be reached before the stamp")
+
+    monkeypatch.setattr(flow_mod, "setup_orchestration", _boom_setup_orchestration)
+
+    with pytest.raises(_StopEarly):
+        await flow_mod._run_flow("claude", "do the thing")
+
+    # li o flow / li play workers are never seats: unconditional parent(1) + 1.
+    assert os.environ[DEPTH_ENV] == "2"
+
+
+@pytest.mark.asyncio
+async def test_ndjson_from_cli_inherits_stamped_depth(monkeypatch):
+    """The CLI engine spawn (shared by claude_code/codex/gemini_code) must
+    pass env=None to create_subprocess_exec while LIONAGI_AGENT_DEPTH is
+    already set in this process's os.environ — that combination is what
+    makes the child inherit the stamp with zero endpoint changes."""
+    import asyncio
+
+    from lionagi.providers._cli_subprocess import ndjson_from_cli
+
+    monkeypatch.setattr(depth_mod, "_INHERITED_DEPTH", 0)
+    depth_mod.stamp_agent_depth("implementer")
+    assert os.environ[DEPTH_ENV] == "1"
+
+    captured_kwargs: dict = {}
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+
+    async def _spy_create_subprocess_exec(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        # os.environ must still carry the stamp at the moment of spawn.
+        captured_kwargs["_depth_at_spawn"] = os.environ.get(DEPTH_ENV)
+        return await real_create_subprocess_exec(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spy_create_subprocess_exec)
+
+    chunks = []
+    async for obj in ndjson_from_cli(["true"]):
+        chunks.append(obj)
+
+    assert captured_kwargs["env"] is None
+    assert captured_kwargs["_depth_at_spawn"] == "1"


### PR DESCRIPTION
External policy hooks need to distinguish a top-level seat session from a worker agent it spawned. Process ancestry cannot provide this: detached children (`nohup`/`setsid`) reparent to the init daemon, destroying the parent-chain signal. An environment variable inherits through detachment.

**Contract.**
- `LIONAGI_AGENT_DEPTH`: integer string. Unset/`0` = top-level; `>=1` = spawned worker. Invalid/negative values read as 0.
- `LIONAGI_SEAT_PROFILES`: operator-configured comma-separated `-a` profile names that stamp depth 0 instead of incrementing. Empty by default; no profile names are hardcoded in source.

**Mechanism.** `li agent` stamps `0` for seat profiles, else `parent+1`; `li o fanout` / `li o flow` (covering `li play`) always stamp `parent+1`. The stamp lands in `os.environ` before any engine spawn; the shared CLI subprocess helper passes `env=None` for all three CLI-backed engines, so the child inherits the marker verbatim — zero endpoint changes. Inherited depth is captured once at import, so the in-process auto-resume recursion re-stamps to the same value instead of double-incrementing.

**Tests.** 22 focused tests: parse edge cases, seat/non-seat/no-profile computation, re-stamp idempotence under auto-resume, and wiring tests pinning the stamp lands before the engine spawn on all three paths.

Full serial suite: 1 pre-existing failure only — `tests/test_class_registry.py::TestGetClassMiss::test_empty_string_raises_value_error` fails identically on clean `main` with the same invocation (order-dependent; passes standalone on both trees). Filed separately.