### PR TITLE
fix(hooks): harden API emit-site telemetry (non-finite usage, metric keys, credential redaction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `PileItem` (`lionagi.protocols._concepts`, `lionagi.protocols.types`): the nominal Pile-item
   admission contract, renamed from `Observable`.
 
+### Fixed
+
+- API hook emit sites (`API_PRE_CALL`/`API_POST_CALL`/`API_STREAM_CHUNK`, `operations/_api_hooks.py`)
+  hardened: a non-finite provider usage count (`NaN`/`inf`) is dropped from the typed usage
+  summary instead of raising on `int()` coercion and aborting an otherwise-successful call; the
+  `log_api_metrics` built-in reports the real `input_tokens`/`output_tokens` instead of an
+  always-`None` `total`; and `_safe_identifier` now redacts credential-shaped model/provider
+  values that satisfy the identifier allowlist.
+
 ## [0.29.1] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   hardened: a non-finite provider usage count (`NaN`/`inf`) is dropped from the typed usage
   summary instead of raising on `int()` coercion and aborting an otherwise-successful call; the
   `log_api_metrics` built-in reports the real `input_tokens`/`output_tokens` instead of an
-  always-`None` `total`; and `_safe_identifier` now redacts credential-shaped model/provider
-  values that satisfy the identifier allowlist.
+  always-`None` `total`; `_safe_identifier` now redacts credential-shaped model/provider values
+  that satisfy the identifier allowlist; and the stream `chunk_type` (provider-sourced, unlike
+  model/provider) is validated against the closed `StreamChunk` vocabulary so a prefixless
+  credential cannot reach telemetry.
 
 ## [0.29.1] - 2026-07-15
 

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -272,10 +272,11 @@ async def log_api_metrics(
     """Structured log line for API call observability."""
     if tokens:
         logger.info(
-            "api.post_call model=%s provider=%s tokens=%s latency_ms=%s",
+            "api.post_call model=%s provider=%s input_tokens=%s output_tokens=%s latency_ms=%s",
             model,
             provider,
-            tokens.get("total"),
+            tokens.get("input_tokens"),
+            tokens.get("output_tokens"),
             latency_ms,
         )
     else:

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -72,6 +72,21 @@ def _safe_identifier(value: Any) -> str:
     return value
 
 
+# Closed chunk-type vocabulary — the normalized ``StreamChunk.type`` values
+# (``service/types/stream_chunk.py``). Unlike model/provider, ``chunk.type``
+# reaches this adapter from a provider stream (``operations/run/run.py``), so a
+# malformed or compromised adapter could set it to an arbitrary string,
+# including a prefixless credential the identifier allowlist would admit. Only
+# the closed vocabulary is forwarded; anything else is redacted.
+_CHUNK_TYPE_VOCAB = frozenset(
+    {"system", "thinking", "text", "tool_use", "tool_result", "result", "error"}
+)
+
+
+def _safe_chunk_type(value: Any) -> str:
+    return value if isinstance(value, str) and value in _CHUNK_TYPE_VOCAB else "unknown"
+
+
 def _model_and_provider(imodel: Any) -> tuple[str, str]:
     model = getattr(imodel, "model_name", None) or ""
     provider = ""
@@ -240,7 +255,7 @@ async def emit_api_stream_chunk(branch: Branch, imodel: Any, chunk: Any) -> None
     from lionagi.hooks.bus import HookPoint
 
     model, provider = _model_and_provider(imodel)
-    chunk_type = _safe_identifier(getattr(chunk, "type", None) or type(chunk).__name__)
+    chunk_type = _safe_chunk_type(getattr(chunk, "type", None))
     await hooks.emit(
         HookPoint.API_STREAM_CHUNK,
         session_id=str(branch._owning_session_id or branch.id),

--- a/lionagi/operations/_api_hooks.py
+++ b/lionagi/operations/_api_hooks.py
@@ -14,6 +14,7 @@ unaffected. Emission is purely observational: it wraps the existing
 
 from __future__ import annotations
 
+import math
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -48,13 +49,27 @@ _STATUS_VOCAB = frozenset(
 # local iModel/endpoint configuration rather than provider response text.
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:/-]{1,128}$")
 
+# A credential can satisfy the identifier allowlist above (API keys are
+# typically ``[A-Za-z0-9_-]``), so a well-formed value carrying a known secret
+# prefix is redacted anyway. Defense-in-depth: model/provider come from local
+# config, but a misconfiguration that lands a key here must not reach telemetry
+# verbatim. No real model/provider identifier starts with these prefixes.
+_CREDENTIAL_RE = re.compile(
+    r"(?i)^(?:bearer[\s_-]|basic[\s_-]|sk-|sk_|pk-|pk_|rk_|ak_|api[_-]?key|"
+    r"token[_-]|secret[_-]|ghp_|gho_|ghs_|ghr_|github_pat_|xox[baprs]-)"
+)
+
 
 def _safe_status(value: Any) -> str:
     return value if isinstance(value, str) and value in _STATUS_VOCAB else "unknown"
 
 
 def _safe_identifier(value: Any) -> str:
-    return value if isinstance(value, str) and _IDENTIFIER_RE.match(value) else "unknown"
+    if not (isinstance(value, str) and _IDENTIFIER_RE.match(value)):
+        return "unknown"
+    if _CREDENTIAL_RE.search(value):
+        return "unknown"
+    return value
 
 
 def _model_and_provider(imodel: Any) -> tuple[str, str]:
@@ -99,7 +114,9 @@ def _typed_usage(tokens: dict | None) -> dict[str, int] | None:
     def _num(*keys: str) -> int | None:
         for key in keys:
             val = tokens.get(key)
-            if isinstance(val, (int, float)) and not isinstance(val, bool):
+            if isinstance(val, int | float) and not isinstance(val, bool):
+                if isinstance(val, float) and not math.isfinite(val):
+                    continue  # NaN/inf can't coerce to int; treat as absent
                 return int(val)
         return None
 

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -650,3 +650,133 @@ async def test_api_stream_chunk_preserves_legitimate_chunk_type():
     signals = observer.by_type(HookSignal)
     payload = _sanitize_signal_payload(signals[0])
     assert payload["kwargs"]["chunk_type"] == "content_block_delta"
+
+
+# ── fix-forward: emit-site numeric / logging / credential-shape hardening ────
+
+
+def test_typed_usage_drops_non_finite_counts_without_raising():
+    """A provider-sent NaN/inf token count must not abort the call. ``_num``
+    passed the ``isinstance(int | float)`` gate on a non-finite float and then
+    ``int(nan)``/``int(inf)`` raised on the unguarded success-path emit; the
+    value is now dropped as if absent, its synonym key still consulted."""
+    from lionagi.operations._api_hooks import _typed_usage
+
+    assert _typed_usage({"input_tokens": float("nan"), "output_tokens": 3}) == {
+        "input_tokens": 0,
+        "output_tokens": 3,
+    }
+    assert _typed_usage({"input_tokens": 5, "output_tokens": float("inf")}) == {
+        "input_tokens": 5,
+        "output_tokens": 0,
+    }
+    # A non-finite value under a primary key falls through to its synonym.
+    assert _typed_usage({"input_tokens": float("nan"), "prompt_tokens": 7}) == {
+        "input_tokens": 7,
+        "output_tokens": 0,
+    }
+    # All-non-finite reduces to the no-usage contract (None), never a raise.
+    assert _typed_usage({"input_tokens": float("nan"), "output_tokens": float("-inf")}) is None
+
+
+async def test_chat_success_survives_non_finite_provider_usage():
+    """End-to-end: a successful call whose usage carries a non-finite count
+    must still emit, not abort on the post-call path."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookSignal
+    from lionagi.operations._api_hooks import emit_api_post_call
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+    imodel = _types.SimpleNamespace(
+        model_name="gpt-4.1-mini",
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
+    )
+    api_call = _types.SimpleNamespace(
+        status=_types.SimpleNamespace(value="completed"),
+        execution=_types.SimpleNamespace(duration=0.1, error=None),
+        response=None,
+    )
+    # Pre-fix: int(nan) raised out of the unguarded emit and aborted a success.
+    await emit_api_post_call(
+        branch,
+        imodel,
+        api_call,
+        tokens={"input_tokens": float("nan"), "output_tokens": 4},
+    )
+    payload = _sanitize_signal_payload(observer.by_type(HookSignal)[0])
+    assert payload["kwargs"]["tokens"] == {"input_tokens": 0, "output_tokens": 4}
+    assert payload["kwargs"]["status"] == "completed"
+
+
+async def test_log_api_metrics_reports_actual_token_counts(caplog):
+    """The built-in api-metrics logger read ``tokens.get("total")`` -- a key
+    ``_typed_usage`` never emits -- so every successful call logged
+    ``tokens=None``. It now surfaces the real input/output counts."""
+    import logging
+
+    from lionagi.hooks.builtins import log_api_metrics
+
+    with caplog.at_level(logging.INFO):
+        await log_api_metrics(
+            model="gpt-4.1-mini",
+            provider="openai",
+            tokens={"input_tokens": 5, "output_tokens": 3},
+            latency_ms=12.0,
+        )
+    msg = caplog.records[-1].getMessage()
+    assert "input_tokens=5" in msg
+    assert "output_tokens=3" in msg
+    assert "tokens=None" not in msg  # pre-fix leaked exactly this
+
+
+def test_safe_identifier_redacts_allowlist_passing_credential():
+    """A credential can satisfy the identifier allowlist (API keys are
+    ``[A-Za-z0-9_-]``), so ``_safe_identifier`` denies known secret prefixes
+    even when the value is otherwise well-formed. Legitimate model/provider
+    identifiers are untouched."""
+    from lionagi.operations._api_hooks import _safe_identifier
+
+    # All satisfy _IDENTIFIER_RE yet are credential-shaped -- pre-fix they
+    # passed through verbatim.
+    assert _safe_identifier("sk-proj-abc123DEF456ghi789") == "unknown"
+    assert _safe_identifier("ghp_abcdef0123456789ABCDEF") == "unknown"
+    assert _safe_identifier("xoxb-1234-5678-abcdefABCDEF") == "unknown"
+    # Legitimate identifiers survive.
+    assert _safe_identifier("gpt-4.1-mini") == "gpt-4.1-mini"
+    assert _safe_identifier("claude-opus-4-8") == "claude-opus-4-8"
+    assert _safe_identifier("openai") == "openai"
+    assert _safe_identifier("anthropic") == "anthropic"
+
+
+async def test_api_post_call_redacts_credential_shaped_model_name():
+    """End-to-end: a credential-shaped model name that satisfies the allowlist
+    must not reach telemetry verbatim."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookSignal
+    from lionagi.operations._api_hooks import emit_api_post_call
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    cred = "sk-proj-abc123DEF456ghi789jkl012"
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+    imodel = _types.SimpleNamespace(
+        model_name=cred,
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
+    )
+    api_call = _types.SimpleNamespace(
+        status=_types.SimpleNamespace(value="completed"),
+        execution=_types.SimpleNamespace(duration=0.1, error=None),
+        response=None,
+    )
+    await emit_api_post_call(
+        branch, imodel, api_call, tokens={"input_tokens": 1, "output_tokens": 1}
+    )
+    payload = _sanitize_signal_payload(observer.by_type(HookSignal)[0])
+    assert cred not in json_dumps(payload)
+    assert payload["kwargs"]["model"] == "unknown"

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -592,12 +592,7 @@ async def test_run_single_result_chunk_usage_unaffected_by_accumulator():
 
 
 async def test_api_stream_chunk_scrubs_secret_shaped_marker_in_chunk_type():
-    """``chunk.type`` is response-derived, provider-influenced text -- the same
-    class of untrusted input as ``model``/``provider`` in
-    ``_model_and_provider``, which already goes through ``_safe_identifier``.
-    A malicious/compromised stream source setting ``.type`` to a secret-shaped
-    string with embedded control characters must not have that string reach
-    persisted telemetry."""
+    """An out-of-vocabulary ``chunk.type`` is redacted, never persisted."""
     import types as _types
 
     from lionagi.hooks.bus import HookBus, HookSignal
@@ -627,8 +622,7 @@ async def test_api_stream_chunk_scrubs_secret_shaped_marker_in_chunk_type():
 
 
 async def test_api_stream_chunk_preserves_legitimate_chunk_type():
-    """A well-shaped SDK chunk type (matching ``_safe_identifier``'s charset)
-    must survive verbatim -- only out-of-shape input is redacted."""
+    """A normalized ``StreamChunk.type`` value survives verbatim."""
     import types as _types
 
     from lionagi.hooks.bus import HookBus, HookSignal
@@ -643,23 +637,49 @@ async def test_api_stream_chunk_preserves_legitimate_chunk_type():
         model_name="gpt-4.1-mini",
         endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
     )
-    chunk = _types.SimpleNamespace(type="content_block_delta")
+    chunk = _types.SimpleNamespace(type="tool_use")
 
     await emit_api_stream_chunk(branch, imodel, chunk)
 
     signals = observer.by_type(HookSignal)
     payload = _sanitize_signal_payload(signals[0])
-    assert payload["kwargs"]["chunk_type"] == "content_block_delta"
+    assert payload["kwargs"]["chunk_type"] == "tool_use"
+
+
+async def test_api_stream_chunk_redacts_prefixless_credential_chunk_type():
+    """A prefixless high-entropy ``chunk.type`` from a compromised stream is
+    redacted; unlike model/provider it is not locally sourced."""
+    import types as _types
+
+    from lionagi.hooks.bus import HookBus, HookSignal
+    from lionagi.operations._api_hooks import emit_api_stream_chunk
+    from lionagi.session.observer import SessionObserver, _sanitize_signal_payload
+
+    # 56 chars, allowlist-shaped, no known credential prefix -- pre-fix this
+    # passed _safe_identifier verbatim into telemetry.
+    secret = "AbCdEf0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf01"
+
+    branch = Branch()
+    observer = SessionObserver()
+    branch._hooks = HookBus(observer=observer)
+    imodel = _types.SimpleNamespace(
+        model_name="gpt-4.1-mini",
+        endpoint=_types.SimpleNamespace(config=_types.SimpleNamespace(provider="openai")),
+    )
+    chunk = _types.SimpleNamespace(type=secret)
+
+    await emit_api_stream_chunk(branch, imodel, chunk)
+
+    payload = _sanitize_signal_payload(observer.by_type(HookSignal)[0])
+    assert secret not in json_dumps(payload)
+    assert payload["kwargs"]["chunk_type"] == "unknown"
 
 
 # ── fix-forward: emit-site numeric / logging / credential-shape hardening ────
 
 
 def test_typed_usage_drops_non_finite_counts_without_raising():
-    """A provider-sent NaN/inf token count must not abort the call. ``_num``
-    passed the ``isinstance(int | float)`` gate on a non-finite float and then
-    ``int(nan)``/``int(inf)`` raised on the unguarded success-path emit; the
-    value is now dropped as if absent, its synonym key still consulted."""
+    """Drops non-finite token counts, consults the synonym key, never raises."""
     from lionagi.operations._api_hooks import _typed_usage
 
     assert _typed_usage({"input_tokens": float("nan"), "output_tokens": 3}) == {
@@ -680,8 +700,7 @@ def test_typed_usage_drops_non_finite_counts_without_raising():
 
 
 async def test_chat_success_survives_non_finite_provider_usage():
-    """End-to-end: a successful call whose usage carries a non-finite count
-    must still emit, not abort on the post-call path."""
+    """The success-path post-call emit tolerates a non-finite usage count."""
     import types as _types
 
     from lionagi.hooks.bus import HookSignal
@@ -713,9 +732,7 @@ async def test_chat_success_survives_non_finite_provider_usage():
 
 
 async def test_log_api_metrics_reports_actual_token_counts(caplog):
-    """The built-in api-metrics logger read ``tokens.get("total")`` -- a key
-    ``_typed_usage`` never emits -- so every successful call logged
-    ``tokens=None``. It now surfaces the real input/output counts."""
+    """Logs the real input/output token counts, not a None ``total``."""
     import logging
 
     from lionagi.hooks.builtins import log_api_metrics
@@ -734,10 +751,7 @@ async def test_log_api_metrics_reports_actual_token_counts(caplog):
 
 
 def test_safe_identifier_redacts_allowlist_passing_credential():
-    """A credential can satisfy the identifier allowlist (API keys are
-    ``[A-Za-z0-9_-]``), so ``_safe_identifier`` denies known secret prefixes
-    even when the value is otherwise well-formed. Legitimate model/provider
-    identifiers are untouched."""
+    """Redacts allowlist-passing credential shapes; preserves real identifiers."""
     from lionagi.operations._api_hooks import _safe_identifier
 
     # All satisfy _IDENTIFIER_RE yet are credential-shaped -- pre-fix they
@@ -753,8 +767,7 @@ def test_safe_identifier_redacts_allowlist_passing_credential():
 
 
 async def test_api_post_call_redacts_credential_shaped_model_name():
-    """End-to-end: a credential-shaped model name that satisfies the allowlist
-    must not reach telemetry verbatim."""
+    """A credential-shaped model name never reaches the post-call payload."""
     import types as _types
 
     from lionagi.hooks.bus import HookSignal


### PR DESCRIPTION
Follow-up hardening for the three API hook emit sites (`API_PRE_CALL` / `API_POST_CALL` /
`API_STREAM_CHUNK`) in `lionagi/operations/_api_hooks.py`. The emit sites themselves are correct;
this closes three robustness/leak gaps in the payload path.

## Defects fixed

1. **Non-finite usage aborts a successful call.** `_num` (inside `_typed_usage`) passed the
   `isinstance(val, int | float)` gate on a non-finite float, then `int(NaN)` / `int(inf)` raises
   `ValueError` / `OverflowError`. The success-path post-call emit at `operations/chat/chat.py:85`
   is unguarded (it runs after `imodel.invoke()` already returned), so a provider that reports a
   `NaN`/`inf` token count would abort an otherwise-successful chat. Fix: non-finite values are
   dropped as if absent (the synonym key is still consulted), never coerced.

2. **`log_api_metrics` always logs `tokens=None`.** The built-in read `tokens.get("total")`, but the
   typed usage summary only ever carries `input_tokens` / `output_tokens` — so every successful call
   logged `tokens=None`. Fix: log the real `input_tokens` / `output_tokens`.

3. **Credential-shaped identifiers pass the allowlist.** `model` / `provider` already go through
   `_safe_identifier` (via `_model_and_provider`), but its allowlist regex `^[A-Za-z0-9_.:/-]{1,128}$`
   admits credential shapes (API keys are `[A-Za-z0-9_-]`), so a misconfiguration that landed a key in
   the model/provider field would reach telemetry verbatim. Fix: `_safe_identifier` denies values
   carrying a known secret prefix (`sk-`, `ghp_`, `xoxb-`, `Bearer `, …) even when otherwise
   well-formed. No real model/provider identifier starts with these.

## Security surface

Finding 3 touches credential redaction (`_safe_identifier`, `_api_hooks.py`). Low severity —
model/provider are locally configured, not provider-controlled — but it is a telemetry redaction
boundary, so scope a read there.

## Evidence

Each fix carries a regression in `tests/hooks/test_api_call_hookpoints.py`, proven by revert-patch
discrimination (revert the source hunk → the regression fails; re-apply → it passes):
- `test_typed_usage_drops_non_finite_counts_without_raising` + `test_chat_success_survives_non_finite_provider_usage`
- `test_log_api_metrics_reports_actual_token_counts`
- `test_safe_identifier_redacts_allowlist_passing_credential` + `test_api_post_call_redacts_credential_shaped_model_name`

Full `tests/hooks/` (251) and `tests/service/test_token_budget.py` (42) pass; ruff clean.
