### PR TITLE
fix(cli,state): monitor SIGTERM, ambiguous-id, fanout notify, transport, schema-version, WAL guard

### DIFF
--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -90,23 +90,58 @@ _TABLE_TO_ENTITY_TYPE = {
 }
 
 
+class AmbiguousIdError(ValueError):
+    """A short id prefix matched more than one row in a single table.
+
+    Raised instead of silently picking one match — the underlying `LIKE`
+    query has no uniqueness guarantee and no `ORDER BY`, so which row a
+    caller got back for a shared prefix was undefined.
+    """
+
+    def __init__(self, table: str, id_or_short: str, matches: list[str]) -> None:
+        self.table = table
+        self.id_or_short = id_or_short
+        self.matches = matches
+        preview = ", ".join(matches[:5])
+        if len(matches) > 5:
+            preview += ", ..."
+        super().__init__(
+            f"{id_or_short!r} matches {len(matches)} {table} ids ({preview}); "
+            "use a longer id prefix to disambiguate"
+        )
+
+
+async def fetch_unique_by_id(db: Any, table: str, id_or_short: str) -> dict[str, Any] | None:
+    """Exact-id fetch for full ids; prefix (`LIKE`) fetch for short ids.
+
+    Raises `AmbiguousIdError` when a short prefix matches more than one row
+    in *table*, instead of returning whichever row the query happened to
+    return first.
+    """
+    id_or_short = id_or_short.strip()
+    if len(id_or_short) < 36:
+        rows = await db.fetch_all(
+            f"SELECT * FROM {table} WHERE id LIKE ? ORDER BY id",  # noqa: S608
+            (id_or_short + "%",),
+        )
+        if len(rows) > 1:
+            raise AmbiguousIdError(table, id_or_short, [r["id"] for r in rows])
+        row = rows[0] if rows else None
+    else:
+        row = await db.fetch_one(
+            f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
+            (id_or_short,),
+        )
+    return db._row_to_dict(row) if row is not None else None
+
+
 async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str, Any]] | None:
     id_or_short = id_or_short.strip()
-    is_prefix = len(id_or_short) < 36
 
     for table in _SEARCH_ORDER:
-        if is_prefix:
-            row = await db.fetch_one(
-                f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-                (id_or_short + "%",),
-            )
-        else:
-            row = await db.fetch_one(
-                f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-                (id_or_short,),
-            )
+        row = await fetch_unique_by_id(db, table, id_or_short)
         if row is not None:
             entity_type = _TABLE_TO_ENTITY_TYPE[table]
-            return table, entity_type, db._row_to_dict(row)
+            return table, entity_type, row
 
     return None

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -465,8 +465,14 @@ async def _do_kill(
     """Resolve entity, kill process, persist cancellation."""
     from lionagi.state.db import StateDB
 
+    from ._util import AmbiguousIdError
+
     async with StateDB() as db:
-        resolved = await _resolve_entity(db, id_or_short)
+        try:
+            resolved = await _resolve_entity(db, id_or_short)
+        except AmbiguousIdError as exc:
+            log_error(str(exc))
+            return 1
         if resolved is None:
             log_error(f"entity not found for id: {id_or_short!r}")
             return 1

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -234,7 +234,11 @@ async def _query_plays_for_show(db: Any, show_id: str) -> list[dict[str, Any]]:
 
 
 async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | None:
-    """Resolve entity_id across all entity tables; returns (entity_type, row) or None."""
+    """Resolve entity_id across all entity tables; returns (entity_type, row) or None.
+    Raises `AmbiguousIdError` if a short prefix matches more than one row in
+    a single table."""
+    from ._util import fetch_unique_by_id
+
     searches = [
         ("session", "sessions"),
         ("invocation", "invocations"),
@@ -248,10 +252,7 @@ async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | 
         )
         if row:
             return entity_type, row
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-            (entity_id + "%",),
-        )
+        row = await fetch_unique_by_id(db, table, entity_id)
         if row:
             return entity_type, row
     return None
@@ -866,7 +867,7 @@ def _watch_loop(
     project: str | None,
 ) -> int:
     """Repeatedly clear screen and reprint; exit cleanly on SIGINT/SIGTERM."""
-    from lionagi.ln.concurrency import run_async
+    from lionagi.ln.concurrency import SigtermInterrupt, run_async
 
     interrupted = False
 
@@ -874,29 +875,43 @@ def _watch_loop(
         nonlocal interrupted
         interrupted = True
 
+    old_sigint_handler = signal.getsignal(signal.SIGINT)
+    old_sigterm_handler = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGINT, _handle_signal)
     signal.signal(signal.SIGTERM, _handle_signal)
 
