### PR TITLE
fix(models): retain field metadata, reject spoofed unions, capture constructor FieldModels

### DIFF
--- a/lionagi/models/field_model.py
+++ b/lionagi/models/field_model.py
@@ -414,18 +414,21 @@ class FieldModel(Params):
         return t_
 
     def to_spec(self) -> Spec:
-        from ..ln.types import Spec
+        # Forward every metadata entry as-is so unknown keys survive, an explicit
+        # default=None is preserved (not gated on `is not None`), and
+        # json_schema_extra stays a nested value rather than being flattened into
+        # field-level kwargs (a "default" key inside it must never become the
+        # runtime default). Metadata is passed as a Meta tuple, not **kwargs, so a
+        # key that collides with a Spec.__init__ parameter (self / base_type /
+        # metadata) survives instead of raising. nullable/listable are derived
+        # flags: supply them explicitly and drop any stored duplicates so
+        # CommonMeta.prepare() sees each key exactly once.
+        existing = () if self._is_sentinel(self.metadata) else self.metadata
+        metas = [m for m in existing if m.key not in ("nullable", "listable")]
+        metas.append(Meta("nullable", self.is_nullable))
+        metas.append(Meta("listable", self.is_listable))
 
-        # Forward every metadata entry as-is: Spec turns each **kw into a Meta, so
-        # unknown keys survive, an explicit default=None is preserved (not gated on
-        # `is not None`), and json_schema_extra stays a nested value rather than
-        # being flattened into field-level kwargs (a "default" key inside it must
-        # never become the runtime default).
-        kwargs = self.metadata_dict()
-        kwargs["nullable"] = self.is_nullable
-        kwargs["listable"] = self.is_listable
-
-        return Spec(self.base_type, **kwargs)
+        return Spec(self.base_type, metadata=tuple(metas))
 
     def metadata_dict(self, exclude: list[str] | None = None) -> dict[str, Any]:
         result = {}

--- a/lionagi/models/field_model.py
+++ b/lionagi/models/field_model.py
@@ -74,7 +74,6 @@ class FieldModel(Params):
                 or isinstance(
                     self.base_type, types.UnionType
                 )  # Python 3.10+ union types (str | None)
-                or str(type(self.base_type)) == "<class 'types.UnionType'>"
             )
             if not is_valid_type:
                 raise ValueError(
@@ -417,39 +416,14 @@ class FieldModel(Params):
     def to_spec(self) -> Spec:
         from ..ln.types import Spec
 
-        kwargs = {}
-        name = self.extract_metadata("name")
-        if name:
-            kwargs["name"] = name
-
+        # Forward every metadata entry as-is: Spec turns each **kw into a Meta, so
+        # unknown keys survive, an explicit default=None is preserved (not gated on
+        # `is not None`), and json_schema_extra stays a nested value rather than
+        # being flattened into field-level kwargs (a "default" key inside it must
+        # never become the runtime default).
+        kwargs = self.metadata_dict()
         kwargs["nullable"] = self.is_nullable
         kwargs["listable"] = self.is_listable
-
-        default = self.extract_metadata("default")
-        if default is not None:
-            kwargs["default"] = default
-
-        default_factory = self.extract_metadata("default_factory")
-        if default_factory is not None:
-            kwargs["default_factory"] = default_factory
-
-        validator = self.extract_metadata("validator")
-        if validator is not None:
-            kwargs["validator"] = validator
-
-        description = self.extract_metadata("description")
-        if description:
-            kwargs["description"] = description
-
-        for key in ["title", "alias", "frozen", "exclude"]:
-            val = self.extract_metadata(key)
-            if val is not None:
-                kwargs[key] = val
-
-        json_schema_extra = self.extract_metadata("json_schema_extra")
-        if json_schema_extra:
-            for k, v in json_schema_extra.items():
-                kwargs[k] = v
 
         return Spec(self.base_type, **kwargs)
 

--- a/lionagi/models/operable_model.py
+++ b/lionagi/models/operable_model.py
@@ -63,18 +63,20 @@ class OperableModel(HashableModel):
     def _validate_extra_fields(
         cls,
         value: list[FieldModel] | dict[str, FieldModel | FieldInfo],
-    ) -> dict[str, FieldInfo]:
+    ) -> dict[str, FieldModel | FieldInfo]:
+        # Preserve FieldModels here (the `| Any` on the field permits it). The
+        # after-validator below converts them to FieldInfos AND captures the
+        # originals into extra_field_models; converting them up front would leave
+        # that mapping empty and silently drop their validators.
         out = {}
         if isinstance(value, dict):
             for k, v in value.items():
