### PR TITLE
fix(flow,hooks): Trio-safe orchestration and hook lifecycle correctness

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -865,8 +865,6 @@ class ReactiveExecutor(DependencyAwareExecutor):
                     await driver_done.wait()
         if driver_errors:
             raise driver_errors[0]
-        if driver_errors:
-            raise driver_errors[0]
 
     async def _run_tracked(self, node: Operation) -> None:
         token = _CURRENT_OP.set(node)

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import anyio
+import sniffio
 
 from lionagi._errors import ExecutionError, OperationError
 from lionagi.ln import AlcallParams
@@ -145,6 +146,10 @@ class DependencyAwareExecutor:
         # NodeSpawned), retained until each finishes so a weakly referenced
         # task can't disappear before it runs. See _emit_best_effort().
         self._signal_tasks: set[asyncio.Task[Any]] = set()
+        # AnyIO task group backing the current execute()/execute_stream() run,
+        # if any — lets _emit_best_effort() schedule signals through anyio
+        # (Trio-safe) instead of the asyncio-only loop.create_task() fallback.
+        self._tg: Any = None
         # Out-of-band handle for a control poller running alongside this flow
         # to reach pause()/resume()/context/graph; set synchronously before
         # any awaiting so it's available the instant execute() starts.
@@ -175,7 +180,12 @@ class DependencyAwareExecutor:
             for node in nodes:
                 _name = node.metadata.get("reference_id", str(node.id)[:8])
                 self.on_progress(str(node.id), _name, "queued", 0.0)
