### PR TITLE
feat(state,studio): terminal notify forwarding for declared schedules

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2447,6 +2447,7 @@ class StateDB:
                 project, threshold_config, last_alert_at,
                 spec_version, managed_by, owner_key, authored_spec,
                 resolved_target, resolved_digest, resolved_timezone,
+                notify_on, notify_command,
                 created_at, updated_at)
                VALUES (:id, :name, :description, :enabled, :trigger_type,
                        :cron_expr, :interval_sec, :github_repo, :github_filter,
@@ -2460,6 +2461,7 @@ class StateDB:
                        :project, :threshold_config, :last_alert_at,
                        :spec_version, :managed_by, :owner_key, :authored_spec,
                        :resolved_target, :resolved_digest, :resolved_timezone,
+                       :notify_on, :notify_command,
                        :created_at, :updated_at)"""
         ).bindparams(
             bindparam("github_filter", type_=JSON),
@@ -2471,6 +2473,7 @@ class StateDB:
             bindparam("threshold_config", type_=JSON),
             bindparam("authored_spec", type_=JSON),
             bindparam("resolved_target", type_=JSON),
+            bindparam("notify_on", type_=JSON),
         )
         params = {
             "id": schedule["id"],
@@ -2515,6 +2518,8 @@ class StateDB:
             "resolved_target": schedule.get("resolved_target"),
             "resolved_digest": schedule.get("resolved_digest"),
             "resolved_timezone": schedule.get("resolved_timezone"),
+            "notify_on": schedule.get("notify_on"),
+            "notify_command": schedule.get("notify_command"),
             "created_at": schedule.get("created_at", now),
             "updated_at": schedule.get("updated_at", now),
         }
@@ -2662,6 +2667,8 @@ class StateDB:
             "resolved_target",
             "resolved_digest",
             "resolved_timezone",
+            "notify_on",
+            "notify_command",
         }
     )
 
@@ -2694,6 +2701,7 @@ class StateDB:
             "threshold_config",
             "authored_spec",
             "resolved_target",
+            "notify_on",
         }
         fields = dict(fields)
         fields["updated_at"] = time.time()
@@ -4845,6 +4853,7 @@ class StateDB:
             "action_args",
             "threshold_config",
             "rate_limit",
+            "notify_on",
             "artifact_contract_json",
             "artifact_verification_json",
             "status_evidence_refs",

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -487,6 +487,12 @@ CREATE TABLE IF NOT EXISTS schedules (
   resolved_target     JSON,
   resolved_digest     TEXT,
   resolved_timezone   TEXT,
+  -- Terminal notification (declaration-layer `notify`): registers the
+  -- existing run terminal-callback machinery on the invocation this
+  -- schedule spawns, filtered to notify_on. Replaces on_fail for
+  -- declaration-managed schedules; NULL/empty means no callback.
+  notify_on           JSON,
+  notify_command      TEXT,
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL
 );

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -552,6 +552,11 @@ schedules = Table(
     Column("resolved_target", JSON),
     Column("resolved_digest", Text),
     Column("resolved_timezone", Text),
+    # Terminal notification: registers the existing run terminal-callback
+    # machinery on the spawned invocation, filtered to notify_on. NULL means
+    # no callback.
+    Column("notify_on", JSON),
+    Column("notify_command", Text),
     Column("created_at", Float, nullable=False),
     Column("updated_at", Float, nullable=False),
 )

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -121,6 +121,9 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("resolved_target", "JSON"),
         ("resolved_digest", "TEXT"),
         ("resolved_timezone", "TEXT"),
+        # Terminal notification: filtered callback on the spawned invocation.
+        ("notify_on", "JSON"),
+        ("notify_command", "TEXT"),
     ],
     "schedule_runs": [
         # ADR-0057: schedule_runs originally had no updated_at.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1800,28 +1800,34 @@ class SchedulerEngine:
         notify_scope = _register_schedule_notify(
             inv_id, schedule.get("notify_on"), schedule.get("notify_command")
         )
-        # Record what was actually sent, not the raw {{var}} template: the
-        # operator-facing invocation should show the substituted prompt.
-        rendered_prompt = _subprocess.render_action_prompt(schedule, trigger_context)
-        await self._svc.create_invocation(
-            {
-                "id": inv_id,
-                "skill": f"scheduled:{schedule['name']}",
-                "plugin": schedule["trigger_type"],
-                # An explicit None check (not `or`) matters here: a template
-                # can render to "" (e.g. an empty trigger_context value),
-                # which build_argv sends to the child as-is. Falling back to
-                # action_playbook on an empty-but-rendered prompt would
-                # persist a value that differs from what was actually sent.
-                "prompt": (
-                    rendered_prompt
-                    if rendered_prompt is not None
-                    else schedule.get("action_playbook")
-                ),
-                "started_at": now,
-                "status": "running",
-            }
-        )
+        try:
+            # Record what was actually sent, not the raw {{var}} template: the
+            # operator-facing invocation should show the substituted prompt.
+            rendered_prompt = _subprocess.render_action_prompt(schedule, trigger_context)
+            await self._svc.create_invocation(
+                {
+                    "id": inv_id,
+                    "skill": f"scheduled:{schedule['name']}",
+                    "plugin": schedule["trigger_type"],
+                    # An explicit None check (not `or`) matters here: a template
+                    # can render to "" (e.g. an empty trigger_context value),
+                    # which build_argv sends to the child as-is. Falling back to
+                    # action_playbook on an empty-but-rendered prompt would
+                    # persist a value that differs from what was actually sent.
+                    "prompt": (
+                        rendered_prompt
+                        if rendered_prompt is not None
+                        else schedule.get("action_playbook")
+                    ),
+                    "started_at": now,
+                    "status": "running",
+                }
+            )
+        except BaseException:
+            # No invocation row exists yet, so no terminal transition can
+            # ever fire for this registration; drop it before propagating.
+            _unregister_schedule_notify(notify_scope)
+            raise
 
         try:
             # kind='command' spawns an allow-listed executable directly, never
@@ -1877,8 +1883,11 @@ class SchedulerEngine:
                 supersedes_run_id=supersedes_run_id,
             )
             if not written_occurrence:
-                _unregister_schedule_notify(notify_scope)
+                # Abandon writes the invocation's cancelled terminal status;
+                # unregister only afterwards so a declared notify on that
+                # status still fires.
                 await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
+                _unregister_schedule_notify(notify_scope)
                 return
             if rate_limit_claim is not None:
                 # The durable row now accounts for this fire across process

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1847,113 +1847,115 @@ class SchedulerEngine:
             )
         except Exception as exc:
             _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
-            _end_time = time.time()
-            next_at = self._compute_next_fire(schedule, now)
-            failed_schedule_fields: dict[str, Any] = {"last_fired_at": now}
-            failed_schedule_fields.update(self._next_fire_field(schedule, next_at))
-            failed_schedule_fields.update(
-                self._threshold_alert_update_fields(schedule, chain_depth, now)
-            )
-            if extra_schedule_fields:
-                failed_schedule_fields.update(extra_schedule_fields)
-            # Occurrence-insert + cursor-advance atomic even on this
-            # invalid-action failure path -- otherwise a permanently
-            # misconfigured github_poll schedule would never advance its
-            # cursor past the offending event and re-fail it forever.
-            # (A recovery re-fire skips the cursor advance and is instead
-            # atomic with tombstoning the orphan it supersedes -- see
-            # _write_occurrence()'s docstring.)
-            written_occurrence = await self._write_occurrence(
-                {
-                    "id": run_id,
-                    "schedule_id": sid,
-                    "invocation_id": inv_id,
-                    "trigger_context": trigger_context,
-                    "action_kind": schedule.get("action_kind"),
-                    "action_args": [],
-                    "status": "failed",
-                    "chain_parent_id": chain_parent_id,
-                    "chain_depth": chain_depth,
-                    "fired_at": now,
-                    "ended_at": _end_time,
-                    "error_detail": str(exc),
-                },
-                schedule_id=sid,
-                schedule_fields=failed_schedule_fields,
-                supersedes_run_id=supersedes_run_id,
-            )
-            if not written_occurrence:
-                # Abandon writes the invocation's cancelled terminal status;
-                # unregister only afterwards so a declared notify on that
-                # status still fires -- but always unregister, even when the
-                # abandon write itself fails.
-                try:
+            # The notify unregister lives in this handler's own finally:
+            # every exit (including a failing terminal write below) drops
+            # the registration, and any terminal write that does land
+            # happens inside the try, before the unregister.
+            try:
+                _end_time = time.time()
+                next_at = self._compute_next_fire(schedule, now)
+                failed_schedule_fields: dict[str, Any] = {"last_fired_at": now}
+                failed_schedule_fields.update(self._next_fire_field(schedule, next_at))
+                failed_schedule_fields.update(
+                    self._threshold_alert_update_fields(schedule, chain_depth, now)
+                )
+                if extra_schedule_fields:
+                    failed_schedule_fields.update(extra_schedule_fields)
+                # Occurrence-insert + cursor-advance atomic even on this
+                # invalid-action failure path -- otherwise a permanently
+                # misconfigured github_poll schedule would never advance its
+                # cursor past the offending event and re-fail it forever.
+                # (A recovery re-fire skips the cursor advance and is instead
+                # atomic with tombstoning the orphan it supersedes -- see
+                # _write_occurrence()'s docstring.)
+                written_occurrence = await self._write_occurrence(
+                    {
+                        "id": run_id,
+                        "schedule_id": sid,
+                        "invocation_id": inv_id,
+                        "trigger_context": trigger_context,
+                        "action_kind": schedule.get("action_kind"),
+                        "action_args": [],
+                        "status": "failed",
+                        "chain_parent_id": chain_parent_id,
+                        "chain_depth": chain_depth,
+                        "fired_at": now,
+                        "ended_at": _end_time,
+                        "error_detail": str(exc),
+                    },
+                    schedule_id=sid,
+                    schedule_fields=failed_schedule_fields,
+                    supersedes_run_id=supersedes_run_id,
+                )
+                if not written_occurrence:
+                    # Abandon writes the invocation's cancelled terminal
+                    # status; the enclosing finally unregisters only after
+                    # it, so a declared notify on that status still fires.
                     await self._abandon_superseded_recovery_fire(
                         inv_id, orphan_id=supersedes_run_id
                     )
-                finally:
-                    _unregister_schedule_notify(notify_scope)
-                return
-            if rate_limit_claim is not None:
-                # The durable row now accounts for this fire across process
-                # restarts; keeping the in-memory reservation would count it twice.
-                rate_limit_claim.release()
-            written = await self._svc.update_status(
-                "schedule_run",
-                run_id,
-                new_status="failed",
-                reason_code=RunReasons.FAILED_EXCEPTION,
-                reason_summary=f"{type(exc).__name__}: {exc}",
-                evidence_refs=[{"kind": "schedule", "id": sid}],
-                source="executor",
-                actor=run_id,
-                metadata={"exception_class": type(exc).__name__},
-            )
-            if written:
-                await self._dispatch_signal(
-                    build_schedule_run_signal(
-                        entity_id=run_id,
-                        new_status="failed",
-                        reason_code=RunReasons.FAILED_EXCEPTION,
-                        schedule_id=sid,
-                        action_kind=schedule.get("action_kind", ""),
-                        chain_depth=chain_depth,
-                        trigger_context=trigger_context,
-                        error_detail=f"{type(exc).__name__}: {exc}",
+                    return
+                if rate_limit_claim is not None:
+                    # The durable row now accounts for this fire across process
+                    # restarts; keeping the in-memory reservation would count it twice.
+                    rate_limit_claim.release()
+                written = await self._svc.update_status(
+                    "schedule_run",
+                    run_id,
+                    new_status="failed",
+                    reason_code=RunReasons.FAILED_EXCEPTION,
+                    reason_summary=f"{type(exc).__name__}: {exc}",
+                    evidence_refs=[{"kind": "schedule", "id": sid}],
+                    source="executor",
+                    actor=run_id,
+                    metadata={"exception_class": type(exc).__name__},
+                )
+                if written:
+                    await self._dispatch_signal(
+                        build_schedule_run_signal(
+                            entity_id=run_id,
+                            new_status="failed",
+                            reason_code=RunReasons.FAILED_EXCEPTION,
+                            schedule_id=sid,
+                            action_kind=schedule.get("action_kind", ""),
+                            chain_depth=chain_depth,
+                            trigger_context=trigger_context,
+                            error_detail=f"{type(exc).__name__}: {exc}",
+                        )
                     )
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                    self._svc, inv_id, fallback_status="failed", exception=exc
                 )
-            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
-                self._svc, inv_id, fallback_status="failed", exception=exc
-            )
-            await self._svc.update_invocation(inv_id, ended_at=_end_time)
-            inv_written = await self._guarded_terminal_status(
-                "invocation",
-                inv_id,
-                new_status=inv_status,
-                reason_code=inv_rc,
-                reason_summary=inv_rs,
-                evidence_refs=inv_ev,
-                source="executor",
-                actor=inv_id,
-                metadata=inv_meta,
-            )
-            if inv_written:
-                await flush_run_telemetry(
-                    self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                await self._svc.update_invocation(inv_id, ended_at=_end_time)
+                inv_written = await self._guarded_terminal_status(
+                    "invocation",
+                    inv_id,
+                    new_status=inv_status,
+                    reason_code=inv_rc,
+                    reason_summary=inv_rs,
+                    evidence_refs=inv_ev,
+                    source="executor",
+                    actor=inv_id,
+                    metadata=inv_meta,
                 )
-            else:
-                # Another finalizer already wrote this invocation's terminal
-                # status, so no flush happens here -- but a schedule_run
-                # signal was still minted onto the bus above. Drop its
-                # counters now instead of letting them sit in the bus's
-                # per-run_id map forever (it never gets a second flush call
-                # for this run_id to consume them).
-                self._signal_bus.pop_run_counters(run_id)
-            # last_fired_at/next_fire_at (and any extra_schedule_fields)
-            # already landed atomically with the occurrence insert above.
-            await self._check_max_runs(schedule, chain_depth)
-            _unregister_schedule_notify(notify_scope)
-            return
+                if inv_written:
+                    await flush_run_telemetry(
+                        self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                    )
+                else:
+                    # Another finalizer already wrote this invocation's terminal
+                    # status, so no flush happens here -- but a schedule_run
+                    # signal was still minted onto the bus above. Drop its
+                    # counters now instead of letting them sit in the bus's
+                    # per-run_id map forever (it never gets a second flush call
+                    # for this run_id to consume them).
+                    self._signal_bus.pop_run_counters(run_id)
+                # last_fired_at/next_fire_at (and any extra_schedule_fields)
+                # already landed atomically with the occurrence insert above.
+                await self._check_max_runs(schedule, chain_depth)
+                return
+            finally:
+                _unregister_schedule_notify(notify_scope)
 
         # Ensure the flow_yaml tmp file is removed on any exception or
         # cancellation in the DB ops below, before spawn_and_wait() runs.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1956,6 +1956,14 @@ class SchedulerEngine:
                 return
             finally:
                 _unregister_schedule_notify(notify_scope)
+        except BaseException:
+            # Cancellation (or any other non-Exception) during action setup
+            # is not an invalid action: propagate it untouched. This window
+            # sits before the main try/finally below, so the registration
+            # must be dropped here; no invocation terminal write has
+            # happened yet on this path.
+            _unregister_schedule_notify(notify_scope)
+            raise
 
         # Ensure the flow_yaml tmp file is removed on any exception or
         # cancellation in the DB ops below, before spawn_and_wait() runs.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1885,9 +1885,14 @@ class SchedulerEngine:
             if not written_occurrence:
                 # Abandon writes the invocation's cancelled terminal status;
                 # unregister only afterwards so a declared notify on that
-                # status still fires.
-                await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
-                _unregister_schedule_notify(notify_scope)
+                # status still fires -- but always unregister, even when the
+                # abandon write itself fails.
+                try:
+                    await self._abandon_superseded_recovery_fire(
+                        inv_id, orphan_id=supersedes_run_id
+                    )
+                finally:
+                    _unregister_schedule_notify(notify_scope)
                 return
             if rate_limit_claim is not None:
                 # The durable row now accounts for this fire across process

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -16,6 +16,8 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from lionagi.ln.concurrency import ExceptionGroup
+from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS, RunTerminalEnvelope
+from lionagi.state.lifecycle.notify_settings import build_handler, resolve_notify_config
 from lionagi.state.reasons import RunReasons, ScheduleReasons
 from lionagi.studio.scheduler import subprocess as _subprocess
 from lionagi.studio.scheduler import threshold as _threshold
@@ -43,6 +45,42 @@ _TICK_INTERVAL = 30  # seconds
 # this many deferrals (the first deferral always emits), so sustained
 # saturation doesn't spam schedule_runs.
 _DEFERRED_RECORD_EVERY = 10
+
+
+def _register_schedule_notify(
+    inv_id: str, notify_on: list[str] | None, notify_command: str | None
+) -> str | None:
+    """Register the declared ``notify`` command on the invocation this fire
+    spawns, scoped to *inv_id* and filtered to *notify_on* -- reuses the
+    existing terminal-callback registry (the same machinery `li agent
+    --notify` registers on its own session), never a second callback path.
+    Returns the registration name to pass to ``_unregister_schedule_notify``
+    in a ``finally``, or ``None`` if this schedule has no notify declared.
+    """
+    if not notify_on or not notify_command:
+        return None
+    resolved = resolve_notify_config(override=notify_command)
+    if resolved is None:
+        return None
+    handler = build_handler(resolved)
+    if handler is None:
+        return None
+    allowed = frozenset(notify_on)
+
+    async def _filtered(envelope: RunTerminalEnvelope) -> None:
+        if envelope.terminal_status in allowed:
+            await handler(envelope)
+
+    name = f"notify.schedule.invocation.{inv_id}"
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        name, _filtered, kinds=["invocation"], ids=[inv_id], override=True
+    )
+    return name
+
+
+def _unregister_schedule_notify(name: str | None) -> None:
+    if name is not None:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(name)
 
 
 class _MaxRunsClaim:
@@ -1755,6 +1793,13 @@ class SchedulerEngine:
         now = time.time()
 
         inv_id = uuid.uuid4().hex[:12]
+        # Registered before the invocation can possibly reach a terminal
+        # status, unregistered on every exit path below (including the
+        # early build_argv-failure return) so a matching registration never
+        # outlives this fire.
+        notify_scope = _register_schedule_notify(
+            inv_id, schedule.get("notify_on"), schedule.get("notify_command")
+        )
         # Record what was actually sent, not the raw {{var}} template: the
         # operator-facing invocation should show the substituted prompt.
         rendered_prompt = _subprocess.render_action_prompt(schedule, trigger_context)
@@ -1832,6 +1877,7 @@ class SchedulerEngine:
                 supersedes_run_id=supersedes_run_id,
             )
             if not written_occurrence:
+                _unregister_schedule_notify(notify_scope)
                 await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
                 return
             if rate_limit_claim is not None:
@@ -1892,6 +1938,7 @@ class SchedulerEngine:
             # last_fired_at/next_fire_at (and any extra_schedule_fields)
             # already landed atomically with the occurrence insert above.
             await self._check_max_runs(schedule, chain_depth)
+            _unregister_schedule_notify(notify_scope)
             return
 
         # Ensure the flow_yaml tmp file is removed on any exception or
@@ -2213,6 +2260,7 @@ class SchedulerEngine:
                 self._signal_bus.pop_run_counters(run_id)
             await self._check_max_runs(schedule, chain_depth)
         finally:
+            _unregister_schedule_notify(notify_scope)
             if chain_depth == 0:
                 self._running.pop(sid, None)
             if _tmp_path is not None:

--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -26,12 +26,15 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lionagi._paths import _find_git_root
-from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES, StateDB
+from lionagi.state.db import INVOCATION_TERMINAL_STATUSES, StateDB
 
 SPEC_VERSION = "lionagi.io/v1alpha1"
 SPEC_KIND = "ScheduleSet"
 
-_NOTIFY_ALLOWED_STATUSES = frozenset(SCHEDULE_RUN_TERMINAL_STATUSES) | {"completed"}
+# notify fires on the spawned invocation's own terminal transition (see
+# _register_schedule_notify in scheduler/engine.py), so the status filter is
+# validated against the invocation vocabulary, not the schedule_run one.
+_NOTIFY_ALLOWED_STATUSES = frozenset(INVOCATION_TERMINAL_STATUSES)
 
 
 # ---------------------------------------------------------------------------
@@ -174,18 +177,32 @@ class Policies(BaseModel):
 
 
 class Notify(BaseModel):
+    """Registers the existing run terminal-callback machinery on the
+    invocation this schedule spawns, filtered to `on`. Replaces on_fail --
+    follow-up work belongs in a flow, not a notification command."""
+
     model_config = ConfigDict(extra="forbid")
-    on: list[str] = Field(default_factory=list)
+    on: list[str]
     command: str
 
     @model_validator(mode="after")
-    def _known_statuses(self) -> Notify:
+    def _valid_on(self) -> Notify:
+        if not self.on:
+            raise ValueError("notify.on must not be empty")
         unknown = sorted(set(self.on) - _NOTIFY_ALLOWED_STATUSES)
         if unknown:
             raise ValueError(
                 f"notify.on has unknown status value(s) {unknown}; allowed: "
                 f"{sorted(_NOTIFY_ALLOWED_STATUSES)}"
             )
+        if len(self.on) != len(set(self.on)):
+            raise ValueError(f"notify.on must not contain duplicate statuses, got {self.on!r}")
+        return self
+
+    @model_validator(mode="after")
+    def _valid_command(self) -> Notify:
+        if not self.command.strip():
+            raise ValueError("notify.command must not be empty")
         return self
 
 
@@ -495,6 +512,8 @@ def _to_db_fields(
         "budget_tokens": member.policies.budget.tokens if member.policies.budget else None,
         "rate_limit": member.policies.rateLimit,
         "description": member.description,
+        "notify_on": member.notify.on if member.notify else None,
+        "notify_command": member.notify.command if member.notify else None,
         # Cleared up-front so a re-apply that changes trigger/target kind
         # doesn't leave a stale value from the previous kind behind.
         "cron_expr": None,

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -647,6 +647,8 @@ _SCHEDULE_DETAIL_KEYS = sorted(
         "missed_fire_policy",
         "name",
         "next_fire_at",
+        "notify_command",
+        "notify_on",
         "on_fail",
         "on_success",
         "overlap_policy",

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -217,8 +217,8 @@ def test_member_level_chain_fields_rejected(chain_field):
         ScheduleSetDocument.model_validate(base)
 
 
-def test_notify_unknown_status_rejected():
-    base = {
+def _notify_manifest(notify: dict) -> dict:
+    return {
         "apiVersion": "lionagi.io/v1alpha1",
         "kind": "ScheduleSet",
         "metadata": {"name": "a", "project": "demo"},
@@ -226,12 +226,48 @@ def test_notify_unknown_status_rejected():
             "m": {
                 "trigger": {"every": "1h"},
                 "target": {"kind": "command", "executable": "x"},
-                "notify": {"on": ["not_a_real_status"], "command": "notify-run"},
+                "notify": notify,
             }
         },
     }
+
+
+def test_notify_unknown_status_rejected():
+    base = _notify_manifest({"on": ["not_a_real_status"], "command": "notify-run"})
     with pytest.raises(ValidationError):
         ScheduleSetDocument.model_validate(base)
+
+
+def test_notify_empty_on_rejected():
+    base = _notify_manifest({"on": [], "command": "notify-run"})
+    with pytest.raises(ValidationError, match="notify.on"):
+        ScheduleSetDocument.model_validate(base)
+
+
+def test_notify_empty_command_rejected():
+    base = _notify_manifest({"on": ["failed"], "command": "   "})
+    with pytest.raises(ValidationError, match="notify.command"):
+        ScheduleSetDocument.model_validate(base)
+
+
+def test_notify_duplicate_status_rejected():
+    base = _notify_manifest({"on": ["failed", "failed"], "command": "notify-run"})
+    with pytest.raises(ValidationError, match="duplicate"):
+        ScheduleSetDocument.model_validate(base)
+
+
+def test_notify_extra_key_rejected():
+    base = _notify_manifest({"on": ["failed"], "command": "notify-run", "bogus": 1})
+    with pytest.raises(ValidationError):
+        ScheduleSetDocument.model_validate(base)
+
+
+def test_notify_valid_accepted():
+    base = _notify_manifest(
+        {"on": ["failed", "timed_out"], "command": "notify-run --payload {payload}"}
+    )
+    doc = ScheduleSetDocument.model_validate(base)
+    assert doc.schedules["m"].notify.on == ["failed", "timed_out"]
 
 
 def _policies_manifest(policies_yaml: str, cwd: Path) -> str:
@@ -858,6 +894,34 @@ async def test_apply_updates_in_place_preserving_id(temp_db_path, agent_profile)
         row2 = await db.get_schedule_by_name("demo/nightly")
         assert row2["id"] == row1["id"]
         assert row2["action_prompt"] == "check other things"
+
+
+@pytest.mark.asyncio
+async def test_apply_persists_notify_and_digest_reacts_to_it(temp_db_path, agent_profile):
+    no_notify = parse_schedule_set(_agent_manifest("nightly", cwd=agent_profile))
+    async with StateDB() as db:
+        await apply_schedule_set(db, no_notify, agent_profile)
+        row1 = await db.get_schedule_by_name("demo/nightly")
+        assert row1["notify_on"] is None
+        assert row1["notify_command"] is None
+
+        with_notify = parse_schedule_set(
+            _agent_manifest(
+                "nightly",
+                cwd=agent_profile,
+                extra_member='    notify:\n      "on": [failed, timed_out]\n      command: notify-run --payload {payload}\n',
+            )
+        )
+        result2 = await apply_schedule_set(db, with_notify, agent_profile)
+        assert (result2.created, result2.updated, result2.unchanged) == (0, 1, 0)
+        row2 = await db.get_schedule_by_name("demo/nightly")
+        assert row2["id"] == row1["id"]
+        assert row2["notify_on"] == ["failed", "timed_out"]
+        assert row2["notify_command"] == "notify-run --payload {payload}"
+
+        # Re-applying the identical notify-bearing doc is UNCHANGED.
+        result3 = await apply_schedule_set(db, with_notify, agent_profile)
+        assert (result3.created, result3.updated, result3.unchanged) == (0, 0, 1)
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the schedule declaration `notify` fire path: registering
+the existing terminal-callback machinery on a scheduled invocation, scoped
+to that invocation's id and filtered to the declared status list."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi.state.lifecycle.callbacks import (
+    DEFAULT_TERMINAL_CALLBACKS,
+    EntityRef,
+    RunTerminalEnvelope,
+)
+from lionagi.studio.scheduler.engine import _register_schedule_notify, _unregister_schedule_notify
+
+
+def _envelope(inv_id: str, status: str) -> RunTerminalEnvelope:
+    return RunTerminalEnvelope(
+        event_id=uuid.uuid4().hex,
+        entity=EntityRef(kind="invocation", id=inv_id),
+        previous_status="running",
+        terminal_status=status,
+        reason_code="test",
+        occurred_at=time.time(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    DEFAULT_TERMINAL_CALLBACKS.clear()
+
+
+def test_no_notify_declared_registers_nothing():
+    assert _register_schedule_notify("inv-1", None, None) is None
+    assert _register_schedule_notify("inv-1", [], "notify-run") is None
+    assert _register_schedule_notify("inv-1", ["failed"], "") is None
+
+
+@pytest.mark.asyncio
+async def test_status_in_on_fires_command(tmp_path):
+    marker = tmp_path / "fired.json"
+    inv_id = f"inv-{uuid.uuid4().hex[:8]}"
+    command = f"python3 -c \"import sys,json,pathlib; pathlib.Path(r'{marker}').write_text(sys.stdin.read())\""
+    name = _register_schedule_notify(inv_id, ["failed", "timed_out"], command)
+    assert name is not None
+    try:
+        await DEFAULT_TERMINAL_CALLBACKS.emit(_envelope(inv_id, "failed"))
+    finally:
+        _unregister_schedule_notify(name)
+
+    payload = json.loads(marker.read_text())
+    assert payload["entity"]["id"] == inv_id
+    assert payload["terminal_status"] == "failed"
+    # The engine unregisters in a `finally` right after the one terminal
+    # transition an invocation ever has -- mirrored here by the test's own
+    # finally block above, so the scope is gone once we get here.
+    assert name not in DEFAULT_TERMINAL_CALLBACKS
+
+
+@pytest.mark.asyncio
+async def test_status_not_in_on_does_not_fire(tmp_path):
+    marker = tmp_path / "fired.json"
+    inv_id = f"inv-{uuid.uuid4().hex[:8]}"
+    command = f"python3 -c \"import pathlib; pathlib.Path(r'{marker}').write_text('fired')\""
+    name = _register_schedule_notify(inv_id, ["failed"], command)
+    try:
+        await DEFAULT_TERMINAL_CALLBACKS.emit(_envelope(inv_id, "completed"))
+    finally:
+        _unregister_schedule_notify(name)
+
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_callback_failure_does_not_raise_or_alter_outcome():
+    """A failing notify adapter (nonexistent binary) is swallowed by the
+    shared terminal-callback machinery -- emit() must never raise, and the
+    envelope this test constructs represents the run's already-decided
+    outcome, which the callback has no way to touch."""
+    inv_id = f"inv-{uuid.uuid4().hex[:8]}"
+    name = _register_schedule_notify(inv_id, ["failed"], "definitely-not-a-real-executable-xyz")
+    try:
+        envelope = _envelope(inv_id, "failed")
+        await DEFAULT_TERMINAL_CALLBACKS.emit(envelope)
+        assert envelope.terminal_status == "failed"
+    finally:
+        _unregister_schedule_notify(name)
+
+
+@pytest.mark.asyncio
+async def test_unregistered_scope_never_fires():
+    inv_id = f"inv-{uuid.uuid4().hex[:8]}"
+    name = _register_schedule_notify(inv_id, ["failed"], "true")
+    _unregister_schedule_notify(name)
+    # No exception, no registration left to match against.
+    await DEFAULT_TERMINAL_CALLBACKS.emit(_envelope(inv_id, "failed"))
+    assert name not in DEFAULT_TERMINAL_CALLBACKS

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -233,6 +233,58 @@ async def test_abandonment_failure_still_unregisters():
 
 
 @pytest.mark.asyncio
+async def test_invalid_argv_terminal_write_failure_still_unregisters():
+    """On the invalid-action path with an accepted occurrence write, a
+    failing schedule_run terminal write must not leak the registration."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    svc.update_status = AsyncMock(side_effect=RuntimeError("terminal write failed"))
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=RuntimeError("bad argv"),
+        ),
+        pytest.raises(RuntimeError, match="terminal write failed"),
+    ):
+        await engine._fire_inner(
+            _notify_schedule(),
+            "run-notify-4",
+            trigger_context={"scheduled": True},
+        )
+
+    assert _notify_registration_names() == []
+
+
+@pytest.mark.asyncio
+async def test_occurrence_write_failure_on_invalid_argv_still_unregisters():
+    """Same path, one step earlier: the occurrence write itself failing must
+    not leak the registration either."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=RuntimeError("occurrence failed"))
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=RuntimeError("bad argv"),
+        ),
+        pytest.raises(RuntimeError, match="occurrence failed"),
+    ):
+        await engine._fire_inner(
+            _notify_schedule(),
+            "run-notify-5",
+            trigger_context={"scheduled": True},
+        )
+
+    assert _notify_registration_names() == []
+
+
+@pytest.mark.asyncio
 async def test_create_invocation_failure_does_not_leak_registration():
     """An exception before the invocation row exists must drop the notify
     registration on the way out instead of leaving it in the process-wide

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -285,6 +285,36 @@ async def test_occurrence_write_failure_on_invalid_argv_still_unregisters():
 
 
 @pytest.mark.asyncio
