### PR TITLE
fix(providers): resolve ollama chat schema off the decorator-free module + dedup multipart helper

### DIFF
--- a/lionagi/providers/_multipart.py
+++ b/lionagi/providers/_multipart.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+
+
+def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
+    """Return a zero-arg callable producing a fresh file object for one retry attempt.
+    See docs/internals/runtime.md for the replay-safety invariant."""
+    if file_data is None:
+        return lambda: None
+    if isinstance(file_data, (bytes, bytearray)):
+        snapshot = bytes(file_data)
+        return lambda: io.BytesIO(snapshot)
+    if not require_replayable:
+        return lambda: file_data
+
+    seekable = getattr(file_data, "seekable", None)
+    if not callable(seekable) or not seekable():
+        if require_replayable:
+            raise TypeError(
+                f"{field_name} must be bytes, bytearray, or a seekable stream to "
+                "support retries; pass bytes, or configure the endpoint with "
+                "max_retries=1 for a non-seekable stream."
+            )
+        return lambda: file_data
+    # Snapshot once, restore position — a live stream handed to each attempt would
+    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
+    start_pos = file_data.tell()
+    snapshot = file_data.read()
+    file_data.seek(start_pos)
+    return lambda: io.BytesIO(snapshot)
+
+
+__all__ = ("_replayable_file_factory",)

--- a/lionagi/providers/groq/audio_transcription.py
+++ b/lionagi/providers/groq/audio_transcription.py
@@ -1,41 +1,12 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-import io
-
+from lionagi.providers._multipart import _replayable_file_factory
 from lionagi.service.connections.endpoint import Endpoint
 
 from ._config import GroqConfigs
 
 __all__ = ("GroqAudioTranscriptionEndpoint",)
-
-
-def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one retry attempt.
-    See docs/internals/runtime.md for the replay-safety invariant."""
-    if file_data is None:
-        return lambda: None
-    if isinstance(file_data, (bytes, bytearray)):
-        snapshot = bytes(file_data)
-        return lambda: io.BytesIO(snapshot)
-    if not require_replayable:
-        return lambda: file_data
-
-    seekable = getattr(file_data, "seekable", None)
-    if not callable(seekable) or not seekable():
-        if require_replayable:
-            raise TypeError(
-                f"{field_name} must be bytes, bytearray, or a seekable stream to "
-                "support retries; pass bytes, or configure the endpoint with "
-                "max_retries=1 for a non-seekable stream."
-            )
-        return lambda: file_data
-    # Snapshot once, restore position — a live stream handed to each attempt would
-    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
-    start_pos = file_data.tell()
-    snapshot = file_data.read()
-    file_data.seek(start_pos)
-    return lambda: io.BytesIO(snapshot)
 
 
 @GroqConfigs.AUDIO_TRANSCRIPTION.register

--- a/lionagi/providers/ollama/_config.py
+++ b/lionagi/providers/ollama/_config.py
@@ -12,7 +12,7 @@ class OllamaConfigs(ProviderConfig, Enum):
         "chat/completions",
         ["chat"],
         EndpointType.API,
-        LazyType("lionagi.providers.ollama.chat:OpenAIChatCompletionsRequest"),
+        LazyType("lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest"),
         "http://localhost:11434/v1",
         "none",
     )

--- a/lionagi/providers/openai/audio.py
+++ b/lionagi/providers/openai/audio.py
@@ -5,10 +5,9 @@
 
 from __future__ import annotations
 
-import io
-
 from pydantic import BaseModel
 
+from lionagi.providers._multipart import _replayable_file_factory
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -21,34 +20,6 @@ __all__ = (
     "OpenaiAudioSpeechEndpoint",
     "OpenaiAudioTranscriptionEndpoint",
 )
-
-
-def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one retry attempt.
-    See docs/internals/runtime.md for the replay-safety invariant."""
-    if file_data is None:
-        return lambda: None
-    if isinstance(file_data, (bytes, bytearray)):
-        snapshot = bytes(file_data)
-        return lambda: io.BytesIO(snapshot)
-    if not require_replayable:
-        return lambda: file_data
-
-    seekable = getattr(file_data, "seekable", None)
-    if not callable(seekable) or not seekable():
-        if require_replayable:
-            raise TypeError(
-                f"{field_name} must be bytes, bytearray, or a seekable stream to "
-                "support retries; pass bytes, or configure the endpoint with "
-                "max_retries=1 for a non-seekable stream."
-            )
-        return lambda: file_data
-    # Snapshot once, restore position — a live stream handed to each attempt would
-    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
-    start_pos = file_data.tell()
-    snapshot = file_data.read()
-    file_data.seek(start_pos)
-    return lambda: io.BytesIO(snapshot)
 
 
 @OpenAIConfigs.AUDIO_SPEECH.register

