### PR TITLE
fix(studio): assistant endpoint, session eviction, nested definitions, approval-chain integrity

### DIFF
--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -190,6 +190,7 @@ async def _write_evidence(
     created_at = time.time()
     payload = {
         "id": evidence_id,
+        "sequence": sequence,
         "event_type": event_type,
         "approval_id": approval_id,
         "action_kind": action_kind,
@@ -265,10 +266,18 @@ async def verify_evidence_chain() -> dict[str, Any]:
 
     key = os.getenv("LIONAGI_STUDIO_EVIDENCE_HMAC_KEY")
     expected_previous = GENESIS_HASH
+    expected_sequence = 1
     for row in rows:
         total += 1
+        if row["sequence"] != expected_sequence:
+            errors.append(
+                f"sequence {row['sequence']}: expected sequence {expected_sequence} "
+                "(non-contiguous)"
+            )
+        expected_sequence += 1
         payload = {
             "id": row["id"],
+            "sequence": row["sequence"],
             "event_type": row["event_type"],
             "approval_id": row["approval_id"],
             "action_kind": row["action_kind"],

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -319,10 +319,22 @@ def _find_definition_file(base: Path, name: str) -> Path | None:
             return candidate
 
     # Fast path 2: nested subdir (base/<name>/<name><ext>)
+    subdir = base / name
     for ext in _EXTENSIONS:
-        candidate = base / name / f"{name}{ext}"
+        candidate = subdir / f"{name}{ext}"
         if candidate.exists():
             return candidate
+
+    # Fast path 3: nested subdir whose definition file doesn't share the
+    # directory's name. list_definitions() names such a definition after its
+    # containing directory, so fetching must resolve the same way: fall back
+    # to the file that listing would have picked (same extension priority,
+    # alphabetical tiebreak).
+    if subdir.is_dir():
+        for ext in _EXTENSIONS:
+            matches = sorted(p for p in subdir.iterdir() if p.is_file() and p.name.endswith(ext))
+            if matches:
+                return matches[0]
 
     # Slow path: scan one level of subdirectories with literal candidates —
     # NOT Path.glob() with untrusted input so no metacharacter expansion occurs.

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -48,8 +48,12 @@ _SESSIONS: dict[str, LeoSession] = {}
 
 
 def _evict_idle(now: float) -> None:
+    # Never evict a session whose lock is held: it is mid-turn, and dropping
+    # it from the registry would orphan the running stream.
     stale = [
-        sid for sid, sess in _SESSIONS.items() if now - sess.last_used_at > _IDLE_EXPIRY_SECONDS
+        sid
+        for sid, sess in _SESSIONS.items()
+        if now - sess.last_used_at > _IDLE_EXPIRY_SECONDS and not sess.lock.locked()
     ]
     for sid in stale:
         del _SESSIONS[sid]
@@ -58,7 +62,12 @@ def _evict_idle(now: float) -> None:
 def _evict_lru_if_full() -> None:
     if len(_SESSIONS) < _MAX_SESSIONS:
         return
-    lru_id = min(_SESSIONS, key=lambda sid: _SESSIONS[sid].last_used_at)
+    # Only consider sessions that aren't mid-turn; if every session is busy,
+    # skip eviction rather than kill an active stream.
+    candidates = [sid for sid, sess in _SESSIONS.items() if not sess.lock.locked()]
+    if not candidates:
+        return
+    lru_id = min(candidates, key=lambda sid: _SESSIONS[sid].last_used_at)
     del _SESSIONS[lru_id]
 
 

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -261,7 +261,17 @@ def create_playbook(name: str, data: dict[str, Any] | None = None) -> dict[str, 
         allow_unicode=True,
         width=120,
     )
-    path.write_text(new_text)
+    # Exclusive create closes the check-then-write TOCTOU: two concurrent
+    # create requests (FastAPI runs sync routes in a threadpool) could both
+    # pass the path.exists() guard above, and a plain write_text would let the
+    # second silently clobber the first. "x" mode makes the write itself the
+    # exclusion; re-raise with the same clean message the guard uses so the
+    # route's 409 detail never leaks the absolute path.
+    try:
+        with open(path, "x", encoding="utf-8") as f:
+            f.write(new_text)
+    except FileExistsError:
+        raise FileExistsError(f"Playbook '{stem}' already exists") from None
 
     return get_playbook(stem)
 

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -217,6 +217,55 @@ _DECLARATIVE_KEYS: tuple[str, ...] = (
 )
 
 
+def create_playbook(name: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Write a brand-new playbook YAML to disk. Raises FileExistsError if one already exists for *name*, ValueError if the spec fields or step/link references are invalid."""
+    stem = name.removesuffix(".playbook.yaml").removesuffix(".yaml")
+    safe_path_join(_PLAYBOOKS_ROOT, f"{stem}.playbook.yaml")
+    path = _PLAYBOOKS_ROOT / f"{stem}.playbook.yaml"
+    if path.exists():
+        raise FileExistsError(f"Playbook '{stem}' already exists")
+
+    data = data or {}
+    spec_err = _check_spec_fields(_normalize_spec_keys(data))
+    if spec_err:
+        raise ValueError(spec_err)
+
+    content: dict[str, Any] = {"description": data.get("description") or ""}
+
+    for key in _DECLARATIVE_KEYS:
+        value = data.get(key)
+        if value not in (None, ""):
+            content[key] = value
+
+    use = data.get("use")
+    if isinstance(use, dict) and use.get("models"):
+        content["use"] = use
+
+    steps = data.get("steps")
+    if isinstance(steps, dict) and len(steps) > 0:
+        content["steps"] = steps
+
+    links = data.get("links")
+    if isinstance(links, list) and len(links) > 0:
+        content["links"] = links
+
+    validation = validate_playbook(stem, content)
+    if not validation["ok"]:
+        raise ValueError("; ".join(validation["errors"] or ["invalid playbook"]))
+
+    ensure_lionagi_dir(_PLAYBOOKS_ROOT)
+    new_text = yaml.dump(
+        content,
+        Dumper=_PlaybookDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        width=120,
+    )
+    path.write_text(new_text)
+
+    return get_playbook(stem)
+
+
 def update_playbook(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
     """Write a playbook YAML back to disk with a conservative merge: description overwrites when present, graph keys (use/steps/links) only when non-empty, declarative keys overwrite or clear on None/"", all other disk keys preserved."""
     stem = name.removesuffix(".playbook.yaml").removesuffix(".yaml")
@@ -324,10 +373,17 @@ async def get_playbook_route(name: str) -> dict[str, Any]:
     return pb
 
 
-@studio_route("/playbooks/{name}", method="POST", area="playbooks")
-async def create_playbook(name: str) -> dict[str, Any]:
-    # TODO(lift-backend-writes)
-    raise HTTPException(status_code=501, detail="Not implemented")
+@studio_route("/playbooks/{name}", method="POST", area="playbooks", name="create_playbook")
+async def create_playbook_route(
+    name: str, body: Annotated[dict[str, Any], Body(default_factory=dict)]
+) -> dict[str, Any]:
+    try:
+        created = await anyio.to_thread.run_sync(partial(create_playbook, name, body))
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return created
 
 
 @studio_route("/playbooks/{name}", method="PUT", area="playbooks", name="update_playbook")

--- a/tests/apps_studio_server/test_approvals.py
+++ b/tests/apps_studio_server/test_approvals.py
@@ -497,6 +497,7 @@ def test_genesis_previous_hash_is_64_zero_chars(tmp_path, monkeypatch):
     expected_content = approvals_mod._compute_content_hash(
         {
             "id": rows[0]["id"],
+            "sequence": rows[0]["sequence"],
             "event_type": rows[0]["event_type"],
             "approval_id": rows[0]["approval_id"],
             "action_kind": rows[0]["action_kind"],
@@ -615,6 +616,7 @@ def test_hmac_stripped_signature_fails_verification(tmp_path, monkeypatch):
 
     forged_payload = {
         "id": row["id"],
+        "sequence": row["sequence"],
         "event_type": row["event_type"],
         "approval_id": row["approval_id"],
         "action_kind": "evil_action",
@@ -642,6 +644,45 @@ def test_hmac_stripped_signature_fails_verification(tmp_path, monkeypatch):
     verdict = _run(approvals_mod.verify_evidence_chain())
     assert verdict["valid"] is False
     assert any("hmac signature missing" in e for e in verdict["errors"])
+
+
+def test_renumbered_sequence_detected_by_verify(tmp_path, monkeypatch):
+    """Renumbering every row by the same offset must break verification.
+
+    Before the fix, the evidence hash/signature did not cover `sequence` and
+    verification never checked sequence contiguity, so shifting every row's
+    sequence by a constant offset (e.g. 1,2 -> 101,102) left the chain
+    reporting valid=True even though the ledger numbering had changed.
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import approvals as approvals_mod
+    from lionagi.studio.services._db import open_db
+
+    row = _run(
+        approvals_mod.create_approval(action_kind="launch_playbook", params={"name": "demo"})
+    )
+    _run(approvals_mod.grant_approval(row["id"]))
+
+    rows = _evidence_rows(db_path)
+    assert [r["sequence"] for r in rows] == [1, 2]
+
+    before = _run(approvals_mod.verify_evidence_chain())
+    assert before["valid"] is True
+
+    async def _renumber():
+        async with open_db(str(db_path)) as db:
+            # Shift high->low to avoid a transient UNIQUE collision on sequence.
+            await db.execute("UPDATE approval_evidence SET sequence = 102 WHERE sequence = 2")
+            await db.execute("UPDATE approval_evidence SET sequence = 101 WHERE sequence = 1")
+            await db.commit()
+
+    _run(_renumber())
+
+    after = _run(approvals_mod.verify_evidence_chain())
+    assert after["valid"] is False
 
 
 def test_deny_with_justification_lands_in_evidence(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -274,6 +274,79 @@ class TestUpdatePlaybookValidation:
         assert pb_path.read_text() == original_content
 
 
+class TestCreatePlaybook:
+    """POST /playbooks/{name} must actually create the playbook, not 501."""
+
+    def test_create_writes_new_file(self, tmp_path, monkeypatch):
+        import lionagi.studio.services.playbooks as svc
+
+        monkeypatch.setattr(svc, "_PLAYBOOKS_ROOT", tmp_path)
+
+        result = svc.create_playbook(
+            "new-pb", {"description": "A test playbook", "prompt": "do the thing"}
+        )
+        assert result is not None
+        assert result["name"] == "new-pb"
+        assert result["data"]["description"] == "A test playbook"
+        assert result["data"]["prompt"] == "do the thing"
+        assert (tmp_path / "new-pb.playbook.yaml").exists()
+
+    def test_create_rejects_existing_name(self, tmp_path, monkeypatch):
+        """Creating over an existing playbook must raise, not silently overwrite."""
+        import lionagi.studio.services.playbooks as svc
+
+        monkeypatch.setattr(svc, "_PLAYBOOKS_ROOT", tmp_path)
+        (tmp_path / "dup.playbook.yaml").write_text("description: original\n")
+
+        with pytest.raises(FileExistsError):
+            svc.create_playbook("dup", {"description": "clobber"})
+
+        assert (tmp_path / "dup.playbook.yaml").read_text() == "description: original\n"
+
+    def test_create_invalid_spec_raises_and_does_not_write(self, tmp_path, monkeypatch):
+        import lionagi.studio.services.playbooks as svc
+
+        monkeypatch.setattr(svc, "_PLAYBOOKS_ROOT", tmp_path)
+
+        with pytest.raises(ValueError):
+            svc.create_playbook("bad-pb", {"workers": 999})
+
+        assert not (tmp_path / "bad-pb.playbook.yaml").exists()
+
+    def test_route_no_longer_returns_501(self, tmp_path, monkeypatch):
+        """POST /playbooks/{name} must create the playbook, not return 501."""
+        import lionagi.studio.services.playbooks as svc
+
+        monkeypatch.setattr(svc, "_PLAYBOOKS_ROOT", tmp_path)
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        import lionagi.studio.services.playbooks  # ensure routes registered
+        from lionagi.studio.registry import iter_studio_routes
+
+        app = FastAPI()
+        for route in iter_studio_routes(area="playbooks"):
+            app.add_api_route(
+                route.path,
+                route.handler,
+                methods=[route.method],
+                response_model=route.response_model,
+                status_code=route.status_code,
+                tags=list(route.tags),
+            )
+        client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+
+        resp = client.post(
+            "/playbooks/demo",
+            json={"description": "from leo", "prompt": "run it"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "demo"
+        assert (tmp_path / "demo.playbook.yaml").exists()
+
+
 class TestUpdatePlaybookSpecFieldValidation:
     """workers/max_ops/effort must be validated on PUT."""
 

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -303,6 +303,36 @@ class TestCreatePlaybook:
 
         assert (tmp_path / "dup.playbook.yaml").read_text() == "description: original\n"
 
+    def test_create_is_atomic_against_toctou_race(self, tmp_path, monkeypatch):
+        """A file that appears AFTER the path.exists() guard but before the
+        write must not be clobbered. FastAPI runs the sync route in a
+        threadpool, so two concurrent creates can both pass the guard; the
+        exclusive-create write must raise FileExistsError (mapped to 409),
+        not silently overwrite the race winner."""
+        import lionagi.studio.services.playbooks as svc
+
+        monkeypatch.setattr(svc, "_PLAYBOOKS_ROOT", tmp_path)
+        target = tmp_path / "race-pb.playbook.yaml"
+
+        # yaml.dump is the last step before the write, so plant a "winner" file
+        # there — the guard at the top of create_playbook has already passed
+        # with the path absent, reproducing the check-then-write window.
+        real_dump = svc.yaml.dump
+
+        def _dump_then_plant(*args, **kwargs):
+            text = real_dump(*args, **kwargs)
+            if not target.exists():
+                target.write_text("description: winner\n")
+            return text
+
+        monkeypatch.setattr(svc.yaml, "dump", _dump_then_plant)
+
+        with pytest.raises(FileExistsError):
+            svc.create_playbook("race-pb", {"description": "loser"})
+
+        # The racing winner survives untouched; the loser did not clobber it.
+        assert target.read_text() == "description: winner\n"
+
     def test_create_invalid_spec_raises_and_does_not_write(self, tmp_path, monkeypatch):
         import lionagi.studio.services.playbooks as svc
 

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -565,6 +565,65 @@ def test_find_definition_file_missing_base_returns_none(tmp_path):
     assert result is None
 
 
+# ---------------------------------------------------------------------------
+# Nested definitions listed under the containing directory's name must also
+# be fetchable by that same name, even when the filename inside differs.
+# ---------------------------------------------------------------------------
+
+
+def test_find_definition_file_resolves_nested_dir_with_different_filename(tmp_path):
+    """A nested definition file named differently than its directory must still
+    resolve by the directory name — the same name list_definitions() reports.
+    """
+    from lionagi.studio.services.definitions import _find_definition_file
+
+    base = tmp_path / "agents"
+    nested = base / "team"
+    nested.mkdir(parents=True)
+    (nested / "profile.md").write_text("# Team profile")
+
+    result = _find_definition_file(base, "team")
+
+    assert result is not None
+    assert result == nested / "profile.md"
+
+
+@pytest.mark.asyncio
+async def test_get_definition_finds_nested_dir_listed_by_list_definitions(tmp_path, monkeypatch):
+    """Regression test: list_definitions() names a nested definition after its
+    containing directory (agents/team/profile.md -> "team"), so get_definition()
+    with that listed name must resolve, not return None.
+    """
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    agents_dir = fake_home / "agents"
+    nested = agents_dir / "team"
+    nested.mkdir(parents=True)
+    (nested / "profile.md").write_text("# Team profile")
+    playbooks_dir = fake_home / "playbooks"
+    playbooks_dir.mkdir(parents=True)
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+
+    listed = await defs_mod.list_definitions("agent")
+    assert [d["name"] for d in listed] == ["team"]
+
+    result = await defs_mod.get_definition("agent", "team")
+
+    assert result is not None, "get_definition must resolve the name list_definitions() reported"
+    assert result["content"] == "# Team profile"
+
+
 @pytest.mark.asyncio
 async def test_save_definition_fresh_home_no_kind_dir(tmp_path, monkeypatch):
     """POST to a fresh home where agents/ doesn't exist must succeed (not 500).

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -102,6 +102,53 @@ def test_session_registry_evicts_lru_over_cap(monkeypatch):
     assert len(leo_svc._SESSIONS) == 3
 
 
+def test_session_registry_skips_busy_session_when_evicting_lru(monkeypatch):
+    """A session whose lock is held (mid-turn) must never be the eviction victim."""
+    import asyncio
+
+    from lionagi.studio.services import leo as leo_svc
+
+    monkeypatch.setattr(leo_svc, "_MAX_SESSIONS", 3)
+
+    ids = [leo_svc.create_session().id for _ in range(3)]
+    now = time.time()
+    leo_svc._SESSIONS[ids[0]].last_used_at = now + 10
+    leo_svc._SESSIONS[ids[1]].last_used_at = now  # oldest, but busy
+    leo_svc._SESSIONS[ids[2]].last_used_at = now + 20
+
+    asyncio.run(leo_svc._SESSIONS[ids[1]].lock.acquire())
+
+    new_sess = leo_svc.create_session()
+
+    assert ids[1] in leo_svc._SESSIONS  # busy session survives even though it's LRU
+    assert leo_svc._SESSIONS[ids[1]].lock.locked()
+    assert ids[0] not in leo_svc._SESSIONS  # next-oldest idle session evicted instead
+    assert ids[2] in leo_svc._SESSIONS
+    assert new_sess.id in leo_svc._SESSIONS
+    assert len(leo_svc._SESSIONS) == 3
+
+
+def test_session_registry_all_busy_exceeds_cap_rather_than_evict(monkeypatch):
+    """When every session is mid-turn, capacity is temporarily exceeded rather than evicting one."""
+    import asyncio
+
+    from lionagi.studio.services import leo as leo_svc
+
+    monkeypatch.setattr(leo_svc, "_MAX_SESSIONS", 3)
+
+    ids = [leo_svc.create_session().id for _ in range(3)]
+    for sid in ids:
+        asyncio.run(leo_svc._SESSIONS[sid].lock.acquire())
+
+    new_sess = leo_svc.create_session()
+
+    for sid in ids:
+        assert sid in leo_svc._SESSIONS
+        assert leo_svc._SESSIONS[sid].lock.locked()
+    assert new_sess.id in leo_svc._SESSIONS
+    assert len(leo_svc._SESSIONS) == 4
+
+
 def test_session_registry_expires_idle_sessions():
     from lionagi.studio.services import leo as leo_svc
 


### PR DESCRIPTION
## Summary

Four Studio fixes: a missing endpoint, a session-eviction race, nested-definition lookup, and approval-chain integrity.

- **Playbook creation endpoint unimplemented** (#2434): `POST /api/playbooks/{name}` was a 501 stub, so a create-playbook proposal always failed. A real `create_playbook()` service function now validates spec/steps and writes the YAML, with 409 on duplicate name and 422 on invalid data.
- **Active session evicted at capacity** (#2436): LRU and idle eviction picked sessions purely by last-used time, so a session mid-turn could be dropped from the registry out from under its running stream. Both paths now exclude locked (busy) sessions, temporarily exceeding the cap rather than evicting a busy one.
- **Nested definitions listed but not fetchable** (#2437): listing names a nested definition after its containing directory, but lookup required the filename to equal the directory name. Lookup now falls back to the first extension-priority file in the directory, matching what listing picked.
- **Approval evidence accepts renumbered rows** (#2438): the evidence `content_hash` omitted the row `sequence`, so renumbering rows by a constant offset left every hash and signature valid. `sequence` is now part of the hashed payload, and verification additionally checks contiguity from 1.

Fixes #2434, #2436, #2437, #2438.

## Testing

Regression tests added per fix (`tests/apps_studio_server/`). The full `tests/apps_studio_server/` suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
