### PR TITLE
fix(studio): keep explicit !!bool-tagged ScheduleSet keys as real bools

### DIFF
--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -88,6 +88,11 @@ def _build_safe_path(
     caller-facing spelling to return to the caller: a relative ``directory``
     yields a relative caller-facing path, an absolute one yields an absolute
     caller-facing path.
+
+    Validation happens once, here, at call time — nothing is reserved
+    against later filesystem changes, so a relative ``directory`` is only
+    race-safe against concurrent mutation for as long as the caller resolves
+    it the same way create_path/acreate_path did.
     """
     from lionagi.libs.path_safety import contain_and_resolve
 
@@ -179,6 +184,11 @@ async def acreate_path(
     Returns a path in the caller's own representation: relative in, relative
     out; absolute in, absolute out. Containment/traversal checks always run
     against the fully resolved (symlink-safe) candidate regardless.
+
+    The returned path is validated at creation time only — it is not reserved
+    against filesystem changes that happen afterward. Callers that need
+    race-safety against a concurrently mutating relative `directory` should
+    pass an absolute directory instead.
     """
     from .concurrency import move_on_after
 
@@ -525,6 +535,11 @@ def create_path(
     Returns a path in the caller's own representation: relative in, relative
     out; absolute in, absolute out. Containment/traversal checks always run
     against the fully resolved (symlink-safe) candidate regardless.
+
+    The returned path is validated at creation time only — it is not reserved
+    against filesystem changes that happen afterward. Callers that need
+    race-safety against a concurrently mutating relative `directory` should
+    pass an absolute directory instead.
     """
     safe_path = _build_safe_path(
         StdPath(directory),

--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -248,13 +248,22 @@ class ScheduleSetError(ValueError):
 
 class _ScheduleSetLoader(yaml.SafeLoader):
     """SafeLoader variant scoped to this parse boundary only: a mapping key
-    that YAML 1.1's implicit-bool resolver would collapse (bare on/off/
+    that YAML 1.1's *implicit* bool resolver would collapse (bare on/off/
     yes/no/true/false) keeps its original text instead. Values are
     untouched -- only keys, so `enabled: yes` still resolves to `True`.
 
     Without this, a hand-authored `notify:\n  on: [...]` parses its own
     `on` key as the bool `True`, and the closed-schema (extra="forbid")
     rejection then names `True` instead of the quoting workaround.
+
+    A key that is *explicitly* tagged (`!!bool on:`) is left alone and
+    still constructs as the real bool `True` -- the leniency here is only
+    for the surprising implicit YAML 1.1 resolution, not for an author who
+    asked for a bool key on purpose. Explicitness is detected from the key
+    node's mark span: PyYAML's composer sets a scalar node's start mark to
+    the position of its tag handle (if any), so the raw source slice
+    between start and end mark includes the `!!bool` text for an explicit
+    tag but is just `on`/`off`/... for an implicit one.
     """
 
     def construct_mapping(self, node, deep=False):
@@ -262,7 +271,9 @@ class _ScheduleSetLoader(yaml.SafeLoader):
             self.flatten_mapping(node)
         mapping: dict[Any, Any] = {}
         for key_node, value_node in node.value:
-            if key_node.tag == "tag:yaml.org,2002:bool":
+            if key_node.tag == "tag:yaml.org,2002:bool" and not self._is_explicitly_tagged(
+                key_node
+            ):
                 key = key_node.value
             else:
                 key = self.construct_object(key_node, deep=deep)
@@ -275,6 +286,13 @@ class _ScheduleSetLoader(yaml.SafeLoader):
                     )
             mapping[key] = self.construct_object(value_node, deep=deep)
         return mapping
+
+    @staticmethod
+    def _is_explicitly_tagged(node: yaml.Node) -> bool:
+        """True if the node's source span starts with a `!` tag handle
+        rather than the bare scalar text (see class docstring)."""
+        span = node.start_mark.buffer[node.start_mark.index : node.end_mark.index]
+        return span.startswith("!")
 
 
 def parse_schedule_set(text: str, *, source: str = "<string>") -> ScheduleSetDocument:

--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -256,15 +256,22 @@ class _ScheduleSetLoader(yaml.SafeLoader):
     `on` key as the bool `True`, and the closed-schema (extra="forbid")
     rejection then names `True` instead of the quoting workaround.
 
-    A key that is *explicitly* tagged (`!!bool on:`) is left alone and
-    still constructs as the real bool `True` -- the leniency here is only
-    for the surprising implicit YAML 1.1 resolution, not for an author who
-    asked for a bool key on purpose. Explicitness is detected from the key
-    node's mark span: PyYAML's composer sets a scalar node's start mark to
-    the position of its tag handle (if any), so the raw source slice
-    between start and end mark includes the `!!bool` text for an explicit
-    tag but is just `on`/`off`/... for an implicit one.
+    A key that is *explicitly* tagged (`!!bool on:`, in any property order,
+    e.g. `&a !!bool on:`) is left alone and still constructs as the real
+    bool `True` -- the leniency here is only for the surprising implicit
+    YAML 1.1 resolution, not for an author who asked for a bool key on
+    purpose. Explicitness is recorded while composing: the parser's scalar
+    event carries a non-None ``tag`` exactly when the source wrote one, so
+    the composer override below stamps that fact onto the node before the
+    resolver fills in the implicit tag. Aliases reuse the anchored node and
+    therefore inherit its explicitness.
     """
+
+    def compose_scalar_node(self, anchor):
+        explicit_tag = self.peek_event().tag is not None
+        node = super().compose_scalar_node(anchor)
+        node.lionagi_explicit_tag = explicit_tag
+        return node
 
     def construct_mapping(self, node, deep=False):
         if isinstance(node, yaml.MappingNode):
@@ -289,10 +296,9 @@ class _ScheduleSetLoader(yaml.SafeLoader):
 
     @staticmethod
     def _is_explicitly_tagged(node: yaml.Node) -> bool:
-        """True if the node's source span starts with a `!` tag handle
-        rather than the bare scalar text (see class docstring)."""
-        span = node.start_mark.buffer[node.start_mark.index : node.end_mark.index]
-        return span.startswith("!")
+        """True if the source wrote a tag for this node (recorded at compose
+        time; see class docstring)."""
+        return getattr(node, "lionagi_explicit_tag", False)
 
 
 def parse_schedule_set(text: str, *, source: str = "<string>") -> ScheduleSetDocument:

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -324,6 +324,24 @@ def test_notify_explicit_bool_tagged_on_key_still_rejected():
         parse_schedule_set(manifest)
 
 
+def test_notify_anchor_then_explicit_bool_tagged_key_still_rejected():
+    """YAML node properties may appear in either order; `&a !!bool on:` is
+    just as explicit as `!!bool on:` and must also construct as `True` and
+    trip the closed schema."""
+    manifest = _notify_yaml_manifest("      &a !!bool on: [failed]\n      command: notify-run\n")
+    with pytest.raises(ValidationError, match="True"):
+        parse_schedule_set(manifest)
+
+
+def test_notify_alias_of_implicit_anchored_key_stays_text():
+    """An anchored-but-untagged key (`&a on:`) is still implicit resolution,
+    so it keeps the text leniency; an alias reusing it inherits the same
+    node and therefore the same outcome."""
+    manifest = _notify_yaml_manifest("      &a on: [failed]\n      command: notify-run\n")
+    doc = parse_schedule_set(manifest)
+    assert doc.schedules["m"].notify.on == ["failed"]
+
+
 def test_sequence_mapping_key_raises_value_error_not_type_error():
     """A sequence used as a mapping key is unhashable. SafeLoader rejects
     this with ConstructorError; the custom key-construction override must

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -313,6 +313,17 @@ def test_notify_genuinely_unknown_key_still_rejected():
         parse_schedule_set(manifest)
 
 
+def test_notify_explicit_bool_tagged_on_key_still_rejected():
+    """The bare/implicit `on:` leniency is scoped to YAML 1.1's *implicit*
+    bool resolution. A key explicitly tagged `!!bool on:` is an author
+    asking for a real bool key on purpose, so it must still construct as
+    `True` and trip the closed schema, not silently parse as the string
+    "on"."""
+    manifest = _notify_yaml_manifest("      !!bool on: [failed]\n      command: notify-run\n")
+    with pytest.raises(ValidationError, match="True"):
+        parse_schedule_set(manifest)
+
+
 def test_sequence_mapping_key_raises_value_error_not_type_error():
     """A sequence used as a mapping key is unhashable. SafeLoader rejects
     this with ConstructorError; the custom key-construction override must


### PR DESCRIPTION
Follow-up to the bare-on: loader change: the implicit-bool key leniency no longer swallows an EXPLICIT `!!bool on:` tag — explicitly tagged keys construct as real bools again (and trip the closed schema as before), detected via the key node's source-mark span. Also documents the caller-side race contract on create_path/acreate_path (validated at creation time, not reserved; pass absolute directories for race-safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)