### PR TITLE
fix(state): make invocations/schedule_runs rebuilds one atomic transaction

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1373,7 +1373,15 @@ class StateDB:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
                 await driver.execute("PRAGMA foreign_keys = OFF")
+                # Everything after the OFF pragma sits inside the outer try so
+                # ANY failure path restores enforcement in the finally block.
+                # The flush commit makes the pragma effective, then BEGIN
+                # IMMEDIATE makes the whole rebuild one atomic transaction —
+                # DDL autocommits per-statement otherwise, so a crash between
+                # DROP and RENAME would strand the data in invocations_new.
                 try:
+                    await driver.commit()
+                    await driver.execute("BEGIN IMMEDIATE")
                     await driver.execute(
                         """
                         CREATE TABLE invocations_new (
@@ -1407,6 +1415,9 @@ class StateDB:
                     for idx_sql in index_sqls:
                         await driver.execute(idx_sql)
                     await driver.commit()
+                except BaseException:
+                    await driver.rollback()
+                    raise
                 finally:
                     await driver.execute("PRAGMA foreign_keys = ON")
                     await driver.commit()
@@ -1529,7 +1540,13 @@ class StateDB:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
                 await driver.execute("PRAGMA foreign_keys = OFF")
+                # Same shape as the invocations rebuild above: flush commit so
+                # the pragma takes effect, then one BEGIN IMMEDIATE transaction
+                # around the whole rebuild so a crash mid-sequence cannot
+                # strand the data in schedule_runs_new.
                 try:
+                    await driver.commit()
+                    await driver.execute("BEGIN IMMEDIATE")
                     await driver.execute(
                         """
                         CREATE TABLE schedule_runs_new (
@@ -1595,6 +1612,9 @@ class StateDB:
                         "WHERE status IN ('queued', 'running', 'retry_wait')"
                     )
                     await driver.commit()
+                except BaseException:
+                    await driver.rollback()
+                    raise
                 finally:
                     await driver.execute("PRAGMA foreign_keys = ON")
                     await driver.commit()

--- a/tests/state/test_check_rebuild_concurrency.py
+++ b/tests/state/test_check_rebuild_concurrency.py
@@ -459,3 +459,72 @@ async def test_drop_legacy_invocations_status_check_swallows_operational_error(t
         assert "'completed_empty'" in row["sql"]
     finally:
         await state.close()
+
+
+async def test_invocations_rebuild_crash_mid_sequence_rolls_back_atomically(tmp_path):
+    """The raw-driver rebuild must be one BEGIN IMMEDIATE transaction. A crash
+    injected between DROP and RENAME must roll the whole rebuild back —
+    leaving the legacy table intact with its rows and no stray
+    ``invocations_new`` — so a later open() can heal the DB. Under
+    per-statement autocommit the same crash strands the data in
+    ``invocations_new`` with ``invocations`` gone, an unrecoverable state."""
+    import aiosqlite
+
+    db_path = tmp_path / "legacy-invocations-crash.db"
+    _create_legacy_invocations_status_db(db_path)
+    with sqlite3.connect(db_path) as seed:
+        seed.execute(
+            "INSERT INTO invocations (id, skill, started_at, created_at, updated_at, status)"
+            " VALUES ('inv-1', 'demo', 0, 0, 0, 'running')"
+        )
+        seed.commit()
+
+    real_execute = aiosqlite.Connection.execute
+    crash = {"armed": True}
+
+    def _crashing_execute(self, sql, *args, **kwargs):
+        if crash["armed"] and "RENAME TO invocations" in str(sql):
+            raise sqlite3.OperationalError("disk I/O error")
+        return real_execute(self, sql, *args, **kwargs)
+
+    aiosqlite.Connection.execute = _crashing_execute
+    try:
+        state = StateDB(db_path)
+        with pytest.raises(sqlite3.OperationalError):
+            await state.open()
+        await state.close()
+    finally:
+        aiosqlite.Connection.execute = real_execute
+
+    # Atomic rollback: legacy table intact with its row, no stray _new table.
+    with sqlite3.connect(db_path) as check:
+        tables = {
+            r[0]
+            for r in check.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'invocations%'"
+            )
+        }
+        assert tables == {"invocations"}, tables
+        rows = list(check.execute("SELECT id FROM invocations"))
+        assert rows == [("inv-1",)]
+
+    # And the DB is healable: a clean re-open completes the rebuild.
+    crash["armed"] = False
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        async with state._read() as conn:
+            sql = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master WHERE type='table' AND name='invocations'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )["sql"]
+        assert "completed_empty" in sql
+    finally:
+        await state.close()


### PR DESCRIPTION
## Summary
- The invocations and schedule_runs CHECK-constraint rebuilds ran their CREATE/INSERT/DROP/RENAME sequence on the raw driver in autocommit mode — Python's sqlite3 driver autocommits DDL per statement — so a crash between `DROP TABLE` and the `RENAME` stranded all rows in the `_new` table with the original table gone. That state is unrecoverable: the migration's own marker check early-returns when the table is missing, so no later open ever heals it.
- Both sequences now use the same shape the schedules rebuilds already had: flush commit so the FK pragma takes effect, one `BEGIN IMMEDIATE` transaction around the whole rebuild, rollback on any error, FK pragma restored in the finally block.

## Tests
- New crash-injection regression: a failure injected at the RENAME step must roll the whole rebuild back (legacy table intact with its rows, no stray `_new` table) and a clean re-open must then complete the migration. Verified discriminating: the test fails against the previous autocommit implementation and passes with this one.
- `tests/state/` green (non-postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)