-                if isinstance(v, FieldModel):
-                    out[k] = v.create_field()
-                elif isinstance(v, FieldInfo):
+                if isinstance(v, FieldModel | FieldInfo):
                     out[k] = v
             return out
 
         elif isinstance(value, list) and is_same_dtype(value, FieldModel):
-            return {v.name: v.create_field() for v in value}
+            return {v.name: v for v in value}
 
         raise ValueError("Invalid extra_fields value")
 

--- a/tests/models/test_field_model.py
+++ b/tests/models/test_field_model.py
@@ -253,3 +253,14 @@ def test_to_spec_does_not_flatten_json_schema_extra():
     spec = FieldModel(base_type=int, default=5, json_schema_extra={"default": 999}).to_spec()
     assert spec.default == 5
     assert spec.get("json_schema_extra") == {"default": 999}
+
+
+@pytest.mark.parametrize("key", ["self", "base_type", "metadata"])
+def test_to_spec_forwards_reserved_metadata_keys(key):
+    """Metadata keys that collide with Spec.__init__ parameters still round-trip.
+
+    Passing metadata as **kwargs would raise (multiple-values / str-iteration);
+    forwarding it as a Meta tuple keeps these keys intact.
+    """
+    spec = FieldModel(base_type=int).with_metadata(key, "kept").to_spec()
+    assert spec.get(key) == "kept"

--- a/tests/models/test_field_model.py
+++ b/tests/models/test_field_model.py
@@ -205,3 +205,51 @@ def test_type_mismatch_between_annotation_and_default(annotation, default_value)
     info = field.create_field()
     assert info.annotation == annotation
     assert info.default == default_value
+
+
+class _SpoofUnionMeta(type):
+    """A metaclass whose str() mimics types.UnionType without being one."""
+
+    def __repr__(cls):
+        return "<class 'types.UnionType'>"
+
+    __str__ = __repr__
+
+
+class _SpoofUnion(metaclass=_SpoofUnionMeta):
+    pass
+
+
+def test_base_type_rejects_spoofed_union():
+    """A non-type object whose str(type(...)) mimics types.UnionType is rejected."""
+    spoof = _SpoofUnion()  # str(type(spoof)) == "<class 'types.UnionType'>"
+    assert str(type(spoof)) == "<class 'types.UnionType'>"
+    with pytest.raises(ValueError, match="base_type must be"):
+        FieldModel(base_type=spoof)
+
+
+def test_base_type_accepts_real_unions():
+    """Genuine PEP 604 and Optional-style unions remain valid base_types."""
+    from typing import Optional, Union
+
+    for tp in (int | None, int | str, Union[int, str], Optional[int]):
+        FieldModel(base_type=tp)  # must not raise
+
+
+def test_to_spec_retains_unknown_metadata():
+    """Metadata keys outside the known set survive to_spec()."""
+    spec = FieldModel(base_type=int, custom_meta="kept").to_spec()
+    assert spec.get("custom_meta") == "kept"
+
+
+def test_to_spec_preserves_explicit_none_default():
+    """An explicit default=None must survive to_spec() (not treated as absent)."""
+    spec = FieldModel(base_type=int, default=None).to_spec()
+    assert spec.default is None
+
+
+def test_to_spec_does_not_flatten_json_schema_extra():
+    """A 'default' key inside json_schema_extra must not become the runtime default."""
+    spec = FieldModel(base_type=int, default=5, json_schema_extra={"default": 999}).to_spec()
+    assert spec.default == 5
+    assert spec.get("json_schema_extra") == {"default": 999}

