### PR TITLE
fix(studio): align validation & persistence with execution, correct error status codes

### DIFF
--- a/apps/studio/frontend/src/components/workflow/WorkflowDraftContext.tsx
+++ b/apps/studio/frontend/src/components/workflow/WorkflowDraftContext.tsx
@@ -147,7 +147,6 @@ export function WorkflowDraftProvider({
       parse: "Parse",
       fanout: "Fan Out",
       engine: "Engine",
-      gate: "Gate",
     };
     dispatch({
       type: "addNode",

--- a/apps/studio/frontend/src/components/workflow/WorkflowNodeCard.tsx
+++ b/apps/studio/frontend/src/components/workflow/WorkflowNodeCard.tsx
@@ -7,7 +7,6 @@ const KIND_GLYPH: Record<WorkflowNodeKind, string> = {
   parse: "⊞",
   fanout: "⋔",
   engine: "⊶",
-  gate: "◇",
 };
 
 const KIND_COLOR: Record<WorkflowNodeKind, string> = {
@@ -16,7 +15,6 @@ const KIND_COLOR: Record<WorkflowNodeKind, string> = {
   parse: "var(--status-pending)",
   fanout: "var(--content-muted)",
   engine: "#a78bfa",
-  gate: "var(--status-warning, #f59e0b)",
 };
 
 interface WorkflowNodeCardProps {

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1378,7 +1378,7 @@ export async function deleteEngineDef(defId: string): Promise<{ ok: boolean }> {
 
 // ─── Workflow definitions ─────────────────────────────────────────────────────
 
-export type WorkflowNodeKind = "input" | "chat" | "parse" | "fanout" | "engine" | "gate";
+export type WorkflowNodeKind = "input" | "chat" | "parse" | "fanout" | "engine";
 
 export interface WorkflowNodePos {
   x: number;
@@ -1393,16 +1393,12 @@ export interface WorkflowEngineConfig {
   options?: Record<string, string>;
 }
 
-export interface WorkflowGateConfig {
-  condition: string;
-}
-
 export interface WorkflowNode {
   id: string;
   kind: WorkflowNodeKind;
   label: string;
   pos: WorkflowNodePos;
-  config?: WorkflowEngineConfig | WorkflowGateConfig | Record<string, unknown>;
+  config?: WorkflowEngineConfig | Record<string, unknown>;
 }
 
 export interface WorkflowEdge {

--- a/apps/studio/frontend/src/lib/workflow/flow.ts
+++ b/apps/studio/frontend/src/lib/workflow/flow.ts
@@ -18,7 +18,6 @@ const KIND_LABEL: Record<string, string> = {
   parse: "parse",
   fanout: "fanout",
   engine: "engine",
-  gate: "gate",
 };
 
 export function specToFlowModel(spec: WorkflowSpec): FlowModel {

--- a/apps/studio/frontend/src/lib/workflow/serialize.test.ts
+++ b/apps/studio/frontend/src/lib/workflow/serialize.test.ts
@@ -20,7 +20,7 @@ const SPEC: WorkflowSpec = {
       pos: { x: 240, y: 120 },
       config: { engine_def_id: "def-1", model: "sonnet" },
     },
-    { id: "n3", kind: "gate", label: "Gate", pos: { x: 420, y: 120 } },
+    { id: "n3", kind: "parse", label: "Parse", pos: { x: 420, y: 120 } },
   ],
   edges: [
     { id: "e1", from: "n1", to: "n2" },
@@ -80,6 +80,16 @@ describe("workflow serialize", () => {
     const result = coerceSpec({
       version: 1,
       nodes: [{ id: "a", kind: "teleport", label: "A", pos: { x: 0, y: 0 } }],
+      edges: [],
+    });
+    expect(result.spec).toBeNull();
+    expect(result.errors.some((e) => e.includes("kind"))).toBe(true);
+  });
+
+  it("rejects 'gate' node kind (removed; the server no longer supports it)", () => {
+    const result = coerceSpec({
+      version: 1,
+      nodes: [{ id: "g", kind: "gate", label: "Gate", pos: { x: 0, y: 0 } }],
       edges: [],
     });
     expect(result.spec).toBeNull();

--- a/apps/studio/frontend/src/lib/workflow/serialize.ts
+++ b/apps/studio/frontend/src/lib/workflow/serialize.ts
@@ -8,7 +8,6 @@ const NODE_KINDS: readonly WorkflowNodeKind[] = [
   "parse",
   "fanout",
   "engine",
-  "gate",
 ];
 
 export interface ParseResult {

--- a/apps/studio/frontend/src/lib/workflow/validation.ts
+++ b/apps/studio/frontend/src/lib/workflow/validation.ts
@@ -103,22 +103,6 @@ export function validateSpec(
     }
   }
 
-  // Rule 5 — gate nodes may have at most 2 outgoing edges
-  const outDegree = new Map<string, number>(spec.nodes.map((n) => [n.id, 0]));
-  for (const e of spec.edges) {
-    if (outDegree.has(e.from)) {
-      outDegree.set(e.from, outDegree.get(e.from)! + 1);
-    }
-  }
-  for (const n of spec.nodes) {
-    if (n.kind === "gate" && (outDegree.get(n.id) ?? 0) > 2) {
-      errors.push({
-        rule: "gate-fan-out",
-        message: `Gate node "${n.label || n.id}" has more than 2 outgoing edges.`,
-      });
-    }
-  }
-
   return errors;
 }
 

--- a/apps/studio/frontend/src/lib/workflow/workflow.test.ts
+++ b/apps/studio/frontend/src/lib/workflow/workflow.test.ts
@@ -231,44 +231,6 @@ describe("validateSpec — rule: engine-no-config / engine-unknown-def", () => {
   });
 });
 
-// ── validateSpec — rule 5: gate fan-out ──────────────────────────────────────
-
-describe("validateSpec — rule: gate-fan-out", () => {
-  it("passes for gate with 2 outgoing edges", () => {
-    const spec = makeSpec({
-      nodes: [
-        { id: "n1", kind: "input", label: "Input", pos: { x: 0, y: 0 } },
-        { id: "n2", kind: "gate", label: "Gate", pos: { x: 200, y: 0 } },
-        { id: "n3", kind: "chat", label: "Chat A", pos: { x: 400, y: 0 } },
-        { id: "n4", kind: "chat", label: "Chat B", pos: { x: 400, y: 100 } },
-      ],
-      edges: [edge("e1", "n1", "n2"), edge("e2", "n2", "n3", "if"), edge("e3", "n2", "n4", "else")],
-    });
-    const errors = validateSpec(spec);
-    expect(errors.find((e) => e.rule === "gate-fan-out")).toBeUndefined();
-  });
-
-  it("fails for gate with 3 outgoing edges", () => {
-    const spec = makeSpec({
-      nodes: [
-        { id: "n1", kind: "input", label: "Input", pos: { x: 0, y: 0 } },
-        { id: "n2", kind: "gate", label: "Gate", pos: { x: 200, y: 0 } },
-        { id: "n3", kind: "chat", label: "A", pos: { x: 400, y: 0 } },
-        { id: "n4", kind: "chat", label: "B", pos: { x: 400, y: 100 } },
-        { id: "n5", kind: "chat", label: "C", pos: { x: 400, y: 200 } },
-      ],
-      edges: [
-        edge("e1", "n1", "n2"),
-        edge("e2", "n2", "n3"),
-        edge("e3", "n2", "n4"),
-        edge("e4", "n2", "n5"),
-      ],
-    });
-    const errors = validateSpec(spec);
-    expect(errors.find((e) => e.rule === "gate-fan-out")).toBeDefined();
-  });
-});
-
 // ── emptySpec ─────────────────────────────────────────────────────────────────
 
 describe("emptySpec", () => {

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -40,6 +40,15 @@ KIND_DIRS: dict[str, Path] = {
     "playbook": PLAYBOOKS_DIR,
 }
 
+# Extension used when creating a new definition of a given kind (i.e. no
+# existing on-disk file to infer it from). Must match what each kind's
+# catalog scans for -- playbooks.py's list_playbooks() only globs
+# *.playbook.yaml, so a new playbook has to land with that suffix.
+_DEFAULT_EXT: dict[str, str] = {
+    "agent": ".md",
+    "playbook": ".playbook.yaml",
+}
+
 
 def _relative_path(full_path: Path) -> str:
     try:
@@ -217,7 +226,7 @@ async def save_definition(
     async with lock:
         disk_file = await anyio.to_thread.run_sync(partial(_find_definition_file, base, name))
         if not disk_file:
-            disk_file = base / f"{name}.md"
+            disk_file = base / f"{name}{_DEFAULT_EXT.get(kind, '.md')}"
 
         now = time.time()
 

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -71,6 +71,41 @@ def _check_spec_fields(spec: dict[str, Any]) -> str | None:
                 f"got {type(val).__name__}"
             )
 
+    for bool_field in ("bare", "dry_run", "show_graph"):
+        if bool_field in spec:
+            val = spec[bool_field]
+            if not isinstance(val, bool):
+                return f"spec field {bool_field!r} must be a bool, got {type(val).__name__}"
+
+    if "prompt" in spec:
+        prompt = spec["prompt"]
+        if not isinstance(prompt, str):
+            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
+        if len(prompt) > 8192:
+            return "spec field 'prompt' exceeds maximum length of 8192 characters"
+
+    if "save" in spec:
+        save = spec["save"]
+        if not isinstance(save, str):
+            return f"spec field 'save' must be a string, got {type(save).__name__}"
+
+    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
+        if str_field in spec:
+            val = spec[str_field]
+            if not isinstance(val, str):
+                return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
+
+    if "artifacts" in spec:
+        artifacts = spec["artifacts"]
+        if artifacts is None:
+            return "spec field 'artifacts' must be a dict, got NoneType"
+        try:
+            from lionagi.state.artifact_verifier import validate_artifact_contract
+
+            validate_artifact_contract(artifacts)
+        except Exception as exc:
+            return f"spec field 'artifacts' is invalid: {exc}"
+
     return None
 
 

--- a/lionagi/studio/services/projects.py
+++ b/lionagi/studio/services/projects.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from typing import Any
 
@@ -15,6 +16,11 @@ from ..registry import studio_route
 from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
+
+
+class NameConflictError(Exception):
+    """Raised when a project name already exists."""
+
 
 _ENSURE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS projects (
@@ -166,27 +172,35 @@ async def create_project(
     now = time.time()
     async with _open_db(_DB) as db:
         await _ensure_table(db)
-        await db.execute(
-            """INSERT INTO projects
-                   (name, source, path, github, description,
-                    created_at, updated_at, last_seen_at)
-               VALUES (?, 'studio', ?, ?, ?, ?, ?, ?)""",
-            (clean_name, path, github, description, now, now, now),
-        )
-        await db.commit()
+        try:
+            await db.execute(
+                """INSERT INTO projects
+                       (name, source, path, github, description,
+                        created_at, updated_at, last_seen_at)
+                   VALUES (?, 'studio', ?, ?, ?, ?, ?, ?)""",
+                (clean_name, path, github, description, now, now, now),
+            )
+            await db.commit()
+        except sqlite3.IntegrityError as exc:
+            raise NameConflictError(f"Project {clean_name!r} already exists") from exc
 
     return {"name": clean_name, "source": "studio", "created_at": now}
 
 
 async def update_project(name: str, fields: dict[str, Any]) -> bool:
-    """Patch mutable project fields. Returns True when a row was updated."""
+    """Patch mutable project fields. Returns True when the project exists --
+    either a field was updated, or no mutable fields were supplied but the
+    project is present (a no-op patch on an existing project isn't a 404)."""
     allowed = {"description", "github", "path"}
     clean = {k: v for k, v in fields.items() if k in allowed}
-    if not clean:
-        return False
 
     async with _open_db(_DB) as db:
         await _ensure_table(db)
+        if not clean:
+            cur = await db.execute("SELECT 1 FROM projects WHERE name = ?", (name,))
+            row = await cur.fetchone()
+            return row is not None
+
         clean["updated_at"] = time.time()
         sets = ", ".join(f"{k} = ?" for k in clean)
         vals = list(clean.values()) + [name]
@@ -291,7 +305,7 @@ async def create_project_route(body: CreateProjectRequest) -> dict[str, Any]:
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:
+    except NameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
@@ -302,7 +316,7 @@ async def update_project_route(name: str, body: UpdateProjectRequest) -> dict[st
     if not ok:
         raise HTTPException(
             status_code=404,
-            detail=f"Project '{name}' not found or no changes",
+            detail=f"Project '{name}' not found",
         )
     return {"ok": True}
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import math
+import sqlite3
 import time
 import uuid
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any
 
 from fastapi import HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
@@ -21,6 +23,11 @@ from ..registry import studio_route
 from . import run_view
 
 _log = logging.getLogger(__name__)
+
+
+class NameConflictError(Exception):
+    """Raised when a schedule name already exists."""
+
 
 _PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
 
@@ -265,6 +272,10 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
     if not isinstance(data, dict):
         return f"flow_yaml spec must be a YAML mapping (dict), got {type(data).__name__}"
 
+    for key in data:
+        if not isinstance(key, str):
+            return f"flow_yaml spec keys must be strings, got {type(key).__name__}"
+
     # Normalize hyphenated keys (e.g. max-ops → max_ops) before field checks.
     spec: dict[str, Any] = {}
     for key, value in data.items():
@@ -305,6 +316,41 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
                 f"spec field 'with_synthesis' must be bool or str (model spec), "
                 f"got {type(val).__name__}"
             )
+
+    for bool_field in ("bare", "dry_run", "show_graph"):
+        if bool_field in spec:
+            val = spec[bool_field]
+            if not isinstance(val, bool):
+                return f"spec field {bool_field!r} must be a bool, got {type(val).__name__}"
+
+    if "prompt" in spec:
+        prompt = spec["prompt"]
+        if not isinstance(prompt, str):
+            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
+        if len(prompt) > 8192:
+            return "spec field 'prompt' exceeds maximum length of 8192 characters"
+
+    if "save" in spec:
+        save = spec["save"]
+        if not isinstance(save, str):
+            return f"spec field 'save' must be a string, got {type(save).__name__}"
+
+    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
+        if str_field in spec:
+            val = spec[str_field]
+            if not isinstance(val, str):
+                return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
+
+    if "artifacts" in spec:
+        artifacts = spec["artifacts"]
+        if artifacts is None:
+            return "spec field 'artifacts' must be a dict, got NoneType"
+        try:
+            from lionagi.state.artifact_verifier import validate_artifact_contract
+
+            validate_artifact_contract(artifacts)
+        except Exception as exc:
+            return f"spec field 'artifacts' is invalid: {exc}"
 
     return None
 
@@ -493,7 +539,10 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
         "action_cwd": action_cwd,
     }
     async with StateDB() as db:
-        await db.create_schedule(schedule)
+        try:
+            await db.create_schedule(schedule)
+        except (sqlite3.IntegrityError, SAIntegrityError) as exc:
+            raise NameConflictError(f"Schedule name {data['name']!r} already exists") from exc
     return {"id": schedule_id, "name": data["name"], "created_at": now}
 
 
@@ -806,7 +855,7 @@ async def create_schedule_route(body: CreateScheduleRequest) -> dict[str, Any]:
         return await create_schedule(body.model_dump(exclude_none=True))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:
+    except NameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -369,3 +369,20 @@ class TestUpdatePlaybookSpecFieldValidation:
         result = svc.validate_playbook("any", {"workers": 0})
         assert not result["ok"]
         assert any("workers" in e for e in result["errors"])
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            {"bare": "true"},
+            {"prompt": 42},
+            {"save": 7},
+            {"model": 42},
+            {"artifacts": None},
+        ],
+    )
+    def test_validate_playbook_rejects_fields_execution_rejects(self, spec):
+        """Fields the CLI execution validator rejects must also fail Studio validation."""
+        import lionagi.studio.services.playbooks as svc
+
+        result = svc.validate_playbook("any", spec)
+        assert not result["ok"], f"{spec} should be rejected"

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -110,6 +110,48 @@ async def test_save_definition_increments_version(tmp_path, monkeypatch):
     assert r2["version"] == 2
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_new_playbook_definition_lands_in_playbook_catalog(tmp_path, monkeypatch):
+    """Creating a new playbook via save_definition() must write a
+    *.playbook.yaml file so it shows up in playbooks.list_playbooks(), not a
+    *.md file that the playbook catalog never scans."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+    import lionagi.studio.services.playbooks as pb_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    agents_dir = fake_home / "agents"
+    playbooks_dir = fake_home / "playbooks"
+    agents_dir.mkdir()
+    playbooks_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+    monkeypatch.setattr(pb_mod, "_PLAYBOOKS_ROOT", playbooks_dir)
+
+    result = await defs_mod.save_definition(
+        "playbook", "new-one", "description: a new playbook\n", "initial save"
+    )
+    assert result["version"] >= 1
+
+    assert not (playbooks_dir / "new-one.md").exists()
+    playbook_file = playbooks_dir / "new-one.playbook.yaml"
+    assert playbook_file.exists(), "new playbook must land as *.playbook.yaml"
+    assert playbook_file.read_text() == "description: a new playbook\n"
+
+    catalog = pb_mod.list_playbooks()
+    assert any(entry["name"] == "new-one" for entry in catalog)
+
+
 @pytest.mark.asyncio
 async def test_save_definition_unknown_kind_raises(tmp_path, monkeypatch):
     """save_definition() with an unknown kind must raise ValueError (not return success)."""

--- a/tests/apps_studio_server/test_projects.py
+++ b/tests/apps_studio_server/test_projects.py
@@ -13,7 +13,9 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
 
-def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def _make_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, raise_server_exceptions: bool = True
+) -> TestClient:
     """Wire a TestClient with a real temp state.db and patched paths."""
     import lionagi.state.db as state_db_mod
     import lionagi.studio.services.projects as projects_mod
@@ -36,7 +38,11 @@ def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     from lionagi.studio.app import app
 
-    return TestClient(app, base_url="http://127.0.0.1:8765")
+    return TestClient(
+        app,
+        base_url="http://127.0.0.1:8765",
+        raise_server_exceptions=raise_server_exceptions,
+    )
 
 
 # ── GET /api/projects/ ────────────────────────────────────────────────────────
@@ -144,6 +150,31 @@ def test_update_project_not_found_returns_404(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
     r = client.put("/api/projects/ghost", json={"description": "x"})
     assert r.status_code == 404
+
+
+def test_update_project_empty_body_on_existing_project_returns_200(tmp_path, monkeypatch):
+    """An empty PUT (no mutable fields) on an existing project is a no-op,
+    not a 404 -- the project is present, it's the patch that's empty."""
+    client = _make_client(tmp_path, monkeypatch)
+    client.post("/api/projects/", json={"name": "no-op-target"})
+    r = client.put("/api/projects/no-op-target", json={})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_create_project_storage_failure_is_not_409(tmp_path, monkeypatch):
+    """A non-conflict exception from the storage layer (e.g. RuntimeError)
+    must not be reported to the client as a 409 name conflict."""
+    client = _make_client(tmp_path, monkeypatch, raise_server_exceptions=False)
+    import lionagi.studio.services.projects as projects_mod
+
+    async def _boom(db):
+        raise RuntimeError("storage offline")
+
+    monkeypatch.setattr(projects_mod, "_ensure_table", _boom)
+    r = client.post("/api/projects/", json={"name": "will-fail"})
+    assert r.status_code != 409
+    assert r.status_code == 500
 
 
 # ── DELETE /api/projects/{name} ───────────────────────────────────────────────

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -9,6 +9,8 @@ import os
 import textwrap
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # subprocess.build_argv tests
 # ---------------------------------------------------------------------------
@@ -149,6 +151,33 @@ def test_validate_flow_yaml_spec_rejects_invalid_field():
     assert "workers" in result
 
 
+@pytest.mark.parametrize(
+    "yaml_text",
+    [
+        'bare: "true"\n',
+        "prompt: 42\n",
+        "save: 7\n",
+        "model: 42\n",
+        "artifacts: null\n",
+    ],
+)
+def test_validate_flow_yaml_spec_rejects_fields_execution_rejects(yaml_text):
+    """Fields the CLI execution validator rejects must also fail Studio validation."""
+    from lionagi.studio.services.schedules import _validate_flow_yaml_spec
+
+    result = _validate_flow_yaml_spec(yaml_text)
+    assert result is not None, f"{yaml_text!r} should be rejected"
+
+
+def test_validate_flow_yaml_spec_rejects_non_string_key():
+    """A YAML mapping with a non-string key must return an error, not raise TypeError."""
+    from lionagi.studio.services.schedules import _validate_flow_yaml_spec
+
+    result = _validate_flow_yaml_spec("1: value\n")
+    assert result is not None
+    assert "string" in result
+
+
 def test_create_schedule_rejects_empty_flow_yaml():
     """create_schedule raises ValueError when action_flow_yaml is missing."""
     import asyncio
@@ -195,6 +224,62 @@ def test_create_schedule_rejects_malformed_flow_yaml():
         raise AssertionError("Should have raised ValueError")
     except ValueError as exc:
         assert "flow_yaml" in str(exc).lower() or "YAML" in str(exc)
+
+
+def _minimal_command_schedule(name: str) -> dict:
+    return {
+        "name": name,
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_prompt": "say hi",
+    }
+
+
+def test_create_schedule_route_duplicate_name_returns_409(tmp_path, monkeypatch):
+    """Creating a schedule with a name that already exists must return 409,
+    not a generic server error."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.schedules as schedules_mod
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", fake_db)
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    client = TestClient(app, base_url="http://127.0.0.1:8765")
+    body = _minimal_command_schedule("dup-schedule")
+    r1 = client.post("/api/schedules/", json=body)
+    assert r1.status_code == 201, r1.text
+    r2 = client.post("/api/schedules/", json=body)
+    assert r2.status_code == 409
+
+
+def test_create_schedule_route_storage_failure_is_not_409(tmp_path, monkeypatch):
+    """A non-conflict exception from the storage layer (e.g. RuntimeError)
+    must not be reported to the client as a 409 name conflict."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.schedules as schedules_mod
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", fake_db)
+
+    async def _boom(self, schedule):
+        raise RuntimeError("storage offline")
+
+    monkeypatch.setattr(state_db_mod.StateDB, "create_schedule", _boom)
+
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+    r = client.post("/api/schedules/", json=_minimal_command_schedule("will-fail-schedule"))
+    assert r.status_code != 409
+    assert r.status_code == 500
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four Studio fixes aligning validation and persistence with execution semantics and correcting error status codes.

- **Validation accepts fields execution rejects** (#2431): the Studio playbook and flow-YAML validators were partial copies of the CLI's authoritative spec-field validator. They now check the full field set (bool/string/artifacts) and return a validation error rather than a `TypeError` for a non-string YAML mapping key.
- **Versioned playbook written outside the catalog** (#2432): saving a new playbook definition fell back to a `<name>.md` path, invisible to the playbook catalog which globs `*.playbook.yaml`. New definitions now use a per-kind default extension so playbooks land as `<name>.playbook.yaml`.
- **Workflow editor accepts gate nodes the server rejects** (#2433): the server dropped `gate` as a valid node kind but the frontend type/parser allowlist still included it, so a `gate` node passed client validation and failed only on save. `gate` is removed from the frontend node-kind union, parser allowlist, and validation rules.
- **Server failures reported as conflicts** (#2435): project and schedule creation wrapped the service call in a broad `except Exception -> 409`, masking storage failures as name conflicts. They now raise 409 only on an actual integrity/name collision; an empty PATCH on an existing project returns 200 rather than 404.

Fixes #2431, #2432, #2433, #2435.

## Testing

Backend regression tests added (`tests/apps_studio_server/`, `tests/cli/test_scheduler_flow_yaml.py`). The #2433 change is frontend TypeScript; the frontend type-check and vitest suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
