### PR TITLE
fix(hooks): give the three API hook points real emit sites

### DIFF
--- a/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
+++ b/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
@@ -36,11 +36,12 @@ receives the argument mapping and may replace it before the callable runs. The S
 block by raising but cannot transform the Tool's argument mapping. An observation adapter cannot
 manufacture the stronger mutation contract.
 
-**P5 — the public Session vocabulary is wider than the wired implementation.** `HookPoint` has
-thirteen values. Nine have production emit sites: session start/end, branch creation/end, tool
-pre/post/error, message addition, and user prompt submission. `API_PRE_CALL`, `API_POST_CALL`,
-`API_STREAM_CHUNK`, and `ARTIFACT_CREATED` have no production `HookBus` emit site. A declared enum
-member is not evidence that its integration exists.
+**P5 — the public Session vocabulary was wider than the wired implementation.** `HookPoint` has
+thirteen values. Twelve now have production emit sites: session start/end, branch creation/end, tool
+pre/post/error, message addition, user prompt submission, and the three API points, which delta 2
+wired through the operation-layer adapter described below. `ARTIFACT_CREATED` alone still has no
+production `HookBus` emit site. A declared enum member is not evidence that its integration
+exists, which is the reason this problem was recorded rather than the reason it stays true.
 
 **P6 — lazy ownership and compatibility surfaces expose real maintenance traps.** Creating
 `Session.hooks` after branches were included does not backfill the bus onto those branches.
@@ -247,9 +248,9 @@ points emit. The shipped production matrix is:
 | `TOOL_ERROR` | `_act()` when invoke raises | `call_id`, `tool_name`, `error`, `duration=None` | wired |
 | `MESSAGE_ADD` | routed Branch message callback | `branch_id`, `message` | conditionally wired by persistence routing |
 | `USER_PROMPT_SUBMIT` | `chat()`/`run()` before provider invocation when a turn-origin token is present | operation-specific prompt context | wired, blocking, at most once per user-originated turn |
-| `API_PRE_CALL` | none | none | dormant |
-| `API_POST_CALL` | none | none | dormant |
-| `API_STREAM_CHUNK` | none | none | dormant |
+| `API_PRE_CALL` | operation layer, before the provider invocation | `session_id`, `branch_id`, `model`, `provider` | wired |
+| `API_POST_CALL` | operation layer, once the call has settled | `model`, `provider`, `status`, `error`, `latency_ms`, `tokens` | wired |
+| `API_STREAM_CHUNK` | operation layer, per stream chunk | redacted `chunk_type` discriminator only | wired |
 | `ARTIFACT_CREATED` | none | none | deprecated compatibility vocabulary; no emit site or payload contract |
 
 `call_id` is a fresh UUID4 string shared by a Tool's pre and post/error emissions. Argument and
@@ -726,9 +727,11 @@ An adapter is valid only when it preserves all of these properties:
 6. **No duplicate canonical event.** `MESSAGE_ADD` uses `MessageAdded` on the observer and suppresses
    a redundant `HookSignal`.
 
-The three dormant API HookPoints may acquire meaning only through a typed optional
-service-to-session adapter that states when it emits, what it redacts, and whether it observes a
-stream chunk before or after the service handler. `ARTIFACT_CREATED` is retained only as deprecated
+The three API HookPoints acquired meaning through the typed optional adapter this required: it
+lives at the operation layer rather than inside the service, is a no-op when a branch carries no
+bus, states when it emits, and redacts a stream chunk to a type discriminator rather than carrying
+its payload. Standalone iModel behavior and service pre-invocation control are unchanged because
+the adapter is never reached from either. `ARTIFACT_CREATED` is retained only as deprecated
 compatibility vocabulary until the artifact owner supplies a payload and emit site. A contract test
 pins both the public deprecation notice and the absence of a production emitter; merely calling
 `bus.emit()` in a test would not be production integration.
@@ -774,7 +777,7 @@ unlike callables.
 | # | Delta | Size | Issue |
 |---|---|---|---|
 | 1 | Make Session hook attachment independent of lazy access order; accept when branches included before or after `Session.hooks` creation receive the same bus and emit the same tool signals. | S | #1964 |
-| 2 | Give the three dormant API `HookPoint` values production semantics through a typed, optional service-to-session observation adapter; accept when a session-bound iModel records API observations without changing service pre-invocation control or standalone iModel behavior. | M | (filled at issue-open time) |
+| 2 | Give the three dormant API `HookPoint` values production semantics through a typed, optional service-to-session observation adapter; accept when a session-bound iModel records API observations without changing service pre-invocation control or standalone iModel behavior. | M | delivered |
 | 3 | `ARTIFACT_CREATED` is deprecated compatibility vocabulary with no production emit site; contract coverage pins both the no-emitter scan and the public warning until an artifact owner supplies a typed payload. | S | — |
 | 4 | Blocked `TOOL_PRE` attempts record a denial signal before the original exception propagates; tests pin both the audit record and the blocked invocation. | S | — |
 | 5 | Align service hook annotations with runtime behavior; accept when `StreamHandlers` describes the actual stream callback arguments and `iModel.create_event()` has one truthful return type covered by static and runtime tests. | S | (filled at issue-open time) |

--- a/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
+++ b/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
@@ -747,9 +747,9 @@ unlike callables.
   behavior, and Tool guards retain argument transformation.
 - Maintainers must identify the operation and owner before registering a “hook.” Import path alone
   is not cosmetic: it determines lifetime, handler signature, and failure semantics.
-- `HookPoint` catalog consumers must distinguish enum availability from production wiring. Three
-  values currently describe reserved vocabulary only, while `ARTIFACT_CREATED` is deprecated
-  compatibility vocabulary.
+- `HookPoint` catalog consumers must distinguish enum availability from production wiring.
+  `ARTIFACT_CREATED` alone currently describes reserved, deprecated compatibility vocabulary with no
+  production emit site; every other catalog value now has one.
 - A `TOOL_PRE` denial records a denial `HookSignal` before the original exception propagates. Audit
   consumers can identify the denied attempt without changing the blocking result.
 - Session bus attachment currently depends on access order. A Branch can have an observer and no

--- a/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
+++ b/docs/adr/ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md
@@ -90,8 +90,11 @@ This ADR does not decide:
   hook execution.
 - The persistence schema for session signals or messages. This ADR records the hook-side payload and
   routing contracts only.
-- A new API-call telemetry bridge. The current absence is recorded; implementing the bridge is a
-  separate change with its own typed payload.
+- Service-hook control semantics. The operation-layer API-call telemetry adapter (`API_PRE_CALL`/
+  `API_POST_CALL`/`API_STREAM_CHUNK`, delivered — see the production matrix below) is
+  observation-only: it wraps `imodel.invoke()`/streaming call sites from the outside and never
+  touches `HookRegistry`/`HookedEvent`, so it does not alter per-`iModel` pre-invocation control
+  (replace/abort/exit).
 - Artifact production ownership. No canonical artifact emit site exists in the hook system today.
 - User code discovery or import trust for hook modules. The loader resolves already registered
   names; it is not a general plugin loader.
@@ -248,8 +251,8 @@ points emit. The shipped production matrix is:
 | `TOOL_ERROR` | `_act()` when invoke raises | `call_id`, `tool_name`, `error`, `duration=None` | wired |
 | `MESSAGE_ADD` | routed Branch message callback | `branch_id`, `message` | conditionally wired by persistence routing |
 | `USER_PROMPT_SUBMIT` | `chat()`/`run()` before provider invocation when a turn-origin token is present | operation-specific prompt context | wired, blocking, at most once per user-originated turn |
-| `API_PRE_CALL` | operation layer, before the provider invocation | `session_id`, `branch_id`, `model`, `provider` | wired |
-| `API_POST_CALL` | operation layer, once the call has settled | `model`, `provider`, `status`, `error`, `latency_ms`, `tokens` | wired |
+| `API_PRE_CALL` | operation layer, before the provider invocation | `session_id`, `branch_id`, `model`, `provider` (identifiers validated against an expected shape) | wired |
+| `API_POST_CALL` | operation layer, once the call has settled | `model`, `provider` (validated), `status` (closed vocabulary), `error` (class-name label), `latency_ms`, `tokens` (typed `input_tokens`/`output_tokens` ints) | wired |
 | `API_STREAM_CHUNK` | operation layer, per stream chunk | redacted `chunk_type` discriminator only | wired |
 | `ARTIFACT_CREATED` | none | none | deprecated compatibility vocabulary; no emit site or payload contract |
 