-    while not interrupted:
-        since = _since_timestamp(since_window) if since_window else None
-        if entity_id:
-            output = run_async(_run_detail(entity_id))
-        else:
-            output = run_async(_run_table(since=since, entity_type=entity_type, project=project))
-        _clear_screen()
-        ts = time.strftime("%H:%M:%S")
-        print(f"{_dim(f'Updated: {ts}  (refresh every {refresh_seconds}s, Ctrl-C to exit)')}")
-        print()
-        print(output)
-        # Sleep in small increments so SIGINT is responsive
-        for _ in range(refresh_seconds * 10):
-            if interrupted:
+    try:
+        while not interrupted:
+            since = _since_timestamp(since_window) if since_window else None
+            try:
+                if entity_id:
+                    output = run_async(_run_detail(entity_id))
+                else:
+                    output = run_async(
+                        _run_table(since=since, entity_type=entity_type, project=project)
+                    )
+            except (KeyboardInterrupt, SigtermInterrupt):
+                # run_async raises these when a signal cancels the refresh
+                # coroutine mid-flight; the handler above already latched
+                # `interrupted`, so just stop the loop cleanly.
                 break
-            time.sleep(0.1)
+            _clear_screen()
+            ts = time.strftime("%H:%M:%S")
+            print(f"{_dim(f'Updated: {ts}  (refresh every {refresh_seconds}s, Ctrl-C to exit)')}")
+            print()
+            print(output)
+            # Sleep in small increments so SIGINT is responsive
+            for _ in range(refresh_seconds * 10):
+                if interrupted:
+                    break
+                time.sleep(0.1)
 
-    if _IS_TTY:
-        print()  # newline after Ctrl-C
-    return 0
+        if _IS_TTY:
+            print()  # newline after Ctrl-C
+        return 0
+    finally:
+        signal.signal(signal.SIGINT, old_sigint_handler)
+        signal.signal(signal.SIGTERM, old_sigterm_handler)
 
 
 # ── Wait-for-terminal primitive (li monitor run / li monitor --run) ───────────
@@ -923,25 +938,37 @@ def _split_watched_ids(raw: list[str]) -> list[str]:
 
 async def _resolve_schedule_run(db: Any, raw_id: str) -> dict[str, Any] | None:
     """Exact match then prefix match. schedule_run ids are 12-char hex, not
-    36-char UUIDs, so _util.py's length-36 prefix heuristic doesn't apply."""
+    36-char UUIDs, so _util.py's length-36 prefix heuristic doesn't apply.
+    Raises `AmbiguousIdError` if the prefix matches more than one run."""
+    from ._util import AmbiguousIdError
+
     row = await db.get_schedule_run(raw_id)
     if row:
         return row
-    return await db.fetch_one(
-        "SELECT * FROM schedule_runs WHERE id LIKE ?",
+    rows = await db.fetch_all(
+        "SELECT * FROM schedule_runs WHERE id LIKE ? ORDER BY id",
         (raw_id + "%",),
     )
+    if len(rows) > 1:
+        raise AmbiguousIdError("schedule_runs", raw_id, [r["id"] for r in rows])
+    return rows[0] if rows else None
 
 
 async def _resolve_session_run(db: Any, raw_id: str) -> dict[str, Any] | None:
-    """Exact match then prefix match against the sessions table (agent/li agent run ids)."""
+    """Exact match then prefix match against the sessions table (agent/li agent run ids).
+    Raises `AmbiguousIdError` if the prefix matches more than one session."""
+    from ._util import AmbiguousIdError
+
     row = await db.get_session(raw_id)
     if row:
         return row
-    return await db.fetch_one(
-        "SELECT * FROM sessions WHERE id LIKE ?",
+    rows = await db.fetch_all(
+        "SELECT * FROM sessions WHERE id LIKE ? ORDER BY id",
         (raw_id + "%",),
     )
+    if len(rows) > 1:
+        raise AmbiguousIdError("sessions", raw_id, [r["id"] for r in rows])
+    return rows[0] if rows else None
 
 
 def _format_session_wait_line(row: dict[str, Any]) -> str:
@@ -1279,6 +1306,7 @@ def _dispatch_wait(
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
     from ._logging import log_error
+    from ._util import AmbiguousIdError
     from .status import EXIT_RUNNING, EXIT_UNKNOWN
 
     if not DEFAULT_DB_PATH.exists():
@@ -1318,7 +1346,11 @@ def _dispatch_wait(
         async with StateDB() as db:
             return await _resolve_watched_runs(db, ids)
 
-    resolved = _run_tick(_resolve())
+    try:
+        resolved = _run_tick(_resolve())
+    except AmbiguousIdError as exc:
+        log_error(str(exc))
+        return EXIT_UNKNOWN
     if resolved is None:
         # Interrupted before resolving completed — "still in progress",
         # not success or failure.

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -132,6 +132,28 @@ async def _run_fanout(
             started_at=_started_at,
         )
 
+    # notify.on_terminal (settings-driven, independent of --notify) outcome
+    # attribution: bind this run into the handler at registration time so a
+    # late-arriving outcome for this entity lands here or nowhere -- never
+    # on a different run this process later allocates. Skipped when --notify
+    # already owns this same entity as an exclusive override (registering a
+    # second override for the same entity would fire the adapter twice).
+    from lionagi.state.lifecycle.notify_settings import (
+        register_run_notify_outcome_scope,
+        unregister_run_notify_outcome_scope,
+    )
+
+    _notify_outcome_scope_name = (
+        None
+        if notify
+        else register_run_notify_outcome_scope(
+            env.run,
+            entity_kind="session",
+            entity_id=str(env.session.id),
+            project_dir=cwd,
+        )
+    )
+
     inner_kw = dict(
         env=env,
         num_workers=num_workers,
@@ -174,6 +196,7 @@ async def _run_fanout(
                 _terminal_status = effective_status
             # Unregister after stop_live_persist fires the terminal transition.
             unregister_flow_notify_scope(_notify_scope_name)
+            unregister_run_notify_outcome_scope(_notify_outcome_scope_name)
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
 

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -46,19 +46,12 @@ _DB_BUSY_TIMEOUT_S = 10.0
 
 async def _fetch_by_id(db: Any, table: str, id_or_short: str) -> dict[str, Any] | None:
     """Exact-id fetch for full ids, prefix (LIKE) fetch for short ids, scoped
