### PR TITLE
fix(cli): codex file-access hint recommends --yolo, not --bypass

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -377,15 +377,16 @@ async def _run_agent(
         )
 
     if branch is None:
-        # Codex sandbox blocks tool calls without bypass. Surface this even
-        # without verbose output; CLI or profile approval flags suppress it.
+        # Codex blocks tool calls until file access is enabled. Surface this
+        # even without verbose output; CLI or profile approval flags suppress it.
         if provider == "codex" and not yolo and not bypass:
             from lionagi.cli._logging import warn
 
             warn(
-                "codex models require --bypass or --yolo for local file access. "
-                "Without one of these flags the agent may hang silently. "
-                "Re-run with --bypass or use an agent profile (-a)."
+                "codex models need file access enabled or the agent may hang "
+                "silently on its first tool call. Re-run with --yolo for the "
+                "sandboxed default, or use an agent profile (-a). --bypass also "
+                "works but disables the sandbox."
             )
         chat_model = build_chat_model(provider, model, yolo, verbose, theme, effort, fast, bypass)
         effort = resolve_persisted_effort(provider, chat_model, effort)

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -185,8 +185,10 @@ async def test_run_agent_codex_no_bypass_emits_warning(monkeypatch, tmp_path):
 
     await _run_agent("codex/gpt-5.3-codex-spark", "do stuff", bypass=False, yolo=False)
 
-    assert any("--bypass" in w or "bypass" in w.lower() for w in warnings_emitted), (
-        f"Expected a bypass warning, got: {warnings_emitted}"
+    # The hint must steer users to --yolo (the sandboxed default) as the
+    # primary remedy, not --bypass (which disables the sandbox).
+    assert any("--yolo" in w for w in warnings_emitted), (
+        f"Expected the warning to recommend --yolo, got: {warnings_emitted}"
     )
 
 


### PR DESCRIPTION
## What

The codex file-access hint recommended `--bypass` as the remedy for a codex leg that hangs on its first tool call. That steers users off the safe path: the codex sandbox default is now `workspace-write`, so `--yolo` enables file access *under a sandbox*, while `--bypass` disables the sandbox entirely.

This repoints the hint at `--yolo` (or an agent profile) as the primary remedy and mentions `--bypass` only as the sandbox-disabling escape hatch. The stale comment is updated to match.

## Why now

Standalone hint fix, deliberately kept out of the 0.30.0 release. It only touches the warning text and its comment plus one test assertion — no behavior change to the flags themselves.

## Test

`test_run_agent_codex_no_bypass_emits_warning` is tightened to assert the warning recommends `--yolo` (previously it only checked for the substring "bypass", which would have passed even against the old wrong wording). Full file green:

```
tests/cli/test_agent_codex_robustness.py .......... 14 passed
```