--- a/docs/reference/agent-hooks.md
+++ b/docs/reference/agent-hooks.md
@@ -13,6 +13,12 @@ lifecycle hook points — and the built-in handlers registered via
 | `MESSAGE_ADD` | `message.add` | `branch.py _persist_via_bus` — every inbound message |
 | `USER_PROMPT_SUBMIT` | `prompt.submit` | `operations/chat/chat.py` and `operations/run/run.py`, immediately before provider invocation / streaming begins — fires only when the operation context carries a turn-origin token (blocking, via `blocking_emit`) |
 | `BRANCH_END` | `branch.end` | `cli/_runs.py teardown_persist` — once per branch the teardown owns, only when the run reached a genuine terminal outcome (never for the "running" reconciliation-suppression case) |
+| `API_PRE_CALL` | `api.pre_call` | `operations/_api_hooks.py emit_api_pre_call`, called from `operations/chat/chat.py` (before `imodel.invoke()`) and `operations/run/run.py` (before the CLI stream starts) — only when the calling Branch is session-bound (`branch._hooks is not None`); a standalone `iModel` never reaches this callsite |
+| `API_POST_CALL` | `api.post_call` | `operations/_api_hooks.py emit_api_post_call`, called from the same two sites once the call has settled — success, a provider-reported failure (`api_call.status`), or a raised exception (`error=...`, `status="error"`) |
+| `API_STREAM_CHUNK` | `api.stream_chunk` | `operations/_api_hooks.py emit_api_stream_chunk`, called from `operations/run/run.py` for every chunk of a session-bound stream; payload carries a redacted `chunk_type` only, not the raw chunk |
+| `TOOL_PRE` | `tool.pre` | `operations/act/act.py`, before tool invocation (blocking via `blocking_emit`) |
+| `TOOL_POST` | `tool.post` | `operations/act/act.py`, after successful tool invocation |
+| `TOOL_ERROR` | `tool.error` | `operations/act/act.py`, on tool invocation failure |
 
 ### Registered in DEFAULT_HOOKS (handlers wired; emit callsite deferred to ADR-0023b)
 
@@ -22,21 +28,18 @@ lifecycle hook points — and the built-in handlers registered via
 | `SESSION_END` | `session.end` | `persist_session_end` |
 | `BRANCH_CREATE` | `branch.create` | `persist_branch_provenance` |
 
-### Reserved (vocabulary only; no handler and no emit callsite yet, per ADR-0023)
+### Dormant (vocabulary only; no handler and no emit callsite)
 
-| Point | Value | Planned surface |
+| Point | Value | Status |
 |-------|-------|----------------|
-| `API_PRE_CALL` | `api.pre_call` | Before each iModel API call |
-| `API_POST_CALL` | `api.post_call` | After each iModel API call (tokens / latency) |
-| `API_STREAM_CHUNK` | `api.stream_chunk` | Per-chunk during streaming responses |
-| `TOOL_PRE` | `tool.pre` | Before tool invocation (blocking via `blocking_emit`) |
-| `TOOL_POST` | `tool.post` | After successful tool invocation |
-| `TOOL_ERROR` | `tool.error` | On tool invocation failure |
-| `ARTIFACT_CREATED` | `artifact.created` | Deprecated/not yet wired: no emit site or payload contract exists |
+| `ARTIFACT_CREATED` | `artifact.created` | Deprecated compatibility vocabulary: no emit site or payload contract exists |
 
 `ARTIFACT_CREATED` is retained only for enum compatibility. Do not register new
 handlers against it until an artifact owner defines a typed payload and a
-production emit site.
+production emit site. `HookBus.on()` emits a `UserWarning` when a handler is
+registered against any point in `lionagi.hooks.DORMANT_POINTS` (today, just
+`ARTIFACT_CREATED`) so that mistake surfaces at registration time instead of
+being discovered later as a handler that silently never ran.
 
 ## Bus dispatch semantics
 

