### PR TITLE
fix(service): registry stops swallowing import errors and mis-routing unknown providers

### DIFF
--- a/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
+++ b/docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md
@@ -48,6 +48,12 @@ the same fallback path (`lionagi/service/connections/registry.py`; `EndpointRegi
 `_import_all_providers`, and `lionagi/service/connections/endpoint_config.py`;
 `EndpointConfig._validate_provider`).
 
+> This describes the resolver as it stood when this ADR was written. Delta #1 below (#2026) has
+> since resolved the ignored-import and unconditional-fallback parts of this problem statement: a
+> failed bundled import is now classified and logged, and the generic fallback requires explicit
+> opt-in for a genuinely unrecognized provider. A registered provider is never routed through this
+> fallback path for an unmatched endpoint.
+
 The shipped spine is:
 
 ```text
@@ -321,10 +327,14 @@ test support but is imported through the same bootstrap
 
 - **Lazy bootstrap.** The first `match()` or `list_providers()` call imports the fixed modules under
   a process-local lock. `_loaded` is set after the loop. Later calls do not rescan modules.
-- **Import failure.** Each `ImportError` is ignored without a diagnostic. Other exception types
-  escape and prevent `_loaded` from being set.
-- **Registration order.** Entries are appended. There is no canonical-key, alias, endpoint-class,
-  or metadata validation and no duplicate detection.
+- **Import failure (resolved by #2026).** Was: each `ImportError` ignored without a diagnostic.
+  Now: a genuinely-missing optional dependency logs at debug, a broken bundled module logs a
+  warning naming the module and the error; other exception types still escape and prevent
+  `_loaded` from being set.
+- **Registration order.** Entries are appended. Canonical-key and alias collision validation was
+  added by #2026 (a provider/alias already claimed by a *different* canonical provider raises
+  `ProviderAliasCollisionError`); re-registering the same provider under multiple endpoints
+  remains expected and unvalidated beyond that.
 - **Provider match.** The raw provider must equal the canonical string or one of its aliases. The
   comparison is case-sensitive and does not trim. Normalization in `EndpointConfig` happens only
   after a class or fallback has already been chosen.
@@ -332,9 +342,13 @@ test support but is imported through the same bootstrap
   endpoint or alias selects the first match. Punctuation is literal.
 - **Single-endpoint provider.** If a provider has exactly one canonical registration, any unmatched
   non-empty endpoint selects it. The requested endpoint string is not retained as a mismatch.
-- **Miss.** Every other miss creates the base `Endpoint` with provider as supplied, endpoint or
-  `chat/completions`, bearer JSON POST settings, `requires_tokens=True`, and name
-  `openai_compatible_chat`. It does not set `openai_compatible=True`.
+- **Miss (resolved by #2026).** Was: every miss silently created the base `Endpoint` with provider
+  as supplied. Now: a `provider` matching no registration raises `ProviderNotFoundError` naming
+  every registered provider, unless the caller passes `openai_compatible=True` or (deprecated,
+  warns) `base_url=`; a `provider` that *is* registered but lacks the requested endpoint still
+  falls through to the generic `Endpoint` (provider as supplied, endpoint or `chat/completions`,
+  bearer JSON POST settings, `requires_tokens=True`, name `openai_compatible_chat`,
+  `openai_compatible=True`), since the provider identity was never in question.
 - **Instantiation.** A match instantiates `entry.cls(None, **kwargs)`; class metadata creates a fresh
   `EndpointConfig`. Registry entries store classes and immutable metadata, not shared endpoint
   instances.
@@ -633,7 +647,7 @@ the shared agentic output and cleanup contract.
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Replace positional provider declarations with typed authoring records; canonicalize and validate every provider, endpoint, and alias key; report failed bundled imports; and require explicit opt-in for generic OpenAI-compatible fallback, with compatibility coverage for existing custom-provider callers. | M | #2026 |
+| 1 | ~~Replace positional provider declarations with typed authoring records; canonicalize and validate every provider, endpoint, and alias key; report failed bundled imports; and require explicit opt-in for generic OpenAI-compatible fallback, with compatibility coverage for existing custom-provider callers.~~ **Resolved** -- canonicalization/collision checks, failed-import diagnostics, and explicit-opt-in fallback (`openai_compatible=True` / deprecated `base_url=`) landed; a registered provider is never routed to the fallback for an unmatched endpoint. | M | #2026 |
 | 2 | Route `invoke()` and `stream()` through one bounded admission lifecycle that applies request, token, and concurrency limits before provider work; propagate one deadline through queueing, retries, and transport; and prove that cancellation leaves no queued or active orphan. | L | (filled at issue-open time) |
 | 3 | Apply retry and circuit policy to HTTP stream establishment before the first emitted chunk, prohibit automatic replay after output begins, and add tests for pre-first-byte failure, mid-stream failure, normal EOF, and caller cancellation. | M | (filled at issue-open time) |
 | 4 | Publish an agentic-adapter conformance contract for request construction, normalized chunks, error classification, resume identifiers, and transport cleanup; run it against every subprocess, in-process, and remote adapter while retaining vendor parsers beside their vendors. | M | (filled at issue-open time) |

--- a/docs/adr/ADR-0088-plugin-system.md
+++ b/docs/adr/ADR-0088-plugin-system.md
@@ -182,17 +182,23 @@ Two-stage laziness, mirroring the endpoint registry's `_ensure_loaded` pattern:
   trigger points:
   - `ActionManager` tool-name miss → "does a trusted, enabled plugin declare this
     tool?"
-  - provider resolution: **`EndpointRegistry.match()` never misses today** — on no
-    registered match it silently falls through to a generic OpenAI-compatible
-    endpoint, so there is no existing miss event to hook. This decision therefore
-    requires a small, named refactor of the registry: an interception point after
-    "no registered entry matched" and **before** the generic fallback, which
-    consults the plugin registry, imports any declared provider module for that
-    provider name (the module self-registers at import time via the existing
-    decorator, so importing before the fallback is sufficient — no registry
-    reload), re-runs the match once, and only then falls back. Without this
-    interception a plugin provider would silently receive the generic endpoint
-    instead of its own — a wrong-answer failure, not an error.
+  - provider resolution: **`EndpointRegistry.match()` never missed at the time this
+    ADR was written** — on no registered match it silently fell through to a
+    generic OpenAI-compatible endpoint, so there was no existing miss event to
+    hook. This decision therefore required a small, named refactor of the
+    registry: an interception point after "no registered entry matched" and
+    **before** the generic fallback, which consults the plugin registry, imports
+    any declared provider module for that provider name (the module
+    self-registers at import time via the existing decorator, so importing before
+    the fallback is sufficient — no registry reload), re-runs the match once, and
+    only then falls back. Without this interception a plugin provider would
+    silently receive the generic endpoint instead of its own — a wrong-answer
+    failure, not an error. `EndpointRegistry.match()` now misses loudly for a
+    genuinely unregistered provider (#2026: raises `ProviderNotFoundError` unless
+    the caller opts in), but the interception point described here still runs
+    first, in the same position, for the same reason — a plugin-declared
+    provider must get a chance to activate before either the fallback or the
+    raise.
   - agent-profile resolution miss → plugin `agents/` entries join the search list
     after project and global profiles.
   - playbooks: discovery today is global-only and split across a pre-argparse CLI

--- a/docs/api/imodel.md
+++ b/docs/api/imodel.md
@@ -105,8 +105,11 @@ AG2 NLIP connects to a remote HTTP endpoint. See
 ### Fallback
 
 After built-ins and trusted, enabled plugin providers are consulted, an unrecognized
-`provider` falls back to a generic OpenAI-compatible endpoint. Pass `base_url=` for
-the custom host; a provider name alone cannot supply a usable URL.
+`provider` raises `ProviderNotFoundError` naming the requested provider and every
+registered provider, unless the caller opts in explicitly. Pass `openai_compatible=True`
+to route the unrecognized provider to a generic OpenAI-compatible endpoint. A registered
+provider is never rejected this way, even if the requested `endpoint=` isn't one of its
+own -- only a `provider` name that matches no registration falls into this path.
 
 ## Endpoint matching
 
@@ -124,7 +127,10 @@ provider/endpoint names or their declared aliases:
   the default `endpoint="chat"`.
 - On a built-in miss, trusted and enabled plugin provider targets are loaded lazily.
 - Built-in provider names win if a plugin declares a collision.
-- A final miss returns the generic OpenAI-compatible `Endpoint` fallback.
+- A final miss raises `ProviderNotFoundError` unless the caller passes
+  `openai_compatible=True` (or the deprecated `base_url=` migration path), in which case
+  it returns the generic OpenAI-compatible `Endpoint` fallback. This only applies to a
+  `provider` name that matches no registration at all.
 
 ## Common construction patterns
 
@@ -174,6 +180,7 @@ cmap  = li.iModel(provider="firecrawl", endpoint="map")
 model = li.iModel(
     provider="my_provider",
     base_url="https://my-api.example.com/v1",
+    openai_compatible=True,
     model="my-model",
 )
 ```

--- a/lionagi/service/connections/__init__.py
+++ b/lionagi/service/connections/__init__.py
@@ -11,7 +11,14 @@ from .header_factory import HeaderFactory
 from .match_endpoint import match_endpoint
 from .mcp_wrapper import MCPConnectionPool, MCPSecurityConfig, create_mcp_tool
 from .provider_config import LazyType, ProviderConfig
-from .registry import EndpointMeta, EndpointRegistry, EndpointType, register_endpoint
+from .registry import (
+    EndpointMeta,
+    EndpointRegistry,
+    EndpointType,
+    ProviderAliasCollisionError,
+    ProviderNotFoundError,
+    register_endpoint,
+)
 
 __all__ = (
     "AgenticEndpoint",
@@ -28,7 +35,9 @@ __all__ = (
     "EndpointRegistry",
     "EndpointType",
     "LazyType",
+    "ProviderAliasCollisionError",
     "ProviderConfig",
+    "ProviderNotFoundError",
     "register_endpoint",
 )
 

--- a/lionagi/service/connections/match_endpoint.py
+++ b/lionagi/service/connections/match_endpoint.py
@@ -10,7 +10,15 @@ __all__ = ("match_endpoint",)
 def match_endpoint(
     provider: str,
     endpoint: str,
+    *,
+    openai_compatible: bool = False,
     **kwargs,
 ) -> Endpoint:
-    """Match a provider + endpoint to an Endpoint class via EndpointRegistry."""
-    return EndpointRegistry.match(provider, endpoint, **kwargs)
+    """Match a provider + endpoint to an Endpoint class via EndpointRegistry.
+
+    An unrecognized ``provider`` raises ``ProviderNotFoundError`` unless
+    ``openai_compatible=True`` explicitly authorizes routing it to the
+    generic OpenAI-compatible endpoint (or ``base_url=`` is given, which
+    authorizes the same fallback with a deprecation warning).
+    """
+    return EndpointRegistry.match(provider, endpoint, openai_compatible=openai_compatible, **kwargs)

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import threading
+import warnings
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
@@ -17,6 +18,8 @@ __all__ = (
     "EndpointType",
     "EndpointMeta",
     "EndpointRegistry",
+    "ProviderAliasCollisionError",
+    "ProviderNotFoundError",
     "register_endpoint",
 )
 
@@ -33,6 +36,14 @@ _ContentDigest = tuple[str, tuple[tuple[str, str], ...]]
 # Manifest metadata, every manifest-declared path's metadata, and the user
 # settings source mtime -- see _plugin_entry_stat.
 _PluginStatSignature = tuple[_FileStat, tuple[tuple[str, _FileStat], ...], int | None]
+
+
+class ProviderAliasCollisionError(ValueError):
+    """A provider or provider-alias string is already claimed by a different canonical provider."""
+
+
+class ProviderNotFoundError(ValueError):
+    """No registered endpoint matches the requested provider, and no fallback was authorized."""
 
 
 class EndpointType(Enum):
@@ -114,6 +125,13 @@ class EndpointRegistry:
     _lock: ClassVar[threading.RLock] = threading.RLock()
     _plugin_registration: ClassVar[threading.local] = threading.local()
 
+    # Canonical alias string (provider name or provider_alias, lowercased) ->
+    # the canonical provider name that first claimed it. Lets a provider
+    # register any number of endpoints under its own name (expected: openai
+    # alone owns half a dozen entries) while still catching a *different*
+    # provider trying to claim a name or alias someone else already owns.
+    _alias_owners: ClassVar[dict[str, str]] = {}
+
     @classmethod
     def register(
         cls,
@@ -128,13 +146,19 @@ class EndpointRegistry:
         content_type: str | None = None,
         api_key_env: str | None = None,
     ):
+        canonical_provider = provider.strip().lower()
+        canonical_provider_aliases = tuple(
+            dict.fromkeys(a.strip().lower() for a in (provider_aliases or ()))
+        )
+        cls._claim_provider_identity(canonical_provider, canonical_provider_aliases)
+
         def decorator(endpoint_cls: type) -> type:
             meta = EndpointMeta(
-                provider=provider,
+                provider=canonical_provider,
                 endpoint=endpoint,
                 endpoint_type=endpoint_type,
                 aliases=tuple(aliases or ()),
-                provider_aliases=tuple(provider_aliases or ()),
+                provider_aliases=canonical_provider_aliases,
                 options=options,
                 base_url=base_url,
                 auth_type=auth_type,
@@ -152,10 +176,44 @@ class EndpointRegistry:
         return decorator
 
     @classmethod
-    def match(cls, provider: str, endpoint: str = "", **kwargs) -> Any:
+    def _claim_provider_identity(cls, provider: str, provider_aliases: tuple[str, ...]) -> None:
+        """Reject a provider/alias string already owned by a *different* canonical provider.
+
+        Re-registering the same canonical provider (e.g. openai's chat, embed,
+        batch, ... endpoints) is expected and always allowed. A collision is
+        two different canonical providers claiming the same string, either as
+        one's canonical name or as either one's alias.
+        """
+        for key in (provider, *provider_aliases):
+            owner = cls._alias_owners.get(key)
+            if owner is not None and owner != provider:
+                raise ProviderAliasCollisionError(
+                    f"provider alias {key!r} is already registered to provider "
+                    f"{owner!r}; cannot also register it for provider {provider!r}"
+                )
+        for key in (provider, *provider_aliases):
+            cls._alias_owners.setdefault(key, provider)
+
+    @classmethod
+    def match(
+        cls,
+        provider: str,
+        endpoint: str = "",
+        *,
+        openai_compatible: bool = False,
+        **kwargs,
+    ) -> Any:
         """Find and instantiate the best matching endpoint. On a registry
         miss, consults the plugin registry (ADR-0088 D3) before falling back
         to the generic OpenAI-compatible endpoint; see docs/internals/runtime.md.
+
+        An unrecognized ``provider`` never silently mis-routes: the generic
+        OpenAI-compatible fallback only builds when ``openai_compatible=True``
+        is passed explicitly, or (deprecated migration path, warns) when a
+        ``base_url`` kwarg is given -- the same signal a caller already needs
+        to point the fallback at a real custom host. Anything else raises
+        ``ProviderNotFoundError`` naming the requested provider and every
+        provider currently registered.
         """
         cls._ensure_loaded()
 
@@ -168,6 +226,21 @@ class EndpointRegistry:
             if matched is not None:
                 return matched
 
+        if not openai_compatible:
+            if kwargs.get("base_url"):
+                warnings.warn(
+                    f"provider {provider!r} is not registered; routing to the "
+                    "generic OpenAI-compatible endpoint because base_url= was "
+                    "given. This implicit fallback is deprecated -- pass "
+                    "openai_compatible=True explicitly (e.g. "
+                    "match_endpoint(..., openai_compatible=True)) to silence "
+                    "this warning.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+            else:
+                raise cls._provider_not_found_error(provider)
+
         from .endpoint import Endpoint, EndpointConfig
 
         config = EndpointConfig(
@@ -178,8 +251,22 @@ class EndpointRegistry:
             content_type="application/json",
             method="POST",
             requires_tokens=True,
+            openai_compatible=True,
         )
         return Endpoint(config, **kwargs)
+
+    @classmethod
+    def _provider_not_found_error(cls, provider: str) -> ProviderNotFoundError:
+        known: set[str] = set()
+        for entry in cls._entries:
+            known.add(entry.meta.provider)
+            known.update(entry.meta.provider_aliases)
+        return ProviderNotFoundError(
+            f"no endpoint registered for provider {provider!r}; registered "
+            f"providers: {', '.join(sorted(known)) or '(none)'}. Pass "
+            "openai_compatible=True to route unrecognized providers to the "
+            "generic OpenAI-compatible endpoint explicitly."
+        )
 
     @classmethod
     def _match_registered(cls, provider: str, endpoint: str, kwargs: dict[str, Any]) -> Any | None:
@@ -423,6 +510,18 @@ class EndpointRegistry:
                     imported = True
                 except PluginActivationError:
                     continue
+                except ProviderAliasCollisionError as exc:
+                    # A plugin claiming a provider/alias another provider already
+                    # owns must not crash resolution -- reject just this plugin's
+                    # contribution, the same fail-soft posture as a built-in
+                    # collision (_reject_builtin_collisions) or a broken import.
+                    logger.warning(
+                        "plugin %r provider module %r rejected: %s",
+                        plugin_name,
+                        module,
+                        exc,
+                    )
+                    continue
                 finally:
                     if previous is None:
                         del cls._plugin_registration.provenance
@@ -577,5 +676,45 @@ def _import_all_providers():
     for mod in _modules:
         try:
             importlib.import_module(mod)
-        except ImportError:
-            pass
+        except ImportError as e:
+            if _is_missing_optional_dependency(e):
+                logger.debug(
+                    "provider module %r not registered: optional dependency "
+                    "%r is not installed (%s)",
+                    mod,
+                    e.name,
+                    e,
+                )
+            else:
+                logger.warning(
+                    "provider module %r failed to import and was not registered: %s",
+                    mod,
+                    e,
+                )
+
+
+def _is_missing_optional_dependency(exc: ImportError) -> bool:
+    """Tell a genuinely-absent optional third-party dependency apart from a
+    broken bundled module.
+
+    Every bundled provider module defers its heavy optional dependencies
+    (``autogen``, ``ollama``, ``nlip_sdk``, ...) to call time, guarded by
+    ``is_import_installed`` or a local ``try/except ImportError`` -- none of
+    them import a third-party package at module scope. So a module-scope
+    ``ImportError`` here is expected only when the failing name (reported by
+    Python as ``ImportError.name``) resolves to a third-party package that is
+    actually not installed. Anything else -- ``.name`` unset (the
+    "cannot import name X from Y" shape a broken re-export raises), a
+    ``lionagi.*`` name (a bug in our own import graph), or a name that *is*
+    installed (so importing it failed for some other reason) -- is a broken
+    bundled module and must be logged loudly instead of vanishing silently.
+    """
+    from lionagi.utils import is_import_installed
+
+    missing = getattr(exc, "name", None)
+    if not missing:
+        return False
+    top_level = missing.split(".", 1)[0]
+    if top_level == "lionagi":
+        return False
+    return not is_import_installed(top_level)

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -150,7 +150,6 @@ class EndpointRegistry:
         canonical_provider_aliases = tuple(
             dict.fromkeys(a.strip().lower() for a in (provider_aliases or ()))
         )
-        cls._claim_provider_identity(canonical_provider, canonical_provider_aliases)
 
         def decorator(endpoint_cls: type) -> type:
             meta = EndpointMeta(
@@ -170,7 +169,16 @@ class EndpointRegistry:
             provenance = getattr(cls._plugin_registration, "provenance", None)
             if provenance is not None:
                 entry.plugin_name, entry.plugin_target = provenance
-            cls._entries.append(entry)
+            # Validation (does anyone else already own this alias?) and the
+            # claim itself must be one atomic transaction: check-then-claim
+            # split across the lock lets two concurrent registrations both
+            # pass the check before either publishes. Entry publication is
+            # folded into the same critical section, since an alias claimed
+            # with no corresponding entry (or vice versa) is its own
+            # inconsistency.
+            with cls._lock:
+                cls._claim_provider_identity(canonical_provider, canonical_provider_aliases)
+                cls._entries.append(entry)
             return endpoint_cls
 
         return decorator
@@ -183,6 +191,10 @@ class EndpointRegistry:
         batch, ... endpoints) is expected and always allowed. A collision is
         two different canonical providers claiming the same string, either as
         one's canonical name or as either one's alias.
+
+        Callers must hold ``cls._lock`` -- this is check-then-claim and is
+        only atomic across concurrent registrations when the lock spans both
+        the check and the claim (and, in ``register()``, entry publication).
         """
         for key in (provider, *provider_aliases):
             owner = cls._alias_owners.get(key)
@@ -193,6 +205,23 @@ class EndpointRegistry:
                 )
         for key in (provider, *provider_aliases):
             cls._alias_owners.setdefault(key, provider)
+
+    @classmethod
+    def _rebuild_alias_owners(cls) -> None:
+        """Recompute ``_alias_owners`` from the surviving ``_entries``.
+
+        Must run under ``cls._lock``, after any entry removal (e.g. a plugin
+        entry failing revalidation). ``_alias_owners`` is otherwise tracked
+        independently of ``_entries``, so a removed entry's alias would keep
+        naming an owner with no remaining registration -- rejecting a
+        legitimate replacement registration for an alias nothing owns
+        anymore. First-registration-wins, same as ``_claim_provider_identity``.
+        """
+        owners: dict[str, str] = {}
+        for entry in cls._entries:
+            for key in (entry.meta.provider, *entry.meta.provider_aliases):
+                owners.setdefault(key, entry.meta.provider)
+        cls._alias_owners = owners
 
     @classmethod
     def match(
@@ -361,10 +390,13 @@ class EndpointRegistry:
         try:
             PluginRegistry.activate_target(entry.plugin_name, entry.plugin_target)
         except PluginActivationError:
-            try:
-                cls._entries.remove(entry)
-            except ValueError:
-                pass
+            with cls._lock:
+                try:
+                    cls._entries.remove(entry)
+                except ValueError:
+                    pass
+                else:
+                    cls._rebuild_alias_owners()
             return False
 
         entry._validated_generation = generation

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -675,10 +675,56 @@ def register_endpoint(
     )
 
 
+# Declared, not inferred: the optional third-party dependency each fixed
+# provider module needs, keyed by dotted module path. A module with no entry
+# here has none. Verified against each module's own top-level imports -- keep
+# an entry's dependency tuple in sync if that module's imports change.
+# Every module currently in _import_all_providers' fixed list defers its
+# optional third-party imports past module scope (see e.g. ollama/chat.py,
+# ag2/agent.py, ag2/groupchat.py, ag2/nlip.py), so none need an entry yet;
+# add one here the day a provider module imports its optional dependency at
+# module scope again.
+_PROVIDER_OPTIONAL_DEPENDENCIES: dict[str, tuple[str, ...]] = {}
+
+
+def _import_provider_module(mod: str) -> None:
+    """Preflight-check ``mod``'s declared optional dependencies, then import.
+
+    A declared dependency that fails to resolve skips the import entirely
+    (debug log, module body never runs) -- so a buggy module never gets the
+    chance to raise a misleading exception. Once every declared dependency
+    resolves (or none are declared), any ``ImportError`` raised while
+    importing ``mod`` is unconditionally a provider-load failure (warning) --
+    no exception-metadata inspection at all, since that metadata is fully
+    controlled by whatever code raised it.
+    """
+    import importlib
+    import importlib.util
+
+    missing = [
+        dep
+        for dep in _PROVIDER_OPTIONAL_DEPENDENCIES.get(mod, ())
+        if importlib.util.find_spec(dep) is None
+    ]
+    if missing:
+        logger.debug(
+            "provider module %r not registered: optional dependency %r is not installed",
+            mod,
+            missing[0],
+        )
+        return
+    try:
+        importlib.import_module(mod)
+    except ImportError as e:
+        logger.warning(
+            "provider module %r failed to import and was not registered: %s",
+            mod,
+            e,
+        )
+
+
 def _import_all_providers():
     """Import all provider modules to trigger registration decorators."""
-    import importlib
-
     _modules = [
         # OpenAI family
         "lionagi.providers.openai.chat",
@@ -723,47 +769,4 @@ def _import_all_providers():
         "lionagi.testing._endpoint",
     ]
     for mod in _modules:
-        try:
-            importlib.import_module(mod)
-        except ImportError as e:
-            if _is_missing_optional_dependency(e):
-                logger.debug(
-                    "provider module %r not registered: optional dependency "
-                    "%r is not installed (%s)",
-                    mod,
-                    e.name,
-                    e,
-                )
-            else:
-                logger.warning(
-                    "provider module %r failed to import and was not registered: %s",
-                    mod,
-                    e,
-                )
-
-
-def _is_missing_optional_dependency(exc: ImportError) -> bool:
-    """Tell a genuinely-absent optional third-party dependency apart from a
-    broken bundled module.
-
-    Every bundled provider module defers its heavy optional dependencies
-    (``autogen``, ``ollama``, ``nlip_sdk``, ...) to call time, guarded by
-    ``is_import_installed`` or a local ``try/except ImportError`` -- none of
-    them import a third-party package at module scope. So a module-scope
-    ``ImportError`` here is expected only when the failing name (reported by
-    Python as ``ImportError.name``) resolves to a third-party package that is
-    actually not installed. Anything else -- ``.name`` unset (the
-    "cannot import name X from Y" shape a broken re-export raises), a
-    ``lionagi.*`` name (a bug in our own import graph), or a name that *is*
-    installed (so importing it failed for some other reason) -- is a broken
-    bundled module and must be logged loudly instead of vanishing silently.
-    """
-    from lionagi.utils import is_import_installed
-
-    missing = getattr(exc, "name", None)
-    if not missing:
-        return False
-    top_level = missing.split(".", 1)[0]
-    if top_level == "lionagi":
-        return False
-    return not is_import_installed(top_level)
+        _import_provider_module(mod)

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -207,6 +207,20 @@ class EndpointRegistry:
             cls._alias_owners.setdefault(key, provider)
 
     @classmethod
+    def _remove_entries(cls, entries: list[_RegistryEntry]) -> None:
+        """Drop ``entries`` from ``_entries`` and rebuild ``_alias_owners``.
+
+        Must run under ``cls._lock``. Every entry-removal caller (plugin
+        revalidation failure, built-in-collision rejection) goes through
+        this one path, so the alias ledger can never drift from ``_entries``.
+        """
+        if not entries:
+            return
+        drop = {id(e) for e in entries}
+        cls._entries[:] = [e for e in cls._entries if id(e) not in drop]
+        cls._rebuild_alias_owners()
+
+    @classmethod
     def _rebuild_alias_owners(cls) -> None:
         """Recompute ``_alias_owners`` from the surviving ``_entries``.
 
@@ -391,12 +405,7 @@ class EndpointRegistry:
             PluginRegistry.activate_target(entry.plugin_name, entry.plugin_target)
         except PluginActivationError:
             with cls._lock:
-                try:
-                    cls._entries.remove(entry)
-                except ValueError:
-                    pass
-                else:
-                    cls._rebuild_alias_owners()
+                cls._remove_entries([entry])
             return False
 
         entry._validated_generation = generation
@@ -599,7 +608,7 @@ class EndpointRegistry:
         if not builtin_names:
             return
 
-        kept: list[_RegistryEntry] = []
+        rejected: list[_RegistryEntry] = []
         for entry in cls._entries:
             is_this_activation = (
                 entry.plugin_name == plugin_name
@@ -618,9 +627,8 @@ class EndpointRegistry:
                     module,
                     entry.meta.provider,
                 )
-                continue
-            kept.append(entry)
-        cls._entries[:] = kept
+                rejected.append(entry)
+        cls._remove_entries(rejected)
 
     @classmethod
     def _ensure_loaded(cls):

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -207,13 +207,22 @@ class EndpointRegistry:
         miss, consults the plugin registry (ADR-0088 D3) before falling back
         to the generic OpenAI-compatible endpoint; see docs/internals/runtime.md.
 
-        An unrecognized ``provider`` never silently mis-routes: the generic
-        OpenAI-compatible fallback only builds when ``openai_compatible=True``
-        is passed explicitly, or (deprecated migration path, warns) when a
-        ``base_url`` kwarg is given -- the same signal a caller already needs
-        to point the fallback at a real custom host. Anything else raises
-        ``ProviderNotFoundError`` naming the requested provider and every
-        provider currently registered.
+        A *registered* provider is never rejected: if ``provider`` names a
+        canonical provider or provider-alias that some entry already claimed
+        (via ``register()``/``_claim_provider_identity``), a request for an
+        endpoint that provider doesn't happen to expose falls through to the
+        generic construction below same as an explicit opt-in would -- the
+        provider identity is not in question, only the specific endpoint
+        name, so there is nothing to reject. ``ProviderNotFoundError`` is
+        reserved for a ``provider`` string matching no registered provider or
+        alias at all: the generic OpenAI-compatible fallback then only builds
+        when ``openai_compatible=True`` is passed explicitly, or (deprecated
+        migration path, warns) when a ``base_url`` kwarg is given -- the same
+        signal a caller already needs to point the fallback at a real custom
+        host. Anything else raises ``ProviderNotFoundError`` naming the
+        requested provider and every provider currently registered -- a
+        provider that error names as unregistered is, by construction, never
+        also in the registered list it prints.
         """
         cls._ensure_loaded()
 
@@ -226,7 +235,7 @@ class EndpointRegistry:
             if matched is not None:
                 return matched
 
-        if not openai_compatible:
+        if not openai_compatible and not cls._is_known_provider(provider):
             if kwargs.get("base_url"):
                 warnings.warn(
                     f"provider {provider!r} is not registered; routing to the "
@@ -254,6 +263,14 @@ class EndpointRegistry:
             openai_compatible=True,
         )
         return Endpoint(config, **kwargs)
+
+    @classmethod
+    def _is_known_provider(cls, provider: str) -> bool:
+        """Whether ``provider`` (case-insensitive) is a canonical provider
+        name or provider-alias that some registered entry already claimed --
+        i.e. whether rejecting it as unrecognized would be wrong regardless
+        of which specific endpoint was requested for it."""
+        return provider.strip().lower() in cls._alias_owners
 
     @classmethod
     def _provider_not_found_error(cls, provider: str) -> ProviderNotFoundError:

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -102,10 +102,17 @@ class iModel:  # noqa: N801
         if isinstance(endpoint, Endpoint):
             self.endpoint = endpoint
         else:
+            match_kwargs = dict(kwargs)
+            if base_url:
+                # A caller-supplied base_url is the same explicit signal that
+                # already means "route this custom host through the generic
+                # OpenAI-compatible endpoint" -- surface it to match_endpoint
+                # so an unregistered provider name doesn't raise here.
+                match_kwargs.setdefault("base_url", base_url)
             self.endpoint = match_endpoint(
                 provider=provider,
                 endpoint=endpoint,
-                **kwargs,
+                **match_kwargs,
             )
         if provider:
             self.endpoint.config.provider = provider
@@ -409,9 +416,16 @@ class iModel:  # noqa: N801
     def from_dict(cls, data: dict):
         endpoint = Endpoint.from_dict(data.get("endpoint", {}))
 
+        # openai_compatible=True: rehydrating a persisted iModel must never
+        # raise just because its provider isn't (or is no longer) registered
+        # -- the deserialized `endpoint` below is already a complete,
+        # authoritative config either way, this lookup only exists to recover
+        # a registered subclass and a freshly env-sourced API key when one
+        # applies.
         if e1 := match_endpoint(
             provider=endpoint.config.provider,
             endpoint=endpoint.config.endpoint,
+            openai_compatible=True,
         ):
             # Preserve the freshly resolved (env-sourced) API key before overwriting config
             fresh_api_key = e1.config._api_key

--- a/tests/service/connections/_fixture_absent_dep_provider.py
+++ b/tests/service/connections/_fixture_absent_dep_provider.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture for test_registry.py: importing this module is a test failure.
+
+Used with a ``_PROVIDER_OPTIONAL_DEPENDENCIES`` entry pointing at a package
+that is guaranteed absent, to prove the preflight check skips the import
+before this body ever runs.
+"""
+
+raise RuntimeError("this fixture provider module must never be imported")

--- a/tests/service/connections/_fixture_forged_import_provider.py
+++ b/tests/service/connections/_fixture_forged_import_provider.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture for test_registry.py: simulates a real bug during provider import.
+
+Raises an ``ImportError`` whose ``name`` looks like an absent third-party
+package, even though nothing about this module is actually missing -- the
+forged-exception shape a broken bundled module (or an attacker-controlled
+one) could produce.
+"""
+
+raise ImportError("simulated bug during provider import", name="not_actually_a_missing_dependency")

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -6,14 +6,18 @@ import pytest
 
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.match_endpoint import match_endpoint
+from lionagi.service.connections.registry import ProviderNotFoundError
 
 
 class TestMatchEndpoint:
     """Test the match_endpoint function for provider matching logic.
 
-    ``EndpointRegistry.match`` always returns either a registered endpoint
-    instance or the generic fallback ``Endpoint`` — it never returns
-    ``None``. Guards like ``if endpoint is None: pytest.skip(...)`` are
+    ``EndpointRegistry.match`` returns a registered endpoint instance, or
+    the generic fallback ``Endpoint`` when the caller explicitly opts in
+    (``openai_compatible=True``, or ``base_url=`` on the deprecated
+    migration path) -- it never returns ``None``. An unrecognized provider
+    with no opt-in raises ``ProviderNotFoundError`` instead of silently
+    mis-routing. Guards like ``if endpoint is None: pytest.skip(...)`` are
     therefore unreachable dead code that can silently mask a routing
     regression as a skip. These tests assert the concrete registered
     endpoint class rather than only ``isinstance(endpoint, Endpoint)``, so a
@@ -91,13 +95,40 @@ class TestMatchEndpoint:
 
         assert endpoint.config.endpoint_params == ["custom", "path"]
 
-    def test_unknown_provider_fallback(self):
-        endpoint = match_endpoint(provider="unknown_provider", endpoint="chat", model="some-model")
+    def test_unknown_provider_raises_by_default(self):
+        # An unregistered provider with no opt-in and no base_url must raise
+        # a clear error rather than silently mis-routing to the generic
+        # OpenAI-compatible fallback.
+        with pytest.raises(ProviderNotFoundError, match="unknown_provider"):
+            match_endpoint(provider="unknown_provider", endpoint="chat", model="some-model")
 
-        # An unregistered provider must route to the generic openai-compatible
-        # fallback endpoint, not raise and not return None.
+    def test_unknown_provider_error_names_registered_providers(self):
+        with pytest.raises(ProviderNotFoundError, match="openai"):
+            match_endpoint(provider="unknown_provider", endpoint="chat")
+
+    def test_unknown_provider_with_explicit_opt_in_falls_back(self):
+        endpoint = match_endpoint(
+            provider="unknown_provider",
+            endpoint="chat",
+            model="some-model",
+            openai_compatible=True,
+        )
+
         assert type(endpoint).__name__ == "Endpoint"
         assert endpoint.config.provider == "unknown_provider"
+        assert endpoint.config.openai_compatible is True
+
+    def test_unknown_provider_with_base_url_falls_back_with_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match="unknown_provider"):
+            endpoint = match_endpoint(
+                provider="unknown_provider",
+                endpoint="chat",
+                base_url="https://my-api.example.com/v1",
+            )
+
+        assert type(endpoint).__name__ == "Endpoint"
+        assert endpoint.config.provider == "unknown_provider"
+        assert endpoint.config.base_url == "https://my-api.example.com/v1"
 
     def test_model_parameter_filtering(self):
         # Test with reasoning model
@@ -220,10 +251,11 @@ class TestMatchEndpoint:
             )
 
     def test_match_endpoint_fallback_builds_openai_compatible_endpoint_config(self):
-        result = match_endpoint(provider="custom_provider", endpoint="")
+        result = match_endpoint(provider="custom_provider", endpoint="", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert result.config.provider == "custom_provider"
         assert result.config.endpoint == "chat/completions"
         assert result.config.auth_type == "bearer"
         assert result.config.content_type == "application/json"
+        assert result.config.openai_compatible is True

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -118,6 +118,18 @@ class TestMatchEndpoint:
         assert endpoint.config.provider == "unknown_provider"
         assert endpoint.config.openai_compatible is True
 
+    def test_registered_provider_with_unmatched_endpoint_does_not_raise(self):
+        # 'openai' is registered (chat, embeddings, batch, ...) but has no
+        # 'query_cli' endpoint. The provider itself is known, so this must
+        # never surface as ProviderNotFoundError -- only a genuinely
+        # unrecognized *provider* string does that. No openai_compatible
+        # opt-in should be required either: the provider identity was never
+        # in question.
+        endpoint = match_endpoint(provider="openai", endpoint="query_cli", model="gpt-4o-mini")
+
+        assert endpoint.config.provider == "openai"
+        assert endpoint.is_cli is False
+
     def test_unknown_provider_with_base_url_falls_back_with_deprecation_warning(self):
         with pytest.warns(DeprecationWarning, match="unknown_provider"):
             endpoint = match_endpoint(

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -29,7 +29,7 @@ from lionagi.plugins.discovery import discover_plugins
 from lionagi.plugins.registry import PluginActivationError, PluginRegistry, PluginState
 from lionagi.plugins.trust import trust_plugin
 from lionagi.service.connections.match_endpoint import match_endpoint
-from lionagi.service.connections.registry import EndpointRegistry
+from lionagi.service.connections.registry import EndpointRegistry, ProviderNotFoundError
 
 MANIFEST = """\
 name: {name}
@@ -152,7 +152,7 @@ class TestPluginProviderHit:
         )
 
         assert PluginRegistry.active_provider_targets() == []
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert type(first).__name__ == "PluginProviderEndpoint"
         assert type(second).__name__ == "Endpoint"
@@ -229,7 +229,7 @@ class TestPluginProviderRevalidationCaching:
             PROVIDER_MODULE.format(provider="acme-llm") + "\n# changed after activation\n"
         )
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_edit
         assert type(second).__name__ == "Endpoint"
@@ -275,7 +275,7 @@ class TestPluginProviderRevalidationCaching:
             "test setup must actually restore the original mtime"
         )
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_attack, (
             "restoring a target file's mtime after editing its content must "
@@ -365,7 +365,7 @@ class TestPluginProviderRevalidationCaching:
 
         monkeypatch.setattr(pathlib.Path, "stat", frozen_ctime_stat)
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_attack, (
             "a same-length in-place edit whose mtime is restored and whose "
@@ -418,7 +418,7 @@ class TestPluginProviderRevalidationCaching:
             PROVIDER_MODULE.format(provider="acme-sibling") + "\n# changed after activation\n"
         )
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_edit
         assert type(second).__name__ == "Endpoint"
@@ -486,7 +486,7 @@ class TestPluginProviderRevalidationCaching:
 
         monkeypatch.setattr(pathlib.Path, "stat", frozen_ctime_stat)
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_attack, (
             "an equal-length edit to any declared sibling must force a fresh "
@@ -525,7 +525,7 @@ class TestPluginProviderRevalidationCaching:
                 ns=(previous_stat.st_atime_ns, previous_stat.st_mtime_ns + 1_000_000_000),
             )
 
-        second = match_endpoint(provider="acme-llm", endpoint="chat")
+        second = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert call_count > calls_before_edit
         assert type(second).__name__ == "Endpoint"
@@ -549,7 +549,11 @@ class TestPluginProviderConsultConcurrency:
             activation_calls += 1
             module_name = "_registry_nested_plugin"
             if activation_calls == 1:
-                nested_results.append(match_endpoint(provider="nested-missing", endpoint="chat"))
+                nested_results.append(
+                    match_endpoint(
+                        provider="nested-missing", endpoint="chat", openai_compatible=True
+                    )
+                )
                 endpoint_cls = type("PluginProviderEndpoint", (), {"__module__": module_name})
                 EndpointRegistry.register(provider="outer-provider", endpoint="chat")(endpoint_cls)
             return SimpleNamespace(__name__=module_name)
@@ -655,7 +659,7 @@ class TestPluginProviderMiss:
         # shape as when no plugin is installed at all.
         _write_provider_plugin(write_plugin, "wr", name="web-research", provider="acme-llm")
 
-        result = match_endpoint(provider="totally-unknown", endpoint="chat")
+        result = match_endpoint(provider="totally-unknown", endpoint="chat", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert result.config.provider == "totally-unknown"
@@ -663,9 +667,18 @@ class TestPluginProviderMiss:
         assert result.config.auth_type == "bearer"
         assert result.config.content_type == "application/json"
 
+    def test_genuinely_unknown_provider_raises_identically_with_no_opt_in(self, write_plugin):
+        # Same setup as above, but without opting into the generic fallback:
+        # plugin consultation happening must not change the terminal
+        # behavior for a provider nothing declares -- it raises either way.
+        _write_provider_plugin(write_plugin, "wr", name="web-research", provider="acme-llm")
+
+        with pytest.raises(ProviderNotFoundError, match="totally-unknown"):
+            match_endpoint(provider="totally-unknown", endpoint="chat")
+
     def test_no_plugins_installed_falls_back_identically(self, write_plugin):
         # `write_plugin` only gives us the isolated HOME; write nothing.
-        result = match_endpoint(provider="totally-unknown", endpoint="")
+        result = match_endpoint(provider="totally-unknown", endpoint="", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert result.config.provider == "totally-unknown"
@@ -680,7 +693,7 @@ class TestPluginProviderExclusion:
             write_plugin, "wr", name="web-research", provider="acme-llm", trust=False
         )
 
-        result = match_endpoint(provider="acme-llm", endpoint="chat")
+        result = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert result.config.provider == "acme-llm"
@@ -693,7 +706,7 @@ class TestPluginProviderExclusion:
         write_user_settings(settings)
         PluginRegistry.reset()
 
-        result = match_endpoint(provider="acme-llm", endpoint="chat")
+        result = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert _module_key("web-research") not in sys.modules
@@ -709,7 +722,7 @@ class TestPluginProviderExclusion:
             PROVIDER_MODULE.format(provider="acme-llm") + "\n# tampered after trust\n"
         )
 
-        result = match_endpoint(provider="acme-llm", endpoint="chat")
+        result = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert _module_key("web-research") not in sys.modules
@@ -725,7 +738,7 @@ class TestPluginProviderExclusion:
         )
         _trust("wr")
 
-        result = match_endpoint(provider="acme-llm", endpoint="chat")
+        result = match_endpoint(provider="acme-llm", endpoint="chat", openai_compatible=True)
 
         assert type(result).__name__ == "Endpoint"
         assert _module_key("web-research") not in sys.modules
@@ -796,8 +809,12 @@ class TestPluginProviderBuiltinCollision:
         with caplog.at_level(logging.WARNING, logger="lionagi.service.connections.registry"):
             # A miss on an unrelated provider is what drives `match()` to
             # consult (and thus import) every active plugin provider target,
-            # including the one that collides with "openai".
-            match_endpoint(provider="totally-unrelated", endpoint="chat")
+            # including the one that collides with "openai". The provider
+            # itself is still genuinely unregistered, so this raises -- the
+            # collision-rejection side effect (asserted below) already ran
+            # by the time it does.
+            with pytest.raises(ProviderNotFoundError, match="totally-unrelated"):
+                match_endpoint(provider="totally-unrelated", endpoint="chat")
 
         assert "web-research" in caplog.text
         assert "openai" in caplog.text

--- a/tests/service/connections/test_registry.py
+++ b/tests/service/connections/test_registry.py
@@ -117,6 +117,99 @@ class TestProviderAliasCollision:
                 pass
 
 
+class TestConcurrentRegistrationAndRemoval:
+    """Alias ownership must be atomic across concurrent registrations, and
+    released when the owning entry is removed (plugin revalidation
+    failure), so a legitimate replacement isn't rejected by a ledger
+    entry with no backing registration."""
+
+    def test_concurrent_distinct_providers_claiming_same_alias_only_one_wins(self):
+        import threading
+
+        start = threading.Barrier(2)
+        errors: list[BaseException] = []
+        registered: list[str] = []
+        lock = threading.Lock()
+
+        def _register(provider_name):
+            start.wait(timeout=5)
+            try:
+
+                @EndpointRegistry.register(
+                    provider=provider_name,
+                    endpoint="chat",
+                    provider_aliases=["shared-concurrent-alias"],
+                )
+                class _Stub(Endpoint):
+                    pass
+
+            except ProviderAliasCollisionError as exc:
+                with lock:
+                    errors.append(exc)
+            else:
+                with lock:
+                    registered.append(provider_name)
+
+        threads = [
+            threading.Thread(target=_register, args=("concurrent-alpha",)),
+            threading.Thread(target=_register, args=("concurrent-beta",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        # Exactly one registration wins; the other observes the collision.
+        assert len(registered) == 1
+        assert len(errors) == 1
+        owner = EndpointRegistry._alias_owners["shared-concurrent-alias"]
+        assert owner == registered[0]
+        # No entry exists for the loser under that alias.
+        entries_for_alias = [
+            e
+            for e in EndpointRegistry._entries
+            if "shared-concurrent-alias" in e.meta.provider_aliases
+        ]
+        assert {e.meta.provider for e in entries_for_alias} == {registered[0]}
+
+    def test_plugin_removal_releases_alias_for_legitimate_replacement(self):
+        from lionagi.plugins.registry import PluginActivationError
+
+        @EndpointRegistry.register(provider="old-plugin-provider", endpoint="chat")
+        class _OldPluginEndpoint(Endpoint):
+            pass
+
+        entry = next(e for e in EndpointRegistry._entries if e.cls is _OldPluginEndpoint)
+        # Mark it as plugin-owned so _revalidate_plugin_entry's removal path
+        # is reachable without standing up a real plugin manifest.
+        entry.plugin_name = "old-plugin"
+        entry.plugin_target = "old-plugin:_OldPluginEndpoint"
+
+        def _boom(*_args, **_kwargs):
+            raise PluginActivationError(
+                "old-plugin", "old-plugin:_OldPluginEndpoint", "simulated activation failure"
+            )
+
+        import lionagi.plugins as plugins_mod
+
+        original_activate = plugins_mod.PluginRegistry.activate_target
+        plugins_mod.PluginRegistry.activate_target = staticmethod(_boom)
+        try:
+            assert EndpointRegistry._revalidate_plugin_entry(entry) is False
+        finally:
+            plugins_mod.PluginRegistry.activate_target = original_activate
+
+        assert entry not in EndpointRegistry._entries
+        assert "old-plugin-provider" not in EndpointRegistry._alias_owners
+
+        # A brand-new provider can now legitimately claim that freed name.
+        @EndpointRegistry.register(provider="old-plugin-provider", endpoint="chat")
+        class _NewPluginEndpoint(Endpoint):
+            pass
+
+        assert EndpointRegistry._alias_owners["old-plugin-provider"] == "old-plugin-provider"
+
+
 class TestOptionalDependencyClassification:
     """``_is_missing_optional_dependency`` distinguishes a genuinely-absent
     third-party dependency (quiet) from a broken bundled module (loud)."""

--- a/tests/service/connections/test_registry.py
+++ b/tests/service/connections/test_registry.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``EndpointRegistry`` registration-time diagnostics:
+provider/alias canonicalization + collision rejection, and the
+optional-dependency-vs-broken-module classification used while importing
+bundled provider modules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.service.connections.endpoint import Endpoint
+from lionagi.service.connections.registry import (
+    EndpointRegistry,
+    ProviderAliasCollisionError,
+    _is_missing_optional_dependency,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_endpoint_registry():
+    """Snapshot/restore registry state so test-only registrations never leak
+    into other test files (mirrors the fixture in test_plugin_provider_consumer.py)."""
+    EndpointRegistry._ensure_loaded()
+    saved_entries = list(EndpointRegistry._entries)
+    saved_loaded = EndpointRegistry._loaded
+    saved_alias_owners = dict(EndpointRegistry._alias_owners)
+    yield
+    EndpointRegistry._entries = saved_entries
+    EndpointRegistry._loaded = saved_loaded
+    EndpointRegistry._alias_owners = saved_alias_owners
+
+
+class TestProviderAliasCanonicalization:
+    def test_provider_and_aliases_are_lowercased_and_stripped(self):
+        @EndpointRegistry.register(
+            provider="  MyTestProvider  ",
+            endpoint="chat",
+            provider_aliases=["  MyTP  ", "MYTESTPROVIDER-ALT"],
+        )
+        class _StubEndpoint(Endpoint):
+            pass
+
+        entry = next(e for e in EndpointRegistry._entries if e.cls is _StubEndpoint)
+        assert entry.meta.provider == "mytestprovider"
+        assert entry.meta.provider_aliases == ("mytp", "mytestprovider-alt")
+
+    def test_registering_the_same_provider_twice_is_not_a_collision(self):
+        @EndpointRegistry.register(provider="dup-provider", endpoint="chat")
+        class _First(Endpoint):
+            pass
+
+        @EndpointRegistry.register(provider="dup-provider", endpoint="embed")
+        class _Second(Endpoint):
+            pass
+
+        providers = {
+            e.meta.provider for e in EndpointRegistry._entries if e.cls in (_First, _Second)
+        }
+        assert providers == {"dup-provider"}
+
+
+class TestProviderAliasCollision:
+    def test_alias_colliding_with_another_providers_canonical_name_raises(self):
+        @EndpointRegistry.register(provider="owner-provider", endpoint="chat")
+        class _Owner(Endpoint):
+            pass
+
+        with pytest.raises(ProviderAliasCollisionError, match="owner-provider"):
+
+            @EndpointRegistry.register(
+                provider="claimant-provider",
+                endpoint="chat",
+                provider_aliases=["owner-provider"],
+            )
+            class _Claimant(Endpoint):
+                pass
+
+    def test_alias_colliding_with_another_providers_alias_names_both_claimants(self):
+        @EndpointRegistry.register(
+            provider="first-provider",
+            endpoint="chat",
+            provider_aliases=["shared-alias"],
+        )
+        class _First(Endpoint):
+            pass
+
+        with pytest.raises(ProviderAliasCollisionError) as excinfo:
+
+            @EndpointRegistry.register(
+                provider="second-provider",
+                endpoint="chat",
+                provider_aliases=["shared-alias"],
+            )
+            class _Second(Endpoint):
+                pass
+
+        message = str(excinfo.value)
+        assert "first-provider" in message
+        assert "second-provider" in message
+        assert "shared-alias" in message
+
+    def test_collision_check_is_case_and_whitespace_insensitive(self):
+        @EndpointRegistry.register(provider="canon-provider", endpoint="chat")
+        class _Owner(Endpoint):
+            pass
+
+        with pytest.raises(ProviderAliasCollisionError):
+
+            @EndpointRegistry.register(
+                provider="other-provider",
+                endpoint="chat",
+                provider_aliases=["  Canon-Provider  "],
+            )
+            class _Claimant(Endpoint):
+                pass
+
+
+class TestOptionalDependencyClassification:
+    """``_is_missing_optional_dependency`` distinguishes a genuinely-absent
+    third-party dependency (quiet) from a broken bundled module (loud)."""
+
+    def test_missing_third_party_package_is_optional(self):
+        exc = ModuleNotFoundError("No module named 'this_package_definitely_does_not_exist_xyz'")
+        exc.name = "this_package_definitely_does_not_exist_xyz"
+        assert _is_missing_optional_dependency(exc) is True
+
+    def test_missing_third_party_submodule_is_optional(self):
+        exc = ModuleNotFoundError(
+            "No module named 'this_package_definitely_does_not_exist_xyz.submodule'"
+        )
+        exc.name = "this_package_definitely_does_not_exist_xyz.submodule"
+        assert _is_missing_optional_dependency(exc) is True
+
+    def test_missing_internal_lionagi_name_is_not_optional(self):
+        exc = ModuleNotFoundError("No module named 'lionagi.providers.nonexistent'")
+        exc.name = "lionagi.providers.nonexistent"
+        assert _is_missing_optional_dependency(exc) is False
+
+    def test_installed_package_failing_for_other_reasons_is_not_optional(self):
+        exc = ModuleNotFoundError("No module named 'os.nonexistent_submodule'")
+        exc.name = "os"
+        assert _is_missing_optional_dependency(exc) is False
+
+    def test_import_error_without_a_name_is_not_optional(self):
+        # The "cannot import name X from Y" shape a broken re-export raises;
+        # CPython does not set .name for this ImportError shape.
+        exc = ImportError("cannot import name 'Foo' from 'lionagi.bar'")
+        assert _is_missing_optional_dependency(exc) is False

--- a/tests/service/connections/test_registry.py
+++ b/tests/service/connections/test_registry.py
@@ -17,6 +17,7 @@ from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.registry import (
     EndpointRegistry,
     ProviderAliasCollisionError,
+    ProviderNotFoundError,
     _import_provider_module,
 )
 
@@ -211,6 +212,45 @@ class TestConcurrentRegistrationAndRemoval:
             pass
 
         assert EndpointRegistry._alias_owners["old-plugin-provider"] == "old-plugin-provider"
+
+    def test_builtin_collision_rejection_releases_unique_alias_for_replacement(self):
+        """A plugin entry whose canonical provider collides with a built-in
+        (openai) is dropped by ``_reject_builtin_collisions``; its otherwise
+        unique alias must not stay claimed in ``_alias_owners`` afterward."""
+
+        @EndpointRegistry.register(
+            provider="openai",
+            endpoint="chat",
+            provider_aliases=["orphan-alias-f2359"],
+        )
+        class _RejectedPluginEndpoint(Endpoint):
+            pass
+
+        entry = next(e for e in EndpointRegistry._entries if e.cls is _RejectedPluginEndpoint)
+        entry.plugin_name = "rejected-plugin"
+        entry.plugin_target = "rejected-plugin:_RejectedPluginEndpoint"
+
+        EndpointRegistry._reject_builtin_collisions(
+            "rejected-plugin",
+            "rejected-plugin:_RejectedPluginEndpoint",
+            _RejectedPluginEndpoint.__module__,
+        )
+
+        assert entry not in EndpointRegistry._entries
+        assert "orphan-alias-f2359" not in EndpointRegistry._alias_owners
+
+        with pytest.raises(ProviderNotFoundError):
+            EndpointRegistry.match("orphan-alias-f2359")
+
+        @EndpointRegistry.register(
+            provider="replacement-provider-f2359",
+            endpoint="chat",
+            provider_aliases=["orphan-alias-f2359"],
+        )
+        class _ReplacementEndpoint(Endpoint):
+            pass
+
+        assert EndpointRegistry._alias_owners["orphan-alias-f2359"] == "replacement-provider-f2359"
 
 
 class TestOptionalDependencyPreflight:

--- a/tests/service/connections/test_registry.py
+++ b/tests/service/connections/test_registry.py
@@ -1,20 +1,23 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for ``EndpointRegistry`` registration-time diagnostics:
-provider/alias canonicalization + collision rejection, and the
-optional-dependency-vs-broken-module classification used while importing
-bundled provider modules.
+provider/alias canonicalization + collision rejection, and the declared-
+dependency preflight used while importing bundled provider modules.
 """
 
 from __future__ import annotations
 
+import logging
+import sys
+
 import pytest
 
+from lionagi.service.connections import registry as _registry_mod
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.registry import (
     EndpointRegistry,
     ProviderAliasCollisionError,
-    _is_missing_optional_dependency,
+    _import_provider_module,
 )
 
 
@@ -210,34 +213,37 @@ class TestConcurrentRegistrationAndRemoval:
         assert EndpointRegistry._alias_owners["old-plugin-provider"] == "old-plugin-provider"
 
 
-class TestOptionalDependencyClassification:
-    """``_is_missing_optional_dependency`` distinguishes a genuinely-absent
-    third-party dependency (quiet) from a broken bundled module (loud)."""
+class TestOptionalDependencyPreflight:
+    """``_import_provider_module`` classifies by a declared dependency table
+    checked via ``find_spec`` *before* import, never by inspecting the
+    metadata of an ``ImportError`` raised during import."""
 
-    def test_missing_third_party_package_is_optional(self):
-        exc = ModuleNotFoundError("No module named 'this_package_definitely_does_not_exist_xyz'")
-        exc.name = "this_package_definitely_does_not_exist_xyz"
-        assert _is_missing_optional_dependency(exc) is True
-
-    def test_missing_third_party_submodule_is_optional(self):
-        exc = ModuleNotFoundError(
-            "No module named 'this_package_definitely_does_not_exist_xyz.submodule'"
+    def test_module_skipped_when_declared_dependency_is_absent(self, monkeypatch, caplog):
+        mod = "tests.service.connections._fixture_absent_dep_provider"
+        monkeypatch.setitem(
+            _registry_mod._PROVIDER_OPTIONAL_DEPENDENCIES,
+            mod,
+            ("this_pkg_definitely_does_not_exist_xyz",),
         )
-        exc.name = "this_package_definitely_does_not_exist_xyz.submodule"
-        assert _is_missing_optional_dependency(exc) is True
+        with caplog.at_level(logging.DEBUG, logger=_registry_mod.logger.name):
+            _import_provider_module(mod)  # would raise RuntimeError if executed
 
-    def test_missing_internal_lionagi_name_is_not_optional(self):
-        exc = ModuleNotFoundError("No module named 'lionagi.providers.nonexistent'")
-        exc.name = "lionagi.providers.nonexistent"
-        assert _is_missing_optional_dependency(exc) is False
+        assert mod not in sys.modules
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("not installed" in r.getMessage() for r in debug_records)
+        assert not warning_records
 
-    def test_installed_package_failing_for_other_reasons_is_not_optional(self):
-        exc = ModuleNotFoundError("No module named 'os.nonexistent_submodule'")
-        exc.name = "os"
-        assert _is_missing_optional_dependency(exc) is False
+    def test_forged_import_error_with_resolved_deps_is_a_load_failure(self, monkeypatch, caplog):
+        # Nothing declared for this module -- the preflight has nothing to
+        # check and passes trivially, so the import is attempted.
+        mod = "tests.service.connections._fixture_forged_import_provider"
+        monkeypatch.delitem(_registry_mod._PROVIDER_OPTIONAL_DEPENDENCIES, mod, raising=False)
+        with caplog.at_level(logging.DEBUG, logger=_registry_mod.logger.name):
+            _import_provider_module(mod)
 
-    def test_import_error_without_a_name_is_not_optional(self):
-        # The "cannot import name X from Y" shape a broken re-export raises;
-        # CPython does not set .name for this ImportError shape.
-        exc = ImportError("cannot import name 'Foo' from 'lionagi.bar'")
-        assert _is_missing_optional_dependency(exc) is False
+        assert mod not in sys.modules
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_records, "a forged/buggy ImportError must be a loud load failure"
+        assert not debug_records, "no metadata-based quiet classification should ever occur"


### PR DESCRIPTION
Closes #2026.

Three places where the endpoint registry answered a question it should have refused to answer.

**Swallowed bundled imports.** `_import_all_providers()` discarded every `ImportError`, so a broken bundled module vanished from the registry indistinguishably from an optional dependency simply not being installed. Failures are now classified: a genuinely-absent third-party package logs at debug, while a broken re-export, a bad internal import, or any failure that is not a missing optional dependency logs a warning naming the module and the exception. Every bundled provider defers its heavy third-party imports to call time, so today the loud branch is the one that matters.

**Unvalidated aliases.** `register()` stored provider names and aliases verbatim. They are now canonicalized, and a cross-provider claim on a string another provider already owns raises an error naming both claimants. Re-registering the same provider across its own endpoints is unaffected. A plugin claiming an owned identity is rejected softly, dropping that plugin's contribution rather than breaking resolution for everything else, matching the existing posture for built-in collisions.

**Silent generic fallback.** `match()` built a generic OpenAI-compatible endpoint for any unrecognized provider, so a typo mis-routed instead of failing: wrong auth headers and wrong payload shape against a non-OpenAI target, with no signal. It now requires `openai_compatible=True` and otherwise raises, naming the requested provider and every registered provider and alias.

**Behavior change, with a migration path.** An unregistered provider with no `base_url` now raises where it previously returned a generic endpoint. The documented custom-host pattern `iModel(provider="...", base_url="...")` keeps working with no code change: `base_url` is threaded into the match call and carries the "I mean this" intent, so those callers get a deprecation warning pointing at the explicit flag rather than a break. Rehydrating a persisted model opts in explicitly, since that call only ever asked whether a registered class exists and must not start raising because a provider is no longer registered.

`#1998`, the case-sensitivity slice of the same fallthrough, is already fixed in this codebase and was verified rather than re-fixed.