-    to one table (see _util.resolve_entity for the multi-table sweep)."""
-    id_or_short = id_or_short.strip()
-    if len(id_or_short) < 36:
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-            (id_or_short + "%",),
-        )
-    else:
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-            (id_or_short,),
-        )
-    return db._row_to_dict(row) if row is not None else None
+    to one table (see _util.resolve_entity for the multi-table sweep).
+    Raises `AmbiguousIdError` (see _util.py) if a short prefix matches more
+    than one row in *table*."""
+    from ._util import fetch_unique_by_id
+
+    return await fetch_unique_by_id(db, table, id_or_short)
 
 
 async def _latest_session(
@@ -428,11 +421,15 @@ async def _run_status_inner(
 
 
 async def _run_status(*, command: str, entity_id: str | None, as_json: bool) -> tuple[str, int]:
+    from ._util import AmbiguousIdError
+
     try:
         return await asyncio.wait_for(
             _run_status_inner(command=command, entity_id=entity_id, as_json=as_json),
             timeout=_DB_BUSY_TIMEOUT_S,
         )
+    except AmbiguousIdError as exc:
+        return str(exc), EXIT_UNKNOWN
     except (TimeoutError, asyncio.TimeoutError):  # 3.10 support: not aliased until 3.11
         return (
             f"state.db busy (no read within {_DB_BUSY_TIMEOUT_S:.0f}s) — "

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -207,6 +207,8 @@ def run_wait(argv: list[str]) -> int:
     from lionagi.ln.concurrency import SigtermInterrupt, run_async
     from lionagi.state.db import DEFAULT_DB_PATH
 
+    from ._util import AmbiguousIdError
+
     parser = argparse.ArgumentParser(prog="li wait", add_help=True)
     parser.add_argument(
         "ids",
@@ -247,6 +249,11 @@ def run_wait(argv: list[str]) -> int:
         outcomes = run_async(
             wait_for_terminal(watched_ids, interval=args.interval, on_result=_on_result)
         )
+    except AmbiguousIdError as exc:
+        # A short prefix matched more than one schedule_runs row — an
+        # unresolvable target, reported like the monitor dispatcher does.
+        log_error(str(exc))
+        return EXIT_UNKNOWN
     except (KeyboardInterrupt, SigtermInterrupt):
         interrupted = True
 

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -122,7 +122,8 @@ async def _run_round_chat(
     chat_param: ChatParam,
 ) -> str:
     """Run one inner-chat turn, dispatching to communicate() (API) or run_and_collect() (CLI) — mirrors operate()'s own selection."""
-    if isinstance(chat_param, RunParam) or getattr(branch.chat_model, "is_cli", False):
+    effective_imodel = chat_param.imodel or branch.chat_model
+    if isinstance(chat_param, RunParam) or getattr(effective_imodel, "is_cli", False):
         from ..run.run import run_and_collect
 
         return await run_and_collect(branch, instruction, chat_param, skip_validation=True)

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -228,7 +228,8 @@ async def operate(
             _pctx = _pctx.with_updates(response_format=response_fmt)
 
     if middle is None:
-        if isinstance(_cctx, RunParam) or getattr(branch.chat_model, "is_cli", False):
+        effective_imodel = _cctx.imodel or branch.chat_model
+        if isinstance(_cctx, RunParam) or getattr(effective_imodel, "is_cli", False):
             from ..run.run import run_and_collect
 
             middle = run_and_collect

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -457,6 +457,12 @@ class StateDB:
         # algorithm to. Cheap to build; deferred only so StateDB.__init__
         # never depends on import order inside lionagi.state.lifecycle.
         self.__lifecycle_service: _LifecycleService | None = None
+        # Set by _rebuild_check_constraint when a legacy CHECK-constraint
+        # rebuild runs during _apply_schema, so schema_meta.version can
+        # distinguish a DB that went through a legacy rebuild (some tables
+        # rebuilt without declared FKs -- see _drop_legacy_session_status_check)
+        # from a database created fresh under the current schema.
+        self._legacy_rebuild_this_open: bool = False
 
     def _lifecycle_service(self) -> _LifecycleService:
         if self.__lifecycle_service is None:
@@ -699,6 +705,13 @@ class StateDB:
             # schedule_runs.status and a NOT NULL schedule_id, from before
             # schedule_runs was generalized into the task-application entity.
             await self._drop_legacy_schedule_runs_check()
+        # Written once, ever, per DB (ON CONFLICT DO NOTHING below): a legacy
+        # rebuild only ever runs on this DB's first open under this codebase,
+        # so this is the one chance to permanently record that some tables
+        # were rebuilt without declared FKs (see _drop_legacy_session_status_check)
+        # -- a shape a later open of the same DB can no longer detect, since
+        # the rebuild markers it checks for are already satisfied by then.
+        schema_version_value = "1-legacy-rebuild" if self._legacy_rebuild_this_open else "1"
         async with self._engine.begin() as conn:
             await conn.run_sync(metadata.create_all)
             await self._reconcile_indexes(conn)
@@ -706,9 +719,10 @@ class StateDB:
             # re-run on every open() because the rows are identity-stable.
             await conn.execute(
                 text(
-                    "INSERT INTO schema_meta (key, value) VALUES ('version', '1') "
+                    "INSERT INTO schema_meta (key, value) VALUES ('version', :version) "
                     "ON CONFLICT (key) DO NOTHING"
-                )
+                ),
+                {"version": schema_version_value},
             )
             await conn.execute(
                 text(
@@ -815,6 +829,12 @@ class StateDB:
     async def _rebuild_check_constraint(self, table: str, already_rebuilt, rebuild) -> None:
         """Run a legacy CHECK-constraint table rebuild, tolerant of a concurrent winner.
 
+        Reaching this call means the caller's own marker check already
+        decided *table* is still in a legacy (pre-rebuild) shape, so mark
+        this open as a legacy rebuild before attempting anything — that
+        holds regardless of whether this process or a racing one actually
+        performs the DDL (see ``_apply_schema``'s schema_meta.version stamp).
+
         Two processes cold-opening the same legacy DB can both observe the
         same stale CHECK and enter the identical DROP/CREATE/INSERT/RENAME
         rebuild. SQLite's write lock serializes the two attempts, but the
@@ -828,6 +848,7 @@ class StateDB:
         (or ``None`` if the table is now missing) and returns whether the
         table is in its post-rebuild shape.
         """
+        self._legacy_rebuild_this_open = True
         try:
             await rebuild()
         # Five of the six rebuilds execute through the raw aiosqlite driver,

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -6,16 +6,44 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
+import sqlite3
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 from lionagi._paths import LIONAGI_HOME
 
+logger = logging.getLogger(__name__)
+
 # sqlite busy_timeout (ms) applied to every connection. Tunable so tests that
 # deliberately hold a write lock fail fast instead of waiting the full default.
 _SQLITE_BUSY_TIMEOUT_MS = 5000
+
+# SQLite has a long-standing WAL-reset bug -- present in every release from
+# 3.7.0 (2010-07-21) through 3.51.2 -- where a checkpoint can skip all or
+# part of a transaction, leaving the database file corrupt. Fixed in 3.51.3
+# and later, with point-release backports for two earlier branches.
+_SQLITE_WAL_RESET_FIX_VERSION = (3, 51, 3)
+_SQLITE_WAL_RESET_FIX_BACKPORTS = ((3, 44, 6), (3, 50, 7))
+
+
+def _sqlite_has_wal_reset_fix(version_info: tuple[int, ...]) -> bool:
+    """Whether *version_info* (as from ``sqlite3.sqlite_version_info``)
+    includes the documented WAL-reset corruption fix."""
+    if version_info >= _SQLITE_WAL_RESET_FIX_VERSION:
+        return True
+    return any(
+        version_info[:2] == (major, minor) and version_info[2] >= patch
+        for major, minor, patch in _SQLITE_WAL_RESET_FIX_BACKPORTS
+    )
+
+
+# Logged at most once per process -- _apply_pragmas runs on every new
+# connection, and this is a startup-time compatibility fact, not a per-
+# connection event.
+_wal_version_warning_emitted = False
 
 
 def _json_serializer(obj):
@@ -111,6 +139,20 @@ def make_engine(url: str, **overrides):
         engine = create_async_engine(url, **kwargs)
 
         def _apply_pragmas(dbapi_conn, _connection_record):
+            global _wal_version_warning_emitted
+            if not _wal_version_warning_emitted and not _sqlite_has_wal_reset_fix(
+                sqlite3.sqlite_version_info
+            ):
+                logger.warning(
+                    "linked SQLite %s lacks the documented WAL-reset corruption fix "
+                    "(fixed in %s, backported to %s) -- enabling WAL mode on this "
+                    "library carries the documented corruption risk under concurrent "
+                    "writers and checkpoint activity; upgrade SQLite if possible.",
+                    sqlite3.sqlite_version,
+                    ".".join(map(str, _SQLITE_WAL_RESET_FIX_VERSION)),
+                    " / ".join(".".join(map(str, v)) for v in _SQLITE_WAL_RESET_FIX_BACKPORTS),
+                )
+                _wal_version_warning_emitted = True
             cursor = dbapi_conn.cursor()
             cursor.execute(f"PRAGMA busy_timeout = {_SQLITE_BUSY_TIMEOUT_MS}")
             cursor.execute("PRAGMA journal_mode = WAL")

--- a/tests/cli/orchestrate/test_fanout_notify_entity_scope.py
+++ b/tests/cli/orchestrate/test_fanout_notify_entity_scope.py
@@ -47,3 +47,81 @@ async def test_notify_scope_is_session_even_with_invocation_id(tmp_path, monkeyp
     assert captured["entity_kind"] == "session"
     assert captured["entity_id"] == str(env.session.id)
     assert captured["invocation_id"] == "parent-inv-456"
+
+
+async def test_settings_notify_outcome_scope_registered_without_notify_flag(tmp_path, monkeypatch):
+    """Without `--notify`, `_run_fanout` must still bind this run into the
+    settings-driven notify.on_terminal outcome scope, so a configured exec
+    adapter's result lands in this run's own notify_outcome.json instead of
+    being handled by the process-wide no-op registration."""
+    env, run, _session = _fanout_env(tmp_path)
+
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=[]))
+
+    captured: dict[str, Any] = {}
+    unregistered: list[Any] = []
+
+    def fake_register_outcome(run_arg, **kwargs: Any) -> str:
+        captured["run"] = run_arg
+        captured.update(kwargs)
+        return "outcome-scope-name"
+
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.register_run_notify_outcome_scope",
+        fake_register_outcome,
+    )
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.unregister_run_notify_outcome_scope",
+        lambda name, **kw: unregistered.append(name),
+    )
+
+    result, status = await fanout_module._run_fanout(
+        "codex/model",
+        "prompt",
+    )
+
+    assert status == "completed"
+    assert captured["run"] is run
+    assert captured["entity_kind"] == "session"
+    assert captured["entity_id"] == str(env.session.id)
+    assert unregistered == ["outcome-scope-name"]
+
+
+async def test_notify_flag_skips_settings_outcome_scope(tmp_path, monkeypatch):
+    """`--notify` already owns this entity as an exclusive override, so the
+    settings-driven outcome scope must not also be registered (it would
+    otherwise fire the configured adapter twice for one terminal transition)."""
+    env, _run, _session = _fanout_env(tmp_path)
+
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    monkeypatch.setattr(
+        fanout_module,
+        "stop_live_persist",
+        AsyncMock(side_effect=lambda env, status: status),
+    )
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=[]))
+    monkeypatch.setattr(fanout_module, "register_flow_notify_scope", lambda **kw: "scope-name")
+    monkeypatch.setattr(fanout_module, "unregister_flow_notify_scope", lambda *a, **kw: None)
+
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.register_run_notify_outcome_scope",
+        lambda *a, **kw: calls.append((a, kw)) or "outcome-scope-name",
+    )
+
+    result, status = await fanout_module._run_fanout(
+        "codex/model",
+        "prompt",
+        notify="fan-hook {status}",
+    )
+
+    assert status == "completed"
+    assert calls == []

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -35,6 +35,7 @@ from lionagi.cli.monitor import (
     _since_timestamp,
     _stdout_is_tty,
     _trunc,
+    _watch_loop,
 )
 from lionagi.state.db import StateDB
 
