### PR TITLE
chore: review follow-ups — error export, guard clarity, alias coverage, fanout error passthrough

### DIFF
--- a/lionagi/_errors.py
+++ b/lionagi/_errors.py
@@ -18,6 +18,7 @@ __all__ = (
     "ExecutionError",
     "ConfigurationError",
     "TimeoutError",
+    "EmptyOutgoingContentError",
     "ItemNotFoundError",
     "ItemExistsError",
 )

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import time
 
-from lionagi._errors import LionError
+from lionagi._errors import EmptyOutgoingContentError, LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import CancelScope, create_task_group, move_on_after
 from lionagi.orchestration import plan
@@ -209,6 +209,8 @@ async def _run_fanout_inner(
             guidance=role_roster(env.default_model_spec),
             max_tasks=num_workers,
         )
+    except EmptyOutgoingContentError:
+        raise
     except ValueError as exc:
         # plan() raises a bare ValueError when the orchestrator still
         # overshoots max_tasks after the cap was stated in guidance — mirror

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -194,8 +194,17 @@ def _prepare_run_kwargs(
 
     kw = (param.imodel_kw or {}).copy()
 
+    # The current turn's content is always the last entry appended to
+    # `_contents` above (guidance-merge branch, action-context branch, and
+    # plain-append branch all push it last). The guard below needs that
+    # entry's rendered output specifically, so it is captured explicitly by
+    # index rather than left to whatever value the loop happens to hold
+    # after its final iteration.
+    _last_index = len(_contents) - 1
+    _current_turn_rendered = None
+
     chat_msgs = []
-    for entry in _contents:
+    for i, entry in enumerate(_contents):
         if _use_render_cache and entry.source is not None and entry.cache_variant is not None:
             source = entry.source
             if entry.cache_variant == "prepared_instruction":
@@ -211,22 +220,21 @@ def _prepare_run_kwargs(
                 )
         else:
             rendered = entry.materialize().rendered
+        if i == _last_index:
+            _current_turn_rendered = rendered
         if not rendered:
             continue
         role = entry.role
         role_str = role.value if isinstance(role, MessageRole) else str(role)
         chat_msgs.append({"role": role_str, "content": rendered})
 
-    # The current turn's content is always the last entry appended to
-    # `_contents` above (guidance-merge branch, action-context branch, and
-    # plain-append branch all push it last). If the caller supplied real
-    # instruction text/media but that entry rendered empty and got filtered
-    # out of `chat_msgs` by `if not rendered: continue` above, the model call
-    # would silently go out carrying only scaffolding (system/guidance) and
-    # no user content — worse than a loud failure, since the run "completes"
-    # with a useless reply. `rendered` here still holds the last loop
-    # iteration's value even when that iteration hit `continue`.
-    if _contents and _has_real_instruction_text(ins.content) and not rendered:
+    # If the caller supplied real instruction text/media but the current
+    # turn's entry rendered empty and got filtered out of `chat_msgs` by
+    # `if not rendered: continue` above, the model call would silently go
+    # out carrying only scaffolding (system/guidance) and no user content —
+    # worse than a loud failure, since the run "completes" with a useless
+    # reply.
+    if _contents and _has_real_instruction_text(ins.content) and not _current_turn_rendered:
         _instruction_text = getattr(ins.content, "instruction", None)
         _plain_content = getattr(ins.content, "plain_content", None)
         _instruction_len = len(_instruction_text) if _instruction_text else 0

--- a/tests/cli/orchestrate/test_fanout_max_tasks_error.py
+++ b/tests/cli/orchestrate/test_fanout_max_tasks_error.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from lionagi._errors import EmptyOutgoingContentError
 from lionagi.cli._util import EXIT_CODE_BY_STATUS
 from lionagi.cli.orchestrate import add_orchestrate_subparser, run_orchestrate
 from lionagi.cli.orchestrate import fanout as fanout_module
@@ -62,6 +63,40 @@ async def test_run_fanout_translates_over_max_tasks_value_error(
     monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
 
     with pytest.raises(FanoutPlanError, match="exceeding max_tasks"):
+        await fanout_module._run_fanout(
+            "codex/model",
+            "work",
+            num_workers=2,
+        )
+
+
+async def test_run_fanout_reraises_empty_outgoing_content_error_as_itself(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """EmptyOutgoingContentError subclasses ValueError, so a genuinely dropped
+    instruction must NOT be misreported as a `FanoutPlanError` (an orchestrator
+    max_tasks overshoot) — it must propagate as itself, mirroring the
+    exemption `li o flow` already carries for the same plan() call."""
+    env, run, session = _fanout_env(tmp_path)
+
+    engine_run = type("EngineRunStub", (), {})()
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    monkeypatch.setattr(
+        fanout_module,
+        "plan",
+        AsyncMock(side_effect=EmptyOutgoingContentError("instruction_len=42")),
+    )
+    monkeypatch.setattr(fanout_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(fanout_module, "role_roster", lambda model: "worker")
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
+
+    with pytest.raises(EmptyOutgoingContentError, match="instruction_len=42"):
         await fanout_module._run_fanout(
             "codex/model",
             "work",

--- a/tests/operations/test_chat_prepare.py
+++ b/tests/operations/test_chat_prepare.py
@@ -8,6 +8,7 @@ import pytest
 from lionagi._errors import EmptyOutgoingContentError
 from lionagi.operations.chat._prepare import _prepare_run_kwargs
 from lionagi.operations.types import ChatParam
+from lionagi.protocols.messages.assistant_response import AssistantResponseContent
 from lionagi.protocols.messages.instruction import InstructionContent
 from lionagi.session.branch import Branch
 
@@ -83,6 +84,49 @@ def test_prepare_run_kwargs_raises_when_real_instruction_renders_empty(monkeypat
     # it gets serialized into persisted failure signals (RunFailed) and
     # must not carry caller-supplied content.
     assert "a real, non-empty prompt" not in str(excinfo.value)
+
+
+def test_prepare_run_kwargs_guard_checks_current_turn_not_earlier_history(monkeypatch):
+    """Multi-item case: history contains an earlier Instruction + a real,
+    non-empty-rendering AssistantResponse, so the loop building `chat_msgs`
+    passes through at least one non-empty render before it ever reaches the
+    current turn's entry. Only InstructionContent is patched to render
+    empty, so the earlier AssistantResponse entry still renders fine — the
+    guard's input (the *current turn's* render) is therefore distinguishable
+    from 'whatever the loop last computed while iterating history'. The
+    guard must still fire because the current turn (always the last entry)
+    is an Instruction and renders empty."""
+    branch = Branch()
+    param = ChatParam()
+
+    branch.msgs.add_message(instruction="initial question")
+    branch.msgs.add_message(assistant_response="a real, non-empty answer")
+
+    monkeypatch.setattr(InstructionContent, "rendered", property(lambda self: ""))
+
+    with pytest.raises(EmptyOutgoingContentError, match="instruction_len="):
+        _prepare_run_kwargs(branch, "a real, non-empty prompt", param)
+
+
+def test_prepare_run_kwargs_guard_ignores_earlier_history_render_state(monkeypatch):
+    """Companion case: an earlier historical AssistantResponse renders empty,
+    but the current turn's own Instruction is unpatched and renders
+    normally. The guard must NOT fire — it must track the current turn's
+    render specifically, not get confused by an unrelated empty render
+    earlier in the same loop (the loop's ambient last-value would coincide
+    here too, but only because the current turn happens to be last; this
+    pins that the guard's read is not sensitive to what came before it)."""
+    branch = Branch()
+    param = ChatParam()
+
+    branch.msgs.add_message(instruction="initial question")
+    branch.msgs.add_message(assistant_response="a stale, now-empty-rendering answer")
+
+    monkeypatch.setattr(AssistantResponseContent, "rendered", property(lambda self: ""))
+
+    _ins, kw = _prepare_run_kwargs(branch, "a real, current prompt", param)
+    messages = kw["messages"]
+    assert any("a real, current prompt" in m["content"] for m in messages)
 
 
 def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeypatch):

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -335,11 +335,38 @@ def test_notify_anchor_then_explicit_bool_tagged_key_still_rejected():
 
 def test_notify_alias_of_implicit_anchored_key_stays_text():
     """An anchored-but-untagged key (`&a on:`) is still implicit resolution,
-    so it keeps the text leniency; an alias reusing it inherits the same
-    node and therefore the same outcome."""
-    manifest = _notify_yaml_manifest("      &a on: [failed]\n      command: notify-run\n")
+    so it keeps the text leniency; an alias (`*a`) reusing it in a second
+    schedule's notify block inherits the same node and therefore the same
+    outcome."""
+    manifest = """
+apiVersion: lionagi.io/v1alpha1
+kind: ScheduleSet
+metadata:
+  name: a
+  project: demo
+schedules:
+  m:
+    trigger:
+      every: 1h
+    target:
+      kind: command
+      executable: notify-run
+    notify:
+      &a on: [failed]
+      command: notify-run
+  n:
+    trigger:
+      every: 1h
+    target:
+      kind: command
+      executable: notify-run
+    notify:
+      *a : [timed_out]
+      command: notify-run
+"""
     doc = parse_schedule_set(manifest)
     assert doc.schedules["m"].notify.on == ["failed"]
+    assert doc.schedules["n"].notify.on == ["timed_out"]
 
 
 def test_sequence_mapping_key_raises_value_error_not_type_error():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,10 +3,13 @@
 
 """Tests for LionAGI error classes."""
 
+import importlib
+
 import pytest
 
 from lionagi._errors import (
     ConfigurationError,
+    EmptyOutgoingContentError,
     ExecutionError,
     ExistsError,
     ItemExistsError,
@@ -19,6 +22,24 @@ from lionagi._errors import (
     RelationError,
     ResourceError,
     ValidationError,
+)
+
+_EXPECTED_ALL = (
+    "LionError",
+    "ValidationError",
+    "NotFoundError",
+    "ExistsError",
+    "ObservationError",
+    "ResourceError",
+    "RateLimitError",
+    "RelationError",
+    "OperationError",
+    "ExecutionError",
+    "ConfigurationError",
+    "TimeoutError",
+    "EmptyOutgoingContentError",
+    "ItemNotFoundError",
+    "ItemExistsError",
 )
 
 
@@ -310,6 +331,37 @@ class TestConfigurationError:
     def test_inheritance(self):
         """Test ConfigurationError inherits from LionError and ValueError."""
         error = ConfigurationError("bad config")
+        assert isinstance(error, LionError)
+        assert isinstance(error, ValueError)
+
+
+class TestPublicSurface:
+    """Tests for the ``lionagi._errors`` module's declared public surface."""
+
+    def test_all_matches_expected(self):
+        """``lionagi._errors.__all__`` contains exactly the declared public names."""
+        mod = importlib.import_module("lionagi._errors")
+        declared = set(mod.__all__)
+        expected = set(_EXPECTED_ALL)
+        missing = expected - declared
+        extra = declared - expected
+        assert not missing, f"Names missing from __all__: {sorted(missing)}"
+        assert not extra, f"Undocumented names in __all__: {sorted(extra)}"
+
+    def test_all_entries_importable(self):
+        """Every name in __all__ must resolve on the module."""
+        mod = importlib.import_module("lionagi._errors")
+        for name in mod.__all__:
+            assert hasattr(mod, name), f"{name!r} declared in __all__ but not defined"
+
+    def test_empty_outgoing_content_error_in_all(self):
+        """EmptyOutgoingContentError must be part of the public, catchable surface."""
+        mod = importlib.import_module("lionagi._errors")
+        assert "EmptyOutgoingContentError" in mod.__all__
+
+    def test_empty_outgoing_content_error_inheritance(self):
+        """EmptyOutgoingContentError inherits from LionError and ValueError."""
+        error = EmptyOutgoingContentError()
         assert isinstance(error, LionError)
         assert isinstance(error, ValueError)
 


### PR DESCRIPTION
Four small follow-ups from review verdicts on recently merged PRs. One commit each.

1. **`EmptyOutgoingContentError` was missing from `lionagi/_errors.__all__`.** It is a public, catchable error; callers need to import it. Adds an `__all__` contract test following the convention in `tests/casts/test_public_import.py`.

2. **The chat-prepare empty-content guard read a loop-scoped value implicitly.** It was correct only because the current turn's entry happens to be the last one iterated. The guard now reads the current turn's render explicitly, so a future edit to the loop cannot silently change what it inspects. Behavior-preserving: the existing tests pass identically before and after, and two new tests distinguish the current turn from earlier history (which the single-item case could not).

3. **A schedule-declaration regression test named for an alias never used one.** It declared an anchor but no `*a`, so it did not exercise the path its docstring described. Now it does, and passes without touching production code.

4. **`fanout` translated any `ValueError` from `plan()` into `FanoutPlanError`.** `EmptyOutgoingContentError` subclasses `ValueError`, so a genuinely dropped instruction was reported as an orchestrator planning overshoot. Mirrors the exemption `flow.py` already carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)