### PR TITLE
fix(ln): preserve caller relative representation in create_path/acreate_path

### DIFF
--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -59,10 +59,16 @@ def _build_safe_path(
     filesystem. Both the sync and async constructors call this so they share
     identical traversal/containment semantics (ADR-0050 D5) — fix the check
     once, here, rather than per-variant.
+
+    Containment is always checked against the resolved (symlink-safe)
+    candidate, but the returned path preserves the caller's own
+    representation: a relative ``directory`` yields a relative return value,
+    an absolute one yields an absolute return value.
     """
     from lionagi.libs.path_safety import contain_and_resolve
 
     directory = StdPath(directory)
+    is_absolute = directory.is_absolute()
 
     # Resolve BEFORE filename can redirect directory into a subdirectory;
     # all containment checks validate against this fixed root.
@@ -121,8 +127,15 @@ def _build_safe_path(
         random_suffix = uuid.uuid4().hex[:random_hash_digits]
         name = f"{name}-{random_suffix}"
 
-    full_path = dir_resolved / f"{name}{ext}"
-    return _contained(full_path.resolve())
+    full_name = f"{name}{ext}"
+    full_path = dir_resolved / full_name
+    resolved_full_path = _contained(full_path.resolve())
+
+    if is_absolute:
+        return resolved_full_path
+    # directory (possibly extended with a slash-separated filename's subdir
+    # component above) still carries the caller's relative representation.
+    return directory / full_name
 
 
 async def acreate_path(
@@ -139,8 +152,9 @@ async def acreate_path(
 ) -> AsyncPath:
     """Async create_path: same validation, same return contract.
 
-    Returns a fully resolved absolute path even when *directory* is relative;
-    callers that need a cwd-relative representation must derive it themselves.
+    Returns a path in the caller's own representation: relative in, relative
+    out; absolute in, absolute out. Containment/traversal checks always run
+    against the fully resolved (symlink-safe) candidate regardless.
     """
     from .concurrency import move_on_after
 
@@ -480,8 +494,9 @@ def create_path(
     directory reached only through a symlink escape, is rejected here just as
     it is in the async constructor.
 
-    Returns a fully resolved absolute path even when *directory* is relative;
-    callers that need a cwd-relative representation must derive it themselves.
+    Returns a path in the caller's own representation: relative in, relative
+    out; absolute in, absolute out. Containment/traversal checks always run
+    against the fully resolved (symlink-safe) candidate regardless.
     """
     full_path = _build_safe_path(
         StdPath(directory),

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -10,7 +10,16 @@ from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path as StdPath
 from types import UnionType
-from typing import Annotated, Any, ParamSpec, TypeVar, Union, get_args, get_origin
+from typing import (
+    Annotated,
+    Any,
+    NamedTuple,
+    ParamSpec,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 from uuid import UUID
 
 from anyio import Path as AsyncPath
@@ -44,6 +53,19 @@ def now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+class _SafePath(NamedTuple):
+    """Caller-facing spelling paired with the validated resolved candidate.
+
+    Filesystem side effects (mkdir, existence checks) must act on
+    ``resolved``, the symlink-safe candidate that was actually validated —
+    never on ``caller_facing``, which can still be redirected by a symlink
+    swapped in after validation but before use.
+    """
+
+    caller_facing: StdPath
+    resolved: StdPath
+
+
 def _build_safe_path(
     directory: StdPath | str,
     filename: str,
@@ -52,7 +74,7 @@ def _build_safe_path(
     time_prefix: bool,
     timestamp_format: str | None,
     random_hash_digits: int,
-) -> StdPath:
+) -> _SafePath:
     """Shared, symlink-safe path construction for create_path/acreate_path.
 
     Validates the filename and resolves the final target without touching the
@@ -61,9 +83,11 @@ def _build_safe_path(
     once, here, rather than per-variant.
 
     Containment is always checked against the resolved (symlink-safe)
-    candidate, but the returned path preserves the caller's own
-    representation: a relative ``directory`` yields a relative return value,
-    an absolute one yields an absolute return value.
+    candidate. The returned pair carries that resolved candidate — the only
+    path callers may use for mkdir/existence side effects — alongside the
+    caller-facing spelling to return to the caller: a relative ``directory``
+    yields a relative caller-facing path, an absolute one yields an absolute
+    caller-facing path.
     """
     from lionagi.libs.path_safety import contain_and_resolve
 
@@ -132,10 +156,10 @@ def _build_safe_path(
     resolved_full_path = _contained(full_path.resolve())
 
     if is_absolute:
-        return resolved_full_path
+        return _SafePath(resolved_full_path, resolved_full_path)
     # directory (possibly extended with a slash-separated filename's subdir
     # component above) still carries the caller's relative representation.
-    return directory / full_name
+    return _SafePath(directory / full_name, resolved_full_path)
 
 
 async def acreate_path(
@@ -159,24 +183,28 @@ async def acreate_path(
     from .concurrency import move_on_after
 
     async def _impl() -> AsyncPath:
-        full_path = AsyncPath(
-            _build_safe_path(
-                StdPath(str(directory)),
-                filename,
-                extension,
-                timestamp,
-                time_prefix,
-                timestamp_format,
-                random_hash_digits,
-            )
+        safe_path = _build_safe_path(
+            StdPath(str(directory)),
+            filename,
+            extension,
+            timestamp,
+            time_prefix,
+            timestamp_format,
+            random_hash_digits,
         )
+        resolved_path = AsyncPath(safe_path.resolved)
 
-        await full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
+        # mkdir and the existence check act on the validated resolved
+        # candidate, never on the caller-facing (possibly relative,
+        # symlink-redirectable) spelling — see _SafePath.
+        await resolved_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
 
-        if await full_path.exists() and not file_exist_ok:
-            raise FileExistsError(f"File {full_path} already exists and file_exist_ok is False.")
+        if await resolved_path.exists() and not file_exist_ok:
+            raise FileExistsError(
+                f"File {safe_path.caller_facing} already exists and file_exist_ok is False."
+            )
 
-        return full_path
+        return AsyncPath(safe_path.caller_facing)
 
     if timeout is None:
         return await _impl()
@@ -498,7 +526,7 @@ def create_path(
     out; absolute in, absolute out. Containment/traversal checks always run
     against the fully resolved (symlink-safe) candidate regardless.
     """
-    full_path = _build_safe_path(
+    safe_path = _build_safe_path(
         StdPath(directory),
         filename,
         extension,
@@ -508,8 +536,13 @@ def create_path(
         random_hash_digits,
     )
 
-    full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
-    if full_path.exists() and not file_exist_ok:
-        raise FileExistsError(f"File {full_path} already exists and file_exist_ok is False.")
+    # mkdir and the existence check act on the validated resolved candidate,
+    # never on the caller-facing (possibly relative, symlink-redirectable)
+    # spelling — see _SafePath.
+    safe_path.resolved.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
+    if safe_path.resolved.exists() and not file_exist_ok:
+        raise FileExistsError(
+            f"File {safe_path.caller_facing} already exists and file_exist_ok is False."
+        )
 
-    return full_path
+    return safe_path.caller_facing

--- a/tests/libs/utils/test_utils_path_traversal.py
+++ b/tests/libs/utils/test_utils_path_traversal.py
@@ -307,3 +307,73 @@ class TestReturnRepresentation:
         (tmp_path / "relbase").mkdir()
         with pytest.raises(ValueError):
             await acreate_path(directory="relbase", filename="../escape.txt")
+
+
+class TestSymlinkSwapBetweenValidationAndMkdir:
+    """A symlink swapped in after validation but before mkdir must not
+    redirect the helper's filesystem side effects outside the checked root.
+
+    Regression: _build_safe_path validated the resolved candidate, but the
+    public helpers ran mkdir/exists against the caller-facing, unresolved
+    ``directory / full_name`` spelling. For a relative directory reached
+    through a symlink, swapping that symlink between validation and mkdir
+    redirected creation outside the checked root even though the check
+    itself had passed. The fix runs mkdir/exists against the resolved
+    candidate captured at validation time, so a later swap of the symlink
+    cannot change where the side effect lands.
+    """
+
+    def _setup(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        base = tmp_path / "race-base"
+        base.mkdir()
+        inside = base / "inside"
+        inside.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = base / "link"
+        _symlink_or_skip(link, inside, target_is_directory=True)
+        return base, inside, outside, link
+
+    def test_create_path_symlink_swap_stays_in_checked_root(self, tmp_path, monkeypatch):
+        base, inside, outside, link = self._setup(tmp_path, monkeypatch)
+
+        swapped = {"done": False}
+        original_mkdir = Path.mkdir
+
+        def swap_then_mkdir(self, *args, **kwargs):
+            if not swapped["done"]:
+                swapped["done"] = True
+                link.unlink()
+                link.symlink_to(outside, target_is_directory=True)
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", swap_then_mkdir)
+
+        create_path(directory="race-base/link", filename="sub/f.txt")
+
+        assert swapped["done"], "mkdir hook never fired; test setup is stale"
+        assert not (outside / "sub").exists(), "swap redirected creation outside the checked root"
+        assert (inside / "sub").is_dir()
+
+    @pytest.mark.anyio
+    async def test_acreate_path_symlink_swap_stays_in_checked_root(self, tmp_path, monkeypatch):
+        base, inside, outside, link = self._setup(tmp_path, monkeypatch)
+
+        swapped = {"done": False}
+        original_mkdir = Path.mkdir
+
+        def swap_then_mkdir(self, *args, **kwargs):
+            if not swapped["done"]:
+                swapped["done"] = True
+                link.unlink()
+                link.symlink_to(outside, target_is_directory=True)
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", swap_then_mkdir)
+
+        await acreate_path(directory="race-base/link", filename="sub/f.txt")
+
+        assert swapped["done"], "mkdir hook never fired; test setup is stale"
+        assert not (outside / "sub").exists(), "swap redirected creation outside the checked root"
+        assert (inside / "sub").is_dir()

--- a/tests/libs/utils/test_utils_path_traversal.py
+++ b/tests/libs/utils/test_utils_path_traversal.py
@@ -254,22 +254,56 @@ class TestCreatePathTraversalContainment:
 
 
 class TestReturnRepresentation:
-    """The shared builder returns a fully resolved absolute path from both
-    constructors, even for a relative directory argument. Previously each
-    constructor returned ``directory / filename`` in the caller's own
-    representation; this pins the new contract as intentional."""
+    """The shared builder preserves the caller's own path representation:
+    a relative ``directory`` argument yields a relative return value (the
+    original create_path/acreate_path contract), while an absolute
+    ``directory`` still yields an absolute return value. Containment and
+    traversal checks always run against the fully resolved candidate
+    regardless of which representation is returned."""
 
-    def test_create_path_relative_directory_returns_resolved_absolute(self, tmp_path, monkeypatch):
+    def test_create_path_relative_directory_returns_relative(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         result = create_path(directory="relbase", filename="file.txt")
+        assert not result.is_absolute()
+        assert result == Path("relbase") / "file.txt"
+        assert result.resolve() == (tmp_path / "relbase" / "file.txt").resolve()
+        # the caller-relative return value must write to the same location
+        # the resolved/contained candidate designates
+        result.write_text("hello")
+        assert (tmp_path / "relbase" / "file.txt").read_text() == "hello"
+
+    def test_create_path_absolute_directory_returns_absolute(self, tmp_path):
+        result = create_path(directory=tmp_path, filename="file.txt")
         assert result.is_absolute()
-        assert result == (tmp_path / "relbase" / "file.txt").resolve()
+        assert result == (tmp_path / "file.txt").resolve()
 
     @pytest.mark.anyio
-    async def test_acreate_path_relative_directory_returns_resolved_absolute(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_acreate_path_relative_directory_returns_relative(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         result = await acreate_path(directory="relbase", filename="file.txt")
-        assert Path(str(result)).is_absolute()
-        assert Path(str(result)) == (tmp_path / "relbase" / "file.txt").resolve()
+        result = Path(str(result))
+        assert not result.is_absolute()
+        assert result == Path("relbase") / "file.txt"
+        assert result.resolve() == (tmp_path / "relbase" / "file.txt").resolve()
+        result.write_text("hello")
+        assert (tmp_path / "relbase" / "file.txt").read_text() == "hello"
+
+    @pytest.mark.anyio
+    async def test_acreate_path_absolute_directory_returns_absolute(self, tmp_path):
+        result = await acreate_path(directory=tmp_path, filename="file.txt")
+        result = Path(str(result))
+        assert result.is_absolute()
+        assert result == (tmp_path / "file.txt").resolve()
+
+    def test_create_path_relative_traversal_still_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "relbase").mkdir()
+        with pytest.raises(ValueError):
+            create_path(directory="relbase", filename="../escape.txt")
+
+    @pytest.mark.anyio
+    async def test_acreate_path_relative_traversal_still_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "relbase").mkdir()
+        with pytest.raises(ValueError):
+            await acreate_path(directory="relbase", filename="../escape.txt")


### PR DESCRIPTION
Closes #2328. Containment/traversal checks still run against the fully resolved candidate, but the return value preserves the caller's representation: relative directory in → relative path out. Restores the pre-hardening public contract; absolute inputs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)