### PR TITLE
fix(cli): translate fanout plan() max_tasks overflow into clean exit

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -16,7 +16,7 @@ from .._logging import hint, log_error
 from .._providers import add_common_cli_args
 from .._util import EXIT_CODE_BY_STATUS
 from ._checkpoint import FlowResumeError
-from .fanout import _run_fanout
+from .fanout import FanoutPlanError, _run_fanout
 from .flow import FlowPlanError, _resume_flow, _run_flow
 
 # ── flow-spec helpers ────────────────────────────────────────────────────────
@@ -952,6 +952,8 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                 notify=getattr(args, "notify", None),
             ),
             verbose=args.verbose,
+            # planning produced no usable assignments — fail loud with actionable message
+            extra_handlers=((FanoutPlanError, EXIT_CODE_BY_STATUS["failed"]),),
         )
         if rc != 0:
             return rc

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import time
 
+from lionagi._errors import LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import CancelScope, create_task_group, move_on_after
 from lionagi.orchestration import plan
@@ -39,6 +40,10 @@ from ._orchestration import (
     team_history_context,
     worker_is_cli,
 )
+
+
+class FanoutPlanError(LionError):
+    """Orchestrator failed to produce a usable plan."""
 
 
 async def _run_fanout(
@@ -195,14 +200,21 @@ async def _run_fanout_inner(
 
     roster = available_roles()
     progress(f"Phase 1: Orchestrator decomposing task into ≤{num_workers} assignments...")
-    assignments = await plan(
-        env.orc_branch,
-        prompt,
-        roles=roster,
-        dag=False,
-        guidance=role_roster(env.default_model_spec),
-        max_tasks=num_workers,
-    )
+    try:
+        assignments = await plan(
+            env.orc_branch,
+            prompt,
+            roles=roster,
+            dag=False,
+            guidance=role_roster(env.default_model_spec),
+            max_tasks=num_workers,
+        )
+    except ValueError as exc:
+        # plan() raises a bare ValueError when the orchestrator still
+        # overshoots max_tasks after the cap was stated in guidance — mirror
+        # `li o flow`'s FlowPlanError translation so this reaches the CLI's
+        # clean-failure exit path instead of escaping as a raw traceback.
+        raise FanoutPlanError(str(exc)) from exc
     t_decompose = time.monotonic() - t0
     if not assignments:
         return "Orchestrator produced no assignments."

--- a/tests/cli/orchestrate/test_fanout_max_tasks_error.py
+++ b/tests/cli/orchestrate/test_fanout_max_tasks_error.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li o fanout`: planner overshooting max_tasks must fail clean, not raw-traceback.
+
+`plan()` raises a bare ValueError when the orchestrator returns more assignments
+than the worker cap even after the cap was stated in guidance. `li o flow`
+translates that into `FlowPlanError` and maps it to a clean exit code via
+`extra_handlers` in `_run_orch_command`. `li o fanout` calls the same `plan()`
+with `max_tasks=num_workers` but had neither translation, so the ValueError
+escaped `run_orchestrate` as a raw traceback instead of a logged error + exit
+code 1. This module covers both halves of the fix: the fanout.py translation
+and the __init__.py exit-code wiring.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.cli._util import EXIT_CODE_BY_STATUS
+from lionagi.cli.orchestrate import add_orchestrate_subparser, run_orchestrate
+from lionagi.cli.orchestrate import fanout as fanout_module
+from lionagi.cli.orchestrate.fanout import FanoutPlanError
+from lionagi.engines import PlanningEngine
+
+from .test_fanout_artifacts import _fanout_env
+
+
+def _parse_fanout_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="li")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_orchestrate_subparser(subparsers)
+    return parser.parse_args(["o", "fanout", *argv])
+
+
+async def test_run_fanout_translates_over_max_tasks_value_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """plan() raising ValueError for an over-cap plan must surface as
+    FanoutPlanError from `_run_fanout`, not a bare ValueError."""
+    env, run, session = _fanout_env(tmp_path)
+
+    engine_run = type("EngineRunStub", (), {})()
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    monkeypatch.setattr(
+        fanout_module,
+        "plan",
+        AsyncMock(
+            side_effect=ValueError("orchestrator returned 3 assignments, exceeding max_tasks=2")
+        ),
+    )
+    monkeypatch.setattr(fanout_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(fanout_module, "role_roster", lambda model: "worker")
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
+
+    with pytest.raises(FanoutPlanError, match="exceeding max_tasks"):
+        await fanout_module._run_fanout(
+            "codex/model",
+            "work",
+            num_workers=2,
+        )
+
+
+def test_run_orchestrate_fanout_plan_error_clean_exit(caplog):
+    """`run_orchestrate` must map a FanoutPlanError from `_run_fanout` to a
+    logged error + non-zero exit code — never let it (or any BaseException)
+    escape as a raw traceback."""
+    args = _parse_fanout_args(["claude", "do the thing"])
+
+    with patch(
+        "lionagi.cli.orchestrate._run_fanout",
+        AsyncMock(
+            side_effect=FanoutPlanError(
+                "orchestrator returned 5 assignments, exceeding max_tasks=3"
+            )
+        ),
+    ):
+        with caplog.at_level("ERROR"):
+            code = run_orchestrate(args)
+
+    assert code == EXIT_CODE_BY_STATUS["failed"]
+    assert any("exceeding max_tasks" in rec.message for rec in caplog.records)
+
+
+def test_run_orchestrate_fanout_unhandled_error_still_propagates():
+    """Sanity check that the new extra_handlers entry is narrow: an unrelated
+    BaseException from `_run_fanout` (not a FanoutPlanError/timeout) must still
+    propagate rather than being swallowed into a clean exit."""
+    args = _parse_fanout_args(["claude", "do the thing"])
+
+    with patch(
+        "lionagi.cli.orchestrate._run_fanout",
+        AsyncMock(side_effect=RuntimeError("unrelated failure")),
+    ):
+        with pytest.raises(RuntimeError, match="unrelated failure"):
+            run_orchestrate(args)


### PR DESCRIPTION
Closes #2324. `plan()`'s fail-loud ValueError for over-cap orchestrator responses now translates to `FanoutPlanError` in `li o fanout`, mirroring the flow caller: logged error + exit code, no raw traceback. Includes narrowness test (unrelated exceptions still propagate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)