### PR TITLE
fix(protocols): stop get_class("") matching leaked empty-named classes

### DIFF
--- a/lionagi/_class_registry.py
+++ b/lionagi/_class_registry.py
@@ -45,6 +45,14 @@ def get_class(class_name: str) -> type:
     name), then dotted-path import, then legacy short-name lookup among the
     built-in modules. Raises ValueError if not found.
     """
+    if not class_name:
+        # An empty name can never be a legitimate class name; the short-name
+        # suffix-match fallback below (``key.endswith(f".{name}")``) would
+        # otherwise match ANY registry key ending in a bare ".", including
+        # keys accidentally left by a Node subclass created with an empty
+        # name (e.g. a dynamic factory called with name="").
+        raise ValueError(f"Unable to find class {class_name!r}")
+
     if class_name in LION_CLASS_REGISTRY:
         return LION_CLASS_REGISTRY[class_name]
 

--- a/scripts/rss_report.py
+++ b/scripts/rss_report.py
@@ -6,7 +6,13 @@ Usage: rss_report.py <dir with rss-*.jsonl>
 Prints, per xdist worker: the final peak RSS, and the tests that raised the
 process high-water mark the most (nonzero delta_kb). When a CI worker dies
 with "node down: Not properly terminated", the killed worker's log ends at
-the moment of death — its last lines and biggest deltas point at the culprit.
+the moment of death.
+
+Each test writes a "start" row before running and an "end" row after. A row
+with phase="start" and no matching "end" row is a test that was IN FLIGHT
+when its worker died — that is the actual crash suspect, distinct from the
+last-COMPLETED test (which older logs from before this row pairing existed
+could only approximate).
 """
 
 import json
@@ -14,12 +20,12 @@ import sys
 from pathlib import Path
 
 
-def main() -> int:
-    log_dir = Path(sys.argv[1])
+def summarize(log_dir: Path) -> str:
+    """Render the peak-RSS / in-flight-crash-suspect report for *log_dir* as text."""
+    out: list[str] = []
     files = sorted(log_dir.glob("rss-*.jsonl"))
     if not files:
-        print("no RSS logs found")
-        return 0
+        return "no RSS logs found"
 
     all_deltas: list[dict] = []
     for f in files:
@@ -36,23 +42,46 @@ def main() -> int:
             except json.JSONDecodeError:
                 skipped += 1
         if skipped:
-            print(f"({f.name}: skipped {skipped} malformed line(s) — truncated write)")
+            out.append(f"({f.name}: skipped {skipped} malformed line(s) — truncated write)")
         if not rows:
             continue
+
         worker = rows[-1]["worker"]
-        peak_mb = rows[-1]["peak_kb"] / 1024
-        print(f"\n== {worker}: {len(rows)} tests, final peak RSS {peak_mb:.0f} MB ==")
-        print(f"   last test logged: {rows[-1]['test']}")
+        ends = [r for r in rows if r.get("phase") == "end"]
+        starts = [r for r in rows if r.get("phase") == "start"]
+        completed_tests = {r["test"] for r in ends}
+        in_flight = [r for r in starts if r["test"] not in completed_tests]
+
+        peak_mb = (ends[-1]["peak_kb"] if ends else rows[-1]["peak_kb"]) / 1024
+        out.append(
+            f"\n== {worker}: {len(ends)} tests completed, final peak RSS {peak_mb:.0f} MB =="
+        )
+        if in_flight:
+            crash_suspect = in_flight[-1]
+            out.append(
+                f"   IN-FLIGHT AT DEATH (never reached an end row — crash suspect): "
+                f"{crash_suspect['test']} (RSS at start: {crash_suspect['peak_kb'] / 1024:.0f} MB)"
+            )
+        elif ends:
+            out.append(f"   last test completed: {ends[-1]['test']}")
+
         growers = sorted(
-            (r for r in rows if r["delta_kb"] > 0), key=lambda r: r["delta_kb"], reverse=True
+            (r for r in ends if r.get("delta_kb", 0) > 0),
+            key=lambda r: r["delta_kb"],
+            reverse=True,
         )
         for r in growers[:10]:
