### PR TITLE
fix(operations): fail loudly when outgoing instruction content is empty

### DIFF
--- a/lionagi/_errors.py
+++ b/lionagi/_errors.py
@@ -156,5 +156,14 @@ class TimeoutError(LionError):  # noqa: A001 — intentional shadowing of builti
     __slots__ = ()
 
 
+class EmptyOutgoingContentError(LionError, ValueError):
+    """Raised when a model call is about to go out with no user content
+    despite a non-empty instruction having been supplied."""
+
+    default_message = "Assembled outgoing message content is empty"
+    default_status_code = 500
+    __slots__ = ()
+
+
 ItemNotFoundError = NotFoundError
 ItemExistsError = ExistsError

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from lionagi._errors import LionError
+from lionagi._errors import EmptyOutgoingContentError, LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.casts.emission import SpawnRequest, TaskAssignment
 from lionagi.ln.concurrency import CancelScope, move_on_after
@@ -1881,6 +1881,8 @@ async def _run_flow_inner(
             assignments = await plan(
                 env.orc_branch, prompt, roles=roster, dag=True, guidance=guidance, max_tasks=max_ops
             )
+        except EmptyOutgoingContentError:
+            raise
         except ValueError as exc:
             # plan() raises a bare ValueError when the orchestrator still
             # overshoots max_tasks after the cap was stated in guidance —
@@ -1900,6 +1902,8 @@ async def _run_flow_inner(
                     + " Return ONLY the assignments list — do not perform the task.",
                     max_tasks=max_ops,
                 )
+            except EmptyOutgoingContentError:
+                raise
             except ValueError as exc:
                 raise FlowPlanError(str(exc)) from exc
         if not assignments:

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import JsonValue
 
+from lionagi._errors import EmptyOutgoingContentError
 from lionagi.ln._to_list import to_list
 from lionagi.protocols.messages import (
     ActionResponse,
@@ -216,6 +217,25 @@ def _prepare_run_kwargs(
         role_str = role.value if isinstance(role, MessageRole) else str(role)
         chat_msgs.append({"role": role_str, "content": rendered})
 
+    # The current turn's content is always the last entry appended to
+    # `_contents` above (guidance-merge branch, action-context branch, and
+    # plain-append branch all push it last). If the caller supplied real
+    # instruction text/media but that entry rendered empty and got filtered
+    # out of `chat_msgs` by `if not rendered: continue` above, the model call
+    # would silently go out carrying only scaffolding (system/guidance) and
+    # no user content — worse than a loud failure, since the run "completes"
+    # with a useless reply. `rendered` here still holds the last loop
+    # iteration's value even when that iteration hit `continue`.
+    if _contents and _has_real_instruction_text(ins.content) and not rendered:
+        raise EmptyOutgoingContentError(
+            "Refusing to call the model: the assembled outgoing message list "
+            "is empty for the current turn despite a non-empty instruction "
+            f"being supplied (instruction={ins.content.instruction!r}, "
+            f"plain_content={ins.content.plain_content!r}). The instruction "
+            "content was lost or filtered during message assembly — this is "
+            "a bug, not a valid empty-prompt call."
+        )
+
     kw["messages"] = chat_msgs
     return ins, kw
 
@@ -255,6 +275,22 @@ async def _apply_context_providers(
     branch._last_context_report.set(report)
     branch._last_context_report_fallback = report
     return ins, report
+
+
+def _has_real_instruction_text(content) -> bool:
+    """True if an InstructionContent carries caller-supplied text/media.
+
+    Deliberately ignores ``guidance``/``prompt_context`` (scaffolding this
+    module injects itself) so the check reflects only what the caller asked
+    for, not what the system/context providers added around it.
+    """
+    if content is None:
+        return False
+    return bool(
+        getattr(content, "instruction", None)
+        or getattr(content, "plain_content", None)
+        or getattr(content, "images", None)
+    )
 
 
 def _collect_action_dicts(act_res_msgs):

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -227,13 +227,18 @@ def _prepare_run_kwargs(
     # with a useless reply. `rendered` here still holds the last loop
     # iteration's value even when that iteration hit `continue`.
     if _contents and _has_real_instruction_text(ins.content) and not rendered:
+        _instruction_text = getattr(ins.content, "instruction", None)
+        _plain_content = getattr(ins.content, "plain_content", None)
+        _instruction_len = len(_instruction_text) if _instruction_text else 0
+        _plain_content_len = len(_plain_content) if _plain_content else 0
+        _has_images = bool(getattr(ins.content, "images", None))
         raise EmptyOutgoingContentError(
             "Refusing to call the model: the assembled outgoing message list "
             "is empty for the current turn despite a non-empty instruction "
-            f"being supplied (instruction={ins.content.instruction!r}, "
-            f"plain_content={ins.content.plain_content!r}). The instruction "
-            "content was lost or filtered during message assembly — this is "
-            "a bug, not a valid empty-prompt call."
+            f"being supplied (instruction_len={_instruction_len}, "
+            f"plain_content_len={_plain_content_len}, has_images={_has_images}). "
+            "The instruction content was lost or filtered during message "
+            "assembly — this is a bug, not a valid empty-prompt call."
         )
 
     kw["messages"] = chat_msgs

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import pytest
 
+from lionagi._errors import EmptyOutgoingContentError
 from lionagi.casts.emission import TaskAssignment
 from lionagi.cli.orchestrate.flow import FlowPlanError, _parse_reactive, _run_flow_inner
 
@@ -25,7 +26,10 @@ class _FakeOrcBranch:
     async def operate(self, **kw):
         self.operate_calls.append(kw)
         if self._results:
-            return self._results.pop(0)
+            result = self._results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
         return SimpleNamespace(assignments=[])
 
 
@@ -124,6 +128,33 @@ async def test_over_max_tasks_on_retry_raises_flow_plan_error(tmp_path):
         await _run_flow_inner(
             "codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True, max_ops=1
         )
+    assert len(orc.operate_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_outgoing_content_propagates_from_initial_plan(tmp_path):
+    """EmptyOutgoingContentError is a ValueError subclass, but it must escape the
+    initial plan() try/except as itself — not be recast into FlowPlanError, which
+    would hide a lost-prompt runtime defect as a planner-cap violation."""
+    orc = _FakeOrcBranch([EmptyOutgoingContentError("outgoing instruction content was empty")])
+    with pytest.raises(EmptyOutgoingContentError):
+        await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
+    assert len(orc.operate_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_outgoing_content_propagates_from_retry_plan(tmp_path):
+    """Same as above but for the reinforced-retry call site: an empty first plan
+    triggers the retry, and the retry's plan() call raises EmptyOutgoingContentError.
+    That must also escape as itself, not FlowPlanError."""
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(assignments=[]),  # triggers the reinforced retry
+            EmptyOutgoingContentError("outgoing instruction content was empty"),
+        ]
+    )
+    with pytest.raises(EmptyOutgoingContentError):
+        await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
     assert len(orc.operate_calls) == 2
 
 

--- a/tests/operations/test_chat_prepare.py
+++ b/tests/operations/test_chat_prepare.py
@@ -76,8 +76,13 @@ def test_prepare_run_kwargs_raises_when_real_instruction_renders_empty(monkeypat
 
     monkeypatch.setattr(InstructionContent, "rendered", property(lambda self: ""))
 
-    with pytest.raises(EmptyOutgoingContentError, match="a real, non-empty prompt"):
+    with pytest.raises(EmptyOutgoingContentError, match="instruction_len=") as excinfo:
         _prepare_run_kwargs(branch, "a real, non-empty prompt", param)
+
+    # The prompt text itself must never appear in the exception message -
+    # it gets serialized into persisted failure signals (RunFailed) and
+    # must not carry caller-supplied content.
+    assert "a real, non-empty prompt" not in str(excinfo.value)
 
 
 def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeypatch):

--- a/tests/operations/test_chat_prepare.py
+++ b/tests/operations/test_chat_prepare.py
@@ -3,8 +3,12 @@
 
 """Tests for lionagi/operations/chat/_prepare.py::_prepare_run_kwargs."""
 
+import pytest
+
+from lionagi._errors import EmptyOutgoingContentError
 from lionagi.operations.chat._prepare import _prepare_run_kwargs
 from lionagi.operations.types import ChatParam
+from lionagi.protocols.messages.instruction import InstructionContent
 from lionagi.session.branch import Branch
 
 # ---------------------------------------------------------------------------
@@ -54,3 +58,37 @@ def test_prepare_run_kwargs_kw_contains_messages_key():
 
     assert "messages" in kw
     assert isinstance(kw["messages"], list)
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud guard (issue #2308): a non-empty instruction must never silently
+# vanish from the outgoing message list.
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_run_kwargs_raises_when_real_instruction_renders_empty(monkeypatch):
+    """If the current turn carries real instruction text but its rendered
+    form comes out empty (an assembly bug of any kind — this guard doesn't
+    care which), the call must fail loudly instead of silently sending the
+    model scaffolding-only content and completing with a useless reply."""
+    branch = Branch()
+    param = ChatParam()
+
+    monkeypatch.setattr(InstructionContent, "rendered", property(lambda self: ""))
+
+    with pytest.raises(EmptyOutgoingContentError, match="a real, non-empty prompt"):
+        _prepare_run_kwargs(branch, "a real, non-empty prompt", param)
+
+
+def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeypatch):
+    """The guard is scoped to *real* instruction text — a turn with no
+    instruction at all (e.g. a bare action-response continuation) that
+    happens to render empty must not be treated as the bug this guards."""
+    branch = Branch()
+    param = ChatParam()
+
+    monkeypatch.setattr(InstructionContent, "rendered", property(lambda self: ""))
+
+    # No instruction text/plain_content/images supplied -> guard must not fire.
+    _ins, kw = _prepare_run_kwargs(branch, None, param)
+    assert kw["messages"] == []


### PR DESCRIPTION
Addresses #2308 (fail-loud floor; root cause investigation documented on the issue follow-up). `_prepare_run_kwargs` now raises `EmptyOutgoingContentError` when a turn carrying real instruction text/media assembles into an empty outgoing message list — converting the worst outcome (model call 'completes' with scaffolding-only content) into a diagnosable failure at the shared chokepoint used by both the API and CLI streaming paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)