### PR TITLE
fix(ln): honor unique/use_values transforms and Trio-safe process grace

### DIFF
--- a/lionagi/ln/_async_call.py
+++ b/lionagi/ln/_async_call.py
@@ -72,7 +72,10 @@ def _normalize_input(
     flatten_tuple_set: bool,
 ) -> list:
     """Convert input to a flat list, treating model instances as single items."""
-    if flatten or dropna:
+    if flatten or dropna or unique:
+        # Route through to_list when unique is requested too, so unique without
+        # flatten raises the documented "unique=True requires flatten=True"
+        # instead of being silently ignored.
         return to_list(
             input_,
             flatten=flatten,

--- a/lionagi/ln/_list_call.py
+++ b/lionagi/ln/_list_call.py
@@ -38,7 +38,11 @@ def lcall(
     if output_unique and not (output_flatten or output_dropna):
         raise ValueError("unique_output requires flatten or dropna for post-processing.")
 
-    if input_flatten or input_dropna:
+    if input_flatten or input_dropna or input_unique or input_use_values:
+        # Route through to_list whenever any input transform is requested, not
+        # only on flatten/dropna: otherwise input_use_values is ignored (a
+        # mapping yields its keys) and input_unique is silently dropped instead
+        # of raising the documented "unique=True requires flatten=True".
         input_ = to_list(
             input_,
             flatten=input_flatten,

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import os
 import signal
 from typing import Any
+
+from .concurrency import move_on_after
 
 
 def _safe_pgid(proc: Any) -> int | None:
@@ -74,9 +75,12 @@ async def aterminate_process_group(
             os.killpg(pgid, sig_first)
     with contextlib.suppress(ProcessLookupError):
         proc.terminate()
-    try:
-        await asyncio.wait_for(proc.wait(), timeout=grace)
-    except (asyncio.TimeoutError, TimeoutError):
+    # Bound the grace wait with an anyio cancel scope, not asyncio.wait_for:
+    # wait_for raises "no running event loop" on an AnyIO/Trio task before the
+    # timeout policy can apply, so the forced-kill escalation never fires.
+    with move_on_after(grace) as scope:
+        await proc.wait()
+    if scope.cancelled_caught:
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)

--- a/lionagi/ln/_to_list.py
+++ b/lionagi/ln/_to_list.py
@@ -131,9 +131,12 @@ def to_list(
                     out.append(i)
             except TypeError:
                 if not use_hash_fallback:
-                    # Restart with hash-based deduplication
+                    # Restart with hash-based deduplication. Bucket by hash and
+                    # confirm actual equality within the bucket: a hash collision
+                    # between unequal items is not a duplicate (hash_dict can
+                    # collide for distinct mappings).
                     use_hash_fallback = True
-                    seen = set()
+                    hash_buckets: dict[Any, list] = {}
                     out = []
                     for j in processed:
                         try:
@@ -145,8 +148,9 @@ def to_list(
                                 raise ValueError(
                                     "Unhashable type encountered in list unique value processing."
                                 ) from None
-                        if hash_value not in seen:
-                            seen.add(hash_value)
+                        bucket = hash_buckets.setdefault(hash_value, [])
+                        if not any(existing == j for existing in bucket):
+                            bucket.append(j)
                             out.append(j)
                     break
         return out

--- a/lionagi/ln/_to_list.py
+++ b/lionagi/ln/_to_list.py
@@ -121,38 +121,34 @@ def to_list(
     processed = _process_list(initial_list, flatten=flatten, dropna=dropna, skip_types=skip_types)
 
     if unique:
-        seen = set()
-        out = []
-        use_hash_fallback = False
+        seen: set = set()
+        unhashable_buckets: dict[Any, list] = {}
+        out: list = []
         for i in processed:
             try:
-                if not use_hash_fallback and i not in seen:
+                if i not in seen:
                     seen.add(i)
                     out.append(i)
             except TypeError:
-                if not use_hash_fallback:
-                    # Restart with hash-based deduplication. Bucket by hash and
-                    # confirm actual equality within the bucket: a hash collision
-                    # between unequal items is not a duplicate (hash_dict can
-                    # collide for distinct mappings).
-                    use_hash_fallback = True
-                    hash_buckets: dict[Any, list] = {}
-                    out = []
-                    for j in processed:
-                        try:
-                            hash_value = hash(j)
-                        except TypeError:
-                            if isinstance(j, _MAP_LIKE):
-                                hash_value = hash_dict(j)
-                            else:
-                                raise ValueError(
-                                    "Unhashable type encountered in list unique value processing."
-                                ) from None
-                        bucket = hash_buckets.setdefault(hash_value, [])
-                        if not any(existing == j for existing in bucket):
-                            bucket.append(j)
-                            out.append(j)
-                    break
+                # Unhashable item (e.g. a dict): bucket by structural hash, then
+                # confirm identity-or-equality within the bucket. This mirrors the
+                # identity-first check that set membership gives the fast path, so a
+                # repeated same instance is still a duplicate while two unequal items
+                # whose structural hashes collide are both kept. Hashable items stay
+                # on the native set above rather than rehashing every element.
+                if isinstance(i, _MAP_LIKE):
+                    hash_value = hash_dict(i)
+                else:
+                    raise ValueError(
+                        "Unhashable type encountered in list unique value processing."
+                    ) from None
+                bucket = unhashable_buckets.get(hash_value)
+                if bucket is None:
+                    unhashable_buckets[hash_value] = [i]
+                    out.append(i)
+                elif not any(existing is i or existing == i for existing in bucket):
+                    bucket.append(i)
+                    out.append(i)
         return out
 
     return processed

--- a/tests/libs/test_to_list.py
+++ b/tests/libs/test_to_list.py
@@ -405,3 +405,13 @@ class TestEdgeCases:
         data = [[1, 2], (3, 4), {5, 6}, [7, 8]]
         result = to_list(data, flatten=True, flatten_tuple_set=True)
         assert set(result) == {1, 2, 3, 4, 5, 6, 7, 8}
+
+
+def test_unique_keeps_hash_colliding_unequal_mappings():
+    """A hash collision between unequal mappings is not a duplicate.
+
+    The unique fallback hashes unhashable items; in CPython hash(-1) == hash(-2),
+    so these two mappings collide structurally while being unequal.
+    """
+    result = to_list([{"x": -1}, {"x": -2}, {"x": -1}], flatten=True, unique=True)
+    assert result == [{"x": -1}, {"x": -2}]

--- a/tests/libs/test_to_list.py
+++ b/tests/libs/test_to_list.py
@@ -415,3 +415,24 @@ def test_unique_keeps_hash_colliding_unequal_mappings():
     """
     result = to_list([{"x": -1}, {"x": -2}, {"x": -1}], flatten=True, unique=True)
     assert result == [{"x": -1}, {"x": -2}]
+
+
+def test_unique_dedups_same_instance_nan_across_fallback():
+    """A repeated same-instance NaN stays a duplicate once fallback activates.
+
+    NaN is not equal to itself, so set membership relies on the identity shortcut
+    to deduplicate a repeated same object. An intervening unhashable mapping pushes
+    the later NaN through the collision-bucket path, which must apply the same
+    identity check rather than equality alone.
+    """
+    nan = float("nan")
+    result = to_list([nan, {"unhashable": 1}, nan], flatten=True, unique=True)
+    assert result == [nan, {"unhashable": 1}]
+
+
+def test_unique_keeps_distinct_nans_across_fallback():
+    """Two different NaN instances are both kept (neither identical nor equal)."""
+    nan_a, nan_b = float("nan"), float("nan")
+    result = to_list([nan_a, {"unhashable": 1}, nan_b], flatten=True, unique=True)
+    assert result == [nan_a, {"unhashable": 1}, nan_b]
+    assert result[0] is nan_a and result[2] is nan_b

--- a/tests/libs/utils/test_alcall.py
+++ b/tests/libs/utils/test_alcall.py
@@ -631,3 +631,13 @@ class TestReturnExceptions:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert child_cancelled.is_set()
+
+
+def test_alcall_input_unique_without_flatten_raises():
+    """alcall input_unique without flatten raises the documented validation error."""
+
+    async def _run():
+        return await alcall([1, 1], lambda x: x, input_unique=True)
+
+    with pytest.raises(ValueError, match="unique=True requires flatten=True"):
+        anyio.run(_run)

--- a/tests/libs/utils/test_lcall.py
+++ b/tests/libs/utils/test_lcall.py
@@ -293,5 +293,20 @@ class TestLCallSyncFunction:
         assert len(result) == 4
 
 
+def _identity(x):
+    return x
+
+
+def test_lcall_input_use_values_extracts_mapping_values():
+    """input_use_values yields a mapping's values even without flatten/dropna."""
+    assert lcall({"first": 1, "second": 2}, _identity, input_use_values=True) == [1, 2]
+
+
+def test_lcall_input_unique_without_flatten_raises():
+    """input_unique without flatten/dropna raises the documented validation error."""
+    with pytest.raises(ValueError, match="unique=True requires flatten=True"):
+        lcall([1, 1], _identity, input_unique=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -305,3 +305,43 @@ def test_terminate_custom_sig_first():
     with patch.object(proc_mod.os, "killpg") as mock_killpg:
         terminate_process_group(proc, grace=5.0, sig_first=signal.SIGHUP)
         mock_killpg.assert_called_once_with(8888, signal.SIGHUP)
+
+
+@pytest.mark.parametrize("backend", ["asyncio", "trio"])
+def test_aterminate_grace_escalates_to_kill_on_backend(backend):
+    """A process that ignores terminate is SIGKILLed after grace on both backends.
+
+    The grace wait uses an anyio cancel scope; asyncio.wait_for previously raised
+    'no running event loop' on a Trio task before the timeout policy could apply,
+    so the forced-kill escalation never ran.
+    """
+    import anyio
+
+    if backend == "trio":
+        pytest.importorskip("trio")
+
+    class _Proc:
+        def __init__(self):
+            self.pid = -1  # _safe_pgid -> None: no real killpg on a fake pid
+            self.terminated = False
+            self.killed = False
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            while not self.killed:
+                await anyio.sleep(0.001)
+            return 0
+
+    proc = _Proc()
+
+    async def _run():
+        await aterminate_process_group(proc, grace=0.01)
+
+    anyio.run(_run, backend=backend)
+    assert proc.terminated is True
+    assert proc.killed is True


### PR DESCRIPTION
## Summary

Three correctness fixes in the `ln` utilities. Each was a path that dropped data,
skipped a requested transform, or failed to enforce a timeout.

**1. `to_list(..., unique=True)` no longer drops unequal items with colliding hashes.**
When the input contains an unhashable value, `unique` falls back to hashing each
item. That fallback deduplicated by hash alone, so two *unequal* mappings whose
structural hashes collide were treated as duplicates and the second was lost. In
CPython `hash(-1) == hash(-2)`, so `{"x": -1}` and `{"x": -2}` collide — `to_list([{"x": -1}, {"x": -2}, {"x": -1}], flatten=True, unique=True)`
returned only `[{"x": -1}]`. The fallback now buckets by hash and confirms actual
equality within each bucket, so a collision between unequal items is not a
duplicate.

**2. `lcall` / `alcall` no longer ignore input transforms without flatten/dropna.**
`lcall` routed the input through `to_list` only when `input_flatten` or
`input_dropna` was set. As a result `input_use_values` was ignored (a mapping
yielded its keys instead of its values) and `input_unique` was silently dropped
instead of raising the documented `unique=True requires flatten=True`. The gate
now also fires on `input_unique` or `input_use_values`; `alcall`'s
`_normalize_input` likewise fires on `unique`. The no-transform path is
unchanged, so ordinary calls behave exactly as before.

**3. `aterminate_process_group` enforces the grace timeout on Trio.**
It bounded the post-`terminate()` wait with `asyncio.wait_for`, which raises
`RuntimeError: no running event loop` when called from an AnyIO/Trio task —
before the timeout policy can apply, so a process that ignores `terminate` is
never force-killed. It now bounds the wait with an anyio cancel scope
(`move_on_after`), which works on both asyncio and Trio backends and preserves
the SIGKILL escalation.

## Tests

Regression tests added for all three, each confirmed to fail without its fix:

- `to_list` retains two hash-colliding unequal mappings under `unique=True`.
- `lcall(..., input_use_values=True)` yields a mapping's values; `lcall` and
  `alcall` raise the documented error for `input_unique` without flatten.
- `aterminate_process_group` force-kills after grace on both the asyncio and Trio
  backends (the Trio case previously raised `no running event loop`).

Full `tests/ln` + `tests/libs` suites green (the only failure is a pre-existing
`pandas`-not-installed skip surfacing as an error in an unrelated DataFrame
adapter test; not touched here).