+async def test_cancellation_during_action_setup_still_unregisters():
+    """CancelledError from action setup is not an Exception: it must
+    propagate untouched (not be recorded as an invalid action) and still
+    drop the registration."""
+    import asyncio
+
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=asyncio.CancelledError(),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await engine._fire_inner(
+            _notify_schedule(),
+            "run-notify-6",
+            trigger_context={"scheduled": True},
+        )
+
+    assert _notify_registration_names() == []
+    # Propagated as cancellation, not converted into a failed-run write.
+    assert not svc.update_status.await_args_list
+
+
+@pytest.mark.asyncio
 async def test_create_invocation_failure_does_not_leak_registration():
     """An exception before the invocation row exists must drop the notify
     registration on the way out instead of leaving it in the process-wide

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -206,6 +206,33 @@ async def test_abandoned_recovery_unregisters_only_after_terminal_write():
 
 
 @pytest.mark.asyncio
+async def test_abandonment_failure_still_unregisters():
+    """If the abandon write itself fails, the registration must not leak."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    svc.tombstone_and_replace_schedule_run = AsyncMock(return_value=False)
+    svc.update_invocation = AsyncMock(side_effect=RuntimeError("db down"))
+    engine = SchedulerEngine(svc=svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=RuntimeError("bad argv"),
+        ),
+        pytest.raises(RuntimeError, match="db down"),
+    ):
+        await engine._fire_inner(
+            _notify_schedule(),
+            "run-notify-3",
+            trigger_context={"scheduled": True},
+            supersedes_run_id="orphan-3",
+        )
+
+    assert _notify_registration_names() == []
+
+
+@pytest.mark.asyncio
 async def test_create_invocation_failure_does_not_leak_registration():
     """An exception before the invocation row exists must drop the notify
     registration on the way out instead of leaving it in the process-wide

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -104,3 +104,123 @@ async def test_unregistered_scope_never_fires():
     # No exception, no registration left to match against.
     await DEFAULT_TERMINAL_CALLBACKS.emit(_envelope(inv_id, "failed"))
     assert name not in DEFAULT_TERMINAL_CALLBACKS
+
+
+# ---------------------------------------------------------------------------
+# _fire_inner registration-lifetime regressions (mock service level)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+
+def _notify_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-notify",
+        "name": "notify-sched",
+        "enabled": 1,
+        "trigger_type": "interval",
+        "trigger_interval_secs": 60,
+        "trigger_cron": None,
+        "trigger_at": None,
+        "next_fire_at": None,
+        "last_fired_at": None,
+        "max_runs": None,
+        "action_kind": "agent",
+        "action_agent": "default",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+        "notify_on": ["cancelled"],
+        "notify_command": "true",
+    }
+    base.update(overrides)
+    return base
+
+
+def _notify_registration_names() -> list[str]:
+    return [
+        n
+        for n in DEFAULT_TERMINAL_CALLBACKS._registrations
+        if n.startswith("notify.schedule.invocation.")
+    ]
+
+
+def _make_engine_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_abandoned_recovery_unregisters_only_after_terminal_write():
+    """A rejected superseded-recovery fire finalizes its invocation as
+    cancelled; the notify registration must still be present at that write
+    (so a declared notify on 'cancelled' can fire) and gone afterwards."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    # Force the pre-spawn exception branch, then reject the recovery
+    # occurrence write (orphan no longer qualifies) so the fire takes the
+    # abandoned-superseded-recovery exit.
+    svc.tombstone_and_replace_schedule_run = AsyncMock(return_value=False)
+    registered_at_terminal_write: list[bool] = []
+
+    async def _update_status(entity_type, entity_id, **kwargs):
+        if entity_type == "invocation" and kwargs.get("new_status") == "cancelled":
+            registered_at_terminal_write.append(bool(_notify_registration_names()))
+        return True
+
+    svc.update_status = AsyncMock(side_effect=_update_status)
+    engine = SchedulerEngine(svc=svc)
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=RuntimeError("bad argv"),
+    ):
+        await engine._fire(
+            _notify_schedule(),
+            "run-notify-1",
+            trigger_context={"scheduled": True},
+            supersedes_run_id="orphan-1",
+        )
+
+    assert registered_at_terminal_write == [True]
+    assert _notify_registration_names() == []
+
+
+@pytest.mark.asyncio
+async def test_create_invocation_failure_does_not_leak_registration():
+    """An exception before the invocation row exists must drop the notify
+    registration on the way out instead of leaving it in the process-wide
+    registry forever."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_engine_svc()
+    svc.create_invocation = AsyncMock(side_effect=RuntimeError("db down"))
+    engine = SchedulerEngine(svc=svc)
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await engine._fire_inner(
+            _notify_schedule(),
+            "run-notify-2",
+            trigger_context={"scheduled": True},
+        )
+
+    assert _notify_registration_names() == []


### PR DESCRIPTION
## Summary

A ScheduleSet member may now declare `notify: {on: [...], command: ...}`, forwarding the run's terminal transition to a command via the **existing** terminal-callback machinery — the same registry `li agent --notify` uses. No second callback path.

- **Model**: `Notify.on` requires a non-empty, duplicate-free list validated against the invocation terminal-status vocabulary (fixes the previously-landed model validating against the schedule-run vocabulary, which wrongly allowed `skipped` and rejected `aborted`/`completed_empty` — the callback fires on the invocation entity). `command` rejects blank strings. Closed schema.
- **Persistence**: additive `notify_on` (JSON) / `notify_command` (TEXT) columns on `schedules`, following the declaration-layer column pattern (schema.sql + schema_meta + migrations + db.py insert/update/decode wiring). Digest includes notify, so an edit produces UPDATE, not UNCHANGED.
- **Fire path**: when the engine fires a schedule carrying notify, it registers a status-filtered wrapper around the standard notify handler on the terminal-callback registry, scoped to the spawned invocation's id, and unregisters it on every exit path. The lifecycle service emits the terminal envelope synchronously after the status commit, so the callback runs at most once per invocation terminal transition and its failure never touches the run's own outcome. All four target kinds are covered since the engine finalizes invocation terminal status uniformly.
- Replaces `on_fail` for declaration-managed schedules; legacy/quick-create `on_success`/`on_fail` columns untouched.

## Testing

15 new/extended cases: model validation surfaces, apply persistence + digest UPDATE/UNCHANGED sensitivity, and a fire-path suite proving status-in-`on` fires, status-not-in-`on` doesn't, adapter failure never raises or alters outcome, and unregistered scopes never fire. Full suite: 14112 passed; one pre-existing order-dependent failure unrelated to this change (#2291). Post-merge-with-main focused scope (including quick-create tests): 1617 passed.

## Known limitation

YAML 1.1 implicit booleans mean a bare `on:` key parses as `True`; authors must quote it (`"on":`). Filed separately as #2300.

## Deferred (separate PRs, same design)

`schedule export` and `--adopt` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)