### PR TITLE
fix(protocols): never let the plugin-shadow diagnostic fail a local tool

### DIFF
--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -36,6 +36,9 @@ class ActionManager(Manager):
         self._tool_pre_hooks: list[ToolPreHook] = []
         self._tool_post_hooks: list[ToolPostHook] = []
         self._plugin_shadow_warned: set[tuple[str, str]] = set()
+        # Keyed by (PluginRegistry.snapshot_generation(), tool name) so a
+        # reset()/rebuild invalidates it structurally, not by size or TTL.
+        self._plugin_shadow_resolution_cache: dict[tuple[int, str], Any] = {}
 
         tools = []
         if args:
@@ -173,15 +176,28 @@ class ActionManager(Manager):
         declaring *name* is irrelevant to a tool that already resolved
         locally, so it is swallowed here rather than raised -- a
         locally-registered tool must never fail to resolve because of this
-        diagnostic."""
+        diagnostic.
+
+        `PluginRegistry.resolve_tool_target` rescans every installed
+        plugin's manifest from disk on every call; since this check is a
+        diagnostic only (never changes which tool actually runs), the
+        resolution is cached per registered-tool name for the lifetime of
+        the current plugin-registry generation, so repeated hits are free.
+        A `PluginRegistry.reset()` bumps the generation and forces exactly
+        one fresh resolution on the next call."""
         from lionagi.plugins.registry import PluginRegistry, PluginToolCollisionError
 
         if not PluginRegistry.list_plugins():
             return
-        try:
-            resolved = PluginRegistry.resolve_tool_target(name)
-        except PluginToolCollisionError:
-            return
+        cache_key = (PluginRegistry.snapshot_generation(), name)
+        if cache_key in self._plugin_shadow_resolution_cache:
+            resolved = self._plugin_shadow_resolution_cache[cache_key]
+        else:
+            try:
+                resolved = PluginRegistry.resolve_tool_target(name)
+            except PluginToolCollisionError:
+                resolved = None
+            self._plugin_shadow_resolution_cache[cache_key] = resolved
         if resolved is None:
             return
         warn_key = (resolved.plugin_name, name)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -169,14 +169,19 @@ class ActionManager(Manager):
         *name* -- the already-registered tool wins and the plugin declaration
         is rejected.
 
-        When more than one enabled plugin declares *name*, that is a peer
-        collision, a hard error regardless of the local registration -- it
-        is not caught here and propagates to the caller."""
-        from lionagi.plugins.registry import PluginRegistry
+        Purely diagnostic: a peer collision between two *other* plugins
+        declaring *name* is irrelevant to a tool that already resolved
+        locally, so it is swallowed here rather than raised -- a
+        locally-registered tool must never fail to resolve because of this
+        diagnostic."""
+        from lionagi.plugins.registry import PluginRegistry, PluginToolCollisionError
 
         if not PluginRegistry.list_plugins():
             return
-        resolved = PluginRegistry.resolve_tool_target(name)
+        try:
+            resolved = PluginRegistry.resolve_tool_target(name)
+        except PluginToolCollisionError:
+            return
         if resolved is None:
             return
         warn_key = (resolved.plugin_name, name)

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -180,6 +180,29 @@ class TestCollisions:
         with pytest.raises(PluginActivationError, match="shared_tool"):
             PluginRegistry.activate_target("p1", "tools/t.py:t")
 
+    def test_activate_target_disabling_colliding_plugin_resolves_without_reset(self, write_plugin):
+        """`activate_target`'s collision check re-derives the *other* plugin's
+        enabled/compatible state fresh (via `_is_live_active`) on every call,
+        even though the other plugin's cached record is only rescanned for
+        the requested plugin itself -- so disabling the colliding plugin
+        resolves the collision on the very next call, with no
+        `PluginRegistry.reset()` in between."""
+        _write_tool_plugin(write_plugin, "p1", tool_name="shared_tool", agent_name="a1")
+        _write_tool_plugin(write_plugin, "p2", tool_name="shared_tool", agent_name="a2")
+        _trust_by_dir_name("p1")
+        _trust_by_dir_name("p2")
+
+        PluginRegistry.reset()
+        with pytest.raises(PluginActivationError, match="shared_tool"):
+            PluginRegistry.activate_target("p1", "tools/t.py:t")
+
+        settings = read_user_settings()
+        settings.setdefault("plugins", {})["p2"] = {"enabled": False}
+        write_user_settings(settings)
+        # No PluginRegistry.reset() here -- this is the behavior under test.
+
+        PluginRegistry.activate_target("p1", "tools/t.py:t")  # should now succeed
+
     def test_two_active_plugins_same_agent_name_is_not_a_collision(self, write_plugin):
         """Agent profiles are namespaced (<plugin>/<name>) — same local name across two
         plugins is not a hard error, only the bare name becomes ambiguous (resolver's job)."""

--- a/tests/plugins/test_tool_consumer.py
+++ b/tests/plugins/test_tool_consumer.py
@@ -183,11 +183,12 @@ class TestToolConsumerCollision:
         result = manager.match_tool({"function": "greet", "arguments": {}})
         assert result.func_tool.function == "greet"
 
-    def test_registered_tool_plus_two_colliding_plugins_still_raises(self, write_plugin):
-        """A registered local tool wins over any single colliding plugin, but
-        it must not mask a *peer* collision between two plugins declaring the
-        same bare name -- that hard error (ADR-0088 D6) is independent of
-        whether the manager already has a local registration for the name."""
+    def test_registered_tool_still_resolves_despite_a_peer_plugin_collision(self, write_plugin):
+        """A registered local tool must resolve regardless of a *peer*
+        collision between two other plugins declaring the same bare name --
+        the shadow check is a diagnostic only; it must never be able to fail
+        an already-successful local resolution (a peer-vs-peer collision
+        never touches the local tool's own resolution)."""
 
         def greet():
             return "local"