-            print(f"   +{r['delta_kb'] / 1024:7.1f} MB  {r['test']}")
+            out.append(f"   +{r['delta_kb'] / 1024:7.1f} MB  {r['test']}")
         all_deltas.extend(growers)
 
-    print("\n== top 20 peak-raisers across all workers ==")
+    out.append("\n== top 20 peak-raisers across all workers ==")
     for r in sorted(all_deltas, key=lambda r: r["delta_kb"], reverse=True)[:20]:
-        print(f"   +{r['delta_kb'] / 1024:7.1f} MB  [{r['worker']}]  {r['test']}")
+        out.append(f"   +{r['delta_kb'] / 1024:7.1f} MB  [{r['worker']}]  {r['test']}")
+    return "\n".join(out)
+
+
+def main() -> int:
+    print(summarize(Path(sys.argv[1])))
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,17 +60,43 @@ if _RSS_LOG_DIR:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(item, nextitem):
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+        log_path = os.path.join(_RSS_LOG_DIR, f"rss-{worker}.jsonl")
         before = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+        # Write a "start" row before running the test: if the worker is killed
+        # mid-test (the exact OOM/SIGKILL crash this log exists for), the
+        # crashing test never reaches the "end" row below, so a plain
+        # after-only log would silently omit it. The start row is the only
+        # trace of which test the worker was actually executing when it died.
+        with open(log_path, "a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "worker": worker,
+                        "test": item.nodeid,
+                        "phase": "start",
+                        "peak_kb": before // _RSS_DIV,
+                    }
+                )
+                + "\n"
+            )
         yield
         after = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
         delta_kb = (after - before) // _RSS_DIV
         peak_kb = after // _RSS_DIV
-        worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-        line = json.dumps(
-            {"worker": worker, "test": item.nodeid, "peak_kb": peak_kb, "delta_kb": delta_kb}
-        )
-        with open(os.path.join(_RSS_LOG_DIR, f"rss-{worker}.jsonl"), "a") as f:
-            f.write(line + "\n")
+        with open(log_path, "a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "worker": worker,
+                        "test": item.nodeid,
+                        "phase": "end",
+                        "peak_kb": peak_kb,
+                        "delta_kb": delta_kb,
+                    }
+                )
+                + "\n"
+            )
 
 
 def pytest_addoption(parser):

--- a/tests/protocols/graph/test_node_serialization.py
+++ b/tests/protocols/graph/test_node_serialization.py
@@ -17,6 +17,27 @@ def _content_hash(content):
     return compute_hash(content, none_as_valid=True)
 
 
+@pytest.fixture(autouse=True)
+def _registry_snapshot():
+    """Snapshot LION_CLASS_REGISTRY before each test; restore on teardown.
+
+    Every ``create_node(...)`` call in this module registers a Node subclass
+    into the process-global registry via ``Node.__pydantic_init_subclass__``
+    and never unregisters it. Left unguarded, those entries (including one
+    created with an empty name, whose key ends in a bare ".") outlive this
+    module's tests and can be picked up by an unrelated later test on the
+    same worker/process (e.g. ``get_class("")``'s short-name suffix match).
+    """
+    from lionagi._class_registry import LION_CLASS_REGISTRY
+
+    registry_snapshot = LION_CLASS_REGISTRY.copy()
+    try:
+        yield
+    finally:
+        LION_CLASS_REGISTRY.clear()
+        LION_CLASS_REGISTRY.update(registry_snapshot)
+
+
 class TestBackwardsCompatibility:
     """Ensure base Node and unaware subclasses remain unaffected."""
 

