### PR TITLE
fix(cli): li kill <show-id> unreachable — accept 'active' show status

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -406,8 +406,12 @@ async def _do_kill(
 
         table, entity_type, row = resolved
         current_status = row.get("status")
+        # Shows never reach "running" (they persist as 'active' per the
+        # shows.status vocabulary in state/db.py); every other entity type
+        # uses "running" as its only killable status.
+        killable_status = "active" if entity_type == "show" else "running"
 
-        if current_status != "running":
+        if current_status != killable_status:
             log_error(
                 f"{entity_type} {row['id'][:12]} is already in terminal state: "
                 f"{current_status!r} — nothing to kill"
@@ -419,6 +423,17 @@ async def _do_kill(
 
         if entity_type == "play":
             children = await _walk_running_children(db, entity_type, row["id"])
+        elif entity_type == "show":
+            # ADR-0104 explicitly defers show-level reaping: a show kill only
+            # marks the show row terminal. --recursive is a documented no-op
+            # here rather than a partial reap of the show's plays/workers.
+            children = []
+            if recursive:
+                warn(
+                    f"show {row['id'][:12]}: --recursive does not reap a show's "
+                    "plays or their workers (deferred per ADR-0104) — kill the "
+                    "play or session ids directly to stop a show's workers"
+                )
         elif recursive:
             children = await _list_running_children(db, entity_type, row["id"])
         else:
@@ -530,7 +545,11 @@ async def _do_kill_all_stale(
                     continue
 
                 pid = _read_pid_from_entity(row_dict)
-                if pid is not None and _pid_alive(pid):
+                # A live pid alone isn't enough: if the original process died
+                # and the OS reused its pid, `_pid_alive` still reports True.
+                # Require the same identity check `_check_pid_identity` uses
+                # in the direct-kill path before treating the row as live.
+                if pid is not None and _pid_alive(pid) and _check_pid_identity(pid, "lionagi"):
                     skipped_live += 1
                     if verbose:
                         print(
@@ -677,14 +696,16 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
         description=(
             "Kill a running lionagi entity by id, or sweep all stale running "
             "entities whose underlying OS process is dead.\n\n"
-            "The entity's status is set to 'cancelled' (sessions/invocations) "
-            "or 'aborted' (shows) with reason tracking per ADR-0028.\n\n"
+            "The entity's status is set to 'cancelled' (sessions/invocations), "
+            "'blocked' (plays), or 'aborted' (shows) with reason tracking per "
+            "ADR-0028.\n\n"
             "Recursion boundary: --recursive walks play -> session -> invocation "
-            "and always reaches the PID-bearing workers. SHOW rows cannot be "
-            "killed by id today: shows persist as 'active' (never 'running'), "
-            "so a show id is rejected as already-terminal. To stop a show's "
-            "work, kill its play ids or session ids directly; --all-stale "
-            "cancels play and show rows once their workers are gone.\n\n"
+            "and always reaches the PID-bearing workers. A SHOW kill ('active' "
+            "-> 'aborted') only marks the show row terminal: --recursive has no "
+            "effect on shows, since reaping a show's plays/workers is deferred "
+            "per ADR-0104. To stop a show's work, kill its play ids or session "
+            "ids directly; --all-stale cancels play and show rows once their "
+            "workers are gone.\n\n"
             "Examples:\n"
             "  li kill abc123                        # kill by id prefix\n"
             "  li kill <play-id>                     # also reap linked workers\n"
@@ -716,10 +737,9 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help=(
             "Also kill direct child entities (e.g. invocations spawned by a session). "
-            "Play kills always reap their linked workers. Does NOT extend to shows: "
-            "show rows are rejected as already-terminal (they persist as 'active', "
-            "never 'running') -- kill the play or session id directly to stop a "
-            "show's workers."
+            "Play kills always reap their linked workers. Has no effect on show kills: "
+            "reaping a show's plays/workers is deferred per ADR-0104 -- kill the play "
+            "or session id directly to stop a show's workers."
         ),
     )
     kill.add_argument(

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -761,8 +761,9 @@ async def test_do_kill_all_stale_cancels_dead_pid(
 async def test_do_kill_all_stale_skips_live_pid(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Running session with a LIVE PID is not touched."""
+    """Running session with a LIVE, identity-matching PID is not touched."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: True)
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -775,6 +776,27 @@ async def test_do_kill_all_stale_skips_live_pid(
         assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
             "status"
         ] == "running"
+
+
+async def test_do_kill_all_stale_sweeps_reused_pid(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A live PID that no longer identifies as the tracked process (reused
+    after the original died) must still be swept, not treated as live."""
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: False)
+
+    old_start = time.time() - 7200
+    async with StateDB() as db:
+        sid = await _seed_session(db, status="running", pid=12345, started_at=old_start)
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
+            "status"
+        ] == "cancelled"
 
 
 async def test_do_kill_all_stale_skips_recent(temp_db_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -960,10 +982,43 @@ async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
         ] == "blocked"
 
 
+async def test_do_kill_active_show_succeeds(temp_db_path: Path):
+    """`li kill <show-id>` on a fresh, unmocked active show maps to 'aborted'."""
+    async with StateDB() as db:
+        show_id = await _seed_show(db)  # default status="active" -- no mocking
+
+    rc = await _do_kill(show_id)
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM shows WHERE id = ?", (show_id,)))[
+            "status"
+        ] == "aborted"
+
+
+@pytest.mark.parametrize("terminal_status", ["completed", "aborted", "imported"])
+async def test_do_kill_show_terminal_statuses_refuse(temp_db_path: Path, terminal_status: str):
+    """A show already in a terminal (non-'active') status is rejected, rc=1."""
+    async with StateDB() as db:
+        show_id = await _seed_show(db, status=terminal_status)
+
+    rc = await _do_kill(show_id)
+    assert rc == 1
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM shows WHERE id = ?", (show_id,)))[
+            "status"
+        ] == terminal_status
+
+
 async def test_do_kill_recursive_show_does_not_reap_play_workers(
-    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ):
-    """A recursive show kill remains limited to its direct running plays."""
+    """--recursive is a documented no-op boundary for shows (ADR-0104): the
+    show row goes terminal, but its plays/workers are left untouched."""
+    from lionagi.cli._logging import configure_cli_logging
+
+    configure_cli_logging(verbose=False)
     signalled_pids: list[int] = []
 
     def fake_terminate(pid: int, **kwargs: Any) -> str:
@@ -974,21 +1029,15 @@ async def test_do_kill_recursive_show_does_not_reap_play_workers(
         invocation_id = await _seed_invocation(db, status="running", pid=43002)
         session_id = await _seed_session(db, status="running", pid=43001)
         await db.update_session(session_id, invocation_id=invocation_id)
-        show_id = await _seed_show(db)
+        show_id = await _seed_show(db)  # default status="active" -- no mocking
         play_id = await _seed_play(db, show_id, session_id=session_id)
 
-    async def resolve_running_show(db: StateDB, id_or_short: str):
-        assert id_or_short == show_id
-        show_row = await db.fetch_one("SELECT * FROM shows WHERE id = ?", (show_id,))
-        assert show_row is not None
-        show_row["status"] = "running"
-        return "shows", "show", show_row
-
-    monkeypatch.setattr("lionagi.cli.kill._resolve_entity", resolve_running_show)
     monkeypatch.setattr("lionagi.cli.kill._terminate_pid", fake_terminate)
 
+    capsys.readouterr()
     assert await _do_kill(show_id, recursive=True) == 0
     assert signalled_pids == []
+    assert "does not reap a show's plays or their workers" in capsys.readouterr().err
 
     async with StateDB() as db:
         assert (await db.fetch_one("SELECT status FROM shows WHERE id = ?", (show_id,)))[
@@ -996,7 +1045,7 @@ async def test_do_kill_recursive_show_does_not_reap_play_workers(
         ] == "aborted"
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
             "status"
-        ] == "blocked"
+        ] == "running"
         assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (session_id,)))[
             "status"
         ] == "running"

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -177,8 +177,12 @@ async def test_do_kill_all_stale_does_not_sweep_play_with_live_session(
     import os
 
     own_pid = os.getpid()
-    # _pid_alive returns True for our own pid, False for others.
+    # _pid_alive returns True for our own pid, False for others. The identity
+    # check is mocked too: our own pid is genuinely the pytest process, not a
+    # lionagi CLI invocation, so the real cmdline check would (correctly)
+    # reject it -- here it stands in for a live, identity-matching session.
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: pid == own_pid)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: True)
 
     old_time = time.time() - 7200
     async with StateDB() as db:


### PR DESCRIPTION
Closes #2319. Shows persist as 'active' (never 'running'), so every real show kill was rejected as already-terminal; the masking test forced an unreachable 'running' status. Now 'active' is the killable show status (mapped to 'aborted'); --recursive on shows is an explicitly warned no-op (show-level reaping deferred per ADR-0104). Also hardens _do_kill_all_stale with the PID-reuse identity check the direct-kill path already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)