### PR TITLE
fix(mcp): stop an omitted-policy get_client from inheriting an earlier caller's trust

### DIFF
--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -42,11 +42,10 @@ not ordinary.** The registry currently accepts a one-entry MCP configuration, di
 remote schemas, builds a local async proxy, remembers transport policy, and reaches a
 process-global client pool. Command and URL transports are fail-closed under direct pool
 use, and the two explicit config-loading helpers no longer upgrade an omitted policy to a
-permissive one: it stays unset and is passed through unchanged. It then reaches the pool's
-fail-closed default only when no policy has already been recorded for the same identity;
-where one has, that remembered authorization is substituted first (see Policy recovery
-below). So loading a config file is no longer an implicit trust act on its own, but it is
-not yet an independent one either. Discovered tools
+permissive one: it stays unset and is passed through unchanged, and reaches the pool's
+fail-closed default with no possibility of substituting a remembered authorization from
+an earlier caller (see Policy recovery below). So loading a config file is no longer an
+implicit trust act at all. Discovered tools
 use the remote tool's unqualified name in the branch registry, so remote servers can
 collide with each other or with local tools (`lionagi/protocols/action/manager.py`;
 `lionagi/service/connections/mcp_wrapper.py`).
@@ -481,17 +480,17 @@ tool:
   `MCPSecurityConfig.trusted()` explicitly, and that choice is threaded per load without
   mutating the process-global default. A transport `PermissionError` is logged and
   re-raised; other server failures become an empty registered-name list or a warning.
-- **Policy recovery is process-scoped, and it is wider than the loader contract
-  intends.** An explicit policy is remembered against the resolved transport so the
-  proxy's own later `get_client()` call, which carries no policy, recovers the same
-  authorization. That recovery is keyed by the same policy identity described under
-  Policy reuse — server name plus resolved transport content for a named server, content
-  alone for an inline config — and by nothing narrower, so a *different* caller that
-  later loads a transport matching that identity with no policy also inherits the earlier
-  authorization rather than being denied. Delta 3 is therefore delivered for a first
-  load in a process and not yet for a subsequent one; closing that gap requires
-  distinguishing the proxy's re-entry from a fresh loader call, which is tracked
-  separately.
+- **Policy recovery is process-scoped and proxy-only.** An explicit policy is
+  remembered against the resolved transport so the proxy's stored callable can recover
+  the same authorization on a later reconnect with no policy of its own. That recovery
+  is keyed by the same policy identity described under Policy reuse — server name plus
+  resolved transport content for a named server, content alone for an inline config —
+  but it is reachable only through `MCPConnectionPool._get_reconnect_client()`, a
+  private method whose only caller is the proxy built by `create_mcp_tool`. The public
+  `get_client()` accepts only an explicit `MCPSecurityConfig` or `None` for its
+  `security` argument (anything else raises `TypeError`) and never recovers a
+  remembered policy, so a fresh loader call that omits a policy is denied even when an
+  earlier caller already authorized the identical resolved transport.
 - **Loader input failure:** config-file existence, JSON shape, and parsing errors occur
   before the per-server recovery loop and propagate. Top-level `load_mcp_tools()` also
   raises `ValueError` when neither `server_names` nor a config path supplies a server
@@ -558,7 +557,7 @@ unqualified names make collision handling a branch-registration concern.
 |---|-------|------|-------|
 | 1 | Version and narrow raw-callable schema derivation so Python defaults remain optional, positional-only and `*args` signatures require an explicit adapter, open `**kwargs` callables require an explicit schema, schemas without `required` are accepted, and tests prove provider schema and runtime validation agree. | M | (filled at issue-open time) |
 | 2 | Move MCP configuration, discovery, namespacing, and pool lifecycle into a service-owned factory that returns ready `Tool` descriptors; acceptance requires `protocols.action` to have no service-layer import, remote identities to be collision-free, and per-tool request models to resolve by that canonical identity without key mutation or silent fallback. | M | (filled at issue-open time) |
-| 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | partly delivered — holds only for the first load of a given identity in a process. Once any caller has authorized that identity explicitly, every later caller that loads it with no policy inherits that authorization and is not denied, regardless of whether that later caller made any trust decision of its own (see Policy recovery above) |
+| 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | delivered — an omitted policy is denied on every load, not only the first, because policy recovery is reachable only through the proxy's private reconnect path and never through the loader-facing `get_client()` call (see Policy recovery above) |
 
 ## Alternatives considered
 
@@ -621,10 +620,11 @@ allowing both transport classes, on the reasoning that selecting and loading a c
 file was itself a trust decision. That convenience created a semantic split: the same
 omitted policy meant "deny" through the pool and "allow" through a loader, and nothing
 in the calling code made the difference visible. Delta 3 replaced it with the behavior
-now described under Loader trust, where an omitted policy denies in both paths on a
-first load and trust is a named, observable choice. The remembered-policy recovery
-described above still carries an earlier authorization into a later omitted-policy load,
-so the original convenience survives in narrower form.
+now described under Loader trust, where an omitted policy denies through every loader
+call, first or later, and trust is a named, observable choice. The remembered-policy
+recovery described above is scoped to the proxy's own reconnect and is not reachable
+through a loader call at all, so the original convenience does not survive even in
+narrower form.
 
 ## Notes
 

--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -46,7 +46,7 @@ permissive one: it stays unset and is passed through unchanged, reaching the poo
 fail-closed default (unless the process owner has separately called
 `set_security_config()`, an explicit process-wide decision documented under Loader trust
 below) with no possibility of substituting a remembered authorization from an earlier
