### PR TITLE
fix(studio): restore file capture and null-timestamp guard in run views

### DIFF
--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -503,6 +503,24 @@ describe("history/RunDetail.tsx — live branch aggregates", () => {
       "terminal-tail",
     ]);
   });
+
+  it("rejects a raw SSE event whose timestamp is not a number before it is cast to SessionMessage", async () => {
+    const { isSessionMessageEvent } = await import("./RunDetail");
+
+    const malformed: Record<string, unknown> = {
+      id: "streamed-later",
+      role: "assistant",
+      branch_id: "branch-1",
+      content: { assistant_response: "live" },
+      sender: "worker",
+      timestamp: null,
+      lion_class: "AssistantResponse",
+    };
+    const wellFormed: Record<string, unknown> = { ...malformed, timestamp: 50 };
+
+    expect(isSessionMessageEvent(malformed)).toBe(false);
+    expect(isSessionMessageEvent(wellFormed)).toBe(true);
+  });
 });
 
 describe("history/RunDetail.tsx — segmented branch totals", () => {
@@ -577,70 +595,6 @@ describe("history/RunDetail.tsx — segmented branch totals", () => {
 
     expect(intermediateBadge).toBeNull();
     expect(finalBadge?.textContent).toBe("6");
-  });
-
-  it("excludes messages with a null timestamp from a segment with unbounded start/end", async () => {
-    const { buildRunSteps } = await import("./RunDetail");
-    const steps = buildRunSteps(
-      {
-        id: "run-2",
-        name: "run",
-        created_at: 0,
-        updated_at: 200,
-        branches: [
-          {
-            id: "branch-1",
-            name: "worker",
-            created_at: 0,
-            first_message_at: 0,
-            last_message_at: 190,
-            message_total: 2,
-            messages: [
-              {
-                id: "undated-streamed",
-                role: "assistant",
-                content: { assistant_response: "streamed, no timestamp yet" },
-                sender: "worker",
-                timestamp: null,
-                lion_class: "AssistantResponse",
-              },
-              {
-                id: "dated",
-                role: "assistant",
-                content: { assistant_response: "dated" },
-                sender: "worker",
-                timestamp: 50,
-                lion_class: "AssistantResponse",
-              },
-            ],
-          },
-        ],
-      },
-      "completed",
-      [
-        {
-          op_id: "op-1",
-          branch_id: "branch-1",
-          branch_name: "worker",
-          status: "completed",
-          started_at: null,
-          ended_at: null,
-        },
-        {
-          op_id: "op-2",
-          branch_id: "branch-1",
-          branch_name: "worker",
-          status: "completed",
-          started_at: 100,
-          ended_at: 200,
-        },
-      ],
-    );
-
-    expect(steps).toHaveLength(2);
-    const firstSegmentTimestamps = (steps[0].messages ?? []).map((m) => m.timestamp);
-    expect(firstSegmentTimestamps).not.toContain(null);
-    expect(firstSegmentTimestamps).toContain(50);
   });
 });
 

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -578,6 +578,70 @@ describe("history/RunDetail.tsx — segmented branch totals", () => {
     expect(intermediateBadge).toBeNull();
     expect(finalBadge?.textContent).toBe("6");
   });