--- a/lionagi/providers/openai/images.py
+++ b/lionagi/providers/openai/images.py
@@ -5,11 +5,11 @@
 
 from __future__ import annotations
 
-import io
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from lionagi.providers._multipart import _replayable_file_factory
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -96,34 +96,6 @@ __all__ = (
     "OpenaiImageGenerationEndpoint",
     "OpenaiImageEditEndpoint",
 )
-
-
-def _replayable_file_factory(file_data, field_name: str, *, require_replayable: bool = True):
-    """Return a zero-arg callable producing a fresh file object for one retry attempt.
-    See docs/internals/runtime.md for the replay-safety invariant."""
-    if file_data is None:
-        return lambda: None
-    if isinstance(file_data, (bytes, bytearray)):
-        snapshot = bytes(file_data)
-        return lambda: io.BytesIO(snapshot)
-    if not require_replayable:
-        return lambda: file_data
-
-    seekable = getattr(file_data, "seekable", None)
-    if not callable(seekable) or not seekable():
-        if require_replayable:
-            raise TypeError(
-                f"{field_name} must be bytes, bytearray, or a seekable stream to "
-                "support retries; pass bytes, or configure the endpoint with "
-                "max_retries=1 for a non-seekable stream."
-            )
-        return lambda: file_data
-    # Snapshot once, restore position — a live stream handed to each attempt would
-    # already be at EOF on retry (RetryConfig re-invokes _call), uploading empty.
-    start_pos = file_data.tell()
-    snapshot = file_data.read()
-    file_data.seek(start_pos)
-    return lambda: io.BytesIO(snapshot)
 
 
 @OpenAIConfigs.IMAGE_GENERATION.register

--- a/tests/providers/test_multipart_helper.py
+++ b/tests/providers/test_multipart_helper.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from lionagi.providers._multipart import _replayable_file_factory
+
+
+class NonSeekable:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    def read(self) -> bytes:
+        return self.data
+
+    def seekable(self) -> bool:
+        return False
+
+
+def test_none_returns_none() -> None:
+    factory = _replayable_file_factory(None, "file")
+    assert factory() is None
+
+
+def test_bytes_are_snapshotted_into_fresh_streams() -> None:
+    source = bytearray(b"abc")
+    factory = _replayable_file_factory(source, "file")
+    source[:] = b"zzz"
+
+    first = factory()
+    second = factory()
+    assert first is not second
+    assert first.read() == b"abc"
+    assert second.read() == b"abc"
+
+
+def test_seekable_stream_preserves_cursor_and_snapshots_suffix() -> None:
+    source = io.BytesIO(b"prefix-payload")
+    source.seek(len(b"prefix-"))
+    original_position = source.tell()
+
+    factory = _replayable_file_factory(source, "image")
+
+    assert source.tell() == original_position
+    first = factory()
+    second = factory()
+    assert first is not second
+    assert first.read() == b"payload"
+    assert second.read() == b"payload"
+
+
+def test_non_seekable_stream_is_rejected_when_retryable() -> None:
+    with pytest.raises(TypeError, match="audio"):
+        _replayable_file_factory(NonSeekable(b"x"), "audio")
+
+
+def test_non_seekable_stream_is_reused_when_not_retryable() -> None:
+    source = NonSeekable(b"x")
+    factory = _replayable_file_factory(
+        source,
+        "audio",
+        require_replayable=False,
+    )
+    assert factory() is source

