### PR TITLE
fix(protocols, ln): container correctness and Spec union-spoof rejection

### DIFF
--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -105,10 +105,14 @@ class Spec:
 
         if not_sentinel(base_type, True):
             import types
+            import typing
 
+            # get_origin, not hasattr("__origin__"): any object can define that
+            # attribute, so presence alone lets an arbitrary instance pose as a
+            # type annotation. get_origin only answers for real typing forms.
             is_valid_type = (
                 isinstance(base_type, type)
-                or hasattr(base_type, "__origin__")
+                or typing.get_origin(base_type) is not None
                 or isinstance(base_type, types.UnionType)
             )
             if not is_valid_type:

--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -110,7 +110,6 @@ class Spec:
                 isinstance(base_type, type)
                 or hasattr(base_type, "__origin__")
                 or isinstance(base_type, types.UnionType)
-                or str(type(base_type)) == "<class 'types.UnionType'>"
             )
             if not is_valid_type:
                 raise ValueError(f"base_type must be a type or type annotation, got {base_type}")

--- a/lionagi/protocols/generic/flow.py
+++ b/lionagi/protocols/generic/flow.py
@@ -52,12 +52,29 @@ class Flow(Element, Generic[E, P]):
                 )
         return self
 
+    @staticmethod
+    def _index_progression_names(progressions: Any) -> dict[str, UUID]:
+        """Map each named progression to its id, rejecting duplicate names.
+
+        add_progression enforces name uniqueness; construction and
+        deserialization must enforce the same invariant, otherwise a
+        later-listed progression silently shadows an earlier one in the name
+        index and the earlier one becomes unreachable by name.
+        """
+        names: dict[str, UUID] = {}
+        for progression in progressions:
+            if progression.name:
+                if progression.name in names:
+                    raise ItemExistsError(
+                        f"Progression with name '{progression.name}' already exists."
+                    )
+                names[progression.name] = progression.id
+        return names
+
     def model_post_init(self, __context: Any) -> None:
         """Rebuild _progression_names index from progressions."""
         super().model_post_init(__context)
-        for progression in self.progressions:
-            if progression.name:
-                self._progression_names[progression.name] = progression.id
+        self._progression_names = self._index_progression_names(self.progressions)
 
     # ==================== Serialization ====================
 
@@ -112,11 +129,8 @@ class Flow(Element, Generic[E, P]):
             **data,
         )
         # Rebuild private attrs that model_construct skips
-        flow._progression_names = {}
         flow._lock = threading.RLock()
-        for prog in flow.progressions:
-            if prog.name:
-                flow._progression_names[prog.name] = prog.id
+        flow._progression_names = cls._index_progression_names(flow.progressions)
         return flow
 
     # ==================== Progression Management ====================

--- a/lionagi/protocols/generic/log.py
+++ b/lionagi/protocols/generic/log.py
@@ -48,8 +48,10 @@ class DataLoggerConfig(BaseModel):
 
     @field_validator("extension")
     def _ensure_dot_extension(cls, value):
+        # Normalize the leading dot first, then validate: an undotted spelling
+        # must be held to the same allowlist as its dotted form.
         if not value.startswith("."):
-            return "." + value
+            value = "." + value
         if value not in {".csv", ".json", ".jsonl"}:
             raise ValueError("Extension must be '.csv', '.json' or '.jsonl'.")
         return value
@@ -143,7 +145,7 @@ class DataLogger:
         try:
             if suffix == ".csv":
                 self.logs.dump(fp, "csv")
-            elif suffix == ".json":
+            elif suffix in (".json", ".jsonl"):
                 self.logs.dump(fp, "json")
             else:
                 raise ValueError(f"Unsupported file extension: {suffix}")
@@ -184,7 +186,7 @@ class DataLogger:
         def _write() -> None:
             if suffix == ".csv":
                 df.to_csv(fp, index=False)
