### PR TITLE
Fix bare notify on key in ScheduleSet YAML

### DIFF
--- a/docs/guides/scheduling-workflows.md
+++ b/docs/guides/scheduling-workflows.md
@@ -100,8 +100,8 @@ li schedule apply schedules.yaml
 
 Notes:
 
-- Quote the notify `"on"` key. Unquoted `on:` is YAML 1.1 boolean `true` and the
-  parser will reject the document with a pointed error.
+- Quoting the notify `"on"` key is recommended for YAML portability. The ScheduleSet
+  parser also accepts bare `on:`, which YAML 1.1 otherwise resolves as boolean `true`.
 - `notify.on` takes terminal statuses (`completed`, `failed`, ...); the command
   runs once per matching terminal event, and a notify failure never affects the
   run's own outcome.

--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -185,6 +185,15 @@ class Notify(BaseModel):
     on: list[str]
     command: str
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_yaml_on_key(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or not any(key is True for key in data):
+            return data
+        if "on" in data:
+            raise ValueError('notify.on is declared twice; quote the key as "on" in YAML')
+        return {"on" if key is True else key: value for key, value in data.items()}
+
     @model_validator(mode="after")
     def _valid_on(self) -> Notify:
         if not self.on:

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -270,6 +270,28 @@ def test_notify_valid_accepted():
     assert doc.schedules["m"].notify.on == ["failed", "timed_out"]
 
 
+def test_notify_bare_on_yaml_key_accepted():
+    manifest = """
+apiVersion: lionagi.io/v1alpha1
+kind: ScheduleSet
+metadata:
+  name: automation
+  project: demo
+schedules:
+  m:
+    trigger:
+      every: 1h
+    target:
+      kind: command
+      executable: refresh-index
+    notify:
+      on: [failed]
+      command: notify-run
+"""
+    doc = parse_schedule_set(manifest)
+    assert doc.schedules["m"].notify.on == ["failed"]
+
+
 def _policies_manifest(policies_yaml: str, cwd: Path) -> str:
     return f"""
 apiVersion: lionagi.io/v1alpha1


### PR DESCRIPTION
Closes #2300

PyYAML resolves a bare `on:` key to boolean `True`, causing ScheduleSet validation to report a missing field. Normalize that key at the `Notify` validation boundary while preserving quoted behavior; the regression covers the bare form and the guide now reflects support.

Tested with the full ScheduleSet declaration test file and changed-file Ruff checks.