### PR TITLE
refactor(protocols): make json/csv serialization pandas-free

### DIFF
--- a/lionagi/protocols/generic/log.py
+++ b/lionagi/protocols/generic/log.py
@@ -15,7 +15,7 @@ from lionagi.models.hashable_model import HashableModel
 from lionagi.utils import to_dict
 
 from .element import Element
-from .pile import Pile
+from .pile import Pile, _serialize_records
 
 __all__ = (
     "DataLoggerConfig",
@@ -175,19 +175,19 @@ class DataLogger:
                 logger.debug("No logs to dump.")
                 return
             fp = persist_path or self._create_path()
+            suffix = fp.suffix.lower()
+            if suffix not in (".csv", ".json"):
+                raise ValueError(f"Unsupported file extension: {suffix}")
             snapshot_ids = set(self.logs.collections.keys())
-            df = self.logs.to_df()
+            records = self.logs._ordered_records()
 
         do_clear = self._config.clear_after_dump if clear is None else clear
-        suffix = fp.suffix.lower()
+        obj_key = "csv" if suffix == ".csv" else "json"
 
         def _write() -> None:
-            if suffix == ".csv":
-                df.to_csv(fp, index=False)
-            elif suffix == ".json":
-                df.to_json(fp, orient="records", lines=True)
-            else:
-                raise ValueError(f"Unsupported file extension: {suffix}")
+            text = _serialize_records(records, obj_key)
+            with open(fp, "w", encoding="utf-8", newline="") as f:
+                f.write(text)
 
         try:
             await run_sync(_write)

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import csv
+import io
+import json
 import threading
 from collections import deque
 from collections.abc import AsyncIterator, Callable, Generator, Iterator, Sequence
@@ -30,6 +33,38 @@ D = TypeVar("D")
 T = TypeVar("T", bound=E)
 
 _ADAPTER_REGISTERED = False
+
+
+def _serialize_records(records: list[dict], obj_key: str) -> str:
+    """Serialize row dicts to a JSONL or CSV string using only the standard
+    library, so the common serialization paths carry no pandas dependency.
+
+    - ``json`` → one compact JSON object per line (JSONL), matching the prior
+      ``DataFrame.to_json(orient="records", lines=True)`` output.
+    - ``csv`` → a header of every key seen (in first-appearance order) followed
+      by one row per record; missing keys render empty, as pandas did.
+
+    ``parquet`` is intentionally unsupported here — it stays on the pandas /
+    ``to_df`` path in ``dump``/``adump`` since it needs a columnar engine.
+    """
+    if obj_key == "json":
+        return "\n".join(json.dumps(r, ensure_ascii=False, separators=(",", ":")) for r in records)
+    if obj_key == "csv":
+        fieldnames: list[str] = []
+        seen: set[str] = set()
+        for r in records:
+            for key in r:
+                if key not in seen:
+                    seen.add(key)
+                    fieldnames.append(key)
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(records)
+        return buf.getvalue()
+    raise ValueError(
+        f"Unsupported obj_key: {obj_key}. Supported keys are 'json', 'csv', 'parquet'."
+    )
 
 
 def _validate_item_type(value, /) -> set[type[T]] | None:
@@ -909,6 +944,12 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
             return df[columns]
         return df
 
+    def _ordered_records(self) -> list[dict]:
+        """Row dicts in progression (logical) order, JSON-mode serialized so
+        every value is a JSON primitive — the shared snapshot behind the
+        pandas-free json/csv dump paths (parquet still goes via ``to_df``)."""
+        return [self.collections[key].to_dict(mode="json") for key in self.progression]
+
     def dump(
         self,
         fp: str | Path | None,
@@ -918,15 +959,20 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         clear=False,
         **kw,
     ) -> str | None:
-        df = self.to_df()
         out = None
         match obj_key:
             case "parquet":
-                df.to_parquet(fp, engine="pyarrow", index=False, **kw)
-            case "json":
-                out = df.to_json(fp, orient="records", lines=True, mode=mode, **kw)
-            case "csv":
-                out = df.to_csv(fp, index=False, mode=mode, **kw)
+                # Parquet needs a columnar engine; keep it on the pandas path.
+                self.to_df().to_parquet(fp, engine="pyarrow", index=False, **kw)
+            case "json" | "csv":
+                text = _serialize_records(self._ordered_records(), obj_key)
+                if fp is None:
+                    # fp=None returns the serialized string, as the old
+                    # DataFrame.to_json/to_csv(path_or_buf=None) did.
+                    out = text
+                else:
+                    with open(fp, mode, encoding="utf-8", newline="") as f:
+                        f.write(text)
             case _:
                 raise ValueError(
                     f"Unsupported obj_key: {obj_key}. Supported keys are 'json', 'csv', 'parquet'."
@@ -949,23 +995,24 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
     ) -> None:
         from lionagi.ln.concurrency import run_sync
 
+        if obj_key not in ("json", "csv", "parquet"):
+            raise ValueError(
+                f"Unsupported obj_key: {obj_key}. Supported keys are 'json', 'csv', 'parquet'."
+            )
+
+        # Snapshot under the lock so a concurrent mutation cannot race the write.
         async with self._both_locks():
             snapshot_ids = set(self.collections.keys())
-            df = self.to_df()
+            df = self.to_df() if obj_key == "parquet" else None
+            records = None if obj_key == "parquet" else self._ordered_records()
 
         def _write() -> None:
-            match obj_key:
-                case "parquet":
-                    df.to_parquet(fp, engine="pyarrow", index=False, **kw)
-                case "json":
-                    df.to_json(fp, orient="records", lines=True, mode=mode, **kw)
-                case "csv":
-                    df.to_csv(fp, index=False, mode=mode, **kw)
-                case _:
-                    raise ValueError(
-                        f"Unsupported obj_key: {obj_key}. "
-                        "Supported keys are 'json', 'csv', 'parquet'."
-                    )
+            if obj_key == "parquet":
+                df.to_parquet(fp, engine="pyarrow", index=False, **kw)
+            else:
+                text = _serialize_records(records, obj_key)
+                with open(fp, mode, encoding="utf-8", newline="") as f:
+                    f.write(text)
 
         await run_sync(_write)
 

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -39,16 +39,25 @@ def _serialize_records(records: list[dict], obj_key: str) -> str:
     """Serialize row dicts to a JSONL or CSV string using only the standard
     library, so the common serialization paths carry no pandas dependency.
 
-    - ``json`` → one compact JSON object per line (JSONL), matching the prior
-      ``DataFrame.to_json(orient="records", lines=True)`` output.
+    - ``json`` → one compact JSON object per line (JSONL), newline-terminated
+      so ``mode="a"`` stays valid JSONL, matching the prior
+      ``DataFrame.to_json(orient="records", lines=True)`` which ended in "\n".
     - ``csv`` → a header of every key seen (in first-appearance order) followed
       by one row per record; missing keys render empty, as pandas did.
+
+    Values come from ``to_dict(mode="json")``, i.e. lionagi's canonical orjson
+    encoding (ISO datetimes, shortest round-trippable floats). That is
+    value-equal and round-trippable via ``Element.from_dict``, but its text is
+    not byte-identical to pandas for datetime/high-precision-float fields
+    (pandas rendered epoch-ms datetimes and double_precision floats).
 
     ``parquet`` is intentionally unsupported here — it stays on the pandas /
     ``to_df`` path in ``dump``/``adump`` since it needs a columnar engine.
     """
     if obj_key == "json":
-        return "\n".join(json.dumps(r, ensure_ascii=False, separators=(",", ":")) for r in records)
+        return "".join(
+            json.dumps(r, ensure_ascii=False, separators=(",", ":")) + "\n" for r in records
+        )
     if obj_key == "csv":
         fieldnames: list[str] = []
         seen: set[str] = set()
@@ -965,6 +974,13 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
                 # Parquet needs a columnar engine; keep it on the pandas path.
                 self.to_df().to_parquet(fp, engine="pyarrow", index=False, **kw)
             case "json" | "csv":
+                # json/csv use the stdlib serializer, not pandas — reject the
+                # old pandas passthrough kwargs loudly rather than dropping them.
+                if kw:
+                    raise TypeError(
+                        f"dump(obj_key={obj_key!r}) takes no extra keyword arguments "
+                        f"(got {sorted(kw)}); it serializes with the stdlib, not pandas."
+                    )
                 text = _serialize_records(self._ordered_records(), obj_key)
                 if fp is None:
                     # fp=None returns the serialized string, as the old
@@ -998,6 +1014,11 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         if obj_key not in ("json", "csv", "parquet"):
             raise ValueError(
                 f"Unsupported obj_key: {obj_key}. Supported keys are 'json', 'csv', 'parquet'."
+            )
+        if obj_key in ("json", "csv") and kw:
+            raise TypeError(
+                f"adump(obj_key={obj_key!r}) takes no extra keyword arguments "
+                f"(got {sorted(kw)}); it serializes with the stdlib, not pandas."
             )
 
         # Snapshot under the lock so a concurrent mutation cannot race the write.

--- a/tests/protocols/generic/test_async_dump.py
+++ b/tests/protocols/generic/test_async_dump.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -176,6 +177,25 @@ class TestDataLoggerAdump:
         fp = tmp_path / "test_dump.xml"
         with pytest.raises(ValueError, match="Unsupported file extension"):
             await logger_with_logs.adump(persist_path=fp)
+
+    @pytest.mark.asyncio
+    async def test_dump_and_adump_need_no_pandas(self, logger_with_logs, tmp_path, monkeypatch):
+        """The activity-log auto-save path (sync dump + async adump) must
+        serialize without pandas — that is the point of removing it from the
+        default serialization path."""
+        monkeypatch.setitem(sys.modules, "pandas", None)
+        with pytest.raises(ImportError):
+            import pandas  # noqa: F401
+
+        sync_fp = tmp_path / "sync.json"
+        logger_with_logs.dump(persist_path=sync_fp)
+        assert len(sync_fp.read_text().strip().splitlines()) == 5
+
+        async_fp = tmp_path / "async.csv"
+        await logger_with_logs.adump(persist_path=async_fp)
+        lines = async_fp.read_text().strip().splitlines()
+        assert lines[0].startswith("id")
+        assert len(lines) == 6  # header + 5 rows
 
     @pytest.mark.asyncio
     async def test_adump_preserves_logs_when_write_fails(self, tmp_path):

--- a/tests/protocols/generic/test_pile_serialization.py
+++ b/tests/protocols/generic/test_pile_serialization.py
@@ -241,6 +241,41 @@ class TestDumpWithoutPandas:
             pile_3.dump(tmp_path / "d.parquet", obj_key="parquet")
 
 
+class TestSerializationFormat:
+    """Format robustness the pandas path had implicitly: newline-terminated
+    JSONL (append-safe), stdlib-only kwargs rejection, and a canonical,
+    round-trippable encoding."""
+
+    def test_json_is_newline_terminated_and_append_safe(self, pile_3, tmp_path):
+        fp = tmp_path / "a.jsonl"
+        pile_3.dump(fp, obj_key="json", mode="w")
+        pile_3.dump(fp, obj_key="json", mode="a")
+        lines = fp.read_text().splitlines()
+        assert len(lines) == 6  # two writes of 3 records, never a run-together line
+        for line in lines:
+            json.loads(line)  # each line is a standalone JSON object
+
+    def test_dumped_json_is_canonical_and_reloads(self, pile_3, tmp_path):
+        fp = tmp_path / "rt.json"
+        pile_3.dump(fp, obj_key="json")
+        parsed = [json.loads(line) for line in fp.read_text().splitlines()]
+        # the file content IS each element's canonical to_dict(mode="json")
+        assert parsed == [e.to_dict(mode="json") for e in pile_3.values()]
+        # and every record reloads to the same identity
+        assert [str(Element.from_dict(p).id) for p in parsed] == [str(e.id) for e in pile_3]
+
+    def test_json_and_csv_reject_pandas_kwargs(self, pile_3, tmp_path):
+        with pytest.raises(TypeError, match="no extra keyword arguments"):
+            pile_3.dump(tmp_path / "x.json", obj_key="json", force_ascii=True)
+        with pytest.raises(TypeError, match="no extra keyword arguments"):
+            pile_3.dump(tmp_path / "x.csv", obj_key="csv", quoting=1)
+
+    @pytest.mark.asyncio
+    async def test_adump_rejects_pandas_kwargs(self, pile_3, tmp_path):
+        with pytest.raises(TypeError, match="no extra keyword arguments"):
+            await pile_3.adump(tmp_path / "x.json", obj_key="json", force_ascii=True)
+
+
 # ---------------------------------------------------------------------------
 # 2. Set operations — __ior__, __iand__, __ixor__ (in-place; these work)
 # ---------------------------------------------------------------------------

--- a/tests/protocols/generic/test_pile_serialization.py
+++ b/tests/protocols/generic/test_pile_serialization.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import importlib
+import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -95,8 +97,9 @@ class TestToDataFrame:
         assert [str(x) for x in df["id"].tolist()] == logical
 
 
-@pytest.mark.skipif(pandas_missing, reason="pandas not installed")
 class TestDump:
+    """json/csv dump is pandas-free; only the parquet cases still need pandas."""
+
     def test_dump_json(self, pile_3):
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             fp = Path(f.name)
@@ -124,6 +127,7 @@ class TestDump:
         fp.unlink()
 
     def test_dump_parquet(self, pile_3):
+        pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
         with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
             fp = Path(f.name)
@@ -136,6 +140,7 @@ class TestDump:
         p = Pile(collections=items)
         with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
             fp = Path(f.name)
+        pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
         p.dump(fp, obj_key="parquet", clear=True)
         assert len(p) == 0
@@ -179,6 +184,61 @@ class TestDump:
         content = fp.read_text()
         assert len(content) > 0
         fp.unlink()
+
+
+class TestDumpWithoutPandas:
+    """Regression: json/csv serialization must not import pandas. Blocking
+    ``import pandas`` here would break the old to_df-backed dump path, so these
+    guard the whole point of the stdlib serializer."""
+
+    @staticmethod
+    def _block_pandas(monkeypatch):
+        # A None entry makes `import pandas` raise ImportError, leaving json/csv
+        # /orjson untouched — a precise stand-in for a pandas-free install.
+        monkeypatch.setitem(sys.modules, "pandas", None)
+        with pytest.raises(ImportError):
+            import pandas  # noqa: F401
+
+    def test_json_and_csv_dump_need_no_pandas(self, pile_3, tmp_path, monkeypatch):
+        self._block_pandas(monkeypatch)
+
+        jf = tmp_path / "d.json"
+        cf = tmp_path / "d.csv"
+        pile_3.dump(jf, obj_key="json")
+        pile_3.dump(cf, obj_key="csv")
+
+        ids = {str(i.id) for i in pile_3.values()}
+        json_lines = jf.read_text().strip().splitlines()
+        assert len(json_lines) == 3
+        for line in json_lines:
+            assert json.loads(line)["id"] in ids  # each line is valid JSON
+
+        csv_lines = cf.read_text().strip().splitlines()
+        assert csv_lines[0].startswith("id")
+        assert len(csv_lines) == 4  # header + 3 rows
+
+    def test_dump_fp_none_returns_string_without_pandas(self, pile_3, monkeypatch):
+        self._block_pandas(monkeypatch)
+        out = pile_3.dump(None, obj_key="json")
+        assert isinstance(out, str)
+        assert len(out.strip().splitlines()) == 3
+
+    @pytest.mark.asyncio
+    async def test_adump_needs_no_pandas(self, pile_3, tmp_path, monkeypatch):
+        self._block_pandas(monkeypatch)
+        jf = tmp_path / "a.json"
+        cf = tmp_path / "a.csv"
+        await pile_3.adump(jf, obj_key="json")
+        await pile_3.adump(cf, obj_key="csv")
+        assert len(jf.read_text().strip().splitlines()) == 3
+        assert len(cf.read_text().strip().splitlines()) == 4
+
+    def test_parquet_still_requires_pandas(self, pile_3, tmp_path, monkeypatch):
+        """Parquet stays on the pandas path — with pandas blocked it must fail,
+        not silently degrade."""
+        self._block_pandas(monkeypatch)
+        with pytest.raises(Exception):
+            pile_3.dump(tmp_path / "d.parquet", obj_key="parquet")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`Pile.dump`/`adump` and `DataLogger.dump`/`adump` previously produced JSON and CSV by going through pandas (`Pile.to_df` → `DataFrame.to_json`/`to_csv`). That pulled pandas — an *optional* dependency — onto the default activity-log persistence path. This serializes JSON and CSV with the standard library instead.

## How

- New `_serialize_records(records, obj_key)` helper in `pile.py` builds JSONL / CSV from each element's `to_dict(mode="json")` snapshot, in progression (logical) order, using `json` + `csv`.
- `Pile.dump`/`Pile.adump` route `json`/`csv` through it; `parquet` still uses `to_df` + pyarrow (it needs a columnar engine).
- `DataLogger.adump` no longer calls `to_df`; `DataLogger.dump` already delegated to `Pile.dump`.
- `to_df`, `DataFrameAdapter`, `Branch.to_df`, `Session.to_df` are unchanged and remain opt-in (lazy pandas import).

## Format

- **Structure preserved:** JSON stays one object per line (JSONL, newline-terminated so `mode="a"` stays valid JSONL); CSV stays a header of first-appearance keys plus one row per element (missing keys empty). `dump(None, ...)` still returns the serialized string.
- **Encoding is now canonical, not pandas-specific:** values come from `to_dict(mode="json")` (orjson) — value-equal and round-trippable via `Element.from_dict`, but *not byte-identical* to pandas for datetime fields (ISO vs pandas epoch-ms) and high-precision floats (shortest exact repr vs pandas `double_precision`). CSV output is byte-identical in the common case.
- **json/csv reject stray kwargs:** the old `**kw` were pandas `to_json`/`to_csv` passthroughs; the stdlib path raises `TypeError` rather than silently ignoring them (parquet still forwards `**kw`).

## Tests

- The `json`/`csv` dump tests no longer require pandas; `to_df` and `parquet` tests stay pandas-gated.
- Regression coverage: blocks `import pandas` and asserts `Pile` + `DataLogger` json/csv serialization (sync + async) still works while parquet still requires pandas; plus append-safety, canonical round-trip via `from_dict`, and kwargs rejection.
- Validated in a genuinely pandas-free venv and with pandas installed (both paths green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
