### PR TITLE
fix(protocols, session, adapters): container identity and adapter inheritance correctness

### DIFF
--- a/lionagi/adapters/_base.py
+++ b/lionagi/adapters/_base.py
@@ -488,12 +488,21 @@ class AdapterRegistry:
 class Adaptable:
     """Mixin adding synchronous adapt-from/adapt-to to any class."""
 
+    _sync_adapter_registry: ClassVar[AdapterRegistry | None] = None
+
     @classmethod
     def _registry(cls) -> AdapterRegistry:
-        registry_attr = f"__adapter_registry_{cls.__name__}_{id(cls)}"
-        if not hasattr(cls, registry_attr):
-            setattr(cls, registry_attr, AdapterRegistry())
-        return getattr(cls, registry_attr)
+        # Own-`__dict__` check (not `hasattr`) distinguishes "this class already
+        # has its registry" from "a base class does" - so a subclass lazily
+        # inherits the base's registered adapters by copying them once, then
+        # keeps registering independently without mutating the base or siblings.
+        if "_sync_adapter_registry" not in cls.__dict__:
+            parent = cls._sync_adapter_registry
+            registry = AdapterRegistry()
+            if parent is not None:
+                registry._reg.update(parent._reg)
+            cls._sync_adapter_registry = registry
+        return cls._sync_adapter_registry
 
     @classmethod
     def register_adapter(cls, adapter_cls: type[Adapter]) -> None:
@@ -629,8 +638,15 @@ class AsyncAdaptable:
 
     @classmethod
     def _areg(cls) -> AsyncAdapterRegistry:
-        if cls._async_registry is None:
-            cls._async_registry = AsyncAdapterRegistry()
+        # See Adaptable._registry(): the same own-`__dict__` copy-on-inherit
+        # pattern, so a subclass sees the base's adapters without sharing the
+        # same mutable registry object with the base or its siblings.
+        if "_async_registry" not in cls.__dict__:
+            parent = cls._async_registry
+            registry = AsyncAdapterRegistry()
+            if parent is not None:
+                registry._reg.update(parent._reg)
+            cls._async_registry = registry
         return cls._async_registry
 
     @classmethod

--- a/lionagi/protocols/generic/flow.py
+++ b/lionagi/protocols/generic/flow.py
@@ -38,6 +38,11 @@ class Flow(Element, Generic[E, P]):
         description="Workflow stages as named progressions.",
     )
     _progression_names: dict[str, UUID] = PrivateAttr(default_factory=dict)
+    # Reverse of `_progression_names` (uuid -> indexed name). Progression.name
+    # is a plain mutable field, so a progression's live `.name` can drift from
+    # whatever name it was indexed under; this lets removal/rename find the
+    # actually-indexed name instead of trusting the (possibly stale) live one.
+    _progression_ids: dict[UUID, str] = PrivateAttr(default_factory=dict)
     _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
 
     @model_validator(mode="after")
@@ -58,6 +63,7 @@ class Flow(Element, Generic[E, P]):
         for progression in self.progressions:
             if progression.name:
                 self._progression_names[progression.name] = progression.id
+                self._progression_ids[progression.id] = progression.name
 
     # ==================== Serialization ====================
 
@@ -113,10 +119,12 @@ class Flow(Element, Generic[E, P]):
         )
         # Rebuild private attrs that model_construct skips
         flow._progression_names = {}
+        flow._progression_ids = {}
         flow._lock = threading.RLock()
         for prog in flow.progressions:
             if prog.name:
                 flow._progression_names[prog.name] = prog.id
+                flow._progression_ids[prog.id] = prog.name
         return flow
 
     # ==================== Progression Management ====================
@@ -135,20 +143,49 @@ class Flow(Element, Generic[E, P]):
             self.progressions.include(progression)
             if progression.name:
                 self._progression_names[progression.name] = progression.id
+                self._progression_ids[progression.id] = progression.name
 
     def remove_progression(self, key: UUID | str | P) -> None:
         """Remove progression by UUID, name, or instance; raises ItemNotFoundError if absent."""
         with self._lock:
             if isinstance(key, str) and key in self._progression_names:
                 uid = self._progression_names.pop(key)
+                self._progression_ids.pop(uid, None)
                 self.progressions.pop(uid)
                 return
 
             uid = ID.get_id(key)
