### PR TITLE
fix(protocols): bring Pile cardinality reads inside the lock boundary

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -353,9 +353,11 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
     def items(self) -> Sequence[tuple[UUID, T]]:
         return [(key, self.collections[key]) for key in self.progression]
 
+    @synchronized
     def is_empty(self) -> bool:
         return len(self.progression) == 0
 
+    @synchronized
     def size(self) -> int:
         return len(self.progression)
 
@@ -383,10 +385,12 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
     def __contains__(self, item: ID.RefSeq | ID.Ref) -> bool:
         return item in self.progression
 
+    @synchronized
     def __len__(self) -> int:
         return len(self.collections)
 
     @override
+    @synchronized
     def __bool__(self) -> bool:
         return not self.is_empty()
 

--- a/tests/protocols/generic/test_pile_cross_lock.py
+++ b/tests/protocols/generic/test_pile_cross_lock.py
@@ -9,6 +9,8 @@ import asyncio
 import threading
 import time
 
+import pytest
+
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile
 
@@ -226,6 +228,7 @@ async def test_async_with_block_excludes_sync_thread():
 async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     # While adump holds its snapshot region, a sync-thread include() must not
     # interleave; it lands only after the region releases.
+    pytest.importorskip("pandas", reason="adump serializes through the optional pandas adapter")
     pile = Pile()
     pile.include([_Item() for _ in range(3)])
 
@@ -351,3 +354,37 @@ async def test_async_pile_iterator_bulk_iteration_yields_between_items():
 
     assert seen == 2000
     assert ticks >= 1000, f"ticker starved during bulk iteration (ticks={ticks})"
+
+
+async def test_cardinality_reads_excluded_while_async_method_holds_locks():
+    # __len__ / size / is_empty / __bool__ must sit inside the cross-family
+    # boundary like every other public read: a sync thread's cardinality
+    # read blocks while an async method holds both locks.
+    from lionagi.ln import async_synchronized
+
+    pile = Pile()
+    pile.include(_Item())
+
+    entered = asyncio.Event()
+
+    @async_synchronized
+    async def slow_op(self):
+        entered.set()
+        await asyncio.sleep(0.5)
+
+    got: list = []
+
+    def sync_reads():
+        got.append((len(pile), pile.size(), pile.is_empty(), bool(pile)))
+
+    task = asyncio.ensure_future(slow_op(pile))
+    await asyncio.wait_for(entered.wait(), 5)
+
+    reader = threading.Thread(target=sync_reads)
+    reader.start()
+    await asyncio.sleep(0.15)
+    assert not got, "cardinality reads must wait while an async method holds the locks"
+
+    await task
+    reader.join(5)
+    assert got == [(1, 1, False, True)]


### PR DESCRIPTION
## Summary
- Follow-up to #2318: `__len__`, `size`, `is_empty`, and `__bool__` still read `collections`/`progression` without the sync lock, so a sync thread could observe divergent intermediate state (the two containers disagree mid-mutation, e.g. during `_clear`) while an async operation held the cross-family boundary. All four now take `@synchronized` like every other public read.
- The adump exclusion test now skips cleanly when the optional pandas adapter is absent instead of failing a core-only environment.

## Tests
- New `test_cardinality_reads_excluded_while_async_method_holds_locks`: a sync thread's len/size/is_empty/bool reads block while an async method holds both locks, then observe consistent state.
- `tests/protocols/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)