### PR TITLE
fix(cli): correlate sweep identity checks and preserve unverifiable pids

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -141,7 +141,9 @@ def _check_pid_identity_tristate(
             create_time_ok = (
                 abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
             )
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+        except psutil.NoSuchProcess:
+            return "not_ours"
+        except psutil.AccessDenied:
             return "unverifiable"
         if not create_time_ok:
             return "not_ours"
@@ -149,6 +151,11 @@ def _check_pid_identity_tristate(
     if expected_session_id is not None:
         try:
             marker = proc.environ().get("LIONAGI_SESSION_ID")
+        except psutil.NoSuchProcess:
+            # The process died between the liveness check and here: the row
+            # is genuinely stale, and letting this escape would abort the
+            # whole sweep with later rows unprocessed.
+            return "not_ours"
         except (psutil.AccessDenied, NotImplementedError):
             marker = None
         if marker is not None:
@@ -161,7 +168,9 @@ def _check_pid_identity_tristate(
 
     try:
         cmdline = proc.cmdline()
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
+    except psutil.NoSuchProcess:
+        return "not_ours"
+    except psutil.AccessDenied:
         return "unverifiable"
 
     return "ours" if _cmdline_is_lionagi(cmdline, expected_cmd) else "not_ours"

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -9,7 +9,7 @@ import os
 import signal
 import time
 from collections import deque
-from typing import Any
+from typing import Any, Literal
 
 import psutil
 
@@ -107,6 +107,64 @@ def _check_pid_identity(
         return False
 
     return _cmdline_is_lionagi(cmdline, expected_cmd)
+
+
+_IdentityVerdict = Literal["ours", "not_ours", "unverifiable"]
+
+
+def _check_pid_identity_tristate(
+    pid: int,
+    expected_cmd: str,
+    *,
+    expected_session_id: str | None = None,
+    expected_create_time: float | None = None,
+) -> _IdentityVerdict:
+    """Sweep-only identity check that separates "definitely not ours" from
+    "cannot tell" (permission denied reading process details).
+
+    The direct-kill path (`_check_pid_identity`) collapses AccessDenied to a
+    refusal, which is the safe default when a human explicitly asked to kill
+    one entity. The stale sweep runs unattended over many rows; if it reused
+    that same collapse, a live worker we simply lack permission to inspect
+    would be swept and its row marked cancelled while the process keeps
+    running. Callers must treat "unverifiable" as still-alive, not as dead.
+    """
+    try:
+        proc = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return "not_ours"
+    except psutil.AccessDenied:
+        return "unverifiable"
+
+    if expected_create_time is not None:
+        try:
+            create_time_ok = (
+                abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return "unverifiable"
+        if not create_time_ok:
+            return "not_ours"
+
+    if expected_session_id is not None:
+        try:
+            marker = proc.environ().get("LIONAGI_SESSION_ID")
+        except (psutil.AccessDenied, NotImplementedError):
+            marker = None
+        if marker is not None:
+            return "ours" if marker == expected_session_id else "not_ours"
+        if expected_create_time is None:
+            # No create_time correlation and the env marker is unreadable:
+            # cmdline alone cannot distinguish this run from a different
+            # concurrent one that recycled the pid.
+            return "unverifiable"
+
+    try:
+        cmdline = proc.cmdline()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return "unverifiable"
+
+    return "ours" if _cmdline_is_lionagi(cmdline, expected_cmd) else "not_ours"
 
 
 def _terminate_pid(
@@ -511,6 +569,7 @@ async def _do_kill_all_stale(
     killed = 0
     skipped_live = 0
     skipped_recent = 0
+    skipped_unverifiable = 0
 
     live_status_for: dict[str, str] = {
         "sessions": "running",
@@ -547,15 +606,51 @@ async def _do_kill_all_stale(
                 pid = _read_pid_from_entity(row_dict)
                 # A live pid alone isn't enough: if the original process died
                 # and the OS reused its pid, `_pid_alive` still reports True.
-                # Require the same identity check `_check_pid_identity` uses
-                # in the direct-kill path before treating the row as live.
-                if pid is not None and _pid_alive(pid) and _check_pid_identity(pid, "lionagi"):
-                    skipped_live += 1
-                    if verbose:
-                        print(
-                            f"  skip {entity_type} {entity_id[:12]}: process {pid} is still alive"
-                        )
-                    continue
+                # Correlate against the row's own session id / recorded
+                # create_time — the same fields the direct-kill path uses —
+                # so a recycled pid occupied by a DIFFERENT lionagi process
+                # doesn't pass as "still alive".
+                if pid is not None and _pid_alive(pid):
+                    meta = (
+                        row_dict.get("node_metadata")
+                        if isinstance(row_dict.get("node_metadata"), dict)
+                        else {}
+                    )
+                    expected_session_id = entity_id if entity_type == "session" else None
+                    raw_ct = meta.get("pid_create_time")
+                    try:
+                        expected_create_time = float(raw_ct) if raw_ct is not None else None
+                    except (TypeError, ValueError):
+                        expected_create_time = None
+
+                    verdict = _check_pid_identity_tristate(
+                        pid,
+                        "lionagi",
+                        expected_session_id=expected_session_id,
+                        expected_create_time=expected_create_time,
+                    )
+                    if verdict == "ours":
+                        skipped_live += 1
+                        if verbose:
+                            print(
+                                f"  skip {entity_type} {entity_id[:12]}: "
+                                f"process {pid} is still alive"
+                            )
+                        continue
+                    if verdict == "unverifiable":
+                        # We couldn't read enough of the process to confirm
+                        # identity either way (e.g. AccessDenied). Treat as
+                        # live rather than sweep it out from under a worker
+                        # we simply can't inspect.
+                        skipped_unverifiable += 1
+                        if verbose:
+                            print(
+                                f"  skip {entity_type} {entity_id[:12]}: process {pid} "
+                                "identity unverifiable (permission denied) — treated as live"
+                            )
+                        continue
+                    # verdict == "not_ours": pid was recycled by an unrelated
+                    # process, fall through and sweep the row.
 
                 if dry_run:
                     print(
@@ -684,7 +779,8 @@ async def _do_kill_all_stale(
     prefix = "(dry-run) would cancel" if dry_run else "cancelled"
     print(
         f"\n{prefix} {killed} stale entities "
-        f"[skipped_recent={skipped_recent}, skipped_live_pid={skipped_live}]"
+        f"[skipped_recent={skipped_recent}, skipped_live_pid={skipped_live}, "
+        f"skipped_unverifiable_pid={skipped_unverifiable}]"
     )
     return 0
 

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -975,6 +975,41 @@ async def test_do_kill_all_stale_access_denied_not_cancelled(
         ] == "running", "AccessDenied must not be treated as a dead/recycled pid"
 
 
+async def test_do_kill_all_stale_process_vanishing_mid_check_does_not_abort_sweep(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A process dying between the liveness check and the psutil detail reads
+    (NoSuchProcess from environ/create_time/cmdline) must classify the row as
+    stale and keep the sweep going — not escape and abort the whole sweep with
+    later rows unprocessed."""
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+
+    fake_no_such = type("NoSuchProcess", (Exception,), {})
+    fake_psutil = MagicMock()
+    fake_psutil.NoSuchProcess = fake_no_such
+    fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    fake_proc = MagicMock()
+    fake_proc.environ.side_effect = fake_no_such("gone")
+    fake_proc.cmdline.side_effect = fake_no_such("gone")
+    fake_proc.create_time.side_effect = fake_no_such("gone")
+    fake_psutil.Process.return_value = fake_proc
+    monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
+
+    old_start = time.time() - 7200
+    async with StateDB() as db:
+        first = await _seed_session(db, status="running", pid=11111, started_at=old_start)
+        second = await _seed_session(db, status="running", pid=22222, started_at=old_start)
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        for sid in (first, second):
+            assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
+                "status"
+            ] == "cancelled", "vanished processes are stale; BOTH rows must be swept"
+
+
 # ── cascade kill ───────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -763,7 +763,7 @@ async def test_do_kill_all_stale_skips_live_pid(
 ):
     """Running session with a LIVE, identity-matching PID is not touched."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: True)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "ours")
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -784,7 +784,9 @@ async def test_do_kill_all_stale_sweeps_reused_pid(
     """A live PID that no longer identifies as the tracked process (reused
     after the original died) must still be swept, not treated as live."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: False)
+    monkeypatch.setattr(
+        "lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "not_ours"
+    )
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -855,6 +857,122 @@ async def test_do_kill_all_stale_uses_stale_auto_reason(
         )
         assert row is not None
         assert row["reason_code"] == RunReasons.CANCELLED_STALE_AUTO
+
+
+async def test_do_kill_all_stale_recycled_pid_swept_with_correlation(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A recycled pid occupied by an unrelated lionagi-shaped process must be
+    swept once the row's own pid_create_time is correlated against it, even
+    though the cmdline alone still looks like a genuine lionagi invocation."""
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+
+    fake_psutil = MagicMock()
+    fake_proc = MagicMock()
+    fake_proc.cmdline.return_value = ["/usr/bin/python3", "-m", "lionagi.cli"]
+    fake_proc.environ.return_value = {}
+    fake_proc.create_time.return_value = 999.0  # does NOT match recorded 100.0
+    fake_psutil.Process.return_value = fake_proc
+    fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
+
+    old_start = time.time() - 7200
+    async with StateDB() as db:
+        sid = str(uuid.uuid4())
+        prog = str(uuid.uuid4())
+        await db.create_progression(prog)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog,
+                "status": "running",
+                "started_at": old_start,
+                "node_metadata": {"pid": 12345, "pid_create_time": 100.0},
+            }
+        )
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
+            "status"
+        ] == "cancelled", "recycled pid with mismatched create_time must be swept"
+
+
+async def test_do_kill_all_stale_matching_correlation_skips_live(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the row's pid_create_time genuinely matches the live process,
+    the sweep must still skip it as live (not a regression on the happy path)."""
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+
+    fake_psutil = MagicMock()
+    fake_proc = MagicMock()
+    fake_proc.cmdline.return_value = ["/usr/bin/python3", "-m", "lionagi.cli"]
+    fake_proc.environ.return_value = {}
+    fake_proc.create_time.return_value = 100.0  # matches recorded value
+    fake_psutil.Process.return_value = fake_proc
+    fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
+
+    old_start = time.time() - 7200
+    async with StateDB() as db:
+        sid = str(uuid.uuid4())
+        prog = str(uuid.uuid4())
+        await db.create_progression(prog)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog,
+                "status": "running",
+                "started_at": old_start,
+                "node_metadata": {"pid": 12345, "pid_create_time": 100.0},
+            }
+        )
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
+            "status"
+        ] == "running", "a genuinely live, correlated process must not be swept"
+
+
+async def test_do_kill_all_stale_access_denied_not_cancelled(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A live pid we cannot inspect (psutil.AccessDenied) must be treated as
+    still alive by the sweep, not cancelled out from under a running worker.
+
+    Discrimination: on unfixed code the sweep's bare `_check_pid_identity`
+    call collapses AccessDenied to False ("not ours"), so the row gets
+    cancelled while the process keeps running. Post-fix the tri-state check
+    reports "unverifiable" and the sweep skips it.
+    """
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
+
+    fake_access_denied = type("AccessDenied", (Exception,), {})
+    fake_psutil = MagicMock()
+    fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake_psutil.AccessDenied = fake_access_denied
+    fake_psutil.Process.side_effect = fake_access_denied("no access")
+    monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
+
+    old_start = time.time() - 7200
+    async with StateDB() as db:
+        sid = await _seed_session(db, status="running", pid=54321, started_at=old_start)
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
+            "status"
+        ] == "running", "AccessDenied must not be treated as a dead/recycled pid"
 
 
 # ── cascade kill ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up hardening on the stale sweep. Adds a sweep-scoped tri-state identity check (ours / not_ours / unverifiable): rows whose live PID cannot be inspected (AccessDenied) are treated as live instead of cancelled, and the sweep now correlates the row's own session id and recorded pid create-time — the same fields the direct-kill path uses — so a recycled PID occupied by a different lionagi-shaped process no longer passes as the recorded worker. Direct-kill semantics unchanged (still refuses on unverifiable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)