### PR TITLE
fix(flow): reactive streaming and signal delivery under the Trio backend

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -808,6 +808,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.session.observe(EscalationRequest, self._on_bus_escalation)
         self._running = True
 
+        driver_done = ConcurrencyEvent()
+
         async def _driver():
             # Owns its own task group (entered/exited in THIS task). The
             # generator must not span a task group across `yield` — anyio forbids
@@ -823,27 +825,65 @@ class ReactiveExecutor(DependencyAwareExecutor):
                         tg.start_soon(self._run_tracked, node)
             finally:
                 await send.aclose()
+                driver_done.set()
 
-        # asyncio-only: flow_stream needs a detached task for the driver
-        # coroutine so the generator can yield events as they arrive.
-        # anyio's create_task_group cannot be used here because the generator
-        # must outlive any single task group scope.
-        driver = asyncio.ensure_future(_driver())
+        try:
+            asyncio.get_running_loop()
+            on_asyncio = True
+        except RuntimeError:
+            on_asyncio = False
+
+        if on_asyncio:
+            # A Task posted straight onto the asyncio loop isn't tracked on
+            # any anyio cancel-scope stack, so it survives this generator
+            # being abandoned (e.g. consumer `break`s without an explicit
+            # aclose()) without corrupting anything.
+            driver = asyncio.ensure_future(_driver())
+            try:
+                async with recv:
+                    async for event in recv:
+                        yield event
+                await driver  # normal end: surface any driver exception
+            finally:
+                self._running = False
+                self._tg = None
+                self._result_sink = None
+                observer.unobserve(self._on_bus_spawn)
+                observer.unobserve(self._on_bus_escalation)
+                if not driver.done():  # early break / consumer close: tear down
+                    driver.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await driver
+            return
+
+        # Non-asyncio anyio backends (Trio) have no ambient loop to post a
+        # detached task onto, so the driver's task group is entered/exited
+        # manually, in this generator's own task, via the context-manager
+        # protocol instead of `async with` (which anyio forbids spanning a
+        # yield). Unlike the asyncio path above, a caller on these backends
+        # that abandons this generator early without closing it (e.g. `break`
+        # with no `contextlib.aclosing`) will not cleanly unwind: Trio has no
+        # way to safely exit a task group from outside the task that entered
+        # it, which is inherent to structured concurrency, not specific to
+        # this driver.
+        driver_tg = anyio.create_task_group()
+        await driver_tg.__aenter__()
+        driver_tg.start_soon(_driver)
         try:
             async with recv:
                 async for event in recv:
                     yield event
-            await driver  # normal end: surface any driver exception
+            await driver_tg.__aexit__(None, None, None)  # normal end: surface any driver exception
         finally:
             self._running = False
             self._tg = None
             self._result_sink = None
             observer.unobserve(self._on_bus_spawn)
             observer.unobserve(self._on_bus_escalation)
-            if not driver.done():  # early break / consumer close: tear down
-                driver.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await driver
+            if not driver_done.is_set():  # early break / consumer close: tear down
+                driver_tg.cancel_scope.cancel()
+                with contextlib.suppress(get_cancelled_exc_class(), Exception):
+                    await driver_tg.__aexit__(None, None, None)
 
     async def _run_tracked(self, node: Operation) -> None:
         token = _CURRENT_OP.set(node)

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -145,6 +145,11 @@ class DependencyAwareExecutor:
         # NodeSpawned), retained until each finishes so a weakly referenced
         # task can't disappear before it runs. See _emit_best_effort().
         self._signal_tasks: set[asyncio.Task[Any]] = set()
+        # AnyIO task group open for the duration of execute()/execute_stream(),
+        # used by _emit_best_effort() to schedule signals on any backend
+        # (including Trio, which has no ambient "current loop" to post a
+        # detached task onto). None outside of a running execute*() call.
+        self._tg: Any = None
         # Out-of-band handle for a control poller running alongside this flow
         # to reach pause()/resume()/context/graph; set synchronously before
         # any awaiting so it's available the instant execute() starts.
@@ -175,7 +180,12 @@ class DependencyAwareExecutor:
             for node in nodes:
                 _name = node.metadata.get("reference_id", str(node.id)[:8])
                 self.on_progress(str(node.id), _name, "queued", 0.0)