--- a/lionagi/hooks/__init__.py
+++ b/lionagi/hooks/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .bus import HookBus, HookPoint, HookSignal, StopHook, hook
+from .bus import DORMANT_POINTS, HookBus, HookPoint, HookSignal, StopHook, hook
 from .loader import (
     DEFAULT_HOOKS,
     build_session_bus,
@@ -20,6 +20,7 @@ __all__ = [
     "HookSignal",
     "StopHook",
     "hook",
+    "DORMANT_POINTS",
     "DEFAULT_HOOKS",
     "build_session_bus",
     "load_hooks_for_agent",

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from enum import Enum
@@ -34,6 +35,7 @@ __all__ = (
     "HookHandler",
     "StopHook",
     "hook",
+    "DORMANT_POINTS",
 )
 
 
@@ -45,7 +47,8 @@ class HookPoint(str, Enum):
     SESSION_END = "session.end"
     BRANCH_CREATE = "branch.create"
     BRANCH_END = "branch.end"
-    # not-yet-wired: no emit() call in the codebase
+    # emitted in operations/chat/chat.py and operations/run/run.py, bracketing
+    # a session-bound iModel invocation/stream (see operations/_api_hooks.py)
     API_PRE_CALL = "api.pre_call"
     API_POST_CALL = "api.post_call"
     API_STREAM_CHUNK = "api.stream_chunk"
@@ -53,11 +56,19 @@ class HookPoint(str, Enum):
     TOOL_POST = "tool.post"  # emitted in operations/act/act.py on successful invocation
     TOOL_ERROR = "tool.error"  # emitted in operations/act/act.py on invocation error
     MESSAGE_ADD = "message.add"  # live: emitted in session/branch.py
-    ARTIFACT_CREATED = "artifact.created"  # not-yet-wired
+    # deprecated compatibility vocabulary: no owner has supplied a payload
+    # contract or production emit site (see docs/reference/agent-hooks.md)
+    ARTIFACT_CREATED = "artifact.created"
     # emitted in operations/chat/chat.py and operations/run/run.py, immediately
     # before provider invocation / streaming begins, when a turn-origin token
     # is present on the operation context (see operations/_turn_origin.py)
     USER_PROMPT_SUBMIT = "prompt.submit"
+
+
+# HookPoints with no production emit site. Registering a handler on one of
+# these is accepted (the enum member is real) but never fires — DORMANT_POINTS
+# is what turns that mismatch from silent into a warned one (see HookBus.on()).
+DORMANT_POINTS = frozenset({HookPoint.ARTIFACT_CREATED})
 
 
 # HookPoints that propagate handler exceptions (rather than logging and
@@ -108,6 +119,14 @@ class HookBus:
 
     def on(self, point: HookPoint | str, handler: HookHandler) -> None:
         point = _normalize_point(point)
+        if point in DORMANT_POINTS:
+            warnings.warn(
+                f"Registering a handler on HookPoint.{point.name} ({point.value!r}), which has "
+                "no production emit site — this handler will never fire. See "
+                "docs/reference/agent-hooks.md for the current wiring status.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._handlers.setdefault(point, []).append(handler)
 
     def off(self, point: HookPoint | str, handler: HookHandler) -> None:

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Typed, optional service-to-session observation adapter for API_PRE_CALL / API_POST_CALL /
+API_STREAM_CHUNK (ADR-0047 delta row 2).
+
+These helpers only fire when the calling Branch is session-bound
+(``branch._hooks is not None``); a standalone ``iModel`` never reaches
+``operations/chat/chat.py`` or ``operations/run/run.py``, so its behavior is
+unaffected. Emission is purely observational: it wraps the existing
+``imodel.invoke()`` / streaming call sites from the outside and never touches
+``HookRegistry``/``HookedEvent``, so per-``iModel`` pre-invocation control
+(replace/abort/exit) is unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+
+__all__ = ("emit_api_pre_call", "emit_api_post_call", "emit_api_stream_chunk")
+
+
+def _model_and_provider(imodel: Any) -> tuple[str, str]:
+    model = getattr(imodel, "model_name", None) or ""
+    provider = ""
+    endpoint = getattr(imodel, "endpoint", None)
+    config = getattr(endpoint, "config", None)
+    if config is not None:
+        provider = getattr(config, "provider", None) or ""
+    return model, provider
+
+
+def _extract_tokens(response: Any) -> dict | None:
+    """Best-effort provider-usage extraction; ``None`` when the shape is unrecognized.
+
+    Mirrors the normalization already used by
+    ``lionagi.session.signal._collect_branch_usage``: a provider's raw
+    response dict (or the last item of a list of them) carries an optional
+    ``usage`` mapping.
+    """
+    item = response[-1] if isinstance(response, list) and response else response
+    if not isinstance(item, dict):
+        return None
+    usage = item.get("usage")
+    return dict(usage) if isinstance(usage, dict) else None
+
+
+async def emit_api_pre_call(branch: Branch, imodel: Any) -> None:
+    """Fire API_PRE_CALL immediately before a session-bound iModel is invoked."""
+    hooks = branch._hooks
+    if hooks is None:
+        return
+    from lionagi.hooks.bus import HookPoint
+
+    model, provider = _model_and_provider(imodel)
+    await hooks.emit(
+        HookPoint.API_PRE_CALL,
+        session_id=str(branch._owning_session_id or branch.id),
+        branch_id=str(branch.id),
+        model=model,
+        provider=provider,
+    )
+
+
+async def emit_api_post_call(
+    branch: Branch,
+    imodel: Any,
+    api_call: Any = None,
+    *,
+    error: BaseException | None = None,
+    tokens: dict | None = None,
+) -> None:
+    """Fire API_POST_CALL once the call has settled — success, provider-reported
+    failure (``api_call.status``), or a raised exception (``error``)."""
+    hooks = branch._hooks
+    if hooks is None:
+        return
+    from lionagi.hooks.bus import HookPoint
+
+    model, provider = _model_and_provider(imodel)
+    duration = getattr(getattr(api_call, "execution", None), "duration", None)
+    latency_ms = duration * 1000.0 if isinstance(duration, int | float) else None
+
+    if error is not None:
+        status = "error"
+    else:
+        status_obj = getattr(api_call, "status", None)
+        status = getattr(status_obj, "value", None)
+
+    if tokens is None and api_call is not None:
+        tokens = _extract_tokens(getattr(api_call, "response", None))
+
+    await hooks.emit(
+        HookPoint.API_POST_CALL,
+        session_id=str(branch._owning_session_id or branch.id),
+        branch_id=str(branch.id),
+        model=model,
+        provider=provider,
+        status=status,
+        latency_ms=latency_ms,
+        tokens=tokens,
+        error=str(error) if error is not None else None,
+    )
+
+
+async def emit_api_stream_chunk(branch: Branch, imodel: Any, chunk: Any) -> None:
+    """Fire API_STREAM_CHUNK for one chunk of a session-bound streaming response.
+
+    Only a redacted chunk-type discriminator is forwarded — matching the
+    TOOL_PRE/TOOL_POST convention of summary-only telemetry (see
+    ``operations/act/act.py``) rather than the raw chunk payload.
+    """
+    hooks = branch._hooks
+    if hooks is None:
+        return
+    from lionagi.hooks.bus import HookPoint
+
+    model, provider = _model_and_provider(imodel)
+    chunk_type = getattr(chunk, "type", None) or type(chunk).__name__
+    await hooks.emit(
+        HookPoint.API_STREAM_CHUNK,
+        session_id=str(branch._owning_session_id or branch.id),
+        branch_id=str(branch.id),
+        model=model,
+        provider=provider,
+        chunk_type=chunk_type,
+    )

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -14,12 +14,47 @@ unaffected. Emission is purely observational: it wraps the existing
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lionagi.session.branch import Branch
 
 __all__ = ("emit_api_pre_call", "emit_api_post_call", "emit_api_stream_chunk")
+
+# Closed status vocabulary for the emitted payload — every EventStatus value
+# (the terminal status an APICalling can settle into) plus "error" (this
+# adapter's own label for a raised exception, never provider-reported).
+# Anything outside this set — a raw provider status string, or a status
+# object whose ``.value`` was never validated against EventStatus — is
+# redacted to "unknown" rather than forwarded.
+_STATUS_VOCAB = frozenset(
+    {
+        "pending",
+        "processing",
+        "completed",
+        "failed",
+        "skipped",
+        "cancelled",
+        "aborted",
+        "error",
+    }
+)
+
+# Expected shape for a model/provider identifier: lionagi's own naming
+# convention (letters, digits, ``. _ - : /``), capped well above any real
+# identifier in use. A value outside this shape is redacted rather than
+# forwarded verbatim, even though these fields are normally sourced from
+# local iModel/endpoint configuration rather than provider response text.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:/-]{1,128}$")
+
+
+def _safe_status(value: Any) -> str:
+    return value if isinstance(value, str) and value in _STATUS_VOCAB else "unknown"
+
+
+def _safe_identifier(value: Any) -> str:
+    return value if isinstance(value, str) and _IDENTIFIER_RE.match(value) else "unknown"
 
 
 def _model_and_provider(imodel: Any) -> tuple[str, str]:
@@ -29,7 +64,7 @@ def _model_and_provider(imodel: Any) -> tuple[str, str]:
     config = getattr(endpoint, "config", None)
     if config is not None:
         provider = getattr(config, "provider", None) or ""
-    return model, provider
+    return _safe_identifier(model), _safe_identifier(provider)
 
 
 def _extract_tokens(response: Any) -> dict | None:
@@ -45,6 +80,34 @@ def _extract_tokens(response: Any) -> dict | None:
         return None
     usage = item.get("usage")
     return dict(usage) if isinstance(usage, dict) else None
+
+
+def _typed_usage(tokens: dict | None) -> dict[str, int] | None:
+    """Reduce a best-effort usage mapping to a typed numeric summary.
+
+    The raw ``tokens`` dict (a provider's own response shape, forwarded
+    verbatim before this fix) can carry non-numeric fields alongside the
+    counts. Only ``input_tokens``/``output_tokens`` (or their
+    ``prompt_tokens``/``completion_tokens`` synonyms — same normalization as
+    ``_collect_branch_usage``) survive, coerced to ``int``; every other key,
+    and any non-numeric value under a recognized key, is dropped. ``None``
+    when neither count is present, matching the prior no-usage contract.
+    """
+    if not isinstance(tokens, dict):
+        return None
+
+    def _num(*keys: str) -> int | None:
+        for key in keys:
+            val = tokens.get(key)
+            if isinstance(val, (int, float)) and not isinstance(val, bool):
+                return int(val)
+        return None
+
+    input_tokens = _num("input_tokens", "prompt_tokens")
+    output_tokens = _num("output_tokens", "completion_tokens")
+    if input_tokens is None and output_tokens is None:
+        return None
+    return {"input_tokens": input_tokens or 0, "output_tokens": output_tokens or 0}
 
 
 def _error_summary(error: str | BaseException | None) -> str | None:
@@ -99,16 +162,18 @@ async def emit_api_post_call(
     call ended:
 
     - ``status``: ``"error"`` when an exception was raised (``error`` is
-      set), otherwise the provider-reported ``api_call.status`` verbatim
-      (``"completed"``/``"failed"``/...).
+      set), otherwise ``api_call.status`` mapped onto the closed status
+      vocabulary (``"completed"``/``"failed"``/... — anything else becomes
+      ``"unknown"``, never a raw provider string).
     - ``error``: populated whenever *either* an exception was raised *or*
       the call settled with a provider-reported failure and nothing was
       raised (``api_call.execution.error``) -- a FAILED ``APICalling`` that
       never raises must not leave this field null just because raising
       wasn't how it failed. Always reduced to a class-name-only summary
       (see ``_error_summary``), never the raw message.
-    - ``tokens``: best-effort usage extracted from the settled response;
-      ``None`` when the shape is unrecognized or the call never produced one.
+    - ``tokens``: typed numeric usage summary (``input_tokens``/
+      ``output_tokens`` ints); ``None`` when the shape is unrecognized or
+      the call never produced one. Never the raw provider usage mapping.
     """
     hooks = branch._hooks
     if hooks is None:
@@ -138,9 +203,9 @@ async def emit_api_post_call(
         branch_id=str(branch.id),
         model=model,
         provider=provider,
-        status=status,
+        status=_safe_status(status),
         latency_ms=latency_ms,
-        tokens=tokens,
+        tokens=_typed_usage(tokens),
         error=_error_summary(error),
     )
 

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -47,6 +47,25 @@ def _extract_tokens(response: Any) -> dict | None:
     return dict(usage) if isinstance(usage, dict) else None
 
 
+def _error_summary(error: str | BaseException | None) -> str | None:
+    """Exception-class-name-only summary of a call failure.
+
+    Matches the ``TOOL_ERROR`` hook convention (``operations/act/act.py``
+    forwards the exception object itself, never a stringified message) --
+    the raw text of a provider exception routinely carries request bodies,
+    full URLs with query parameters, or header/credential fragments, and
+    this payload is persisted verbatim to observer telemetry. A
+    non-exception failure reason (``APICalling.execution.error`` can be a
+    plain ``str``) is equally capable of embedding that text, so it gets the
+    same generic, content-free label rather than a per-type name.
+    """
+    if error is None:
+        return None
+    if isinstance(error, BaseException):
+        return type(error).__name__
+    return "ProviderError"
+
+
 async def emit_api_pre_call(branch: Branch, imodel: Any) -> None:
     """Fire API_PRE_CALL immediately before a session-bound iModel is invoked."""
     hooks = branch._hooks
@@ -69,7 +88,7 @@ async def emit_api_post_call(
     imodel: Any,
     api_call: Any = None,
     *,
-    error: BaseException | None = None,
+    error: str | BaseException | None = None,
     tokens: dict | None = None,
 ) -> None:
     """Fire API_POST_CALL once the call has settled — success, provider-reported
@@ -101,7 +120,7 @@ async def emit_api_post_call(
         status=status,
         latency_ms=latency_ms,
         tokens=tokens,
-        error=str(error) if error is not None else None,
+        error=_error_summary(error),
     )
 
 

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -223,7 +223,7 @@ async def emit_api_stream_chunk(branch: Branch, imodel: Any, chunk: Any) -> None
     from lionagi.hooks.bus import HookPoint
 
     model, provider = _model_and_provider(imodel)
-    chunk_type = getattr(chunk, "type", None) or type(chunk).__name__
+    chunk_type = _safe_identifier(getattr(chunk, "type", None) or type(chunk).__name__)
     await hooks.emit(
         HookPoint.API_STREAM_CHUNK,
         session_id=str(branch._owning_session_id or branch.id),

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -92,7 +92,24 @@ async def emit_api_post_call(
     tokens: dict | None = None,
 ) -> None:
     """Fire API_POST_CALL once the call has settled — success, provider-reported
-    failure (``api_call.status``), or a raised exception (``error``)."""
+    failure (``api_call.status``), or a raised exception (``error``).
+
+    Every ``API_PRE_CALL`` this adapter's caller emits is paired with exactly
+    one ``API_POST_CALL`` carrying whatever is actually known about how the
+    call ended:
+
+    - ``status``: ``"error"`` when an exception was raised (``error`` is
+      set), otherwise the provider-reported ``api_call.status`` verbatim
+      (``"completed"``/``"failed"``/...).
+    - ``error``: populated whenever *either* an exception was raised *or*
+      the call settled with a provider-reported failure and nothing was
+      raised (``api_call.execution.error``) -- a FAILED ``APICalling`` that
+      never raises must not leave this field null just because raising
+      wasn't how it failed. Always reduced to a class-name-only summary
+      (see ``_error_summary``), never the raw message.
+    - ``tokens``: best-effort usage extracted from the settled response;
+      ``None`` when the shape is unrecognized or the call never produced one.
+    """
     hooks = branch._hooks
     if hooks is None:
         return
@@ -102,11 +119,15 @@ async def emit_api_post_call(
     duration = getattr(getattr(api_call, "execution", None), "duration", None)
     latency_ms = duration * 1000.0 if isinstance(duration, int | float) else None
 
+    status_obj = getattr(api_call, "status", None)
+    provider_status = getattr(status_obj, "value", None)
+
     if error is not None:
         status = "error"
     else:
-        status_obj = getattr(api_call, "status", None)
-        status = getattr(status_obj, "value", None)
+        status = provider_status
+        if provider_status == "failed":
+            error = getattr(getattr(api_call, "execution", None), "error", None)
 
     if tokens is None and api_call is not None:
         tokens = _extract_tokens(getattr(api_call, "response", None))

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -74,7 +74,12 @@ async def chat(
     await emit_api_pre_call(branch, imodel)
     try:
         api_call = await imodel.invoke(**kw)
-    except Exception as exc:
+    except BaseException as exc:
+        # BaseException, not Exception: asyncio.CancelledError is a
+        # BaseException, and cancellation mid-invoke must still pair with a
+        # post emission -- an unpaired pre-call leaves an open span for any
+        # observer of the hook bus. The original exception always propagates
+        # unchanged.
         await emit_api_post_call(branch, imodel, error=exc)
         raise
     await emit_api_post_call(branch, imodel, api_call)

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -9,6 +9,7 @@ from lionagi._errors import ExecutionError
 from lionagi.protocols.generic import EventStatus
 from lionagi.protocols.messages import AssistantResponse, Instruction
 
+from .._api_hooks import emit_api_post_call, emit_api_pre_call
 from .._turn_origin import consume_turn_origin
 from ..types import ChatParam
 from ._prepare import _apply_context_providers, _build_instruction, _prepare_run_kwargs
@@ -69,7 +70,14 @@ async def chat(
 
     if not chat_param._is_sentinel(chat_param.include_token_usage_to_model):
         kw["include_token_usage_to_model"] = chat_param.include_token_usage_to_model
-    api_call = await imodel.invoke(**kw)
+
+    await emit_api_pre_call(branch, imodel)
+    try:
+        api_call = await imodel.invoke(**kw)
+    except Exception as exc:
+        await emit_api_post_call(branch, imodel, error=exc)
+        raise
+    await emit_api_post_call(branch, imodel, api_call)
 
     await branch.emit_and_log(api_call)
 

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -474,13 +474,17 @@ async def run(
         # Provider-reported usage from the terminal "result" chunk (codex: tokens; claude_code: cost/turns/duration).
         # Stamped onto the final AssistantResponse; re-tokenizing message history undercounts internal tool turns.
         result_meta: dict = {}
-        # Last known usage mapping, tracked independently of result_meta:
-        # _flush_response() clears result_meta right after stamping it onto a
-        # message (to avoid double-counting on a later flush within the same
-        # run() call), so by the time the terminal API_POST_CALL emission
-        # below reads it, a run that flushes its last text after the "result"
-        # chunk would see an already-cleared dict and report tokens=None even
-        # though usage was in fact received. last_usage survives that clear.
+        # Whole-call usage accumulator: never cleared (unlike result_meta,
+        # which resets on every flush so each AssistantResponse only carries
+        # its own window's metadata). Codex splits one run() call into
+        # multiple flush windows (tool-response flushes between "result"
+        # chunks) and emits marginal per-window deltas, so the terminal
+        # API_POST_CALL must sum every window's usage, not just the last
+        # one. _accumulate_result_meta's "usage" branch always adds
+        # (never overwrites), so feeding it every incoming chunk here, in
+        # parallel with result_meta, sums exactly once per chunk — no
+        # double-count regardless of how many flushes land in between.
+        _total_usage_meta: dict = {}
         last_usage: dict | None = None
 
         async def _flush_response() -> AssistantResponse | None:
@@ -605,8 +609,9 @@ async def run(
                         case "result":
                             if chunk.metadata:
                                 _accumulate_result_meta(result_meta, chunk.metadata)
-                                if isinstance(result_meta.get("usage"), dict):
-                                    last_usage = dict(result_meta["usage"])
+                                _accumulate_result_meta(_total_usage_meta, chunk.metadata)
+                                if isinstance(_total_usage_meta.get("usage"), dict):
+                                    last_usage = dict(_total_usage_meta["usage"])
 
                         case "error":
                             # A CLI provider marks a resumed-session end-of-stream by

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -474,6 +474,14 @@ async def run(
         # Provider-reported usage from the terminal "result" chunk (codex: tokens; claude_code: cost/turns/duration).
         # Stamped onto the final AssistantResponse; re-tokenizing message history undercounts internal tool turns.
         result_meta: dict = {}
+        # Last known usage mapping, tracked independently of result_meta:
+        # _flush_response() clears result_meta right after stamping it onto a
+        # message (to avoid double-counting on a later flush within the same
+        # run() call), so by the time the terminal API_POST_CALL emission
+        # below reads it, a run that flushes its last text after the "result"
+        # chunk would see an already-cleared dict and report tokens=None even
+        # though usage was in fact received. last_usage survives that clear.
+        last_usage: dict | None = None
 
         async def _flush_response() -> AssistantResponse | None:
             if not text_parts:
@@ -597,6 +605,8 @@ async def run(
                         case "result":
                             if chunk.metadata:
                                 _accumulate_result_meta(result_meta, chunk.metadata)
+                                if isinstance(result_meta.get("usage"), dict):
+                                    last_usage = dict(result_meta["usage"])
 
                         case "error":
                             # A CLI provider marks a resumed-session end-of-stream by
@@ -723,7 +733,7 @@ async def run(
                 branch.chat_model,
                 _terminal_api_call,
                 error=_run_exc,
-                tokens=result_meta.get("usage") if result_meta else None,
+                tokens=last_usage,
             )
 
         if has_observer and not _terminal_emitted:

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -537,7 +537,8 @@ async def run(
         try:
             try:
                 async for chunk in stream_gen:
-                    await emit_api_stream_chunk(branch, model, chunk)
+                    if branch._hooks is not None:
+                        await emit_api_stream_chunk(branch, model, chunk)
                     match chunk.type:
                         case "system":
                             if sid := chunk.metadata.get("session_id"):

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -25,6 +25,7 @@ from lionagi.protocols.messages import (
 )
 from lionagi.providers._provider_errors import WorkerLivenessError, classify_provider_error
 
+from .._api_hooks import emit_api_post_call, emit_api_pre_call, emit_api_stream_chunk
 from .._turn_origin import consume_turn_origin
 from ..chat._prepare import _apply_context_providers, _build_instruction, _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
@@ -365,6 +366,7 @@ async def run(
 
     _run_exc: BaseException | None = None
     _terminal_emitted: bool = False
+    _api_call_started: bool = False
     _t0_run = _time.monotonic()
 
     try:
@@ -527,12 +529,15 @@ async def run(
 
         kw["stream"] = True
         _api_call_holder: list = []
+        await emit_api_pre_call(branch, model)
+        _api_call_started = True
         stream_gen = _stream_with_liveness(
             model, kw, _stream_deadline, _liveness_timeout, _api_call_holder
         )
         try:
             try:
                 async for chunk in stream_gen:
+                    await emit_api_stream_chunk(branch, model, chunk)
                     match chunk.type:
                         case "system":
                             if sid := chunk.metadata.get("session_id"):
@@ -709,6 +714,16 @@ async def run(
     finally:
         # _terminal_emitted guards against double emission on Python <3.11 where finally also runs after GeneratorExit.
         await branch.drain_signals()
+
+        if _api_call_started:
+            _terminal_api_call = _api_call_holder[0] if _api_call_holder else None
+            await emit_api_post_call(
+                branch,
+                branch.chat_model,
+                _terminal_api_call,
+                error=_run_exc,
+                tokens=result_meta.get("usage") if result_meta else None,
+            )
 
         if has_observer and not _terminal_emitted:
             _terminal_emitted = True

--- a/tests/docs/test_adr_0047_hook_matrix_consistency.py
+++ b/tests/docs/test_adr_0047_hook_matrix_consistency.py
@@ -1,0 +1,49 @@
+"""ADR-0047's Consequences section must not drift from its own production matrix.
+
+Regression: after delta 2 wired API_PRE_CALL/API_POST_CALL/API_STREAM_CHUNK, the
+Consequences section still claimed "Three values currently describe reserved
+vocabulary only" -- false at that head, since only ARTIFACT_CREATED remained
+unwired, and directly contradicted the production matrix ~200 lines above it.
+"""
+
+from pathlib import Path
+
+ADR_PATH = (
+    Path(__file__).parents[2]
+    / "docs"
+    / "adr"
+    / "ADR-0047-hook-mechanism-scopes-and-canonical-ownership.md"
+)
+
+
+def _text() -> str:
+    return ADR_PATH.read_text(encoding="utf-8")
+
+
+def test_consequences_section_names_only_artifact_created_as_unwired():
+    text = _text()
+    assert "Three\n  values currently describe reserved vocabulary only" not in text
+    assert "Three values currently describe reserved vocabulary only" not in text
+
+    consequences_start = text.index("## Consequences")
+    delta_table_start = text.index("## Current-vs-ideal delta")
+    consequences = text[consequences_start:delta_table_start]
+
+    assert "`ARTIFACT_CREATED` alone currently describes reserved" in consequences
+
+
+def test_production_matrix_and_consequences_agree_on_unwired_count():
+    text = _text()
+    matrix_start = text.index(
+        "| Point | Production source | Payload supplied at that source | State |"
+    )
+    matrix_end = text.index("\n\n", matrix_start)
+    matrix = text[matrix_start:matrix_end]
+
+    # Every catalog row except ARTIFACT_CREATED must show a real production
+    # emit site (i.e. not "none" in both the HookBus/SessionObserver columns).
+    unwired_rows = [
+        line for line in matrix.splitlines() if line.startswith("| `") and "| none | none |" in line
+    ]
+    assert len(unwired_rows) == 1
+    assert "ARTIFACT_CREATED" in unwired_rows[0]

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -586,3 +586,67 @@ async def test_run_single_result_chunk_usage_unaffected_by_accumulator():
 
     post = calls[HookPoint.API_POST_CALL][0]
     assert post["tokens"] == {"input_tokens": 5, "output_tokens": 3}
+
+
+# ── stream chunk_type redaction (issue #1965 fix leg r4) ────────────────────
+
+
+async def test_api_stream_chunk_scrubs_secret_shaped_marker_in_chunk_type():
+    """``chunk.type`` is response-derived, provider-influenced text -- the same
+    class of untrusted input as ``model``/``provider`` in
+    ``_model_and_provider``, which already goes through ``_safe_identifier``.
+    A malicious/compromised stream source setting ``.type`` to a secret-shaped
+    string with embedded control characters must not have that string reach
+    persisted telemetry."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookBus, HookSignal
+    from lionagi.operations._api_hooks import emit_api_stream_chunk
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    secret = "sk-LEAK-\n\x00-drop-table"
+
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+
+    imodel = _types.SimpleNamespace(
+        model_name="gpt-4.1-mini",
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
+    )
+    chunk = _types.SimpleNamespace(type=secret)
+
+    await emit_api_stream_chunk(branch, imodel, chunk)
+
+    signals = observer.by_type(HookSignal)
+    assert len(signals) == 1
+    payload = _sanitize_signal_payload(signals[0])
+
+    assert secret not in json_dumps(payload)
+    assert payload["kwargs"]["chunk_type"] == "unknown"
+
+
+async def test_api_stream_chunk_preserves_legitimate_chunk_type():
+    """A well-shaped SDK chunk type (matching ``_safe_identifier``'s charset)
+    must survive verbatim -- only out-of-shape input is redacted."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookBus, HookSignal
+    from lionagi.operations._api_hooks import emit_api_stream_chunk
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+
+    imodel = _types.SimpleNamespace(
+        model_name="gpt-4.1-mini",
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
+    )
+    chunk = _types.SimpleNamespace(type="content_block_delta")
+
+    await emit_api_stream_chunk(branch, imodel, chunk)
+
+    signals = observer.by_type(HookSignal)
+    payload = _sanitize_signal_payload(signals[0])
+    assert payload["kwargs"]["chunk_type"] == "content_block_delta"

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -333,10 +333,12 @@ async def test_chat_api_post_call_never_leaks_secret_shaped_error_text():
 # | provider FAILED, not raised      | "failed"    | class-name/label | best-effort    |
 # | raised exception                 | "error"     | class-name/label | None           |
 # | cancellation (BaseException)     | "error"     | "CancelledError" | None           |
+# | CLI stream completion            | known/None   | None             | best-effort    |
+# | CLI stream failure               | "error"     | class-name/label | partial/None   |
 #
 # A single parametrized test asserting this table generically -- rather than
-# three separate hardcoded scenario tests -- is what catches a *fourth* exit
-# path added later that forgets to populate `error` on failure, or that
+# separate hardcoded scenario tests -- is what catches an exit path added later
+# that forgets to populate `error` on failure, or that
 # reintroduces raw message text: a scenario-specific test only checks the
 # exact value it was written against, so a new path with the same shape but
 # a different bug (e.g. `error` populated but with the raw message again)
@@ -401,17 +403,45 @@ async def _run_chat_scenario(scenario: str):
     raise AssertionError(f"unknown scenario {scenario!r}")
 
 
-@pytest.mark.parametrize("scenario", ["success", "failed_status", "raised", "cancelled"])
+async def _run_stream_scenario(scenario: str):
+    branch = Branch()
+    if scenario == "stream_success":
+        chunks = [StreamChunk(type="text", content="hello")]
+    elif scenario == "stream_failure":
+        chunks = [StreamChunk(type="error", content="boom: leak-me-not")]
+    else:  # pragma: no cover - caller is parametrized below
+        raise AssertionError(f"unknown scenario {scenario!r}")
+
+    branch.chat_model = _make_fake_cli_model(chunks)
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+    if scenario == "stream_failure":
+        with pytest.raises(Exception):
+            async for _ in run(branch, "hi there", RunParam()):
+                pass
+    else:
+        async for _ in run(branch, "hi there", RunParam()):
+            pass
+    return calls
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["success", "failed_status", "raised", "cancelled", "stream_success", "stream_failure"],
+)
 async def test_api_post_call_field_invariant_holds_across_exit_paths(scenario):
-    calls = await _run_chat_scenario(scenario)
+    if scenario.startswith("stream_"):
+        calls = await _run_stream_scenario(scenario)
+    else:
+        calls = await _run_chat_scenario(scenario)
 
     # Pairing: exactly one pre-call, exactly one post-call, regardless of exit path.
     assert len(calls[HookPoint.API_PRE_CALL]) == 1
     assert len(calls[HookPoint.API_POST_CALL]) == 1
     post = calls[HookPoint.API_POST_CALL][0]
 
-    if scenario == "success":
-        assert post["status"] == "completed"
+    if scenario in ("success", "stream_success"):
+        if scenario == "success":
+            assert post["status"] == "completed"
         assert post["error"] is None
     else:
         # Every non-success exit path must populate error (never silently
@@ -423,3 +453,136 @@ async def test_api_post_call_field_invariant_holds_across_exit_paths(scenario):
         assert post["error"] is not None
         assert "leak-me-not" not in post["error"]
         assert post["status"] in ("failed", "error")
+
+
+# ── closed telemetry payload (issue #1965 fix leg r3) ───────────────────────
+
+
+async def test_api_post_call_closed_payload_scrubs_secret_shaped_marker_everywhere():
+    """SessionObserver-backed probe: a settled call whose status object,
+    tokens mapping, model name, and provider name all carry the SAME
+    secret-shaped marker. The adapter boundary must build a closed,
+    allowlisted payload -- none of the four fields may reach persistence
+    with the marker intact, because field-by-field redaction is a treadmill
+    and the wrong class of fix."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookBus, HookSignal
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    secret = "sk-LEAK var=name;drop-table"
+
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+
+    imodel = _types.SimpleNamespace(
+        model_name=secret,
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider=secret)),
+    )
+    api_call = _types.SimpleNamespace(
+        # A status object whose .value is raw text, not validated against
+        # EventStatus -- exactly the shape a non-exception provider failure
+        # reason can take without ever raising.
+        status=_types.SimpleNamespace(value=secret),
+        execution=_types.SimpleNamespace(duration=None, error=None),
+        response=None,
+    )
+    tokens = {"input_tokens": 5, "output_tokens": 3, "raw_provider_debug": secret}
+
+    from lionagi.operations._api_hooks import emit_api_post_call
+
+    await emit_api_post_call(branch, imodel, api_call, tokens=tokens)
+
+    signals = observer.by_type(HookSignal)
+    assert len(signals) == 1
+    payload = _sanitize_signal_payload(signals[0])
+
+    assert secret not in json_dumps(payload)
+    kwargs = payload["kwargs"]
+    assert kwargs["status"] == "unknown"
+    assert kwargs["model"] == "unknown"
+    assert kwargs["provider"] == "unknown"
+    assert kwargs["tokens"] == {"input_tokens": 5, "output_tokens": 3}
+
+
+async def test_api_post_call_closed_payload_preserves_legitimate_values():
+    """The closed-payload rewrite must not collapse ordinary, well-shaped
+    values to "unknown" -- only out-of-vocabulary/out-of-shape input is
+    redacted."""
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    await branch.chat("hi there")
+
+    pre = calls[HookPoint.API_PRE_CALL][0]
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert pre["model"] == "gpt-4o-mini"
+    assert pre["provider"] == "openai"
+    assert post["status"] == "completed"
+
+
+# ── multi-turn usage accumulation (issue #1965 fix leg r3) ──────────────────
+
+
+async def test_run_accumulates_usage_across_multiple_flush_windows():
+    """Codex splits one run() call into multiple flush windows (a tool-call
+    round-trip forces a flush between "result" chunks) and reports marginal
+    per-window deltas, not a running total. The terminal API_POST_CALL must
+    report the SUM of every window's usage, not just the last window's --
+    overwriting last_usage from each window's result_meta silently drops
+    every earlier window's tokens."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            StreamChunk(type="text", content="hello"),
+            StreamChunk(
+                type="result",
+                metadata={"usage": {"input_tokens": 2, "output_tokens": 1}},
+            ),
+            StreamChunk(
+                type="tool_use",
+                tool_name="lookup",
+                tool_id="t1",
+                tool_input={"q": "x"},
+            ),
+            StreamChunk(type="tool_result", tool_id="t1", tool_output="ok"),
+            StreamChunk(type="text", content="world"),
+            StreamChunk(
+                type="result",
+                metadata={"usage": {"input_tokens": 10, "output_tokens": 7}},
+            ),
+        ]
+    )
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    results = []
+    async for msg in run(branch, "hi there", RunParam()):
+        results.append(msg)
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["tokens"] == {"input_tokens": 12, "output_tokens": 8}
+
+
+async def test_run_single_result_chunk_usage_unaffected_by_accumulator():
+    """A provider that emits exactly one "result" chunk per run() call
+    (claude_code, gemini_code) must report exactly that chunk's usage --
+    the whole-call accumulator must not introduce a double-count when there
+    is nothing to accumulate across."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            StreamChunk(type="text", content="hello"),
+            StreamChunk(
+                type="result",
+                metadata={"usage": {"input_tokens": 5, "output_tokens": 3}},
+            ),
+        ]
+    )
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    async for _ in run(branch, "hi there", RunParam()):
+        pass
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["tokens"] == {"input_tokens": 5, "output_tokens": 3}

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0047 delta row 2 (issue #1965): API_PRE_CALL / API_POST_CALL / API_STREAM_CHUNK
+gain a real emit site through the typed, optional service-to-session adapter in
+``operations/_api_hooks.py``, wired at ``operations/chat/chat.py`` (one-shot API
+calls) and ``operations/run/run.py`` (CLI streaming). A standalone iModel (no
+Branch, no HookBus) must be completely unaffected -- these callsites live in the
+Branch-facing operation layer, never inside ``iModel``/``HookRegistry`` itself.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from lionagi.hooks.bus import HookBus, HookPoint
+from lionagi.operations.run.run import run
+from lionagi.operations.types import RunParam
+from lionagi.protocols.generic.event import EventStatus
+from lionagi.service.imodel import iModel
+from lionagi.service.types.stream_chunk import StreamChunk
+from lionagi.session.branch import Branch
+from lionagi.testing import LionAGIMockFactory
+
+
+def _wire(branch: Branch, *points: HookPoint) -> dict[HookPoint, list[dict]]:
+    bus = HookBus()
+    calls: dict[HookPoint, list[dict]] = {p: [] for p in points}
+
+    def _make(point):
+        async def _handler(**kw):
+            calls[point].append(kw)
+
+        return _handler
+
+    for p in points:
+        bus.on(p, _make(p))
+    branch._hooks = bus
+    return calls
+
+
+def _make_fake_cli_model(chunks: list[StreamChunk]) -> iModel:
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    m.endpoint = types.SimpleNamespace(is_cli=True, session_id=None, to_dict=lambda: {})
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    from unittest.mock import AsyncMock
+
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+    return m
+
+
+# ── chat() (one-shot API path) ───────────────────────────────────────────────
+
+
+async def test_chat_emits_api_pre_and_post_call_on_success():
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    result = await branch.chat("hi there")
+
+    assert result == "hello"
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+
+    pre = calls[HookPoint.API_PRE_CALL][0]
+    assert pre["branch_id"] == str(branch.id)
+    assert pre["model"] == "gpt-4o-mini"
+    assert pre["provider"] == "openai"
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["branch_id"] == str(branch.id)
+    assert post["status"] == "completed"
+    assert post["error"] is None
+    # The mocked APICalling never runs through Event.invoke()'s timing
+    # wrapper, so execution.duration stays unset — latency_ms is correctly
+    # None rather than fabricated. "latency_ms" key presence is what matters.
+    assert "latency_ms" in post
+
+
+async def test_chat_emits_api_post_call_with_failed_status_before_raising():
+    branch = LionAGIMockFactory.create_mocked_branch(response="broken", status=EventStatus.FAILED)
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    from lionagi._errors import ExecutionError
+
+    with pytest.raises(ExecutionError):
+        await branch.chat("hi there")
+
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+    assert calls[HookPoint.API_POST_CALL][0]["status"] == "failed"
+
+
+async def test_chat_emits_api_post_call_with_error_status_when_invoke_raises():
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    async def _boom(**kw):
+        raise RuntimeError("provider is down")
+
+    branch.chat_model.invoke = _boom
+
+    with pytest.raises(RuntimeError, match="provider is down"):
+        await branch.chat("hi there")
+
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["status"] == "error"
+    assert "provider is down" in post["error"]
+
+
+async def test_chat_without_session_bus_does_not_crash():
+    """A Branch with no HookBus attached (branch._hooks is None, the default)
+    must behave exactly as before -- the adapter is a strict no-op."""
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    assert branch._hooks is None
+
+    result = await branch.chat("hi there")
+    assert result == "hello"
+
+
+# ── run() (CLI streaming path) ───────────────────────────────────────────────
+
+
+async def test_run_emits_pre_call_stream_chunks_and_post_call():
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            StreamChunk(type="text", content="hel"),
+            StreamChunk(type="text", content="lo"),
+        ]
+    )
+    calls = _wire(
+        branch, HookPoint.API_PRE_CALL, HookPoint.API_STREAM_CHUNK, HookPoint.API_POST_CALL
+    )
+
+    results = []
+    async for msg in run(branch, "hi there", RunParam()):
+        results.append(msg)
+
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_STREAM_CHUNK]) == 2
+    assert all(c["chunk_type"] == "text" for c in calls[HookPoint.API_STREAM_CHUNK])
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+
+
+async def test_run_emits_post_call_once_even_on_stream_failure():
+    """A provider error mid-stream must still settle exactly one API_POST_CALL
+    (status="error"), pairing with the one API_PRE_CALL that started the call."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content="boom")])
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    with pytest.raises(Exception):
+        async for _ in run(branch, "hi there", RunParam()):
+            pass
+
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+    assert calls[HookPoint.API_POST_CALL][0]["status"] == "error"
+
+
+async def test_run_without_session_bus_does_not_crash():
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="text", content="ok")])
+    assert branch._hooks is None
+
+    results = []
+    async for msg in run(branch, "hi there", RunParam()):
+        results.append(msg)
+    assert results  # ran to completion unaffected

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -128,6 +128,34 @@ async def test_chat_emits_api_post_call_with_error_status_when_invoke_raises():
     assert "provider is down" not in post["error"]
 
 
+async def test_chat_emits_api_post_call_error_from_failed_status_without_raise():
+    """A provider-returned FAILED APICalling carries its failure reason on
+    ``api_call.execution.error``, not as a raised exception -- the payload's
+    error field must still reflect it rather than staying null, and must not
+    leak the raw failure text either."""
+    branch = LionAGIMockFactory.create_mocked_branch(response="broken", status=EventStatus.FAILED)
+
+    async def _failed_invoke(**kw):
+        api_call = LionAGIMockFactory.create_api_calling_mock(
+            response_data="broken", status=EventStatus.FAILED
+        )
+        api_call.execution.error = "rate limited: sk-secret-token-12345"
+        return api_call
+
+    branch.chat_model.invoke = _failed_invoke
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    from lionagi._errors import ExecutionError
+
+    with pytest.raises(ExecutionError):
+        await branch.chat("hi there")
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["status"] == "failed"
+    assert post["error"] is not None
+    assert "sk-secret-token-12345" not in post["error"]
+
+
 async def test_chat_emits_paired_post_call_on_cancellation_during_invoke():
     """asyncio.CancelledError is a BaseException, not an Exception -- a bare
     ``except Exception`` around ``imodel.invoke()`` lets cancellation mid-call
