### PR TITLE
fix(cli): don't conflate a post-DAG finalize error with a DAG failure

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -415,6 +415,7 @@ async def _teardown_common(
     extras: dict | None = None,
     identity_markers: dict | None = None,
     escalated_evidence: list[dict] | None = None,
+    finalize_error: dict | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -578,6 +579,30 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
+    # A post-completion finalize step (persistence/team-teardown) raised after
+    # the DAG itself already produced its result. That failure is real and must
+    # not be silently dropped, but it is not a DAG failure either — surface it
+    # via reason_code/metadata only, never by overwriting a "completed" status.
+    if finalize_error:
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["finalize_error"] = finalize_error
+        if final_status == "completed":
+            final_reason_code = RunReasons.COMPLETED_FINALIZE_ERROR
+            final_reason_summary = (
+                "DAG completed successfully; a post-completion finalize step raised "
+                f"{finalize_error.get('error_class', 'an error')}: "
+                f"{finalize_error.get('error', '')}"
+            )
+            final_evidence_refs = [
+                {
+                    "kind": "finalize_error",
+                    "id": finalize_error.get("error_class", "error"),
+                    "label": finalize_error.get("error", ""),
+                }
+            ]
+
     from lionagi.state.db import SESSION_TERMINAL_STATUSES, TransitionRejectedError
 
     # Snapshot of status observed at the start of this teardown; used only as the
@@ -678,6 +703,7 @@ async def teardown_persist(
     exception: BaseException | None = None,
     extras: dict | None = None,
     escalated_evidence: list[dict] | None = None,
+    finalize_error: dict | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -699,6 +725,7 @@ async def teardown_persist(
             extras=extras,
             identity_markers=ctx.get("identity_markers"),
             escalated_evidence=escalated_evidence,
+            finalize_error=finalize_error,
             cwd=cwd,
             engine_session_uid=engine_session_uid,
             defer_terminal=defer_terminal,

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -416,6 +416,7 @@ async def _teardown_common(
     identity_markers: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
+    artifact_write_error: dict | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -579,6 +580,32 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
+    # The synthesis artifact IS the run's output. A DAG that completed but
+    # whose output write raised has not delivered anything -- that is a real
+    # failure of the run, not a best-effort finalize hiccup, so this flips
+    # "completed" to "failed" instead of only annotating the reason code the
+    # way COMPLETED_FINALIZE_ERROR below does.
+    if artifact_write_error:
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["artifact_write_error"] = artifact_write_error
+        if final_status == "completed":
+            final_status = "failed"
+            final_reason_code = RunReasons.FAILED_ARTIFACT_WRITE
+            final_reason_summary = (
+                "DAG completed successfully but writing its output artifact raised "
+                f"{artifact_write_error.get('error_class', 'an error')}: "
+                f"{artifact_write_error.get('error', '')}"
+            )
+            final_evidence_refs = [
+                {
+                    "kind": "artifact_write_error",
+                    "id": artifact_write_error.get("error_class", "error"),
+                    "label": artifact_write_error.get("error", ""),
+                }
+            ]
+
     # A post-completion finalize step (persistence/team-teardown) raised after
     # the DAG itself already produced its result. That failure is real and must
     # not be silently dropped, but it is not a DAG failure either — surface it
@@ -704,6 +731,7 @@ async def teardown_persist(
     extras: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
+    artifact_write_error: dict | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -726,6 +754,7 @@ async def teardown_persist(
             identity_markers=ctx.get("identity_markers"),
             escalated_evidence=escalated_evidence,
             finalize_error=finalize_error,
+            artifact_write_error=artifact_write_error,
             cwd=cwd,
             engine_session_uid=engine_session_uid,
             defer_terminal=defer_terminal,

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -43,6 +43,7 @@ def _legacy_payload_builder(
             "kind": kind,
             "playbook": playbook,
             "status": envelope.terminal_status,
+            "reason_code": envelope.reason_code,
             "save_dir": save_dir,
             "cwd": cwd,
             "exit_class": exit_class,

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -1258,6 +1258,7 @@ async def stop_live_persist(
     extras = getattr(env, "_finalize_extras", None)
     escalated_evidence = getattr(env, "_escalated_evidence", None)
     finalize_error = getattr(env, "_finalize_error", None)
+    artifact_write_error = getattr(env, "_artifact_write_error", None)
     final_status = await teardown_persist(
         ctx,
         status=status,
@@ -1265,6 +1266,7 @@ async def stop_live_persist(
         extras=extras,
         escalated_evidence=escalated_evidence,
         finalize_error=finalize_error,
+        artifact_write_error=artifact_write_error,
         cwd=env.cwd,
     )
     env._run_manifest["status"] = final_status

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -1257,12 +1257,14 @@ async def stop_live_persist(
     ctx = env._live_persist
     extras = getattr(env, "_finalize_extras", None)
     escalated_evidence = getattr(env, "_escalated_evidence", None)
+    finalize_error = getattr(env, "_finalize_error", None)
     final_status = await teardown_persist(
         ctx,
         status=status,
         exception=exception,
         extras=extras,
         escalated_evidence=escalated_evidence,
+        finalize_error=finalize_error,
         cwd=env.cwd,
     )
     env._run_manifest["status"] = final_status

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -290,6 +290,33 @@ async def _resolve_invocation_terminal_flow(
                     metadata,
                 )
             if all(s == "completed" for s in child_statuses):
+                # A child can be "completed" (its DAG produced its result) yet
+                # carry COMPLETED_FINALIZE_ERROR because a guarded best-effort
+                # teardown step (team post, snapshot, resume pointer, graph)
+                # failed. Collapsing that into plain COMPLETED_OK here would
+                # make the invocation report clean success while the child's
+                # own record says a finalize step failed -- surface the same
+                # degraded reason at the invocation level instead of hiding it.
+                degraded = [
+                    s
+                    for s in sessions
+                    if str(s.get("status_reason_code") or "") == RunReasons.COMPLETED_FINALIZE_ERROR
+                ]
+                if degraded:
+                    degraded_metadata = dict(metadata)
+                    degraded_metadata["finalize_error_session_ids"] = [
+                        s["id"] for s in degraded if s.get("id")
+                    ]
+                    return (
+                        "completed",
+                        RunReasons.COMPLETED_FINALIZE_ERROR,
+                        "Flow completed successfully, but at least one child "
+                        "session recorded a non-output finalize error (a "
+                        "best-effort teardown step failed after that "
+                        "child's own DAG already produced its result).",
+                        [{"kind": "session", "id": s["id"]} for s in degraded if s.get("id")],
+                        degraded_metadata,
+                    )
                 return (
                     "completed",
                     RunReasons.COMPLETED_OK,
@@ -1507,10 +1534,35 @@ def _finalize_flow(
             )
             env._artifact_write_error = {"error_class": type(exc).__name__, "error": str(exc)}
 
-    try:
-        if env.team_data:
-            _post_results_to_team(env.team_data, agent_results, agent_ids, synthesis_result)
+    # Each best-effort side effect below is guarded independently: one
+    # raising (e.g. a stuck team-inbox file lock) must not skip the ones
+    # after it (snapshot, resume pointer, graph image).
+    finalize_errors: list[dict] = []
 
+    def _guard_finalize_step(label: str, fn) -> None:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "flow finalize step (%s) failed after the DAG already "
+                "completed; DAG result is unaffected: %s",
+                label,
+                exc,
+                exc_info=True,
+            )
+            finalize_errors.append(
+                {"step": label, "error_class": type(exc).__name__, "error": str(exc)}
+            )
+
+    if env.team_data:
+        _guard_finalize_step(
+            "team_post",
+            lambda: _post_results_to_team(
+                env.team_data, agent_results, agent_ids, synthesis_result
+            ),
+        )
+
+    def _snapshot_and_resume_pointer() -> None:
         # "agents" must cover every id "operations" (below) references, so it
         # walks agent_results (which includes spawned nodes), not just the
         # fixed-size plan-time assignments, or a spawned id resolves to nothing.
@@ -1555,23 +1607,31 @@ def _finalize_flow(
             },
         )
 
-        if show_graph:
+    _guard_finalize_step("snapshot", _snapshot_and_resume_pointer)
+
+    if show_graph:
+
+        def _write_graph_image() -> None:
             from lionagi.operations._visualize_graph import visualize_graph
 
-            with contextlib.suppress(Exception):
-                visualize_graph(
-                    env.builder,
-                    title=f"Flow DAG — {len(assignments)} assignments (+{n_spawned} spawned)",
-                    save_path=str(env.run.dag_image_path),
-                )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "flow finalize step failed after the DAG already completed; "
-            "DAG result is unaffected: %s",
-            exc,
-            exc_info=True,
-        )
-        env._finalize_error = {"error_class": type(exc).__name__, "error": str(exc)}
+            visualize_graph(
+                env.builder,
+                title=f"Flow DAG — {len(assignments)} assignments (+{n_spawned} spawned)",
+                save_path=str(env.run.dag_image_path),
+            )
+
+        _guard_finalize_step("graph", _write_graph_image)
+
+    if finalize_errors:
+        if len(finalize_errors) == 1:
+            env._finalize_error = {k: v for k, v in finalize_errors[0].items() if k != "step"}
+        else:
+            env._finalize_error = {
+                "error_class": "MultipleFinalizeErrors",
+                "error": "; ".join(
+                    f"{e['step']}: {e['error_class']}: {e['error']}" for e in finalize_errors
+                ),
+            }
 
     return output
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1462,15 +1462,27 @@ def _finalize_flow(
     output_format: str,
     show_graph: bool,
 ) -> str:
-    """Format output, write synthesis artifact, post team messages, and finalize run.
+    """Format output, write the synthesis artifact, then run best-effort teardown.
 
     The DAG already has its result by the time this runs, so ``output`` is
-    computed first and always returned. Everything below it is post-completion
-    persistence/teardown (synthesis file, team inbox post, branch snapshots,
-    run pointer) — best-effort. A failure there is a real defect but not a DAG
-    failure: it's caught and stashed on ``env._finalize_error`` for the run's
-    teardown to surface via its own reason code, rather than raising and
-    letting the caller conflate it with the DAG's own outcome.
+    computed first and always returned. The synthesis artifact write happens
+    next, ahead of everything else and outside any guard: it IS the run's
+    output, so a failure there is a real failure of the run, not a finalize
+    hiccup — it's stashed on ``env._artifact_write_error`` for the run's
+    teardown to flip the terminal status to "failed" over, rather than being
+    swallowed alongside best-effort side effects.
+
+    Everything after that — team inbox post, branch snapshots, resume
+    pointer, the DAG graph image — is post-completion persistence/telemetry
+    whose failure should never fail the run. It's caught and stashed on
+    ``env._finalize_error`` for the run's teardown to surface via its own
+    reason code, rather than raising and letting the caller conflate it with
+    the DAG's own outcome.
+
+    Ordering matters: the output write runs first and unguarded, so a
+    telemetry failure below can never prevent the output from being written,
+    and an output failure is recorded on its own field so a later guarded
+    failure can never mask it.
     """
     agent_results = exec_result.agent_results
     n_spawned = exec_result.n_spawned
@@ -1483,10 +1495,19 @@ def _finalize_flow(
     else:
         output = _format_result_text(agent_results, synthesis_result, header_fn=_flow_header_fn)
 
-    try:
-        if synthesis_result:
+    if synthesis_result:
+        try:
             env.run.synthesis_path.write_text(synthesis_result["response"])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "flow finalize: writing the synthesis artifact failed; the run "
+                "produced no output and cannot be reported as completed: %s",
+                exc,
+                exc_info=True,
+            )
+            env._artifact_write_error = {"error_class": type(exc).__name__, "error": str(exc)}
 
+    try:
         if env.team_data:
             _post_results_to_team(env.team_data, agent_results, agent_ids, synthesis_result)
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1462,7 +1462,16 @@ def _finalize_flow(
     output_format: str,
     show_graph: bool,
 ) -> str:
-    """Format output, write synthesis artifact, post team messages, and finalize run."""
+    """Format output, write synthesis artifact, post team messages, and finalize run.
+
+    The DAG already has its result by the time this runs, so ``output`` is
+    computed first and always returned. Everything below it is post-completion
+    persistence/teardown (synthesis file, team inbox post, branch snapshots,
+    run pointer) — best-effort. A failure there is a real defect but not a DAG
+    failure: it's caught and stashed on ``env._finalize_error`` for the run's
+    teardown to surface via its own reason code, rather than raising and
+    letting the caller conflate it with the DAG's own outcome.
+    """
     agent_results = exec_result.agent_results
     n_spawned = exec_result.n_spawned
     assignments = plan_result.assignments
@@ -1474,65 +1483,74 @@ def _finalize_flow(
     else:
         output = _format_result_text(agent_results, synthesis_result, header_fn=_flow_header_fn)
 
-    if synthesis_result:
-        env.run.synthesis_path.write_text(synthesis_result["response"])
+    try:
+        if synthesis_result:
+            env.run.synthesis_path.write_text(synthesis_result["response"])
 
-    if env.team_data:
-        _post_results_to_team(env.team_data, agent_results, agent_ids, synthesis_result)
+        if env.team_data:
+            _post_results_to_team(env.team_data, agent_results, agent_ids, synthesis_result)
 
-    # "agents" must cover every id "operations" (below) references, so it
-    # walks agent_results (which includes spawned nodes), not just the
-    # fixed-size plan-time assignments, or a spawned id resolves to nothing.
-    agents_meta = [
-        {
-            "id": agent_ids[i],
-            "name": agent_ids[i],
-            "model": worker_models[i],
-            "artifact_dir": str(env.run.agent_artifact_dir(agent_ids[i])),
-            "spawned": False,
-        }
-        for i in range(len(assignments))
-    ]
-    agents_meta.extend(
-        {
-            "id": r["agent_id"],
-            "name": r.get("assignee") or r["name"],
-            "model": r.get("model", ""),
-            "artifact_dir": str(env.run.agent_artifact_dir(r["agent_id"])),
-            "spawned": True,
-        }
-        for r in agent_results
-        if r.get("spawned")
-    )
+        # "agents" must cover every id "operations" (below) references, so it
+        # walks agent_results (which includes spawned nodes), not just the
+        # fixed-size plan-time assignments, or a spawned id resolves to nothing.
+        agents_meta = [
+            {
+                "id": agent_ids[i],
+                "name": agent_ids[i],
+                "model": worker_models[i],
+                "artifact_dir": str(env.run.agent_artifact_dir(agent_ids[i])),
+                "spawned": False,
+            }
+            for i in range(len(assignments))
+        ]
+        agents_meta.extend(
+            {
+                "id": r["agent_id"],
+                "name": r.get("assignee") or r["name"],
+                "model": r.get("model", ""),
+                "artifact_dir": str(env.run.agent_artifact_dir(r["agent_id"])),
+                "spawned": True,
+            }
+            for r in agent_results
+            if r.get("spawned")
+        )
 
-    finalize_orchestration(
-        env,
-        kind="flow",
-        prompt=prompt,
-        extras={
-            "agents": agents_meta,
-            "operations": [
-                {
-                    "id": r["id"],
-                    "agent_id": r["agent_id"],
-                    "control": False,
-                    "spawned": r.get("spawned", False),
-                    "depends_on": r.get("depends_on") or [],
-                }
-                for r in agent_results
-            ],
-        },
-    )
+        finalize_orchestration(
+            env,
+            kind="flow",
+            prompt=prompt,
+            extras={
+                "agents": agents_meta,
+                "operations": [
+                    {
+                        "id": r["id"],
+                        "agent_id": r["agent_id"],
+                        "control": False,
+                        "spawned": r.get("spawned", False),
+                        "depends_on": r.get("depends_on") or [],
+                    }
+                    for r in agent_results
+                ],
+            },
+        )
 
-    if show_graph:
-        from lionagi.operations._visualize_graph import visualize_graph
+        if show_graph:
+            from lionagi.operations._visualize_graph import visualize_graph
 
-        with contextlib.suppress(Exception):
-            visualize_graph(
-                env.builder,
-                title=f"Flow DAG — {len(assignments)} assignments (+{n_spawned} spawned)",
-                save_path=str(env.run.dag_image_path),
-            )
+            with contextlib.suppress(Exception):
+                visualize_graph(
+                    env.builder,
+                    title=f"Flow DAG — {len(assignments)} assignments (+{n_spawned} spawned)",
+                    save_path=str(env.run.dag_image_path),
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "flow finalize step failed after the DAG already completed; "
+            "DAG result is unaffected: %s",
+            exc,
+            exc_info=True,
+        )
+        env._finalize_error = {"error_class": type(exc).__name__, "error": str(exc)}
 
     return output
 

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -78,6 +78,11 @@ class RunReasons:
     FAILED_ESCALATED = "run.failed.escalated"  # undeclared-artifact backstop
     # Loop exited clean but no commits/artifacts were produced (completion-trust gate).
     COMPLETED_EMPTY_NO_EVIDENCE = "run.completed_empty.no_evidence"
+    # DAG produced a genuine result but a post-completion finalize step
+    # (persistence/team-teardown) raised. Status stays "completed" — the
+    # DAG's own outcome, not the finalize step's — this reason code is what
+    # distinguishes it from a clean COMPLETED_OK run.
+    COMPLETED_FINALIZE_ERROR = "run.completed.finalize_error"
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
     CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -83,6 +83,13 @@ class RunReasons:
     # DAG's own outcome, not the finalize step's — this reason code is what
     # distinguishes it from a clean COMPLETED_OK run.
     COMPLETED_FINALIZE_ERROR = "run.completed.finalize_error"
+    # The DAG itself completed, but writing its own output (the synthesis
+    # artifact) raised. Unlike COMPLETED_FINALIZE_ERROR, this is a real
+    # failure: a run that cannot deliver its output has not succeeded, so
+    # status flips to "failed" rather than staying "completed". Distinct
+    # from FAILED_MISSING_ARTIFACT (ADR-0029), which is a post-hoc contract
+    # verification gap rather than a raised exception during the write.
+    FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
     CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -1321,6 +1321,79 @@ def test_finalize_flow_agents_includes_spawned_node(tmp_path):
     assert spawned_agent["spawned"] is True
 
 
+# ── issue #2053: post-DAG finalize failures must not become DAG failures ──────
+
+
+def test_finalize_flow_team_post_failure_still_returns_output_and_records_error(tmp_path):
+    """A DAG that already produced its result must not lose that result because
+    a post-completion step (posting to the team inbox) raised. `_finalize_flow`
+    must still return the formatted output and stash the failure on
+    `env._finalize_error` instead of letting it propagate — a caller that let
+    this propagate used to have `_run_flow`'s `except BaseException` handler
+    reclassify a clean DAG completion as `failed` (classify_exception maps any
+    non-timeout/cancel exception to "failed")."""
+    env = _make_env(tmp_path, team_data={"id": "team-x", "name": "team-x"})
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {
+                "id": "researcher",
+                "agent_id": "researcher",
+                "name": "researcher",
+                "model": "codex/gpt-5.5",
+                "depends_on": [],
+                "spawned": False,
+                "response": "great research",
+                "time_ms": 100,
+            }
+        ],
+        n_spawned=0,
+        t_exec_elapsed=1.0,
+    )
+
+    with (
+        patch(
+            "lionagi.cli.orchestrate.flow._post_results_to_team",
+            side_effect=RuntimeError("team inbox lock timed out"),
+        ),
+        patch("lionagi.cli.orchestrate.flow.finalize_orchestration"),
+    ):
+        output = _finalize_flow(
+            env,
+            "task",
+            plan_result,
+            dag_state,
+            exec_result,
+            None,
+            output_format="text",
+            show_graph=False,
+        )
+
+    # The DAG's own result must survive the finalize-step failure.
+    assert isinstance(output, str)
+    assert len(output) > 0
+    # The failure is recorded, not silently dropped, but on its own field.
+    assert env._finalize_error is not None
+    assert env._finalize_error["error_class"] == "RuntimeError"
+    assert "team inbox lock timed out" in env._finalize_error["error"]
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -1394,6 +1394,95 @@ def test_finalize_flow_team_post_failure_still_returns_output_and_records_error(
     assert "team inbox lock timed out" in env._finalize_error["error"]
 
 
+def test_finalize_flow_artifact_write_failure_is_split_from_finalize_error(tmp_path):
+    """The synthesis artifact IS the run's output, not a best-effort finalize
+    side effect — a failure writing it must land on its own field
+    (`env._artifact_write_error`), distinct from `env._finalize_error`, and
+    must not prevent the rest of teardown (team post, `finalize_orchestration`)
+    from still running. Pre-split, this write shared the same try/except as
+    the team-inbox post and would have landed on `env._finalize_error`
+    instead — which the run's teardown treats as a mere hiccup that leaves
+    status="completed", exactly the "exit 0 with no artifact" outcome this
+    fix must prevent."""
+    finalize_calls: list = []
+
+    def _fake_finalize(env, *, kind, prompt, extras=None):
+        finalize_calls.append(extras)
+
+    env = _make_env(tmp_path, team_data={"id": "team-x", "name": "team-x"})
+    bad_synthesis_path = MagicMock()
+    bad_synthesis_path.write_text.side_effect = OSError("disk full")
+    env.run.synthesis_path = bad_synthesis_path
+
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {
+                "id": "researcher",
+                "agent_id": "researcher",
+                "name": "researcher",
+                "model": "codex/gpt-5.5",
+                "depends_on": [],
+                "spawned": False,
+                "response": "great research",
+                "time_ms": 100,
+            }
+        ],
+        n_spawned=1,
+        t_exec_elapsed=1.0,
+    )
+    synthesis_result = {
+        "model": "codex/gpt-5.5",
+        "response": "the synthesized answer",
+        "time_ms": 500,
+    }
+
+    with (
+        patch("lionagi.cli.orchestrate.flow._post_results_to_team") as fake_post,
+        patch("lionagi.cli.orchestrate.flow.finalize_orchestration", side_effect=_fake_finalize),
+    ):
+        output = _finalize_flow(
+            env,
+            "task",
+            plan_result,
+            dag_state,
+            exec_result,
+            synthesis_result,
+            output_format="text",
+            show_graph=False,
+        )
+
+    assert isinstance(output, str)
+    assert len(output) > 0
+
+    # The failure is on its own field, not folded into env._finalize_error.
+    assert env._artifact_write_error is not None
+    assert env._artifact_write_error["error_class"] == "OSError"
+    assert "disk full" in env._artifact_write_error["error"]
+    assert getattr(env, "_finalize_error", None) is None
+
+    # The guarded, non-output side effects still ran — an output failure
+    # must not block best-effort teardown.
+    fake_post.assert_called_once()
+    assert len(finalize_calls) == 1
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1414,6 +1414,65 @@ async def test_stop_finalize_error_does_not_override_real_dag_failure_reason(
     assert s["status_reason_code"] == "run.failed.exception"
 
 
+# ── output-write failure is a real failure, not a finalize hiccup ─────────────
+
+
+async def test_stop_artifact_write_error_flips_completed_to_failed_with_distinct_reason(
+    temp_db_path: Path,
+):
+    """Unlike a finalize hiccup (team post, snapshots), the synthesis artifact
+    IS the run's output. A DAG that completed but whose output write raised
+    must be reported as failed (exit 1), not completed — exit 0 with no
+    artifact is a success claim for a run that produced nothing. This must
+    fail against the pre-split code, where the write shared the same
+    `env._finalize_error` field as best-effort side effects and never
+    flipped `final_status`."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    # Mirrors what _finalize_flow (lionagi/cli/orchestrate/flow.py) stashes on
+    # the env when writing the synthesis artifact itself raises.
+    env._artifact_write_error = {"error_class": "OSError", "error": "disk full"}
+
+    final_status = await stop_live_persist(env, status="completed")
+    assert final_status == "failed"
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.artifact_write"
+    assert s["status_reason_code"] not in ("run.completed.ok", "run.completed.finalize_error")
+    assert "OSError" in s["status_reason_summary"]
+
+
+async def test_stop_artifact_write_error_does_not_override_real_dag_failure_reason(
+    temp_db_path: Path,
+):
+    """When the DAG itself failed for an unrelated reason, an artifact-write
+    error found alongside it must not mask the real failure reason — the
+    original exception's reason code stays, with the write error recorded
+    only in metadata."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    env._artifact_write_error = {"error_class": "OSError", "error": "disk full"}
+    dag_exc = RuntimeError("planner blew up")
+
+    final_status = await stop_live_persist(env, status="failed", exception=dag_exc)
+    assert final_status == "failed"
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.exception"
+
+
 # ── ADR-0064 + ADR-0057: session→invocation propagation on missing artifact ──
 #
 # The tests above prove the *session* row flips to failed/FAILED_MISSING_ARTIFACT.

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1953,6 +1953,184 @@ async def test_all_legs_completed_resolves_invocation_completed(
     assert inv_status == "completed"
 
 
+async def test_child_finalize_error_surfaces_at_invocation_not_flattened_to_ok(
+    temp_db_path: Path,
+):
+    """issue #2053, seam 2: a child session can be "completed" (its own DAG
+    produced its result) while carrying a COMPLETED_FINALIZE_ERROR reason
+    (a guarded best-effort teardown step -- team post, snapshot, resume
+    pointer, graph -- failed). _resolve_invocation_terminal_flow must not
+    flatten that into plain COMPLETED_OK: a reader of the invocation record
+    needs to see the same degraded-but-not-failed distinction the child
+    record already carries, not a false "all clean" signal.
+
+    This must FAIL against the pre-fix resolver, which only inspects
+    child_statuses (all "completed") and returns RunReasons.COMPLETED_OK
+    regardless of status_reason_code.
+    """
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-child-finalize-error"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+
+    # Mirrors what _finalize_flow stashes on the env when a post-DAG,
+    # non-output finalize step (e.g. the team-inbox post) raises after the
+    # DAG already produced its result.
+    env._finalize_error = {"error_class": "TimeoutError", "error": "team lock timed out"}
+
+    final_status = await stop_live_persist(env, status="completed")
+    assert final_status == "completed"
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] == RunReasons.COMPLETED_FINALIZE_ERROR
+
+    (
+        inv_status,
+        inv_reason_code,
+        inv_summary,
+        inv_evidence,
+        _inv_metadata,
+    ) = await _resolve_invocation_terminal_flow(invocation_id, fallback_status="completed")
+
+    # The DAG's own work succeeded -- do not fail the run for a best-effort
+    # teardown step.
+    assert inv_status == "completed"
+    # But the degraded reason must survive the child->invocation hop, not
+    # collapse into indistinguishable clean success.
+    assert inv_reason_code == RunReasons.COMPLETED_FINALIZE_ERROR
+    assert inv_reason_code != RunReasons.COMPLETED_OK
+    assert any(e.get("id") == ctx["session_id"] for e in inv_evidence)
+
+    # Persist and read back exactly as _run_flow's finally block does --
+    # "the record a status-reader sees" for the invocation itself.
+    async with StateDB() as db:
+        await db.update_status(
+            "invocation",
+            invocation_id,
+            new_status=inv_status,
+            reason_code=inv_reason_code,
+            reason_summary=inv_summary,
+            evidence_refs=inv_evidence,
+            source="executor",
+            actor=invocation_id,
+            metadata=_inv_metadata,
+        )
+        inv_row = await db.get_invocation(invocation_id)
+    assert inv_row is not None
+    assert inv_row["status"] == "completed"
+    assert inv_row["status_reason_code"] == RunReasons.COMPLETED_FINALIZE_ERROR
+
+
+async def test_finalize_side_effects_guarded_independently(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """issue #2053, secondary: the best-effort finalize side effects (team
+    post, snapshot/resume-pointer, graph image) must each be guarded on
+    their own -- a raising team post must not skip the snapshot/resume
+    pointer step that runs after it.
+
+    This must FAIL against the pre-fix code, where all three shared one
+    try/except: the first raise (team post) skipped `finalize_orchestration`
+    entirely, so no session snapshot/resume pointer was ever written.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+    from lionagi.cli.orchestrate.flow import (
+        _DagState,
+        _ExecResult,
+        _finalize_flow,
+        _PlanResult,
+    )
+
+    monkeypatch.setattr(orch_mod, "save_last_branch_pointer", lambda run_id, bid: None)
+
+    env = _minimal_env()
+    env.team_data = {"id": "team-x", "name": "team-x"}
+    configure_run_for_finalize(env, tmp_path)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    plan_result = _PlanResult(
+        assignments=[SimpleNamespace(assignee="worker")],
+        agent_ids=["op1"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["op1"],
+        known_nodes={"op1"},
+        deps_by_node={"op1": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {
+                "id": "op1",
+                "agent_id": "op1",
+                "name": "worker",
+                "assignee": "worker",
+                "response": "done",
+                "model": "claude",
+                "spawned": False,
+                "time_ms": 100.0,
+            }
+        ],
+        n_spawned=0,
+        t_exec_elapsed=0.1,
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate.flow._post_results_to_team",
+        side_effect=RuntimeError("team lock timed out"),
+    ):
+        _finalize_flow(
+            env,
+            "do the thing",
+            plan_result,
+            dag_state,
+            exec_result,
+            None,
+            output_format="text",
+            show_graph=False,
+        )
+
+    assert env._finalize_error is not None
+    assert env._finalize_error["error_class"] == "RuntimeError"
+
+    final_status = await stop_live_persist(env, status="completed")
+    assert final_status == "completed"
+
+    async with StateDB() as db:
+        session = await db.get_session(ctx["session_id"])
+    assert session is not None
+    assert session["status_reason_code"] == "run.completed.finalize_error"
+    node_metadata = session["node_metadata"]
+    assert isinstance(node_metadata, dict)
+    # The snapshot/resume-pointer step (finalize_orchestration) ran despite
+    # the earlier team-post failure -- proven by its extras landing in
+    # node_metadata.
+    assert node_metadata.get("agents") is not None
+    assert node_metadata["agents"][0]["id"] == "op1"
+
+
 # ── bench545 regressions: plan-time per-leg wiring + escalation backstop ──────
 #
 # Both tests below reproduce the actual production gap (play fe9a23ac,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1357,6 +1357,63 @@ async def test_stop_verification_preserves_non_completed_reason(
     assert v["status"] == "failed"
 
 
+# ── issue #2053: post-completion finalize error must not flip a successful DAG ──
+
+
+async def test_stop_finalize_error_stays_completed_with_distinct_reason(
+    temp_db_path: Path,
+):
+    """A DAG that completed cleanly, but whose post-completion finalize step
+    (team-teardown/persistence) raised, must keep status="completed" (exit 0)
+    — the finalize error surfaces via its own reason code instead of flipping
+    the run's terminal status, and is distinguishable from both a clean
+    completion and a real DAG failure."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    # Mirrors what _finalize_flow (lionagi/cli/orchestrate/flow.py) stashes on
+    # the env when a post-DAG finalize step (e.g. _post_results_to_team's file
+    # lock) raises after the DAG already produced its result.
+    env._finalize_error = {"error_class": "TimeoutError", "error": "team lock timed out"}
+
+    final_status = await stop_live_persist(env, status="completed")
+    assert final_status == "completed"
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] == "run.completed.finalize_error"
+    assert s["status_reason_code"] not in ("run.completed.ok", "run.failed.exception")
+    assert "TimeoutError" in s["status_reason_summary"]
+
+
+async def test_stop_finalize_error_does_not_override_real_dag_failure_reason(
+    temp_db_path: Path,
+):
+    """When the DAG itself failed, a finalize error must not mask the real
+    failure reason — it's recorded, but FAILED_EXCEPTION (or whatever the DAG
+    raised) stays the reason code, not COMPLETED_FINALIZE_ERROR."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    env._finalize_error = {"error_class": "OSError", "error": "disk full"}
+    dag_exc = RuntimeError("planner blew up")
+
+    final_status = await stop_live_persist(env, status="failed", exception=dag_exc)
+    assert final_status == "failed"
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.exception"
+
+
 # ── ADR-0064 + ADR-0057: session→invocation propagation on missing artifact ──
 #
 # The tests above prove the *session* row flips to failed/FAILED_MISSING_ARTIFACT.

--- a/tests/cli/orchestrate/test_notify.py
+++ b/tests/cli/orchestrate/test_notify.py
@@ -25,6 +25,7 @@ from lionagi.state.lifecycle.callbacks import (
     TerminalCallbackRegistry,
 )
 from lionagi.state.lifecycle.notify_settings import ResolvedNotifyHandler, build_handler
+from lionagi.state.reasons import RunReasons
 
 
 def _capture_command(out_file: Path) -> str:
@@ -75,6 +76,7 @@ async def test_registered_scope_fires_with_legacy_payload_shape(tmp_path: Path):
         "kind": "flow",
         "playbook": None,
         "status": "completed",
+        "reason_code": "run.completed.ok",
         "save_dir": "/tmp/saves",
         "cwd": "/repo",
         "exit_class": "success",
@@ -84,6 +86,64 @@ async def test_registered_scope_fires_with_legacy_payload_shape(tmp_path: Path):
 
     unregister_flow_notify_scope(name, registry)
     assert name not in registry
+
+
+async def test_payload_carries_reason_code_for_degraded_finalize(tmp_path: Path):
+    """A `completed` run whose finalize step degraded must still notify
+    `status="completed", exit_class="success"` (the primary work did
+    complete) but distinguish itself from a clean run via `reason_code` --
+    otherwise a --notify consumer can't tell the two apart."""
+    degraded_out = tmp_path / "degraded.json"
+    ok_out = tmp_path / "ok.json"
+    registry = TerminalCallbackRegistry()
+
+    name = register_flow_notify_scope(
+        registry,
+        override=_capture_command(degraded_out),
+        entity_kind="invocation",
+        entity_id="inv-degraded",
+        invocation_id="inv-degraded",
+        flow_kind="flow",
+        playbook=None,
+        save_dir=None,
+        cwd="/repo",
+        started_at=1.0,
+    )
+    assert name is not None
+    await registry.emit(
+        RunTerminalEnvelope(
+            event_id="ev-degraded",
+            entity=EntityRef(kind="invocation", id="inv-degraded"),
+            previous_status="running",
+            terminal_status="completed",
+            reason_code=RunReasons.COMPLETED_FINALIZE_ERROR,
+            occurred_at=2.0,
+        )
+    )
+    degraded_payload = json.loads(degraded_out.read_text())
+    assert degraded_payload["reason_code"] == RunReasons.COMPLETED_FINALIZE_ERROR
+    # The primary work did complete -- status/exit_class stay success.
+    assert degraded_payload["status"] == "completed"
+    assert degraded_payload["exit_class"] == "success"
+
+    registry2 = TerminalCallbackRegistry()
+    register_flow_notify_scope(
+        registry2,
+        override=_capture_command(ok_out),
+        entity_kind="invocation",
+        entity_id="inv-ok",
+        invocation_id="inv-ok",
+        flow_kind="flow",
+        playbook=None,
+        save_dir=None,
+        cwd="/repo",
+        started_at=1.0,
+    )
+    await registry2.emit(_envelope(eid="inv-ok", status="completed"))
+    ok_payload = json.loads(ok_out.read_text())
+    assert ok_payload["reason_code"] == RunReasons.COMPLETED_OK
+
+    assert degraded_payload["reason_code"] != ok_payload["reason_code"]
 
 
 async def test_scope_only_fires_for_its_own_entity(tmp_path: Path):


### PR DESCRIPTION
Closes #2053.

## Root cause

`_finalize_flow` runs after the DAG has already produced its full result: every gate passed, every artifact on disk. It then performs four unguarded side effects in order — write the synthesis artifact, post to the team inbox under a file lock, build the run metadata, and write branch snapshots and resume pointers.

Any exception in that region propagates out of `_run_flow_inner` into `_run_flow`'s `except BaseException`, where `classify_exception` maps anything that is not a timeout or a cancellation to `failed`. The `finally` block then persists that flipped status, and the re-raised exception reaches process exit 1.

So a fully successful run whose team-inbox post hit lock contention, or whose snapshot write hit an IO error, records `status=failed` and exits 1 with its own completed artifacts sitting on disk. Because the failure happens after the DAG's streaming output already reached stdout, the tail of stdout looks like a normal finish, which matches the reported symptom of no visible traceback.

The third reported repro, a commit gate blocked on missing optional extras, is the same class from a different raise site inside the same unguarded region. The fix closes the class at the seam rather than patching one raise site.

## Fix

`output` is computed first, from the already-known result, and is always returned. The four side effects are wrapped in one `try/except Exception` that logs a warning and stashes `{"error_class", "error"}` on `env._finalize_error` instead of raising. `_finalize_flow` no longer raises for a post-DAG failure, so `_terminal_status` stays whatever the DAG actually produced.

The error is surfaced rather than swallowed, in the existing vocabulary rather than a new one. Sessions already carry `status_reason_code`, `status_reason_summary`, and evidence refs, so `stop_live_persist` reads `env._finalize_error` (the same pattern already used for `env._escalated_evidence`) and threads it to `teardown_persist`, which merges it into metadata and, when the run's own status is `completed`, sets a new `RunReasons.COMPLETED_FINALIZE_ERROR`. It never touches `final_status`.

Three outcomes are now distinguishable:

| Case | status | reason_code |
|---|---|---|
| clean run | completed | run.completed.ok |
| DAG succeeded, finalize hiccup | completed | run.completed.finalize_error |
| real DAG failure | failed | run.failed.exception |

A finalize error alongside a genuine DAG failure is still recorded in metadata but never overrides the DAG's own reason code.

Consumers reading exit code or raw status get a correct pass/fail signal. Consumers reading the reason code get the finer distinction.

## Tests

Three regression tests, all failing pre-fix:

- `test_finalize_flow_team_post_failure_still_returns_output_and_records_error` — the actual raise site. Pre-fix the `RuntimeError` propagates uncaught.
- `test_stop_finalize_error_stays_completed_with_distinct_reason` — pre-fix asserts `run.completed.ok` where `run.completed.finalize_error` is required.
- `test_stop_finalize_error_does_not_override_real_dag_failure_reason` — pins the precedence rule.

`tests/cli` and `tests/state` pass; ruff clean on all six changed files.

## Deliberately out of scope

`_run_fanout` in `fanout.py` has the structurally identical unguarded sequence inline. The reported evidence is entirely about `li play` and `li o flow`, so the fix stays on the reported surface. Filed separately as a known-analogous latent defect.

A speculative guard around `_run_flow`'s own branch-shutdown loop was implemented, then reverted: instrumenting the path showed `env.session.branches` is already empty there because `teardown_persist` releases every hooked branch before returning, so the test did not discriminate. That loop is a no-op today on the normal path; if it ever crashes it is a narrower bug deserving its own evidence.