-        await self._alcall(nodes, self._execute_operation, limiter=limiter)
+        async with create_task_group() as tg:
+            self._tg = tg
+            try:
+                await self._alcall(nodes, self._execute_operation, limiter=limiter)
+            finally:
+                self._tg = None
 
         completed_ops = [
             op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
@@ -277,16 +287,27 @@ class DependencyAwareExecutor:
             logger.warning("flow signal construction failed: %s", e)
             return
 
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return  # no running loop — tests / sync contexts, not a failure
-
         async def _emit() -> None:
             try:
                 await self.session.emit(sig)
             except Exception as e:  # noqa: BLE001
                 logger.warning("flow signal emission failed for %s: %s", type(sig).__name__, e)
+
+        if self._tg is not None:
+            # Backend-agnostic path: an execute()/execute_stream() task
+            # group is open, so schedule directly on it. This is the only
+            # way to fire-and-forget under Trio, which has no ambient loop
+            # to post a detached task onto outside of a task group.
+            try:
+                self._tg.start_soon(_emit)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("flow signal scheduling failed for %s: %s", type(sig).__name__, e)
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop — tests / sync contexts, not a failure
 
         coro = _emit()
         try:
@@ -716,7 +737,6 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._spawn_count = 0
         self._dropped_spawns: list[dict[str, Any]] = []
         self._running = False
-        self._tg: Any = None
         self._graph_lock = threading.Lock()
         self._seen_reqs: set[int] = set()
         self._spawned_ids: set[Any] = set()

--- a/tests/operations/test_flow_pause.py
+++ b/tests/operations/test_flow_pause.py
@@ -9,6 +9,7 @@ import asyncio
 import importlib
 import logging
 
+import anyio
 import pytest
 
 from lionagi.ln.concurrency import CapacityLimiter
@@ -469,6 +470,86 @@ async def test_emit_best_effort_task_set_is_empty_after_successful_emission():
     assert executor._signal_tasks == set()
     assert len(signals) == 1
     assert signals[0].op_id == "x"
+
+
+# ---------------------------------------------------------------------------
+# _emit_best_effort: must deliver signals on every anyio backend, not just
+# asyncio — the executor's own open task group (self._tg) is the scheduling
+# mechanism during a real execute()/execute_stream() run, so it works
+# identically under Trio, which has no ambient loop to post a detached task
+# onto.
+#
+# These use a bare `anyio.run(..., backend="trio")` rather than
+# `@pytest.mark.anyio` — this repo's `asyncio_mode = "auto"` pytest-asyncio
+# setting hijacks any `async def` test regardless of markers, so a
+# `[trio]`-parametrized anyio test still silently executes on asyncio. Only a
+# synchronous test driving its own `anyio.run` is guaranteed to actually
+# exercise the Trio backend.
+# ---------------------------------------------------------------------------
+
+
+def test_pause_signal_delivered_on_reactive_executor_under_trio():
+    async def op_fn(**kw):
+        return "ok"
+
+    from lionagi.session.signal import NodePaused
+
+    async def _body():
+        session = _session_with_ops(op=op_fn)
+        signals: list[NodePaused] = []
+        session.observe(NodePaused, handler=lambda s, _ctx: signals.append(s))
+
+        graph = Graph()
+        graph.add_node(Operation(operation="op"))
+
+        executor = ReactiveExecutor(session=session, graph=graph, max_concurrent=5)
+        executor.pause()
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(executor.execute)
+            with anyio.fail_after(2):
+                while not signals:
+                    await anyio.sleep(0.01)
+            executor.resume()
+
+        assert len(signals) == 1
+        assert signals[0].op_id
+
+    anyio.run(_body, backend="trio")
+
+
+def test_pause_signal_delivered_on_base_executor_under_trio():
+    """Same as above but for the plain (non-reactive) execute() path, which
+    schedules operations via _alcall rather than a task group it owns for
+    running nodes — it must still open one for signal delivery."""
+
+    async def op_fn(**kw):
+        return "ok"
+
+    from lionagi.session.signal import NodePaused
+
+    async def _body():
+        session = _session_with_ops(op=op_fn)
+        signals: list[NodePaused] = []
+        session.observe(NodePaused, handler=lambda s, _ctx: signals.append(s))
+
+        graph = Graph()
+        graph.add_node(Operation(operation="op"))
+
+        executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=5)
+        executor.pause()
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(executor.execute)
+            with anyio.fail_after(2):
+                while not signals:
+                    await anyio.sleep(0.01)
+            executor.resume()
+
+        assert len(signals) == 1
+        assert signals[0].op_id
+
+    anyio.run(_body, backend="trio")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/operations/test_flow_stream.py
+++ b/tests/operations/test_flow_stream.py
@@ -105,6 +105,40 @@ async def test_early_break_does_not_hang():
     assert seen == 1
 
 
+def test_stream_runs_its_driver_under_trio():
+    """Regression: execute_stream's driver must actually run on every anyio
+    backend. It used to schedule itself with asyncio.ensure_future, which
+    silently never runs under Trio (no ambient asyncio loop to post onto),
+    so the stream produced no events and callers hung until their own
+    timeout fired.
+
+    Uses a bare `anyio.run(..., backend="trio")` rather than
+    `@pytest.mark.anyio` — this repo's `asyncio_mode = "auto"` pytest-asyncio
+    setting hijacks any `async def` test regardless of markers, so a
+    `[trio]`-parametrized anyio test still silently executes on asyncio.
+    Only a synchronous test driving its own `anyio.run` is guaranteed to
+    actually exercise the Trio backend.
+    """
+
+    async def quick(**kw):
+        return "done"
+
+    async def _body():
+        session = _session(quick=quick)
+        g = Graph()
+        g.add_node(create_operation("quick", parameters={}))
+
+        events = []
+        with anyio.fail_after(2):
+            async for ev in session.flow_stream(g):
+                events.append(ev)
+
+        assert len(events) == 1
+        assert events[0].result == "done"
+
+    anyio.run(_body, backend="trio")
+
+
 @pytest.mark.asyncio
 async def test_dependent_op_streams_after_predecessor():
     order = []


### PR DESCRIPTION
Fixes two Trio-backend defects in reactive flow execution, each reproduced first with a standalone Trio script and pinned by a regression test that fails on the prior code.

- **Streaming driver never starts.** `ReactiveExecutor.execute_stream()` did not start its driver under Trio, so reactive streaming produced no output on that backend. The driver now runs under Trio.
- **Dropped signals.** `DependencyAwareExecutor._emit_best_effort` dropped pause, escalation, and spawn signals when the executor ran on Trio. Those signals are now delivered.

Regression tests added for both; the operations flow suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