@@ -244,6 +272,32 @@ async def test_run_without_session_bus_does_not_crash():
     assert results  # ran to completion unaffected
 
 
+async def test_run_terminal_tokens_survive_the_final_response_flush():
+    """The last text flush (which happens after the stream loop ends, at the
+    same point the terminal API_POST_CALL is emitted) clears result_meta
+    right after stamping it onto the AssistantResponse -- a run whose
+    "result" chunk arrives before its final text must still report the
+    tokens it received, not None, at the terminal post-call emission."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            StreamChunk(type="text", content="hello"),
+            StreamChunk(
+                type="result",
+                metadata={"usage": {"input_tokens": 5, "output_tokens": 3}},
+            ),
+        ]
+    )
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    results = []
+    async for msg in run(branch, "hi there", RunParam()):
+        results.append(msg)
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert post["tokens"] == {"input_tokens": 5, "output_tokens": 3}
+
+
 async def test_chat_api_post_call_never_leaks_secret_shaped_error_text():
     """A provider exception's message can carry request bodies, full URLs
     with query parameters, or credential fragments -- none of that may reach
@@ -266,3 +320,106 @@ async def test_chat_api_post_call_never_leaks_secret_shaped_error_text():
 
     post = calls[HookPoint.API_POST_CALL][0]
     assert secret not in json_dumps(post)
