### PR TITLE
feat(studio,cli): li schedule export — legacy conversion and declaration re-export

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -10,6 +10,7 @@ import contextlib
 import json
 import math
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1229,9 +1230,18 @@ def _cmd_apply_set(args: argparse.Namespace) -> int:
     return 1 if has_errors else 0
 
 
+# Distinct from 0 (clean success) and 1 (hard failure, e.g. an unreadable
+# input file elsewhere in this CLI); mirrors the EXIT_UNKNOWN=2 "ambiguous,
+# needs attention" convention used by `li status`/`li monitor`/`li wait` --
+# the document and report are still emitted exactly as on a clean export.
+EXIT_EXPORT_PARTIAL = 2
+
+
 def _cmd_export(args: argparse.Namespace) -> int:
-    """`li schedule export` — convert rows into a ScheduleSet document.
-    Read-only: never opens a write transaction against the database."""
+    """`li schedule export` — convert rows into ScheduleSet document(s), one
+    per distinct project when the export spans more than one. Read-only:
+    never opens a write transaction against the database. Exit code 2 (not
+    0/1) when any row was BLOCKED -- see EXIT_EXPORT_PARTIAL."""
     from lionagi.state.db import StateDB
     from lionagi.studio.services.schedule_export import (
         build_managed_export_document,
@@ -1261,14 +1271,21 @@ def _cmd_export(args: argparse.Namespace) -> int:
                 )
             return build_managed_export_document([r for r in rows if is_managed_row(r)])
 
-    doc, lines = asyncio.run(_run())
-    yaml_text = dump_schedule_set_yaml(doc)
+    docs, lines = asyncio.run(_run())
 
     if output_path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(yaml_text)
+        if len(docs) == 1:
+            output_path.write_text(dump_schedule_set_yaml(docs[0]))
+        else:
+            # Mixed-project export: one file per project, suffixed with its
+            # project so none collide and none silently overwrite `--output`.
+            for doc in docs:
+                token = re.sub(r"[^a-zA-Z0-9_.-]", "_", doc.metadata.project)
+                sibling = output_path.with_name(f"{output_path.stem}.{token}{output_path.suffix}")
+                sibling.write_text(dump_schedule_set_yaml(doc))
     else:
-        print(yaml_text, end="")
+        print("\n---\n".join(dump_schedule_set_yaml(doc) for doc in docs), end="")
 
     report_text = format_report(lines)
     if args.report:
@@ -1278,7 +1295,8 @@ def _cmd_export(args: argparse.Namespace) -> int:
     else:
         print(report_text, file=sys.stderr, end="")
 
-    return 0
+    has_blocked = any(line.status == "BLOCKED" for line in lines)
+    return EXIT_EXPORT_PARTIAL if has_blocked else 0
 
 
 # ---------------------------------------------------------------------------
@@ -1925,7 +1943,17 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog=(
             "Examples:\n"
             "  li schedule export --legacy --output schedules.yaml\n"
-            "  li schedule export --output schedules.yaml"
+            "  li schedule export --output schedules.yaml\n"
+            "\n"
+            "Exit codes: 0 all rows READY, 2 some rows BLOCKED (document and "
+            "report are still emitted -- see stderr/--report), 1 hard failure.\n"
+            "A row spanning multiple projects is split into one document per "
+            "project so every original qualified name round-trips exactly; "
+            "with --output, extra projects are written to sibling "
+            "<name>.<project>.yaml files.\n"
+            "An exported flow target's snapshot file is an absolute host "
+            "path -- the document only re-applies on this host, or after "
+            "the sidecar file moves with it."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1229,6 +1229,58 @@ def _cmd_apply_set(args: argparse.Namespace) -> int:
     return 1 if has_errors else 0
 
 
+def _cmd_export(args: argparse.Namespace) -> int:
+    """`li schedule export` — convert rows into a ScheduleSet document.
+    Read-only: never opens a write transaction against the database."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedule_export import (
+        build_managed_export_document,
+        convert_legacy_rows,
+        dump_schedule_set_yaml,
+        format_report,
+        is_legacy_row,
+        is_managed_row,
+    )
+
+    output_path = Path(args.output).resolve() if args.output else None
+    manifest_dir = output_path.parent if output_path else Path.cwd()
+    flows_dir = (
+        manifest_dir / f"{output_path.stem}.flows"
+        if output_path
+        else manifest_dir / "exported-flows"
+    )
+
+    async def _run():
+        async with StateDB() as db:
+            rows = await db.list_schedules(limit=1_000_000)
+            if args.legacy:
+                return convert_legacy_rows(
+                    [r for r in rows if is_legacy_row(r)],
+                    flows_dir=flows_dir,
+                    manifest_dir=manifest_dir,
+                )
+            return build_managed_export_document([r for r in rows if is_managed_row(r)])
+
+    doc, lines = asyncio.run(_run())
+    yaml_text = dump_schedule_set_yaml(doc)
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(yaml_text)
+    else:
+        print(yaml_text, end="")
+
+    report_text = format_report(lines)
+    if args.report:
+        report_path = Path(args.report)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report_text)
+    else:
+        print(report_text, file=sys.stderr, end="")
+
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Typed quick-create — `li schedule create <kind> <name> ...`
 #
@@ -1866,6 +1918,38 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
     )
     apply_p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON.")
 
+    # export
+    export_p = sched_sub.add_parser(
+        "export",
+        help="Convert schedules into a ScheduleSet document (never writes the database).",
+        epilog=(
+            "Examples:\n"
+            "  li schedule export --legacy --output schedules.yaml\n"
+            "  li schedule export --output schedules.yaml"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    export_p.add_argument(
+        "--legacy",
+        action="store_true",
+        help=(
+            "Convert chain-free legacy rows (managed_by is null, i.e. rows "
+            "predating the declaration layer) instead of declaration/cli-"
+            "managed rows. A row with on_success/on_fail is reported BLOCKED "
+            "and omitted."
+        ),
+    )
+    export_p.add_argument(
+        "--output",
+        metavar="PATH",
+        help="Write the ScheduleSet YAML here (default: stdout).",
+    )
+    export_p.add_argument(
+        "--report",
+        metavar="PATH",
+        help="Write the human-readable conversion report here (default: stderr).",
+    )
+
     # enable / disable / delete
     for sub_name, sub_help, example in (
         ("enable", "Enable a schedule.", "li schedule enable sched-abc123"),
@@ -1970,6 +2054,7 @@ _ACTION_MAP = {
     "status": _cmd_status,
     "validate": _cmd_validate_set,
     "apply": _cmd_apply_set,
+    "export": _cmd_export,
 }
 
 
@@ -1979,7 +2064,7 @@ def run_schedule(args: argparse.Namespace) -> int:
     if fn is None:
         print(
             "Usage: li schedule <subcommand>  (list|get|limits|create|enable|disable|"
-            "trigger|delete|runs|run|status|validate|apply)"
+            "trigger|delete|runs|run|status|validate|apply|export)"
         )
         return 1
     if action == "runs" and not (1 <= args.limit <= 200):

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from lionagi.cli._logging import warn
+from lionagi.cli._logging import log_error, warn
 from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES
 
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
@@ -1279,9 +1279,22 @@ def _cmd_export(args: argparse.Namespace) -> int:
             output_path.write_text(dump_schedule_set_yaml(docs[0]))
         else:
             # Mixed-project export: one file per project, suffixed with its
-            # project so none collide and none silently overwrite `--output`.
+            # project so none silently overwrite `--output`. The sanitizer is
+            # not injective (foo/bar and foo:bar both become foo_bar), so
+            # collisions are rejected before ANY sibling is written rather
+            # than letting the last document win.
+            tokens: dict[str, str] = {}
             for doc in docs:
                 token = re.sub(r"[^a-zA-Z0-9_.-]", "_", doc.metadata.project)
+                if token in tokens:
+                    log_error(
+                        f"cannot export: projects {tokens[token]!r} and "
+                        f"{doc.metadata.project!r} both sanitize to sibling file "
+                        f"token {token!r}; export to stdout or rename a project"
+                    )
+                    return 1
+                tokens[token] = doc.metadata.project
+            for doc, token in zip(docs, tokens, strict=True):
                 sibling = output_path.with_name(f"{output_path.stem}.{token}{output_path.suffix}")
                 sibling.write_text(dump_schedule_set_yaml(doc))
     else:

--- a/lionagi/studio/services/schedule_export.py
+++ b/lionagi/studio/services/schedule_export.py
@@ -18,6 +18,7 @@ Two modes, both never touching the database:
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -137,7 +138,15 @@ def _rename_note(row: dict[str, Any], base_name: str) -> str | None:
 
 
 def _ready_note(row: dict[str, Any], member: ScheduleMember, base_name: str) -> str | None:
-    notes = [n for n in (_rename_note(row, base_name), _flow_portability_note(member)) if n]
+    notes = [
+        n
+        for n in (
+            _rename_note(row, base_name),
+            _flow_portability_note(member),
+            _absolute_cwd_note(member),
+        )
+        if n
+    ]
     return "; ".join(notes) or None
 
 
@@ -203,7 +212,7 @@ def _flow_snapshot_path(flows_dir: Path, qualified_name: str) -> Path:
     return flows_dir / f"{safe}.flow.yaml"
 
 
-def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
+def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path, manifest_dir: Path) -> Target:
     kind = row.get("action_kind")
     if kind not in _CONVERTIBLE_ACTION_KINDS:
         raise ValueError(f"action_kind {kind!r} has no v1 target equivalent -- not exportable")
@@ -245,7 +254,18 @@ def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
         flows_dir.mkdir(parents=True, exist_ok=True)
         path = _flow_snapshot_path(flows_dir, row["name"])
         path.write_text(content)
-        return FlowTarget(kind="flow", file=str(path.resolve()), inputs={})
+        # The document is designed to be committed to a repo, so the sidecar
+        # reference must not embed this host's filesystem layout. A relative
+        # path re-resolves against the manifest dir on apply, exactly like a
+        # hand-authored declaration.
+        try:
+            rel = os.path.relpath(path.resolve(), manifest_dir.resolve())
+        except ValueError as exc:
+            raise ValueError(
+                f"flow snapshot at {path} cannot be expressed relative to the "
+                f"output directory {manifest_dir}: {exc}"
+            ) from exc
+        return FlowTarget(kind="flow", file=rel, inputs={})
     # kind == "command"
     executable = row.get("action_command")
     if not executable:
@@ -254,9 +274,11 @@ def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
     return CommandTarget(kind="command", executable=executable, args=args)
 
 
-def _build_legacy_member(row: dict[str, Any], *, flows_dir: Path) -> ScheduleMember:
+def _build_legacy_member(
+    row: dict[str, Any], *, flows_dir: Path, manifest_dir: Path
+) -> ScheduleMember:
     trigger = _convert_legacy_trigger(row)
-    target = _convert_legacy_target(row, flows_dir=flows_dir)
+    target = _convert_legacy_target(row, flows_dir=flows_dir, manifest_dir=manifest_dir)
     execution = Execution(
         cwd=row.get("action_cwd") or None, project=row.get("action_project") or None
     )
@@ -285,17 +307,37 @@ def _build_legacy_member(row: dict[str, Any], *, flows_dir: Path) -> ScheduleMem
 
 
 def _flow_portability_note(member: ScheduleMember) -> str | None:
-    """Every exported ``flow`` target names an absolute host path (the
-    snapshot file, whether freshly written by legacy conversion or simply
-    re-validated from an already-typed authored_spec) -- disclose that the
-    resulting document only re-applies on this host, or after the sidecar
-    file is moved alongside it and the path rewritten."""
+    """Disclose how an exported ``flow`` target's snapshot file travels.
+    Legacy conversion writes the sidecar itself and references it relative to
+    the manifest dir, so the pair commits and moves together; a re-exported
+    authored_spec may still carry an absolute path the author wrote, which
+    makes the document host-bound and is called out loudly."""
     if member.target.kind != "flow":
         return None
+    file = member.target.file
+    if Path(file).is_absolute():
+        return (
+            f"flow snapshot is an absolute host path ({file}); this "
+            "document is host-bound until the sidecar file moves with it"
+        )
     return (
-        f"flow snapshot is an absolute host path ({member.target.file}); this "
-        "document is host-bound until the sidecar file moves with it"
+        f"flow snapshot sidecar at {file} (relative to this document); "
+        "commit and move the sidecar together with the document"
     )
+
+
+def _absolute_cwd_note(member: ScheduleMember) -> str | None:
+    """An absolute ``execution.cwd`` is kept verbatim -- a schedule's working
+    directory is machine-local by design, like a cron entry -- but a document
+    meant to be committed must not carry host paths silently, so the report
+    line flags every one written."""
+    cwd = member.execution.cwd if member.execution else None
+    if cwd and Path(cwd).is_absolute():
+        return (
+            f"execution.cwd is an absolute host path ({cwd}); kept verbatim, "
+            "review before committing this document"
+        )
+    return None
 
 
 def _group_into_documents(
@@ -380,7 +422,7 @@ def convert_legacy_rows(
             )
             continue
         try:
-            member = _build_legacy_member(row, flows_dir=flows_dir)
+            member = _build_legacy_member(row, flows_dir=flows_dir, manifest_dir=manifest_dir)
         except ValueError as exc:
             lines.append(ExportReportLine(name, "BLOCKED", str(exc)))
             continue

--- a/lionagi/studio/services/schedule_export.py
+++ b/lionagi/studio/services/schedule_export.py
@@ -95,26 +95,50 @@ def _pick_project(rows: list[dict[str, Any]], fallback: str) -> str:
 def _member_key(row: dict[str, Any], doc_project: str, used: set[str]) -> str:
     """The document's schedule-map key for *row*.
 
-    Strips a leading ``"{action_project}/"`` from the row's (globally
-    unique) ``name`` when that prefix matches *doc_project* -- reapplying
-    then reconstructs the identical qualified name
-    (``doc_project/local_name``), which is what lets a single-project export
-    round-trip a row's original identity. Rows whose own project differs
-    from *doc_project*, or whose stripped local name collides with one
-    already used, fall back to the full original name (still unique) so no
-    two members are ever silently merged.
+    Strips a leading ``"{doc_project}/"`` from the row's (globally unique)
+    ``name`` -- reapplying then reconstructs the identical qualified name
+    (``doc_project/local_name``), which is what lets an export round-trip a
+    row's original identity. Grouping (``_group_into_documents``) guarantees
+    a row lands in the document matching its effective project, so the
+    prefix either matches or the name is bare. A stripped local name that
+    collides with one already used falls back to the full original name
+    (still unique) so no two members are ever silently merged.
     """
     name = row["name"]
-    project = row.get("action_project")
-    local = (
-        name[len(project) + 1 :]
-        if project == doc_project and name.startswith(f"{project}/")
-        else name
-    )
+    local = name[len(doc_project) + 1 :] if name.startswith(f"{doc_project}/") else name
     if local in used:
         local = name
     used.add(local)
     return local
+
+
+def _effective_project(row: dict[str, Any]) -> str | None:
+    """The project namespace a row's name lives under: the stored project
+    column when set, else the qualified name's own prefix. Rows created
+    before the project column existed carry qualified names but a NULL
+    column; grouping them by name prefix is what lets their identity
+    round-trip instead of being re-qualified under a fallback project.
+    ``None`` means the name is bare and cannot round-trip untouched (every
+    document carries a project) -- callers disclose the resulting rename."""
+    project = row.get("action_project")
+    if project:
+        return project
+    name = row["name"]
+    return name.split("/", 1)[0] if "/" in name else None
+
+
+def _rename_note(row: dict[str, Any], base_name: str) -> str | None:
+    if _effective_project(row) is not None:
+        return None
+    return (
+        f"row has no project and a bare name; re-applies as "
+        f"{base_name}/{row['name']} (the document's project supplies the namespace)"
+    )
+
+
+def _ready_note(row: dict[str, Any], member: ScheduleMember, base_name: str) -> str | None:
+    notes = [n for n in (_rename_note(row, base_name), _flow_portability_note(member)) if n]
+    return "; ".join(notes) or None
 
 
 def _reusable_target_fields(row: dict[str, Any]) -> dict[str, Any]:
@@ -276,17 +300,19 @@ def _group_into_documents(
     base_name: str,
 ) -> list[ScheduleSetDocument]:
     """Split *ready* rows into one ``ScheduleSet`` document per distinct