@@ -248,6 +249,36 @@ def test_pid_alive_nonexistent():
     # Use a very high PID unlikely to exist instead.
     result = _pid_alive(9_999_999)
     assert result is False or result is None  # platform-dependent
+
+
+def test_watch_loop_exits_cleanly_on_sigterm_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SIGTERM arriving mid-refresh must not escape `_watch_loop` as an
+    uncaught `SigtermInterrupt`, and the pre-existing SIGTERM handler must be
+    restored once the loop exits."""
+    import lionagi.ln.concurrency as concurrency
+
+    def _fake_run_async(coro):
+        coro.close()
+        raise concurrency.SigtermInterrupt("simulated SIGTERM")
+
+    monkeypatch.setattr(concurrency, "run_async", _fake_run_async)
+
+    prior_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        exit_code = _watch_loop(
+            refresh_seconds=1,
+            entity_id="some-entity-id",
+            since_window=None,
+            entity_type=None,
+            project=None,
+        )
+    finally:
+        signal.signal(signal.SIGTERM, prior_handler)
+
+    assert exit_code == 0
+    assert signal.getsignal(signal.SIGTERM) is prior_handler
 
 
 # ── Unit: table formatting ────────────────────────────────────────────────────

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from lionagi.cli._util import AmbiguousIdError
 from lionagi.cli.status import (
     EXIT_RUNNING,
     EXIT_UNKNOWN,
@@ -303,6 +304,38 @@ async def test_resolve_agent_target_prefix_match(temp_db_path: Path):
         result = await _resolve_agent_target(db, sid[:6], None)
     assert result is not None
     assert result[1]["id"] == sid
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_target_ambiguous_prefix_raises(temp_db_path: Path):
+    """Two sessions sharing a short prefix must not silently resolve to
+    whichever one the LIKE query happens to return first — it must raise."""
+    async with StateDB() as db:
+        sid1 = await _make_session(db)
+        sid2 = await _make_session(db)
+        await db.execute("UPDATE sessions SET id = ? WHERE id = ?", ("abc" + sid1[3:], sid1))
+        await db.execute("UPDATE sessions SET id = ? WHERE id = ?", ("abc" + sid2[3:], sid2))
+        with pytest.raises(AmbiguousIdError):
+            await _resolve_agent_target(db, "abc", None)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_agent_ambiguous_prefix_reports_error(
+    temp_db_path: Path, no_project, caplog: pytest.LogCaptureFixture
+):
+    """`li agent status <ambiguous-prefix>` must report a clean error and
+    EXIT_UNKNOWN instead of crashing with an uncaught exception."""
+    async with StateDB() as db:
+        sid1 = await _make_session(db)
+        sid2 = await _make_session(db)
+        await db.execute("UPDATE sessions SET id = ? WHERE id = ?", ("def" + sid1[3:], sid1))
+        await db.execute("UPDATE sessions SET id = ? WHERE id = ?", ("def" + sid2[3:], sid2))
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        exit_code = _dispatch("agent", "def", False)
+    assert exit_code == EXIT_UNKNOWN
+    assert "matches" in caplog.text.lower()
+    assert "def" in caplog.text.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -337,3 +337,37 @@ def test_run_wait_unknown_id_returns_exit_unknown(temp_db_path: Path) -> None:
 def test_run_wait_requires_at_least_one_id(temp_db_path: Path) -> None:
     with pytest.raises(SystemExit):
         run_wait([])
+
+
+def test_run_wait_ambiguous_schedule_run_prefix_reports_error_not_crash(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`li wait <prefix>` where the prefix matches two schedule_runs must
+    report a clean error and EXIT_UNKNOWN — the schedule-run resolver raises
+    AmbiguousIdError, and this CLI entry point must catch it rather than crash
+    with an uncaught traceback (it previously caught only signal interrupts)."""
+    import asyncio
+    import logging
+
+    async def _setup() -> None:
+        async with StateDB() as db:
+            sched_id = await _make_schedule(db)
+            rid1 = await _make_schedule_run(db, sched_id)
+            rid2 = await _make_schedule_run(db, sched_id)
+            # Force a shared short prefix that resolves to neither a session,
+            # invocation, nor play — so resolution reaches _resolve_schedule_run
+            # and its LIKE query matches both rows.
+            await db.execute(
+                "UPDATE schedule_runs SET id = ? WHERE id = ?", ("abc" + rid1[3:], rid1)
+            )
+            await db.execute(
+                "UPDATE schedule_runs SET id = ? WHERE id = ?", ("abc" + rid2[3:], rid2)
+            )
+
+    asyncio.run(_setup())
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        exit_code = run_wait(["abc"])
+    assert exit_code == EXIT_UNKNOWN
+    assert "matches" in caplog.text.lower()
+    assert "abc" in caplog.text.lower()

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -233,6 +233,34 @@ class TestRunRoundChatDispatch:
         fake.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_dispatches_to_run_and_collect_for_chat_param_imodel_cli_override(self):