-        await self._alcall(nodes, self._execute_operation, limiter=limiter)
+        async with create_task_group() as tg:
+            self._tg = tg
+            try:
+                await self._alcall(nodes, self._execute_operation, limiter=limiter)
+            finally:
+                self._tg = None
 
         completed_ops = [
             op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
@@ -277,16 +287,26 @@ class DependencyAwareExecutor:
             logger.warning("flow signal construction failed: %s", e)
             return
 
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return  # no running loop — tests / sync contexts, not a failure
-
         async def _emit() -> None:
             try:
                 await self.session.emit(sig)
             except Exception as e:  # noqa: BLE001
                 logger.warning("flow signal emission failed for %s: %s", type(sig).__name__, e)
+
+        if self._tg is not None:
+            # A flow run is in progress: schedule through its anyio task
+            # group, which works under both asyncio and Trio (the raw
+            # asyncio loop below only ever runs under asyncio).
+            try:
+                self._tg.start_soon(_emit)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("flow signal scheduling failed for %s: %s", type(sig).__name__, e)
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop — tests / sync contexts, not a failure
 
         coro = _emit()
         try:
@@ -716,7 +736,6 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._spawn_count = 0
         self._dropped_spawns: list[dict[str, Any]] = []
         self._running = False
-        self._tg: Any = None
         self._graph_lock = threading.Lock()
         self._seen_reqs: set[int] = set()
         self._spawned_ids: set[Any] = set()
@@ -788,42 +807,66 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.session.observe(EscalationRequest, self._on_bus_escalation)
         self._running = True
 
+        driver_cancel_scope = anyio.CancelScope()
+        driver_done = anyio.Event()
+        driver_errors: list[BaseException] = []
+
         async def _driver():
             # Owns its own task group (entered/exited in THIS task). The
             # generator must not span a task group across `yield` — anyio forbids
             # it — so the driver runs detached and the generator only drains the
             # channel. Closing `send` on completion ends the consumer's loop.
-            try:
-                async with create_task_group() as tg:
-                    self._tg = tg
-                    for node in initial:
-                        if self.on_progress:
-                            _name = node.metadata.get("reference_id", str(node.id)[:8])
-                            self.on_progress(str(node.id), _name, "queued", 0.0)
-                        tg.start_soon(self._run_tracked, node)
-            finally:
-                await send.aclose()
+            with driver_cancel_scope:
+                try:
+                    async with create_task_group() as tg:
+                        self._tg = tg
+                        for node in initial:
+                            if self.on_progress:
+                                _name = node.metadata.get("reference_id", str(node.id)[:8])
+                                self.on_progress(str(node.id), _name, "queued", 0.0)
+                            tg.start_soon(self._run_tracked, node)
+                except get_cancelled_exc_class():
+                    raise  # let driver_cancel_scope absorb our own cancellation
+                except BaseException as e:  # noqa: BLE001
+                    driver_errors.append(e)
+                finally:
+                    await send.aclose()
+            driver_done.set()
 
-        # asyncio-only: flow_stream needs a detached task for the driver
-        # coroutine so the generator can yield events as they arrive.
-        # anyio's create_task_group cannot be used here because the generator
-        # must outlive any single task group scope.
-        driver = asyncio.ensure_future(_driver())
+        # flow_stream needs a detached task for the driver coroutine so the
+        # generator can yield events as they arrive. anyio's create_task_group
+        # cannot be used here because the generator must outlive any single
+        # task group scope (yielding across a task group's `async with` is
+        # unsafe on Trio once the consumer can close the generator early).
+        # asyncio has no structured-concurrency requirement, so a plain task
+        # suffices there; Trio requires a system task, which is immune to
+        # any enclosing cancel scope and is stopped via driver_cancel_scope
+        # instead.
+        if sniffio.current_async_library() == "trio":
+            import trio  # noqa: PLC0415
+
+            trio.lowlevel.spawn_system_task(_driver)
+        else:
+            asyncio.ensure_future(_driver())
         try:
             async with recv:
                 async for event in recv:
                     yield event
-            await driver  # normal end: surface any driver exception
+            await driver_done.wait()  # normal end: surface any driver exception
         finally:
             self._running = False
             self._tg = None
             self._result_sink = None
             observer.unobserve(self._on_bus_spawn)
             observer.unobserve(self._on_bus_escalation)
-            if not driver.done():  # early break / consumer close: tear down
-                driver.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await driver
+            if not driver_done.is_set():  # early break / consumer close: tear down
+                driver_cancel_scope.cancel()
+                with contextlib.suppress(get_cancelled_exc_class(), Exception):
+                    await driver_done.wait()
+        if driver_errors:
+            raise driver_errors[0]
+        if driver_errors:
+            raise driver_errors[0]
 
     async def _run_tracked(self, node: Operation) -> None:
         token = _CURRENT_OP.set(node)

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -29,6 +29,7 @@ from lionagi.lndl import (
 )
 
 from .._defaults import get_default_action_call
+from .._turn_origin import TurnOrigin
 from ..types import ActionParam, ChatParam, ParseParam, RunParam
 
 if TYPE_CHECKING:
@@ -208,11 +209,15 @@ def build_lndl_middle(round_budget: int = DEFAULT_ROUND_BUDGET):
         last_error: str | None = None
 
         for round_num in range(1, round_budget + 1):
-            round_chat_param = (
-                stripped_chat_param.with_updates(guidance=lndl_guidance)
-                if round_num == 1
-                else stripped_chat_param
-            )
+            if round_num == 1:
+                round_chat_param = stripped_chat_param.with_updates(guidance=lndl_guidance)
+            else:
+                # A continuation/repair round is not a fresh user submission —
+                # the outer call's boundary already fired at most once for
+                # round 1; later rounds must never re-fire USER_PROMPT_SUBMIT.
+                round_chat_param = stripped_chat_param.with_updates(
+                    turn_origin=TurnOrigin.no_origin()
+                )
             round_instruction = _round_instruction(instruction, round_num, round_budget, last_error)
 
             text = await _run_round_chat(branch, round_instruction, round_chat_param)

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -99,9 +99,21 @@ class HookedEvent(Event):
             yield chunk
 
         # Post-stream hook failure: data already sent, must not reraise — log at WARNING only.
+        # HookRegistry.post_invocation() records a handler's raised exception on the
+        # HookEvent (status FAILED/CANCELLED/ABORTED) rather than re-raising it out of
+        # invoke(), so the failure must be detected via status, not a try/except.
         if h_ev := self._post_invoke_hook_event:
             try:
                 await h_ev.invoke()
+                if h_ev.execution.status in (
+                    EventStatus.FAILED,
+                    EventStatus.CANCELLED,
+                    EventStatus.ABORTED,
+                ):
+                    _logger.warning(
+                        "Post-stream hook failed (data already sent): %s",
+                        h_ev.execution.error,
+                    )
             except Exception as _hook_exc:
                 _logger.warning(
                     "Post-stream hook failed (data already sent): %s",

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -172,7 +172,11 @@ class iModel:  # noqa: N801
 
         if issubclass(create_event_type, HookedEvent):
             api_call = None
-            if create_event_type is APICalling:
+            if h_ev and isinstance(h_ev.execution.response, create_event_type):
+                # PreEventCreate replaced the event outright — use it as-is
+                # instead of building a fresh one from the original kwargs.
+                api_call = h_ev.execution.response
+            elif create_event_type is APICalling:
                 api_call = self.create_api_calling(**kwargs)
             else:
                 api_call = create_event_type(**kwargs)

--- a/tests/operations/test_flow_pause.py
+++ b/tests/operations/test_flow_pause.py
@@ -9,6 +9,7 @@ import asyncio
 import importlib
 import logging
 
+import anyio
 import pytest
 
 from lionagi.ln.concurrency import CapacityLimiter
@@ -510,6 +511,29 @@ async def test_flow_reactive_without_pause_behaves_normally():
     result = await flow(session, graph, max_concurrent=5, reactive=True)
     assert len(result["completed_operations"]) == 3
     assert sorted(executed) == ["op_0", "op_1", "op_2"]
+
+
+def test_emit_best_effort_schedules_via_task_group_under_trio():
+    """A running flow's anyio task group must be used to schedule signals,
+    not asyncio.get_running_loop(), which raises RuntimeError under Trio
+    and silently drops the signal."""
+    from lionagi.ln.concurrency import create_task_group
+    from lionagi.session.signal import NodePaused
+
+    async def scenario():
+        session = Session()
+        executor = DependencyAwareExecutor(session=session, graph=Graph())
+        signals: list[NodePaused] = []
+        session.observe(NodePaused, handler=lambda s, _ctx: signals.append(s))
+
+        async with create_task_group() as tg:
+            executor._tg = tg
+            executor._emit_best_effort(lambda: NodePaused(op_id="x", name="x"))
+
+        return signals
+
+    signals = anyio.run(scenario, backend="trio")
+    assert len(signals) == 1
 
 
 if __name__ == "__main__":

--- a/tests/operations/test_flow_stream.py
+++ b/tests/operations/test_flow_stream.py
@@ -172,3 +172,56 @@ async def test_non_mapping_response_context_streams_failed_event():
     assert events[0].status == "failed"
     assert not events[0].ok
     assert "must be a Mapping" in events[0].result["error"]
+
+
+def test_execute_stream_yields_events_under_trio():
+    """The streaming driver must be scheduled by whatever anyio backend is
+    active. asyncio.ensure_future() silently no-ops under Trio, leaving the
+    stream waiting forever for an operation that already completed."""
+
+    async def quick(**kw):
+        return "done"
+
+    async def scenario():
+        session = _session(quick=quick)
+        graph = Graph()
+        graph.add_node(create_operation("quick", parameters={}))
+
+        events = []
+        with anyio.fail_after(2):
+            async for ev in session.flow_stream(graph):
+                events.append(ev)
+        return events
+
+    events = anyio.run(scenario, backend="trio")
+
+    assert len(events) == 1
+    assert events[0].result == "done"
+
+
+def test_execute_stream_early_break_cancels_driver_under_trio():
+    """An early consumer break must still cancel the still-running driver
+    task promptly, not hang until the slow operation finishes."""
+
+    async def quick(**kw):
+        return "quick-done"
+
+    async def slow(**kw):
+        await anyio.sleep(10)
+        return "never"
+
+    async def scenario():
+        session = _session(quick=quick, slow=slow)
+        graph = Graph()
+        graph.add_node(create_operation("quick", parameters={}))
+        graph.add_node(create_operation("slow", parameters={}))
+
+        seen = 0
+        with anyio.fail_after(2):
+            async for _ev in session.flow_stream(graph):
+                seen += 1
+                break
+        return seen
+
+    seen = anyio.run(scenario, backend="trio")
+    assert seen == 1

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -337,6 +337,33 @@ class TestRetryAndRepair:
         result = await lndl_middle(branch, "answer", chat_param)
         assert result.answer == "fixed"
 
+    @pytest.mark.asyncio
+    async def test_repair_round_fires_user_prompt_submit_once(self):
+        """A one-repair-round LNDL run is still one user turn: only round 1
+        may fire USER_PROMPT_SUBMIT. A later round reusing the caller's
+        unset turn_origin would mint (and fire) a fresh token every round."""
+        branch = TestBranch.from_text(
+            [
+                "```lndl\nOUT{answer: [missing]}\n```",
+                "```lndl\n<lvar a>fixed</lvar>\nOUT{answer: [a]}\n```",
+            ]
+        )
+        bus = HookBus()
+        submits: list[dict] = []
+
+        async def on_submit(**kw):
+            submits.append(kw)
+
+        bus.on(HookPoint.USER_PROMPT_SUBMIT, on_submit)
+        branch._hooks = bus
+
+        chat_param = ChatParam(response_format=AnswerModel)
+        result = await lndl_middle(branch, "answer", chat_param)
+
+        assert result.answer == "fixed"
+        assert len(TestBranch.calls(branch)) == 2
+        assert len(submits) == 1
+
 
 class TestRoundBudgetExhaustion:
     """The Middle raises LNDLError rather than leaking a raw last_error str

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -267,3 +267,20 @@ async def test_stream_post_hook_failure_silenced():
     # Should NOT raise — stream data already sent
     chunks = [c async for c in h._stream()]
     assert chunks == ["chunk1", "chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_aborted_status_logs_warning(caplog):
+    """A normal (non-raising) post-hook failure — the shape HookRegistry.
+    post_invocation() actually produces, recording the error on the
+    HookEvent with status ABORTED instead of raising out of invoke() — must
+    still log the promised warning, not be silently dropped."""
+    h = SimpleHooked()
+    h._post_invoke_hook_event = _fake_hook(EventStatus.ABORTED)
+    h._post_invoke_hook_event.execution.error = "post hook probe failure"
+
+    with caplog.at_level("WARNING", logger="lionagi.service.hooks.hooked_event"):
+        chunks = [c async for c in h._stream()]
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert any("Post-stream hook failed" in r.message for r in caplog.records)

--- a/tests/service/test_imodel_hooks.py
+++ b/tests/service/test_imodel_hooks.py
@@ -107,6 +107,34 @@ class TestiModelHooks:
         assert result.status == EventStatus.COMPLETED
 
     @pytest.mark.asyncio
+    async def test_pre_event_create_hook_replacement_is_used(self):
+        """A PreEventCreate handler returning a prepared APICalling must be
+        the event create_event() returns — not a fresh one built from the
+        original kwargs, which would silently discard the handler's payload
+        edits."""
+
+        imodel = iModel(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="test-key",
+        )
+
+        replacement = imodel.create_api_calling(
+            messages=[{"role": "user", "content": "replacement payload"}]
+        )
+
+        async def pre_create_hook(event_type, **kwargs):
+            return replacement
+
+        imodel.hook_registry = HookRegistry(hooks={HookEventTypes.PreEventCreate: pre_create_hook})
+
+        api_call = await imodel.create_event(
+            messages=[{"role": "user", "content": "original payload"}]
+        )
+
+        assert api_call is replacement
+
+    @pytest.mark.asyncio
     async def test_hook_error_handling(self):
 
         async def failing_hook(event, **kwargs):


### PR DESCRIPTION
## Summary

Five fixes making flow orchestration and the hook lifecycle correct under Trio and for hook-driven event replacement.

- **Flow signals dropped under Trio** (#2416): best-effort signal emission scheduled via `asyncio.get_running_loop().create_task()`, which raises under Trio and silently dropped the signal. Emission now goes through an anyio task group active for the duration of `execute()`, working identically on asyncio and Trio.
- **Reactive stream driver never starts under Trio** (#2417): `execute_stream()` scheduled its driver with `asyncio.ensure_future`, which never runs under Trio. The driver is now spawned as a real detached task per the active backend, with cancellation on early consumer break via an explicit cancel scope, avoiding nursery corruption across the generator's yield.
- **LNDL repair rounds re-fire USER_PROMPT_SUBMIT** (#2402): repair rounds reused the caller's `ChatParam`, minting a fresh submission token each round. Continuation rounds now carry `TurnOrigin.no_origin()`, so only the first round fires the hook.
- **PreEventCreate replacement ignored** (#2407): `iModel.create_event()` checked only the hook's exit flag and discarded a hook-returned event. It now uses the returned event instance when the hook provides one of the expected type.
- **Post-stream hook failures not warned** (#2408): a post-hook that fails is recorded on the hook event's status rather than raised, so the existing except-based warning never fired. The status is now checked and warned on in addition to the raise path.

Fixes #2416, #2417, #2402, #2407, #2408.

## Testing

Regression tests added per fix, including Trio-backed tests for the flow-signal and streaming paths. Touched-module suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
