### PR TITLE
fix(protocols): preserve caller state, honor logical order and clear on Pile/Flow

### DIFF
--- a/lionagi/protocols/generic/flow.py
+++ b/lionagi/protocols/generic/flow.py
@@ -85,7 +85,9 @@ class Flow(Element, Generic[E, P]):
     def from_dict(cls, data: dict) -> Flow:
         """Deserialize from dict; reconstructs Pile fields explicitly (model_validate can't round-trip them)."""
         data = data.copy()
-        metadata = data.pop("metadata", {})
+        # Copy the nested metadata dict: data.copy() is shallow, so popping
+        # lion_class off the original would mutate the caller's snapshot.
+        metadata = dict(data.pop("metadata", None) or {})
         metadata.pop("lion_class", None)
 
         # Coerce scalar fields that model_construct won't validate
@@ -181,11 +183,11 @@ class Flow(Element, Generic[E, P]):
                 else:
                     progs_list = list(progressions)
 
+                # Resolve every reference through the owned progression pile,
+                # including bare Progression instances: appending to an unowned
+                # progression would mutate an ordering the flow does not track.
                 for p in progs_list:
-                    if isinstance(p, Progression):
-                        resolved.append(p)
-                    else:
-                        resolved.append(self.get_progression(p))
+                    resolved.append(self.get_progression(p))
 
             self.items.include(item)
 

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -901,7 +901,10 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
                 "Please install it via: pip install pandas  or  uv add pandas"
             ) from e
 
-        df = DataFrameAdapter.to_obj(list(self.collections.values()), adapt_meth="to_dict", **kw)
+        # Serialize in progression (logical) order, not dict insertion order,
+        # so the frame matches iteration and every ordered dump/adump path.
+        ordered = [self.collections[key] for key in self.progression]
+        df = DataFrameAdapter.to_obj(ordered, adapt_meth="to_dict", **kw)
         if columns:
             return df[columns]
         return df
@@ -914,24 +917,26 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         mode: Literal["w", "a"] = "w",
         clear=False,
         **kw,
-    ) -> None:
+    ) -> str | None:
         df = self.to_df()
+        out = None
         match obj_key:
             case "parquet":
                 df.to_parquet(fp, engine="pyarrow", index=False, **kw)
             case "json":
                 out = df.to_json(fp, orient="records", lines=True, mode=mode, **kw)
-                return out if out is not None else None
             case "csv":
                 out = df.to_csv(fp, index=False, mode=mode, **kw)
-                return out if out is not None else None
             case _:
                 raise ValueError(
                     f"Unsupported obj_key: {obj_key}. Supported keys are 'json', 'csv', 'parquet'."
                 )
 
+        # Clear only after a successful write, and for every format: the json/csv
+        # branches previously returned early and skipped this.
         if clear:
             self.clear()