-            elif suffix == ".json":
+            elif suffix in (".json", ".jsonl"):
                 df.to_json(fp, orient="records", lines=True)
             else:
                 raise ValueError(f"Unsupported file extension: {suffix}")

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -867,8 +867,11 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
 
     @classmethod
     def list_adapters(cls) -> list[str]:
-        syn_ = cls._adapter_registry._reg.keys()
-        asy_ = cls._async_registry._reg.keys()
+        # Reach the registries through their accessors: the sync registry is a
+        # per-class attribute created on demand, and the async registry is None
+        # until first use, so the bare class attributes do not exist.
+        syn_ = cls._registry()._reg.keys()
+        asy_ = cls._areg()._reg.keys()
         return list(set(syn_) | set(asy_))
 
     def adapt_to(self, obj_key: str, many=False, **kw: Any) -> Any:

--- a/tests/libs/test_spec.py
+++ b/tests/libs/test_spec.py
@@ -324,8 +324,22 @@ class TestSpecBaseTypeValidation:
 
         Spec(int)  # plain type
         Spec(int | str)  # PEP 604 UnionType
-        Spec(typing.Union[int, str])  # typing.Union carries __origin__
-        Spec(list[int])  # generic alias carries __origin__
+        Spec(typing.Union[int, str])  # typing.Union
+        Spec(list[int])  # generic alias
+        Spec(typing.Optional[int])
+        Spec(typing.Annotated[int, "meta"])
+        Spec(typing.Callable[[int], str])
+        Spec(dict[str, int])
+
+    def test_rejects_origin_attribute_spoof(self):
+        # Any object can define __origin__, so attribute presence cannot stand
+        # in for being a type annotation. Rejection must happen at construction,
+        # before the value is observable on the instance.
+        class _OriginSpoof:
+            __origin__ = int
+
+        with pytest.raises(ValueError, match="base_type must be a type"):
+            Spec(_OriginSpoof())
 
     def test_rejects_uniontype_string_spoof(self):
         # An instance is not a valid type just because its type's repr equals

--- a/tests/libs/test_spec.py
+++ b/tests/libs/test_spec.py
@@ -313,3 +313,29 @@ class TestSpecDefaultValueEdgeCases:
 
         result = await spec.acreate_default_value()
         assert result == "x"
+
+
+class TestSpecBaseTypeValidation:
+    """base_type must be a real type/annotation, not merely something whose
+    type repr looks like UnionType."""
+
+    def test_accepts_real_type_forms(self):
+        import typing
+
+        Spec(int)  # plain type
+        Spec(int | str)  # PEP 604 UnionType
+        Spec(typing.Union[int, str])  # typing.Union carries __origin__
+        Spec(list[int])  # generic alias carries __origin__
+
+    def test_rejects_uniontype_string_spoof(self):
+        # An instance is not a valid type just because its type's repr equals
+        # UnionType's; validation must not be fooled by the string form.
+        class _FakeUnion:
+            pass
+
+        _FakeUnion.__module__ = "types"
+        _FakeUnion.__qualname__ = "UnionType"
+        spoof = _FakeUnion()
+        assert str(type(spoof)) == "<class 'types.UnionType'>"
+        with pytest.raises(ValueError, match="base_type must be a type"):
+            Spec(spoof)

--- a/tests/protocols/generic/test_flow.py
+++ b/tests/protocols/generic/test_flow.py
@@ -9,6 +9,7 @@ import pytest
 
 from lionagi._errors import ItemExistsError, ItemNotFoundError
 from lionagi.protocols.generic.flow import Flow
+from lionagi.protocols.generic.pile import Pile
 from lionagi.protocols.generic.progression import Progression
 from lionagi.protocols.graph.node import Node
 
@@ -356,3 +357,46 @@ class TestReferentialIntegrityOnInit:
                 items={"collections": []},
                 progressions={"collections": [prog]},
             )