-    ``action_project`` (rows with no project share a single *base_name*-keyed
-    group). Grouping *before* computing member keys guarantees a row's own
-    project always matches its document's project, so ``_member_key`` never
-    has to fall back for a project mismatch -- this is what fixes
+    effective project (``_effective_project``: stored column, else the
+    qualified name's prefix; bare-named rows share a single
+    *base_name*-keyed group). Grouping *before* computing member keys
+    guarantees a row's effective project always matches its document's
+    project, so ``_member_key`` never has to fall back for a mismatch --
+    this is what fixes
     mixed-project double-qualification: a single document spanning multiple
     projects used to key a mismatched row by its already-qualified name, and
     re-applying then prepended the document's project a second time,
     producing e.g. ``alpha/beta/task`` instead of ``beta/task``."""
     grouped: dict[str, list[tuple[dict[str, Any], ScheduleMember]]] = {}
     for row, member in ready:
-        proj = row.get("action_project") or base_name
+        proj = _effective_project(row) or base_name
         grouped.setdefault(proj, []).append((row, member))
 
     if not grouped:
@@ -359,7 +385,7 @@ def convert_legacy_rows(
             lines.append(ExportReportLine(name, "BLOCKED", f"static resolution failed: {exc}"))
             continue
         ready.append((row, member))
-        lines.append(ExportReportLine(name, "READY", _flow_portability_note(member)))
+        lines.append(ExportReportLine(name, "READY", _ready_note(row, member, "legacy-export")))
 
     docs = _group_into_documents(ready, rows, base_name="legacy-export")
     return docs, lines
@@ -396,7 +422,7 @@ def build_managed_export_document(
             )
             continue
         ready.append((row, member))
-        lines.append(ExportReportLine(name, "READY", _flow_portability_note(member)))
+        lines.append(ExportReportLine(name, "READY", _ready_note(row, member, "export")))
 
     docs = _group_into_documents(ready, rows, base_name="export")
     return docs, lines

--- a/lionagi/studio/services/schedule_export.py
+++ b/lionagi/studio/services/schedule_export.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Read-only conversion of ``schedules`` rows into a ``ScheduleSet`` document.
+
+Two modes, both never touching the database:
+
+- Legacy conversion (``managed_by IS NULL`` -- rows created before the
+  declaration layer): reconstructs a typed ``ScheduleMember`` per row from
+  its raw ``action_*``/trigger columns, running each candidate through the
+  same ``resolve_member`` static resolution a real ``apply`` would use so a
+  malformed row is caught here rather than emitted half-valid. A row with
+  ``on_success``/``on_fail`` is never converted -- chained follow-up actions
+  have no v1 equivalent and must be redesigned as a flow by hand.
+- Declaration/cli re-export (``managed_by IN ('cli', 'declaration')``):
+  simply re-validates each row's already-typed ``authored_spec`` back into a
+  ``ScheduleMember`` -- there is no structural conversion to do.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from lionagi.studio.services.schedule_declaration import (
+    SPEC_KIND,
+    SPEC_VERSION,
+    AgentTarget,
+    Budget,
+    CommandTarget,
+    CronTrigger,
+    Execution,
+    FlowTarget,
+    GithubTriggerSpec,
+    Notify,
+    PlaybookTarget,
+    Policies,
+    ScheduleMember,
+    ScheduleSetDocument,
+    ScheduleSetMetadata,
+    Target,
+    Trigger,
+    resolve_member,
+)
+
+# managed_by is NULL for every row created before the declaration layer; the
+# schedules.managed_by CHECK constraint never actually admits the literal
+# 'legacy' (only NULL/'cli'/'declaration'), but the predicate accepts it too
+# in case a future migration starts stamping rows explicitly.
+_LEGACY_MANAGED_BY = (None, "legacy")
+_MANAGED_MANAGED_BY = ("cli", "declaration")
+
+# Legacy action_kind -> the v1 target kind it can be expressed as. 'flow'
+# (the `li o flow -- <model> <prompt>` positional launch) and 'fanout' have
+# no v1 target equivalent -- FlowTarget always launches the typed
+# flow-YAML-snapshot path, never the positional one.
+_CONVERTIBLE_ACTION_KINDS = frozenset({"agent", "play", "flow_yaml", "command"})
+
+
+def is_legacy_row(row: dict[str, Any]) -> bool:
+    return row.get("managed_by") in _LEGACY_MANAGED_BY
+
+
+def is_managed_row(row: dict[str, Any]) -> bool:
+    return row.get("managed_by") in _MANAGED_MANAGED_BY
+
+
+@dataclass
+class ExportReportLine:
+    qualified_name: str
+    status: str  # "READY" | "BLOCKED"
+    message: str | None = None
+
+
+def _pick_project(rows: list[dict[str, Any]], fallback: str) -> str:
+    """Deterministic single project for a document collapsing rows that may
+    originally have belonged to different projects/owners: the
+    lexicographically-first non-empty ``action_project`` among the rows, or
+    *fallback* if none carry one. Each member's own ``execution.project`` --
+    set explicitly below from that row's ``action_project`` -- is what
+    actually governs a later re-apply; this value is metadata only."""
+    projects = sorted({row["action_project"] for row in rows if row.get("action_project")})
+    return projects[0] if projects else fallback
+
+
+def _member_key(row: dict[str, Any], doc_project: str, used: set[str]) -> str:
+    """The document's schedule-map key for *row*.
+
+    Strips a leading ``"{action_project}/"`` from the row's (globally
+    unique) ``name`` when that prefix matches *doc_project* -- reapplying
+    then reconstructs the identical qualified name
+    (``doc_project/local_name``), which is what lets a single-project export
+    round-trip a row's original identity. Rows whose own project differs
+    from *doc_project*, or whose stripped local name collides with one
+    already used, fall back to the full original name (still unique) so no
+    two members are ever silently merged.
+    """
+    name = row["name"]
+    project = row.get("action_project")
+    local = (
+        name[len(project) + 1 :]
+        if project == doc_project and name.startswith(f"{project}/")
+        else name
+    )
+    if local in used:
+        local = name
+    used.add(local)
+    return local
+
+
+def _reusable_target_fields(row: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "action_kind",
+        "action_model",
+        "action_prompt",
+        "action_agent",
+        "action_playbook",
+        "action_command",
+        "action_command_args",
+        "action_flow_yaml",
+    )
+    return {k: row[k] for k in keys if row.get(k) not in (None, "", [])}
+
+
+def _convert_legacy_trigger(row: dict[str, Any]) -> Trigger:
+    kind = row.get("trigger_type")
+    if kind == "cron":
+        expr = row.get("cron_expr")
+        if not expr:
+            raise ValueError("trigger_type='cron' row has no cron_expr")
+        # Legacy rows never persisted a timezone (that field is new with the
+        # declaration layer); UTC is the documented default for conversion.
+        tz = row.get("resolved_timezone") or "UTC"
+        return Trigger(cron=CronTrigger(expression=expr, timezone=tz))
+    if kind == "interval":
+        secs = row.get("interval_sec")
+        if not secs or secs <= 0:
+            raise ValueError(f"trigger_type='interval' row has invalid interval_sec={secs!r}")
+        return Trigger(every=f"{int(secs)}s")
+    if kind == "at":
+        epoch = row.get("next_fire_at")
+        if not epoch:
+            raise ValueError(
+                "trigger_type='at' row has no next_fire_at to reconstruct the "
+                "one-shot fire time (already fired or disabled)"
+            )
+        return Trigger(at=datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat())
+    if kind == "github_poll":
+        repo = row.get("github_repo")
+        if not repo:
+            raise ValueError("trigger_type='github_poll' row has no github_repo")
+        return Trigger(github=GithubTriggerSpec(repo=repo, filter=row.get("github_filter")))
+    raise ValueError(f"unsupported trigger_type: {kind!r}")
+
+
+def _flow_snapshot_path(flows_dir: Path, qualified_name: str) -> Path:
+    safe = re.sub(r"[^a-zA-Z0-9_.-]", "_", qualified_name)
+    return flows_dir / f"{safe}.flow.yaml"
+
+
+def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
+    kind = row.get("action_kind")
+    if kind not in _CONVERTIBLE_ACTION_KINDS:
+        raise ValueError(f"action_kind {kind!r} has no v1 target equivalent -- not exportable")
+    if kind == "agent":
+        profile = row.get("action_agent")
+        prompt = row.get("action_prompt")
+        if not profile:
+            raise ValueError(
+                "action_kind='agent' row has no action_agent (profile) to "
+                f"reference; reusable fields: {_reusable_target_fields(row)}"
+            )
+        if not prompt:
+            raise ValueError("action_kind='agent' row has no action_prompt")
+        return AgentTarget(
+            kind="agent", profile=profile, prompt=prompt, model=row.get("action_model")
+        )
+    if kind == "play":
+        name = row.get("action_playbook")
+        if not name:
+            raise ValueError("action_kind='play' row has no action_playbook")
+        return PlaybookTarget(kind="playbook", name=name, args={})
+    if kind == "flow_yaml":
+        content = row.get("action_flow_yaml")
+        if not content:
+            raise ValueError("action_kind='flow_yaml' row has no action_flow_yaml content")
+        flows_dir.mkdir(parents=True, exist_ok=True)
+        path = _flow_snapshot_path(flows_dir, row["name"])
+        path.write_text(content)
+        return FlowTarget(kind="flow", file=str(path.resolve()), inputs={})
+    # kind == "command"
+    executable = row.get("action_command")
+    if not executable:
+        raise ValueError("action_kind='command' row has no action_command")
+    args = [str(a) for a in (row.get("action_command_args") or [])]
+    return CommandTarget(kind="command", executable=executable, args=args)
+
+
+def _build_legacy_member(row: dict[str, Any], *, flows_dir: Path) -> ScheduleMember:
+    trigger = _convert_legacy_trigger(row)
+    target = _convert_legacy_target(row, flows_dir=flows_dir)
+    execution = Execution(
+        cwd=row.get("action_cwd") or None, project=row.get("action_project") or None
+    )
+    has_budget = row.get("budget_usd") is not None or row.get("budget_tokens") is not None
+    policies = Policies(
+        missedFire=row.get("missed_fire_policy") or "skip",
+        overlap=row.get("overlap_policy") or "skip",
+        maxRuns=row.get("max_runs"),
+        budget=Budget(usd=row.get("budget_usd"), tokens=row.get("budget_tokens"))
+        if has_budget
+        else None,
+        rateLimit=row.get("rate_limit"),
+    )
+    notify = None
+    if row.get("notify_on") and row.get("notify_command"):
+        notify = Notify(on=list(row["notify_on"]), command=row["notify_command"])
+    return ScheduleMember(
+        description=row.get("description"),
+        enabled=bool(row.get("enabled", 1)),
+        trigger=trigger,
+        target=target,
+        execution=execution,
+        policies=policies,
+        notify=notify,
+    )
+
+
+def convert_legacy_rows(
+    rows: list[dict[str, Any]], *, flows_dir: Path, manifest_dir: Path
+) -> tuple[ScheduleSetDocument, list[ExportReportLine]]:
+    """Convert every chain-free, expressible legacy row into a member of one
+    ``ScheduleSet`` document. Rows with ``on_success``/``on_fail``, an
+    unsupported action_kind, or a malformed trigger are reported ``BLOCKED``
+    and omitted -- never half-emitted. A row whose own project matches the
+    document's chosen project is keyed by its local (prefix-stripped) name,
+    so re-applying reconstructs its original qualified name exactly; others
+    fall back to the full original name (see ``_member_key``)."""
+    project = _pick_project(rows, "legacy-export")
+    schedules: dict[str, ScheduleMember] = {}
+    lines: list[ExportReportLine] = []
+    used_keys: set[str] = set()
+    for row in sorted(rows, key=lambda r: r["name"]):
+        name = row["name"]
+        if row.get("on_success") or row.get("on_fail"):
+            lines.append(
+                ExportReportLine(
+                    name,
+                    "BLOCKED",
+                    "dependency conversion required (on_success/on_fail present); "
+                    f"reusable target fields: {_reusable_target_fields(row)}",
+                )
+            )
+            continue
+        try:
+            member = _build_legacy_member(row, flows_dir=flows_dir)
+        except ValueError as exc:
+            lines.append(ExportReportLine(name, "BLOCKED", str(exc)))
+            continue
+        try:
+            resolve_member(name, member, manifest_dir=manifest_dir, project=None, is_global=False)
+        except ValueError as exc:
+            lines.append(ExportReportLine(name, "BLOCKED", f"static resolution failed: {exc}"))
+            continue
+        schedules[_member_key(row, project, used_keys)] = member
+        lines.append(ExportReportLine(name, "READY"))
+
+    doc = ScheduleSetDocument(
+        apiVersion=SPEC_VERSION,
+        kind=SPEC_KIND,
+        metadata=ScheduleSetMetadata(name="legacy-export", project=project),
+        schedules=schedules,
+    )
+    return doc, lines
+
+
+def build_managed_export_document(
+    rows: list[dict[str, Any]],
+) -> tuple[ScheduleSetDocument, list[ExportReportLine]]:
+    """Re-serialize every declaration/cli-managed row's persisted
+    ``authored_spec`` back into a single ``ScheduleSet`` document. A row
+    whose own project matches the document's chosen project is keyed by its
+    local (prefix-stripped) name so re-applying reconstructs its original
+    qualified name; others fall back to the full original name (see
+    ``_member_key``)."""
+    project = _pick_project(rows, "export")
+    schedules: dict[str, ScheduleMember] = {}
+    lines: list[ExportReportLine] = []
+    used_keys: set[str] = set()
+    for row in sorted(rows, key=lambda r: r["name"]):
+        name = row["name"]
+        authored = row.get("authored_spec")
+        if not isinstance(authored, dict):
+            lines.append(ExportReportLine(name, "BLOCKED", "row has no authored_spec to re-export"))
+            continue
+        authored = dict(authored)
+        execution = dict(authored.get("execution") or {})
+        if not execution.get("project") and row.get("action_project"):
+            execution["project"] = row["action_project"]
+        authored["execution"] = execution
+        try:
+            member = ScheduleMember.model_validate(authored)
+        except Exception as exc:  # noqa: BLE001 - reported per-row, never raised
+            lines.append(
+                ExportReportLine(name, "BLOCKED", f"authored_spec failed validation: {exc}")
+            )
+            continue
+        schedules[_member_key(row, project, used_keys)] = member
+        lines.append(ExportReportLine(name, "READY"))
+
+    doc = ScheduleSetDocument(
+        apiVersion=SPEC_VERSION,
+        kind=SPEC_KIND,
+        metadata=ScheduleSetMetadata(name="export", project=project),
+        schedules=schedules,
+    )
+    return doc, lines
+
+
+class _QuotedStr(str):
+    """Marker wrapper: force a double-quoted YAML scalar for this string."""
+
+
+class _ExportDumper(yaml.SafeDumper):
+    pass
+
+
+def _represent_quoted(dumper: yaml.Dumper, data: _QuotedStr) -> yaml.Node:
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data), style='"')
+
+
+_ExportDumper.add_representer(_QuotedStr, _represent_quoted)
+
+
+def _quote_notify_on_keys(obj: Any) -> Any:
+    """YAML 1.1 parses a bare ``on:`` mapping key as the boolean ``True`` --
+    force it quoted wherever it appears as a ``notify`` block's key so the
+    document round-trips as the string ``"on"``."""
+    if isinstance(obj, dict):
+        return {
+            (_QuotedStr(k) if k == "on" else k): _quote_notify_on_keys(v) for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_quote_notify_on_keys(v) for v in obj]
+    return obj
+
+
+def dump_schedule_set_yaml(doc: ScheduleSetDocument) -> str:
+    data = doc.model_dump(mode="json")
+    quoted = _quote_notify_on_keys(data)
+    return yaml.dump(quoted, Dumper=_ExportDumper, sort_keys=True, default_flow_style=False)
+
+
+def format_report(lines: list[ExportReportLine]) -> str:
+    out = [
+        f"{line.status:<8} {line.qualified_name}" + (f"  {line.message}" if line.message else "")
+        for line in lines
+    ]
+    ready = sum(1 for line in lines if line.status == "READY")
+    blocked = sum(1 for line in lines if line.status == "BLOCKED")
+    out.append(f"{ready} ready, {blocked} blocked")
+    return "\n".join(out) + "\n"

--- a/lionagi/studio/services/schedule_export.py
+++ b/lionagi/studio/services/schedule_export.py
@@ -60,6 +60,11 @@ _MANAGED_MANAGED_BY = ("cli", "declaration")
 # flow-YAML-snapshot path, never the positional one.
 _CONVERTIBLE_ACTION_KINDS = frozenset({"agent", "play", "flow_yaml", "command"})
 
+# Mirrors the `schedule.get("poll_interval_sec") or schedule.get("interval_sec")
+# or 300` fallback in scheduler/engine.py -- a github_poll row at this value
+# is indistinguishable from one with no override, so it stays exportable.
+_GITHUB_POLL_DEFAULT_SEC = 300
+
 
 def is_legacy_row(row: dict[str, Any]) -> bool:
     return row.get("managed_by") in _LEGACY_MANAGED_BY
@@ -153,6 +158,13 @@ def _convert_legacy_trigger(row: dict[str, Any]) -> Trigger:
         repo = row.get("github_repo")
         if not repo:
             raise ValueError("trigger_type='github_poll' row has no github_repo")
+        poll_interval = row.get("poll_interval_sec")
+        if poll_interval is not None and poll_interval != _GITHUB_POLL_DEFAULT_SEC:
+            raise ValueError(
+                f"trigger_type='github_poll' row has poll_interval_sec={poll_interval!r} "
+                f"(default {_GITHUB_POLL_DEFAULT_SEC}) but GithubTriggerSpec has no "
+                "poll-interval field to carry a non-default value"
+            )
         return Trigger(github=GithubTriggerSpec(repo=repo, filter=row.get("github_filter")))
     raise ValueError(f"unsupported trigger_type: {kind!r}")
 
@@ -166,6 +178,13 @@ def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
     kind = row.get("action_kind")
     if kind not in _CONVERTIBLE_ACTION_KINDS:
         raise ValueError(f"action_kind {kind!r} has no v1 target equivalent -- not exportable")
+    extra_args = row.get("action_extra_args")
+    if extra_args:
+        raise ValueError(
+            f"action_kind={kind!r} row has action_extra_args={extra_args!r} but no v1 "
+            "target field can carry launch-time extra args -- dropping them would "
+            "silently change fire behavior"
+        )
     if kind == "agent":
         profile = row.get("action_agent")
         prompt = row.get("action_prompt")
@@ -188,6 +207,12 @@ def _convert_legacy_target(row: dict[str, Any], *, flows_dir: Path) -> Target:
         content = row.get("action_flow_yaml")
         if not content:
             raise ValueError("action_kind='flow_yaml' row has no action_flow_yaml content")
+        if row.get("action_model"):
+            raise ValueError(
+                f"action_kind='flow_yaml' row has action_model={row['action_model']!r} set "
+                f"but FlowTarget has no model field to carry it; reusable fields: "
+                f"{_reusable_target_fields(row)}"
+            )
         flows_dir.mkdir(parents=True, exist_ok=True)
         path = _flow_snapshot_path(flows_dir, row["name"])
         path.write_text(content)
@@ -230,20 +255,87 @@ def _build_legacy_member(row: dict[str, Any], *, flows_dir: Path) -> ScheduleMem
     )
 
 
+def _flow_portability_note(member: ScheduleMember) -> str | None:
+    """Every exported ``flow`` target names an absolute host path (the
+    snapshot file, whether freshly written by legacy conversion or simply
+    re-validated from an already-typed authored_spec) -- disclose that the
+    resulting document only re-applies on this host, or after the sidecar
+    file is moved alongside it and the path rewritten."""
+    if member.target.kind != "flow":
+        return None
+    return (
+        f"flow snapshot is an absolute host path ({member.target.file}); this "
+        "document is host-bound until the sidecar file moves with it"
+    )
+
+
+def _group_into_documents(
+    ready: list[tuple[dict[str, Any], ScheduleMember]],
+    all_rows: list[dict[str, Any]],
+    *,
+    base_name: str,
+) -> list[ScheduleSetDocument]:
+    """Split *ready* rows into one ``ScheduleSet`` document per distinct
+    ``action_project`` (rows with no project share a single *base_name*-keyed
+    group). Grouping *before* computing member keys guarantees a row's own
+    project always matches its document's project, so ``_member_key`` never
+    has to fall back for a project mismatch -- this is what fixes
+    mixed-project double-qualification: a single document spanning multiple
+    projects used to key a mismatched row by its already-qualified name, and
+    re-applying then prepended the document's project a second time,
+    producing e.g. ``alpha/beta/task`` instead of ``beta/task``."""
+    grouped: dict[str, list[tuple[dict[str, Any], ScheduleMember]]] = {}
+    for row, member in ready:
+        proj = row.get("action_project") or base_name
+        grouped.setdefault(proj, []).append((row, member))
+
+    if not grouped:
+        return [
+            ScheduleSetDocument(
+                apiVersion=SPEC_VERSION,
+                kind=SPEC_KIND,
+                metadata=ScheduleSetMetadata(
+                    name=base_name, project=_pick_project(all_rows, base_name)
+                ),
+                schedules={},
+            )
+        ]
+
+    multi = len(grouped) > 1
+    docs: list[ScheduleSetDocument] = []
+    for proj in sorted(grouped):
+        used_keys: set[str] = set()
+        schedules: dict[str, ScheduleMember] = {}
+        for row, member in grouped[proj]:
+            schedules[_member_key(row, proj, used_keys)] = member
+        doc_name = f"{base_name}-{proj}" if multi else base_name
+        docs.append(
+            ScheduleSetDocument(
+                apiVersion=SPEC_VERSION,
+                kind=SPEC_KIND,
+                metadata=ScheduleSetMetadata(name=doc_name, project=proj),
+                schedules=schedules,
+            )
+        )
+    return docs
+
+
 def convert_legacy_rows(
     rows: list[dict[str, Any]], *, flows_dir: Path, manifest_dir: Path
-) -> tuple[ScheduleSetDocument, list[ExportReportLine]]:
-    """Convert every chain-free, expressible legacy row into a member of one
-    ``ScheduleSet`` document. Rows with ``on_success``/``on_fail``, an
-    unsupported action_kind, or a malformed trigger are reported ``BLOCKED``
-    and omitted -- never half-emitted. A row whose own project matches the
-    document's chosen project is keyed by its local (prefix-stripped) name,
-    so re-applying reconstructs its original qualified name exactly; others
-    fall back to the full original name (see ``_member_key``)."""
-    project = _pick_project(rows, "legacy-export")
-    schedules: dict[str, ScheduleMember] = {}
+) -> tuple[list[ScheduleSetDocument], list[ExportReportLine]]:
+    """Convert every chain-free, expressible legacy row into a member of a
+    ``ScheduleSet`` document -- one document per distinct project among the
+    rows (see ``_group_into_documents``), so a mixed-project export still
+    round-trips every row's original qualified name exactly. Rows with
+    ``on_success``/``on_fail``, an unsupported action_kind, a legacy-only
+    field with no v1 equivalent (a flow_yaml row's action_model, non-empty
+    action_extra_args, a non-default github poll_interval_sec), or a
+    malformed trigger are reported ``BLOCKED`` and omitted -- never
+    half-emitted. Within each document, a row whose own project matches is
+    keyed by its local (prefix-stripped) name, so re-applying reconstructs
+    its original qualified name exactly (see ``_member_key``)."""
     lines: list[ExportReportLine] = []
-    used_keys: set[str] = set()
+    ready: list[tuple[dict[str, Any], ScheduleMember]] = []
     for row in sorted(rows, key=lambda r: r["name"]):
         name = row["name"]
         if row.get("on_success") or row.get("on_fail"):
@@ -266,31 +358,25 @@ def convert_legacy_rows(
         except ValueError as exc:
             lines.append(ExportReportLine(name, "BLOCKED", f"static resolution failed: {exc}"))
             continue
-        schedules[_member_key(row, project, used_keys)] = member
-        lines.append(ExportReportLine(name, "READY"))
+        ready.append((row, member))
+        lines.append(ExportReportLine(name, "READY", _flow_portability_note(member)))
 
-    doc = ScheduleSetDocument(
-        apiVersion=SPEC_VERSION,
-        kind=SPEC_KIND,
-        metadata=ScheduleSetMetadata(name="legacy-export", project=project),
-        schedules=schedules,
-    )
-    return doc, lines
+    docs = _group_into_documents(ready, rows, base_name="legacy-export")
+    return docs, lines
 
 
 def build_managed_export_document(
     rows: list[dict[str, Any]],
-) -> tuple[ScheduleSetDocument, list[ExportReportLine]]:
+) -> tuple[list[ScheduleSetDocument], list[ExportReportLine]]:
     """Re-serialize every declaration/cli-managed row's persisted
