### PR TITLE
fix(ci): close three publication-hygiene gate gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,14 @@ jobs:
 
   docs:
     needs: changes
-    if: ${{ always() && needs.changes.result == 'success' }}
+    # The `needs: changes` edge exists only so the ADR steps below can read
+    # needs.changes.outputs.adr; the rest of this job (docs contracts, strict
+    # build, markdownlint, link check) does not depend on that output. Gating
+    # the whole job on the changes job succeeding would skip all of it when
+    # changes fails or is skipped, which is how those checks silently stopped
+    # running. The ADR steps stay output-gated and simply skip when the output
+    # is absent.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: Continuous Integration
 
 on:
+  # No paths-ignore on push: a notebook-only push previously skipped the whole
+  # workflow (GitHub Actions skips a run when every changed path matches
+  # paths-ignore), including the publication-hygiene lint job, which itself
+  # scans notebooks. A leak introduced only in a notebook must still be gated.
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - '**/*.ipynb'
-  # No paths-ignore on pull_request: ci-gate is a required status check, so the
-  # workflow must report on every PR — a filtered-out PR would block on a check
-  # that never runs.
+  # No paths-ignore on pull_request either: ci-gate is a required status check,
+  # so the workflow must report on every PR — a filtered-out PR would block on
+  # a check that never runs.
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -286,8 +286,10 @@ _hygiene_rg_scan() {
 # Same contract as _hygiene_rg_scan (0=pass, 1=match found, 2=scanner error).
 # Public credits are allowlisted only as complete, known lines; sharing a line
 # with a public name must not hide separate process narration. Of the remaining
-# mentions, retain only actor/action, possessive-directive, role-level, and
-# passive-attribution forms so geographic or common-noun uses do not fire.
+# mentions, the possessive form ("Ocean's <anything>") is always narration and
+# stays a catch-all; bare-name mentions are narrowed to actor/action,
+# role-level, and passive-attribution forms so geographic or common-noun uses
+# do not fire.
 _hygiene_founder_name_scan() {
   local rg_bin="$1"
   local label="$2"
@@ -306,7 +308,7 @@ _hygiene_founder_name_scan() {
   local public_credit_re
   public_credit_re='^[^:]+:[0-9]+:(lionagi: author Haiyang \(Ocean\) Li|Author: Haiyang Li - Ocean|copyright: Copyright &copy; 2024-2026 Ocean Li and LionAGI Contributors)$'
   local process_re
-  process_re="(^|[^[:alnum:]_])Ocean('s[[:space:]]+(directive|direction|decision|request|approval|instruction|guidance|review|feedback|plan|preference|mandate)|[[:space:]]+(approved|confirmed|said|says|wants|wanted|decided|directed|reviewed|requested|instructed|asked|agreed|rejected|preferred|mandated)|-level)([^[:alnum:]_]|$)|(^|[^[:alnum:]_])(approved|confirmed|directed|reviewed|requested|instructed)([[:space:]]+[[:alnum:]_-]+){0,3}[[:space:]]+by[[:space:]]+Ocean([^[:alnum:]_]|$)"
+  process_re="(^|[^[:alnum:]_])Ocean's([^[:alnum:]_]|$)|(^|[^[:alnum:]_])Ocean([[:space:]]+(approved|confirmed|said|says|wants|wanted|decided|directed|reviewed|requested|instructed|asked|agreed|rejected|preferred|mandated)|-level)([^[:alnum:]_]|$)|(^|[^[:alnum:]_])(approved|confirmed|directed|reviewed|requested|instructed)([[:space:]]+[[:alnum:]_-]+){0,3}[[:space:]]+by[[:space:]]+Ocean([^[:alnum:]_]|$)"
 
   local leaked
   leaked="$(printf '%s\n' "$output" | grep -vE "$public_credit_re" | grep -E "$process_re" || true)"

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -212,6 +212,22 @@ def test_required_ci_wrapper_excludes_only_performance_and_quarantine() -> None:
     assert "pytest-rerunfailures" not in script
 
 
+def test_docs_job_always_guard_survives_upstream_changes_failure() -> None:
+    # Regression: `docs` gained `needs: changes` (so its two new
+    # ADR-check steps can read `needs.changes.outputs.adr`) with no job-level
+    # `if:`. Under GitHub Actions default semantics, a job with `needs:` and
+    # no `if:` implicitly runs only when the needed job succeeds -- so a
+    # transient failure/timeout of `changes` would silently skip `docs`,
+    # including its two pre-existing, unconditional markdownlint/lychee
+    # steps that don't depend on `changes` output at all. `docs` must use the
+    # same always()-guard pattern as `studio-docker`.
+    workflow = CI_WORKFLOW.read_text()
+    docs_job = workflow.split("  docs:", 1)[1].split("  test:", 1)[0]
+
+    assert "needs: changes" in docs_job
+    assert "if: ${{ always() && needs.changes.result == 'success' }}" in docs_job
+
+
 def test_every_required_ci_exclusion_has_a_workflow_lane() -> None:
     workflow = CI_WORKFLOW.read_text()
     performance_job = workflow.split("  performance:", 1)[1].split("  quarantine:", 1)[0]

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -213,19 +213,23 @@ def test_required_ci_wrapper_excludes_only_performance_and_quarantine() -> None:
 
 
 def test_docs_job_always_guard_survives_upstream_changes_failure() -> None:
-    # Regression: `docs` gained `needs: changes` (so its two new
-    # ADR-check steps can read `needs.changes.outputs.adr`) with no job-level
-    # `if:`. Under GitHub Actions default semantics, a job with `needs:` and
-    # no `if:` implicitly runs only when the needed job succeeds -- so a
-    # transient failure/timeout of `changes` would silently skip `docs`,
-    # including its two pre-existing, unconditional markdownlint/lychee
-    # steps that don't depend on `changes` output at all. `docs` must use the
-    # same always()-guard pattern as `studio-docker`.
+    # Regression: `docs` gained `needs: changes` (so its ADR-check steps can
+    # read `needs.changes.outputs.adr`) with no job-level `if:`. Under GitHub
+    # Actions default semantics, a job with `needs:` and no `if:` runs only
+    # when the needed job succeeds -- so a failed, skipped, or cancelled
+    # `changes` silently skipped `docs`, including its documentation contract,
+    # strict build, markdownlint and link-check steps, none of which read that
+    # output. The job-level guard must therefore NOT depend on the `changes`
+    # job's result; only the ADR steps are output-gated.
     workflow = CI_WORKFLOW.read_text()
     docs_job = workflow.split("  docs:", 1)[1].split("  test:", 1)[0]
 
     assert "needs: changes" in docs_job
-    assert "if: ${{ always() && needs.changes.result == 'success' }}" in docs_job
+    assert "if: ${{ !cancelled() }}" in docs_job
+    assert "needs.changes.result" not in docs_job
+    # The ADR steps remain gated on the output, so they skip (rather than
+    # fail) when `changes` produced no output.
+    assert docs_job.count("if: needs.changes.outputs.adr == 'true'") >= 1
 
 
 def test_every_required_ci_exclusion_has_a_workflow_lane() -> None:

--- a/tests/scripts/test_ci_hygiene.py
+++ b/tests/scripts/test_ci_hygiene.py
@@ -71,7 +71,7 @@ def test_ci_lint_job_runs_publication_hygiene() -> None:
 
 
 def test_push_trigger_has_no_notebook_paths_ignore() -> None:
-    # Regression for #2313: GitHub Actions skips an entire workflow run when
+    # Regression: GitHub Actions skips an entire workflow run when
     # every changed path matches paths-ignore. A push trigger that ignores
     # notebooks would bypass the lint job (and its publication-hygiene scan)
     # for a notebook-only push to main/develop.
@@ -247,7 +247,7 @@ def test_possessive_founder_name_mention_is_still_rejected(public_repo: Path) ->
 def test_possessive_founder_name_mention_with_non_whitelisted_noun_is_rejected(
     public_repo: Path, content: str
 ) -> None:
-    # Regression for #2268: #2185 narrowed the possessive branch to a 12-word
+    # Regression: an earlier change narrowed the possessive branch to a 12-word
     # noun whitelist (directive/direction/decision/.../mandate), so leaks like
     # "Ocean's notes"/"Ocean's opinion" silently passed. The possessive form
     # must stay a catch-all regardless of the noun that follows.

--- a/tests/scripts/test_ci_hygiene.py
+++ b/tests/scripts/test_ci_hygiene.py
@@ -70,6 +70,19 @@ def test_ci_lint_job_runs_publication_hygiene() -> None:
     assert "run: scripts/ci.sh lint-hygiene" in workflow
 
 
+def test_push_trigger_has_no_notebook_paths_ignore() -> None:
+    # Regression for #2313: GitHub Actions skips an entire workflow run when
+    # every changed path matches paths-ignore. A push trigger that ignores
+    # notebooks would bypass the lint job (and its publication-hygiene scan)
+    # for a notebook-only push to main/develop.
+    workflow = CI_WORKFLOW.read_text()
+    push_block = workflow.split("  push:", 1)[1].split("  pull_request:", 1)[0]
+    push_keys = {line.strip() for line in push_block.splitlines()}
+
+    assert not any(key.startswith("paths-ignore:") for key in push_keys)
+    assert "*.ipynb" not in push_block
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/tests/scripts/test_ci_hygiene.py
+++ b/tests/scripts/test_ci_hygiene.py
@@ -236,6 +236,29 @@ def test_possessive_founder_name_mention_is_still_rejected(public_repo: Path) ->
     assert "founder-name process narration" in result.stdout
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "documented in Ocean's notes on the matter\n",
+        "this reflects Ocean's opinion\n",
+        "captures Ocean's take on the design\n",
+    ],
+)
+def test_possessive_founder_name_mention_with_non_whitelisted_noun_is_rejected(
+    public_repo: Path, content: str
+) -> None:
+    # Regression for #2268: #2185 narrowed the possessive branch to a 12-word
+    # noun whitelist (directive/direction/decision/.../mandate), so leaks like
+    # "Ocean's notes"/"Ocean's opinion" silently passed. The possessive form
+    # must stay a catch-all regardless of the noun that follows.
+    (public_repo / "docs" / "example.md").write_text(content)
+
+    result = _run_hygiene(public_repo)
+
+    assert result.returncode != 0
+    assert "founder-name process narration" in result.stdout
+
+
 def test_founder_actor_narration_with_public_name_on_same_line_is_rejected(
     public_repo: Path,
 ) -> None:


### PR DESCRIPTION
Closes #2313. Closes #2268. Closes #2039.

- A notebook-only push to main/develop matched `paths-ignore` for the whole workflow, so GitHub skipped every job including the publication-hygiene lint that explicitly scans notebooks.
- The founder-name possessive check had narrowed from a catch-all to a 12-word noun whitelist, so the same leak shape with any other following word passed silently. Restored to a catch-all for the possessive form, with the process-narration branch kept separate.
- The `docs` job gained `needs: changes` with no job-level `if:`, so it silently skips (not fails) when the needed job has trouble.

Each is covered by a test that parses the workflow/script and asserts the invariant, following the existing convention in `tests/scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)