### PR TITLE
test(operations): pin the premise the current-turn guard reads by index

### DIFF
--- a/tests/operations/test_chat_prepare.py
+++ b/tests/operations/test_chat_prepare.py
@@ -141,3 +141,77 @@ def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeyp
     # No instruction text/plain_content/images supplied -> guard must not fire.
     _ins, kw = _prepare_run_kwargs(branch, None, param)
     assert kw["messages"] == []
+
+
+# ---------------------------------------------------------------------------
+# The premise the guard rests on: the current turn is the LAST assembled entry.
+#
+# The guard reads the current turn's render by index, which is only the current
+# turn's render because every assembly branch appends the current turn last. The
+# tests above cannot see a violation of that premise: they patch renders and
+# observe the guard, and both the by-index read and a bare after-the-loop read
+# agree as long as the premise holds. So a future edit that appends anything
+# after the current turn would leave those tests green while the guard silently
+# started inspecting the wrong entry — and in the direction that matters, a
+# genuinely dropped instruction going unnoticed.
+#
+# These pin the premise itself, one per assembly branch, through the public
+# return: with every entry rendering normally, the last outgoing message is the
+# current turn's.
+# ---------------------------------------------------------------------------
+
+
+def test_current_turn_is_last_message_without_system():
+    """Plain-append branch: no system message, so the current turn is appended
+    directly onto whatever history produced."""
+    branch = Branch()
+    param = ChatParam()
+
+    branch.msgs.add_message(instruction="an earlier question")
+    branch.msgs.add_message(assistant_response="an earlier answer")
+
+    _ins, kw = _prepare_run_kwargs(branch, "the current prompt", param)
+
+    assert "the current prompt" in kw["messages"][-1]["content"]
+
+
+def test_current_turn_is_last_message_with_system():
+    """Guidance-merge branch: a system message rewrites the first entry's
+    guidance and then appends the current turn, which must still end up last."""
+    branch = Branch(system="you are a helpful assistant")
+    param = ChatParam()
+
+    branch.msgs.add_message(instruction="an earlier question")
+    branch.msgs.add_message(assistant_response="an earlier answer")
+
+    _ins, kw = _prepare_run_kwargs(branch, "the current prompt", param)
+
+    assert "the current prompt" in kw["messages"][-1]["content"]
+
+
+def test_current_turn_is_last_message_with_trailing_action_context():
+    """Action-context branch: trailing action responses are folded into the
+    current turn's prompt context rather than appended as their own entry, so
+    the current turn must still be last and must carry the action output."""
+    from lionagi.protocols.messages import ActionRequest
+
+    branch = Branch()
+    param = ChatParam()
+
+    branch.msgs.add_message(instruction="an earlier question")
+    request = ActionRequest(
+        content={"function": "lookup", "arguments": {"key": "k"}},
+        sender="x",
+        recipient="user",
+    )
+    branch.msgs.add_message(action_request=request)
+    branch.msgs.add_message(
+        action_request=request,
+        action_output={"value": "a distinctive action result"},
+    )
+
+    _ins, kw = _prepare_run_kwargs(branch, "the current prompt", param)
+
+    last = kw["messages"][-1]["content"]
+    assert "the current prompt" in last
+    assert "a distinctive action result" in last


### PR DESCRIPTION
Test-only. Closes the gap flagged during the review of the current-turn guard refactor.

## What was missing

The empty-content guard in `_prepare_run_kwargs` captures the current turn's rendered value by index. That value is the current turn's only because every assembly branch appends the current turn last: the guidance-merge branch, the action-context branch, and the plain-append branch all push it at the end.

The existing tests in that file patch renders and observe whether the guard fires. They cannot see a violation of that premise, because the by-index read and a bare after-the-loop read agree with each other for exactly as long as the premise holds. The reviewer said as much when the refactor landed: the tests validate the guard's intended semantics but do not distinguish the old implementation from the new one, which is correct for a behavior-preserving refactor and also means nothing pins the thing the refactor now depends on.

So an edit that appended anything to the assembled contents after the current turn would leave every existing test green while the guard quietly began inspecting the wrong entry. The failure direction matters: it is the one where a genuinely dropped instruction goes out unnoticed, which is the bug the guard exists to prevent.

## What this adds

Three tests, one per assembly branch, asserting through the public return that the last outgoing message is the current turn's. With every entry rendering normally there is no patching involved, so they read as a statement about assembly order rather than about the guard.

The action-context case additionally asserts the trailing action output is folded into the current turn's context rather than appended as its own entry, since that branch is the one where an extra entry would be most natural to add.

## Discrimination

Injecting a trailing entry after the current turn, which is precisely the premise violation these exist to catch:

```
FAILED test_current_turn_is_last_message_without_system
FAILED test_current_turn_is_last_message_with_system
FAILED test_current_turn_is_last_message_with_trailing_action_context
```

Every pre-existing test in the file passed against that same injection. That contrast is the gap being closed. Reverting the injection returns all ten to passing.
