### PR TITLE
fix(providers): map gemini-3.6-flash onto the 3.6 High tier, never downgrade to 3.5

### DIFF
--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -381,6 +381,7 @@ async def stream_gemini_cli(
                 saw_object = True
                 status = str(obj.get("status", "")).upper()
                 response = (obj.get("response") or "").strip()
+                cli_error = str(obj.get("error") or "").strip()
 
                 session.session_id = obj.get("conversation_id") or session.session_id
                 session.model = resolve_agy_model(request.model)
@@ -391,6 +392,16 @@ async def stream_gemini_cli(
                 if duration is not None:
                     session.duration_ms = int(float(duration) * 1000)
                 session.is_error = status not in ("SUCCESS", "")
+
+                # A success carrying no content cannot be distinguished from a
+                # turn whose tool calls were all denied: headless print mode has
+                # no way to prompt for a tool permission, so it auto-denies and
+                # still reports SUCCESS. Passing that through as an empty answer
+                # fails open, which is the worst direction here — a caller using
+                # this engine for verification reads silence as assent.
+                empty_success = not session.is_error and not response
+                if empty_success:
+                    session.is_error = True
 
                 # Session id must be captured before the error branch — a failed
                 # turn can still report a live conversation id to resume into.
@@ -403,10 +414,26 @@ async def stream_gemini_cli(
                     yield sys_sc
 
                 if session.is_error:
-                    # Error chunk leads with status, not delivered content — a degraded
-                    # termination after a complete response would otherwise impersonate it.
-                    detail = f": {response[:500]}" if response else ""
-                    msg = f"agy returned status={status or 'UNKNOWN'}{detail}"
+                    if empty_success:
+                        msg = (
+                            "agy reported status=SUCCESS with no response content. "
+                            "A tool call was most likely auto-denied, because headless "
+                            "print mode cannot prompt for a tool permission. Re-run with "
+                            "yolo to auto-approve tools, or add an allow-rule under "
+                            "permissions.allow in the agy settings."
+                        )
+                        if cli_error:
+                            msg = f"{msg} CLI error: {cli_error}"
+                        session.result = msg
+                    else:
+                        # Error chunk leads with status, not delivered content — a degraded
+                        # termination after a complete response would otherwise impersonate it.
+                        # `error` is preferred over `response`: agy reports the cause there
+                        # and commonly leaves `response` empty on a failed turn.
+                        detail = cli_error or response[:500]
+                        msg = f"agy returned status={status or 'UNKNOWN'}"
+                        if detail:
+                            msg = f"{msg}: {detail}"
                     sc = StreamChunk(type="error", content=msg, is_error=True, metadata=obj)
                     session.chunks.append(sc)
                     yield sc

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -66,6 +66,7 @@ __all__ = (
 
 # agy models expose ~1M-token context (verified against `agy models`).
 CONTEXT_WINDOWS: dict[str, int] = {
+    "gemini-3.6-flash": 1_048_576,
     "gemini-3.5-flash": 1_048_576,
     "gemini-3.1-pro": 1_048_576,
     "gemini-3-flash-preview": 1_048_576,
@@ -81,6 +82,9 @@ CONTEXT_WINDOWS: dict[str, int] = {
 # through so agy surfaces a clear error rather than us silently forcing a default.
 _AGY_MODELS: frozenset[str] = frozenset(
     {
+        "Gemini 3.6 Flash (Medium)",
+        "Gemini 3.6 Flash (High)",
+        "Gemini 3.6 Flash (Low)",
         "Gemini 3.5 Flash (Medium)",
         "Gemini 3.5 Flash (High)",
         "Gemini 3.5 Flash (Low)",
@@ -93,6 +97,14 @@ _AGY_MODELS: frozenset[str] = frozenset(
 )
 
 _MODEL_ALIASES: dict[str, str] = {
+    # 3.6 flash: newest flagship. Gemini carries effort as the model-id suffix
+    # (no separate --effort), so a bare id resolves to the strong tier by default
+    # (`gemini-3.6-flash` -> High). Suffixed forms map to their exact tier.
+    "gemini-3.6-flash": "Gemini 3.6 Flash (High)",
+    "gemini-3.6-flash-high": "Gemini 3.6 Flash (High)",
+    "gemini-3.6-flash-medium": "Gemini 3.6 Flash (Medium)",
+    "gemini-3.6-flash-low": "Gemini 3.6 Flash (Low)",
+    "gemini-3.6": "Gemini 3.6 Flash (High)",
     # flash family -> default medium effort
     "gemini-3-flash-preview": "Gemini 3.5 Flash (Medium)",
     "gemini-3-flash": "Gemini 3.5 Flash (Medium)",
@@ -119,6 +131,12 @@ _MODEL_ALIASES: dict[str, str] = {
 }
 
 
+def _gemini_flash_family(key: str) -> str:
+    """The flash-family display prefix for a free-form model key. Version-aware so
+    an explicit newer id (e.g. gemini-3.6-flash) never silently downgrades to 3.5."""
+    return "Gemini 3.6 Flash" if "3.6" in key else "Gemini 3.5 Flash"
+
+
 def resolve_agy_model(
     model: str | None,
     effort: str | None = None,
@@ -131,6 +149,8 @@ def resolve_agy_model(
         model = "gemini-3.5-flash"
     if model in _AGY_MODELS:
         if reapply_effort and effort is not None:
+            if model.startswith("Gemini 3.6 Flash"):
+                return f"Gemini 3.6 Flash ({_clamp_gemini_effort(effort, False)})"
             if model.startswith("Gemini 3.5 Flash"):
                 return f"Gemini 3.5 Flash ({_clamp_gemini_effort(effort, False)})"
             if model.startswith("Gemini 3.1 Pro"):
@@ -141,6 +161,8 @@ def resolve_agy_model(
         target = _MODEL_ALIASES[key]
         if effort is None:
             return target
+        if target.startswith("Gemini 3.6 Flash"):
+            return f"Gemini 3.6 Flash ({_clamp_gemini_effort(effort, False)})"
         if target.startswith("Gemini 3.5 Flash"):
             return f"Gemini 3.5 Flash ({_clamp_gemini_effort(effort, False)})"
         if target.startswith("Gemini 3.1 Pro"):
@@ -151,7 +173,7 @@ def resolve_agy_model(
     # from it so --effort works on forward-compatible model names.
     is_pro = "pro" in key
     if effort is not None and (is_pro or "flash" in key or "gemini" in key):
-        family = "Gemini 3.1 Pro" if is_pro else "Gemini 3.5 Flash"
+        family = "Gemini 3.1 Pro" if is_pro else _gemini_flash_family(key)
         return f"{family} ({_clamp_gemini_effort(effort, is_pro)})"
 
     # Heuristic fallback: derive (family, effort) from a free-form string so
@@ -165,7 +187,7 @@ def resolve_agy_model(
     if is_pro:
         return f"Gemini 3.1 Pro ({'High' if heuristic == 'Medium' else heuristic})"
     if "flash" in key or "gemini" in key:
-        return f"Gemini 3.5 Flash ({heuristic})"
+        return f"{_gemini_flash_family(key)} ({heuristic})"
 
     # Not recognizable — pass through; agy rejects an invalid name clearly.
     return model
@@ -194,9 +216,10 @@ class GeminiCodeRequest(BaseModel):
         default="gemini-3.5-flash",
         description=(
             "Model spec; mapped onto an `agy --model` name by resolve_agy_model. "
-            "Accepts gemini-3.5-flash, gemini-3.1-pro, legacy Gemini CLI names "
-            "(gemini-3-flash-preview, gemini-3-pro-preview), bare family names "
-            "(flash/pro), or an exact agy display name."
+            "Accepts gemini-3.6-flash (defaults to the High tier), gemini-3.5-flash, "
+            "gemini-3.1-pro, legacy Gemini CLI names (gemini-3-flash-preview, "
+            "gemini-3-pro-preview), bare family names (flash/pro), or an exact agy "
+            "display name."
         ),
     )
     yolo: bool = Field(

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -9,6 +9,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import re
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any, Literal
@@ -131,10 +132,17 @@ _MODEL_ALIASES: dict[str, str] = {
 }
 
 
+# A delimited 3.6 version token, not a bare substring: matches the "3.6" in
+# "gemini-3.6-flash" but not the "3.6" inside "gemini-13.6-flash" or
+# "gemini-3.60-flash", where a neighbouring digit means it is a different number.
+_GEMINI_36_TOKEN = re.compile(r"(?<!\d)3\.6(?!\d)")
+
+
 def _gemini_flash_family(key: str) -> str:
-    """The flash-family display prefix for a free-form model key. Version-aware so
-    an explicit newer id (e.g. gemini-3.6-flash) never silently downgrades to 3.5."""
-    return "Gemini 3.6 Flash" if "3.6" in key else "Gemini 3.5 Flash"
+    """The flash-family display prefix for a free-form model key. Version-aware:
+    an explicit 3.6 id never silently downgrades to 3.5, and an unrelated number
+    that merely contains "3.6" (13.6, 3.60) never falsely upgrades to 3.6."""
+    return "Gemini 3.6 Flash" if _GEMINI_36_TOKEN.search(key) else "Gemini 3.5 Flash"
 
 
 def resolve_agy_model(

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -429,6 +429,10 @@ async def test_on_text_loop_closed_error_propagates():
         # A free-form 3.6 name not in the alias table still stays on the 3.6
         # family via the version-aware heuristic — no downgrade to 3.5.
         ("gemini-3.6-flash-preview", "Gemini 3.6 Flash (Medium)"),
+        # ...but a number that merely CONTAINS "3.6" is not version 3.6: the
+        # version match is a delimited token, so 13.6 / 3.60 do not upgrade.
+        ("gemini-13.6-flash", "Gemini 3.5 Flash (Medium)"),
+        ("gemini-3.60-flash", "Gemini 3.5 Flash (Medium)"),
     ],
 )
 def test_resolve_agy_model(spec, expected):
@@ -496,6 +500,9 @@ def test_resolve_agy_model_36_flash_defaults_high_never_downgrades():
         assert got.startswith("Gemini 3.6 Flash"), (spec, got)
     # explicit effort folds onto the 3.6 family, not a 3.5 downgrade
     assert resolve_agy_model("gemini-3.6-flash", effort="low") == "Gemini 3.6 Flash (Low)"
+    # a number that merely contains "3.6" is NOT version 3.6 — no false upgrade
+    for spec in ("gemini-13.6-flash", "gemini-3.60-flash"):
+        assert not resolve_agy_model(spec).startswith("Gemini 3.6 Flash"), spec
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -131,10 +131,55 @@ async def test_no_object_flagged_error():
 
 
 @pytest.mark.asyncio
-async def test_empty_success_response_not_error():
+async def test_empty_success_response_is_an_error():
+    """A SUCCESS carrying no content must not read as a successful empty answer.
+
+    Headless print mode cannot prompt for a tool permission, so it auto-denies
+    the call and still reports SUCCESS with an empty response. Passing that
+    through as a completed-but-empty turn fails open: a caller using this engine
+    for a second opinion receives silence stamped success and reads it as assent.
+    """
     session = await _run_objects([_success_obj(response="")])
-    assert session.is_error is False
-    assert session.result == ""
+    assert session.is_error is True
+    assert session.result
+
+
+@pytest.mark.asyncio
+async def test_empty_success_error_names_the_permission_remedy():
+    """The error has to be actionable — the operator needs the remedy, not just a flag."""
+    chunks = await _run_chunks([_success_obj(response="")])
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    content = error_chunks[0].content.lower()
+    assert "no response content" in content
+    assert "permission" in content
+
+
+@pytest.mark.asyncio
+async def test_empty_success_emits_no_text_or_result_chunk():
+    """An empty text chunk downstream is exactly what made this look like a real answer."""
+    chunks = await _run_chunks([_success_obj(response="")])
+    types = [c.type for c in chunks]
+    assert "text" not in types
+    assert "result" not in types
+
+
+@pytest.mark.asyncio
+async def test_error_object_surfaces_its_error_field():
+    """agy reports failures in `error` while leaving `response` empty; a bare
+    status line drops the only text that says what actually went wrong."""
+    chunks = await _run_chunks(
+        [
+            _success_obj(
+                status="ERROR",
+                response="",
+                error='invalid model selection (--model "gemini-3.9-flash")',
+            )
+        ]
+    )
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    assert "invalid model selection" in error_chunks[0].content
 
 
 @pytest.mark.asyncio

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -420,6 +420,15 @@ async def test_on_text_loop_closed_error_propagates():
         ("pro", "Gemini 3.1 Pro (High)"),
         ("Gemini 3.5 Flash (High)", "Gemini 3.5 Flash (High)"),  # exact passthrough
         (None, "Gemini 3.5 Flash (Medium)"),
+        # gemini-3.6-flash defaults to High and must never silently resolve to a
+        # 3.5 display name.
+        ("gemini-3.6-flash", "Gemini 3.6 Flash (High)"),
+        ("gemini-3.6", "Gemini 3.6 Flash (High)"),
+        ("gemini-3.6-flash-medium", "Gemini 3.6 Flash (Medium)"),
+        ("Gemini 3.6 Flash (Low)", "Gemini 3.6 Flash (Low)"),  # exact passthrough
+        # A free-form 3.6 name not in the alias table still stays on the 3.6
+        # family via the version-aware heuristic — no downgrade to 3.5.
+        ("gemini-3.6-flash-preview", "Gemini 3.6 Flash (Medium)"),
     ],
 )
 def test_resolve_agy_model(spec, expected):
@@ -458,6 +467,12 @@ def test_resolve_agy_model(spec, expected):
         # No effort given: family default from _MODEL_ALIASES, unaffected.
         ("gemini-3.5-flash", None, "Gemini 3.5 Flash (Medium)"),
         ("gemini-3.1-pro", None, "Gemini 3.1 Pro (High)"),
+        # gemini-3.6-flash: effort folds onto the 3.6 family (not a 3.5
+        # downgrade); bare default is High per the alias.
+        ("gemini-3.6-flash", "low", "Gemini 3.6 Flash (Low)"),
+        ("gemini-3.6-flash", "high", "Gemini 3.6 Flash (High)"),
+        ("gemini-3.6-flash", "xhigh", "Gemini 3.6 Flash (High)"),
+        ("gemini-3.6-flash", None, "Gemini 3.6 Flash (High)"),
     ],
 )
 def test_resolve_agy_model_effort_folding(spec, effort, expected):
@@ -468,6 +483,19 @@ def test_resolve_agy_model_effort_ignored_for_cross_family_alias():
     """Claude/GPT-OSS routed through agy have no Low/Medium/High tiers —
     effort is accepted but has no suffix to fold into."""
     assert resolve_agy_model("opus", effort="high") == "Claude Opus 4.6 (Thinking)"
+
+
+def test_resolve_agy_model_36_flash_defaults_high_never_downgrades():
+    """gemini-3.6-flash defaults to the High tier: gemini bakes effort into the
+    model id, so a bare 3.6 spec must land on the High variant, and no 3.6 spec
+    may ever silently resolve to a 3.5 name."""
+    assert resolve_agy_model("gemini-3.6-flash") == "Gemini 3.6 Flash (High)"
+    # every 3.6 form stays on the 3.6 family, aliased or free-form
+    for spec in ("gemini-3.6-flash", "gemini-3.6", "gemini-3.6-flash-preview"):
+        got = resolve_agy_model(spec)
+        assert got.startswith("Gemini 3.6 Flash"), (spec, got)
+    # explicit effort folds onto the 3.6 family, not a 3.5 downgrade
+    assert resolve_agy_model("gemini-3.6-flash", effort="low") == "Gemini 3.6 Flash (Low)"
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +512,9 @@ def test_resolve_agy_model_effort_ignored_for_cross_family_alias():
         ("Gemini 3.1 Pro (Low)", "high", "Gemini 3.1 Pro (High)"),
         # medium clamps to High for the Pro family, same as fresh resolution.
         ("Gemini 3.1 Pro (Low)", "medium", "Gemini 3.1 Pro (High)"),
+        # reapply on a persisted 3.6 model stays on the 3.6 family.
+        ("Gemini 3.6 Flash (Low)", "high", "Gemini 3.6 Flash (High)"),
+        ("Gemini 3.6 Flash (High)", "low", "Gemini 3.6 Flash (Low)"),
     ],
 )
 def test_resolve_agy_model_reapply_effort_overrides_persisted_suffix(spec, effort, expected):


### PR DESCRIPTION
Maps the `gemini-3.6-flash` family in the Antigravity (`agy`) gemini provider.
(The companion empty-`agy`-SUCCESS→error fix shipped separately as #2386 and is
already in `main`; this branch now carries only the 3.6 mapping.)

## `gemini-3.6-flash` maps to the 3.6 High tier (no silent 3.5 downgrade)

`agy` encodes reasoning effort as the model-id suffix (`... (Low|Medium|High)`),
not as a separate flag — so lionagi folds effort into the resolved `--model`
name in `resolve_agy_model`. That function had no 3.6 entries: the alias table,
the effort-folding branches, and the free-form heuristic all hardcoded
`Gemini 3.5 Flash`, so **any** 3.6 spec silently resolved to a 3.5 display name.

- Add the 3.6 flash family to `CONTEXT_WINDOWS`, the `_AGY_MODELS` set, and the
  alias table. Bare `gemini-3.6-flash` and `gemini-3.6` resolve to the High
  tier by default (gemini has no separate effort param); suffixed forms
  (`-high`/`-medium`/`-low`) map to their exact tier.
- Add a version-aware `_gemini_flash_family` helper so the effort-folding and
  heuristic fallbacks stay on the 3.6 family for any free-form 3.6 name instead
  of downgrading to 3.5. The version match is a **delimited token**
  (`(?<!\d)3\.6(?!\d)`), so an unrelated number that merely contains `3.6`
  (`gemini-13.6-flash`, `gemini-3.60-flash`) is not treated as version 3.6.

Verified end-to-end: `agy --model "Gemini 3.6 Flash (High)"` returns a response
(rc=0), so the resolved display name is one `agy` accepts.

## Tests

`tests/providers/google/gemini_code/test_ndjson_mapping.py` covers the new 3.6
resolution across bare/suffixed/exact/free-form specs, effort folding, and
reapply-effort; a named regression asserts a bare `gemini-3.6-flash` lands on
High and no 3.6 spec resolves to a 3.5 name; and negative cases assert
`13.6`/`3.60` do not false-match 3.6. Full mapping file, `tests/cli/test_providers.py`,
and `tests/providers/test_gemini_cli_endpoint.py` pass.