+        return out
 
     async def adump(
         self,

--- a/tests/protocols/generic/test_flow.py
+++ b/tests/protocols/generic/test_flow.py
@@ -226,6 +226,18 @@ class TestAddItem:
         with pytest.raises(ItemNotFoundError):
             flow.add_item(node, progressions="ghost")
 
+    def test_add_item_unowned_progression_instance_rejected(self):
+        """A Progression the flow does not own must not be silently mutated."""
+        flow = Flow()
+        node = Node(content="x")
+        external = Progression(name="external")
+        with pytest.raises(ItemNotFoundError):
+            flow.add_item(node, progressions=external)
+        # The operation fails atomically: neither the flow nor the external
+        # progression is touched.
+        assert node.id not in flow.items
+        assert node.id not in external
+
 
 # ---------------------------------------------------------------------------
 # remove_item

--- a/tests/protocols/generic/test_flow_serialization.py
+++ b/tests/protocols/generic/test_flow_serialization.py
@@ -184,6 +184,18 @@ class TestFlowRoundTrip:
             for uid in prog:
                 assert uid in item_ids
 
+    def test_from_dict_does_not_mutate_caller_metadata(self):
+        """from_dict must not strip lion_class from the caller's own payload."""
+        flow, _, _ = _flow_with_progression(2)
+        d = flow.to_dict()
+        assert d["metadata"].get("lion_class")  # present before deserialization
+        Flow.from_dict(d)
+        # The caller's dict is untouched: the payload stays reusable for a second
+        # reconstruction, logging, or comparison.
+        assert d["metadata"].get("lion_class")
+        flow2 = Flow.from_dict(d)
+        assert flow2.name == flow.name
+
 
 # ---------------------------------------------------------------------------
 # _progression_names index rebuild

--- a/tests/protocols/generic/test_pile_serialization.py
+++ b/tests/protocols/generic/test_pile_serialization.py
@@ -85,6 +85,15 @@ class TestToDataFrame:
         df = p.to_df()
         assert sorted(df["value"].tolist()) == list(range(5))
 
+    def test_to_df_preserves_progression_order(self, three_items):
+        """to_df must follow logical (progression) order, not dict insertion order."""
+        p = Pile(collections=three_items)
+        head = Item(value=99)
+        p.insert(0, head)  # logical order is now head, *three_items
+        logical = [str(x.id) for x in p]
+        df = p.to_df()
+        assert [str(x) for x in df["id"].tolist()] == logical
+
 
 @pytest.mark.skipif(pandas_missing, reason="pandas not installed")
 class TestDump:
@@ -131,6 +140,36 @@ class TestDump:
         p.dump(fp, obj_key="parquet", clear=True)
         assert len(p) == 0
         fp.unlink()
+
+    def test_dump_json_clear_empties_pile(self, pile_3):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            fp = Path(f.name)
+        assert len(pile_3) == 3
+        pile_3.dump(fp, obj_key="json", clear=True)
+        assert len(pile_3) == 0
+        # data was written to the file before clearing
+        assert len(fp.read_text().strip().splitlines()) == 3
+        fp.unlink()
+
+    def test_dump_csv_clear_empties_pile(self, pile_3):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            fp = Path(f.name)
+        pile_3.dump(fp, obj_key="csv", clear=True)
+        assert len(pile_3) == 0
+        assert len(fp.read_text().strip().splitlines()) == 4  # header + 3 rows
+        fp.unlink()
+
+    def test_dump_json_no_clear_preserves_pile(self, pile_3):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            fp = Path(f.name)
+        pile_3.dump(fp, obj_key="json", clear=False)
+        assert len(pile_3) == 3
+        fp.unlink()
+
+    def test_dump_fp_none_returns_serialized_string(self, pile_3):
+        out = pile_3.dump(None, obj_key="json")
+        assert isinstance(out, str) and out.strip()
+        assert len(pile_3) == 3  # default clear=False leaves the pile intact
 
     @pytest.mark.asyncio
     async def test_adump_json(self, pile_3):


### PR DESCRIPTION
## Summary

Four correctness fixes in the `protocols/generic` primitives. Each changes a
path that silently lost or corrupted caller state.

**1. `Flow.from_dict` no longer mutates the caller's payload.**
`from_dict` did `data.copy()` (shallow) and then `metadata.pop("lion_class")`,
which mutated the caller-owned nested `metadata` dict. A payload retained for
logging, comparison, retry, or a second reconstruction was changed by
deserialization. The metadata dict is now copied before the pop.

**2. `Flow.add_item` rejects an unowned `Progression` instead of mutating it.**
Passing a bare `Progression` the flow did not own appended the item to that
external progression and reported success, while the flow's serialization,
removal, and `clear()` did not track it. Every progression reference now
resolves through the owned progression pile, so an unowned instance raises
`ItemNotFoundError` before any mutation. The call fails atomically — neither the
flow nor the external progression is touched. Owned references (by name, UUID,
or instance) are unchanged.

**3. `Pile.to_df` serializes in logical order.**
`to_df` iterated the backing dict in insertion order rather than the pile's
progression order, so the frame disagreed with iteration and with every ordered
`dump`/`adump`. It now iterates progression order. Because `dump` and `adump`
share `to_df`, this fixes both.

**4. `Pile.dump` honors `clear=True` for json and csv.**
The json and csv branches returned before the shared `if clear:` branch, so
`clear=True` was silently ignored for those two formats (parquet already
cleared). The return is unified so `clear` fires after a successful write for
every format. `dump`'s return type is now `str | None`, matching the string it
already returned for json/csv when `fp` is `None`.

## Tests

- `from_dict` leaves the caller payload intact (`lion_class` still present).
- `add_item` rejects an unowned `Progression` with no side effects.
- `to_df` follows progression order after an out-of-insertion-order insert.
- json and csv `dump` empty the pile with `clear=True` after writing the records,
  preserve it with `clear=False`, and `fp=None` returns the serialized string.

Full `tests/protocols/generic` suite passes; `tests/protocols` and
`tests/adapters` pass as a dependent-surface check.