+
+  it("excludes messages with a null timestamp from a segment with unbounded start/end", async () => {
+    const { buildRunSteps } = await import("./RunDetail");
+    const steps = buildRunSteps(
+      {
+        id: "run-2",
+        name: "run",
+        created_at: 0,
+        updated_at: 200,
+        branches: [
+          {
+            id: "branch-1",
+            name: "worker",
+            created_at: 0,
+            first_message_at: 0,
+            last_message_at: 190,
+            message_total: 2,
+            messages: [
+              {
+                id: "undated-streamed",
+                role: "assistant",
+                content: { assistant_response: "streamed, no timestamp yet" },
+                sender: "worker",
+                timestamp: null,
+                lion_class: "AssistantResponse",
+              },
+              {
+                id: "dated",
+                role: "assistant",
+                content: { assistant_response: "dated" },
+                sender: "worker",
+                timestamp: 50,
+                lion_class: "AssistantResponse",
+              },
+            ],
+          },
+        ],
+      },
+      "completed",
+      [
+        {
+          op_id: "op-1",
+          branch_id: "branch-1",
+          branch_name: "worker",
+          status: "completed",
+          started_at: null,
+          ended_at: null,
+        },
+        {
+          op_id: "op-2",
+          branch_id: "branch-1",
+          branch_name: "worker",
+          status: "completed",
+          started_at: 100,
+          ended_at: 200,
+        },
+      ],
+    );
+
+    expect(steps).toHaveLength(2);
+    const firstSegmentTimestamps = (steps[0].messages ?? []).map((m) => m.timestamp);
+    expect(firstSegmentTimestamps).not.toContain(null);
+    expect(firstSegmentTimestamps).toContain(50);
+  });
 });
 
 describe("history/RunDetail.tsx — overview aggregates are lifetime totals", () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -296,6 +296,7 @@ export function buildRunSteps(
     branchSegments.forEach((segment, index) => {
       const segmentMessages = branch.messages.filter((message) => {
         const timestamp = message.timestamp;
+        if (timestamp == null) return false;
         const after = segment.started_at == null || timestamp >= segment.started_at;
         const before = segment.ended_at == null || timestamp <= segment.ended_at + 1;
         return after && before;

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -104,15 +104,24 @@ export function appendStreamedMessage(
       if (branch.id !== branchId) return branch;
       const firstMessageAt = branch.first_message_at ?? branch.started_at;
       const lastMessageAt = branch.last_message_at ?? branch.ended_at;
+      const timestamp = message.timestamp;
       return {
         ...branch,
         messages: [...branch.messages, message],
         message_total:
           Math.max(branch.message_total ?? branch.messages.length, branch.messages.length) + 1,
         first_message_at:
-          firstMessageAt == null ? message.timestamp : Math.min(firstMessageAt, message.timestamp),
+          timestamp == null
+            ? firstMessageAt
+            : firstMessageAt == null
+              ? timestamp
+              : Math.min(firstMessageAt, timestamp),
         last_message_at:
-          lastMessageAt == null ? message.timestamp : Math.max(lastMessageAt, message.timestamp),
+          timestamp == null
+            ? lastMessageAt
+            : lastMessageAt == null
+              ? timestamp
+              : Math.max(lastMessageAt, timestamp),
       };
     }),
   };

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -73,6 +73,15 @@ export function shouldRenderAuthoredGraph(
   return !(isEdgeless && opGraph.edges.length > 0);
 }
 
+// Raw SSE payloads arrive as an untyped Record — this is the boundary where
+// an event is asserted to be a SessionMessage. SessionMessage.timestamp is a
+// required number (the server column is REAL NOT NULL), so a malformed or
+// future event carrying a non-numeric timestamp must be rejected here rather
+// than let the cast manufacture a value the type promises can't happen.
+export function isSessionMessageEvent(event: Record<string, unknown>): boolean {
+  return !!(event.id && event.role && event.branch_id && typeof event.timestamp === "number");
+}
+
 export function appendStreamedMessage(
   session: SessionDetail,
   branchId: string,
@@ -104,24 +113,15 @@ export function appendStreamedMessage(
       if (branch.id !== branchId) return branch;
       const firstMessageAt = branch.first_message_at ?? branch.started_at;
       const lastMessageAt = branch.last_message_at ?? branch.ended_at;
-      const timestamp = message.timestamp;
       return {
         ...branch,
         messages: [...branch.messages, message],
         message_total:
           Math.max(branch.message_total ?? branch.messages.length, branch.messages.length) + 1,
         first_message_at:
-          timestamp == null
-            ? firstMessageAt
-            : firstMessageAt == null
-              ? timestamp
-              : Math.min(firstMessageAt, timestamp),
+          firstMessageAt == null ? message.timestamp : Math.min(firstMessageAt, message.timestamp),
         last_message_at:
-          timestamp == null
-            ? lastMessageAt
-            : lastMessageAt == null
-              ? timestamp
-              : Math.max(lastMessageAt, timestamp),
+          lastMessageAt == null ? message.timestamp : Math.max(lastMessageAt, message.timestamp),
       };
     }),
   };
@@ -305,7 +305,6 @@ export function buildRunSteps(
     branchSegments.forEach((segment, index) => {
       const segmentMessages = branch.messages.filter((message) => {
         const timestamp = message.timestamp;
-        if (timestamp == null) return false;
         const after = segment.started_at == null || timestamp >= segment.started_at;
         const before = segment.ended_at == null || timestamp <= segment.ended_at + 1;
         return after && before;
@@ -930,7 +929,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         return;
       }
       setLive(true);
-      if (event.id && event.role && event.branch_id) {
+      if (isSessionMessageEvent(event)) {
         const msg = event as unknown as SessionMessage;
         setSession((prev) => {
           if (!prev) return prev;

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -592,7 +592,7 @@ export interface SessionMessage {
   role: string;
   content: Record<string, unknown>;
   sender: string | null;
-  timestamp: number;
+  timestamp: number | null;
   lion_class: string;
   branch_id?: string;
 }
@@ -600,7 +600,7 @@ export interface SessionMessage {
 export interface SessionBranch {
   id: string;
   name: string;
-  created_at: number;
+  created_at: number | null;
   /** Persisted full-progression bounds, independent of the messages window. */
   first_message_at?: number | null;
   last_message_at?: number | null;

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -592,7 +592,7 @@ export interface SessionMessage {
   role: string;
   content: Record<string, unknown>;
   sender: string | null;
-  timestamp: number | null;
+  timestamp: number;
   lion_class: string;
   branch_id?: string;
 }
@@ -600,7 +600,7 @@ export interface SessionMessage {
 export interface SessionBranch {
   id: string;
   name: string;
-  created_at: number | null;
+  created_at: number;
   /** Persisted full-progression bounds, independent of the messages window. */
   first_message_at?: number | null;
   last_message_at?: number | null;

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -433,7 +433,7 @@ def _branch_message_stats(
         arguments = content.get("arguments")
         arguments = arguments if isinstance(arguments, dict) else {}
         tool_name = str(function).lower().replace("-", "_").rsplit("__", 1)[-1].rsplit(".", 1)[-1]
-        if tool_name in {
+        if not tool_name or tool_name in {
             "read",
             "read_file",
             "write",

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -1106,6 +1106,32 @@ def test_branch_file_stats_only_accept_structured_file_tool_paths():
     assert stats["files"] == ["/repo/Makefile", "/repo/src/main.py"]
 
 
+def test_branch_file_stats_capture_empty_or_missing_function_name():
+    from lionagi.studio.services.sessions import _branch_message_stats
+
+    action_messages = [
+        {
+            "id": "empty-fn",
+            "lion_class": "ActionRequest",
+            "content": {"function": "", "arguments": {"file_path": "/repo/src/empty.py"}},
+        },
+        {
+            "id": "missing-fn",
+            "lion_class": "ActionRequest",
+            "content": {"arguments": {"path": "/repo/src/missing.py"}},
+        },
+        {
+            "id": "bash",
+            "lion_class": "ActionRequest",
+            "content": {"function": "Bash", "arguments": {"path": "//"}},
+        },
+    ]
+
+    stats = _branch_message_stats(3, {"action": 3}, action_messages)
+
+    assert stats["files"] == ["/repo/src/empty.py", "/repo/src/missing.py"]
+
+
 async def test_get_session_message_count_is_db_aggregate_not_progression_length(
     patched_sessions_db,
 ):


### PR DESCRIPTION
Closes #2264. Closes #2265.

- Server-side: gating file-path capture behind a structured tool-name allowlist meant an action message with an empty or missing `function` derived the tool name `""`, never matched, and silently dropped its file. Capture is restored for the unnamed case without reopening the leak the allowlist closed.
- Frontend: #2265 reported that extracting the `steps` `useMemo` body into `buildRunSteps` dropped the per-segment filter's null-timestamp guard, and the first attempt here simply restored it. That was wrong, and review caught it. `messages.created_at` and `branches.created_at` are `REAL NOT NULL`, the session service maps the timestamp straight from that column, and the SSE generator serializes those rows unchanged, so no supported server path produces an undated message. A restored guard there is dead code, and making a test fixture produce the state it guards against required widening the API type to claim messages may be undated, a contract the server cannot emit.

  The defense belongs at the only genuinely untyped seam instead. The SSE handler casts a raw `Record<string, unknown>` straight to `SessionMessage`; that cast now also requires a numeric timestamp, and a frame failing it is skipped rather than appended. The segment-filter guard is removed and the API types stay non-nullable, so the type and the runtime agree about what can exist.