-    ``authored_spec`` back into a single ``ScheduleSet`` document. A row
-    whose own project matches the document's chosen project is keyed by its
-    local (prefix-stripped) name so re-applying reconstructs its original
-    qualified name; others fall back to the full original name (see
-    ``_member_key``)."""
-    project = _pick_project(rows, "export")
-    schedules: dict[str, ScheduleMember] = {}
+    ``authored_spec`` back into ``ScheduleSet`` documents -- one per distinct
+    project among the rows (see ``_group_into_documents``), so a
+    mixed-project export still round-trips every row's original qualified
+    name exactly. Within each document, a row whose own project matches is
+    keyed by its local (prefix-stripped) name so re-applying reconstructs
+    its original qualified name (see ``_member_key``)."""
     lines: list[ExportReportLine] = []
-    used_keys: set[str] = set()
+    ready: list[tuple[dict[str, Any], ScheduleMember]] = []
     for row in sorted(rows, key=lambda r: r["name"]):
         name = row["name"]
         authored = row.get("authored_spec")
@@ -309,16 +395,11 @@ def build_managed_export_document(
                 ExportReportLine(name, "BLOCKED", f"authored_spec failed validation: {exc}")
             )
             continue
-        schedules[_member_key(row, project, used_keys)] = member
-        lines.append(ExportReportLine(name, "READY"))
+        ready.append((row, member))
+        lines.append(ExportReportLine(name, "READY", _flow_portability_note(member)))
 