+
+
+class TestFlowDuplicateProgressionNames:
+    """Duplicate progression names are rejected on every construction path,
+    matching add_progression's uniqueness contract."""
+
+    def test_add_progression_rejects_duplicate_name(self):
+        flow, nodes = _flow_with_items(2)
+        flow.add_progression(Progression(order=[nodes[0].id], name="dup"))
+        with pytest.raises(ItemExistsError):
+            flow.add_progression(Progression(order=[nodes[1].id], name="dup"))
+
+    def test_construction_rejects_duplicate_names(self):
+        nodes = _make_nodes(2)
+        p1 = Progression(order=[nodes[0].id], name="dup")
+        p2 = Progression(order=[nodes[1].id], name="dup")
+        with pytest.raises(ItemExistsError):
+            Flow(
+                items={"collections": nodes},
+                progressions={"collections": [p1, p2]},
+            )
+
+    def test_from_dict_rejects_duplicate_names(self):
+        nodes = _make_nodes(2)
+        p1 = Progression(order=[nodes[0].id], name="dup")
+        p2 = Progression(order=[nodes[1].id], name="dup")
+        with pytest.raises(ItemExistsError):
+            Flow.from_dict(
+                {
+                    "items": Pile(collections=nodes),
+                    "progressions": Pile(collections=[p1, p2]),
+                }
+            )
+
+    def test_distinct_names_still_allowed(self):
+        nodes = _make_nodes(2)
+        p1 = Progression(order=[nodes[0].id], name="a")
+        p2 = Progression(order=[nodes[1].id], name="b")
+        flow = Flow(
+            items={"collections": nodes},
+            progressions={"collections": [p1, p2]},
+        )
+        assert len(flow.progressions) == 2

--- a/tests/protocols/generic/test_flow.py
+++ b/tests/protocols/generic/test_flow.py
@@ -363,12 +363,6 @@ class TestFlowDuplicateProgressionNames:
     """Duplicate progression names are rejected on every construction path,
     matching add_progression's uniqueness contract."""
 
-    def test_add_progression_rejects_duplicate_name(self):
-        flow, nodes = _flow_with_items(2)
-        flow.add_progression(Progression(order=[nodes[0].id], name="dup"))
-        with pytest.raises(ItemExistsError):
-            flow.add_progression(Progression(order=[nodes[1].id], name="dup"))
-
     def test_construction_rejects_duplicate_names(self):
         nodes = _make_nodes(2)
         p1 = Progression(order=[nodes[0].id], name="dup")

--- a/tests/protocols/generic/test_log.py
+++ b/tests/protocols/generic/test_log.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from lionagi.protocols.generic.element import Element
@@ -45,10 +47,6 @@ class TestLogManagerConfig:
 
         config = LogManagerConfig(extension=".json")
         assert config.extension == ".json"
-
-    def test_extension_jsonl_accepted(self):
-        # .jsonl is on the allowlist and must be a valid config value.
-        assert LogManagerConfig(extension=".jsonl").extension == ".jsonl"
 
     def test_extension_undotted_honors_allowlist(self):
         # An undotted extension is normalized then validated, so a value the
@@ -159,15 +157,17 @@ class TestLogManager:
         assert file.stat().st_size > 0
 
     def test_file_persistence_jsonl(self, temp_dir):
-        # A config-valid .jsonl extension must actually dump, not raise
-        # "Unsupported file extension".
+        # A config-valid .jsonl extension must dump valid line-delimited JSON,
+        # not raise "Unsupported file extension".
         manager = LogManager(persist_dir=temp_dir, extension=".jsonl")
         manager.log(Log(content={"key": "value"}))
         manager.dump()
 
         file = next(temp_dir.glob("*.jsonl"))
