### PR TITLE
feat(cli): typed quick-create schedule commands (li schedule create <kind>)

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -655,6 +655,17 @@ def main(argv: list[str] | None = None) -> int:
     # "did you mean --X?" suggestion instead of argparse's generic usage dump.
     if selected is _COMMAND_BY_NAME["schedule"]:
         schedule_parser = selected_parser
+        # `li schedule create <kind> <name> ...` — a typed quick-create form
+        # additive to the legacy flat `li schedule create NAME ...`. The kind
+        # token is reserved (agent/flow/playbook/command) and dispatched here,
+        # before argparse ever sees it, so the legacy positional NAME keeps
+        # working unchanged for any other value.
+        if (
+            len(_argv) > 2
+            and _argv[1] == "create"
+            and _argv[2] in _load_studio().QUICK_CREATE_KINDS
+        ):
+            return _load_studio().run_schedule_quick_create(_argv[2], _argv[3:])
         ns, extras = schedule_parser.parse_known_args(_argv[1:])
         if extras:
             from lionagi.studio.cli import suggest_schedule_flag

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1229,6 +1229,352 @@ def _cmd_apply_set(args: argparse.Namespace) -> int:
     return 1 if has_errors else 0
 
 
+# ---------------------------------------------------------------------------
+# Typed quick-create — `li schedule create <kind> <name> ...`
+#
+# Dispatched from cli/main.py *before* the legacy `sched_sub` argparse tree
+# (a reserved kind token right after "create", mirroring how `agent status` /
+# `monitor run` / `wait` are special-cased there) so the existing flat
+# `li schedule create NAME --cron ... --prompt ...` form is untouched.
+# Compiles straight into a ScheduleMember and runs it through the identical
+# resolve_member()/create_quick_schedule() path a ScheduleSet member uses —
+# no forked validation, per the schedule-declaration design.
+# ---------------------------------------------------------------------------
+
+QUICK_CREATE_KINDS = ("agent", "flow", "playbook", "command")
+
+
+def _quick_create_add_trigger_flags(parser: argparse.ArgumentParser) -> None:
+    trigger = parser.add_mutually_exclusive_group(required=True)
+    trigger.add_argument(
+        "--at",
+        metavar="RFC3339",
+        help=(
+            "Fire once at this absolute instant. RFC 3339 with a mandatory "
+            "UTC offset and 'T' date/time separator, e.g. "
+            "2026-07-15T09:00:00-04:00. Implies max-runs=1."
+        ),
+    )
+    trigger.add_argument(
+        "--cron",
+        metavar="EXPR",
+        help='Cron expression, e.g. "0 2 * * *". Requires --timezone.',
+    )
+    trigger.add_argument(
+        "--every",
+        metavar="DURATION",
+        help="Strict positive duration, e.g. 30s / 15m / 6h / 2d.",
+    )
+    trigger.add_argument(
+        "--github",
+        metavar="OWNER/NAME",
+        help="Poll this GitHub repository. Optional --github-filter narrows which PRs fire.",
+    )
+    parser.add_argument(
+        "--timezone",
+        metavar="IANA_TZ",
+        help="IANA timezone for --cron, e.g. America/New_York. Required with --cron.",
+    )
+    parser.add_argument(
+        "--github-filter",
+        dest="github_filter",
+        metavar="JSON",
+        help='JSON object filtering which PRs fire --github, e.g. \'{"state": "open"}\'.',
+    )
+
+
+def _quick_create_add_policy_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--cwd",
+        metavar="PATH",
+        help="Execution root for the spawned process (default: this CLI's invocation directory).",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Sugar for --max-runs 1 — fire once, then auto-disable.",
+    )
+    parser.add_argument(
+        "--max-runs",
+        dest="max_runs",
+        type=int,
+        metavar="N",
+        help="Auto-disable once N total runs have fired (default: unlimited). "
+        "Mutually exclusive with --once.",
+    )
+    parser.add_argument(
+        "--overlap",
+        choices=("skip", "allow"),
+        default="skip",
+        help="Overlap policy when a prior run is still in-flight (default: skip).",
+    )
+    parser.add_argument(
+        "--missed-fire",
+        dest="missed_fire",
+        choices=("skip", "run_once"),
+        default="skip",
+        help="Missed-fire policy (default: skip).",
+    )
+    parser.add_argument("--budget-usd", dest="budget_usd", type=float, metavar="USD")
+    parser.add_argument("--budget-tokens", dest="budget_tokens", type=int, metavar="N")
+    parser.add_argument(
+        "--rate-limit",
+        dest="rate_limit",
+        metavar="JSON",
+        help='Rolling-window fire cap, e.g. \'{"max_fires": 3, "window_sec": 3600}\'.',
+    )
+    parser.add_argument("--description", help="Human-readable description.")
+    parser.add_argument("--disabled", action="store_true", help="Create the schedule disabled.")
+
+
+def build_quick_create_parser(kind: str) -> argparse.ArgumentParser:
+    """Build the standalone parser for `li schedule create <kind>`."""
+    parser = argparse.ArgumentParser(
+        prog=f"li schedule create {kind}",
+        description=f"Create a typed {kind!r} schedule.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("name", help="Schedule name.")
+    if kind == "agent":
+        parser.add_argument("--profile", required=True, help="Agent profile name.")
+        parser.add_argument("--prompt", help="Prompt text (alternative to --prompt-file).")
+        parser.add_argument(
+            "--prompt-file",
+            dest="prompt_file",
+            metavar="PATH",
+            help="Read the prompt from a file; '-' reads stdin.",
+        )
+        parser.add_argument("--model", help="Explicit model override (default: profile's model).")
+    elif kind == "flow":
+        parser.add_argument("--file", required=True, help="Path to an `li o flow` YAML spec file.")
+    elif kind == "playbook":
+        parser.add_argument("--playbook", required=True, help="Playbook name.")
+        parser.add_argument(
+            "--arg",
+            dest="args",
+            action="append",
+            metavar="KEY=VALUE",
+            help="Typed playbook argument, repeatable.",
+        )
+    elif kind == "command":
+        # The executable + its argv are captured separately, by splitting the
+        # raw argv on a literal '--' *before* this parser ever runs (see
+        # run_schedule_quick_create) — nargs=REMAINDER can't be used here
+        # since it would greedily swallow the trigger/policy flags that
+        # follow `name` too, not just the tokens after '--'.
+        pass
+    else:  # pragma: no cover — gated by QUICK_CREATE_KINDS at the dispatch site
+        raise ValueError(f"unknown quick-create kind: {kind!r}")
+    _quick_create_add_trigger_flags(parser)
+    _quick_create_add_policy_flags(parser)
+    return parser
+
+
+def _quick_create_trigger(args: argparse.Namespace) -> Any:
+    from lionagi.studio.services.schedule_declaration import CronTrigger, GithubTriggerSpec, Trigger
+
+    if args.at:
+        return Trigger(at=args.at)
+    if args.cron:
+        if not args.timezone:
+            print("Error: --cron requires --timezone.", file=sys.stderr)
+            return None
+        return Trigger(cron=CronTrigger(expression=args.cron, timezone=args.timezone))
+    if args.every:
+        return Trigger(every=args.every)
+    # args.github — the only remaining branch, guaranteed by the required
+    # mutually-exclusive trigger group.
+    github_filter = None
+    if getattr(args, "github_filter", None):
+        try:
+            github_filter = json.loads(args.github_filter)
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --github-filter must be valid JSON: {exc}", file=sys.stderr)
+            return None
+        if not isinstance(github_filter, dict):
+            print("Error: --github-filter must be a JSON object.", file=sys.stderr)
+            return None
+    return Trigger(github=GithubTriggerSpec(repo=args.github, filter=github_filter))
+
+
+def _quick_create_policies(args: argparse.Namespace) -> Any:
+    from pydantic import ValidationError
+
+    from lionagi.studio.services.schedule_declaration import Budget, Policies
+
+    if args.once and args.max_runs is not None:
+        print("Error: --once and --max-runs are mutually exclusive.", file=sys.stderr)
+        return None
+    max_runs = 1 if args.once else args.max_runs
+
+    budget = None
+    if args.budget_usd is not None or args.budget_tokens is not None:
+        try:
+            budget = Budget(usd=args.budget_usd, tokens=args.budget_tokens)
+        except ValidationError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return None
+
+    rate_limit = None
+    if getattr(args, "rate_limit", None):
+        try:
+            rate_limit = json.loads(args.rate_limit)
+        except (ValueError, TypeError) as exc:
+            print(f"Error: --rate-limit must be valid JSON: {exc}", file=sys.stderr)
+            return None
+
+    try:
+        return Policies(
+            missedFire=args.missed_fire,
+            overlap=args.overlap,
+            maxRuns=max_runs,
+            budget=budget,
+            rateLimit=rate_limit,
+        )
+    except ValidationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return None
+
+
+def _quick_create_target(kind: str, args: argparse.Namespace) -> Any:
+    from lionagi.studio.services.schedule_declaration import (
+        AgentTarget,
+        CommandTarget,
+        FlowTarget,
+        PlaybookTarget,
+    )
+
+    if kind == "agent":
+        prompt = args.prompt
+        if args.prompt_file:
+            if prompt is not None:
+                print("Error: --prompt and --prompt-file are mutually exclusive.", file=sys.stderr)
+                return None
+            if args.prompt_file == "-":
+                prompt = sys.stdin.read()
+            else:
+                try:
+                    prompt = Path(args.prompt_file).read_text()
+                except OSError as exc:
+                    print(f"Error: could not read --prompt-file: {exc}", file=sys.stderr)
+                    return None
+        if not prompt or not prompt.strip():
+            print("Error: agent target requires --prompt or --prompt-file.", file=sys.stderr)
+            return None
+        return AgentTarget(kind="agent", profile=args.profile, prompt=prompt, model=args.model)
+
+    if kind == "flow":
+        return FlowTarget(kind="flow", file=args.file)
+
+    if kind == "playbook":
+        arg_dict: dict[str, str] = {}
+        for item in args.args or []:
+            if "=" not in item:
+                print(f"Error: --arg must be key=value, got {item!r}.", file=sys.stderr)
+                return None
+            key, _, value = item.partition("=")
+            arg_dict[key] = value
+        return PlaybookTarget(kind="playbook", name=args.playbook, args=arg_dict)
+
+    # kind == "command": trailing `-- argv...`, never a shell string. The
+    # executable/args tokens were already split off before argparse ran (see
+    # run_schedule_quick_create) and attached as args.command_argv.
+    rest = getattr(args, "command_argv", None)
+    if not rest:
+        print(
+            "Error: command target requires a trailing '--' before the "
+            "executable, e.g. `li schedule create command NAME --every 15m "
+            "-- refresh-index --incremental`.",
+            file=sys.stderr,
+        )
+        return None
+    return CommandTarget(kind="command", executable=rest[0], args=rest[1:])
+
+
+def run_schedule_quick_create(kind: str, argv: list[str]) -> int:
+    """`li schedule create <kind> <name> ...` entry point."""
+    from pydantic import ValidationError
+
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedule_declaration import (
+        Execution,
+        ScheduleMember,
+        ScheduleSetError,
+        create_quick_schedule,
+    )
+
+    parser = build_quick_create_parser(kind)
+    command_argv: list[str] = []
+    if kind == "command":
+        # Split off the executable/argv at a literal '--' *before* argparse
+        # runs: nargs=REMAINDER on a positional would otherwise greedily
+        # swallow the trigger/policy flags that come after `name` too.
+        if "--" not in argv:
+            print(
+                "Error: command target requires a trailing '--' before the "
+                "executable, e.g. `li schedule create command NAME --every 15m "
+                "-- refresh-index --incremental`.",
+                file=sys.stderr,
+            )
+            return 1
+        i = argv.index("--")
+        argv, command_argv = argv[:i], argv[i + 1 :]
+    args = parser.parse_args(argv)
+    if kind == "command":
+        args.command_argv = command_argv
+
+    target = _quick_create_target(kind, args)
+    if target is None:
+        return 1
+    trigger = _quick_create_trigger(args)
+    if trigger is None:
+        return 1
+    policies = _quick_create_policies(args)
+    if policies is None:
+        return 1
+
+    cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd()
+
+    # Best-effort project auto-detection, same cascade as the legacy create
+    # path; any failure here must never block schedule creation.
+    project: str | None = None
+    with contextlib.suppress(Exception):
+        from lionagi.cli._project import detect_project
+        from lionagi.studio.scheduler.subprocess import _validate_identifier
+
+        detected, _source = detect_project(cwd)
+        if detected:
+            _validate_identifier(detected, "action_project")
+            project = detected
+
+    try:
+        member = ScheduleMember(
+            description=args.description,
+            enabled=not args.disabled,
+            trigger=trigger,
+            target=target,
+            execution=Execution(cwd=str(cwd)),
+            policies=policies,
+        )
+    except ValidationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    async def _run():
+        async with StateDB() as db:
+            return await create_quick_schedule(db, args.name, member, cwd=cwd, project=project)
+
+    try:
+        schedule_id, resolved = asyncio.run(_run())
+    except ScheduleSetError as exc:
+        for _name, message in exc.errors:
+            print(f"Error: {message}", file=sys.stderr)
+        return 1
+
+    print(f"Created: {schedule_id}  {resolved.qualified_name}")
+    return 0
+
+
 # Common wrong spellings mapped to the real flag, checked before the fuzzy
 # match below since some (e.g. --every) aren't close enough for difflib.
 _SCHEDULE_FLAG_SYNONYMS: dict[str, str] = {

--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -553,7 +553,7 @@ def resolve_member(
     member: ScheduleMember,
     *,
     manifest_dir: Path,
-    project: str,
+    project: str | None,
     is_global: bool,
 ) -> ResolvedMember:
     qualified_name = f"{'global' if is_global else project}/{name}"
@@ -584,6 +584,62 @@ def resolve_member(
         timezone=resolved_trigger.get("timezone"),
         db_fields=db_fields,
     )
+
+
+async def create_quick_schedule(
+    db: StateDB,
+    name: str,
+    member: ScheduleMember,
+    *,
+    cwd: Path,
+    project: str | None,
+) -> tuple[str, ResolvedMember]:
+    """Compile + persist one `li schedule create <kind>` quick-create row
+    through the exact same static-resolution path (``resolve_member``) a
+    ``ScheduleSet`` member uses -- there is no second, forked validator.
+
+    Persisted with ``managed_by='cli'`` and no ``owner_key``, so a later
+    ``ScheduleSet apply`` targeting the same qualified name still hits the
+    ownership-collision guard in ``build_plan()``. Raises ``ScheduleSetError``
+    (zero writes) on a resolution failure or a name collision.
+    """
+    qualified_name = f"{project}/{name}" if project else name
+    try:
+        resolved = resolve_member(name, member, manifest_dir=cwd, project=project, is_global=False)
+    except ValueError as exc:
+        raise ScheduleSetError([(qualified_name, str(exc))]) from exc
+
+    existing = await db.get_schedule_by_name(qualified_name)
+    if existing is not None:
+        raise ScheduleSetError(
+            [
+                (
+                    qualified_name,
+                    f"a schedule named {qualified_name!r} already exists "
+                    f"(id={existing['id']}, managed_by={existing.get('managed_by')!r})",
+                )
+            ]
+        )
+
+    schedule_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    row = {
+        "id": schedule_id,
+        "name": qualified_name,
+        "spec_version": SPEC_VERSION,
+        "managed_by": "cli",
+        "owner_key": None,
+        "authored_spec": resolved.authored,
+        "resolved_target": resolved.resolved,
+        "resolved_digest": resolved.digest,
+        "resolved_timezone": resolved.timezone,
+        "created_at": now,
+        "updated_at": now,
+        **resolved.db_fields,
+    }
+    await db.create_schedule(row)
+    resolved.qualified_name = qualified_name
+    return schedule_id, resolved
 
 
 def resolve_schedule_set(doc: ScheduleSetDocument, manifest_dir: Path) -> dict[str, ResolvedMember]:

--- a/tests/cli/test_schedule_quick_create.py
+++ b/tests/cli/test_schedule_quick_create.py
@@ -1,0 +1,438 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li schedule create <kind> <name> ...` typed quick-create:
+per-kind compilation into a ScheduleMember, resolution via the exact
+resolve_member() path a ScheduleSet member uses, trigger validation
+surfaces, and additive compatibility with the legacy flat create form."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+pytest.importorskip("croniter", reason="studio extra not installed")
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+@pytest.fixture
+def agent_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A minimal .lionagi/agents/reviewer.md discoverable via cwd, and cwd
+    itself carrying no project markers (git/config.toml) so quick-create
+    project auto-detection resolves to None -- see test_schedule_declaration.py
+    for the identical rationale on pinning _find_lionagi_dirs directly."""
+    import lionagi.cli._providers as providers_mod
+
+    agents_dir = tmp_path / ".lionagi" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "reviewer.md").write_text("---\nmodel: anthropic/claude-sonnet-5\n---\nBody.\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(providers_mod, "_find_lionagi_dirs", lambda: [agents_dir.parent])
+    return tmp_path
+
+
+def _run(kind: str, argv: list[str]) -> int:
+    from lionagi.studio.cli import run_schedule_quick_create
+
+    return run_schedule_quick_create(kind, argv)
+
+
+async def _get(name: str) -> dict:
+    async with StateDB() as db:
+        row = await db.get_schedule_by_name(name)
+    assert row is not None, f"schedule {name!r} was not created"
+    return row
+
+
+async def _get_or_none(name: str) -> dict | None:
+    async with StateDB() as db:
+        return await db.get_schedule_by_name(name)
+
+
+# ---------------------------------------------------------------------------
+# Per-kind happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_agent_at_trigger(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        [
+            "release-check",
+            "--profile",
+            "reviewer",
+            "--prompt",
+            "Check the release candidate",
+            "--at",
+            "2026-07-15T09:00:00-04:00",
+        ],
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Created:" in out
+    row = asyncio.run(_get("release-check"))
+    assert row["managed_by"] == "cli"
+    assert row["owner_key"] is None
+    assert row["spec_version"] == "lionagi.io/v1alpha1"
+    assert row["action_kind"] == "agent"
+    assert row["action_agent"] == "reviewer"
+    assert row["action_model"] == "anthropic/claude-sonnet-5"
+    assert row["action_prompt"] == "Check the release candidate"
+    assert row["trigger_type"] == "at"
+    assert row["max_runs"] == 1  # forced by an 'at' trigger
+    assert row["next_fire_at"] is not None
+    assert row["action_cwd"] == str(agent_profile)
+    assert row["resolved_digest"]
+    # resolved_target/authored_spec are stored as JSON text and are not in
+    # StateDB._row_to_dict's decode allowlist (a pre-existing gap shared by
+    # the ScheduleSet apply path, out of scope here) -- decode explicitly.
+    assert json.loads(row["resolved_target"])["target"]["kind"] == "agent"
+
+
+def test_quick_create_agent_prompt_file(temp_db_path, agent_profile):
+    prompt_file = agent_profile / "prompt.txt"
+    prompt_file.write_text("Summarize overnight activity")
+    rc = _run(
+        "agent",
+        [
+            "from-file",
+            "--profile",
+            "reviewer",
+            "--prompt-file",
+            str(prompt_file),
+            "--every",
+            "1h",
+        ],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("from-file"))
+    assert row["action_prompt"] == "Summarize overnight activity"
+
+
+def test_quick_create_flow_cron_trigger(temp_db_path, agent_profile):
+    flow_file = agent_profile / "flow.yaml"
+    flow_file.write_text(
+        "agents:\n  - id: a1\n    model: anthropic/claude-sonnet-5\n    prompt: hi\n"
+    )
+    rc = _run(
+        "flow",
+        [
+            "nightly-review",
+            "--cron",
+            "0 2 * * *",
+            "--timezone",
+            "America/New_York",
+            "--file",
+            str(flow_file),
+        ],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("nightly-review"))
+    assert row["action_kind"] == "flow_yaml"
+    assert row["trigger_type"] == "cron"
+    assert row["cron_expr"] == "0 2 * * *"
+    assert row["resolved_timezone"] == "America/New_York"
+    assert "agents:" in row["action_flow_yaml"]
+
+
+def test_quick_create_playbook_every_trigger(temp_db_path, agent_profile):
+    rc = _run(
+        "playbook",
+        [
+            "health-audit",
+            "--every",
+            "6h",
+            "--playbook",
+            "health-audit",
+            "--arg",
+            "project=lionagi",
+        ],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("health-audit"))
+    assert row["action_kind"] == "play"
+    assert row["action_playbook"] == "health-audit"
+    assert row["trigger_type"] == "interval"
+    assert row["interval_sec"] == 6 * 3600
+    assert json.loads(row["resolved_target"])["target"]["args"] == {"project": "lionagi"}
+
+
+def test_quick_create_command_argv_form(temp_db_path, agent_profile, monkeypatch):
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    rc = _run(
+        "command",
+        ["refresh", "--every", "15m", "--", "refresh-index", "full"],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("refresh"))
+    assert row["action_kind"] == "command"
+    assert row["action_command"] == "refresh-index"
+    assert row["action_command_args"] == ["full"]
+
+
+# ---------------------------------------------------------------------------
+# --once sugar
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_once_is_max_runs_one(temp_db_path, agent_profile):
+    rc = _run(
+        "agent",
+        ["once-job", "--profile", "reviewer", "--prompt", "hi", "--every", "1h", "--once"],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("once-job"))
+    assert row["max_runs"] == 1
+
+
+def test_quick_create_once_and_max_runs_mutually_exclusive(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        [
+            "conflict",
+            "--profile",
+            "reviewer",
+            "--prompt",
+            "hi",
+            "--every",
+            "1h",
+            "--once",
+            "--max-runs",
+            "5",
+        ],
+    )
+    assert rc == 1
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Trigger validation failure surfaces -- each rejects with zero DB writes
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_bad_cron_expression_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        [
+            "bad-cron",
+            "--profile",
+            "reviewer",
+            "--prompt",
+            "hi",
+            "--cron",
+            "not a cron",
+            "--timezone",
+            "UTC",
+        ],
+    )
+    assert rc == 1
+    assert "cron" in capsys.readouterr().err.lower()
+    assert asyncio.run(_get_or_none("bad-cron")) is None
+
+
+def test_quick_create_cron_missing_timezone_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        ["missing-tz", "--profile", "reviewer", "--prompt", "hi", "--cron", "0 2 * * *"],
+    )
+    assert rc == 1
+    assert "--timezone" in capsys.readouterr().err
+
+
+def test_quick_create_space_separated_at_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        [
+            "space-at",
+            "--profile",
+            "reviewer",
+            "--prompt",
+            "hi",
+            "--at",
+            "2026-07-15 09:00:00-04:00",
+        ],
+    )
+    assert rc == 1
+    assert "RFC 3339" in capsys.readouterr().err
+
+
+def test_quick_create_zero_duration_every_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        ["zero-every", "--profile", "reviewer", "--prompt", "hi", "--every", "0m"],
+    )
+    assert rc == 1
+    assert "positive" in capsys.readouterr().err
+
+
+def test_quick_create_malformed_github_filter_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run(
+        "agent",
+        [
+            "bad-gh",
+            "--profile",
+            "reviewer",
+            "--prompt",
+            "hi",
+            "--github",
+            "owner/repo",
+            "--github-filter",
+            '{"bogus": true}',
+        ],
+    )
+    assert rc == 1
+    assert "unknown key" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Command target: never a shell string
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_command_requires_trailing_separator(temp_db_path, agent_profile, capsys):
+    rc = _run("command", ["no-sep", "--every", "15m", "refresh-index", "full"])
+    assert rc == 1
+    assert "--" in capsys.readouterr().err
+
+
+def test_quick_create_command_rejects_single_shell_string_token(
+    temp_db_path, agent_profile, monkeypatch, capsys
+):
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    rc = _run(
+        "command",
+        ["shell-like", "--every", "15m", "--", "refresh-index --incremental"],
+    )
+    assert rc == 1
+    assert asyncio.run(_get_or_none("shell-like")) is None
+
+
+# ---------------------------------------------------------------------------
+# Name qualification: <project>/<name> when a project is detected
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_qualifies_name_with_detected_project(temp_db_path, agent_profile):
+    config_dir = agent_profile / ".lionagi"
+    (config_dir / "config.toml").write_text('[project]\nname = "demo"\n')
+    rc = _run(
+        "agent",
+        ["nightly", "--profile", "reviewer", "--prompt", "hi", "--every", "1h"],
+    )
+    assert rc == 0
+    row = asyncio.run(_get("demo/nightly"))
+    assert row["action_project"] == "demo"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-name collisions (self and cross-owner-from-apply)
+# ---------------------------------------------------------------------------
+
+
+def test_quick_create_duplicate_name_rejected(temp_db_path, agent_profile, capsys):
+    rc = _run("agent", ["dup", "--profile", "reviewer", "--prompt", "hi", "--every", "1h"])
+    assert rc == 0
+    rc2 = _run("agent", ["dup", "--profile", "reviewer", "--prompt", "hi", "--every", "1h"])
+    assert rc2 == 1
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_apply_collides_with_quick_created_schedule(temp_db_path, agent_profile):
+    """A later ScheduleSet apply targeting the same qualified name as a
+    CLI quick-create row must still hit the ownership-collision guard."""
+    from lionagi.studio.services.schedule_declaration import (
+        ScheduleSetError,
+        apply_schedule_set,
+        parse_schedule_set,
+    )
+
+    (agent_profile / ".lionagi" / "config.toml").write_text('[project]\nname = "demo"\n')
+
+    rc = _run("agent", ["nightly", "--profile", "reviewer", "--prompt", "hi", "--every", "1h"])
+    assert rc == 0
+    assert asyncio.run(_get_or_none("demo/nightly")) is not None
+
+    manifest = f"""
+apiVersion: lionagi.io/v1alpha1
+kind: ScheduleSet
+metadata:
+  name: automation
+  project: demo
+schedules:
+  nightly:
+    trigger:
+      cron:
+        expression: "0 2 * * *"
+        timezone: America/New_York
+    target:
+      kind: agent
+      profile: reviewer
+      prompt: "check things"
+    execution:
+      cwd: {agent_profile}
+"""
+    doc = parse_schedule_set(manifest)
+
+    async def _apply():
+        async with StateDB() as db:
+            await apply_schedule_set(db, doc, agent_profile)
+
+    with pytest.raises(ScheduleSetError):
+        asyncio.run(_apply())
+
+
+# ---------------------------------------------------------------------------
+# Additive compatibility: the legacy flat `create` form is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_create_dispatch_unaffected_by_quick_create_kinds(monkeypatch):
+    """`li schedule create NAME ...` (NAME not a reserved kind token) must
+    still be routed to the legacy HTTP-backed _cmd_create, not quick-create."""
+    import lionagi.studio.cli as schedule_cli
+    from lionagi.cli.main import main
+
+    captured = {}
+
+    def fake_api(path, method="GET", body=None):
+        captured.update(path=path, method=method, body=body)
+        return {"id": "legacy-id", "name": body.get("name") if body else None}
+
+    monkeypatch.setattr(schedule_cli, "_api", fake_api)
+    rc = main(["schedule", "create", "my-legacy-sched", "--cron", "0 * * * *", "--prompt", "ping"])
+    assert rc == 0
+    assert captured["method"] == "POST"
+    assert captured["body"]["name"] == "my-legacy-sched"
+
+
+def test_quick_create_kind_tokens_reserved_from_legacy_positional(monkeypatch):
+    """A quick-create kind token as the first arg after 'create' is always
+    routed to typed quick-create, even without further matching flags --
+    this is the documented additive-compatibility tradeoff."""
+    import lionagi.studio.cli as schedule_cli
+
+    called = {}
+    monkeypatch.setattr(
+        schedule_cli,
+        "run_schedule_quick_create",
+        lambda kind, argv: called.update(kind=kind, argv=argv) or 0,
+    )
+    from lionagi.cli.main import main
+
+    rc = main(
+        ["schedule", "create", "agent", "foo", "--profile", "x", "--prompt", "y", "--every", "1h"]
+    )
+    assert rc == 0
+    assert called["kind"] == "agent"
+    assert called["argv"] == ["foo", "--profile", "x", "--prompt", "y", "--every", "1h"]


### PR DESCRIPTION
## Summary

Adds typed per-kind quick-create subcommands to `li schedule create`: `agent`, `flow`, `playbook`, and `command`. Each kind gets its own flag surface (e.g. `--profile`/`--prompt` for agent, `--file` for flow, trailing `-- argv...` for command) and compiles into a `ScheduleMember` that runs through the same resolve/validation path as the declaration layer — no second flags-only data model, no forked validation.

- Exactly one trigger flag required: `--at` (RFC3339, mandatory offset and T separator), `--cron` (requires `--timezone`, IANA), `--every` (strict positive duration), or `--github`.
- Shared policy flags: `--cwd`, `--once` (sugar for max-runs 1) / `--max-runs`, overlap/missed-fire policy, budget, rate-limit, `--description`, `--disabled`.
- Persisted rows carry `managed_by='cli'`, `owner_key=NULL`, and the same resolved snapshot/digest/timezone and fire-time fields as declaration-applied rows (`at` → next_fire_at + max_runs=1; flow → flow_yaml snapshot; cron → resolved_timezone).
- Command targets take literal argv after `--` (split before argparse), never a shell string.
- `--cwd` defaults to the invocation cwd (a project set's default remains the project root).

## Compatibility decision

The legacy `li schedule create` flag form keeps working unchanged. Dispatch is intercepted in `cli/main.py` before argparse parses the schedule tree: only `li schedule create <kind> ...` where `<kind>` is one of the four quick-create kinds routes to the new parsers. Known tradeoff (documented in code): a legacy schedule literally named `agent`, `flow`, `playbook`, or `command` would route to the typed parser — those names are now reserved tokens for the create subcommand.

## Testing

- 19 new tests covering per-kind happy paths (row fields incl. managed_by, snapshot, digest, fire-time fields), each trigger validation failure surface, `--once` sugar, argv command form, legacy-form regression, and ownership collision with a later declaration apply.
- Full suite: 14113 passed, 15 skipped; one pre-existing order-dependent failure unrelated to this change (#2291).

## Deferred (separate PRs, same design)

Terminal notify forwarding, `schedule export`, and `--adopt` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)