+
+
+# ── unified pairing/field invariant ──────────────────────────────────────────
+#
+# Every API_PRE_CALL is followed by exactly one API_POST_CALL carrying
+# whatever is actually known at that point about how the call ended:
+#
+# | exit path                       | status      | error            | tokens         |
+# |----------------------------------|-------------|------------------|----------------|
+# | success                          | "completed" | None             | best-effort    |
+# | provider FAILED, not raised      | "failed"    | class-name/label | best-effort    |
+# | raised exception                 | "error"     | class-name/label | None           |
+# | cancellation (BaseException)     | "error"     | "CancelledError" | None           |
+#
+# A single parametrized test asserting this table generically -- rather than
+# three separate hardcoded scenario tests -- is what catches a *fourth* exit
+# path added later that forgets to populate `error` on failure, or that
+# reintroduces raw message text: a scenario-specific test only checks the
+# exact value it was written against, so a new path with the same shape but
+# a different bug (e.g. `error` populated but with the raw message again)
+# would slip through unless every failure path is checked against the same
+# generic assertions.
+
+
+async def _run_chat_scenario(scenario: str):
+    if scenario == "success":
+        branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+        calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+        await branch.chat("hi there")
+        return calls
+
+    if scenario == "failed_status":
+        branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+
+        async def _failed_invoke(**kw):
+            api_call = LionAGIMockFactory.create_api_calling_mock(
+                response_data="broken", status=EventStatus.FAILED
+            )
+            api_call.execution.error = "boom: leak-me-not"
+            return api_call
+
+        branch.chat_model.invoke = _failed_invoke
+        calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+        with pytest.raises(Exception):
+            await branch.chat("hi there")
+        return calls
+
+    if scenario == "raised":
+        branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+
+        async def _boom(**kw):
+            raise RuntimeError("leak-me-not")
+
+        branch.chat_model.invoke = _boom
+        calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+        with pytest.raises(RuntimeError):
+            await branch.chat("hi there")
+        return calls
+
+    if scenario == "cancelled":
+        import asyncio
+
+        branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+        calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+        invoke_started = asyncio.Event()
+
+        async def _blocking_invoke(**kwargs):
+            invoke_started.set()
+            await asyncio.Event().wait()
+
+        branch.chat_model.invoke = _blocking_invoke
+        task = asyncio.ensure_future(branch.chat("hi there"))
+        await invoke_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        return calls
+
+    raise AssertionError(f"unknown scenario {scenario!r}")
+
+
+@pytest.mark.parametrize("scenario", ["success", "failed_status", "raised", "cancelled"])
+async def test_api_post_call_field_invariant_holds_across_exit_paths(scenario):
+    calls = await _run_chat_scenario(scenario)
+
+    # Pairing: exactly one pre-call, exactly one post-call, regardless of exit path.
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+    post = calls[HookPoint.API_POST_CALL][0]
+
+    if scenario == "success":
+        assert post["status"] == "completed"
+        assert post["error"] is None
+    else:
+        # Every non-success exit path must populate error (never silently
+        # null just because the failure surfaced via a status field instead
+        # of a raised exception), and it must never carry raw message text --
+        # every scenario above embeds a distinct marker string that would
+        # appear verbatim in `error` if the fix regressed to str(error) /
+        # str(execution.error).
+        assert post["error"] is not None
+        assert "leak-me-not" not in post["error"]
+        assert post["status"] in ("failed", "error")

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -123,6 +123,35 @@ async def test_chat_emits_api_post_call_with_error_status_when_invoke_raises():
     assert "provider is down" in post["error"]
 
 