-            prog = self.progressions[uid]
-            if prog.name and prog.name in self._progression_names:
-                del self._progression_names[prog.name]
+            # Look up the name this uuid was actually indexed under, rather
+            # than trusting the progression's current (possibly renamed)
+            # `.name` - the two can disagree if it was renamed directly.
+            indexed_name = self._progression_ids.pop(uid, None)
+            if indexed_name is not None:
+                self._progression_names.pop(indexed_name, None)
             self.progressions.pop(uid)
+
+    def rename_progression(self, key: UUID | str | P, new_name: str | None) -> None:
+        """Rename an owned progression, keeping the Flow's name index in sync.
+
+        Raises ItemExistsError if `new_name` already names a different
+        progression, ItemNotFoundError if `key` does not resolve.
+        """
+        with self._lock:
+            progression = self.get_progression(key)
+            if (
+                new_name
+                and new_name in self._progression_names
+                and self._progression_names[new_name] != progression.id
+            ):
+                raise ItemExistsError(f"Progression with name '{new_name}' already exists.")
+
+            old_name = self._progression_ids.pop(progression.id, None)
+            if old_name is not None:
+                self._progression_names.pop(old_name, None)
+
+            progression.name = new_name
+            if new_name:
+                self._progression_names[new_name] = progression.id
+                self._progression_ids[progression.id] = new_name
 
     def get_progression(self, key: UUID | str | P) -> P:
         """Return progression by UUID, name, or instance; raises ItemNotFoundError if absent."""
@@ -211,6 +248,7 @@ class Flow(Element, Generic[E, P]):
             self.items.clear()
             self.progressions.clear()
             self._progression_names.clear()
+            self._progression_ids.clear()
 
     def __repr__(self) -> str:
         name_str = f", name='{self.name}'" if self.name else ""

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -193,6 +193,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
     # may call @synchronized siblings while the wrapper already holds it.
     _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
     _async_lock: ConcurrencyLock = PrivateAttr(default_factory=ConcurrencyLock)
+    _iterator: Iterator[T] | None = PrivateAttr(default=None)
 
     @classmethod
     def _validate_before(cls, data: dict[str, Any]) -> dict[str, Any]:
@@ -372,9 +373,15 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
             yield self.collections[key]
 
     def __next__(self) -> T:
+        # `iter(self)` must be the SAME generator across calls - a fresh one
+        # per call would always yield the first element instead of advancing,
+        # so the live iterator is cached on the instance.
+        if self._iterator is None:
+            self._iterator = iter(self)
         try:
-            return next(iter(self))
+            return next(self._iterator)
         except StopIteration:
+            self._iterator = None
             raise StopIteration("End of pile") from None
 
     @synchronized

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -867,8 +867,8 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
 
     @classmethod
     def list_adapters(cls) -> list[str]:
-        syn_ = cls._adapter_registry._reg.keys()
-        asy_ = cls._async_registry._reg.keys()
+        syn_ = cls._registry()._reg.keys()
+        asy_ = cls._areg()._reg.keys()
         return list(set(syn_) | set(asy_))
 
     def adapt_to(self, obj_key: str, many=False, **kw: Any) -> Any:

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -24,6 +24,91 @@ __all__ = (
 )
 
 
