### PR TITLE
fix(session): stop dropping mail and mutating snapshots; one lifecycle pair per operate

### DIFF
--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -468,15 +468,23 @@ class Branch(Element, Relational):
 
             await self._safe_emit(RunStart())
         _t0 = _time.monotonic()
+        # This wrapper owns the lifecycle pair for the operation; suppress the
+        # nested run() generator's own pair so one CLI-backed operate() emits
+        # exactly one RunStart/RunEnd (same task-scoped mechanism ReAct uses).
+        from ._lifecycle_ctx import suppress_lifecycle_var
+
+        _lc_token = suppress_lifecycle_var.set(True)
         try:
             result = await coro
         except BaseException as exc:
+            suppress_lifecycle_var.reset(_lc_token)
             await self.drain_signals()
             if has_observer:
                 from .signal import RunFailed
 
                 await self._safe_emit(RunFailed(data=exc))
             raise
+        suppress_lifecycle_var.reset(_lc_token)
         await self.drain_signals()
         if has_observer:
             from .signal import build_run_end
@@ -653,8 +661,12 @@ class Branch(Element, Relational):
     def _serialize_metadata_if_clone(self, v):
         if "clone_from" not in v:
             return v
-        v = dict(v)
         source = v["clone_from"]
+        # A clone restored via from_dict keeps clone_from as the already-serialized
+        # dict; re-serializing must be idempotent, not dereference source.id on a dict.
+        if isinstance(source, dict):
+            return v
+        v = dict(v)
         v["clone_from"] = {
             "id": str(source.id),
             "user": str(source.user),
@@ -698,6 +710,10 @@ class Branch(Element, Relational):
 
     @classmethod
     def from_dict(cls, data: dict):
+        # Copy first: the pops below would otherwise strip messages, chat_model,
+        # and log_config out of the caller's snapshot, so it could not be reused
+        # for a retry, comparison, or a second restoration.
+        data = dict(data)
         dict_ = {
             "messages": data.pop("messages", Unset),
             "logs": data.pop("logs", Unset),

--- a/lionagi/session/exchange.py
+++ b/lionagi/session/exchange.py
@@ -109,16 +109,16 @@ class Exchange(Element):
                     deliveries.append((message.recipient, message))
             self._mark_in_flight(deliveries, increment=True)
         if deliveries:
-            try:
-                await gather(
-                    *[
-                        self._deliver_to(recipient_id, message)
-                        for recipient_id, message in deliveries
-                    ],
-                    return_exceptions=True,
-                )
-            finally:
-                self._mark_in_flight(deliveries, increment=False)
+            # _deliver_to removes each entry from in-flight on a successful
+            # delivery and leaves it in place if the inbox write raises. Do not
+            # unconditionally clear in-flight afterwards: that dropped a failed
+            # delivery from every recovery surface (outbox and items are already
+            # emptied), silently losing the message. Leaving it in-flight keeps
+            # it recoverable via drain_pending().
+            await gather(
+                *[self._deliver_to(recipient_id, message) for recipient_id, message in deliveries],
+                return_exceptions=True,
+            )
 
         unique_messages = {message.id for _, message in deliveries}
         return len(unique_messages)
@@ -223,16 +223,19 @@ class Exchange(Element):
             elif message.recipient is not None and message.recipient in self._owner_index:
                 deliveries.append((message.recipient, message))
 
+        # Track in-flight before delivering (as the async path does) so a raising
+        # inbox write leaves the message recoverable via drain_pending() rather
+        # than dropping it; the outbox and items entries are already gone.
+        self._mark_in_flight(deliveries, increment=True)
         for recipient_id, message in deliveries:
-            recipient_flow = self.get(recipient_id)
-            if recipient_flow is None:
-                continue
-            inbox_name = _inbox_name(message.sender)
-            try:
-                recipient_flow.add_progression(Progression(name=inbox_name))
-            except ItemExistsError:
-                pass
-            recipient_flow.add_item(message, progressions=inbox_name)
+            with self._in_flight_lock:
+                pending = self._in_flight.get(recipient_id, [])
+                if not any(candidate is message for candidate in pending):
+                    continue
+                # Deliver first, then drop from in-flight: if add_item raises the
+                # entry stays in place and remains recoverable.
+                self._deliver_locked(recipient_id, message)
+                self._remove_in_flight_locked(recipient_id, message)
 
         return len({m.id for _, m in deliveries})
 

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -279,7 +279,13 @@ class Session(Node, Relational):
 
     async def asplit(self, branch: ID.Ref) -> Branch:
         async with self.branches:
-            return self.split(branch)
+            branch: Branch = self.branches[branch]
+            # Use aclone, not the sync split path: aclone holds the message
+            # snapshot lock across the clone, so a concurrent sync-thread message
+            # removal cannot race the copy and raise KeyError mid-clone.
+            branch_clone = await branch.aclone(sender=self.id)
+            self.include_branches(branch_clone)
+            return branch_clone
 
     def split(self, branch: ID.Ref) -> Branch:
         branch: Branch = self.branches[branch]

--- a/tests/session/test_core_bugs.py
+++ b/tests/session/test_core_bugs.py
@@ -297,3 +297,73 @@ class TestObserveByRole:
         obs = SessionObserver()
         with pytest.raises(TypeError):
             obs.observe(None, lambda e, ctx: None)
+
+
+# ---------------------------------------------------------------------------
+# Branch / Session serialization and split regressions
+# ---------------------------------------------------------------------------
+
+
+class TestBranchStateRegressions:
+    def test_restored_clone_can_be_reserialized(self):
+        """A clone restored via from_dict must serialize again.
+
+        The metadata serializer wrote clone_from as a dict; a restored clone
+        keeps that dict, so re-serializing must be idempotent instead of
+        dereferencing source.id on a dict.
+        """
+        import copy
+
+        from lionagi.session.branch import Branch
+
+        s = Session()
+        b = s.new_branch()
+        b.msgs.add_message(instruction="hi")
+        clone = s.split(b.id)
+
+        d1 = clone.to_dict()
+        restored = Branch.from_dict(copy.deepcopy(d1))
+        # Previously raised AttributeError: 'dict' object has no attribute 'id'.
+        d2 = restored.to_dict()
+        assert d2["metadata"]["clone_from"] == d1["metadata"]["clone_from"]
+
+    def test_from_dict_does_not_mutate_snapshot(self):
+        """Branch.from_dict must not strip fields out of the caller's snapshot."""
+        import copy
+
+        from lionagi.session.branch import Branch
+
+        s = Session()
+        b = s.new_branch()
+        b.msgs.add_message(instruction="hello")
+        snap = b.to_dict(include_log_config=True)
+        before = copy.deepcopy(snap)
+
+        Branch.from_dict(snap)
+
+        assert snap == before  # reusable for a retry / second restoration
+        assert "messages" in snap and "chat_model" in snap
+
+    async def test_asplit_clones_under_message_lock(self, monkeypatch):
+        """asplit must clone via aclone (holds the message snapshot lock), not
+        the bare sync clone path that can race a concurrent message removal."""
+        from lionagi.session.branch import Branch
+
+        s = Session()
+        b = s.new_branch()
+        b.msgs.add_message(instruction="hi")
+
+        aclone_calls = 0
+        real_aclone = Branch.aclone
+
+        async def spy_aclone(self, sender=None):
+            nonlocal aclone_calls
+            aclone_calls += 1
+            return await real_aclone(self, sender)
+
+        monkeypatch.setattr(Branch, "aclone", spy_aclone)
+
+        clone = await s.asplit(b.id)
+        assert aclone_calls == 1
+        assert clone.id != b.id
+        assert len(clone.messages) == len(b.messages)

--- a/tests/session/test_exchange.py
+++ b/tests/session/test_exchange.py
@@ -466,3 +466,56 @@ class TestExchangeEdgeCases:
         count = await exchange.collect(owner_id)
 
         assert count == 0
+
+
+class TestExchangeDeliveryFailureRecovery:
+    """A failed inbox delivery must leave the message recoverable, not dropped.
+
+    The outbox and items entries are consumed before delivery, so in-flight is
+    the only recovery surface; a failed delivery must stay there.
+    """
+
+    @staticmethod
+    def _patch_inbox_write_to_fail(monkeypatch):
+        from lionagi.protocols.generic.flow import Flow
+
+        def _boom(self, *args, **kwargs):
+            raise RuntimeError("inbox write failed")
+
+        monkeypatch.setattr(Flow, "add_item", _boom)
+
+    @pytest.mark.anyio
+    async def test_async_collect_retains_message_on_delivery_failure(self, monkeypatch):
+        exchange = Exchange()
+        sender, recipient = uuid4(), uuid4()
+        exchange.register(sender)
+        exchange.register(recipient)
+        exchange.send(sender, recipient, content={"text": "keep me"})
+
+        self._patch_inbox_write_to_fail(monkeypatch)
+        # return_exceptions=True swallows the failure; collect returns normally.
+        await exchange.collect(sender)
+
+        assert exchange.receive(recipient, sender=sender) == []
+        assert exchange._in_flight.get(recipient)  # retained -> recoverable
+
+        monkeypatch.undo()
+        drained = exchange.drain_pending(recipient)
+        assert len(drained) == 1
+
+    def test_sync_collect_retains_message_on_delivery_failure(self, monkeypatch):
+        exchange = Exchange()
+        sender, recipient = uuid4(), uuid4()
+        exchange.register(sender)
+        exchange.register(recipient)
+        exchange.send(sender, recipient, content={"text": "keep me"})
+
+        self._patch_inbox_write_to_fail(monkeypatch)
+        with pytest.raises(RuntimeError):
+            exchange.collect_sync(sender)
+
+        assert exchange._in_flight.get(recipient)  # retained -> recoverable
+
+        monkeypatch.undo()
+        drained = exchange.drain_pending(recipient)
+        assert len(drained) == 1

--- a/tests/session/test_run_lifecycle.py
+++ b/tests/session/test_run_lifecycle.py
@@ -153,6 +153,26 @@ async def test_react_emits_exactly_one_run_start():
     assert len(ends) == 1, f"expected 1 RunEnd, got {len(ends)}"
 
 
+async def test_cli_operate_emits_exactly_one_lifecycle_pair():
+    """A CLI-backed Branch.operate() must emit one RunStart/RunEnd, not two.
+
+    _observed_run owns the outer pair; the nested run() generator must suppress
+    its own so observers do not double-count the operation (or its usage).
+    """
+    s = Session()
+    model = _make_fake_cli_model([StreamChunk(type="text", content="hello")])
+    s.default_branch.chat_model = model
+
+    starts, ends = [], []
+    s.observe(RunStart, lambda sig, _: starts.append(sig))
+    s.observe(RunEnd, lambda sig, _: ends.append(sig))
+
+    await s.default_branch.operate(instruction="go", skip_validation=True)
+
+    assert len(starts) == 1, f"expected 1 RunStart, got {len(starts)}: nested run() not suppressed"
+    assert len(ends) == 1, f"expected 1 RunEnd, got {len(ends)}"
+
+
 async def test_react_emits_run_failed_on_exception():
     """Branch.ReAct() must emit RunFailed when the inner call raises."""
     s = Session()


### PR DESCRIPTION
## Summary

Five correctness fixes in the session layer. Each was a path that silently lost
message or branch state, or double-counted an operation.

**1. `Exchange` no longer drops mail when an inbox delivery fails.**
Async `collect()` emptied the outbox and items entries, then unconditionally
cleared in-flight in a `finally` — including deliveries whose inbox write had
raised (swallowed by `return_exceptions=True`). Sync `collect_sync()` removed the
message before the inbox append and tracked no in-flight at all. Either way a
failed delivery was lost from every recovery surface. `_deliver_to` already
removes an entry on success and leaves it on failure, so the async path no longer
clears in-flight afterwards, and the sync path tracks in-flight first and drops
the entry only after a successful `_deliver_locked`. A failed delivery stays
recoverable via `drain_pending()`.

**2. A restored clone can be serialized again.**
The metadata serializer wrote `clone_from` as a dict, but a clone restored via
`from_dict` keeps that dict, and re-serializing dereferenced `source.id` on it.
The serializer now passes an already-serialized `clone_from` through unchanged.

**3. `Branch.from_dict` does not mutate the caller's snapshot.**
It popped `messages`, `chat_model`, and `log_config` out of the supplied mapping,
so a snapshot could not be reused for a retry, comparison, or a second
restoration. It now copies the mapping before popping.

**4. `Session.asplit()` clones under the message lock.**
`asplit()` invoked the sync clone path, which iterates the message pile without
the snapshot lock, so a concurrent removal could race the copy and raise
`KeyError`. `asplit()` now uses `aclone()`, which holds the message lock across
the clone.

**5. A CLI-backed `Branch.operate()` emits one lifecycle pair, not two.**
It emitted a `RunStart`/`RunEnd` pair from `_observed_run` and another from the
nested `run()` generator. `_observed_run` now sets the task-scoped
`suppress_lifecycle_var` around the wrapped coroutine (the mechanism `ReAct`
already uses), so one operation emits exactly one pair.

## Tests

- Async and sync `collect` leave the message recoverable when the inbox write
  raises (in-flight retained, `drain_pending` recovers it).
- A restored clone re-serializes; `from_dict` leaves the snapshot intact.
- `asplit` clones via `aclone` (holds the message lock).
- A CLI-backed `operate` emits exactly one `RunStart`/`RunEnd`.

Each new test fails without its fix. Full `tests/session` and `tests/operations`
suites pass, plus the messenger/team exchange consumers.