+        """An API-backed branch with a CLI ChatParam.imodel override must
+        still dispatch to run_and_collect — the effective imodel is the
+        override, not branch.chat_model."""
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=False))
+        fake = AsyncMock(return_value="cli text")
+        with patch("lionagi.operations.run.run.run_and_collect", new=fake):
+            result = await _run_round_chat(
+                branch, "hi", ChatParam(imodel=SimpleNamespace(is_cli=True))
+            )
+        assert result == "cli text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_communicate_for_chat_param_imodel_api_override(self):
+        """A CLI-backed branch with an API ChatParam.imodel override must
+        dispatch to communicate — the effective imodel is the override, not
+        branch.chat_model."""
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=True))
+        fake = AsyncMock(return_value="api text")
+        with patch("lionagi.operations.communicate.communicate.communicate", new=fake):
+            result = await _run_round_chat(
+                branch, "hi", ChatParam(imodel=SimpleNamespace(is_cli=False))
+            )
+        assert result == "api text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_real_scripted_branch_round_trips_via_run_and_collect(self):
         """End-to-end sanity check with a real TestBranch (necessarily
         CLI-routed, see class docstring) — confirms the dispatch wiring

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -555,3 +555,97 @@ async def test_operate_reason_only_constructs_operative_with_reason_field():
         f"'reason' field missing from generated response_format {fmt}; "
         "Operative was not constructed or reason spec was dropped"
     )
+
+
+# ---------------------------------------------------------------------------
+# Default transport selection (middle=None) must key off the effective
+# ChatParam.imodel override, not branch.chat_model.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCliModel:
+    is_cli = True
+
+
+class _FakeApiModel:
+    is_cli = False
+
+
+@pytest.mark.asyncio
+async def test_operate_default_transport_honours_chat_param_imodel_cli_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An API-backed branch with a CLI ChatParam.imodel override must select
+    run_and_collect, not communicate (operate.py:230)."""
+    import lionagi.operations.communicate.communicate as communicate_mod
+    import lionagi.operations.run.run as run_mod
+
+    branch = Branch()
+    assert branch.chat_model.is_cli is False
+
+    calls = []
+
+    async def fake_run_and_collect(b, ins, cctx, pctx, clear, **kw):
+        calls.append("run_and_collect")
+        return "cli-result"
+
+    async def fake_communicate(b, ins, cctx, pctx, clear, **kw):
+        calls.append("communicate")
+        return "api-result"
+
+    monkeypatch.setattr(run_mod, "run_and_collect", fake_run_and_collect)
+    monkeypatch.setattr(communicate_mod, "communicate", fake_communicate)
+
+    chat_param = ChatParam(imodel=_FakeCliModel())
+    result = await operate(
+        branch,
+        "test",
+        chat_param,
+        skip_validation=True,
+        invoke_actions=False,
+    )
+
+    assert calls == ["run_and_collect"]
+    assert result == "cli-result"
+
+
+@pytest.mark.asyncio
+async def test_operate_default_transport_honours_chat_param_imodel_api_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A CLI-backed branch with an API ChatParam.imodel override must select
+    communicate, not run_and_collect (operate.py:230)."""
+    import lionagi.operations.communicate.communicate as communicate_mod
+    import lionagi.operations.run.run as run_mod
+
+    branch = Branch()
+    # branch.chat_model must report is_cli=True — its setter only accepts a
+    # real iModel, so flip the property on its concrete class instead of
+    # swapping in a fake object.
+    monkeypatch.setattr(type(branch.chat_model), "is_cli", property(lambda self: True))
+    assert branch.chat_model.is_cli is True
+
+    calls = []
+
+    async def fake_run_and_collect(b, ins, cctx, pctx, clear, **kw):
+        calls.append("run_and_collect")
+        return "cli-result"
+
+    async def fake_communicate(b, ins, cctx, pctx, clear, **kw):
+        calls.append("communicate")
+        return "api-result"
+
+    monkeypatch.setattr(run_mod, "run_and_collect", fake_run_and_collect)
+    monkeypatch.setattr(communicate_mod, "communicate", fake_communicate)
+
+    chat_param = ChatParam(imodel=_FakeApiModel())
+    result = await operate(
+        branch,
+        "test",
+        chat_param,
+        skip_validation=True,
+        invoke_actions=False,
+    )
+
+    assert calls == ["communicate"]
+    assert result == "api-result"

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -12,7 +12,9 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from lionagi.state import engine as engine_module
 from lionagi.state.engine import (
+    _sqlite_has_wal_reset_fix,
     dialect_of,
     make_engine,
     make_readonly_engine,
@@ -139,6 +141,76 @@ def test_make_engine_sqlite_creates_engine():
     import asyncio
 
     asyncio.run(engine.dispose())
+
+
+# ── WAL-reset SQLite version gate ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "version_info,expected",
+    [
+        ((3, 46, 0), False),  # affected -- no fix, no backport
+        ((3, 51, 2), False),  # last affected mainline release
+        ((3, 51, 3), True),  # first fully-fixed mainline release
+        ((3, 52, 0), True),  # later mainline release
+        ((3, 44, 5), False),  # just below the 3.44.x backport point
+        ((3, 44, 6), True),  # 3.44.x backport
+        ((3, 44, 7), True),  # later within the 3.44.x branch
+        ((3, 50, 6), False),  # just below the 3.50.x backport point
+        ((3, 50, 7), True),  # 3.50.x backport
+    ],
+)
+def test_sqlite_has_wal_reset_fix(version_info, expected):
+    assert _sqlite_has_wal_reset_fix(version_info) is expected
+
+
+def test_make_engine_warns_when_linked_sqlite_lacks_wal_reset_fix(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """An affected linked SQLite library must produce a startup warning
+    before WAL is enabled — not a silent risky configuration."""
+    monkeypatch.setattr(engine_module, "_wal_version_warning_emitted", False)
+    monkeypatch.setattr(engine_module.sqlite3, "sqlite_version_info", (3, 46, 0))
+    monkeypatch.setattr(engine_module.sqlite3, "sqlite_version", "3.46.0")
+
+    async def _connect_once():
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            async with engine.connect():
+                pass
+        finally:
+            await engine.dispose()
+
+    import asyncio
+
+    with caplog.at_level("WARNING", logger="lionagi.state.engine"):
+        asyncio.run(_connect_once())
+
+    assert "3.46.0" in caplog.text
+    assert "WAL-reset" in caplog.text
+
+
+def test_make_engine_does_not_warn_when_linked_sqlite_has_wal_reset_fix(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.setattr(engine_module, "_wal_version_warning_emitted", False)
+    monkeypatch.setattr(engine_module.sqlite3, "sqlite_version_info", (3, 51, 3))
+    monkeypatch.setattr(engine_module.sqlite3, "sqlite_version", "3.51.3")
+
+    async def _connect_once():
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            async with engine.connect():
+                pass
+        finally:
+            await engine.dispose()
+
+    import asyncio
+
+    with caplog.at_level("WARNING", logger="lionagi.state.engine"):
+        asyncio.run(_connect_once())
+
+    assert "WAL-reset" not in caplog.text
 
 
 # ── make_readonly_engine ──────────────────────────────────────────────────────

--- a/tests/state/test_session_status_vocabulary.py
+++ b/tests/state/test_session_status_vocabulary.py
@@ -173,6 +173,75 @@ async def test_drop_legacy_check_rebuilds_table(tmp_path: Path):
         await state.close()
 
 
+async def test_schema_version_distinguishes_fresh_from_legacy_rebuilt_db(tmp_path: Path):
+    """A fresh DB and a legacy DB that got rebuilt on open (losing declared
+    FKs on `sessions` — see _drop_legacy_session_status_check) must report
+    different schema_version values, so a caller can tell the two shapes
+    apart instead of both reading '1'."""
+    legacy_path = tmp_path / "legacy.db"
+    fresh_path = tmp_path / "fresh.db"
+
+    async with aiosqlite.connect(str(legacy_path)) as old:
+        await old.execute(
+            """
+            CREATE TABLE progressions (
+              id          TEXT    PRIMARY KEY,
+              created_at  REAL    NOT NULL,
+              collection  TEXT    NOT NULL DEFAULT '[]'
+            )
+            """
+        )
+        await old.execute(
+            """
+            CREATE TABLE sessions (
+              id              TEXT    PRIMARY KEY,
+              created_at      REAL    NOT NULL,
+              node_metadata   JSON,
+              name            TEXT,
+              user            TEXT,
+              progression_id  TEXT    NOT NULL REFERENCES progressions(id),
+              first_msg_id    TEXT,
+              last_msg_id     TEXT,
+              updated_at      REAL,
+              status          TEXT CHECK(
+                                status IS NULL
+                                OR status IN ('running', 'completed', 'failed', 'aborted')
+                              )
+            )
+            """
+        )
+        await old.commit()
+
+    legacy_db = StateDB(legacy_path)
+    await legacy_db.open()
+    try:
+        legacy_version = await legacy_db.schema_version()
+    finally:
+        await legacy_db.close()
+
+    fresh_db = StateDB(fresh_path)
+    await fresh_db.open()
+    try:
+        fresh_version = await fresh_db.schema_version()
+    finally:
+        await fresh_db.close()
+
+    assert legacy_version != fresh_version
+    assert fresh_version == "1"
+    assert legacy_version == "1-legacy-rebuild"
+
+    # Re-opening the migrated DB later must not lose the recorded shape —
+    # the rebuild marker check now finds the table already in its
+    # post-rebuild shape and no longer fires, so this proves the version is
+    # a permanent stamp, not derived fresh on every open.
+    legacy_db2 = StateDB(legacy_path)
+    await legacy_db2.open()
+    try:
+        assert await legacy_db2.schema_version() == "1-legacy-rebuild"
+    finally:
+        await legacy_db2.close()
+
+
 async def test_drop_legacy_check_is_idempotent(tmp_path: Path):
     """Re-opening a migrated DB is a no-op (no further table rebuild)."""
     path = tmp_path / "twice.db"


### PR DESCRIPTION
## Summary

Six correctness fixes across the CLI, operations transport selection, and StateDB, each as its own commit with a regression test confirmed to fail before the fix.

- **`li monitor` crashes on SIGTERM during a refresh** (#2404): `_watch_loop` called `run_async()` with no handling for the `SigtermInterrupt`/`KeyboardInterrupt` it raises when a signal cancels the coroutine, and never restored prior signal handlers. It now catches those cleanly and restores handlers in a `finally`.
- **Short id prefix can select the wrong run** (#2405): several resolvers matched a short id via `WHERE id LIKE '<prefix>%'` with no ambiguity check, silently returning whichever row the query plan produced first. A shared `fetch_unique_by_id` helper now raises `AmbiguousIdError`, and status/wait/monitor/kill report a clean error instead of guessing.
- **Fan-out drops settings-driven notify outcomes** (#2406): `_run_fanout` registered the notify-outcome scope only under `--notify`, so a settings-configured `notify.on_terminal` adapter had no run to bind to and never produced `notify_outcome.json`. It now registers the same outcome scope `_run_flow` already used, skipping it when `--notify` owns the entity.
- **`operate` picks transport from the wrong model** (#2403): `operate()` and `lndl_middle` chose CLI vs API transport from `branch.chat_model.is_cli`, but `chat()` resolves the model as `chat_param.imodel or branch.chat_model`. Both call sites now check the effective imodel, matching what `chat()` actually invokes.
- **Schema version indistinguishable after a legacy rebuild** (#2429): `schema_meta.version` was a hardcoded `"1"`, so a database that went through a legacy CHECK-constraint rebuild reported the same version as a fresh one despite a different table shape. A legacy rebuild now stamps `"1-legacy-rebuild"`, persisting the distinction across later opens.
- **WAL enabled without a version check** (#2430): `_apply_pragmas` unconditionally set `journal_mode = WAL`, but SQLite has a WAL-reset corruption bug in every release from 3.7.0 through 3.51.2 (fixed in 3.51.3, backported to 3.44.6 / 3.50.7). A once-per-process warning now names the linked version and the fix/backport versions when the linked library lacks the fix.

Fixes #2404, #2405, #2406, #2403, #2429, #2430.

## Testing

Regression tests added per fix (`tests/cli/`, `tests/operations/`, `tests/state/`). The `tests/state/` sweep passes locally (762 passed, 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
