### PR TITLE
fix(agent): forward spec.cwd to every CLI provider's repo kwarg

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -73,6 +73,7 @@ async def create_agent(
         from lionagi.service.providers import (
             CLI_PROVIDERS,
             PROVIDER_EFFORT_KWARG,
+            PROVIDER_REPO_KWARG,
             PROVIDER_YOLO_KWARGS,
             parse_model_spec,
         )
@@ -100,12 +101,15 @@ async def create_agent(
         if provider in CLI_PROVIDERS:
             extra["api_key"] = "dummy"
 
-        # Codex executes `-C <repo>`; the request model's repo defaults to the
-        # calling process cwd, so an agent assigned a workspace via spec.cwd
-        # would otherwise run against whatever directory the host process
-        # happens to be in.
-        if provider == "codex" and spec.cwd:
-            extra["repo"] = spec.cwd
+        # CLI providers execute as a subprocess against a working directory;
+        # each request model's repo/workspace field defaults to the calling
+        # process cwd, so an agent assigned a workspace via spec.cwd would
+        # otherwise run against whatever directory the host process happens
+        # to be in.
+        if spec.cwd:
+            repo_kwarg = PROVIDER_REPO_KWARG.get(provider)
+            if repo_kwarg:
+                extra[repo_kwarg] = spec.cwd
 
         chat_model = iModel(
             provider=provider,

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -15,6 +15,7 @@ __all__ = (
     "PROVIDER_BYPASS_KWARGS",
     "PROVIDER_EFFORT_KWARG",
     "PROVIDER_FAST_KWARGS",
+    "PROVIDER_REPO_KWARG",
     "PROVIDER_TO_ALIAS",
     "PROVIDER_YOLO_KWARGS",
     "PROVIDERS_EFFORT_VIA_MODEL_NAME",
@@ -135,6 +136,13 @@ PROVIDER_EFFORT_KWARG: dict[str, str] = {
     "codex": "reasoning_effort",
     "pi": "thinking",
 }
+
+# Every CLI provider's request model runs its subprocess against a `repo`
+# field that defaults to the calling process's cwd (CodexCodeRequest,
+# ClaudeCodeRequest, GeminiCodeRequest, PiCodeRequest all declare
+# `repo: Path = Field(default_factory=Path.cwd, exclude=True)`), so an agent
+# assigned a workspace needs that value forwarded explicitly.
+PROVIDER_REPO_KWARG: dict[str, str] = {p: "repo" for p in CLI_PROVIDERS}
 
 # agy-backed aliases fold effort into the resolved --model name via resolve_agy_model
 # instead of a kwarg — classified separately from PROVIDER_EFFORT_KWARG below.

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -528,6 +528,54 @@ async def test_create_agent_backends_alias_unaffected(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# spec.cwd forwarded into the CLI provider request's repo/workspace field —
+# every CLI provider's request model runs its subprocess against `repo`
+# (defaults to the calling process cwd), so a workspace assigned via
+# spec.cwd must reach it or the agent silently runs in the host cwd instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["codex/gpt-5.5", "claude_code/sonnet", "gemini_code/gemini-3.5-flash"],
+)
+async def test_create_agent_forwards_spec_cwd_to_provider_repo_kwarg(monkeypatch, tmp_path, model):
+    import lionagi.service.imodel as imodel_mod
+
+    captured = {}
+    real_init = imodel_mod.iModel.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(imodel_mod.iModel, "__init__", spy_init)
+
+    config = AgentSpec.compose("implementer", model=model, cwd=str(tmp_path))
+    await create_agent(config, load_settings=False)
+
+    assert captured.get("repo") == str(tmp_path)
+
+
+async def test_create_agent_no_cwd_does_not_set_repo_kwarg(monkeypatch):
+    import lionagi.service.imodel as imodel_mod
+
+    captured = {}
+    real_init = imodel_mod.iModel.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(imodel_mod.iModel, "__init__", spy_init)
+
+    config = AgentSpec.compose("implementer", model="claude_code/sonnet")
+    await create_agent(config, load_settings=False)
+
+    assert "repo" not in captured
+
+
+# ---------------------------------------------------------------------------
 # system_prompt without lion_system (line 104)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `create_agent` mapped `spec.cwd` into the provider request's `repo` field for codex only; claude_code, gemini_code (and pi) share the identical `repo: Path = Field(default_factory=Path.cwd)` shape, so agents composed with a workspace on those providers silently ran their CLI subprocess in the host process cwd.
- Replaces the codex-only branch with a data-driven `PROVIDER_REPO_KWARG` table (mirrors `PROVIDER_EFFORT_KWARG`) covering all CLI provider aliases. Codex behavior is unchanged.

## Tests
- Parametrized regression over codex/claude_code/gemini_code asserting the composed workspace reaches the iModel kwargs (fails pre-fix for claude_code/gemini_code).
- Guard test that no `repo` kwarg lands when `spec.cwd` is unset, preserving `Path.cwd()` defaulting.
- `uv run pytest tests/agent/test_factory.py -q` green; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)