### PR TITLE
fix(hooks, service, lndl): event dispatch and retry-hook correctness

### DIFF
--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -132,6 +132,28 @@ async def _run_fanout(
             started_at=_started_at,
         )
 
+    # notify.on_terminal (settings-driven, independent of --notify) outcome
+    # attribution: bind this run into the handler at registration time so a
+    # late-arriving adapter outcome lands on this run's artifact directory --
+    # or nowhere -- rather than being dropped. Skipped when --notify already
+    # owns this same entity as an exclusive override (registering a second
+    # override for the same entity would fire the adapter twice).
+    from lionagi.state.lifecycle.notify_settings import (
+        register_run_notify_outcome_scope,
+        unregister_run_notify_outcome_scope,
+    )
+
+    _notify_outcome_scope_name = (
+        None
+        if notify
+        else register_run_notify_outcome_scope(
+            env.run,
+            entity_kind="session",
+            entity_id=str(env.session.id),
+            project_dir=cwd,
+        )
+    )
+
     inner_kw = dict(
         env=env,
         num_workers=num_workers,
@@ -174,6 +196,7 @@ async def _run_fanout(
                 _terminal_status = effective_status
             # Unregister after stop_live_persist fires the terminal transition.
             unregister_flow_notify_scope(_notify_scope_name)
+            unregister_run_notify_outcome_scope(_notify_outcome_scope_name)
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
 

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -29,6 +29,7 @@ from lionagi.lndl import (
 )
 
 from .._defaults import get_default_action_call
+from .._turn_origin import TurnOrigin
 from ..types import ActionParam, ChatParam, ParseParam, RunParam
 
 if TYPE_CHECKING:
@@ -203,6 +204,13 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
         # LNDL uses a free-text <lact>/OUT{} protocol, not native
         # function-calling, so strip tool schemas and response_format here.
         stripped_chat_param = chat_param.with_updates(tool_schemas=[], response_format=None)
+        # Round 1 carries the caller's own turn origin (it is the genuine
+        # user-prompt submission); every repair round after it is an
+        # internal retry within the same operate() call and must not
+        # re-mint/re-fire USER_PROMPT_SUBMIT.
+        continuation_chat_param = stripped_chat_param.with_updates(
+            turn_origin=TurnOrigin.no_origin()
+        )
 
         action_results: dict[str, Any] = {}
         last_error: str | None = None
@@ -211,7 +219,7 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
             round_chat_param = (
                 stripped_chat_param.with_updates(guidance=lndl_guidance)
                 if round_num == 1
-                else stripped_chat_param
+                else continuation_chat_param
             )
             round_instruction = _round_instruction(instruction, round_num, round_budget, last_error)
 

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -99,6 +99,10 @@ class HookedEvent(Event):
             yield chunk
 
         # Post-stream hook failure: data already sent, must not reraise — log at WARNING only.
+        # A hook exception is recorded on h_ev (status FAILED/CANCELLED/ABORTED,
+        # execution.error set) rather than raised out of h_ev.invoke() -- see
+        # HookRegistry.post_invocation -- so a plain try/except around the
+        # call never observes it; the recorded status must be checked instead.
         if h_ev := self._post_invoke_hook_event:
             try:
                 await h_ev.invoke()
@@ -108,6 +112,16 @@ class HookedEvent(Event):
                     _hook_exc,
                     exc_info=True,
                 )
+            else:
+                if h_ev.execution.status in (
+                    EventStatus.FAILED,
+                    EventStatus.CANCELLED,
+                    EventStatus.ABORTED,
+                ):
+                    _logger.warning(
+                        "Post-stream hook failed (data already sent): %s",
+                        h_ev.execution.error,
+                    )
             await global_hook_logger.alog(h_ev)
 
     def create_pre_invoke_hook(

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -172,7 +172,15 @@ class iModel:  # noqa: N801
 
         if issubclass(create_event_type, HookedEvent):
             api_call = None
-            if create_event_type is APICalling:
+            if (
+                h_ev is not None
+                and h_ev.execution.status == EventStatus.COMPLETED
+                and isinstance(h_ev.execution.response, create_event_type)
+            ):
+                # PreEventCreate returned a prepared replacement event; honor
+                # it instead of constructing a fresh one from kwargs.
+                api_call = h_ev.execution.response
+            elif create_event_type is APICalling:
                 api_call = self.create_api_calling(**kwargs)
             else:
                 api_call = create_event_type(**kwargs)

--- a/tests/cli/orchestrate/test_fanout_notify_outcome_scope.py
+++ b/tests/cli/orchestrate/test_fanout_notify_outcome_scope.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o fanout` binds a settings-driven notify.on_terminal exec adapter's
+outcome to the fan-out run directory, independently of `--notify` -- see
+lionagi/state/lifecycle/notify_settings.py's register_run_notify_outcome_scope
+contract. fanout.py imports register_/unregister_run_notify_outcome_scope
+locally inside `_run_fanout`, so patches target the source module
+(`notify_settings`), not `fanout_module`."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import lionagi.state.lifecycle.notify_settings as notify_settings_mod
+from lionagi.cli.orchestrate import fanout as fanout_module
+
+from .test_fanout_artifacts import _fanout_env
+
+
+def _patch_fanout_scaffold(monkeypatch, env) -> None:
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    # Empty assignments short-circuits _run_fanout_inner before any
+    # worker/DAG machinery runs -- the minimal path to "completed".
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=[]))
+
+
+async def test_settings_outcome_scope_registered_independently_of_notify_flag(
+    tmp_path, monkeypatch
+):
+    """The missing binding: without `--notify`, `_run_fanout` must still
+    scope the settings-driven notify.on_terminal adapter's outcome to this
+    run, so a late-arriving adapter result lands in the run directory
+    instead of nowhere."""
+    env, run, _session = _fanout_env(tmp_path)
+    _patch_fanout_scaffold(monkeypatch, env)
+
+    captured: dict[str, Any] = {}
+
+    def fake_register(run_arg, **kwargs: Any) -> str:
+        captured["run"] = run_arg
+        captured.update(kwargs)
+        return "outcome-scope-name"
+
+    fake_unregister = MagicMock()
+    monkeypatch.setattr(notify_settings_mod, "register_run_notify_outcome_scope", fake_register)
+    monkeypatch.setattr(notify_settings_mod, "unregister_run_notify_outcome_scope", fake_unregister)
+
+    result, status = await fanout_module._run_fanout(
+        "codex/model",
+        "prompt",
+        cwd="/some/project",
+    )
+
+    assert status == "completed"
+    assert captured["run"] is run
+    assert captured["entity_kind"] == "session"
+    assert captured["entity_id"] == str(env.session.id)
+    assert captured["project_dir"] == "/some/project"
+    fake_unregister.assert_called_once_with("outcome-scope-name")
+
+
+async def test_notify_flag_skips_settings_outcome_scope_to_avoid_double_fire(tmp_path, monkeypatch):
+    """When `--notify` already owns this run's session entity as an
+    exclusive override, a second override for the settings-driven outcome
+    scope must not also be registered -- registering both would fire the
+    adapter twice for the same terminal event (see register_flow_notify_scope
+    vs. register_run_notify_outcome_scope: both register(..., override=True)
+    for the same entity_kind/entity_id, and TerminalCallbackRegistry.emit()
+    runs every override match concurrently)."""
+    env, _run, _session = _fanout_env(tmp_path)
+    _patch_fanout_scaffold(monkeypatch, env)
+    monkeypatch.setattr(fanout_module, "register_flow_notify_scope", lambda **kw: "flow-scope")
+    monkeypatch.setattr(fanout_module, "unregister_flow_notify_scope", lambda *a, **kw: None)
+
+    called = False
+
+    def fake_register(*args, **kwargs):
+        nonlocal called
+        called = True
+        return "outcome-scope-name"
+
+    monkeypatch.setattr(notify_settings_mod, "register_run_notify_outcome_scope", fake_register)
+    monkeypatch.setattr(
+        notify_settings_mod, "unregister_run_notify_outcome_scope", lambda *a, **kw: None
+    )
+
+    result, status = await fanout_module._run_fanout(
+        "codex/model",
+        "prompt",
+        notify="some-hook {status}",
+    )
+
+    assert status == "completed"
+    assert called is False

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -502,6 +502,37 @@ class TestChatParamStripping:
         assert calls[0].tool_names == []
 
 
+class TestTurnOriginSingleFire:
+    """A repair round is an internal retry within one operate() call, not a
+    fresh user-prompt submission — USER_PROMPT_SUBMIT must fire at most once
+    per lndl_middle() invocation, no matter how many rounds it takes."""
+
+    @pytest.mark.asyncio
+    async def test_retry_round_does_not_refire_user_prompt_submit(self):
+        branch = TestBranch.from_text(
+            [
+                "```lndl\nOUT{answer: [missing]}\n```",
+                "```lndl\n<lvar a>fixed</lvar>\nOUT{answer: [a]}\n```",
+            ]
+        )
+
+        bus = HookBus()
+        submits: list[dict] = []
+
+        async def on_submit(**kw):
+            submits.append(kw)
+
+        bus.on(HookPoint.USER_PROMPT_SUBMIT, on_submit)
+        branch._hooks = bus
+
+        chat_param = ChatParam(response_format=AnswerModel)
+        result = await lndl_middle(branch, "answer", chat_param)
+
+        assert result.answer == "fixed"
+        assert len(TestBranch.calls(branch)) == 2
+        assert len(submits) == 1
+
+
 class TestRoundBudget:
     @pytest.mark.asyncio
     async def test_custom_round_budget_respected(self):

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -267,3 +267,28 @@ async def test_stream_post_hook_failure_silenced():
     # Should NOT raise — stream data already sent
     chunks = [c async for c in h._stream()]
     assert chunks == ["chunk1", "chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_recorded_failure_warns(caplog):
+    """A normal post-hook failure -- e.g. HookRegistry.post_invocation
+    converting a handler's raised error into an ABORTED HookEvent instead of
+    re-raising -- must still surface as a warning, even though ``invoke()``
+    itself returns without raising."""
+    h = SimpleHooked()
+
+    class AbortedPostHook:
+        execution = SimpleNamespace(status=EventStatus.ABORTED, error="post hook probe failure")
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            pass
+
+    h._post_invoke_hook_event = AbortedPostHook()
+
+    with caplog.at_level("WARNING", logger="lionagi.service.hooks.hooked_event"):
+        chunks = [c async for c in h._stream()]
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert any("post hook probe failure" in record.getMessage() for record in caplog.records)

--- a/tests/service/test_imodel_hooks.py
+++ b/tests/service/test_imodel_hooks.py
@@ -484,6 +484,95 @@ class TestiModelHooks:
 
 
 # ---------------------------------------------------------------------------
+# PreEventCreate replacement — a successful hook response must be used as
+# the created event instead of a fresh one built from kwargs.
+# ---------------------------------------------------------------------------
+
+
+class TestPreEventCreateReplacement:
+    @pytest.mark.asyncio
+    async def test_hook_replacement_event_is_used(self, mock_response):
+        imodel = iModel(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="test-key",
+        )
+        replacement_holder = {}
+
+        async def pre_create_hook(event_type, **kwargs):
+            replacement = imodel.create_api_calling(
+                messages=[{"role": "user", "content": "replaced"}]
+            )
+            replacement_holder["event"] = replacement
+            return replacement
+
+        imodel.hook_registry = HookRegistry(hooks={HookEventTypes.PreEventCreate: pre_create_hook})
+
+        with patch.object(
+            imodel.endpoint,
+            "call",
+            return_value=mock_response.json.return_value,
+        ):
+            result = await imodel.invoke(messages=[{"role": "user", "content": "original"}])
+
+        assert result.id == replacement_holder["event"].id
+        assert result.payload["messages"][0]["content"] == "replaced"
+        assert result.status == EventStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_hook_default_none_still_creates_from_kwargs(self, mock_response):
+        """A hook that returns None (the documented default-creation signal)
+        must leave the ordinary kwargs-built event untouched."""
+        imodel = iModel(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="test-key",
+        )
+
+        async def pre_create_hook(event_type, **kwargs):
+            return None
+
+        imodel.hook_registry = HookRegistry(hooks={HookEventTypes.PreEventCreate: pre_create_hook})
+
+        with patch.object(
+            imodel.endpoint,
+            "call",
+            return_value=mock_response.json.return_value,
+        ):
+            result = await imodel.invoke(messages=[{"role": "user", "content": "original"}])
+
+        assert result.payload["messages"][0]["content"] == "original"
+        assert result.status == EventStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_hook_incompatible_result_falls_back_to_default_creation(self, mock_response):
+        """A hook response that is not an instance of create_event_type is
+        not a usable replacement — fall back to the normal kwargs-built
+        event rather than propagating the incompatible value."""
+        imodel = iModel(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="test-key",
+        )
+
+        async def pre_create_hook(event_type, **kwargs):
+            return {"not": "an event"}
+
+        imodel.hook_registry = HookRegistry(hooks={HookEventTypes.PreEventCreate: pre_create_hook})
+
+        with patch.object(
+            imodel.endpoint,
+            "call",
+            return_value=mock_response.json.return_value,
+        ):
+            result = await imodel.invoke(messages=[{"role": "user", "content": "original"}])
+
+        assert isinstance(result, APICalling)
+        assert result.payload["messages"][0]["content"] == "original"
+        assert result.status == EventStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
 # D12 – process_chunk raises exception from exit tuple
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes four defects in the hook and event dispatch paths, each with a regression test that fails on the prior code.

- **LNDL retry hook duplication.** Repair rounds reused a chat param whose `turn_origin` stayed unset, so each internal retry re-fired `USER_PROMPT_SUBMIT`. A prompt guard could approve the first round and reject an internal retry after output was already recorded. Round one now keeps the caller's real origin; later rounds are marked no-origin.
- **PreEventCreate replacement.** `iModel.create_event()` awaited the pre-hook but discarded its result, so a hook returning a prepared replacement event had no effect. A completed hook returning a correctly-typed event is now used; `None` or a wrong-typed result still falls through to default creation.
- **Post-stream hook failures.** Failures recorded by the hook registry after streaming were not surfaced at warning level. They are now logged.
- **Fan-out notify scope.** Settings-driven fan-out notification outcomes were not persisted per run; they are now scoped to the run.

Regression tests added for each; the operations, service, and cli suites pass (pre-existing failures unrelated to these files excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