-        assert file.exists()
-        assert file.stat().st_size > 0
+        lines = [ln for ln in file.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["content"] == {"key": "value"}
 
     @pytest.mark.asyncio
     async def test_async_file_persistence_jsonl(self, temp_dir):
@@ -176,8 +176,10 @@ class TestLogManager:
         await manager.adump()
 
         file = next(temp_dir.glob("*.jsonl"))
-        assert file.exists()
-        assert file.stat().st_size > 0
+        lines = [ln for ln in file.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["content"] == {"key": "value"}
 
     def test_capacity_auto_dump(self, temp_dir):
         manager = LogManager(persist_dir=temp_dir, capacity=1)

--- a/tests/protocols/generic/test_log.py
+++ b/tests/protocols/generic/test_log.py
@@ -46,6 +46,17 @@ class TestLogManagerConfig:
         config = LogManagerConfig(extension=".json")
         assert config.extension == ".json"
 
+    def test_extension_jsonl_accepted(self):
+        # .jsonl is on the allowlist and must be a valid config value.
+        assert LogManagerConfig(extension=".jsonl").extension == ".jsonl"
+
+    def test_extension_undotted_honors_allowlist(self):
+        # An undotted extension is normalized then validated, so a value the
+        # dotted form would reject is rejected here too.
+        assert LogManagerConfig(extension="jsonl").extension == ".jsonl"
+        with pytest.raises(ValueError):
+            LogManagerConfig(extension="txt")
+
     def test_edge_cases(self):
         config = LogManagerConfig(capacity=0)
         assert config.capacity == 0
@@ -144,6 +155,27 @@ class TestLogManager:
         manager.dump()
 
         file = next(temp_dir.glob("*.csv"))
+        assert file.exists()
+        assert file.stat().st_size > 0
+
+    def test_file_persistence_jsonl(self, temp_dir):
+        # A config-valid .jsonl extension must actually dump, not raise
+        # "Unsupported file extension".
+        manager = LogManager(persist_dir=temp_dir, extension=".jsonl")
+        manager.log(Log(content={"key": "value"}))
+        manager.dump()
+
+        file = next(temp_dir.glob("*.jsonl"))
+        assert file.exists()
+        assert file.stat().st_size > 0
+
+    @pytest.mark.asyncio
+    async def test_async_file_persistence_jsonl(self, temp_dir):
+        manager = LogManager(persist_dir=temp_dir, extension=".jsonl")
+        manager.log(Log(content={"key": "value"}))
+        await manager.adump()
+
+        file = next(temp_dir.glob("*.jsonl"))
         assert file.exists()
         assert file.stat().st_size > 0
 

--- a/tests/protocols/generic/test_pile.py
+++ b/tests/protocols/generic/test_pile.py
@@ -688,3 +688,11 @@ async def test_async_type_checking():
         await p.ainclude("not an Node")
 
     assert len(p) == 1
+
+
+def test_list_adapters_returns_registered_keys():
+    # list_adapters must reach the adapter registries through their accessors;
+    # the default csv/json adapters are registered at import time.
+    adapters = Pile.list_adapters()
+    assert "csv" in adapters
+    assert "json" in adapters


### PR DESCRIPTION
## Summary

Four independent correctness fixes in the protocols container layer and the `ln` Spec.

- **Flow** rejects duplicate progression names on construction and `from_dict`, matching `add_progression`'s existing uniqueness contract. Previously a duplicate name silently shadowed an earlier progression in the name index, leaving it unreachable via `get_progression` / `remove_progression`.
- **DataLogger** accepts and executes the `.jsonl` extension its config validator already allows — both `dump` and `adump` previously raised "Unsupported file extension" for a config-valid `.jsonl`. Undotted extensions are now validated against the same allowlist as their dotted form.
- **`Pile.list_adapters`** reaches the adapter registries through their accessors. The bare class attributes it referenced (`_adapter_registry`, `_async_registry`) do not exist, so the method always raised `AttributeError`. It has no callers.
- **`Spec`** drops the string-repr `UnionType` check that accepted any object whose type repr matched `types.UnionType`. Real unions are already covered by the `isinstance` and `__origin__` checks; the string check only added a spoof hole.

## Tests

Each fix ships a regression test that fails without it (verified by reverting each source change against the new tests). Full affected suites pass: `tests/protocols/generic/test_{flow,log,pile}.py` and `tests/libs/test_spec.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
