### PR TITLE
fix(cli): scope team-lifecycle signals to the attaching run's generation

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -182,6 +182,20 @@ the coordinator to do about it: no unread `kind="message"` mail sitting in
 an **idle** worker's inbox, and either the round budget is exhausted or the
 caller isn't asking for one more round anyway.
 
+`history_boundary` scopes the active/idle/retired classification to the
+current run generation: `--team-attach` reuses one team file (and often the
+same role-derived worker names) across runs, so a prior run's `done`/
+`finished`/`wakeup` signals sit in the same message list a fresh run reads.
+Without a boundary those signals would classify this run's workers as
+already idle or retired before either has posted anything of its own —
+`TeamLifecycleCoordinator` snapshots `len(messages)` at attach time
+(`message_boundary`, wired through `make_team_lifecycle_coordinator`) and
+only messages at or after it count toward active/idle/retired. Content
+(`kind="message"`) mail is deliberately exempt from the boundary — the
+pending-mail scan always looks at the full history, so `--team-attach`'s
+"prior content stays visible" contract holds even though prior *lifecycle*
+signals no longer leak into the new run.
+
 ## `_context_from.py` — context-ref resolution and distillation
 
 `li agent --context-from <ref>`: resolve prior-run refs into a bounded context block.

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -765,6 +765,13 @@ class TeamLifecycleCoordinator:
     # In-process Exchange (env.exchange); messenger `send` lands here, not
     # in the team file. None for CLI-only teams.
     exchange: Any = None
+    # Index into the team file's `messages` at the moment this run attached
+    # (0 for a freshly created team). `check_round` passes this to
+    # `compute_quiescence` as `history_boundary` so a prior run's done/
+    # finished/wakeup signals — left behind by `--team-attach` reusing the
+    # same team file and role-derived worker names — never mark this run's
+    # workers idle/retired before they post a signal of their own.
+    message_boundary: int = 0
     rounds_run: int = field(default=0, init=False)
 
     def on_done(self, *, name: str, sender_id: Any, reason: str) -> None:
@@ -823,6 +830,7 @@ class TeamLifecycleCoordinator:
             rounds_run=self.rounds_run,
             max_rounds=self.max_rounds,
             coordinator_wants_round=coordinator_wants_round,
+            history_boundary=self.message_boundary,
         )
         exchange_pending = self._exchange_pending(state.idle_workers)
         if not exchange_pending:
@@ -935,6 +943,7 @@ def make_team_lifecycle_coordinator(
     messenger_bound: dict[str, bool] | None = None,
     max_rounds: int = 2,
     exchange: Any = None,
+    message_boundary: int = 0,
 ) -> TeamLifecycleCoordinator:
     return TeamLifecycleCoordinator(
         team_id=team_id,
@@ -943,6 +952,7 @@ def make_team_lifecycle_coordinator(
         messenger_bound=dict(messenger_bound or {}),
         max_rounds=max_rounds,
         exchange=exchange,
+        message_boundary=message_boundary,
     )
 
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1040,6 +1040,11 @@ async def _execute_dag(
             messenger_bound=dag_state.messenger_bound,
             max_rounds=team_max_rounds,
             exchange=getattr(env, "exchange", None),
+            # env.team_data is the snapshot `_load_team`/`_create_fanout_team`
+            # returned when this run attached/created the team, before this
+            # run posted anything — its message count is exactly this run's
+            # history boundary (0 for a freshly created team).
+            message_boundary=len(env.team_data.get("messages", [])),
         )
         env.messenger.on("done", _team_coordinator.on_done)
         env.messenger.on("finished", _team_coordinator.on_finished)

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -381,16 +381,28 @@ def compute_quiescence(
     rounds_run: int,
     max_rounds: int,
     coordinator_wants_round: bool = False,
+    history_boundary: int = 0,
 ) -> QuiescenceState:
     """Pure predicate: is this team-mode run done, or does it need another
     wakeup round? Reads only message ``kind``/``from``/``to``/``read_by``,
     never a file/branch/agent. See docs/internals/cli.md for the lifecycle
     model (active/idle/retired) and the quiescence condition.
+
+    ``history_boundary`` is the index (into ``messages``) at which the
+    current run generation begins — everything before it is a prior run's
+    history. ``--team-attach`` reuses one team file (and often the same
+    role-derived worker names) across runs, so a prior run's ``done``/
+    ``finished``/``wakeup`` signals must not classify this run's workers as
+    already idle/retired before they have posted anything themselves; only
+    signals at or after the boundary count toward active/idle/retired.
+    Content (``kind="message"``) mail is exempt from the boundary — prior
+    runs' unread mail must still be delivered to this run's workers, so the
+    pending-mail scan below always looks at the full ``messages`` sequence.
     """
     names = list(dict.fromkeys(worker_names))  # de-dup, preserve order
     state: dict[str, str] = dict.fromkeys(names, "active")
 
-    for msg in messages:
+    for msg in messages[history_boundary:]:
         kind = msg.get("kind", MESSAGE_KIND)
         sender = msg.get("from")
         if kind == DONE_KIND and sender in state:

--- a/tests/cli/orchestrate/test_team_lifecycle_wiring.py
+++ b/tests/cli/orchestrate/test_team_lifecycle_wiring.py
@@ -113,6 +113,67 @@ class TestTeamLifecycleCoordinatorCheckRound:
         state1 = coord.check_round()
         assert state1.quiescent  # both done, no pending mail
 
+    def test_attached_team_ignores_prior_run_done_and_wakes_only_this_runs_own_idle(self):
+        """Integration reproduction of the issue: `--team-attach` reuses a
+        team file whose prior run left `researcher` and `critic` both
+        `done`, plus one still-unread message from that prior run addressed
+        to `critic`. Wired the way `_execute_dag` wires it in production
+        (`message_boundary=len(messages already on disk at attach time)`),
+        the coordinator must NOT treat this fresh run's workers as already
+        idle/pending before either has posted a signal of its own."""
+        team_id = "attach-t"
+        _make_team(team_id, ["orchestrator", "researcher", "critic"])
+        team.post_done_signal(team_id, worker="researcher", summary="prior run pass 1")
+        team.post_done_signal(team_id, worker="critic", summary="prior run pass 1")
+        with team._locked_team(team_id) as data:
+            data["messages"].append(
+                {
+                    "id": "hist1",
+                    "from": "researcher",
+                    "to": ["critic"],
+                    "content": "leftover from last run",
+                    "kind": "message",
+                    "read_by": {},
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            )
+
+        # This is what `_execute_dag` does: snapshot the message count at
+        # attach time and hand it in as the new run's history boundary.
+        attach_snapshot = team._load_team(team_id)
+        boundary = len(attach_snapshot["messages"])
+
+        coord = make_team_lifecycle_coordinator(
+            team_id,
+            ["researcher", "critic"],
+            {"researcher": _FakeBranch("researcher"), "critic": _FakeBranch("critic")},
+            message_boundary=boundary,
+        )
+
+        # Neither worker has done anything in THIS run yet — must read as
+        # still active, not quiescent, and no round pending for critic.
+        state0 = coord.check_round()
+        assert state0.active_workers == frozenset({"researcher", "critic"})
+        assert not state0.should_continue
+        assert not state0.quiescent
+
+        # researcher finishes its own first turn in this run.
+        coord.on_done(name="researcher", sender_id=uuid4(), reason="this run pass 1")
+        state1 = coord.check_round()
+        # critic hasn't posted its own signal yet in this run -> still
+        # active -> no premature round injected on its behalf.
+        assert "critic" in state1.active_workers
+        assert not state1.should_continue
+
+        # critic now finishes its own first turn in this run too.
+        coord.on_done(name="critic", sender_id=uuid4(), reason="this run pass 1")
+        state2 = coord.check_round()
+        # Both idle for real now -> the leftover historical mail to critic
+        # (never scoped out for content messages) still surfaces as a round.
+        assert state2.idle_workers == frozenset({"researcher", "critic"})
+        assert state2.pending_targets == frozenset({"critic"})
+        assert state2.should_continue
+
 
 class TestTeamLifecycleCoordinatorBuildRoundOperations:
     def test_build_round_operations_targets_the_workers_own_branch(self):

--- a/tests/cli/test_team_lifecycle.py
+++ b/tests/cli/test_team_lifecycle.py
@@ -195,6 +195,95 @@ class TestComputeQuiescence:
         )
         assert state.active_workers == frozenset({"alice", "bob"})
 
+    def test_history_boundary_excludes_prior_run_signals_from_state(self):
+        """Reproduction from the issue: a `--team-attach` team file carries
+        `done` for both workers from a prior run plus one still-unread
+        historical message to `critic`. Against a fresh run generation
+        (`history_boundary` at the end of that history), both workers must
+        still read as active — the prior run's `done` signals must not
+        leak into this run before either worker posts anything itself."""
+        msgs = [
+            {"from": "researcher", "to": ["*"], "kind": "done", "content": "x", "read_by": {}},
+            {"from": "critic", "to": ["*"], "kind": "done", "content": "x", "read_by": {}},
+            {
+                "from": "researcher",
+                "to": ["critic"],
+                "kind": "message",
+                "content": "fyi",
+                "read_by": {},
+            },
+        ]
+        state = team.compute_quiescence(
+            msgs,
+            worker_names=["researcher", "critic"],
+            rounds_run=0,
+            max_rounds=2,
+            history_boundary=len(msgs),
+        )
+        assert state.active_workers == frozenset({"researcher", "critic"})
+        assert state.idle_workers == frozenset()
+        assert state.pending_targets == frozenset()
+        assert not state.should_continue
+        assert not state.quiescent
+
+    def test_default_history_boundary_reproduces_the_attach_leak(self):
+        """Same message log as above with the default `history_boundary=0`
+        (i.e. no run-generation filtering) reproduces the exact bug: the
+        prior run's `done` signals and unread mail are misread as this
+        run's own state, and the coordinator wrongly wants a round before
+        either worker has done anything in this run."""
+        msgs = [
+            {"from": "researcher", "to": ["*"], "kind": "done", "content": "x", "read_by": {}},
+            {"from": "critic", "to": ["*"], "kind": "done", "content": "x", "read_by": {}},
+            {
+                "from": "researcher",
+                "to": ["critic"],
+                "kind": "message",
+                "content": "fyi",
+                "read_by": {},
+            },
+        ]
+        state = team.compute_quiescence(
+            msgs, worker_names=["researcher", "critic"], rounds_run=0, max_rounds=2
+        )
+        assert state.active_workers == frozenset()
+        assert state.pending_targets == frozenset({"critic"})
+        assert state.should_continue
+
+    def test_prior_content_message_still_pending_once_current_run_goes_idle(self):
+        """A `--team-attach` unread historical message must still surface
+        once THIS run's worker actually goes idle (posts its own `done`) —
+        only the lifecycle *signals* are scoped to the run generation, not
+        ordinary content mail (per the issue: prior CONTENT messages must
+        remain visible to the new run)."""
+        history = [
+            {
+                "from": "researcher",
+                "to": ["critic"],
+                "kind": "message",
+                "content": "fyi from last run",
+                "read_by": {},
+            },
+        ]
+        this_run_done = {
+            "from": "critic",
+            "to": ["*"],
+            "kind": "done",
+            "content": "x",
+            "read_by": {},
+        }
+        msgs = [*history, this_run_done]
+        state = team.compute_quiescence(
+            msgs,
+            worker_names=["critic"],
+            rounds_run=0,
+            max_rounds=2,
+            history_boundary=len(history),
+        )
+        assert state.idle_workers == frozenset({"critic"})
+        assert state.pending_targets == frozenset({"critic"})
+        assert state.should_continue
+
     def test_done_from_an_unknown_sender_is_ignored(self):
         """A message kind='done' from a name outside worker_names (e.g. a
         stray or future teammate) must not silently mutate unrelated state."""


### PR DESCRIPTION
Closes #2320.

`--team-attach` retains prior messages by design, but lifecycle signals (`done`/`finished`) from earlier runs were counted toward the new run's quiescence. With two workers whose role-derived names repeat across runs, a fresh run started with both classified idle, so the first completion callback could schedule a wakeup round for a worker whose initial operation was still running.

Lifecycle signals are now scoped to the attaching run's generation; prior content messages remain visible, which is what team-attach exists for. Covered at the predicate level (the issue's exact reproduction) and with an attached-team integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)