-caller (see Policy recovery below). So loading a config file is no longer an implicit
+caller, connected client cache notwithstanding (see Policy recovery below). So loading a config file is no longer an implicit
 trust act on its own. Discovered tools
 use the remote tool's unqualified name in the branch registry, so remote servers can
 collide with each other or with local tools (`lionagi/protocols/action/manager.py`;
@@ -412,7 +412,9 @@ class MCPConnectionPool:
     _clients: dict[str, Any] = {}
     _configs: dict[str, dict] = {}
     _security: MCPSecurityConfig | None = None
-    _server_security: dict[str, MCPSecurityConfig] = {}
+    # No config-keyed policy map: recovery authority is an opaque
+    # `_MCPRecoveryCapability` object minted per authorized proxy and held
+    # only in that proxy's own closure -- see Policy recovery below.
 
     @classmethod
     async def get_client(
@@ -484,39 +486,55 @@ tool:
   explicitly, and that choice is threaded per load without mutating the process-global
   default. A transport `PermissionError` is logged and re-raised; other server failures
   become an empty registered-name list or a warning.
-- **Policy recovery is process-scoped and proxy-only.** An explicit policy is
-  remembered against the resolved transport so the proxy's stored callable can recover
-  the same authorization on a later reconnect with no policy of its own. That recovery
-  is keyed by the same policy identity described under Policy reuse — server name plus
-  resolved transport content for a named server, content alone for an inline config —
-  but it is reachable only through `MCPConnectionPool._get_reconnect_client()`, a
-  private method whose only caller is the proxy built by `create_mcp_tool`. The public
-  `get_client()` accepts only an explicit `MCPSecurityConfig` or `None` for its
-  `security` argument (anything else raises `TypeError`) and never recovers a policy a
-  DIFFERENT caller authorized for the same identity, so a fresh loader call that omits a
-  policy is denied even when an earlier caller already authorized the identical resolved
-  transport -- unless, as under Loader trust above, the process owner has set a
-  process-global policy, which is a distinct, explicit, process-wide decision rather than
-  one caller inheriting another's.
+- **Policy recovery is capability-bound, not config-keyed.** `register_mcp_server()`
+  mints one opaque `_MCPRecoveryCapability` per call, bound to that call's effective
+  security (explicit argument, else the process-global policy, else the fail-closed
+  default), and passes it into `create_mcp_tool()` for every `Tool` it builds from that
+  call. The capability lives only in `create_mcp_tool`'s closure and in `Tool`'s
+  `mcp_capability` field, which is `exclude=True` -- it is never part of `mcp_config`,
+  never returned by `to_dict()`/`to_json()`, and `Tool.from_dict()` remains
+  unimplemented, so no persisted or reconstructed `Tool` carries one. Recovery happens
+  only through `MCPConnectionPool._get_reconnect_client(config, capability)`, which
+  requires that exact capability object by IDENTITY (`isinstance` plus object identity
+  inside the pool, not a content match) and raises `PermissionError` when it is absent or
+  the wrong instance -- so a direct call, a stored bound method, a subclass exposing the
+  method under a public alias, or a `Tool` rebuilt from a serialized `mcp_config` (e.g.
+  `Tool(**serialized_dict)`) all fail closed with no recovery. There is no way to obtain a
+  valid capability except by being the proxy `register_mcp_server()` built it for. The
+  public `get_client()` accepts only an explicit `MCPSecurityConfig` or `None` for its
+  `security` argument (anything else raises `TypeError`), has no parameter that accepts a
+  capability, and its cache key folds in the fingerprint of ITS OWN effective security
+  (see Pool identity below) -- so a fresh, policy-omitting call is denied even when an
+  earlier caller already authorized the identical resolved transport and that caller's
+  client is still connected, and even when a live capability for that transport exists
+  elsewhere in the process -- unless, as under Loader trust above, the process owner has
+  set a process-global policy, which is a distinct, explicit, process-wide decision rather
+  than one caller inheriting another's.
 - **Loader input failure:** config-file existence, JSON shape, and parsing errors occur
   before the per-server recovery loop and propagate. Top-level `load_mcp_tools()` also
   raises `ValueError` when neither `server_names` nor a config path supplies a server
   set.
-- **Policy reuse:** an explicit policy is remembered so the proxy's later `get_client()`
-  call can recover the same authorization. For a named server the key binds the server's
-  name together with its resolved transport content, so an authorization granted for one
-  named server is never recovered for a different one that happens to resolve to the same
-  transport. An anonymous inline configuration has no name to bind, so its key is derived
-  from content alone.
-- **Pool identity:** a named config's cache identity contains the server name together
-  with its resolved transport content, with `server:<name>` only its prefix, so a
-  connected client is reused only when both match. Reloading a different command or URL
-  under the same name yields a different identity and the stale client is dropped rather
-  than reused. Inline configs use the command plus the Python dictionary's
-  object identity, so reuse occurs only when the same dictionary object is passed again;
-  the MCP proxy creates a fresh metadata-stripped dictionary for each call and has no
-  stable inline reuse key. A disconnected cached client is dropped, and `cleanup()`
-  attempts every client exit before clearing the map.
+- **Policy reuse:** each `create_mcp_tool`-built proxy carries its own capability (see
+  Policy recovery above), minted per `register_mcp_server()` call, so recovery is scoped
+  to the specific authorized call that created that proxy rather than to any server-name
+  or transport-content key.
+- **Pool identity:** the client-cache key folds together the resolved transport identity
+  (server name plus resolved transport content for a named server, content plus Python
+  object identity for an inline config) AND a fingerprint of the CALLER'S OWN effective
+  security (`MCPConnectionPool._security_fingerprint`), so two calls to the identical
+  transport with different effective security -- e.g. one explicitly trusted, one
+  omitted -- always resolve to different cache entries and a cache hit can only ever
+  return a client whose key already encodes the caller's own effective security. This is
+  the primary fix for cross-caller trust inheritance, not a secondary check: an
+  omitted-policy call cannot be satisfied by a cache entry a differently-authorized
+  caller created, connected or not, and always re-validates through `_create_client`'s
+  fail-closed path when it misses. Reloading a different command or URL under the same
+  name yields a different transport-content component and the stale client is dropped
+  (`load_config`'s cache-prefix eviction) rather than reused. Inline configs additionally
+  key on the Python dictionary's object identity, so reuse occurs only when the same
+  dictionary object is passed again; the MCP proxy creates a fresh metadata-stripped
+  dictionary for each call and has no stable inline reuse key. A disconnected cached
+  client is dropped, and `cleanup()` attempts every client exit before clearing the map.
 - **Environment:** command transport starts with the parent environment plus configured
   values, removes variables whose names contain sensitive patterns by default, and adds
   quiet logging defaults unless debug mode is active.
@@ -564,7 +582,7 @@ unqualified names make collision handling a branch-registration concern.
 |---|-------|------|-------|
 | 1 | Version and narrow raw-callable schema derivation so Python defaults remain optional, positional-only and `*args` signatures require an explicit adapter, open `**kwargs` callables require an explicit schema, schemas without `required` are accepted, and tests prove provider schema and runtime validation agree. | M | (filled at issue-open time) |
 | 2 | Move MCP configuration, discovery, namespacing, and pool lifecycle into a service-owned factory that returns ready `Tool` descriptors; acceptance requires `protocols.action` to have no service-layer import, remote identities to be collision-free, and per-tool request models to resolve by that canonical identity without key mutation or silent fallback. | M | (filled at issue-open time) |
-| 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | delivered — an omitted policy is denied on every load, not only the first, because policy recovery is reachable only through the proxy's private reconnect path and never through the loader-facing `get_client()` call (see Policy recovery above) |
+| 3 | Require the MCP-loading caller to make an explicit transport-trust decision; acceptance requires omitted policy to preserve the wrapper's fail-closed command and URL defaults and an explicit trusted-config mode to be observable. | S | delivered — an omitted policy is denied on every load, including a second load of an already-trusted, still-connected server, because the client-cache key folds in the caller's own effective security and recovery requires a capability the loader-facing `get_client()` call can neither produce nor accept (see Policy recovery above) |
 
 ## Alternatives considered
 
@@ -628,10 +646,11 @@ file was itself a trust decision. That convenience created a semantic split: the
 omitted policy meant "deny" through the pool and "allow" through a loader, and nothing
 in the calling code made the difference visible. Delta 3 replaced it with the behavior
 now described under Loader trust, where an omitted policy denies through every loader
-call, first or later, and trust is a named, observable choice. The remembered-policy
-recovery described above is scoped to the proxy's own reconnect and is not reachable
-through a loader call at all, so the original convenience does not survive even in
-narrower form.
+call, first or later -- even a still-connected, already-trusted server -- and trust is a
+named, observable choice. The capability-bound recovery described above is scoped to the
+specific proxy `register_mcp_server()` minted it for and is not reachable through a
+loader call, a config, or any other proxy at all, so the original convenience does not
+survive even in narrower form.
 
 ## Notes
 

--- a/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
+++ b/docs/adr/ADR-0011-function-tool-descriptor-and-branch-registry.md
@@ -42,10 +42,12 @@ not ordinary.** The registry currently accepts a one-entry MCP configuration, di
 remote schemas, builds a local async proxy, remembers transport policy, and reaches a
 process-global client pool. Command and URL transports are fail-closed under direct pool
 use, and the two explicit config-loading helpers no longer upgrade an omitted policy to a
-permissive one: it stays unset and is passed through unchanged, and reaches the pool's
-fail-closed default with no possibility of substituting a remembered authorization from
-an earlier caller (see Policy recovery below). So loading a config file is no longer an
-implicit trust act at all. Discovered tools
+permissive one: it stays unset and is passed through unchanged, reaching the pool's own
+fail-closed default (unless the process owner has separately called
+`set_security_config()`, an explicit process-wide decision documented under Loader trust
+below) with no possibility of substituting a remembered authorization from an earlier
+caller (see Policy recovery below). So loading a config file is no longer an implicit
+trust act on its own. Discovered tools
 use the remote tool's unqualified name in the branch registry, so remote servers can
 collide with each other or with local tools (`lionagi/protocols/action/manager.py`;
 `lionagi/service/connections/mcp_wrapper.py`).
@@ -473,13 +475,15 @@ tool:
   only. URLs require `allow_urls=True`, an `https` or `wss` scheme, and an optional host
   allowlist.
 - **Loader trust:** `load_mcp_config()` and top-level `load_mcp_tools()` leave an
-  omitted policy unset and thread it through to registration unchanged. In a process
-  where that transport has not already been authorized, it reaches the pool's own
-  fail-closed default and a command or URL transport is denied exactly as it is under
-  direct pool use. A caller that wants both transport classes allowed passes
-  `MCPSecurityConfig.trusted()` explicitly, and that choice is threaded per load without
-  mutating the process-global default. A transport `PermissionError` is logged and
-  re-raised; other server failures become an empty registered-name list or a warning.
+  omitted policy unset and thread it through to registration unchanged, so it reaches
+  the pool's own fail-closed default and a command or URL transport is denied exactly as
+  it is under direct pool use -- unless the process owner has separately called
+  `MCPConnectionPool.set_security_config()`, an explicit process-wide policy that then
+  applies to every omitted-policy call in the process until changed. A caller that wants
+  both transport classes allowed for its own load passes `MCPSecurityConfig.trusted()`
+  explicitly, and that choice is threaded per load without mutating the process-global
+  default. A transport `PermissionError` is logged and re-raised; other server failures
+  become an empty registered-name list or a warning.
 - **Policy recovery is process-scoped and proxy-only.** An explicit policy is
   remembered against the resolved transport so the proxy's stored callable can recover
   the same authorization on a later reconnect with no policy of its own. That recovery
@@ -488,9 +492,12 @@ tool:
   but it is reachable only through `MCPConnectionPool._get_reconnect_client()`, a
   private method whose only caller is the proxy built by `create_mcp_tool`. The public
   `get_client()` accepts only an explicit `MCPSecurityConfig` or `None` for its
-  `security` argument (anything else raises `TypeError`) and never recovers a
-  remembered policy, so a fresh loader call that omits a policy is denied even when an
-  earlier caller already authorized the identical resolved transport.
+  `security` argument (anything else raises `TypeError`) and never recovers a policy a
+  DIFFERENT caller authorized for the same identity, so a fresh loader call that omits a
+  policy is denied even when an earlier caller already authorized the identical resolved
+  transport -- unless, as under Loader trust above, the process owner has set a
+  process-global policy, which is a distinct, explicit, process-wide decision rather than
+  one caller inheriting another's.
 - **Loader input failure:** config-file existence, JSON shape, and parsing errors occur
   before the per-server recovery loop and propagate. Top-level `load_mcp_tools()` also
   raises `ValueError` when neither `server_names` nor a config path supplies a server

--- a/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
+++ b/docs/adr/ADR-0041-agent-specification-and-branch-construction.md
@@ -265,10 +265,12 @@ MCP discovery follows this search contract:
 | `mcp_servers is None` | discover all configured servers |
 | explicit list | load only the named servers |
 
-The current `ActionManager.load_mcp_config()` supplies
-`MCPSecurityConfig(allow_commands=True, allow_urls=True)` when no transport policy is passed.
-The factory does not expose an `mcp_security` argument. This is current behavior, not the
-aspirational trust contract in ADR-0044.
+The factory calls `ActionManager.load_mcp_config()` with `mcp_security=MCPSecurityConfig.trusted()`
+explicitly for every explicitly selected MCP path -- it does not rely on `load_mcp_config()`'s own
+omitted-policy handling, which fails closed now that an omission is no longer upgraded to a
+permissive policy (ADR-0011 delta row 3). `AgentSpec` does not expose an `mcp_security` field, so a
+caller building through this path cannot request a narrower transport policy than `trusted()`. This
+is current behavior, not the aspirational trust contract in ADR-0044.
 
 **Error and repetition semantics.**
 

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -348,10 +348,13 @@ class ActionManager(Manager):
     ) -> list[str]:
         registered_tools = []
 
-        if security is not None:
-            from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
-            MCPConnectionPool.remember_security(server_config, security)
+        # Mint the recovery authorization once, bound to this call's
+        # effective security, and thread it into every Tool created below.
+        # It never touches `_server_security`/config-keyed state: each Tool
+        # holds the capability only in its own excluded, non-serialized slot.
+        capability = MCPConnectionPool._mint_capability(security)
 
         server_name = None
         if isinstance(server_config, dict) and "server" in server_config:
@@ -389,12 +392,15 @@ class ActionManager(Manager):
                 if request_options and tool_name in request_options:
                     tool_request_options = request_options[tool_name]
 
-                tool = Tool(mcp_config=mcp_config, request_options=tool_request_options)
+                tool = Tool(
+                    mcp_config=mcp_config,
+                    request_options=tool_request_options,
+                    mcp_capability=capability,
+                )
                 self.register_tool(tool, update=update)
                 registered_tools.append(tool_name)
         else:
             from lionagi.service.connections.mcp_wrapper import (
-                MCPConnectionPool,
                 validate_mcp_tool_admission,
             )
 
@@ -444,6 +450,7 @@ class ActionManager(Manager):
                         mcp_config=mcp_config,
                         request_options=tool_request_options,
                         tool_schema=tool_schema,
+                        mcp_capability=capability,
                     )
                     self.register_tool(tool_obj, update=update)
                     registered_tools.append(tool_name)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -465,13 +465,14 @@ class ActionManager(Manager):
 
         # An omitted policy is not upgraded to a permissive one here:
         # `mcp_security` stays None and flows through to
-        # `register_mcp_server` -> `MCPConnectionPool.get_client`. There it
+        # `register_mcp_server` -> `MCPConnectionPool.get_client`, which
         # reaches the wrapper's own fail-closed `MCPSecurityConfig()` default
-        # only when no policy has already been recorded for the same identity;
-        # if one has, the pool substitutes that remembered authorization, so a
-        # load in a process that already authorized this transport is not
-        # denied. A caller wanting the permissive behavior outright passes
-        # `mcp_security=MCPSecurityConfig.trusted()` explicitly.
+        # every time, regardless of whether this identity was already
+        # authorized in this process. Recovering a remembered authorization
+        # is not reachable through this loader path at all -- only the MCP
+        # proxy's own reconnect does that. A caller wanting the permissive
+        # behavior outright passes `mcp_security=MCPSecurityConfig.trusted()`
+        # explicitly.
         loaded_names = MCPConnectionPool.load_config(config_path)
 
         if server_names is None:
@@ -508,9 +509,9 @@ async def load_mcp_tools(
     manager = ActionManager()
 
     # See load_mcp_config's matching comment: an omitted policy stays None
-    # rather than being silently upgraded to a permissive one, and reaches the
-    # wrapper's fail-closed default only when no policy is already recorded for
-    # the same identity.
+    # rather than being silently upgraded to a permissive one, and always
+    # reaches the wrapper's fail-closed default -- it never recovers a policy
+    # some earlier caller authorized for the same identity.
 
     if config_path:
         MCPConnectionPool.load_config(config_path)

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -466,11 +466,12 @@ class ActionManager(Manager):
         # An omitted policy is not upgraded to a permissive one here:
         # `mcp_security` stays None and flows through to
         # `register_mcp_server` -> `MCPConnectionPool.get_client`, which
-        # reaches the wrapper's own fail-closed `MCPSecurityConfig()` default
-        # every time, regardless of whether this identity was already
-        # authorized in this process. Recovering a remembered authorization
-        # is not reachable through this loader path at all -- only the MCP
-        # proxy's own reconnect does that. A caller wanting the permissive
+        # reaches the wrapper's fail-closed `MCPSecurityConfig()` default --
+        # unless the process owner has called `set_security_config()`, an
+        # explicit process-wide decision that then applies to every
+        # omitted-policy call. Either way, this loader path never recovers a
+        # policy some OTHER caller authorized for the same identity; only the
+        # MCP proxy's own reconnect does that. A caller wanting the permissive
         # behavior outright passes `mcp_security=MCPSecurityConfig.trusted()`
         # explicitly.
         loaded_names = MCPConnectionPool.load_config(config_path)
@@ -509,9 +510,10 @@ async def load_mcp_tools(
     manager = ActionManager()
 
     # See load_mcp_config's matching comment: an omitted policy stays None
-    # rather than being silently upgraded to a permissive one, and always
-    # reaches the wrapper's fail-closed default -- it never recovers a policy
-    # some earlier caller authorized for the same identity.
+    # rather than being silently upgraded to a permissive one, and reaches
+    # the wrapper's fail-closed default unless a process-global policy was
+    # explicitly set. Either way, it never recovers a policy some earlier
+    # caller authorized for the same identity.
 
     if config_path:
         MCPConnectionPool.load_config(config_path)

--- a/lionagi/protocols/action/tool.py
+++ b/lionagi/protocols/action/tool.py
@@ -31,6 +31,10 @@ class Tool(Element):
     mcp_config: dict[str, dict[str, Any]] | None = None
     """{tool_name: mcp_config dict}"""
 
+    mcp_capability: Any = Field(default=None, exclude=True)
+    """Recovery authorization for the wrapped MCP proxy (opaque, identity-checked).
+    Excluded from serialization/dict output; a rehydrated Tool never has one."""
+
     tool_schema: dict[str, Any] | None = Field(
         default=None,
         description="Schema describing the function's parameters and structure",
@@ -86,7 +90,7 @@ class Tool(Element):
 
             from lionagi.service.connections.mcp_wrapper import create_mcp_tool
 
-            func_callable = create_mcp_tool(config, tool_name)
+            func_callable = create_mcp_tool(config, tool_name, data.get("mcp_capability"))
         else:
             from lionagi.libs.validate.common_field_validators import validate_callable
 

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -80,6 +80,24 @@ class MCPSecurityConfig:
         return cls(allow_commands=True, allow_urls=True)
 
 
+class _MCPRecoveryCapability:
+    """Opaque, unforgeable proof that a proxy is authorized to recover the
+    security policy it was created under.
+
+    Minted once per authorization (`MCPConnectionPool._mint_capability`) and
+    checked by IDENTITY, never by content -- an equal-content instance is not
+    accepted. Only the closure `create_mcp_tool` builds holds a reference;
+    it is never assigned into `Tool.mcp_config`, returned by `to_dict()`, or
+    otherwise persisted, so it cannot survive serialization or be forged from
+    a config dict.
+    """
+
+    __slots__ = ("security",)
+
+    def __init__(self, security: MCPSecurityConfig) -> None:
+        self.security = security
+
+
 # --- Generic-executor admission rule -----------------------------------
 # Registration-time admission control, independent of MCPSecurityConfig
 # (transport auth) and PermissionPolicy (invocation-time) — see docs/internals/runtime.md.
@@ -1510,25 +1528,17 @@ class MCPConnectionPool:
     _lock: Lock | None = None
     _lock_guard: threading.Lock = threading.Lock()
     _security: MCPSecurityConfig | None = None
-    # Per-server policy keyed by server name + content signature so
-    # reconnects re-apply the same authorization instead of falling back to
-    # fail-closed, while trust entries stay scoped per server: two servers
-    # never share a decision just because their resolved transports match.
-    _server_security: dict[str, MCPSecurityConfig] = {}
 
     @staticmethod
     def _policy_key(config: dict[str, Any], server_name: str | None = None) -> str:
-        """Key for the per-server policy registry, scoped to the identity a
-        trust decision is actually about.
+        """Content fingerprint of a resolved transport config, folded into
+        the client-cache key so two distinct transports never collide there.
 
         Callers MUST pass an already-*resolved* transport config (see
-        `_resolve_config`) -- never a bare `{"server": name}` reference. When
-        the config was resolved from a named server reference, `server_name`
-        must be supplied so the key binds to that server's name as well as
-        its transport content: two servers with different names must never
-        share a trust decision even if their resolved transports happen to
-        be identical, and a name reloaded with a different transport must
-        never recover the policy authorized for its prior transport.
+        `_resolve_config`) -- never a bare `{"server": name}` reference. This
+        is NOT a security/authorization key: it is derived purely from the
+        (forgeable, serializable) config, so it must never gate recovery --
+        see `_MCPRecoveryCapability` for the actual recovery authority.
         """
         material = {k: v for k, v in config.items() if not k.startswith("_")}
         blob = json.dumps(material, sort_keys=True, default=str)
@@ -1536,6 +1546,46 @@ class MCPConnectionPool:
         if server_name is not None:
             return f"{server_name}:{content_hash}"
         return content_hash
+
+    @staticmethod
+    def _security_fingerprint(security: MCPSecurityConfig) -> str:
+        """Content fingerprint of an effective security decision, folded
+        into the client-cache key so a trusted client and a fail-closed
+        client for the same transport are never the same cache entry."""
+        material = {
+            "allow_commands": security.allow_commands,
+            "command_allowlist": sorted(security.command_allowlist)
+            if security.command_allowlist is not None
+            else None,
+            "allow_urls": security.allow_urls,
+            "url_allowlist": sorted(security.url_allowlist)
+            if security.url_allowlist is not None
+            else None,
+            "env_denylist_patterns": sorted(security.env_denylist_patterns),
+            "filter_sensitive_env": security.filter_sensitive_env,
+            "max_connections_per_server": security.max_connections_per_server,
+        }
+        blob = json.dumps(material, sort_keys=True, default=str)
+        return compute_hash(blob)
+
+    @classmethod
+    def _effective_security(cls, security: MCPSecurityConfig | None) -> MCPSecurityConfig:
+        """Precedence: explicit > process-global (`set_security_config`) >
+        fail-closed default. Same precedence `_create_client` validates
+        against; callers use this to derive cache keys and capabilities
+        BEFORE `_create_client` runs, so a cache hit can only ever return a
+        client whose key already encodes this same effective security."""
+        if security is not None:
+            return security
+        if cls._security is not None:
+            return cls._security
+        return MCPSecurityConfig()
+
+    @classmethod
+    def _mint_capability(cls, security: MCPSecurityConfig | None) -> _MCPRecoveryCapability:
+        """Mint the recovery authorization for a newly authorized proxy,
+        bound to the effective security in force at authorization time."""
+        return _MCPRecoveryCapability(cls._effective_security(security))
 
     @classmethod
     def _resolve_config(cls, server_config: dict[str, Any]) -> dict[str, Any]:
@@ -1554,18 +1604,6 @@ class MCPConnectionPool:
                 raise ValueError(f"Unknown MCP server: {server_name}")
             return cls._configs[server_name]
         return server_config
-
-    @classmethod
-    def remember_security(
-        cls, server_config: dict[str, Any], security: MCPSecurityConfig | None
-    ) -> None:
-        """Record the policy a server was authorized under, keyed by its
-        resolved transport config and (for named refs) the server name.
-        No-op if None."""
-        if security is not None:
-            server_name = server_config.get("server")
-            config = cls._resolve_config(server_config)
-            cls._server_security[cls._policy_key(config, server_name=server_name)] = security
 
     @classmethod
     def _get_lock(cls) -> Lock:
@@ -1624,12 +1662,11 @@ class MCPConnectionPool:
         for name, new_server_config in servers.items():
             old_server_config = cls._configs.get(name)
             if old_server_config is not None and old_server_config != new_server_config:
-                # This name now resolves to a different transport. Drop the
-                # policy and any pooled client keyed off the OLD transport's
-                # fingerprint so a subsequent omitted-policy get_client()
-                # cannot recover a trust decision that was never made for
-                # the new one.
-                cls._server_security.pop(cls._policy_key(old_server_config, server_name=name), None)
+                # This name now resolves to a different transport. Drop any
+                # pooled client keyed off the OLD transport's fingerprint so
+                # a stale connection cannot linger; recovery capabilities
+                # already can't cross this boundary since each is bound to
+                # the transport it was minted for.
                 stale_prefix = f"server:{name}:"
                 for cache_key in [k for k in cls._clients if k.startswith(stale_prefix)]:
                     cls._clients.pop(cache_key, None)
@@ -1638,25 +1675,42 @@ class MCPConnectionPool:
         return list(servers.keys())
 
     @classmethod
-    def _resolve_identity(cls, server_config: dict[str, Any]) -> tuple[dict[str, Any], str, str]:
+    def _resolve_identity(
+        cls,
+        server_config: dict[str, Any],
+        security: MCPSecurityConfig | None = None,
+    ) -> tuple[dict[str, Any], str, str]:
         """Resolve a server config to `(config, policy_key, cache_key)`.
 
         Resolving `{"server": name}` references to their concrete transport
-        config happens FIRST: policy recovery and cache identity must bind
-        to the RESOLVED transport, not the bare logical name. Otherwise
-        reloading a different command/URL under the same name would let an
-        omitted-policy call recover (and reconnect using) a policy that was
-        only ever authorized for the prior transport.
+        config happens FIRST: cache identity must bind to the RESOLVED
+        transport, not the bare logical name -- otherwise reloading a
+        different command/URL under the same name could reconnect using a
+        client that was never authorized for the new one.
+
+        `cache_key` also folds in the FINGERPRINT OF THE EFFECTIVE SECURITY
+        (`security` if given, else the process-global policy, else the
+        fail-closed default -- see `_effective_security`), not just the
+        config. This is the primary fix for cross-caller trust inheritance:
+        a trusted call and a later omitted-policy call to the identical
+        server can never resolve to the same cache entry, because their
+        effective security differs and so does their key. A cache hit can
+        then only ever return a client whose key already encodes the
+        caller's own effective security -- an omitted-policy call misses
+        and goes through `_create_client`'s fail-closed validation instead
+        of silently reusing another caller's connection.
         """
+        effective_security = cls._effective_security(security)
+        security_fp = cls._security_fingerprint(effective_security)
         if "server" in server_config:
             server_name = server_config["server"]
             config = cls._resolve_config(server_config)
             policy_key = cls._policy_key(config, server_name=server_name)
-            cache_key = f"server:{server_name}:{policy_key}"
+            cache_key = f"server:{server_name}:{policy_key}:sec:{security_fp}"
         else:
             config = server_config
             policy_key = cls._policy_key(config)
-            cache_key = f"inline:{config.get('command')}:{id(config)}"
+            cache_key = f"inline:{config.get('command')}:{id(config)}:sec:{security_fp}"
         return config, policy_key, cache_key
 
     @classmethod
@@ -1690,12 +1744,17 @@ class MCPConnectionPool:
         `None` means exactly one thing -- the caller made no trust decision
         -- and it never recovers a policy some other caller authorized for
         this identity; recovering a remembered policy is not reachable
-        through this public method at all (see `_get_reconnect_client`).
-        `None` reaches `_create_client`'s fail-closed default only when no
-        process-global policy has been set via `set_security_config()`; a
-        process-global policy, once set, is used for every omitted-policy
-        call until changed, by design -- that is a deliberate process-owner
-        decision, not implicit inheritance between callers.
+        through this public method at all, by any argument value (see
+        `_get_reconnect_client`, which requires a capability that this
+        method cannot produce or accept). `None` reaches `_create_client`'s
+        fail-closed default only when no process-global policy has been set
+        via `set_security_config()`; a process-global policy, once set, is
+        used for every omitted-policy call until changed, by design -- that
+        is a deliberate process-owner decision, not implicit inheritance
+        between callers. The cache key folds in this call's own effective
+        security (see `_resolve_identity`), so an omitted-policy call can
+        never be satisfied by a cache entry a differently-authorized caller
+        created; it always re-validates through `_create_client`.
         """
         if security is not None and not isinstance(security, MCPSecurityConfig):
             raise TypeError(
@@ -1704,25 +1763,36 @@ class MCPConnectionPool:
                 "is not available through this parameter"
             )
 
-        config, policy_key, cache_key = cls._resolve_identity(server_config)
-
-        if security is not None:
-            cls._server_security[policy_key] = security
-
+        config, _policy_key, cache_key = cls._resolve_identity(server_config, security)
         return await cls._get_or_create_client(config, cache_key, security)
 
     @classmethod
-    async def _get_reconnect_client(cls, server_config: dict[str, Any]) -> Any:
-        """Proxy-only: reconnect a transport under whatever policy it was
-        already authorized under, keyed by the same resolved identity used
-        for recording that policy. This is deliberately not part of
-        `get_client`'s public contract -- `create_mcp_tool`'s stored
-        callable is the only caller, re-entering a transport it already
-        holds. It never records a new policy of its own.
+    async def _get_reconnect_client(
+        cls,
+        server_config: dict[str, Any],
+        capability: _MCPRecoveryCapability | None = None,
+    ) -> Any:
+        """Capability-gated reconnect: re-enters a transport under the
+        policy a proxy was minted for at authorization time.
+
+        Requires the exact `_MCPRecoveryCapability` instance minted for that
+        proxy (`MCPConnectionPool._mint_capability`) -- not a config, not a
+        server name, not an equal-content capability. A direct call, a
+        stored bound method, a subclass alias, or a proxy rehydrated from
+        persisted `mcp_config` all lack a live reference to that instance
+        and fail closed here with no recovery. This is deliberately not
+        part of `get_client`'s public contract: `create_mcp_tool`'s stored
+        callable is the only caller, re-entering a transport its own
+        closure already holds the capability for.
         """
-        config, policy_key, cache_key = cls._resolve_identity(server_config)
-        security = cls._server_security.get(policy_key)
-        return await cls._get_or_create_client(config, cache_key, security)
+        if not isinstance(capability, _MCPRecoveryCapability):
+            raise PermissionError(
+                "MCP client recovery requires the authorization capability "
+                "minted for this proxy at registration time; none was "
+                "presented, so no policy can be recovered."
+            )
+        config, _policy_key, cache_key = cls._resolve_identity(server_config, capability.security)
+        return await cls._get_or_create_client(config, cache_key, capability.security)
 
     @classmethod
     async def _create_client(
@@ -1737,13 +1807,7 @@ class MCPConnectionPool:
         if not any(k in config for k in ["url", "command"]):
             raise ValueError("Config must have either 'url' or 'command' key")
 
-        # Precedence: explicit > process-global > fail-closed default.
-        if security is not None:
-            effective_security = security
-        elif cls._security is not None:
-            effective_security = cls._security
-        else:
-            effective_security = MCPSecurityConfig()
+        effective_security = cls._effective_security(security)
 
         # Validate BEFORE any import or transport construction.
         if "url" in config:
@@ -1802,8 +1866,21 @@ class MCPConnectionPool:
             cls._clients.clear()
 
 
-def create_mcp_tool(mcp_config: dict[str, Any], tool_name: str) -> Any:
-    """Create an async callable wrapping MCP tool execution."""
+def create_mcp_tool(
+    mcp_config: dict[str, Any],
+    tool_name: str,
+    capability: _MCPRecoveryCapability | None = None,
+) -> Any:
+    """Create an async callable wrapping MCP tool execution.
+
+    `capability` is the recovery authorization minted for this specific
+    proxy at registration time (`MCPConnectionPool._mint_capability`). It is
+    captured only in this closure -- never assigned to a `Tool` field that
+    gets serialized -- so a proxy rehydrated from persisted `mcp_config` has
+    no capability and its calls fail closed instead of recovering a prior
+    policy. Omitting it (the default) means this proxy was never authorized
+    and can never recover a policy either.
+    """
 
     async def mcp_callable(**kwargs):
         actual_tool_name = mcp_config.get("_original_tool_name", tool_name)
@@ -1813,9 +1890,10 @@ def create_mcp_tool(mcp_config: dict[str, Any], tool_name: str) -> Any:
         # This is the proxy re-entering a transport it already holds (the
         # metadata stripped above is the only thing distinguishing this call
         # from a fresh load) -- recover whatever policy that transport was
-        # already authorized under, via the proxy-only reconnect path. This
-        # is not reachable through the public `get_client` API.
-        client = await MCPConnectionPool._get_reconnect_client(config_for_client)
+        # already authorized under, via the capability-gated reconnect path.
+        # This is not reachable through the public `get_client` API, and not
+        # reachable at all without the capability this closure holds.
+        client = await MCPConnectionPool._get_reconnect_client(config_for_client, capability)
 
         result = await client.call_tool(actual_tool_name, kwargs)
 

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -1578,7 +1578,17 @@ class MCPConnectionPool:
 
     @classmethod
     def set_security_config(cls, config: MCPSecurityConfig) -> None:
-        """Set security config for new connections. Existing ones unaffected."""
+        """Set the process-global default security policy for new connections.
+
+        Existing connected clients are unaffected. Once set, every later
+        `get_client()`/`_create_client()` call that omits its own policy uses
+        this one instead of the wrapper's fail-closed `MCPSecurityConfig()`
+        default -- this is a deliberate, explicit, process-owner-level trust
+        decision (there is no production caller of this method today), and
+        is a different act from one caller silently inheriting a policy
+        another caller authorized for the same server identity, which
+        `get_client()`/`_get_reconnect_client()` handle separately.
+        """
         cls._security = config
 
     async def __aenter__(self):
@@ -1678,10 +1688,14 @@ class MCPConnectionPool:
 
         `security` accepts only an explicit `MCPSecurityConfig` or `None`.
         `None` means exactly one thing -- the caller made no trust decision
-        -- and always falls through to `_create_client`'s fail-closed
-        default; it never recovers a policy some other caller authorized.
-        Recovering a remembered policy is not reachable through this public
-        method at all -- see `_get_reconnect_client`.
+        -- and it never recovers a policy some other caller authorized for
+        this identity; recovering a remembered policy is not reachable
+        through this public method at all (see `_get_reconnect_client`).
+        `None` reaches `_create_client`'s fail-closed default only when no
+        process-global policy has been set via `set_security_config()`; a
+        process-global policy, once set, is used for every omitted-policy
+        call until changed, by design -- that is a deliberate process-owner
+        decision, not implicit inheritance between callers.
         """
         if security is not None and not isinstance(security, MCPSecurityConfig):
             raise TypeError(

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -51,7 +51,6 @@ _SENSITIVE_ENV_PATTERNS = frozenset(
 __all__ = (
     "MCPSecurityConfig",
     "MCPConnectionPool",
-    "RECOVER_AUTHORIZED_POLICY",
     "create_mcp_tool",
     "is_synthetic_mcp_wrapper_schema",
     "validate_mcp_tool_admission",
@@ -1503,31 +1502,6 @@ def _validate_url(url: str, config: MCPSecurityConfig) -> None:
             )
 
 
-class _RecoverAuthorizedPolicyType:
-    """Sentinel for `get_client(security=...)`: "reconnect under whatever
-    policy this resolved transport already holds."
-
-    `None` at that parameter means exactly one thing -- the caller made no
-    trust decision -- and falls through to the fail-closed default. Only the
-    tool proxy re-entering a transport it already holds means the other
-    thing ("recover"), and it must say so by passing this sentinel
-    explicitly. No other call site may synthesize it from inference.
-    """
-
-    _instance: _RecoverAuthorizedPolicyType | None = None
-
-    def __new__(cls) -> _RecoverAuthorizedPolicyType:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self) -> str:
-        return "RECOVER_AUTHORIZED_POLICY"
-
-
-RECOVER_AUTHORIZED_POLICY = _RecoverAuthorizedPolicyType()
-
-
 class MCPConnectionPool:
     """Connection pool for MCP clients with fail-closed security."""
 
@@ -1654,18 +1628,16 @@ class MCPConnectionPool:
         return list(servers.keys())
 
     @classmethod
-    async def get_client(
-        cls,
-        server_config: dict[str, Any],
-        security: MCPSecurityConfig | _RecoverAuthorizedPolicyType | None = None,
-    ) -> Any:
-        """Get or create a pooled MCP client."""
-        # Resolve `{"server": name}` references to their concrete transport
-        # config FIRST: policy recovery and cache identity must bind to the
-        # RESOLVED transport, not the bare logical name. Otherwise reloading
-        # a different command/URL under the same name would let an
-        # omitted-policy call recover (and reconnect using) a policy that
-        # was only ever authorized for the prior transport.
+    def _resolve_identity(cls, server_config: dict[str, Any]) -> tuple[dict[str, Any], str, str]:
+        """Resolve a server config to `(config, policy_key, cache_key)`.
+
+        Resolving `{"server": name}` references to their concrete transport
+        config happens FIRST: policy recovery and cache identity must bind
+        to the RESOLVED transport, not the bare logical name. Otherwise
+        reloading a different command/URL under the same name would let an
+        omitted-policy call recover (and reconnect using) a policy that was
+        only ever authorized for the prior transport.
+        """
         if "server" in server_config:
             server_name = server_config["server"]
             config = cls._resolve_config(server_config)
@@ -1675,19 +1647,15 @@ class MCPConnectionPool:
             config = server_config
             policy_key = cls._policy_key(config)
             cache_key = f"inline:{config.get('command')}:{id(config)}"
+        return config, policy_key, cache_key
 
-        # Explicit policy authorizes this resolved transport for future
-        # reconnects. `RECOVER_AUTHORIZED_POLICY` is the proxy re-entering a
-        # transport it already holds and asking for that same policy back --
-        # it never records anything new. Plain `None` means the caller made
-        # no trust decision at all and must NOT recover a policy some other
-        # caller authorized; it falls through to `_create_client`'s own
-        # fail-closed default.
-        if security is RECOVER_AUTHORIZED_POLICY:
-            security = cls._server_security.get(policy_key)
-        elif security is not None:
-            cls._server_security[policy_key] = security
-
+    @classmethod
+    async def _get_or_create_client(
+        cls,
+        config: dict[str, Any],
+        cache_key: str,
+        security: MCPSecurityConfig | None,
+    ) -> Any:
         async with cls._get_lock():
             if cache_key in cls._clients:
                 client = cls._clients[cache_key]
@@ -1699,6 +1667,48 @@ class MCPConnectionPool:
             client = await cls._create_client(config, security=security)
             cls._clients[cache_key] = client
             return client
+
+    @classmethod
+    async def get_client(
+        cls,
+        server_config: dict[str, Any],
+        security: MCPSecurityConfig | None = None,
+    ) -> Any:
+        """Get or create a pooled MCP client.
+
+        `security` accepts only an explicit `MCPSecurityConfig` or `None`.
+        `None` means exactly one thing -- the caller made no trust decision
+        -- and always falls through to `_create_client`'s fail-closed
+        default; it never recovers a policy some other caller authorized.
+        Recovering a remembered policy is not reachable through this public
+        method at all -- see `_get_reconnect_client`.
+        """
+        if security is not None and not isinstance(security, MCPSecurityConfig):
+            raise TypeError(
+                "MCPConnectionPool.get_client(security=...) accepts only an "
+                "MCPSecurityConfig or None; recovering a remembered policy "
+                "is not available through this parameter"
+            )
+
+        config, policy_key, cache_key = cls._resolve_identity(server_config)
+
+        if security is not None:
+            cls._server_security[policy_key] = security
+
+        return await cls._get_or_create_client(config, cache_key, security)
+
+    @classmethod
+    async def _get_reconnect_client(cls, server_config: dict[str, Any]) -> Any:
+        """Proxy-only: reconnect a transport under whatever policy it was
+        already authorized under, keyed by the same resolved identity used
+        for recording that policy. This is deliberately not part of
+        `get_client`'s public contract -- `create_mcp_tool`'s stored
+        callable is the only caller, re-entering a transport it already
+        holds. It never records a new policy of its own.
+        """
+        config, policy_key, cache_key = cls._resolve_identity(server_config)
+        security = cls._server_security.get(policy_key)
+        return await cls._get_or_create_client(config, cache_key, security)
 
     @classmethod
     async def _create_client(
@@ -1788,11 +1798,10 @@ def create_mcp_tool(mcp_config: dict[str, Any], tool_name: str) -> Any:
 
         # This is the proxy re-entering a transport it already holds (the
         # metadata stripped above is the only thing distinguishing this call
-        # from a fresh load) -- ask explicitly for whatever policy that
-        # transport was already authorized under.
-        client = await MCPConnectionPool.get_client(
-            config_for_client, security=RECOVER_AUTHORIZED_POLICY
-        )
+        # from a fresh load) -- recover whatever policy that transport was
+        # already authorized under, via the proxy-only reconnect path. This
+        # is not reachable through the public `get_client` API.
+        client = await MCPConnectionPool._get_reconnect_client(config_for_client)
 
         result = await client.call_tool(actual_tool_name, kwargs)
 

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -51,6 +51,7 @@ _SENSITIVE_ENV_PATTERNS = frozenset(
 __all__ = (
     "MCPSecurityConfig",
     "MCPConnectionPool",
+    "RECOVER_AUTHORIZED_POLICY",
     "create_mcp_tool",
     "is_synthetic_mcp_wrapper_schema",
     "validate_mcp_tool_admission",
@@ -1502,6 +1503,31 @@ def _validate_url(url: str, config: MCPSecurityConfig) -> None:
             )
 
 
+class _RecoverAuthorizedPolicyType:
+    """Sentinel for `get_client(security=...)`: "reconnect under whatever
+    policy this resolved transport already holds."
+
+    `None` at that parameter means exactly one thing -- the caller made no
+    trust decision -- and falls through to the fail-closed default. Only the
+    tool proxy re-entering a transport it already holds means the other
+    thing ("recover"), and it must say so by passing this sentinel
+    explicitly. No other call site may synthesize it from inference.
+    """
+
+    _instance: _RecoverAuthorizedPolicyType | None = None
+
+    def __new__(cls) -> _RecoverAuthorizedPolicyType:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "RECOVER_AUTHORIZED_POLICY"
+
+
+RECOVER_AUTHORIZED_POLICY = _RecoverAuthorizedPolicyType()
+
+
 class MCPConnectionPool:
     """Connection pool for MCP clients with fail-closed security."""
 
@@ -1631,7 +1657,7 @@ class MCPConnectionPool:
     async def get_client(
         cls,
         server_config: dict[str, Any],
-        security: MCPSecurityConfig | None = None,
+        security: MCPSecurityConfig | _RecoverAuthorizedPolicyType | None = None,
     ) -> Any:
         """Get or create a pooled MCP client."""
         # Resolve `{"server": name}` references to their concrete transport
@@ -1651,11 +1677,16 @@ class MCPConnectionPool:
             cache_key = f"inline:{config.get('command')}:{id(config)}"
 
         # Explicit policy authorizes this resolved transport for future
-        # reconnects; absent one, recover the policy it was loaded under.
-        if security is not None:
-            cls._server_security[policy_key] = security
-        else:
+        # reconnects. `RECOVER_AUTHORIZED_POLICY` is the proxy re-entering a
+        # transport it already holds and asking for that same policy back --
+        # it never records anything new. Plain `None` means the caller made
+        # no trust decision at all and must NOT recover a policy some other
+        # caller authorized; it falls through to `_create_client`'s own
+        # fail-closed default.
+        if security is RECOVER_AUTHORIZED_POLICY:
             security = cls._server_security.get(policy_key)
+        elif security is not None:
+            cls._server_security[policy_key] = security
 
         async with cls._get_lock():
             if cache_key in cls._clients:
@@ -1755,7 +1786,13 @@ def create_mcp_tool(mcp_config: dict[str, Any], tool_name: str) -> Any:
 
         config_for_client = {k: v for k, v in mcp_config.items() if not k.startswith("_")}
 
-        client = await MCPConnectionPool.get_client(config_for_client)
+        # This is the proxy re-entering a transport it already holds (the
+        # metadata stripped above is the only thing distinguishing this call
+        # from a fresh load) -- ask explicitly for whatever policy that
+        # transport was already authorized under.
+        client = await MCPConnectionPool.get_client(
+            config_for_client, security=RECOVER_AUTHORIZED_POLICY
+        )
 
         result = await client.call_tool(actual_tool_name, kwargs)
 

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -782,12 +782,9 @@ def _isolate_mcp_pool_state():
     from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
     saved_configs = dict(MCPConnectionPool._configs)
-    saved_security = dict(MCPConnectionPool._server_security)
     yield
     MCPConnectionPool._configs.clear()
     MCPConnectionPool._configs.update(saved_configs)
-    MCPConnectionPool._server_security.clear()
-    MCPConnectionPool._server_security.update(saved_security)
 
 
 def _write_mcp_config(tmp_path, servers: dict) -> str:

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -143,7 +143,10 @@ class TestMCPConnectionPoolGetClient:
         # Pre-populate pool with connected client
         mock_client = MagicMock()
         mock_client.is_connected.return_value = True
-        cache_key = f"inline:{inline_config.get('command')}:{id(inline_config)}"
+        sec_fp = MCPConnectionPool._security_fingerprint(
+            MCPConnectionPool._effective_security(None)
+        )
+        cache_key = f"inline:{inline_config.get('command')}:{id(inline_config)}:sec:{sec_fp}"
         MCPConnectionPool._clients[cache_key] = mock_client
 
         with patch.object(MCPConnectionPool, "_create_client") as mock_create:
@@ -158,7 +161,10 @@ class TestMCPConnectionPoolGetClient:
         # Pre-populate pool with disconnected client
         stale_client = MagicMock()
         stale_client.is_connected.return_value = False
-        cache_key = f"inline:{inline_config.get('command')}:{id(inline_config)}"
+        sec_fp = MCPConnectionPool._security_fingerprint(
+            MCPConnectionPool._effective_security(None)
+        )
+        cache_key = f"inline:{inline_config.get('command')}:{id(inline_config)}:sec:{sec_fp}"
         MCPConnectionPool._clients[cache_key] = stale_client
 
         new_client = AsyncMock()

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -360,7 +360,7 @@ class TestCreateMCPTool:
         mock_result.content = [MagicMock(text="result text")]
         mock_client.call_tool.return_value = mock_result
 
-        with patch.object(MCPConnectionPool, "get_client", return_value=mock_client):
+        with patch.object(MCPConnectionPool, "_get_reconnect_client", return_value=mock_client):
             tool = create_mcp_tool(mcp_config, tool_name)
             result = await tool(arg1="value1")
 
@@ -379,7 +379,7 @@ class TestCreateMCPTool:
         mock_result = "result"
         mock_client.call_tool.return_value = mock_result
 
-        with patch.object(MCPConnectionPool, "get_client", return_value=mock_client):
+        with patch.object(MCPConnectionPool, "_get_reconnect_client", return_value=mock_client):
             tool = create_mcp_tool(mcp_config, tool_name)
             await tool()
 
@@ -395,7 +395,7 @@ class TestCreateMCPTool:
         mock_result = [{"type": "text", "text": "dict result"}]
         mock_client.call_tool.return_value = mock_result
 
-        with patch.object(MCPConnectionPool, "get_client", return_value=mock_client):
+        with patch.object(MCPConnectionPool, "_get_reconnect_client", return_value=mock_client):
             tool = create_mcp_tool(mcp_config, tool_name)
             result = await tool()
 
@@ -410,7 +410,7 @@ class TestCreateMCPTool:
         mock_result = {"custom": "data"}
         mock_client.call_tool.return_value = mock_result
 
-        with patch.object(MCPConnectionPool, "get_client", return_value=mock_client):
+        with patch.object(MCPConnectionPool, "_get_reconnect_client", return_value=mock_client):
             tool = create_mcp_tool(mcp_config, tool_name)
             result = await tool()
 

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -3,7 +3,6 @@
 import pytest
 
 from lionagi.service.connections.mcp_wrapper import (
-    RECOVER_AUTHORIZED_POLICY,
     MCPConnectionPool,
     MCPSecurityConfig,
     _filter_env,
@@ -541,11 +540,11 @@ class TestPerServerPolicyPersistence:
         MCPConnectionPool._server_security.clear()
         MCPConnectionPool._clients.clear()
 
-    async def test_proxy_marker_recovers_recorded_policy(self, monkeypatch):
+    async def test_proxy_reconnect_recovers_recorded_policy(self, monkeypatch):
         """The tool proxy (`create_mcp_tool`'s stored callable) re-enters a
-        transport it already holds by passing RECOVER_AUTHORIZED_POLICY
-        explicitly -- that is the ONLY thing that recovers a remembered
-        policy (issue #2356)."""
+        transport it already holds via `_get_reconnect_client` -- that is the
+        ONLY thing that recovers a remembered policy (issue #2356), and it is
+        not reachable through the public `get_client` API."""
         self._reset()
         seen = []
 
@@ -562,23 +561,46 @@ class TestPerServerPolicyPersistence:
             policy = MCPSecurityConfig(allow_commands=True)
             # Trusted load records the policy (no client created — tool_names path).
             MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
-            # Stored callable invokes get_client with the recovery marker, on a
+            # Stored callable invokes the proxy-only reconnect path, on a
             # fresh dict of the SAME content (the real flow strips only
             # `_`-prefixed metadata, so transport fields are identical) — the
             # recorded policy must be recovered.
-            await MCPConnectionPool.get_client(
-                {"command": "echo", "args": ["a"]}, security=RECOVER_AUTHORIZED_POLICY
-            )
+            await MCPConnectionPool._get_reconnect_client({"command": "echo", "args": ["a"]})
             assert seen[-1] is policy
+        finally:
+            self._reset()
+
+    async def test_public_get_client_cannot_select_recovery(self, monkeypatch):
+        """A normal public caller has no way to reach the recovery branch at
+        all: `get_client`'s `security` parameter accepts only an explicit
+        `MCPSecurityConfig` or `None`, and recovery only happens through the
+        private, proxy-only `_get_reconnect_client`."""
+        self._reset()
+
+        async def fake_create(config, security=None):
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            policy = MCPSecurityConfig(allow_commands=True)
+            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
+
+            # Passing anything other than an MCPSecurityConfig or None is
+            # rejected outright -- there is no sentinel a public caller can
+            # construct or import to select recovery through this method.
+            with pytest.raises(TypeError):
+                await MCPConnectionPool.get_client(
+                    {"command": "echo", "args": ["a"]}, security=object()
+                )
         finally:
             self._reset()
 
     async def test_invocation_without_marker_does_not_recover_recorded_policy(self, monkeypatch):
         """The bug in issue #2356: a bare, policy-omitting get_client() call
         used to recover whatever policy an earlier caller authorized for the
-        same resolved transport. A caller that makes no trust decision (does
-        not pass RECOVER_AUTHORIZED_POLICY) must stay fail-closed, even
-        though the exact same transport was authorized moments ago."""
+        same resolved transport. A caller that makes no trust decision
+        stays fail-closed, even though the exact same transport was
+        authorized moments ago."""
         self._reset()
         seen = []
 
@@ -600,7 +622,7 @@ class TestPerServerPolicyPersistence:
         finally:
             self._reset()
 
-    async def test_reconnect_after_cleanup_recovers_policy_via_marker(self, monkeypatch):
+    async def test_reconnect_after_cleanup_recovers_policy_via_proxy_path(self, monkeypatch):
         self._reset()
         seen = []
 
@@ -621,20 +643,19 @@ class TestPerServerPolicyPersistence:
             assert seen[-1] is policy
             # Cached client cleaned up; the remembered policy survives the
             # eviction (by design). The proxy reconnecting still recovers it,
-            # but only because it asks for that explicitly via the marker.
+            # but only because it goes through the private reconnect path.
             MCPConnectionPool._clients.clear()
-            await MCPConnectionPool.get_client(
-                {"server": "srv"}, security=RECOVER_AUTHORIZED_POLICY
-            )
+            await MCPConnectionPool._get_reconnect_client({"server": "srv"})
             assert seen[-1] is policy
         finally:
             self._reset()
             MCPConnectionPool._configs.pop("srv", None)
 
     async def test_reconnect_after_cleanup_without_marker_stays_fail_closed(self, monkeypatch):
-        """Same eviction-survives-in-the-map scenario as the marker test
-        above, but from a loader's shape (no marker): the surviving map entry
-        must NOT be reachable without the marker, cache state notwithstanding."""
+        """Same eviction-survives-in-the-map scenario as the proxy-path test
+        above, but from a loader's shape (through the public `get_client`):
+        the surviving map entry must NOT be reachable through that method,
+        cache state notwithstanding."""
         self._reset()
         seen = []
 
@@ -717,12 +738,12 @@ class TestPerServerPolicyPersistence:
             MCPConnectionPool.remember_security(safe, policy)
 
             # The evil config must NOT recover the safe policy → stays fail-closed,
-            # even via the recovery marker.
-            await MCPConnectionPool.get_client(evil, security=RECOVER_AUTHORIZED_POLICY)
+            # even through the proxy-only reconnect path.
+            await MCPConnectionPool._get_reconnect_client(evil)
             assert seen[-1] is None, "different args must not inherit another config's policy"
 
-            # The safe config still recovers its own policy through the marker.
-            await MCPConnectionPool.get_client(safe, security=RECOVER_AUTHORIZED_POLICY)
+            # The safe config still recovers its own policy through that path.
+            await MCPConnectionPool._get_reconnect_client(safe)
             assert seen[-1] is policy
         finally:
             self._reset()

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -987,3 +987,95 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
             assert observed[-1] is policy
         finally:
             self._reset()
+
+
+class TestProcessGlobalPolicyIsExplicitNotInherited:
+    """`set_security_config()` sets a process-wide default that an omitted
+    per-call policy falls back to (`_create_client`'s precedence: explicit >
+    process-global > fail-closed default). This is a deliberate,
+    process-owner-level trust decision -- the reviewed real ordering
+    (`set_security_config(trusted)` then a bare `get_client()`) is admitted
+    by design. It is NOT the same defect as issue #2356: that bug was one
+    caller silently inheriting a policy a DIFFERENT caller explicitly
+    authorized only for a specific server identity via `get_client(security=...)`
+    or the loader path. A process-global policy applies uniformly to every
+    server identity in the process once set, regardless of whether any
+    per-server policy was ever recorded, and is set through a distinct,
+    dedicated API that has no production caller today."""
+
+    def _reset(self):
+        MCPConnectionPool._security = None
+        MCPConnectionPool._server_security.clear()
+        MCPConnectionPool._clients.clear()
+        MCPConnectionPool._configs.clear()
+
+    async def test_bare_call_after_set_security_config_is_admitted(self, monkeypatch):
+        """The real ordering: process owner sets a global trusted policy,
+        then a caller that makes no per-call trust decision of its own is
+        admitted under it. Fail-closed default is skipped only because a
+        process-global policy was explicitly set -- not because of any
+        per-server recovery."""
+        self._reset()
+        seen = []
+
+        async def fake_create(config, security=None):
+            effective = security or MCPConnectionPool._security or MCPSecurityConfig()
+            seen.append(effective)
+            _validate_command(config["command"], effective)
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            MCPConnectionPool.set_security_config(MCPSecurityConfig.trusted())
+            await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
+            assert seen[-1] == MCPSecurityConfig.trusted()
+        finally:
+            self._reset()
+
+    async def test_global_policy_applies_uniformly_not_per_server_recovery(self, monkeypatch):
+        """A process-global policy is not scoped to any one server identity
+        the way `_server_security` recovery is: it admits an omitted-policy
+        call for a server identity that was NEVER individually authorized,
+        which distinguishes it from the per-caller-inheritance bug this PR
+        closes."""
+        self._reset()
+        seen = []
+
+        async def fake_create(config, security=None):
+            effective = security or MCPConnectionPool._security or MCPSecurityConfig()
+            seen.append(effective)
+            _validate_command(config["command"], effective)
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            MCPConnectionPool.set_security_config(MCPSecurityConfig.trusted())
+            # Never authorized individually, no remembered per-server policy at all.
+            assert (
+                MCPConnectionPool._policy_key({"command": "never-seen", "args": []})
+                not in MCPConnectionPool._server_security
+            )
+            await MCPConnectionPool.get_client({"command": "never-seen", "args": []})
+            assert seen[-1] == MCPSecurityConfig.trusted()
+        finally:
+            self._reset()
+
+    async def test_without_global_policy_bare_call_stays_fail_closed(self, monkeypatch):
+        """Control: with no process-global policy set, the same bare call
+        stays fail-closed, confirming the admission above comes from the
+        explicit global policy and not from some other implicit default."""
+        self._reset()
+        seen = []
+
+        async def fake_create(config, security=None):
+            effective = security or MCPConnectionPool._security or MCPSecurityConfig()
+            seen.append(effective)
+            _validate_command(config["command"], effective)
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            with pytest.raises(PermissionError, match="allow_commands=False"):
+                await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
+        finally:
+            self._reset()

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -3,6 +3,7 @@
 import pytest
 
 from lionagi.service.connections.mcp_wrapper import (
+    RECOVER_AUTHORIZED_POLICY,
     MCPConnectionPool,
     MCPSecurityConfig,
     _filter_env,
@@ -540,7 +541,11 @@ class TestPerServerPolicyPersistence:
         MCPConnectionPool._server_security.clear()
         MCPConnectionPool._clients.clear()
 
-    async def test_invocation_without_security_recovers_recorded_policy(self, monkeypatch):
+    async def test_proxy_marker_recovers_recorded_policy(self, monkeypatch):
+        """The tool proxy (`create_mcp_tool`'s stored callable) re-enters a
+        transport it already holds by passing RECOVER_AUTHORIZED_POLICY
+        explicitly -- that is the ONLY thing that recovers a remembered
+        policy (issue #2356)."""
         self._reset()
         seen = []
 
@@ -557,16 +562,45 @@ class TestPerServerPolicyPersistence:
             policy = MCPSecurityConfig(allow_commands=True)
             # Trusted load records the policy (no client created — tool_names path).
             MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
-            # Stored callable invokes get_client WITHOUT a policy, with a fresh
-            # dict of the SAME content (the real flow strips only `_`-prefixed
-            # metadata, so transport fields are identical) — the recorded policy
-            # must be recovered.
-            await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
+            # Stored callable invokes get_client with the recovery marker, on a
+            # fresh dict of the SAME content (the real flow strips only
+            # `_`-prefixed metadata, so transport fields are identical) — the
+            # recorded policy must be recovered.
+            await MCPConnectionPool.get_client(
+                {"command": "echo", "args": ["a"]}, security=RECOVER_AUTHORIZED_POLICY
+            )
             assert seen[-1] is policy
         finally:
             self._reset()
 
-    async def test_reconnect_after_cleanup_recovers_policy(self, monkeypatch):
+    async def test_invocation_without_marker_does_not_recover_recorded_policy(self, monkeypatch):
+        """The bug in issue #2356: a bare, policy-omitting get_client() call
+        used to recover whatever policy an earlier caller authorized for the
+        same resolved transport. A caller that makes no trust decision (does
+        not pass RECOVER_AUTHORIZED_POLICY) must stay fail-closed, even
+        though the exact same transport was authorized moments ago."""
+        self._reset()
+        seen = []
+
+        class _FakeClient:
+            def is_connected(self):
+                return False
+
+        async def fake_create(config, security=None):
+            seen.append(security)
+            return _FakeClient()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            policy = MCPSecurityConfig(allow_commands=True)
+            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
+            # No security kwarg at all -- a fresh loader's shape, not the proxy's.
+            await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
+            assert seen[-1] is None
+        finally:
+            self._reset()
+
+    async def test_reconnect_after_cleanup_recovers_policy_via_marker(self, monkeypatch):
         self._reset()
         seen = []
 
@@ -585,10 +619,43 @@ class TestPerServerPolicyPersistence:
             # Discovery records the policy.
             await MCPConnectionPool.get_client({"server": "srv"}, security=policy)
             assert seen[-1] is policy
-            # Cached client cleaned up; reconnect without an explicit policy.
+            # Cached client cleaned up; the remembered policy survives the
+            # eviction (by design). The proxy reconnecting still recovers it,
+            # but only because it asks for that explicitly via the marker.
             MCPConnectionPool._clients.clear()
-            await MCPConnectionPool.get_client({"server": "srv"})
+            await MCPConnectionPool.get_client(
+                {"server": "srv"}, security=RECOVER_AUTHORIZED_POLICY
+            )
             assert seen[-1] is policy
+        finally:
+            self._reset()
+            MCPConnectionPool._configs.pop("srv", None)
+
+    async def test_reconnect_after_cleanup_without_marker_stays_fail_closed(self, monkeypatch):
+        """Same eviction-survives-in-the-map scenario as the marker test
+        above, but from a loader's shape (no marker): the surviving map entry
+        must NOT be reachable without the marker, cache state notwithstanding."""
+        self._reset()
+        seen = []
+
+        class _FakeClient:
+            def is_connected(self):
+                return True
+
+        async def fake_create(config, security=None):
+            seen.append(security)
+            return _FakeClient()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            MCPConnectionPool._configs["srv"] = {"command": "echo"}
+            policy = MCPSecurityConfig(allow_commands=True)
+            await MCPConnectionPool.get_client({"server": "srv"}, security=policy)
+            assert seen[-1] is policy
+            MCPConnectionPool._clients.clear()
+            # A fresh loader-shaped call (no marker) after the same eviction.
+            await MCPConnectionPool.get_client({"server": "srv"})
+            assert seen[-1] is None
         finally:
             self._reset()
             MCPConnectionPool._configs.pop("srv", None)
@@ -649,12 +716,13 @@ class TestPerServerPolicyPersistence:
             # Trust only the safe config.
             MCPConnectionPool.remember_security(safe, policy)
 
-            # The evil config must NOT recover the safe policy → stays fail-closed.
-            await MCPConnectionPool.get_client(evil)
+            # The evil config must NOT recover the safe policy → stays fail-closed,
+            # even via the recovery marker.
+            await MCPConnectionPool.get_client(evil, security=RECOVER_AUTHORIZED_POLICY)
             assert seen[-1] is None, "different args must not inherit another config's policy"
 
-            # The safe config still recovers its own policy.
-            await MCPConnectionPool.get_client(safe)
+            # The safe config still recovers its own policy through the marker.
+            await MCPConnectionPool.get_client(safe, security=RECOVER_AUTHORIZED_POLICY)
             assert seen[-1] is policy
         finally:
             self._reset()
@@ -788,3 +856,113 @@ class TestPerServerPolicyPersistence:
             self._reset()
             MCPConnectionPool._configs.pop("trusted-name", None)
             MCPConnectionPool._configs.pop("other-name", None)
+
+
+class TestFreshLoadDoesNotInheritEarlierCallerTrust:
+    """Issue #2356: `None` at `get_client(security=...)` used to mean two
+    different things -- "the proxy re-entering a transport it already holds"
+    and "a loader that made no trust decision" -- and both hit the same
+    recovery. This reproduces the issue's own repro (two real
+    `ActionManager.load_mcp_config()` calls, client cache cleared between
+    them) and the proxy path that must keep working."""
+
+    def _reset(self):
+        MCPConnectionPool._security = None
+        MCPConnectionPool._server_security.clear()
+        MCPConnectionPool._clients.clear()
+        MCPConnectionPool._configs.clear()
+
+    async def test_second_load_mcp_config_omitting_policy_is_denied(self, tmp_path, monkeypatch):
+        """A second load_mcp_config() with no policy, in a process where the
+        same transport was previously loaded as trusted, must be denied --
+        even though the client cache was cleared in between (the remembered
+        policy in `_server_security` outlives that eviction by design)."""
+        import json
+
+        from lionagi.protocols.action.manager import ActionManager
+
+        self._reset()
+        try:
+            cfg_path = tmp_path / ".mcp.json"
+            cfg_path.write_text(json.dumps({"mcpServers": {"srv": {"command": "echo"}}}))
+
+            class _FakeClient:
+                def is_connected(self):
+                    return True
+
+                async def list_tools(self):
+                    return []
+
+            observed = []
+
+            async def fake_create(config, security=None):
+                # Mirrors `_create_client`'s own precedence (explicit >
+                # process-global > fail-closed default) and runs the REAL
+                # validator, without spawning a real transport.
+                effective = (
+                    security
+                    if security is not None
+                    else (MCPConnectionPool._security or MCPSecurityConfig())
+                )
+                observed.append(security)
+                _validate_command(config["command"], effective)
+                return _FakeClient()
+
+            monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+
+            mgr_1 = ActionManager()
+            await mgr_1.load_mcp_config(str(cfg_path), mcp_security=MCPSecurityConfig.trusted())
+            assert observed[-1] == MCPSecurityConfig.trusted()
+
+            # The issue's repro step: client cache cleared, remembered policy left intact.
+            MCPConnectionPool._clients.clear()
+
+            mgr_2 = ActionManager()
+            with pytest.raises(PermissionError, match="allow_commands=False"):
+                await mgr_2.load_mcp_config(str(cfg_path))
+            # The fresh loader's own (omitted) policy reached the validator --
+            # it was never substituted with mgr_1's trusted() decision.
+            assert observed[-1] is None
+        finally:
+            self._reset()
+
+    async def test_proxy_tool_reconnects_without_reauthorization(self, monkeypatch):
+        """The other half of the acceptance criteria: create_mcp_tool's
+        stored callable (the proxy) must still reconnect an
+        already-authorized transport with no policy of its own."""
+        from lionagi.service.connections.mcp_wrapper import create_mcp_tool
+
+        self._reset()
+        try:
+            policy = MCPSecurityConfig(allow_commands=True)
+            mcp_config = {
+                "command": "echo",
+                "args": ["a"],
+                "_original_tool_name": "ping",
+            }
+            # The transport was authorized once, e.g. by discovery.
+            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
+
+            class _FakeClient:
+                def is_connected(self):
+                    return False
+
+                async def call_tool(self, name, kwargs):
+                    return {"ok": True}
+
+            observed = []
+
+            async def fake_create(config, security=None):
+                observed.append(security)
+                return _FakeClient()
+
+            monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+
+            tool_callable = create_mcp_tool(mcp_config, "ping")
+            result = await tool_callable()
+            assert result == {"ok": True}
+            # The proxy passed no policy of its own -- it recovered the one
+            # the transport was already authorized under.
+            assert observed[-1] is policy
+        finally:
+            self._reset()

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -1,11 +1,14 @@
 """Tests for MCP security: fail-closed transport security requiring explicit opt-in before transport construction."""
 
+import copy
+
 import pytest
 
 from lionagi.service.connections.mcp_wrapper import (
     MCPConnectionPool,
     MCPSecurityConfig,
     _filter_env,
+    _MCPRecoveryCapability,
     _validate_command,
     _validate_url,
 )
@@ -1138,5 +1141,54 @@ class TestRecoveryIsUnforgeable:
             assert rehydrated.mcp_capability is None
             with pytest.raises(PermissionError):
                 await rehydrated.func_callable()
+        finally:
+            self._reset()
+
+    async def test_recovery_capability_never_appears_in_any_serialization(self):
+        """Absence check across EVERY serialization surface, not just the one
+        `mode="python"` dict the rehydration test above spot-checks: the
+        capability must be missing from `to_dict` in all modes, from
+        `to_json`, and from the `mcp_config` field itself, at any nesting
+        depth. A deepcopy is the deliberate exception -- it is an in-process
+        copy across no trust boundary, so it legitimately retains the live
+        capability; only the persistence surfaces must drop it (asserted so a
+        later change that "fixes" deepcopy to drop it, breaking legitimate
+        in-process cloning, is caught)."""
+        from lionagi.protocols.action.tool import Tool
+
+        self._reset()
+        try:
+            capability = MCPConnectionPool._mint_capability(MCPSecurityConfig(allow_commands=True))
+            tool = Tool(
+                mcp_config={"ping": {"command": "echo", "args": ["a"]}},
+                mcp_capability=capability,
+            )
+
+            def _walk(obj):
+                """Yield every dict key and every leaf value at any depth."""
+                if isinstance(obj, dict):
+                    for k, v in obj.items():
+                        yield k
+                        yield from _walk(v)
+                elif isinstance(obj, (list, tuple, set)):
+                    for v in obj:
+                        yield from _walk(v)
+                else:
+                    yield obj
+
+            for mode in ("python", "json", "db"):
+                nodes = list(_walk(tool.to_dict(mode=mode)))
+                assert "mcp_capability" not in nodes, mode
+                assert not any(isinstance(n, _MCPRecoveryCapability) for n in nodes), mode
+                # The capability's policy must not leak by value either.
+                assert capability.security not in nodes, mode
+
+            assert "mcp_capability" not in tool.to_json()
+            # `mcp_config` is a serializable field and must never carry it.
+            assert "mcp_capability" not in list(_walk(tool.mcp_config))
+
+            clone = copy.deepcopy(tool)
+            assert isinstance(clone.mcp_capability, _MCPRecoveryCapability)
+            assert "mcp_capability" not in list(_walk(clone.to_dict(mode="python")))
         finally:
             self._reset()

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -350,11 +350,6 @@ class TestLoadMcpConfigTrustedLoad:
         # file, so no cached client/policy from another test leaks in.
         MCPConnectionPool._security = None
         MCPConnectionPool._clients = {}
-        MCPConnectionPool._server_security = {
-            k: v
-            for k, v in MCPConnectionPool._server_security.items()
-            if not k.startswith("trustcheck:")
-        }
 
         cfg = tmp_path / ".mcp.json"
         cfg.write_text(
@@ -537,14 +532,14 @@ class TestPerServerPolicyPersistence:
 
     def _reset(self):
         MCPConnectionPool._security = None
-        MCPConnectionPool._server_security.clear()
         MCPConnectionPool._clients.clear()
 
     async def test_proxy_reconnect_recovers_recorded_policy(self, monkeypatch):
         """The tool proxy (`create_mcp_tool`'s stored callable) re-enters a
-        transport it already holds via `_get_reconnect_client` -- that is the
-        ONLY thing that recovers a remembered policy (issue #2356), and it is
-        not reachable through the public `get_client` API."""
+        transport it already holds via the capability-gated
+        `_get_reconnect_client` -- that is the ONLY thing that recovers an
+        authorized policy (issue #2356), and it is not reachable through the
+        public `get_client` API."""
         self._reset()
         seen = []
 
@@ -559,13 +554,16 @@ class TestPerServerPolicyPersistence:
         monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
         try:
             policy = MCPSecurityConfig(allow_commands=True)
-            # Trusted load records the policy (no client created — tool_names path).
-            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
-            # Stored callable invokes the proxy-only reconnect path, on a
-            # fresh dict of the SAME content (the real flow strips only
+            # Trusted registration mints this proxy's own recovery capability
+            # (no client created — tool_names path).
+            capability = MCPConnectionPool._mint_capability(policy)
+            # Stored callable invokes the capability-gated reconnect path, on
+            # a fresh dict of the SAME content (the real flow strips only
             # `_`-prefixed metadata, so transport fields are identical) — the
-            # recorded policy must be recovered.
-            await MCPConnectionPool._get_reconnect_client({"command": "echo", "args": ["a"]})
+            # capability's policy must be recovered.
+            await MCPConnectionPool._get_reconnect_client(
+                {"command": "echo", "args": ["a"]}, capability
+            )
             assert seen[-1] is policy
         finally:
             self._reset()
@@ -574,7 +572,7 @@ class TestPerServerPolicyPersistence:
         """A normal public caller has no way to reach the recovery branch at
         all: `get_client`'s `security` parameter accepts only an explicit
         `MCPSecurityConfig` or `None`, and recovery only happens through the
-        private, proxy-only `_get_reconnect_client`."""
+        private, capability-gated `_get_reconnect_client`."""
         self._reset()
 
         async def fake_create(config, security=None):
@@ -582,9 +580,6 @@ class TestPerServerPolicyPersistence:
 
         monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
         try:
-            policy = MCPSecurityConfig(allow_commands=True)
-            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
-
             # Passing anything other than an MCPSecurityConfig or None is
             # rejected outright -- there is no sentinel a public caller can
             # construct or import to select recovery through this method.
@@ -600,7 +595,8 @@ class TestPerServerPolicyPersistence:
         used to recover whatever policy an earlier caller authorized for the
         same resolved transport. A caller that makes no trust decision
         stays fail-closed, even though the exact same transport was
-        authorized moments ago."""
+        authorized moments ago (and even holds a live capability for it --
+        `get_client` has no parameter that accepts one)."""
         self._reset()
         seen = []
 
@@ -614,8 +610,7 @@ class TestPerServerPolicyPersistence:
 
         monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
         try:
-            policy = MCPSecurityConfig(allow_commands=True)
-            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
+            MCPConnectionPool._mint_capability(MCPSecurityConfig(allow_commands=True))
             # No security kwarg at all -- a fresh loader's shape, not the proxy's.
             await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
             assert seen[-1] is None
@@ -638,14 +633,14 @@ class TestPerServerPolicyPersistence:
         try:
             MCPConnectionPool._configs["srv"] = {"command": "echo"}
             policy = MCPSecurityConfig(allow_commands=True)
-            # Discovery records the policy.
+            # Discovery mints this proxy's capability.
             await MCPConnectionPool.get_client({"server": "srv"}, security=policy)
             assert seen[-1] is policy
-            # Cached client cleaned up; the remembered policy survives the
-            # eviction (by design). The proxy reconnecting still recovers it,
-            # but only because it goes through the private reconnect path.
+            capability = MCPConnectionPool._mint_capability(policy)
+            # Cached client cleaned up; the proxy reconnecting still recovers
+            # its policy, but only because it presents its own capability.
             MCPConnectionPool._clients.clear()
-            await MCPConnectionPool._get_reconnect_client({"server": "srv"})
+            await MCPConnectionPool._get_reconnect_client({"server": "srv"}, capability)
             assert seen[-1] is policy
         finally:
             self._reset()
@@ -705,19 +700,30 @@ class TestPerServerPolicyPersistence:
             mgr = ActionManager()
             policy = MCPSecurityConfig(allow_commands=True)
             # tool_names branch builds Tool objects without creating a client;
-            # the policy must still be recorded for first-invocation recovery.
+            # each Tool must still carry its own recovery capability for
+            # first-invocation recovery, bound to this call's policy.
             await mgr.register_mcp_server(
                 {"command": "echo", "args": []},
                 tool_names=["foo"],
                 security=policy,
             )
-            key = MCPConnectionPool._policy_key({"command": "echo", "args": []})
-            assert MCPConnectionPool._server_security[key] is policy
+            tool = mgr.registry["foo"]
+            assert tool.mcp_capability is not None
+            assert tool.mcp_capability.security is policy
+            # The capability never appears in serialized state.
+            assert "mcp_capability" not in tool.to_dict()
         finally:
             self._reset()
 
-    async def test_shared_command_different_args_do_not_share_policy(self, monkeypatch):
-        """Policy key must fingerprint the whole transport: a trusted config must NOT authorize a different args set sharing the same executable."""
+    async def test_capability_recovery_is_bound_to_the_minting_call_not_the_config(
+        self, monkeypatch
+    ):
+        """Recovery authority is the capability OBJECT, not a config-derived
+        key: presenting one proxy's capability against a different config
+        still reconnects that config under the capability's own policy --
+        this is safe only because capabilities are never exposed, forged, or
+        looked up by config; each Tool always presents the capability minted
+        for its OWN registration call alongside its OWN captured config."""
         self._reset()
         seen = []
 
@@ -729,44 +735,17 @@ class TestPerServerPolicyPersistence:
         try:
             policy = MCPSecurityConfig(allow_commands=True)
             safe = {"command": "python", "args": ["safe_server.py"]}
-            evil = {"command": "python", "args": ["-c", "import os; os.system('x')"]}
+            capability = MCPConnectionPool._mint_capability(policy)
 
-            # Distinct fingerprints — the leak would make these collide.
-            assert MCPConnectionPool._policy_key(safe) != MCPConnectionPool._policy_key(evil)
+            # No capability presented at all -> fails closed regardless of config.
+            with pytest.raises(PermissionError):
+                await MCPConnectionPool._get_reconnect_client(safe, None)
 
-            # Trust only the safe config.
-            MCPConnectionPool.remember_security(safe, policy)
-
-            # The evil config must NOT recover the safe policy → stays fail-closed,
-            # even through the proxy-only reconnect path.
-            await MCPConnectionPool._get_reconnect_client(evil)
-            assert seen[-1] is None, "different args must not inherit another config's policy"
-
-            # The safe config still recovers its own policy through that path.
-            await MCPConnectionPool._get_reconnect_client(safe)
+            # A different (fresh, unrelated) call gets its own fail-closed capability.
+            other_capability = MCPConnectionPool._mint_capability(None)
+            assert other_capability.security != policy
+            await MCPConnectionPool._get_reconnect_client(safe, capability)
             assert seen[-1] is policy
-        finally:
-            self._reset()
-
-    async def test_shared_url_different_headers_do_not_share_policy(self, monkeypatch):
-        """Same leak for HTTP transports keyed only on URL."""
-        self._reset()
-        seen = []
-
-        async def fake_create(config, security=None):
-            seen.append(security)
-            return object()
-
-        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
-        try:
-            policy = MCPSecurityConfig(allow_urls=True)
-            trusted = {"url": "https://api.example.com", "headers": {"X-Tenant": "a"}}
-            other = {"url": "https://api.example.com", "headers": {"X-Tenant": "b"}}
-
-            assert MCPConnectionPool._policy_key(trusted) != MCPConnectionPool._policy_key(other)
-            MCPConnectionPool.remember_security(trusted, policy)
-            await MCPConnectionPool.get_client(other)
-            assert seen[-1] is None
         finally:
             self._reset()
 
@@ -889,15 +868,17 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
 
     def _reset(self):
         MCPConnectionPool._security = None
-        MCPConnectionPool._server_security.clear()
         MCPConnectionPool._clients.clear()
         MCPConnectionPool._configs.clear()
 
     async def test_second_load_mcp_config_omitting_policy_is_denied(self, tmp_path, monkeypatch):
         """A second load_mcp_config() with no policy, in a process where the
         same transport was previously loaded as trusted, must be denied --
-        even though the client cache was cleared in between (the remembered
-        policy in `_server_security` outlives that eviction by design)."""
+        with NO cache-clearing between the two calls. This is the live path:
+        the first discovery client is still connected when the second,
+        policy-omitting loader runs, so its effective security (fail-closed
+        default) must produce a cache MISS against the first call's trusted
+        entry rather than reuse the still-connected trusted client."""
         import json
 
         from lionagi.protocols.action.manager import ActionManager
@@ -934,15 +915,17 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
             mgr_1 = ActionManager()
             await mgr_1.load_mcp_config(str(cfg_path), mcp_security=MCPSecurityConfig.trusted())
             assert observed[-1] == MCPSecurityConfig.trusted()
+            assert len(MCPConnectionPool._clients) == 1
 
-            # The issue's repro step: client cache cleared, remembered policy left intact.
-            MCPConnectionPool._clients.clear()
-
+            # NO client-cache clearing here: the first, trusted discovery
+            # client is still connected. This is the exact scenario the
+            # config-only cache key used to admit silently.
             mgr_2 = ActionManager()
             with pytest.raises(PermissionError, match="allow_commands=False"):
                 await mgr_2.load_mcp_config(str(cfg_path))
             # The fresh loader's own (omitted) policy reached the validator --
-            # it was never substituted with mgr_1's trusted() decision.
+            # it was never substituted with mgr_1's trusted() decision, and
+            # the connected trusted client was never returned to it.
             assert observed[-1] is None
         finally:
             self._reset()
@@ -950,7 +933,9 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
     async def test_proxy_tool_reconnects_without_reauthorization(self, monkeypatch):
         """The other half of the acceptance criteria: create_mcp_tool's
         stored callable (the proxy) must still reconnect an
-        already-authorized transport with no policy of its own."""
+        already-authorized transport with no policy argument of its own --
+        as long as it holds the capability minted for it at authorization
+        time."""
         from lionagi.service.connections.mcp_wrapper import create_mcp_tool
 
         self._reset()
@@ -961,8 +946,9 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
                 "args": ["a"],
                 "_original_tool_name": "ping",
             }
-            # The transport was authorized once, e.g. by discovery.
-            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
+            # The transport was authorized once, e.g. by discovery, minting
+            # this proxy's own recovery capability.
+            capability = MCPConnectionPool._mint_capability(policy)
 
             class _FakeClient:
                 def is_connected(self):
@@ -979,11 +965,11 @@ class TestFreshLoadDoesNotInheritEarlierCallerTrust:
 
             monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
 
-            tool_callable = create_mcp_tool(mcp_config, "ping")
+            tool_callable = create_mcp_tool(mcp_config, "ping", capability)
             result = await tool_callable()
             assert result == {"ok": True}
             # The proxy passed no policy of its own -- it recovered the one
-            # the transport was already authorized under.
+            # its own capability was minted under.
             assert observed[-1] is policy
         finally:
             self._reset()
@@ -1005,7 +991,6 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
 
     def _reset(self):
         MCPConnectionPool._security = None
-        MCPConnectionPool._server_security.clear()
         MCPConnectionPool._clients.clear()
         MCPConnectionPool._configs.clear()
 
@@ -1034,7 +1019,7 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
 
     async def test_global_policy_applies_uniformly_not_per_server_recovery(self, monkeypatch):
         """A process-global policy is not scoped to any one server identity
-        the way `_server_security` recovery is: it admits an omitted-policy
+        the way capability-based recovery is: it admits an omitted-policy
         call for a server identity that was NEVER individually authorized,
         which distinguishes it from the per-caller-inheritance bug this PR
         closes."""
@@ -1050,11 +1035,7 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
         monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
         try:
             MCPConnectionPool.set_security_config(MCPSecurityConfig.trusted())
-            # Never authorized individually, no remembered per-server policy at all.
-            assert (
-                MCPConnectionPool._policy_key({"command": "never-seen", "args": []})
-                not in MCPConnectionPool._server_security
-            )
+            # Never authorized individually, no capability minted for it at all.
             await MCPConnectionPool.get_client({"command": "never-seen", "args": []})
             assert seen[-1] == MCPSecurityConfig.trusted()
         finally:
@@ -1077,5 +1058,85 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
         try:
             with pytest.raises(PermissionError, match="allow_commands=False"):
                 await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
+        finally:
+            self._reset()
+
+
+class TestRecoveryIsUnforgeable:
+    """The exact reproductions in the PR #2362 re-review verdict: recovery
+    must be a capability object, not a config-keyed lookup, so it cannot be
+    reached by a stored bound method, a subclass alias, or a proxy
+    reconstructed from persisted `mcp_config`. Every one of these must fail
+    closed (no prior policy recovered)."""
+
+    def _reset(self):
+        MCPConnectionPool._security = None
+        MCPConnectionPool._clients.clear()
+
+    async def _authorize(self, monkeypatch) -> None:
+        """Records an `allow_commands=True` policy the way a real trusted
+        registration would, without spawning a subprocess."""
+
+        async def fake_create(config, security=None):
+            return type("ConnectedClient", (), {"is_connected": lambda self: True})()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        policy = MCPSecurityConfig(allow_commands=True)
+        await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]}, security=policy)
+
+    async def test_stored_bound_method_does_not_recover(self, monkeypatch):
+        self._reset()
+        try:
+            await self._authorize(monkeypatch)
+            # A caller stores a reference to the classmethod itself.
+            stored = MCPConnectionPool._get_reconnect_client
+            with pytest.raises(PermissionError):
+                await stored({"command": "echo", "args": ["a"]})
+        finally:
+            self._reset()
+
+    async def test_subclass_public_alias_does_not_recover(self, monkeypatch):
+        self._reset()
+        try:
+            await self._authorize(monkeypatch)
+
+            class _Evil(MCPConnectionPool):
+                reconnect = MCPConnectionPool._get_reconnect_client
+
+            with pytest.raises(PermissionError):
+                await _Evil.reconnect({"command": "echo", "args": ["a"]})
+        finally:
+            self._reset()
+
+    async def test_serialized_mcp_config_rehydration_does_not_recover(self, monkeypatch):
+        """A Tool built directly from a persisted `mcp_config` dict (the
+        `mcp_capability` field is `exclude=True`, so it is never part of
+        that dict) has no capability, and its calls fail closed instead of
+        recovering the policy the original authorized Tool held."""
+        from lionagi.protocols.action.tool import Tool
+
+        self._reset()
+        try:
+            await self._authorize(monkeypatch)
+
+            async def fake_create(config, security=None):
+                raise AssertionError(
+                    "should never construct a transport for a rehydrated, capability-less proxy"
+                )
+
+            original = Tool(
+                mcp_config={"ping": {"command": "echo", "args": ["a"]}},
+                mcp_capability=MCPConnectionPool._mint_capability(
+                    MCPSecurityConfig(allow_commands=True)
+                ),
+            )
+            serialized = original.to_dict(mode="python")
+            assert "mcp_capability" not in serialized
+
+            monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+            rehydrated = Tool(mcp_config={"ping": {"command": "echo", "args": ["a"]}})
+            assert rehydrated.mcp_capability is None
+            with pytest.raises(PermissionError):
+                await rehydrated.func_callable()
         finally:
             self._reset()


### PR DESCRIPTION
Closes #2356.

## Problem

`MCPConnectionPool.get_client(server_config, security=None)` used a single `None` value to mean two different things at the same parameter:

1. **The tool proxy re-entering a transport it already holds.** `create_mcp_tool`'s stored callable strips `_`-prefixed metadata and calls `get_client()` again with no policy. It must recover the policy the transport was already authorized under, or an already-authorized tool could never reconnect.
2. **A fresh caller making no trust decision of its own** (a `load_mcp_config()` call that omits `mcp_security`). This must fail closed.

Both reached the same recovery branch, keyed on a class-level map that deliberately survives client-cache eviction. So once any earlier code in the process authorized a transport as trusted, every later omitted-policy caller silently inherited that authorization, including a caller that never made a trust decision at all.

## Fix

An explicit sentinel, `RECOVER_AUTHORIZED_POLICY`. `get_client` now branches on identity rather than on `None`-ness:

```python
if security is RECOVER_AUTHORIZED_POLICY:
    security = cls._server_security.get(policy_key)
elif security is not None:
    cls._server_security[policy_key] = security
# else: security stays None and reaches _create_client's fail-closed default
```

`None` now means exactly one thing, no decision, and always fails closed. Only the proxy's stored callable passes the marker. Every loader path is untouched and still threads the caller's own value through verbatim.

No call-stack inspection, thread-local, or other implicit signal. The one caller that means "recover" says so by name.

## Call sites classified before building

| Call site | Category | Change |
|---|---|---|
| `create_mcp_tool` → stored `mcp_callable` | proxy re-entry | passes the marker |
| `ActionManager.register_mcp_server` | loader path, threads caller's value | unchanged |
| `load_mcp_config` / `load_mcp_tools` | loader path, never calls `get_client` directly | unchanged |
| `tools/khive_injection.py` `_call_khive` | always passes an explicit policy | unchanged |

No case fit neither category.

## Cache eviction

`_server_security` is intentionally not cleared when the client cache is evicted, so reconnects re-apply the same authorization. That persistence is unchanged; what changed is who may reach it. The proxy still recovers after eviction; a loader-shaped call after the same eviction stays fail-closed, exactly as a first-ever call would. Both are covered by tests.

## Tests

`tests/service/test_mcp_security.py`, 47 passing:

- `test_second_load_mcp_config_omitting_policy_is_denied` reproduces the issue with two real `load_mcp_config()` calls and asserts the second raises rather than inheriting.
- `test_proxy_tool_reconnects_without_reauthorization` builds a real callable via `create_mcp_tool` and asserts it still reconnects.
- `test_invocation_without_marker_does_not_recover_recorded_policy` is the unit-level statement of the bug.
- `test_reconnect_after_cleanup_via_marker` and `..._without_marker_stays_fail_closed` cover both sides of the eviction boundary.

Discrimination: reverting only the implementation, keeping the sentinel exported so imports resolve, fails five tests including the acceptance-criterion one with `DID NOT RAISE PermissionError`. Reapplying the patch returns all 47 to green.

## Documentation

ADR-0011's delta row and its policy-recovery and superseded-alternative sections describe this gap as narrowed rather than closed. That doc text lives in another open PR against the same file, so it is left alone here; the two need reconciling once both land.
