### PR TITLE
fix(studio): keep bare on/off/yes/no ScheduleSet YAML keys as strings

### DIFF
--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -12,6 +12,7 @@ UNCHANGED / DISABLE -- atomically: any invalid member means zero writes.
 
 from __future__ import annotations
 
+import collections.abc
 import hashlib
 import json
 import re
@@ -245,9 +246,42 @@ class ScheduleSetError(ValueError):
         super().__init__("; ".join(f"{name}: {message}" for name, message in errors))
 
 
+class _ScheduleSetLoader(yaml.SafeLoader):
+    """SafeLoader variant scoped to this parse boundary only: a mapping key
+    that YAML 1.1's implicit-bool resolver would collapse (bare on/off/
+    yes/no/true/false) keeps its original text instead. Values are
+    untouched -- only keys, so `enabled: yes` still resolves to `True`.
+
+    Without this, a hand-authored `notify:\n  on: [...]` parses its own
+    `on` key as the bool `True`, and the closed-schema (extra="forbid")
+    rejection then names `True` instead of the quoting workaround.
+    """
+
+    def construct_mapping(self, node, deep=False):
+        if isinstance(node, yaml.MappingNode):
+            self.flatten_mapping(node)
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            if key_node.tag == "tag:yaml.org,2002:bool":
+                key = key_node.value
+            else:
+                key = self.construct_object(key_node, deep=deep)
+                if not isinstance(key, collections.abc.Hashable):
+                    raise yaml.constructor.ConstructorError(
+                        "while constructing a mapping",
+                        node.start_mark,
+                        "found unhashable key",
+                        key_node.start_mark,
+                    )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
 def parse_schedule_set(text: str, *, source: str = "<string>") -> ScheduleSetDocument:
     try:
-        data = yaml.safe_load(text)
+        # _ScheduleSetLoader subclasses SafeLoader and only overrides key
+        # construction -- no unsafe tag resolution is added.
+        data = yaml.load(text, Loader=_ScheduleSetLoader)  # noqa: S506
     except yaml.YAMLError as exc:
         raise ValueError(f"{source}: not valid YAML: {exc}") from exc
     if not isinstance(data, dict):

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -270,6 +270,57 @@ def test_notify_valid_accepted():
     assert doc.schedules["m"].notify.on == ["failed", "timed_out"]
 
 
+def _notify_yaml_manifest(notify_body: str) -> str:
+    return f"""
+apiVersion: lionagi.io/v1alpha1
+kind: ScheduleSet
+metadata:
+  name: a
+  project: demo
+schedules:
+  m:
+    trigger:
+      every: 1h
+    target:
+      kind: command
+      executable: notify-run
+    notify:
+{notify_body}
+"""
+
+
+def test_notify_bare_on_key_parses_as_string_not_bool():
+    """PyYAML's SafeLoader resolves a bare `on` key to the bool True (YAML
+    1.1 implicit booleans). A hand-authored notify block with an unquoted
+    `on:` must still parse and validate, not fail extra="forbid" naming
+    `True`."""
+    manifest = _notify_yaml_manifest("      on: [failed]\n      command: notify-run\n")
+    doc = parse_schedule_set(manifest)
+    assert doc.schedules["m"].notify.on == ["failed"]
+
+
+def test_notify_quoted_on_key_still_works():
+    manifest = _notify_yaml_manifest('      "on": [failed]\n      command: notify-run\n')
+    doc = parse_schedule_set(manifest)
+    assert doc.schedules["m"].notify.on == ["failed"]
+
+
+def test_notify_genuinely_unknown_key_still_rejected():
+    manifest = _notify_yaml_manifest(
+        "      on: [failed]\n      command: notify-run\n      bogus: 1\n"
+    )
+    with pytest.raises(ValidationError, match="bogus"):
+        parse_schedule_set(manifest)
+
+
+def test_sequence_mapping_key_raises_value_error_not_type_error():
+    """A sequence used as a mapping key is unhashable. SafeLoader rejects
+    this with ConstructorError; the custom key-construction override must
+    preserve that check instead of raising an uncaught TypeError."""
+    with pytest.raises(ValueError, match="invalid.yaml"):
+        parse_schedule_set("[a, b]: value\n", source="invalid.yaml")
+
+
 def _policies_manifest(policies_yaml: str, cwd: Path) -> str:
     return f"""
 apiVersion: lionagi.io/v1alpha1


### PR DESCRIPTION
Closes #2300. A SafeLoader subclass scoped to the ScheduleSet parse boundary keeps original text for mapping keys the YAML 1.1 implicit-bool resolver would collapse, so hand-authored `on:` in notify blocks parses without quoting. Values are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)