--- a/tests/models/test_operable_model.py
+++ b/tests/models/test_operable_model.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 from pydantic import Field
+from pydantic.fields import FieldInfo
 
 from lionagi.models import FieldModel, OperableModel, SchemaModel
 
@@ -286,6 +287,40 @@ def test_update_field_with_new_default_factory():
     # If we remove the current value to trigger a re-init
     delattr(model, "dynamic_list")
     assert model.dynamic_list == ["a", "b", "c"]
+
+
+def test_constructor_extra_fields_captures_field_models():
+    """FieldModels passed via the constructor are captured in extra_field_models.
+
+    The field validator converts them to FieldInfos, but the after-validator must
+    still capture the originals so their validators are enforced on assignment.
+    """
+
+    def positive(v: int) -> bool:
+        return v > 0
+
+    fm = FieldModel(base_type=int, name="qty", validator=positive)
+    model = OperableModel(extra_fields={"qty": fm})
+
+    # captured, not silently dropped
+    assert "qty" in model.extra_field_models
+    assert model.extra_field_models["qty"] is fm
+    # and extra_fields is materialized to a FieldInfo
+    assert isinstance(model.extra_fields["qty"], FieldInfo)
+
+    # the validator is enforced on assignment
+    with pytest.raises(Exception):
+        model.qty = -1
+
+
+def test_constructor_extra_fields_list_captures_field_models():
+    """A list of FieldModels via the constructor is also captured by name."""
+
+    fm = FieldModel(base_type=int, name="count", validator=lambda v: v >= 0)
+    model = OperableModel(extra_fields=[fm])
+
+    assert "count" in model.extra_field_models
+    assert isinstance(model.extra_fields["count"], FieldInfo)
 
 
 def test_update_non_existent_field_creates_new():


### PR DESCRIPTION
## Summary

Three correctness fixes in the models layer. Each was a path that silently lost
field metadata, accepted an invalid type, or dropped a validator.

**1. `FieldModel.to_spec()` no longer loses or corrupts field metadata.**
It copied only a fixed set of known metadata keys, so any other metadata was
dropped on the way to `Spec`. It gated the default on `is not None`, so an
explicit `default=None` became absent rather than a real `None` default. And it
flattened `json_schema_extra` into field-level kwargs, so a key named `default`
inside `json_schema_extra` silently became the field's runtime default.
`to_spec()` now forwards every metadata entry as-is: `Spec` turns each into a
`Meta`, so unknown keys survive, an explicit `default=None` is preserved, and
`json_schema_extra` stays a nested value instead of leaking into the field's
top-level parameters.

**2. `FieldModel` rejects non-type objects that spoof a union type.**
`base_type` validation accepted anything whose `str(type(...))` equalled the
`types.UnionType` repr string, so an object with a crafted metaclass passed as a
valid `base_type`. That string comparison is removed. Genuine PEP 604 unions
(`int | None`) and `typing.Union` / `typing.Optional` values are still accepted
through the existing `isinstance(..., types.UnionType)` and `__origin__` checks.

**3. `OperableModel` captures `FieldModel`s passed through its constructor.**
The `extra_fields` field validator converted `FieldModel`s to `FieldInfo`s
before the after-model validator could record the originals, so
`extra_field_models` stayed empty and those `FieldModel`s' validators were never
enforced on assignment. The field validator now preserves `FieldModel`s (the
field's `| Any` union permits it); the after-validator converts them to
`FieldInfo`s and captures the originals into `extra_field_models`.

## Tests

Regression tests added for all three, each confirmed to fail without its fix:

- `to_spec` retains unknown metadata, preserves an explicit `default=None`, and
  does not let a `json_schema_extra` `default` key override the runtime default.
- A spoofed-union object is rejected; genuine unions are still accepted.
- A `FieldModel` supplied via the constructor (dict and list forms) is captured
  in `extra_field_models` and its validator is enforced on assignment.

Full `tests/models` suite green; broad regression sweep across the
`agent` / `operations` / `lndl` / `typing` / `ln` consumers of these APIs green.
