### PR TITLE
fix(agent): create secret-bearing codex profile 0600 from the first byte

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -887,8 +887,12 @@ def _write_codex_mcp_secret_profile(
     profile_path = codex_home / f"{profile_name}.config.toml"
 
     profile_doc = {"mcp_servers": {name: dict(fields) for name, fields in secret_fields.items()}}
-    profile_path.write_text(toml.dumps(profile_doc))
-    os.chmod(profile_path, 0o600)
+    # The profile carries secrets: create it 0600 from the first byte instead
+    # of write-then-chmod, which leaves a umask-permission window where the
+    # contents are readable (and a wrong-mode file if the write is interrupted).
+    fd = os.open(profile_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(toml.dumps(profile_doc))
     atexit.register(lambda: profile_path.unlink(missing_ok=True))
 
     branch.chat_model.endpoint.config.kwargs["profile"] = profile_name

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -1525,3 +1525,40 @@ async def test_search_tool_gets_workspace_root_from_cwd(tmp_path):
     result = await tool.func_callable(action="grep", pattern="x", path=str(outside))
     assert result["success"] is False
     assert "workspace root" in (result.get("error") or "")
+
+
+async def test_forward_mcp_codex_profile_created_0600_without_chmod_window(tmp_path, monkeypatch):
+    """The secret-bearing profile must be 0600 from the moment it exists.
+    A write-then-chmod sequence leaves a umask-permission window where the
+    secrets are world/group-readable (and a wrong-mode file if the write is
+    interrupted), so the file has to be created with mode 0600 directly —
+    proven here by a permissive umask plus asserting no chmod ever ran on it."""
+    import os as os_mod
+    import stat
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex_home"))
+
+    chmodded: list = []
+    real_chmod = os_mod.chmod
+    monkeypatch.setattr(
+        os_mod, "chmod", lambda p, m, **kw: (chmodded.append(str(p)), real_chmod(p, m, **kw))
+    )
+
+    old_umask = os_mod.umask(0)
+    try:
+        mcp_path = _write_mcp_config(
+            tmp_path,
+            {"khive": {"command": "kkernel", "env": {"API_KEY": "top-secret-value"}}},
+        )
+        config = AgentSpec.compose("reviewer", model="codex/gpt-5.5")
+        config.mcp_config_path = mcp_path
+        branch = await create_agent(config, load_settings=False)
+    finally:
+        os_mod.umask(old_umask)
+
+    profile_name = branch.chat_model.endpoint.config.kwargs["profile"]
+    profile_path = tmp_path / "codex_home" / f"{profile_name}.config.toml"
+    assert profile_path.exists()
+    # 0600 despite umask 0: the mode came from creation, not a later chmod.
+    assert stat.S_IMODE(profile_path.stat().st_mode) == 0o600
+    assert str(profile_path) not in chmodded


### PR DESCRIPTION
## Summary
- The codex MCP profile file carries secrets (API keys routed off the command line). It was written with `write_text` (umask-derived permissions) and only then `chmod(0600)`, leaving a window where the secrets are group/world-readable — and a wrong-mode file behind if the write is interrupted. It is now created with `os.open(..., O_CREAT|O_EXCL, 0o600)` so the mode is correct from the first byte; `O_EXCL` also refuses to follow a pre-planted path.

## Tests
- New regression creates the profile under `umask 0` and asserts mode 0600 with **no** `chmod` call on the path — proving the mode comes from creation, not a later fix-up. Existing 0600 assertions unchanged.
- `tests/agent/test_factory.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)