### PR TITLE
fix(providers): treat an empty agy SUCCESS as an error instead of an empty answer

### DIFF
--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -381,6 +381,7 @@ async def stream_gemini_cli(
                 saw_object = True
                 status = str(obj.get("status", "")).upper()
                 response = (obj.get("response") or "").strip()
+                cli_error = str(obj.get("error") or "").strip()
 
                 session.session_id = obj.get("conversation_id") or session.session_id
                 session.model = resolve_agy_model(request.model)
@@ -391,6 +392,16 @@ async def stream_gemini_cli(
                 if duration is not None:
                     session.duration_ms = int(float(duration) * 1000)
                 session.is_error = status not in ("SUCCESS", "")
+
+                # A success carrying no content cannot be distinguished from a
+                # turn whose tool calls were all denied: headless print mode has
+                # no way to prompt for a tool permission, so it auto-denies and
+                # still reports SUCCESS. Passing that through as an empty answer
+                # fails open, which is the worst direction here — a caller using
+                # this engine for verification reads silence as assent.
+                empty_success = not session.is_error and not response
+                if empty_success:
+                    session.is_error = True
 
                 # Session id must be captured before the error branch — a failed
                 # turn can still report a live conversation id to resume into.
@@ -403,10 +414,26 @@ async def stream_gemini_cli(
                     yield sys_sc
 
                 if session.is_error:
-                    # Error chunk leads with status, not delivered content — a degraded
-                    # termination after a complete response would otherwise impersonate it.
-                    detail = f": {response[:500]}" if response else ""
-                    msg = f"agy returned status={status or 'UNKNOWN'}{detail}"
+                    if empty_success:
+                        msg = (
+                            "agy reported status=SUCCESS with no response content. "
+                            "A tool call was most likely auto-denied, because headless "
+                            "print mode cannot prompt for a tool permission. Re-run with "
+                            "yolo to auto-approve tools, or add an allow-rule under "
+                            "permissions.allow in the agy settings."
+                        )
+                        if cli_error:
+                            msg = f"{msg} CLI error: {cli_error}"
+                        session.result = msg
+                    else:
+                        # Error chunk leads with status, not delivered content — a degraded
+                        # termination after a complete response would otherwise impersonate it.
+                        # `error` is preferred over `response`: agy reports the cause there
+                        # and commonly leaves `response` empty on a failed turn.
+                        detail = cli_error or response[:500]
+                        msg = f"agy returned status={status or 'UNKNOWN'}"
+                        if detail:
+                            msg = f"{msg}: {detail}"
                     sc = StreamChunk(type="error", content=msg, is_error=True, metadata=obj)
                     session.chunks.append(sc)
                     yield sc

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -131,10 +131,55 @@ async def test_no_object_flagged_error():
 
 
 @pytest.mark.asyncio
-async def test_empty_success_response_not_error():
+async def test_empty_success_response_is_an_error():
+    """A SUCCESS carrying no content must not read as a successful empty answer.
+
+    Headless print mode cannot prompt for a tool permission, so it auto-denies
+    the call and still reports SUCCESS with an empty response. Passing that
+    through as a completed-but-empty turn fails open: a caller using this engine
+    for a second opinion receives silence stamped success and reads it as assent.
+    """
     session = await _run_objects([_success_obj(response="")])
-    assert session.is_error is False
-    assert session.result == ""
+    assert session.is_error is True
+    assert session.result
+
+
+@pytest.mark.asyncio
+async def test_empty_success_error_names_the_permission_remedy():
+    """The error has to be actionable — the operator needs the remedy, not just a flag."""
+    chunks = await _run_chunks([_success_obj(response="")])
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    content = error_chunks[0].content.lower()
+    assert "no response content" in content
+    assert "permission" in content
+
+
+@pytest.mark.asyncio
+async def test_empty_success_emits_no_text_or_result_chunk():
+    """An empty text chunk downstream is exactly what made this look like a real answer."""
+    chunks = await _run_chunks([_success_obj(response="")])
+    types = [c.type for c in chunks]
+    assert "text" not in types
+    assert "result" not in types
+
+
+@pytest.mark.asyncio
+async def test_error_object_surfaces_its_error_field():
+    """agy reports failures in `error` while leaving `response` empty; a bare
+    status line drops the only text that says what actually went wrong."""
+    chunks = await _run_chunks(
+        [
+            _success_obj(
+                status="ERROR",
+                response="",
+                error='invalid model selection (--model "gemini-3.9-flash")',
+            )
+        ]
+    )
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    assert "invalid model selection" in error_chunks[0].content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2385.

## Problem

A `gemini-code` prompt that requires a tool call returned an empty assistant message stamped as a successful run: exit 0, `status=SUCCESS`, a branch record holding the Instruction with no assistant content. Nothing distinguished "the model answered with nothing" from "every tool call was denied and the turn produced no output".

The Antigravity CLI cannot prompt for a tool permission in headless print mode, so it auto-denies the call and still returns `status=SUCCESS` with an empty `response` (usage is non-zero — the turn ran and was suppressed at the tool boundary). The parser computed `is_error = status not in ("SUCCESS", "")`, so that took the non-error branch and emitted an empty text chunk plus a result chunk carrying real usage. Downstream that reads as a completed turn that said nothing.

This fails open, which is the worst direction for this engine's roles. A caller using it for a REFUTE-mirror or second opinion receives silence stamped success, and silence reads as assent. An engine that reports failure gets retried; one that reports success gets believed.

## Fix

- `SUCCESS` with an empty `response` is now an error, with a message naming the likely cause (headless tool auto-denial) and both remedies (yolo, or a `permissions.allow` rule).
- The error branch prefers the object's `error` field over `response`. A failed agy turn commonly reports its cause in `error` and leaves `response` empty, which previously produced a bare `agy returned status=ERROR` with no explanation.
- No text or result chunk is emitted for the empty-success case, so it can no longer impersonate a real (empty) answer downstream.

## The overturned test

`test_empty_success_response_not_error` asserted the old behavior. That assertion was incidental to the bulk agy-migration commit rather than a considered ruling, and is inverted here (`test_empty_success_response_is_an_error`) with the reasoning recorded in the test docstring.

## Tests

Four regressions added; the first fails on the parent commit for exactly this bug. Full `tests/providers/` suite passes (259).

## Root-cause dating

The Antigravity CLI auto-updated to 1.1.5 on 2026-07-23 ~05:43 local, whose changelog adds "headless runs now honor persisted settings.json policies, including permissions". Soft-deny events appear only in 1.1.5-era CLI logs; the last prior run was 1.1.3 on 2026-07-18 with no denials. So the live breakage began at that update, not earlier — a caller-side hardening this fix makes safe regardless of CLI version.

## Interim for operators

Pass `--yolo` (lionagi's own surface for headless tool auto-approval) to unblock read/verify tasks. Verified working. The narrower alternative is a targeted `permissions.allow` entry in the CLI's settings.