+class _SyncedDeque(deque):
+    """deque that keeps its owning Progression's `_members` cache in sync.
+
+    `Progression.order` is a public field, so callers can mutate the deque
+    object directly (`progression.order.append(x)`, `.clear()`, ...) instead
+    of going through Progression's own methods. Every mutating method is
+    overridden here so `_members`, which `__contains__` actually checks,
+    never drifts from `order` regardless of how it was mutated.
+    """
+
+    def __init__(self, iterable=(), owner: Progression | None = None):
+        super().__init__(iterable)
+        self._owner = owner
+
+    def append(self, item) -> None:
+        super().append(item)
+        if self._owner is not None:
+            self._owner._members.add(item)
+
+    def appendleft(self, item) -> None:
+        super().appendleft(item)
+        if self._owner is not None:
+            self._owner._members.add(item)
+
+    def extend(self, iterable) -> None:
+        items = list(iterable)
+        super().extend(items)
+        if self._owner is not None:
+            self._owner._members.update(items)
+
+    def extendleft(self, iterable) -> None:
+        items = list(iterable)
+        super().extendleft(items)
+        if self._owner is not None:
+            self._owner._members.update(items)
+
+    def insert(self, index, item) -> None:
+        super().insert(index, item)
+        if self._owner is not None:
+            self._owner._members.add(item)
+
+    def pop(self):
+        item = super().pop()
+        if self._owner is not None and item not in self:
+            self._owner._members.discard(item)
+        return item
+
+    def popleft(self):
+        item = super().popleft()
+        if self._owner is not None and item not in self:
+            self._owner._members.discard(item)
+        return item
+
+    def remove(self, value) -> None:
+        super().remove(value)
+        if self._owner is not None and value not in self:
+            self._owner._members.discard(value)
+
+    def clear(self) -> None:
+        super().clear()
+        if self._owner is not None:
+            self._owner._members.clear()
+
+    def __delitem__(self, index) -> None:
+        # deque itself only supports integer indices here (slicing raises
+        # TypeError natively); Progression's own slice handling never calls
+        # this directly, it rebuilds the whole deque via `_replace_order`.
+        item = self[index]
+        super().__delitem__(index)
+        if self._owner is not None and item not in self:
+            self._owner._members.discard(item)
+
+    def __setitem__(self, index, value) -> None:
+        old = self[index]
+        super().__setitem__(index, value)
+        if self._owner is not None:
+            if old not in self:
+                self._owner._members.discard(old)
+            self._owner._members.add(value)
+
+    def __iadd__(self, other):
+        self.extend(other)
+        return self
+
+
 class Progression(Element, Ordering[T], Generic[T]):
     """Ordered sequence of item UUIDs with set-backed O(1) membership checks."""
 
@@ -41,10 +126,20 @@ class Progression(Element, Ordering[T], Generic[T]):
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
+        self.order = _SyncedDeque(self.order, owner=self)
         self._members = set(self.order)
 
     def _rebuild_members(self) -> None:
         self._members = set(self.order)
+
+    def _replace_order(self, items) -> None:
+        """Reconstruct `order` from `items`, preserving the `_SyncedDeque` wrapper.
+
+        A bare `self.order = deque(items)` would swap in a plain deque and
+        silently drop future membership syncing for direct mutations.
+        """
+        self.order = _SyncedDeque(items, owner=self)
+        self._rebuild_members()
 
     @field_validator("order", mode="before")
     def _validate_ordering(cls, value: Any) -> deque[UUID]:
@@ -88,8 +183,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         if isinstance(key, slice):
             as_list = list(self.order)
             as_list[key] = refs
-            self.order = deque(as_list)
-            self._rebuild_members()
+            self._replace_order(as_list)
         else:
             try:
                 old = self.order[key]
@@ -105,10 +199,10 @@ class Progression(Element, Ordering[T], Generic[T]):
         if isinstance(key, slice):
             as_list = list(self.order)
             del as_list[key]
-            self.order = deque(as_list)
+            self._replace_order(as_list)
         else:
             del self.order[key]
-        self._rebuild_members()
+            self._rebuild_members()
 
     def __iter__(self):
         return iter(self.order)
@@ -152,8 +246,7 @@ class Progression(Element, Ordering[T], Generic[T]):
 
         before = len(self.order)
         rset = set(refs)
-        self.order = deque(x for x in self.order if x not in rset)
-        self._rebuild_members()
+        self._replace_order(x for x in self.order if x not in rset)
         return len(self.order) < before
 
     def append(self, item: Any, /) -> None:
@@ -199,8 +292,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         if missing:
             raise ItemNotFoundError(str(missing))
         rset = set(refs)
-        self.order = deque(x for x in self.order if x not in rset)
-        self._rebuild_members()
+        self._replace_order(x for x in self.order if x not in rset)
 
     def count(self, item: Any, /) -> int:
         ref = ID.get_id(item)

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -123,6 +123,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         description="A human-readable identifier for the progression.",
     )
     _members: set[UUID] = PrivateAttr(default_factory=set)
+    _iterator: Any = PrivateAttr(default=None)
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
@@ -208,9 +209,15 @@ class Progression(Element, Ordering[T], Generic[T]):
         return iter(self.order)
 
     def __next__(self) -> UUID:
