### PR TITLE
chore(deps): floor mcp at the release that verifies transport request origin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ mcp = [
     # fastmcp -> mcp pulls Starlette transitively but mcp only pins
     # starlette>=0.27, so floor the patched version here too (mirrors [studio]).
     "starlette>=1.3.1",
+    # fastmcp does not floor mcp itself; 1.28.1 is the first release whose
+    # HTTP and WebSocket transports verify request origin and session
+    # ownership, so floor it here for the same reason as starlette above.
+    "mcp>=1.28.1",
 ]
 
 rich = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,9 @@ mcp = [
     # fastmcp -> mcp pulls Starlette transitively but mcp only pins
     # starlette>=0.27, so floor the patched version here too (mirrors [studio]).
     "starlette>=1.3.1",
-    # fastmcp does not floor mcp itself, so pull the patched release forward
-    # here for the same dependency-hygiene reason as starlette above. lionagi
+    # fastmcp only requires mcp>=1.24.0,<2.0, which predates the advisories,
+    # so pull the patched release forward here for the same dependency-hygiene
+    # reason as starlette above. lionagi
     # uses MCP as a client only, so this floors the version we resolve rather
     # than turning on any server-side transport protection.
     "mcp>=1.28.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,10 @@ mcp = [
     # fastmcp -> mcp pulls Starlette transitively but mcp only pins
     # starlette>=0.27, so floor the patched version here too (mirrors [studio]).
     "starlette>=1.3.1",
-    # fastmcp does not floor mcp itself; 1.28.1 is the first release whose
-    # HTTP and WebSocket transports verify request origin and session
-    # ownership, so floor it here for the same reason as starlette above.
+    # fastmcp does not floor mcp itself, so pull the patched release forward
+    # here for the same dependency-hygiene reason as starlette above. lionagi
+    # uses MCP as a client only, so this floors the version we resolve rather
+    # than turning on any server-side transport protection.
     "mcp>=1.28.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3139,6 +3139,7 @@ all = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "matplotlib" },
+    { name = "mcp" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ollama" },
@@ -3155,6 +3156,7 @@ graph = [
 ]
 mcp = [
     { name = "fastmcp" },
+    { name = "mcp" },
     { name = "starlette" },
 ]
 ollama = [
@@ -3265,6 +3267,7 @@ requires-dist = [
     { name = "lionagi", extras = ["studio"], marker = "extra == 'all'" },
     { name = "lionagi", extras = ["xml"], marker = "extra == 'all'" },
     { name = "matplotlib", marker = "extra == 'graph'", specifier = ">=3.7.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "networkx", marker = "extra == 'graph'", specifier = ">=3.0.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.6.1" },
@@ -3655,7 +3658,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3673,9 +3676,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`fastmcp` requires `mcp>=1.24.0,<2.0`, a lower bound that predates the advisories, so the lock resolved to 1.27.0. This floors `mcp>=1.28.1` directly in the `[mcp]` extra, mirroring how `starlette` is already floored right above it for the same class of reason.

This is dependency hygiene rather than transport hardening: lionagi constructs MCP clients only and has no server, session manager or HTTP transport of its own, so the pin activates no server-side origin or session-ownership check. What it does is close the advisories on the package we resolve.

Closes the three open high-severity dependabot alerts on the default branch (all three are the same package).

## Verification

- `uv lock`: `mcp v1.27.0 -> v1.28.1`, no other package moved.
- `uv sync --all-extras` clean.
- `uv run pytest tests/service/test_mcp_security.py tests/service/connections/mcp/ tests/tools/test_khive_injection.py`: all passed at the new version.
- `uv run pytest tests/protocols/action`: passed.

## Not in scope

The remaining low-severity `torch` alert is a transitive dep of the heavy `accelerate` optional; bumping it is a separate change with a much wider blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
