### PR TITLE
fix(state): decode authored_spec/resolved_target in schedule row reads

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4854,6 +4854,8 @@ class StateDB:
             "threshold_config",
             "rate_limit",
             "notify_on",
+            "authored_spec",
+            "resolved_target",
             "artifact_contract_json",
             "artifact_verification_json",
             "status_evidence_refs",

--- a/tests/cli/test_schedule_quick_create.py
+++ b/tests/cli/test_schedule_quick_create.py
@@ -8,7 +8,6 @@ surfaces, and additive compatibility with the legacy flat create form."""
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 
 import pytest
@@ -94,10 +93,7 @@ def test_quick_create_agent_at_trigger(temp_db_path, agent_profile, capsys):
     assert row["next_fire_at"] is not None
     assert row["action_cwd"] == str(agent_profile)
     assert row["resolved_digest"]
-    # resolved_target/authored_spec are stored as JSON text and are not in
-    # StateDB._row_to_dict's decode allowlist (a pre-existing gap shared by
-    # the ScheduleSet apply path, out of scope here) -- decode explicitly.
-    assert json.loads(row["resolved_target"])["target"]["kind"] == "agent"
+    assert row["resolved_target"]["target"]["kind"] == "agent"
 
 
 def test_quick_create_agent_prompt_file(temp_db_path, agent_profile):
@@ -165,7 +161,7 @@ def test_quick_create_playbook_every_trigger(temp_db_path, agent_profile):
     assert row["action_playbook"] == "health-audit"
     assert row["trigger_type"] == "interval"
     assert row["interval_sec"] == 6 * 3600
-    assert json.loads(row["resolved_target"])["target"]["args"] == {"project": "lionagi"}
+    assert row["resolved_target"]["target"]["args"] == {"project": "lionagi"}
 
 
 def test_quick_create_command_argv_form(temp_db_path, agent_profile, monkeypatch):

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -878,6 +878,21 @@ async def test_apply_is_idempotent_on_double_apply(temp_db_path, agent_profile):
 
 
 @pytest.mark.asyncio
+async def test_get_schedule_decodes_authored_spec_and_resolved_target(temp_db_path, agent_profile):
+    """The JSON columns written by apply must come back as decoded objects
+    from every schedule getter, consistent with the rest of the row shape."""
+    doc = parse_schedule_set(_agent_manifest("nightly", cwd=agent_profile))
+    async with StateDB() as db:
+        await apply_schedule_set(db, doc, agent_profile)
+        by_name = await db.get_schedule_by_name("demo/nightly")
+        assert isinstance(by_name["authored_spec"], dict)
+        assert isinstance(by_name["resolved_target"], dict)
+        by_id = await db.get_schedule(by_name["id"])
+        assert isinstance(by_id["authored_spec"], dict)
+        assert isinstance(by_id["resolved_target"], dict)
+
+
+@pytest.mark.asyncio
 async def test_apply_updates_in_place_preserving_id(temp_db_path, agent_profile):
     doc = parse_schedule_set(_agent_manifest("nightly", cwd=agent_profile))
     async with StateDB() as db:


### PR DESCRIPTION
Closes #2296. `StateDB._row_to_dict`'s JSON-decode allowlist omitted the two JSON columns the declaration layer writes, so `get_schedule`/`get_schedule_by_name` returned them as raw JSON strings while every other JSON column came back decoded. Adds both to the allowlist plus a round-trip regression (apply → both getters return dicts; fails without the fix). Declaration suite (67) and tests/state (733) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)