+        # `iter(self.order)` must be the SAME iterator across calls - a fresh
+        # `iter(...)` per call would always yield the first element instead of
+        # advancing, so the live iterator is cached on the instance.
+        if self._iterator is None:
+            self._iterator = iter(self.order)
         try:
-            return next(iter(self.order))
+            return next(self._iterator)
         except StopIteration:
+            self._iterator = None
             raise StopIteration("No more items in the progression") from None
 
     def __list__(self) -> list[UUID]:

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -561,10 +561,17 @@ class Branch(Element, Relational):
             else self.parse_model
         )
 
+        cloned_messages = []
+        old_to_new_id: dict = {}
+        for msg in self.msgs.messages:
+            cloned = msg.clone()
+            old_to_new_id[msg.id] = cloned.id
+            cloned_messages.append(cloned)
+
         branch_clone = Branch(
             system=system,
             user=self.user,
-            messages=[msg.clone() for msg in self.msgs.messages],
+            messages=cloned_messages,
             tools=tools,
             chat_model=chat_model,
             parse_model=parse_model,
@@ -573,6 +580,19 @@ class Branch(Element, Relational):
         for message in branch_clone.msgs.messages:
             message.sender = sender or self.id
             message.recipient = branch_clone.id
+
+        # A source current_progression is an intentional eviction of some
+        # durable messages from the active context. Cloned messages get new
+        # IDs, so the source's evicted-subset progression has to be remapped
+        # onto them - otherwise it's silently dropped and Branch.progression
+        # falls back to the clone's complete (uninentionally un-evicted)
+        # message set.
+        source_progression = self.metadata.get("current_progression")
+        if source_progression is not None:
+            remapped_order = [
+                old_to_new_id[uid] for uid in source_progression.order if uid in old_to_new_id
+            ]
+            branch_clone.metadata["current_progression"] = Progression(order=remapped_order)
 
         return branch_clone
 

--- a/tests/adapters/test_adaptable_registry.py
+++ b/tests/adapters/test_adaptable_registry.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from lionagi.adapters._base import Adaptable, AsyncAdaptable
+
+
+class _SyncBase(Adaptable):
+    pass
+
+
+class _SyncChild(_SyncBase):
+    pass
+
+
+class _SyncSibling(_SyncBase):
+    pass
+
+
+class _AsyncBase(AsyncAdaptable):
+    pass
+
+
+class _AsyncChild(_AsyncBase):
+    pass
+
+
+class _AsyncSibling(_AsyncBase):
+    pass
+
+
+class _FakeAdapter:
+    adapter_key = "fake"
+
+
+class _FakeAsyncAdapter:
+    obj_key = "fake_async"
+
+
+def test_sync_registration_on_base_is_visible_to_derived_class():
+    _SyncBase.register_adapter(_FakeAdapter)
+
+    assert "fake" in _SyncBase._registry()._reg
+    assert "fake" in _SyncChild._registry()._reg
+
+
+def test_sync_registration_on_child_does_not_leak_to_base_or_sibling():
+    _SyncBase.register_adapter(_FakeAdapter)
+
+    class _OnlyChildAdapter:
+        adapter_key = "child_only"
+
+    _SyncChild.register_adapter(_OnlyChildAdapter)
+
+    assert "child_only" in _SyncChild._registry()._reg
+    assert "child_only" not in _SyncBase._registry()._reg
+    assert "child_only" not in _SyncSibling._registry()._reg
+
+
+def test_async_registration_on_base_is_visible_to_derived_class():
+    _AsyncBase.register_async_adapter(_FakeAsyncAdapter)
+
+    assert "fake_async" in _AsyncBase._areg()._reg
+    assert "fake_async" in _AsyncChild._areg()._reg
+
+
+def test_async_registration_on_child_does_not_leak_to_base_or_sibling():
+    _AsyncBase.register_async_adapter(_FakeAsyncAdapter)
+
+    class _OnlyChildAsyncAdapter:
+        obj_key = "child_only_async"
+
+    _AsyncChild.register_async_adapter(_OnlyChildAsyncAdapter)
+
+    assert "child_only_async" in _AsyncChild._areg()._reg
+    assert "child_only_async" not in _AsyncBase._areg()._reg
+    assert "child_only_async" not in _AsyncSibling._areg()._reg
+
+
+def test_pile_list_adapters_does_not_raise():
+    from lionagi.protocols.generic.pile import Pile
+
+    adapters = Pile.list_adapters()
+    assert isinstance(adapters, list)
+    assert "json" in adapters

--- a/tests/protocols/generic/test_core_bugs.py
+++ b/tests/protocols/generic/test_core_bugs.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from uuid import uuid4
+
+import pytest
+
+from lionagi._errors import ItemExistsError, ItemNotFoundError
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.flow import Flow
+from lionagi.protocols.generic.progression import Progression
+
+# ---------------------------------------------------------------------------
+# Direct Progression.order mutation must keep the membership cache in sync
+# ---------------------------------------------------------------------------
+
+
+def test_direct_order_append_updates_membership():
+    a, b = uuid4(), uuid4()
+    prog = Progression(order=[a])
+
+    prog.order.append(b)
+
+    assert len(prog) == 2
+    assert b in prog
+
+
+def test_direct_order_clear_updates_membership():
+    a = uuid4()
+    prog = Progression(order=[a])
+
+    prog.order.clear()
+
+    assert len(prog) == 0
+    assert a not in prog
+
+
+def test_direct_order_remove_and_delitem_update_membership():
+    a, b, c = uuid4(), uuid4(), uuid4()
+    prog = Progression(order=[a, b, c])
+
+    prog.order.remove(b)
+    assert b not in prog
+    assert len(prog) == 2
+
+    del prog.order[0]
+    assert a not in prog
+    assert len(prog) == 1
+
+
+def test_direct_order_setitem_updates_membership():
+    a, b, c = uuid4(), uuid4(), uuid4()
+    prog = Progression(order=[a, b])
+
+    prog.order[0] = c
+
+    assert a not in prog
+    assert c in prog
+    assert len(prog) == 2
+
+
+# ---------------------------------------------------------------------------
+# Flow: renaming an owned progression must keep the name index consistent
+# ---------------------------------------------------------------------------
+
+
+def test_flow_rename_progression_updates_index():
+    item = Element()
+    flow = Flow()
+    flow.add_item(item)
+    prog = Progression(order=[item.id], name="before")
+    flow.add_progression(prog)
+
+    flow.rename_progression("before", "after")
+
+    with pytest.raises(ItemNotFoundError):
+        flow.get_progression("before")
+    assert flow.get_progression("after") is prog
+
+
+def test_flow_rename_progression_rejects_existing_name():
+    item = Element()
+    flow = Flow()
+    flow.add_item(item)
+    prog_a = Progression(order=[item.id], name="a")
+    prog_b = Progression(order=[item.id], name="b")
+    flow.add_progression(prog_a)
+    flow.add_progression(prog_b)
+
+    with pytest.raises(ItemExistsError):
+        flow.rename_progression("a", "b")
+
+
+def test_flow_remove_progression_by_uuid_clears_stale_name_index():
+    item = Element()
+    flow = Flow()
+    flow.add_item(item)
+    prog = Progression(order=[item.id], name="before")
+    flow.add_progression(prog)
+
+    flow.rename_progression("before", "after")
+    flow.remove_progression(prog.id)
+
+    assert flow._progression_names == {}
+    assert flow._progression_ids == {}
+    with pytest.raises(ItemNotFoundError):
+        flow.get_progression("after")

--- a/tests/protocols/generic/test_iterator_advance.py
+++ b/tests/protocols/generic/test_iterator_advance.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from uuid import uuid4
+
+import pytest
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.generic.progression import Progression
+
+
+def test_progression_next_advances():
+    a, b = uuid4(), uuid4()
+    prog = Progression(order=[a, b])
+
+    assert next(prog) == a
+    assert next(prog) == b
+    with pytest.raises(StopIteration):
+        next(prog)
+
+
+def test_progression_next_restarts_after_exhaustion():
+    a, b = uuid4(), uuid4()
+    prog = Progression(order=[a, b])
+
+    assert next(prog) == a
+    assert next(prog) == b
+    with pytest.raises(StopIteration):
+        next(prog)
+    # A fresh round of direct next() calls should work again.
+    assert next(prog) == a
+    assert next(prog) == b
+
+
+def test_pile_next_advances():
+    e1, e2 = Element(), Element()
+    pile = Pile(collections=[e1, e2])
+
+    assert next(pile) is e1
+    assert next(pile) is e2
+    with pytest.raises(StopIteration):
+        next(pile)

--- a/tests/protocols/generic/test_progression_enhanced.py
+++ b/tests/protocols/generic/test_progression_enhanced.py
@@ -224,11 +224,11 @@ class TestRebuildMembers:
     """_rebuild_members reconstructs _members from order."""
 
     def test_rebuild_after_manual_order_mutation(self, prog, elems):
-        # Directly mutate order (bypassing normal API) to test _rebuild
+        # Directly mutating order (bypassing normal API) keeps _members in
+        # sync automatically; _rebuild_members() stays a correct no-op.
         new_id = uuid4()
         prog.order.append(new_id)
-        # _members is now stale
-        assert new_id not in prog._members
+        assert new_id in prog._members
         prog._rebuild_members()
         assert new_id in prog._members
         assert prog._members == set(prog.order)

--- a/tests/session/test_core_bugs.py
+++ b/tests/session/test_core_bugs.py
@@ -327,6 +327,49 @@ class TestBranchStateRegressions:
         d2 = restored.to_dict()
         assert d2["metadata"]["clone_from"] == d1["metadata"]["clone_from"]
 
+    def test_split_preserves_current_progression(self):
+        """A source branch's evicted-context subset must survive split().
+
+        current_progression is an intentional eviction of some durable
+        messages from the active context. Cloned messages get new IDs, so
+        the source progression has to be remapped onto the clone's messages
+        instead of being dropped (which silently un-evicts the message).
+        """
+        from lionagi.protocols.generic.progression import Progression
+
+        s = Session()
+        b = s.new_branch()
+        b.msgs.add_message(instruction="first")
+        b.msgs.add_message(instruction="second")
+        kept = list(b.msgs.messages)[-1]
+        b.metadata["current_progression"] = Progression(order=[kept.id])
+        assert len(b.progression) == 1
+
+        clone = s.split(b.id)
+
+        assert len(clone.msgs.messages) == 2
+        assert len(clone.progression) == 1
+        cloned_active_msg = clone.msgs.messages[list(clone.progression)[0]]
+        assert cloned_active_msg.metadata.get("clone_from") == str(kept.id)
+
+    async def test_asplit_preserves_current_progression(self):
+        """Async split must remap current_progression the same as sync split."""
+        from lionagi.protocols.generic.progression import Progression
+
+        s = Session()
+        b = s.new_branch()
+        b.msgs.add_message(instruction="first")
+        b.msgs.add_message(instruction="second")
+        kept = list(b.msgs.messages)[-1]
+        b.metadata["current_progression"] = Progression(order=[kept.id])
+
+        clone = await s.asplit(b.id)
+
+        assert len(clone.msgs.messages) == 2
+        assert len(clone.progression) == 1
+        cloned_active_msg = clone.msgs.messages[list(clone.progression)[0]]
+        assert cloned_active_msg.metadata.get("clone_from") == str(kept.id)
+
     def test_from_dict_does_not_mutate_snapshot(self):
         """Branch.from_dict must not strip fields out of the caller's snapshot."""
         import copy


### PR DESCRIPTION
Fixes four correctness defects in the collection and session primitives, each with a regression test that fails on the prior code.

- **Adapter registry inheritance.** `Adaptable._registry()` keyed the registry per concrete class, so adapters registered on a base class were invisible to subclasses, and async child registrations could leak to the parent and siblings depending on init order. `Pile.list_adapters()` also raised `AttributeError` instead of returning the registered keys. Registration now inherits correctly across subclasses without cross-class leakage.
- **Progression index consistency.** Direct mutation of the public `Progression.order` deque left the membership index and the owning `Flow`'s name index stale. Membership now stays synced, and `Flow` gains rename support for the same reason.
- **Repeated iteration.** `Progression.__next__` and `Pile.__next__` did not advance on repeated calls. Iteration now progresses as expected.
- **Branch clone message state.** `Branch.clone()` rebuilt its message list in a way that could reintroduce previously evicted messages into active context. Cloning now remaps `current_progression` correctly.

Regression tests added for each; the protocols, session, and adapters suites pass (pre-existing failures unrelated to these files excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