@@ -201,10 +202,8 @@ class TestToolConsumerCollision:
         _trust("p2")
         PluginRegistry.reset()
 
-        with pytest.raises(PluginToolCollisionError) as excinfo:
-            manager.match_tool({"function": "greet", "arguments": {}})
-        assert "plugin-one" in str(excinfo.value)
-        assert "plugin-two" in str(excinfo.value)
+        result = manager.match_tool({"function": "greet", "arguments": {}})
+        assert result.func_tool.func_callable is greet
 
 
 class TestLiveRescanWithoutReset:
@@ -399,7 +398,11 @@ class TestBuiltinToolCollisionDiagnostic:
 
         assert caplog.text.count("greeter") == 1
 
-    def test_new_peer_collision_is_detected_without_registry_reset(self, write_plugin):
+    def test_new_peer_collision_is_swallowed_not_raised(self, write_plugin):
+        """A peer collision that appears between the manager's first and
+        second call (a plugin trusted in between, no registry reset) must
+        stay a diagnostic -- the local tool keeps winning, never a raise."""
+
         def greet():
             return "local"
 
@@ -422,7 +425,5 @@ class TestBuiltinToolCollisionDiagnostic:
 
         _trust("p2")
 
-        with pytest.raises(PluginToolCollisionError) as excinfo:
-            manager.match_tool({"function": "greet", "arguments": {}})
-        assert "greeter" in str(excinfo.value)
-        assert "plugin-two" in str(excinfo.value)
+        second = manager.match_tool({"function": "greet", "arguments": {}})
+        assert second.func_tool.func_callable is greet

--- a/tests/plugins/test_tool_consumer.py
+++ b/tests/plugins/test_tool_consumer.py
@@ -398,10 +398,12 @@ class TestBuiltinToolCollisionDiagnostic:
 
         assert caplog.text.count("greeter") == 1
 
-    def test_new_peer_collision_is_swallowed_not_raised(self, write_plugin):
-        """A peer collision that appears between the manager's first and
-        second call (a plugin trusted in between, no registry reset) must
-        stay a diagnostic -- the local tool keeps winning, never a raise."""
+    def test_shadow_resolution_is_cached_until_reset(self, write_plugin):
+        """The shadow-diagnostic resolution is cached per plugin-registry
+        generation: a new peer plugin trusted after the cache was populated
+        is not consulted until `PluginRegistry.reset()` bumps the
+        generation -- and even after reset, the peer collision stays a
+        diagnostic only, never a raise (the local tool always wins)."""
 
         def greet():
             return "local"
@@ -425,5 +427,60 @@ class TestBuiltinToolCollisionDiagnostic:
 
         _trust("p2")
 
+        # No reset(): same generation, cached resolution reused -- the
+        # newly trusted peer plugin is not consulted yet.
         second = manager.match_tool({"function": "greet", "arguments": {}})
         assert second.func_tool.func_callable is greet
+
+        PluginRegistry.reset()
+
+        # A fresh generation forces one fresh resolution -- still resolves
+        # the local tool, and still never raises even though p1 and p2 now
+        # peer-collide on "greet".
+        third = manager.match_tool({"function": "greet", "arguments": {}})
+        assert third.func_tool.func_callable is greet
+
+
+class TestShadowResolutionCacheCost:
+    """A registered-tool hit against `match_tool` must not pay for a fresh
+    plugin-manifest rescan (`PluginRegistry.resolve_tool_target`) on every
+    call once any plugin is trusted -- only once per plugin-registry
+    generation -- repeated rescans were a real disk-I/O regression."""
+
+    def test_repeated_hits_within_a_generation_resolve_the_plugin_registry_once(
+        self, write_plugin, monkeypatch
+    ):
+        import lionagi.plugins.registry as registry_mod
+
+        def greet():
+            return "local"
+
+        manager = ActionManager()
+        manager.register_tool(greet)
+
+        _write_tool_plugin(write_plugin, "p1", name="greeter", tool_name="greet")
+        _trust("p1")
+        PluginRegistry.reset()
+
+        calls = []
+        original = registry_mod.PluginRegistry.resolve_tool_target.__func__
+
+        def counting_resolve_tool_target(cls, tool_name):
+            calls.append(tool_name)
+            return original(cls, tool_name)
+
+        monkeypatch.setattr(
+            registry_mod.PluginRegistry,
+            "resolve_tool_target",
+            classmethod(counting_resolve_tool_target),
+        )
+
+        for _ in range(5):
+            result = manager.match_tool({"function": "greet", "arguments": {}})
+            assert result.func_tool.func_callable is greet
+
+        assert len(calls) == 1
+
+        PluginRegistry.reset()
+        manager.match_tool({"function": "greet", "arguments": {}})
+        assert len(calls) == 2


### PR DESCRIPTION
Closes #2188. Closes #2262. Closes #2282.

`match_tool` called `resolve_tool_target` on a registry **hit** purely to log a shadow diagnostic, so a diagnostic could raise `PluginToolCollisionError` for a tool that was already resolved locally. A diagnostic must never change the outcome of the operation it describes.

With that fixed, the shadow resolution is also cached per plugin-registry generation, which is the cache an earlier PR described but never implemented. Adds the missing test for the documented claim that disabling a colliding plugin resolves the collision without a registry reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)