--- a/tests/service/connections/test_schema_import_boundaries.py
+++ b/tests/service/connections/test_schema_import_boundaries.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _schema_files() -> list[Path]:
+    return sorted(
+        path
+        for path in (REPO_ROOT / "lionagi" / "providers").rglob("*.py")
+        if path.name == "_schemas.py" or path.name.endswith("_schemas.py")
+    )
+
+
+def _module_name(path: Path) -> str:
+    return ".".join(path.relative_to(REPO_ROOT).with_suffix("").parts)
+
+
+def _is_register_decorator(node: ast.expr) -> bool:
+    target = node.func if isinstance(node, ast.Call) else node
+    return isinstance(target, ast.Attribute) and target.attr == "register"
+
+
+def _run_fresh(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (str(REPO_ROOT), env.get("PYTHONPATH"))))
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_schema_only_modules_have_no_registration_decorators() -> None:
+    files = _schema_files()
+    observed = {path.relative_to(REPO_ROOT).as_posix() for path in files}
+    expected = {
+        "lionagi/providers/openai/_chat_schemas.py",
+        "lionagi/providers/openai/_audio_schemas.py",
+        "lionagi/providers/exa/_schemas.py",
+        "lionagi/providers/firecrawl/_schemas.py",
+    }
+    assert expected <= observed
+
+    violations: list[tuple[str, int]] = []
+    for path in files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            for decorator in getattr(node, "decorator_list", ()):
+                if _is_register_decorator(decorator):
+                    violations.append((path.relative_to(REPO_ROOT).as_posix(), node.lineno))
+    assert violations == []
+
+
+def test_importing_schema_only_modules_does_not_register_endpoints() -> None:
+    modules = [_module_name(path) for path in _schema_files()]
+    script = f"""
+import importlib
+from lionagi.service.connections.registry import EndpointRegistry
+
+assert EndpointRegistry._loaded is False
+assert EndpointRegistry._entries == []
+for module in {json.dumps(modules)}:
+    before = tuple(EndpointRegistry._entries)
+    importlib.import_module(module)
+    assert tuple(EndpointRegistry._entries) == before, module
+assert EndpointRegistry._loaded is False
+"""
+    _run_fresh(script)
+
+
+def test_resolving_ollama_chat_schema_does_not_register_endpoint() -> None:
+    script = """
+from lionagi.service.connections.registry import EndpointRegistry
+assert EndpointRegistry._loaded is False
+assert EndpointRegistry._entries == []
+
+from lionagi.providers.ollama._config import OllamaConfigs
+resolved = OllamaConfigs.CHAT.options
+
+assert resolved.__name__ == "OpenAIChatCompletionsRequest"
+assert EndpointRegistry._loaded is False
+assert EndpointRegistry._entries == []
+"""
+    _run_fresh(script)


### PR DESCRIPTION
## Summary

Two independent hygiene fixes in the providers layer.

**1. Resolve the Ollama chat request schema off a decorator-free module.**
`OllamaConfigs.CHAT.options` resolved `OpenAIChatCompletionsRequest` through
`lionagi.providers.ollama.chat` — a module whose import registers the Ollama
chat endpoint as a side effect (`@register`). Reading the config's request
schema therefore eagerly registered an endpoint, coupling plain data access to
endpoint registration and breaking the lazy-import contract (a bare
`import lionagi` followed by touching a config should not populate the endpoint
registry). The `LazyType` now points at `openai._chat_schemas`, the
decorator-free schema module that already defines the identical class. Endpoint
registration is unchanged: `OllamaChatEndpoint` still registers on the full
provider import path with the same `OpenAIChatCompletionsRequest` request
schema.

**2. De-duplicate the multipart file-factory helper.**
`_replayable_file_factory` was copied byte-for-byte into three endpoint modules
(`openai/audio.py`, `openai/images.py`, `groq/audio_transcription.py`). Extract
it once into `lionagi/providers/_multipart.py` and import it from all three. No
behavior change — the extracted body is identical to the three copies it
replaces.

## Tests

- `tests/providers/test_multipart_helper.py` — the shared helper: `None`
  passthrough, bytes snapshot isolation, seekable-stream cursor restoration,
  non-seekable rejection when retryable, non-seekable reuse when not retryable.
- `tests/service/connections/test_schema_import_boundaries.py` — import-boundary
  regression: the schema-only modules carry no registration decorators,
  importing them registers nothing, and resolving `OllamaConfigs.CHAT.options`
  registers no endpoint.

Full `tests/providers` and `tests/service/connections` suites pass with all
extras installed.