--- a/tests/scripts/test_rss_report.py
+++ b/tests/scripts/test_rss_report.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/rss_report.py: peak-RSS summary and in-flight crash-suspect detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.rss_report import summarize
+
+
+def _write_log(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+
+def test_no_logs_found(tmp_path: Path) -> None:
+    assert summarize(tmp_path) == "no RSS logs found"
+
+
+def test_worker_with_only_completed_tests_reports_last_completed(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path / "rss-gw0.jsonl",
+        [
+            {"worker": "gw0", "test": "t1", "phase": "start", "peak_kb": 100},
+            {"worker": "gw0", "test": "t1", "phase": "end", "peak_kb": 110, "delta_kb": 10},
+            {"worker": "gw0", "test": "t2", "phase": "start", "peak_kb": 110},
+            {"worker": "gw0", "test": "t2", "phase": "end", "peak_kb": 120, "delta_kb": 10},
+        ],
+    )
+
+    report = summarize(tmp_path)
+
+    assert "2 tests completed" in report
+    assert "last test completed: t2" in report
+    assert "IN-FLIGHT" not in report
+
+
+def test_worker_killed_mid_test_reports_in_flight_crash_suspect(tmp_path: Path) -> None:
+    """A test with a "start" row but no matching "end" row is the one running
+    when the worker died -- exactly the case a truncated log leaves behind."""
+    _write_log(
+        tmp_path / "rss-gw1.jsonl",
+        [
+            {"worker": "gw1", "test": "t1", "phase": "start", "peak_kb": 100},
+            {"worker": "gw1", "test": "t1", "phase": "end", "peak_kb": 110, "delta_kb": 10},
+            {"worker": "gw1", "test": "t2_crashes", "phase": "start", "peak_kb": 110},
+            # No "end" row for t2_crashes: the worker died mid-test.
+        ],
+    )
+
+    report = summarize(tmp_path)
+
+    assert "IN-FLIGHT AT DEATH" in report
+    assert "t2_crashes" in report
+    assert "1 tests completed" in report
+
+
+def test_malformed_trailing_line_is_skipped_not_fatal(tmp_path: Path) -> None:
+    log = tmp_path / "rss-gw2.jsonl"
+    log.write_text(
+        json.dumps({"worker": "gw2", "test": "t1", "phase": "start", "peak_kb": 100})
+        + "\n"
+        + json.dumps({"worker": "gw2", "test": "t1", "phase": "end", "peak_kb": 105, "delta_kb": 5})
+        + "\n"
+        + '{"worker": "gw2", "test": "t2", "phase":'  # truncated mid-write
+    )
+
+    report = summarize(tmp_path)
+
+    assert "skipped 1 malformed line" in report
+    assert "last test completed: t1" in report
+
+
+def test_top_growers_ranked_across_workers(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path / "rss-gw0.jsonl",
+        [
+            {"worker": "gw0", "test": "small", "phase": "start", "peak_kb": 100},
+            {"worker": "gw0", "test": "small", "phase": "end", "peak_kb": 105, "delta_kb": 5},
+        ],
+    )
+    _write_log(
+        tmp_path / "rss-gw1.jsonl",
+        [
+            {"worker": "gw1", "test": "big", "phase": "start", "peak_kb": 100},
+            {"worker": "gw1", "test": "big", "phase": "end", "peak_kb": 50100, "delta_kb": 50000},
+        ],
+    )
+
+    report = summarize(tmp_path)
+    top_section = report.split("top 20 peak-raisers")[1]
+
+    # The biggest grower (big, on gw1) must be listed before the smaller one.
+    assert top_section.index("big") < top_section.index("small")


### PR DESCRIPTION
Closes #2291. Refs #2152, #1679.

`tests/test_class_registry.py::TestGetClassMiss::test_empty_string_raises_value_error` failed deterministically in a serial full-suite run: an earlier test registered a class under an empty name, and `get_class("")` then resolved instead of raising. Fixed at the registry rather than by loosening the assertion.

For the 3.14 xdist worker crashes (no traceback, consistent with SIGKILL/OOM): root cause is **not** proven and this PR does not claim a fix. It adds RSS logging at test start so the next occurrence names the test it died in, which is the missing diagnostic — the crash reports currently identify the worker but not reliably the culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)