+async def test_chat_emits_paired_post_call_on_cancellation_during_invoke():
+    """asyncio.CancelledError is a BaseException, not an Exception -- a bare
+    ``except Exception`` around ``imodel.invoke()`` lets cancellation mid-call
+    skip the post emission entirely, leaving an unpaired open span."""
+    import asyncio
+
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    invoke_started = asyncio.Event()
+
+    async def _blocking_invoke(**kwargs):
+        invoke_started.set()
+        await asyncio.Event().wait()  # never resolves; only cancellation ends this
+
+    branch.chat_model.invoke = _blocking_invoke
+
+    task = asyncio.ensure_future(branch.chat("hi there"))
+    await invoke_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(calls[HookPoint.API_PRE_CALL]) == 1
+    assert len(calls[HookPoint.API_POST_CALL]) == 1
+    assert calls[HookPoint.API_POST_CALL][0]["status"] == "error"
+
+
 async def test_chat_without_session_bus_does_not_crash():
     """A Branch with no HookBus attached (branch._hooks is None, the default)
     must behave exactly as before -- the adapter is a strict no-op."""

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -16,6 +16,7 @@ import types
 import pytest
 
 from lionagi.hooks.bus import HookBus, HookPoint
+from lionagi.ln import json_dumps
 from lionagi.operations.run.run import run
 from lionagi.operations.types import RunParam
 from lionagi.protocols.generic.event import EventStatus