-    doc = ScheduleSetDocument(
-        apiVersion=SPEC_VERSION,
-        kind=SPEC_KIND,
-        metadata=ScheduleSetMetadata(name="export", project=project),
-        schedules=schedules,
-    )
-    return doc, lines
+    docs = _group_into_documents(ready, rows, base_name="export")
+    return docs, lines
 
 
 class _QuotedStr(str):

--- a/lionagi/studio/services/schedule_export.py
+++ b/lionagi/studio/services/schedule_export.py
@@ -182,12 +182,17 @@ def _convert_legacy_trigger(row: dict[str, Any]) -> Trigger:
         repo = row.get("github_repo")
         if not repo:
             raise ValueError("trigger_type='github_poll' row has no github_repo")
-        poll_interval = row.get("poll_interval_sec")
-        if poll_interval is not None and poll_interval != _GITHUB_POLL_DEFAULT_SEC:
+        # Mirror the engine's full cadence fallback chain: a NULL
+        # poll_interval_sec row with interval_sec set polls at interval_sec
+        # today, so it drifts just as much on re-apply as an explicit value.
+        effective = (
+            row.get("poll_interval_sec") or row.get("interval_sec") or _GITHUB_POLL_DEFAULT_SEC
+        )
+        if effective != _GITHUB_POLL_DEFAULT_SEC:
             raise ValueError(
-                f"trigger_type='github_poll' row has poll_interval_sec={poll_interval!r} "
-                f"(default {_GITHUB_POLL_DEFAULT_SEC}) but GithubTriggerSpec has no "
-                "poll-interval field to carry a non-default value"
+                f"trigger_type='github_poll' row polls every {effective}s "
+                f"(default {_GITHUB_POLL_DEFAULT_SEC}s) but GithubTriggerSpec has no "
+                "poll-interval field to carry a non-default cadence"
             )
         return Trigger(github=GithubTriggerSpec(repo=repo, filter=row.get("github_filter")))
     raise ValueError(f"unsupported trigger_type: {kind!r}")

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -136,6 +136,7 @@ SCHEDULE_SUBCOMMANDS = [
     "runs",
     "run",
     "status",
+    "export",
 ]
 
 SCHEDULE_CREATE_HELP_FLAGS = [

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -248,6 +248,7 @@ SCHEDULE_OBSERVABILITY_SUBCOMMAND_SHAPES = {
     "status": (["--help", "--json", "--wait", "-h"], ["id"]),
     "validate": (["--help", "--json", "-h"], ["file"]),
     "apply": (["--adopt", "--dry-run", "--help", "--json", "-h"], ["file"]),
+    "export": (["--help", "--legacy", "--output", "--report", "-h"], []),
 }
 
 

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li schedule export`: legacy-row conversion (happy path per
+action kind, on_success/on_fail BLOCKED, unsupported action_kind BLOCKED,
+malformed trigger BLOCKED, round-trip through validate+apply to a fresh DB),
+default declaration/cli re-export (authored_spec round-trip incl. a quoted
+notify "on" key, deterministic ordering), and the CLI surface (--output vs
+stdout, never writes the database)."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+pytest.importorskip("croniter", reason="studio extra not installed")
+
+import yaml
+
+from lionagi.state.db import StateDB
+from lionagi.studio.services.schedule_declaration import apply_schedule_set, parse_schedule_set
+from lionagi.studio.services.schedule_export import (
+    build_managed_export_document,
+    convert_legacy_rows,
+    dump_schedule_set_yaml,
+    format_report,
+)
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+@pytest.fixture
+def agent_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A minimal .lionagi/agents/reviewer.md discoverable via cwd; see
+    test_schedule_declaration.py for the identical fixture rationale."""
+    import lionagi.cli._providers as providers_mod
+
+    agents_dir = tmp_path / ".lionagi" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "reviewer.md").write_text("---\nmodel: anthropic/claude-sonnet-5\n---\nBody.\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(providers_mod, "_find_lionagi_dirs", lambda: [agents_dir.parent])
+    return tmp_path
+
+
+async def _create_legacy_row(row: dict) -> None:
+    async with StateDB() as db:
+        await db.create_schedule(row)
+
+
+def _legacy_row(schedule_id: str, name: str, *, cwd: Path, **overrides) -> dict:
+    row = {
+        "id": schedule_id,
+        "name": name,
+        "trigger_type": "cron",
+        "cron_expr": "0 2 * * *",
+        "action_kind": "agent",
+        "action_agent": "reviewer",
+        "action_prompt": "check things",
+        "action_cwd": str(cwd),
+        "enabled": 1,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Legacy conversion — happy path per action kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_agent_row_converts_ready(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(_legacy_row("a1", "demo/nightly", cwd=agent_profile))
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+    assert "demo/nightly" in doc.schedules
+    member = doc.schedules["demo/nightly"]
+    assert member.target.kind == "agent"
+    assert member.target.profile == "reviewer"
+    assert member.target.prompt == "check things"
+
+
+@pytest.mark.asyncio
+async def test_legacy_command_row_converts_ready(temp_db_path, agent_profile, monkeypatch):
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "c1",
+                "demo/refresh",
+                cwd=agent_profile,
+                trigger_type="interval",
+                cron_expr=None,
+                interval_sec=900,
+                action_kind="command",
+                action_agent=None,
+                action_prompt=None,
+                action_command="refresh-index",
+                action_command_args=["incremental"],
+            )
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+    member = doc.schedules["demo/refresh"]
+    assert member.target.kind == "command"
+    assert member.target.executable == "refresh-index"
+    assert member.target.args == ["incremental"]
+    assert member.trigger.every == "900s"
+
+
+@pytest.mark.asyncio
+async def test_legacy_playbook_row_converts_ready(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "p1",
+                "demo/audit",
+                cwd=agent_profile,
+                action_kind="play",
+                action_agent=None,
+                action_prompt=None,
+                action_playbook="health-audit",
+            )
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+    member = doc.schedules["demo/audit"]
+    assert member.target.kind == "playbook"
+    assert member.target.name == "health-audit"
+
+
+@pytest.mark.asyncio
+async def test_legacy_flow_yaml_row_converts_ready(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "f1",
+                "demo/nightly-flow",
+                cwd=agent_profile,
+                trigger_type="interval",
+                cron_expr=None,
+                interval_sec=3600,
+                action_kind="flow_yaml",
+                action_agent=None,
+                action_prompt=None,
+                action_flow_yaml="workers: 2\n",
+            )
+        )
+        rows = await db.list_schedules()
+    flows_dir = agent_profile / "flows"
+    doc, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    assert [line.status for line in lines] == ["READY"]
+    member = doc.schedules["demo/nightly-flow"]
+    assert member.target.kind == "flow"
+    written = Path(member.target.file)
+    assert written.is_file()
+    assert written.read_text() == "workers: 2\n"
+
+
+# ---------------------------------------------------------------------------
+# Legacy conversion — BLOCKED cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_with_on_success_is_blocked_and_omitted(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "b1",
+                "demo/chained",
+                cwd=agent_profile,
+                on_success={"prompt": "notify done"},
+            )
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert len(lines) == 1
+    assert lines[0].status == "BLOCKED"
+    assert "dependency conversion required" in lines[0].message
+    assert "demo/chained" not in doc.schedules
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_with_on_fail_is_blocked_and_omitted(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("b2", "demo/chained-fail", cwd=agent_profile, on_fail={"prompt": "alert"})
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert lines[0].status == "BLOCKED"
+    assert "demo/chained-fail" not in doc.schedules
+
+
+@pytest.mark.asyncio
+async def test_legacy_unsupported_action_kind_is_blocked_and_omitted(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "u1",
+                "demo/unsupported",
+                cwd=agent_profile,
+                action_kind="fanout",
+                action_agent=None,
+                action_prompt=None,
+            )
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert lines[0].status == "BLOCKED"
+    assert "no v1 target equivalent" in lines[0].message
+    assert doc.schedules == {}
+
+
+@pytest.mark.asyncio
+async def test_legacy_malformed_trigger_is_blocked_and_omitted(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("m1", "demo/badcron", cwd=agent_profile, cron_expr="not a cron expr")
+        )
+        rows = await db.list_schedules()
+    doc, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert lines[0].status == "BLOCKED"
+    assert "demo/badcron" not in doc.schedules
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: export legacy -> validate -> apply to a fresh DB -> compare
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_export_round_trips_to_a_fresh_db(tmp_path, monkeypatch, agent_profile):
+    source_db = tmp_path / "source.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", source_db)
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("orig1", "demo/nightly", cwd=agent_profile, action_project="demo")
+        )
+        rows = await db.list_schedules()
+
+    flows_dir = tmp_path / "export.flows"
+    doc, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    assert [line.status for line in lines] == ["READY"]
+
+    output_path = tmp_path / "schedules.yaml"
+    output_path.write_text(dump_schedule_set_yaml(doc))
+
+    # `li schedule validate` re-parses + statically resolves without writing.
+    reparsed = parse_schedule_set(output_path.read_text(), source=str(output_path))
+
+    fresh_db = tmp_path / "fresh.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", fresh_db)
+    async with StateDB() as db:
+        result = await apply_schedule_set(db, reparsed, output_path.parent)
+        assert result.created == 1
+        applied = await db.get_schedule_by_name("demo/nightly")
+    assert applied is not None
+    resolved_target = applied["resolved_target"]["target"]
+    assert resolved_target["kind"] == "agent"
+    assert resolved_target["profile"] == "reviewer"
+    assert resolved_target["prompt"] == "check things"
+    assert resolved_target["model"] == "anthropic/claude-sonnet-5"
+
+
+# ---------------------------------------------------------------------------
+# Default export — authored_spec round-trip incl. quoted notify "on"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_export_round_trips_notify_with_quoted_on_key(temp_db_path, agent_profile):
+    authored_spec = {
+        "description": None,
+        "enabled": True,
+        "trigger": {
+            "cron": {"expression": "0 2 * * *", "timezone": "UTC"},
+            "every": None,
+            "at": None,
+            "github": None,
+        },
+        "target": {"kind": "agent", "profile": "reviewer", "prompt": "check things", "model": None},
+        "execution": {"cwd": str(agent_profile), "project": None},
+        "policies": {
+            "missedFire": "skip",
+            "overlap": "skip",
+            "maxRuns": None,
+            "budget": None,
+            "rateLimit": None,
+        },
+        "notify": {"on": ["completed", "failed"], "command": "notify-done"},
+    }
+    async with StateDB() as db:
+        await db.create_schedule(
+            {
+                "id": "d1",
+                "name": "demo/nightly",
+                "trigger_type": "cron",
+                "cron_expr": "0 2 * * *",
+                "action_kind": "agent",
+                "action_agent": "reviewer",
+                "action_prompt": "check things",
+                "action_project": "demo",
+                "managed_by": "declaration",
+                "authored_spec": authored_spec,
+                "notify_on": ["completed", "failed"],
+                "notify_command": "notify-done",
+            }
+        )
+        rows = await db.list_schedules()
+
+    doc, lines = build_managed_export_document(rows)
+    assert [line.status for line in lines] == ["READY"]
+    # The row's own project ("demo") matches the document's chosen project,
+    # so it is keyed by its local name -- re-applying reconstructs
+    # "demo/nightly" exactly (see _member_key).
+    member = doc.schedules["nightly"]
+    assert member.notify.on == ["completed", "failed"]
+
+    yaml_text = dump_schedule_set_yaml(doc)
+    assert '"on":' in yaml_text
+
+    # Round-trips as the string "on", not the boolean True a bare key would
+    # parse to under YAML 1.1.
+    raw = yaml.safe_load(yaml_text)
+    notify_block = raw["schedules"]["nightly"]["notify"]
+    assert "on" in notify_block
+    assert True not in notify_block
+    assert notify_block["on"] == ["completed", "failed"]
+
+    # And the document as a whole is still a valid ScheduleSet.
+    reparsed = parse_schedule_set(yaml_text)
+    assert reparsed.schedules["nightly"].notify.on == ["completed", "failed"]
+
+
+@pytest.mark.asyncio
+async def test_default_export_is_deterministically_name_sorted(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        for schedule_id, name in (("z1", "demo/zzz-last"), ("a1", "demo/aaa-first")):
+            await db.create_schedule(
+                {
+                    "id": schedule_id,
+                    "name": name,
+                    "trigger_type": "cron",
+                    "cron_expr": "0 2 * * *",
+                    "action_kind": "agent",
+                    "action_agent": "reviewer",
+                    "action_prompt": "check things",
+                    "managed_by": "cli",
+                    "authored_spec": {
+                        "description": None,
+                        "enabled": True,
+                        "trigger": {"cron": {"expression": "0 2 * * *", "timezone": "UTC"}},
+                        "target": {
+                            "kind": "agent",
+                            "profile": "reviewer",
+                            "prompt": "check things",
+                        },
+                    },
+                }
+            )
+        rows = await db.list_schedules()
+
+    doc, lines = build_managed_export_document(rows)
+    assert list(doc.schedules.keys()) == ["demo/aaa-first", "demo/zzz-last"]
+    report_lines = [line.qualified_name for line in lines]
+    assert report_lines == ["demo/aaa-first", "demo/zzz-last"]
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — --output vs stdout, never writes the database
+# ---------------------------------------------------------------------------
+
+
+def _export_args(**overrides) -> types.SimpleNamespace:
+    base = {"legacy": False, "output": None, "report": None}
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+def test_cli_export_writes_output_file_and_report_file(temp_db_path, agent_profile, tmp_path):
+    # _cmd_export runs its own event loop (asyncio.run) internally, so this
+    # test must stay a plain sync function, not @pytest.mark.asyncio.
+    import asyncio
+
+    from lionagi.studio.cli import _cmd_export
+
+    asyncio.run(_create_legacy_row(_legacy_row("cli1", "demo/nightly", cwd=agent_profile)))
+
+    output_path = tmp_path / "out" / "schedules.yaml"
+    report_path = tmp_path / "out" / "report.txt"
+    rc = _cmd_export(_export_args(legacy=True, output=str(output_path), report=str(report_path)))
+    assert rc == 0
+    assert output_path.is_file()
+    doc = yaml.safe_load(output_path.read_text())
+    assert doc["kind"] == "ScheduleSet"
+    assert "demo/nightly" in doc["schedules"]
+    report_text = report_path.read_text()
+    assert "READY" in report_text
+    assert "1 ready, 0 blocked" in report_text
+
+
+def test_cli_export_prints_to_stdout_and_stderr_by_default(temp_db_path, agent_profile, capsys):
+    import asyncio
+
+    from lionagi.studio.cli import _cmd_export
+
+    asyncio.run(_create_legacy_row(_legacy_row("cli2", "demo/nightly", cwd=agent_profile)))
+
+    rc = _cmd_export(_export_args(legacy=True))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "kind: ScheduleSet" in captured.out
+    assert "READY" in captured.err
+
+
+def test_export_never_writes_the_database(temp_db_path, agent_profile, tmp_path):
+    import asyncio
+
+    from lionagi.studio.cli import _cmd_export
+
+    async def _setup():
+        async with StateDB() as db:
+            await db.create_schedule(_legacy_row("cli3", "demo/nightly", cwd=agent_profile))
+            return await db.list_schedules()
+
+    before = asyncio.run(_setup())
+
+    output_path = tmp_path / "schedules.yaml"
+    rc = _cmd_export(_export_args(legacy=True, output=str(output_path)))
+    assert rc == 0
+
+    async def _reread():
+        async with StateDB() as db:
+            return await db.list_schedules()
+
+    after = asyncio.run(_reread())
+
+    assert len(before) == len(after) == 1
+    assert before[0]["updated_at"] == after[0]["updated_at"]
+    assert before[0]["enabled"] == after[0]["enabled"]

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -85,9 +85,10 @@ async def test_legacy_agent_row_converts_ready(temp_db_path, agent_profile):
     async with StateDB() as db:
         await db.create_schedule(_legacy_row("a1", "demo/nightly", cwd=agent_profile))
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
     assert "demo/nightly" in doc.schedules
     member = doc.schedules["demo/nightly"]
@@ -116,9 +117,10 @@ async def test_legacy_command_row_converts_ready(temp_db_path, agent_profile, mo
             )
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
     member = doc.schedules["demo/refresh"]
     assert member.target.kind == "command"
@@ -142,9 +144,10 @@ async def test_legacy_playbook_row_converts_ready(temp_db_path, agent_profile):
             )
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
     member = doc.schedules["demo/audit"]
     assert member.target.kind == "playbook"
@@ -170,7 +173,8 @@ async def test_legacy_flow_yaml_row_converts_ready(temp_db_path, agent_profile):
         )
         rows = await db.list_schedules()
     flows_dir = agent_profile / "flows"
-    doc, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
     member = doc.schedules["demo/nightly-flow"]
     assert member.target.kind == "flow"
@@ -196,9 +200,10 @@ async def test_legacy_row_with_on_success_is_blocked_and_omitted(temp_db_path, a
             )
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert len(lines) == 1
     assert lines[0].status == "BLOCKED"
     assert "dependency conversion required" in lines[0].message
@@ -212,9 +217,10 @@ async def test_legacy_row_with_on_fail_is_blocked_and_omitted(temp_db_path, agen
             _legacy_row("b2", "demo/chained-fail", cwd=agent_profile, on_fail={"prompt": "alert"})
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert lines[0].status == "BLOCKED"
     assert "demo/chained-fail" not in doc.schedules
 
@@ -233,9 +239,10 @@ async def test_legacy_unsupported_action_kind_is_blocked_and_omitted(temp_db_pat
             )
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert lines[0].status == "BLOCKED"
     assert "no v1 target equivalent" in lines[0].message
     assert doc.schedules == {}
@@ -248,9 +255,10 @@ async def test_legacy_malformed_trigger_is_blocked_and_omitted(temp_db_path, age
             _legacy_row("m1", "demo/badcron", cwd=agent_profile, cron_expr="not a cron expr")
         )
         rows = await db.list_schedules()
-    doc, lines = convert_legacy_rows(
+    docs, lines = convert_legacy_rows(
         rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
     )
+    doc = docs[0]
     assert lines[0].status == "BLOCKED"
     assert "demo/badcron" not in doc.schedules
 
@@ -271,7 +279,8 @@ async def test_legacy_export_round_trips_to_a_fresh_db(tmp_path, monkeypatch, ag
         rows = await db.list_schedules()
 
     flows_dir = tmp_path / "export.flows"
-    doc, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
 
     output_path = tmp_path / "schedules.yaml"
@@ -340,7 +349,8 @@ async def test_default_export_round_trips_notify_with_quoted_on_key(temp_db_path
         )
         rows = await db.list_schedules()
 
-    doc, lines = build_managed_export_document(rows)
+    docs, lines = build_managed_export_document(rows)
+    doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
     # The row's own project ("demo") matches the document's chosen project,
     # so it is keyed by its local name -- re-applying reconstructs
@@ -392,7 +402,8 @@ async def test_default_export_is_deterministically_name_sorted(temp_db_path, age
             )
         rows = await db.list_schedules()
 
-    doc, lines = build_managed_export_document(rows)
+    docs, lines = build_managed_export_document(rows)
+    doc = docs[0]
     assert list(doc.schedules.keys()) == ["demo/aaa-first", "demo/zzz-last"]
     report_lines = [line.qualified_name for line in lines]
     assert report_lines == ["demo/aaa-first", "demo/zzz-last"]
@@ -470,3 +481,298 @@ def test_export_never_writes_the_database(temp_db_path, agent_profile, tmp_path)
     assert len(before) == len(after) == 1
     assert before[0]["updated_at"] == after[0]["updated_at"]
     assert before[0]["enabled"] == after[0]["enabled"]
+
+
+# ---------------------------------------------------------------------------
+# Mixed-project export -- one document per project, exact qualified-name
+# round-trip (no double-qualification)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_mixed_project_export_round_trips_exact_qualified_names(
+    tmp_path, monkeypatch, agent_profile
+):
+    source_db = tmp_path / "source.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", source_db)
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("orig-a", "alpha/nightly", cwd=agent_profile, action_project="alpha")
+        )
+        await db.create_schedule(
+            _legacy_row("orig-b", "beta/nightly", cwd=agent_profile, action_project="beta")
+        )
+        rows = await db.list_schedules()
+
+    flows_dir = tmp_path / "export.flows"
+    docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    assert [line.status for line in lines] == ["READY", "READY"]
+
+    # One document per project -- neither keys the other project's row under
+    # its own project, which is what used to double-qualify on apply.
+    assert len(docs) == 2
+    docs_by_project = {doc.metadata.project: doc for doc in docs}
+    assert set(docs_by_project) == {"alpha", "beta"}
+    assert docs_by_project["alpha"].schedules.keys() == {"nightly"}
+    assert docs_by_project["beta"].schedules.keys() == {"nightly"}
+
+    fresh_db = tmp_path / "fresh.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", fresh_db)
+    async with StateDB() as db:
+        for doc in docs:
+            output_path = tmp_path / f"schedules.{doc.metadata.project}.yaml"
+            output_path.write_text(dump_schedule_set_yaml(doc))
+            reparsed = parse_schedule_set(output_path.read_text(), source=str(output_path))
+            result = await apply_schedule_set(db, reparsed, output_path.parent)
+            assert result.created == 1
+
+        alpha = await db.get_schedule_by_name("alpha/nightly")
+        beta = await db.get_schedule_by_name("beta/nightly")
+        # The double-qualification bug would have produced
+        # "alpha/beta/nightly" (doc project "alpha" prepended a second
+        # time onto the already-qualified "beta/nightly" member key).
+        doubled = await db.get_schedule_by_name("alpha/beta/nightly")
+    assert alpha is not None
+    assert beta is not None
+    assert doubled is None
+
+
+@pytest.mark.asyncio
+async def test_managed_mixed_project_export_round_trips_exact_qualified_names(
+    tmp_path, monkeypatch, agent_profile
+):
+    def _managed_row(schedule_id: str, name: str, project: str) -> dict:
+        return {
+            "id": schedule_id,
+            "name": name,
+            "trigger_type": "cron",
+            "cron_expr": "0 2 * * *",
+            "action_kind": "agent",
+            "action_agent": "reviewer",
+            "action_prompt": "check things",
+            "action_project": project,
+            "managed_by": "cli",
+            "authored_spec": {
+                "description": None,
+                "enabled": True,
+                "trigger": {"cron": {"expression": "0 2 * * *", "timezone": "UTC"}},
+                "target": {"kind": "agent", "profile": "reviewer", "prompt": "check things"},
+            },
+        }
+
+    source_db = tmp_path / "source.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", source_db)
+    async with StateDB() as db:
+        await db.create_schedule(_managed_row("m-a", "alpha/svc", "alpha"))
+        await db.create_schedule(_managed_row("m-b", "beta/svc", "beta"))
+        rows = await db.list_schedules()
+
+    docs, lines = build_managed_export_document(rows)
+    assert [line.status for line in lines] == ["READY", "READY"]
+    assert len(docs) == 2
+    docs_by_project = {doc.metadata.project: doc for doc in docs}
+    assert docs_by_project["alpha"].schedules.keys() == {"svc"}
+    assert docs_by_project["beta"].schedules.keys() == {"svc"}
+
+    fresh_db = tmp_path / "fresh.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", fresh_db)
+    async with StateDB() as db:
+        for doc in docs:
+            output_path = tmp_path / f"schedules.{doc.metadata.project}.yaml"
+            output_path.write_text(dump_schedule_set_yaml(doc))
+            reparsed = parse_schedule_set(output_path.read_text(), source=str(output_path))
+            result = await apply_schedule_set(db, reparsed, output_path.parent)
+            assert result.created == 1
+
+        alpha = await db.get_schedule_by_name("alpha/svc")
+        beta = await db.get_schedule_by_name("beta/svc")
+        doubled = await db.get_schedule_by_name("alpha/beta/svc")
+    assert alpha is not None
+    assert beta is not None
+    assert doubled is None
+
+
+# ---------------------------------------------------------------------------
+# flow_yaml action_model override -- BLOCKED, not silently dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_flow_yaml_with_action_model_is_blocked(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "fm1",
+                "demo/model-flow",
+                cwd=agent_profile,
+                trigger_type="interval",
+                cron_expr=None,
+                interval_sec=3600,
+                action_kind="flow_yaml",
+                action_agent=None,
+                action_prompt=None,
+                action_flow_yaml="workers: 2\n",
+                action_model="anthropic/claude-sonnet-5",
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    doc = docs[0]
+    assert lines[0].status == "BLOCKED"
+    assert "action_model" in lines[0].message
+    assert "demo/model-flow" not in doc.schedules
+
+
+# ---------------------------------------------------------------------------
+# action_extra_args -- BLOCKED, not silently dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_with_action_extra_args_is_blocked(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "ea1",
+                "demo/extra-args",
+                cwd=agent_profile,
+                action_extra_args=["incremental"],
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    doc = docs[0]
+    assert lines[0].status == "BLOCKED"
+    assert "action_extra_args" in lines[0].message
+    assert "demo/extra-args" not in doc.schedules
+
+
+# ---------------------------------------------------------------------------
+# github_poll poll_interval_sec -- BLOCKED only when set and non-default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_github_poll_with_nondefault_interval_is_blocked(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "gp1",
+                "demo/poll-custom",
+                cwd=agent_profile,
+                trigger_type="github_poll",
+                cron_expr=None,
+                github_repo="octo/repo",
+                poll_interval_sec=900,
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    doc = docs[0]
+    assert lines[0].status == "BLOCKED"
+    assert "poll_interval_sec" in lines[0].message
+    assert "demo/poll-custom" not in doc.schedules
+
+
+@pytest.mark.asyncio
+async def test_legacy_github_poll_at_default_interval_stays_ready(temp_db_path, agent_profile):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "gp2",
+                "demo/poll-default",
+                cwd=agent_profile,
+                trigger_type="github_poll",
+                cron_expr=None,
+                github_repo="octo/repo",
+                poll_interval_sec=300,
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    doc = docs[0]
+    assert [line.status for line in lines] == ["READY"]
+    assert doc.schedules["demo/poll-default"].trigger.github.repo == "octo/repo"
+
+
+# ---------------------------------------------------------------------------
+# CLI exit code -- 2 when any row is BLOCKED, document + report still emitted
+# ---------------------------------------------------------------------------
+
+
+def test_cli_export_returns_partial_exit_code_when_a_row_is_blocked(
+    temp_db_path, agent_profile, tmp_path
+):
+    import asyncio
+
+    from lionagi.studio.cli import EXIT_EXPORT_PARTIAL, _cmd_export
+
+    asyncio.run(_create_legacy_row(_legacy_row("cli-ready", "demo/nightly", cwd=agent_profile)))
+    asyncio.run(
+        _create_legacy_row(
+            _legacy_row(
+                "cli-blocked",
+                "demo/chained",
+                cwd=agent_profile,
+                on_success={"prompt": "notify done"},
+            )
+        )
+    )
+
+    output_path = tmp_path / "out" / "schedules.yaml"
+    report_path = tmp_path / "out" / "report.txt"
+    rc = _cmd_export(_export_args(legacy=True, output=str(output_path), report=str(report_path)))
+    assert rc == EXIT_EXPORT_PARTIAL
+    assert rc != 0
+    # The document and report are still emitted exactly as on a clean export.
+    assert output_path.is_file()
+    doc = yaml.safe_load(output_path.read_text())
+    assert "demo/nightly" in doc["schedules"]
+    report_text = report_path.read_text()
+    assert "READY" in report_text
+    assert "BLOCKED" in report_text
+    assert "1 ready, 1 blocked" in report_text
+
+
+# ---------------------------------------------------------------------------
+# Flow snapshot portability disclosure -- absolute host path is stated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_flow_yaml_report_line_discloses_absolute_host_path(
+    temp_db_path, agent_profile
+):
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "fp1",
+                "demo/flow-port",
+                cwd=agent_profile,
+                trigger_type="interval",
+                cron_expr=None,
+                interval_sec=3600,
+                action_kind="flow_yaml",
+                action_agent=None,
+                action_prompt=None,
+                action_flow_yaml="workers: 2\n",
+            )
+        )
+        rows = await db.list_schedules()
+    flows_dir = agent_profile / "flows"
+    docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
+    doc = docs[0]
+    member = doc.schedules["demo/flow-port"]
+    assert lines[0].status == "READY"
+    assert lines[0].message is not None
+    assert "absolute" in lines[0].message
+    assert member.target.file in lines[0].message
+    assert Path(member.target.file).is_absolute()

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -677,7 +677,7 @@ async def test_legacy_github_poll_with_nondefault_interval_is_blocked(temp_db_pa
     )
     doc = docs[0]
     assert lines[0].status == "BLOCKED"
-    assert "poll_interval_sec" in lines[0].message
+    assert "poll" in lines[0].message
     assert "demo/poll-custom" not in doc.schedules
 
 
@@ -822,3 +822,105 @@ async def test_legacy_bare_name_without_project_disclosed_in_report(temp_db_path
     assert [line.status for line in lines] == ["READY"]
     assert lines[0].message is not None
     assert "legacy-export/nightly" in lines[0].message
+
+
+# ---------------------------------------------------------------------------
+# GitHub cadence fallback and sibling-file collisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_github_poll_interval_sec_fallback_is_blocked(temp_db_path, agent_profile):
+    """With poll_interval_sec NULL the engine polls at interval_sec; exporting
+    such a row must BLOCK, not silently re-apply at the 300s default."""
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "gf1",
+                "demo/poll-fallback",
+                cwd=agent_profile,
+                trigger_type="github_poll",
+                cron_expr=None,
+                interval_sec=900,
+                poll_interval_sec=None,
+                github_repo="octo/repo",
+                action_kind="agent",
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["BLOCKED"]
+    assert "900" in lines[0].message
+    assert not docs[0].schedules
+
+
+@pytest.mark.asyncio
+async def test_legacy_github_poll_explicit_default_with_interval_sec_stays_ready(
+    temp_db_path, agent_profile
+):
+    """An explicit poll_interval_sec at the default wins over interval_sec in
+    the engine's fallback chain, so the row is exportable."""
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row(
+                "gf2",
+                "demo/poll-explicit",
+                cwd=agent_profile,
+                trigger_type="github_poll",
+                cron_expr=None,
+                interval_sec=900,
+                poll_interval_sec=300,
+                github_repo="octo/repo",
+                action_kind="agent",
+            )
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+
+
+def test_cli_export_rejects_sibling_filename_collisions(temp_db_path, agent_profile, tmp_path):
+    """Two projects whose sanitized filename tokens collide must fail loudly
+    before any sibling file is written, never silently overwrite one."""
+    import asyncio
+
+    from lionagi.studio.cli import _cmd_export
+
+    asyncio.run(
+        _create_legacy_row(
+            _legacy_row("sc1", "foo/bar/a", cwd=agent_profile, action_project="foo/bar")
+        )
+    )
+    asyncio.run(
+        _create_legacy_row(
+            _legacy_row("sc2", "foo:bar/b", cwd=agent_profile, action_project="foo:bar")
+        )
+    )
+
+    output_path = tmp_path / "out" / "schedules.yaml"
+    rc = _cmd_export(_export_args(legacy=True, output=str(output_path)))
+    assert rc == 1
+    assert not any((tmp_path / "out").glob("*.yaml")) if (tmp_path / "out").exists() else True
+
+
+def test_cli_export_distinct_sibling_tokens_write_all_files(temp_db_path, agent_profile, tmp_path):
+    import asyncio
+
+    from lionagi.studio.cli import _cmd_export
+
+    asyncio.run(
+        _create_legacy_row(_legacy_row("sd1", "alpha/a", cwd=agent_profile, action_project="alpha"))
+    )
+    asyncio.run(
+        _create_legacy_row(_legacy_row("sd2", "beta/b", cwd=agent_profile, action_project="beta"))
+    )
+
+    output_path = tmp_path / "out" / "schedules.yaml"
+    rc = _cmd_export(_export_args(legacy=True, output=str(output_path)))
+    assert rc == 0
+    names = sorted(p.name for p in (tmp_path / "out").glob("*.yaml"))
+    assert names == ["schedules.alpha.yaml", "schedules.beta.yaml"]

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -90,8 +90,9 @@ async def test_legacy_agent_row_converts_ready(temp_db_path, agent_profile):
     )
     doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
-    assert "demo/nightly" in doc.schedules
-    member = doc.schedules["demo/nightly"]
+    assert doc.metadata.project == "demo"
+    assert "nightly" in doc.schedules
+    member = doc.schedules["nightly"]
     assert member.target.kind == "agent"
     assert member.target.profile == "reviewer"
     assert member.target.prompt == "check things"
@@ -122,7 +123,7 @@ async def test_legacy_command_row_converts_ready(temp_db_path, agent_profile, mo
     )
     doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
-    member = doc.schedules["demo/refresh"]
+    member = doc.schedules["refresh"]
     assert member.target.kind == "command"
     assert member.target.executable == "refresh-index"
     assert member.target.args == ["incremental"]
@@ -149,7 +150,7 @@ async def test_legacy_playbook_row_converts_ready(temp_db_path, agent_profile):
     )
     doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
-    member = doc.schedules["demo/audit"]
+    member = doc.schedules["audit"]
     assert member.target.kind == "playbook"
     assert member.target.name == "health-audit"
 
@@ -176,7 +177,7 @@ async def test_legacy_flow_yaml_row_converts_ready(temp_db_path, agent_profile):
     docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
     doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
-    member = doc.schedules["demo/nightly-flow"]
+    member = doc.schedules["nightly-flow"]
     assert member.target.kind == "flow"
     written = Path(member.target.file)
     assert written.is_file()
@@ -404,7 +405,7 @@ async def test_default_export_is_deterministically_name_sorted(temp_db_path, age
 
     docs, lines = build_managed_export_document(rows)
     doc = docs[0]
-    assert list(doc.schedules.keys()) == ["demo/aaa-first", "demo/zzz-last"]
+    assert list(doc.schedules.keys()) == ["aaa-first", "zzz-last"]
     report_lines = [line.qualified_name for line in lines]
     assert report_lines == ["demo/aaa-first", "demo/zzz-last"]
 
@@ -436,7 +437,7 @@ def test_cli_export_writes_output_file_and_report_file(temp_db_path, agent_profi
     assert output_path.is_file()
     doc = yaml.safe_load(output_path.read_text())
     assert doc["kind"] == "ScheduleSet"
-    assert "demo/nightly" in doc["schedules"]
+    assert "nightly" in doc["schedules"]
     report_text = report_path.read_text()
     assert "READY" in report_text
     assert "1 ready, 0 blocked" in report_text
@@ -700,7 +701,7 @@ async def test_legacy_github_poll_at_default_interval_stays_ready(temp_db_path, 
     )
     doc = docs[0]
     assert [line.status for line in lines] == ["READY"]
-    assert doc.schedules["demo/poll-default"].trigger.github.repo == "octo/repo"
+    assert doc.schedules["poll-default"].trigger.github.repo == "octo/repo"
 
 
 # ---------------------------------------------------------------------------
@@ -735,7 +736,7 @@ def test_cli_export_returns_partial_exit_code_when_a_row_is_blocked(
     # The document and report are still emitted exactly as on a clean export.
     assert output_path.is_file()
     doc = yaml.safe_load(output_path.read_text())
-    assert "demo/nightly" in doc["schedules"]
+    assert "nightly" in doc["schedules"]
     report_text = report_path.read_text()
     assert "READY" in report_text
     assert "BLOCKED" in report_text
@@ -770,9 +771,54 @@ async def test_legacy_flow_yaml_report_line_discloses_absolute_host_path(
     flows_dir = agent_profile / "flows"
     docs, lines = convert_legacy_rows(rows, flows_dir=flows_dir, manifest_dir=agent_profile)
     doc = docs[0]
-    member = doc.schedules["demo/flow-port"]
+    member = doc.schedules["flow-port"]
     assert lines[0].status == "READY"
     assert lines[0].message is not None
     assert "absolute" in lines[0].message
     assert member.target.file in lines[0].message
     assert Path(member.target.file).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Rows with no stored project — name identity across re-apply
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_without_project_but_qualified_name_round_trips_exactly(
+    temp_db_path, agent_profile
+):
+    """A row whose project column is empty but whose name is qualified must
+    group under its name's prefix, so re-applying reproduces the name."""
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("np1", "demo/nightly", cwd=agent_profile, action_project=None)
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.metadata.project == "demo"
+    assert "nightly" in doc.schedules
+    # doc project + local key reconstructs the original qualified name
+    assert f"{doc.metadata.project}/nightly" == "demo/nightly"
+
+
+@pytest.mark.asyncio
+async def test_legacy_bare_name_without_project_disclosed_in_report(temp_db_path, agent_profile):
+    """A bare, unqualified name cannot round-trip untouched (a document always
+    carries a project); the READY line must disclose the re-applied name."""
+    async with StateDB() as db:
+        await db.create_schedule(
+            _legacy_row("np2", "nightly", cwd=agent_profile, action_project=None)
+        )
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    assert [line.status for line in lines] == ["READY"]
+    assert lines[0].message is not None
+    assert "legacy-export/nightly" in lines[0].message

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -744,12 +744,13 @@ def test_cli_export_returns_partial_exit_code_when_a_row_is_blocked(
 
 
 # ---------------------------------------------------------------------------
-# Flow snapshot portability disclosure -- absolute host path is stated
+# Flow snapshot portability -- sidecar path is relative, YAML carries no
+# host prefix, absolute cwd is flagged on the report line
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_legacy_flow_yaml_report_line_discloses_absolute_host_path(
+async def test_legacy_flow_sidecar_is_relative_and_yaml_has_no_host_prefix(
     temp_db_path, agent_profile
 ):
     async with StateDB() as db:
@@ -765,6 +766,7 @@ async def test_legacy_flow_yaml_report_line_discloses_absolute_host_path(
                 action_agent=None,
                 action_prompt=None,
                 action_flow_yaml="workers: 2\n",
+                action_cwd=None,
             )
         )
         rows = await db.list_schedules()
@@ -773,10 +775,36 @@ async def test_legacy_flow_yaml_report_line_discloses_absolute_host_path(
     doc = docs[0]
     member = doc.schedules["flow-port"]
     assert lines[0].status == "READY"
+    # the sidecar reference must survive committing the document to a repo:
+    # relative to the manifest dir, resolvable the same way a later apply
+    # resolves it, and never leaking the exporting host's filesystem layout
+    assert not Path(member.target.file).is_absolute()
+    assert (agent_profile / member.target.file).is_file()
+    yaml_text = dump_schedule_set_yaml(doc)
+    assert str(agent_profile) not in yaml_text
+    # the sidecar relationship is still disclosed on the report line
     assert lines[0].message is not None
-    assert "absolute" in lines[0].message
     assert member.target.file in lines[0].message
-    assert Path(member.target.file).is_absolute()
+
+
+@pytest.mark.asyncio
+async def test_legacy_absolute_cwd_kept_verbatim_but_flagged_on_report_line(
+    temp_db_path, agent_profile
+):
+    async with StateDB() as db:
+        await db.create_schedule(_legacy_row("a1", "demo/nightly", cwd=agent_profile))
+        rows = await db.list_schedules()
+    docs, lines = convert_legacy_rows(
+        rows, flows_dir=agent_profile / "flows", manifest_dir=agent_profile
+    )
+    member = docs[0].schedules["nightly"]
+    # cwd stays verbatim (a schedule's cwd is machine-local by design) ...
+    assert member.execution.cwd == str(agent_profile)
+    # ... but the export report must surface the absolute path it wrote
+    assert lines[0].status == "READY"
+    assert lines[0].message is not None
+    assert "cwd" in lines[0].message
+    assert str(agent_profile) in lines[0].message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `li schedule export`, the migration bridge for the declarative schedule surface.

- **`--legacy`**: converts chain-free legacy rows (`managed_by IS NULL`) into a `ScheduleSet` document plus a report. Each reconstructed member runs through the real `resolve_member()` as a dry run, so malformed rows (bad cron, disallowed command, missing profile) are reported and omitted, never half-emitted. Rows with `on_success`/`on_fail` are reported `BLOCKED: dependency conversion required` with their reusable target fields named, and omitted from the ready-to-apply set. Export never writes the database.
- **Default**: re-serializes declaration/cli-managed rows' persisted `authored_spec` back into a document via the pydantic models (no string templating). Notify blocks round-trip with the `"on"` key force-quoted (YAML 1.1 parses a bare `on:` as boolean, see #2300).
- Output: YAML to stdout or `--output PATH`; report to stderr or `--report PATH`. Rows emit name-sorted for diffable output.
- Naming: rows whose project matches the document's project are keyed by local name so a later `apply` reconstructs the original qualified name; others keep their full name to avoid collisions.

## Testing

14 new tests in `tests/studio/test_schedule_export.py`: per-kind legacy conversion, BLOCKED surfaces (`on_success`/`on_fail`, unsupported action kind, malformed cron), full round-trip (export → validate/parse → apply to fresh DB → compare `resolved_target`), notify round-trip with quoted key, deterministic ordering, output routing, and a never-writes-DB assertion. CLI contract/surface goldens updated. Full suite: 14146 passed; one pre-existing order-dependent failure unrelated to this change (#2291).

## Known limitations

Legacy `flow_yaml` conversion references the written snapshot by absolute path (portability across machines deferred); the fallback document name when exported rows share no project is a literal `"export"`/`"legacy-export"`.

## Deferred

`--adopt` migration (final part of the signed design) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)