### PR TITLE
fix(service): default retry_exceptions now cover real transport errors

### DIFF
--- a/lionagi/service/resilience.py
+++ b/lionagi/service/resilience.py
@@ -26,13 +26,20 @@ def _default_retry_exceptions() -> tuple[type[Exception], ...]:
     # production code actually raises.
     global _default_retry_exceptions_cache
     if _default_retry_exceptions_cache is None:
+        import asyncio
+
         import aiohttp
 
+        # asyncio.TimeoutError is a distinct class from the builtin
+        # TimeoutError before Python 3.11, and it is what timed-out awaits
+        # actually raise there — both are needed to match the native
+        # endpoint fallback's retry set on every supported runtime.
         _default_retry_exceptions_cache = (
             APIClientError,
             CircuitBreakerOpenError,
             ConnectionError,
             TimeoutError,
+            asyncio.TimeoutError,
             aiohttp.ClientError,
         )
     return _default_retry_exceptions_cache

--- a/lionagi/service/resilience.py
+++ b/lionagi/service/resilience.py
@@ -16,6 +16,27 @@ from lionagi.ln.concurrency import retry as _canonical_retry
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
+_default_retry_exceptions_cache: tuple[type[Exception], ...] | None = None
+
+
+def _default_retry_exceptions() -> tuple[type[Exception], ...]:
+    # aiohttp is lazily imported (matches connections/endpoint.py's convention)
+    # so module import stays cheap; aiohttp.ClientError covers the
+    # aiohttp.ClientResponseError(429/5xx) and connector errors that
+    # production code actually raises.
+    global _default_retry_exceptions_cache
+    if _default_retry_exceptions_cache is None:
+        import aiohttp
+
+        _default_retry_exceptions_cache = (
+            APIClientError,
+            CircuitBreakerOpenError,
+            ConnectionError,
+            TimeoutError,
+            aiohttp.ClientError,
+        )
+    return _default_retry_exceptions_cache
+
 
 class APIClientError(Exception):
     """Base exception for API client errors."""
@@ -207,12 +228,7 @@ class RetryConfig:
         backoff_factor: float = 2.0,
         jitter: bool = True,
         jitter_factor: float = 0.2,
-        retry_exceptions: tuple[type[Exception], ...] = (
-            APIClientError,
-            CircuitBreakerOpenError,
-            ConnectionError,
-            TimeoutError,
-        ),
+        retry_exceptions: tuple[type[Exception], ...] | None = None,
         exclude_exceptions: tuple[type[Exception], ...] = (),
     ):
         if backoff_factor < 1.0:
@@ -223,7 +239,9 @@ class RetryConfig:
         self.backoff_factor = backoff_factor
         self.jitter = jitter
         self.jitter_factor = jitter_factor
-        self.retry_exceptions = retry_exceptions
+        self.retry_exceptions = (
+            retry_exceptions if retry_exceptions is not None else _default_retry_exceptions()
+        )
         self.exclude_exceptions = exclude_exceptions
 
     def to_dict(self) -> dict[str, Any]:
@@ -251,12 +269,7 @@ class RetryConfig:
 async def retry_with_backoff(
     func: Callable[..., Awaitable[T]],
     *args: Any,
-    retry_exceptions: tuple[type[Exception], ...] = (
-        APIClientError,
-        CircuitBreakerOpenError,
-        ConnectionError,
-        TimeoutError,
-    ),
+    retry_exceptions: tuple[type[Exception], ...] | None = None,
     exclude_exceptions: tuple[type[Exception], ...] = (),
     max_retries: int = 3,
     base_delay: float = 1.0,
@@ -266,6 +279,9 @@ async def retry_with_backoff(
     jitter_factor: float = 0.2,
     **kwargs: Any,
 ) -> T:
+    if retry_exceptions is None:
+        retry_exceptions = _default_retry_exceptions()
+
     async def _fn() -> T:
         return await func(*args, **kwargs)
 
@@ -345,12 +361,7 @@ def with_retry(
     backoff_factor: float = 2.0,
     jitter: bool = True,
     jitter_factor: float = 0.2,
-    retry_exceptions: tuple[type[Exception], ...] = (
-        APIClientError,
-        CircuitBreakerOpenError,
-        ConnectionError,
-        TimeoutError,
-    ),
+    retry_exceptions: tuple[type[Exception], ...] | None = None,
     exclude_exceptions: tuple[type[Exception], ...] = (),
 ) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
     """Decorator applying retry with exponential backoff to an async function."""

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -1108,3 +1108,154 @@ class TestSingleRetryPathParity:
                         await endpoint._call_aiohttp({}, {})
         # max_retries is a total-attempt cap (was backoff's max_tries): 2 → 2 attempts
         assert call_count == 2
+
+
+class TestRetryConfigDefaultRetriesRealErrors:
+    """RetryConfig() with unmodified defaults, exercised through endpoint.call()
+    (the opt-in retry_config path), must retry the errors production code
+    actually raises — not just APIClientError, which nothing ever constructs."""
+
+    def _make_endpoint(self, max_retries: int = 3) -> Endpoint:
+        from lionagi.service.resilience import RetryConfig
+
+        config = EndpointConfig(
+            name="test",
+            provider="test",
+            endpoint="v1/chat",
+            base_url="https://api.test.com",
+            auth_type="bearer",
+            api_key="test-key",
+        )
+        return Endpoint(
+            config=config,
+            retry_config=RetryConfig(max_retries=max_retries, base_delay=0.01),
+        )
+
+    def _make_mock_session(self, responses):
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        calls = iter(responses)
+
+        async def _request(*args, **kwargs):
+            return next(calls)
+
+        mock_session.request = _request
+        return mock_session
+
+    def _make_ok_response(self, body: dict | None = None):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = 200
+        r.closed = False
+        r.release = MagicMock()
+        r.json = AsyncMock(return_value=body or {"ok": True})
+        return r
+
+    def _make_error_response(self, status: int):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = status
+        r.closed = False
+        r.release = MagicMock()
+        r.request_info = MagicMock()
+        r.history = []
+        r.headers = {}
+        r.json = AsyncMock(return_value={"error": f"status {status}"})
+
+        def _raise_for_status():
+            raise aiohttp.ClientResponseError(
+                request_info=r.request_info,
+                history=r.history,
+                status=status,
+                message=f"status {status}",
+                headers=r.headers,
+            )
+
+        r.raise_for_status = _raise_for_status
+        return r
+
+    @pytest.mark.asyncio
+    async def test_429_is_retried_with_default_retry_config(self):
+        endpoint = self._make_endpoint(max_retries=3)
+        r429 = self._make_error_response(429)
+        ok = self._make_ok_response({"retried": True})
+
+        attempt = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                return self._make_mock_session([r429])
+            return self._make_mock_session([ok])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    result = await endpoint.call({}, skip_payload_creation=True)
+        assert result == {"retried": True}
+        assert attempt == 2
+
+    @pytest.mark.asyncio
+    async def test_500_is_retried_with_default_retry_config(self):
+        endpoint = self._make_endpoint(max_retries=3)
+        r500 = self._make_error_response(500)
+        ok = self._make_ok_response({"retried": True})
+
+        attempt = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                return self._make_mock_session([r500])
+            return self._make_mock_session([ok])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    result = await endpoint.call({}, skip_payload_creation=True)
+        assert result == {"retried": True}
+        assert attempt == 2
+
+    @pytest.mark.asyncio
+    async def test_404_is_not_retried_with_default_retry_config(self):
+        endpoint = self._make_endpoint(max_retries=3)
+        r404 = self._make_error_response(404)
+
+        call_count = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._make_mock_session([r404])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await endpoint.call({}, skip_payload_creation=True)
+        assert exc_info.value.status == 404
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_connection_error_is_retried_with_default_retry_config(self):
+        endpoint = self._make_endpoint(max_retries=2)
+
+        call_count = 0
+
+        async def _raise_connection_error(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("boom")
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.request = _raise_connection_error
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", return_value=mock_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    with pytest.raises(ConnectionError):
+                        await endpoint.call({}, skip_payload_creation=True)
+        assert call_count == 3

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -1238,6 +1238,34 @@ class TestRetryConfigDefaultRetriesRealErrors:
         assert call_count == 1
 
     @pytest.mark.asyncio
+    async def test_asyncio_timeout_is_retried_with_default_retry_config(self):
+        # asyncio.TimeoutError != builtin TimeoutError before Python 3.11;
+        # the defaults must retry the asyncio class the same as the native
+        # endpoint fallback does.
+        import asyncio as _asyncio
+
+        endpoint = self._make_endpoint(max_retries=2)
+
+        call_count = 0
+
+        async def _raise_timeout(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise _asyncio.TimeoutError()
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.request = _raise_timeout
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", return_value=mock_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    with pytest.raises(_asyncio.TimeoutError):
+                        await endpoint.call({}, skip_payload_creation=True)
+        assert call_count == 3
+
+    @pytest.mark.asyncio
     async def test_connection_error_is_retried_with_default_retry_config(self):
         endpoint = self._make_endpoint(max_retries=2)
 

--- a/tests/service/test_resilience.py
+++ b/tests/service/test_resilience.py
@@ -283,6 +283,19 @@ class TestRetryConfig:
         assert config.jitter is True
         assert config.jitter_factor == 0.2
 
+    def test_default_retry_exceptions_cover_real_aiohttp_errors(self):
+        """Defaults must retry the errors production code actually raises
+        (aiohttp.ClientResponseError for 429/5xx, connector errors), not just
+        APIClientError, which nothing in production ever constructs."""
+        import aiohttp
+
+        config = RetryConfig()
+
+        error = aiohttp.ClientResponseError(
+            request_info=None, history=(), status=429, message="rate limited"
+        )
+        assert isinstance(error, config.retry_exceptions)
+
     def test_init_custom_values(self):
         config = RetryConfig(
             max_retries=5,


### PR DESCRIPTION
## Summary
- `RetryConfig`/`retry_with_backoff`/`with_retry` defaulted `retry_exceptions` to a tuple headed by `APIClientError` — a class no production code ever raises. Real 429/5xx failures surface as `aiohttp.ClientResponseError` (via `raise_for_status()`), so the documented opt-in retry path retried nothing on exactly the errors users opt in to retry, while the native fallback path classified correctly.
- Defaults now resolve lazily (preserving the package's no-top-level-aiohttp convention) to the previous tuple plus `aiohttp.ClientError`. The existing `_NonRetryableClientError` exclusion keeps non-retryable 4xx giving up immediately. Public signatures unchanged; prior members kept for backward compatibility.
- Normalizing endpoint errors into `APIClientError` was considered and rejected: larger blast radius across exception chains and callers asserting on aiohttp types, with no added correctness.

## Tests
- New endpoint-path regressions with untouched defaults: 429 retried (fails pre-fix), 5xx retried, 404 not retried, connector errors retried.
- `uv run pytest tests/service/ -q` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)