@@ -120,7 +121,11 @@ async def test_chat_emits_api_post_call_with_error_status_when_invoke_raises():
     assert len(calls[HookPoint.API_POST_CALL]) == 1
     post = calls[HookPoint.API_POST_CALL][0]
     assert post["status"] == "error"
-    assert "provider is down" in post["error"]
+    # Class-name-only summary -- the raised exception's message must never
+    # reach the emitted payload (it can carry request bodies, full URLs, or
+    # credential fragments from the provider).
+    assert post["error"] == "RuntimeError"
+    assert "provider is down" not in post["error"]
 
 
 async def test_chat_emits_paired_post_call_on_cancellation_during_invoke():
@@ -237,3 +242,27 @@ async def test_run_without_session_bus_does_not_crash():
     async for msg in run(branch, "hi there", RunParam()):
         results.append(msg)
     assert results  # ran to completion unaffected
+
+
+async def test_chat_api_post_call_never_leaks_secret_shaped_error_text():
+    """A provider exception's message can carry request bodies, full URLs
+    with query parameters, or credential fragments -- none of that may reach
+    the emitted API_POST_CALL payload, which is persisted verbatim to
+    observer telemetry."""
+    branch = LionAGIMockFactory.create_mocked_branch(response="hello")
+    calls = _wire(branch, HookPoint.API_PRE_CALL, HookPoint.API_POST_CALL)
+
+    secret = "sk-live-do-not-leak-4f3a9c2b"
+
+    async def _boom(**kw):
+        raise RuntimeError(
+            f"POST https://api.openai.com/v1/chat/completions?api_key={secret} failed"
+        )
+
+    branch.chat_model.invoke = _boom
+
+    with pytest.raises(RuntimeError):
+        await branch.chat("hi there")
+
+    post = calls[HookPoint.API_POST_CALL][0]
+    assert secret not in json_dumps(post)

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -203,6 +203,31 @@ async def test_run_emits_post_call_once_even_on_stream_failure():
     assert calls[HookPoint.API_POST_CALL][0]["status"] == "error"
 
 
+async def test_run_without_session_bus_never_calls_stream_chunk_adapter():
+    """The no-bus guard belongs at the run.py call site, not only inside the
+    adapter -- otherwise every streamed chunk still pays for constructing and
+    awaiting a coroutine object that only checks ``branch._hooks is None``
+    and returns. Patching the call site's own reference to
+    ``emit_api_stream_chunk`` and asserting zero calls proves no coroutine
+    for it is ever created on the no-bus path (not just that its body
+    short-circuits)."""
+    from unittest.mock import patch
+
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [StreamChunk(type="text", content="a"), StreamChunk(type="text", content="b")]
+    )
+    assert branch._hooks is None
+
+    with patch("lionagi.operations.run.run.emit_api_stream_chunk") as mock_emit:
+        results = []
+        async for msg in run(branch, "hi there", RunParam()):
+            results.append(msg)
+
+    assert results
+    mock_emit.assert_not_called()
+
+
 async def test_run_without_session_bus_does_not_crash():
     branch = Branch()
     branch.chat_model = _make_fake_cli_model([StreamChunk(type="text", content="ok")])

--- a/tests/hooks/test_bus.py
+++ b/tests/hooks/test_bus.py
@@ -237,6 +237,56 @@ def test_handlers_for_invalid_string_raises_value_error():
         bus.handlers_for("session.starts")
 
 
+# ── Dormant-point registration warns (issue #1965) ───────────────────────────
+
+
+def test_registering_on_dormant_point_warns():
+    """ARTIFACT_CREATED has no production emit site — registering a handler on
+    it must not be silently accepted; the caller learns about it via warning,
+    not a hard error (see lionagi.hooks.DORMANT_POINTS)."""
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    with pytest.warns(UserWarning, match="ARTIFACT_CREATED"):
+        bus.on(HookPoint.ARTIFACT_CREATED, h)
+
+    # The registration itself still succeeds — it's a warning, not a rejection.
+    assert bus.handlers_for(HookPoint.ARTIFACT_CREATED) == [h]
+
+
+def test_registering_on_dormant_point_by_string_value_warns():
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    with pytest.warns(UserWarning, match="api.stream_chunk|artifact.created"):
+        bus.on("artifact.created", h)
+
+
+@pytest.mark.parametrize(
+    "point",
+    [
+        HookPoint.API_PRE_CALL,
+        HookPoint.API_POST_CALL,
+        HookPoint.API_STREAM_CHUNK,
+    ],
+)
+def test_registering_on_now_wired_api_points_does_not_warn(recwarn, point):
+    """Regression guard for issue #1965: these three used to be dormant.
+    Now that they have production emit sites (operations/_api_hooks.py),
+    registering a handler on them must NOT trigger the dormant-point warning."""
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    bus.on(point, h)
+    assert not any(issubclass(w.category, UserWarning) for w in recwarn.list)
+
+
 # ── FIX 2: blocking_emit propagates exceptions for TOOL_PRE ──────────────────
 
 


### PR DESCRIPTION
Closes #1965.

`API_PRE_CALL`, `API_POST_CALL` and `API_STREAM_CHUNK` were declared in the closed `HookPoint` enum with zero emit sites anywhere in source, so registering a handler on any of them silently never fired.

ADR-0047 delta row 2 already specified the ending: give them production semantics through a typed, optional service-to-session observation adapter, accepted when a session-bound iModel records API observations without changing service pre-invocation control or standalone iModel behavior. That is what this does, so the three points are wired rather than reserved or removed.

- New operation-layer adapter emitting all three. It is a no-op when a branch carries no bus, and it lives outside `iModel`/`HookRegistry` entirely, so standalone iModel behavior and service pre-invocation control are unchanged by construction rather than by a runtime check inside the service layer. This mirrors how `USER_PROMPT_SUBMIT` is already emitted from the operation layer.
- `API_STREAM_CHUNK` carries a redacted chunk-type discriminator only, never the chunk payload, following the existing argument- and result-summary truncation convention on the tool points.
- `API_POST_CALL` fires exactly once per call, paired with a prior pre-call, on success, on a provider-reported failure, and on a raised exception.
- `ARTIFACT_CREATED` is now the only point with no emit site. Registering a handler on it emits a warning naming the point; registration still succeeds, because that member is intentionally retained as registrable and rejecting it would break the register-ahead-of-wiring case this change is itself an instance of.
- ADR-0047's production matrix and P5 problem statement listed these three as dormant with no emit site or payload. Both became false with the first commit, so they are corrected here: a reader consults that matrix to learn what fires.
