### PR TITLE
fix(service): surface stream failures and usage-only terminal events

### DIFF
--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -531,6 +531,15 @@ class Endpoint:
                     )
             return StreamChunk(type="system", metadata={"raw": event})
 
+        # Usage-only terminal event: a Chat Completions stream with
+        # stream_options.include_usage ends with {"choices": [], "usage": {...}}.
+        # Without this branch the empty-choices list would fall through to a
+        # "system" chunk and consumers that read terminal accounting from result
+        # chunks would miss the provider-reported usage.
+        usage = event.get("usage")
+        if usage is not None and isinstance(choices, list):
+            return StreamChunk(type="result", metadata={"raw": event, "usage": usage})
+
         return None
 
     def to_dict(self):

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -24,6 +24,23 @@ from .hooks import (
 from .rate_limited_processor import RateLimitedAPIExecutor
 
 
+def _terminal_stream_error(api_call: APICalling) -> BaseException | None:
+    """The captured cause when a streamed call ended FAILED, else None.
+
+    ``Event.stream()`` records a transport/provider failure as ``FAILED`` and
+    stops yielding rather than re-raising, so the shared processor can run
+    events concurrently without one failure cancelling the batch. Always
+    returns a ``BaseException`` (never a bare string) so it is safe to chain
+    with ``raise ... from``.
+    """
+    if api_call.status != EventStatus.FAILED:
+        return None
+    err = api_call.execution.error
+    if isinstance(err, BaseException):
+        return err
+    return RuntimeError(str(err) if err is not None else "stream failed without a recorded cause")
+
+
 class iModel:  # noqa: N801
     """Provider endpoint wrapper with rate-limiting, hooks, and streaming."""
 
@@ -285,25 +302,38 @@ class iModel:  # noqa: N801
 
         if self.executor.processor._concurrency_sem:
             async with self.executor.processor._concurrency_sem:
+                stream_error = None
                 try:
                     async for i in api_call.stream():
                         result = await self.process_chunk(i)
                         yield result if result is not None else i
+                    # api_call.stream() captures a transport/provider failure as
+                    # FAILED instead of raising (so the shared processor can fire
+                    # events concurrently without one failure cancelling the batch).
+                    # This public boundary must not report that as a clean end —
+                    # surface it after iteration so the caller sees the error.
+                    stream_error = _terminal_stream_error(api_call)
                 except Exception as e:
                     raise ValueError(f"Failed to stream API call: {e}") from e
                 finally:
                     # Pop without yielding — yield-in-finally would swallow CancelledError
                     # during generator cleanup, breaking anyio.fail_after timeout enforcement.
                     self.executor.pile.pop(api_call.id, None)
+                if stream_error is not None:
+                    raise ValueError(f"Failed to stream API call: {stream_error}") from stream_error
         else:
+            stream_error = None
             try:
                 async for i in api_call.stream():
                     result = await self.process_chunk(i)
                     yield result if result is not None else i
+                stream_error = _terminal_stream_error(api_call)
             except Exception as e:
                 raise ValueError(f"Failed to stream API call: {e}") from e
             finally:
                 self.executor.pile.pop(api_call.id, None)
+            if stream_error is not None:
+                raise ValueError(f"Failed to stream API call: {stream_error}") from stream_error
 
     async def invoke(self, api_call: APICalling = None, **kw) -> APICalling:
         try:

--- a/tests/engines/test_engines_scripted_e2e.py
+++ b/tests/engines/test_engines_scripted_e2e.py
@@ -182,7 +182,9 @@ async def test_hypothesis_repair_recovers_weak_model_e2e(tmp_path, monkeypatch):
         [
             _when("Extract the architectural questions", text="Let me think about this..."),
             _when(
-                "produced no valid emission",
+                # The scripted provider is a CLI worker, so the repair turn carries
+                # the CLI re-prompt, not the API one.
+                "no fenced JSON block",
                 {
                     "question_raised": {
                         "area": "ql",
@@ -228,6 +230,9 @@ async def test_hypothesis_repair_recovers_weak_model_e2e(tmp_path, monkeypatch):
     )
     assert "taste conclusion" in report
     assert any(e["type"] == "emission_repair" for e in notified)
+    # emission_repair only records that a repair was attempted; without this the
+    # test passes even when the repair turn never produced a valid emission.
+    assert not any(e["type"] == "emission_missing" for e in notified)
 
 
 @pytest.mark.asyncio
@@ -327,7 +332,9 @@ async def test_review_repair_recovers_prose_reviewer_e2e(tmp_path, monkeypatch):
         [
             _when("for **correctness** only", text="The cursor logic looks suspicious..."),
             _when(
-                "produced no valid emission",
+                # The scripted provider is a CLI worker, so the repair turn carries
+                # the CLI re-prompt, not the API one.
+                "no fenced JSON block",
                 {
                     "issue_found": {
                         "dimension": "correctness",
@@ -335,6 +342,17 @@ async def test_review_repair_recovers_prose_reviewer_e2e(tmp_path, monkeypatch):
                         "severity": "major",
                         "location": "store.rs:41",
                         "confidence": 0.7,
+                    }
+                },
+            ),
+            # A recovered repair emits a real issue, which spawns the verifier.
+            _when(
+                "Adversarially verify",
+                {
+                    "verify_result": {
+                        "issue": "off-by-one in cursor advance",
+                        "holds": True,
+                        "rationale": "boundary test confirms skip of last row",
                     }
                 },
             ),
@@ -350,6 +368,9 @@ async def test_review_repair_recovers_prose_reviewer_e2e(tmp_path, monkeypatch):
     )
     assert "REQUEST-CHANGES" in out
     assert any(e["type"] == "emission_repair" for e in notified)
+    # emission_repair only records that a repair was attempted; without this the
+    # test passes even when the repair turn never produced a valid emission.
+    assert not any(e["type"] == "emission_missing" for e in notified)
 
 
 @pytest.mark.asyncio

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -579,6 +579,53 @@ class TestEndpoint:
         assert chunks[0].content == "hi"
         assert chunks[1].metadata == {"done": True}
 
+    def test_usage_only_event_is_result_chunk(self, openai_config):
+        """A Chat Completions usage-only terminal event ({"choices": [],
+        "usage": {...}}) must normalize to a result chunk carrying the usage,
+        not a system chunk that terminal-accounting consumers skip."""
+        endpoint = Endpoint(config=openai_config)
+        usage = {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+        chunk = endpoint._event_to_stream_chunk({"choices": [], "usage": usage})
+        assert chunk is not None
+        assert chunk.type == "result"
+        assert chunk.metadata["usage"] == usage
+
+    def test_empty_choices_without_usage_is_not_result(self, openai_config):
+        """Empty choices with no usage stays a non-result (unchanged behavior)."""
+        endpoint = Endpoint(config=openai_config)
+        assert endpoint._event_to_stream_chunk({"choices": []}) is None
+
+    @pytest.mark.asyncio
+    async def test_stream_aiohttp_usage_only_terminal_event(self, openai_config):
+        """End-to-end: the usage-only line surfaces as a result chunk with usage."""
+        endpoint = Endpoint(config=openai_config)
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+
+        async def mock_content_iter():
+            yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+            yield b'data: {"choices":[],"usage":{"total_tokens":18}}\n\n'
+            yield b"data: [DONE]\n\n"
+
+        mock_response.content = mock_content_iter()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock()
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock()
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch("aiohttp.ClientSession", return_value=mock_session):
+                request = {"messages": [{"role": "user", "content": "test"}]}
+                chunks = [chunk async for chunk in endpoint.stream(request)]
+
+        assert [c.type for c in chunks] == ["text", "result", "result"]
+        # the usage-only result carries the provider usage
+        assert chunks[1].metadata["usage"] == {"total_tokens": 18}
+
     @pytest.mark.asyncio
     async def test_stream_with_extra_headers(self, openai_config):
         endpoint = Endpoint(config=openai_config)

--- a/tests/service/test_imodel_hooks.py
+++ b/tests/service/test_imodel_hooks.py
@@ -570,3 +570,56 @@ class TestProcessChunkExitTuple:
         ):
             with pytest.raises(RuntimeError, match="Streaming hook requested exit without a cause"):
                 await imodel.process_chunk(_FakeChunk())
+
+
+class TestiModelStreamFailurePropagation:
+    """A transport/provider failure during streaming must reach the caller of
+    imodel.stream(), not end as a silent, complete-looking iteration."""
+
+    def _imodel(self):
+        return iModel(provider="openai", model="gpt-4.1-mini", api_key="test-key")
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_failure_raises_at_boundary(self):
+        imodel = self._imodel()
+
+        async def failing_stream():
+            yield {"choices": [{"delta": {"content": "partial"}}]}
+            raise RuntimeError("connection dropped mid-stream")
+
+        seen = []
+        with patch.object(imodel.endpoint, "stream", return_value=failing_stream()):
+            with pytest.raises(ValueError, match="connection dropped mid-stream"):
+                async for chunk in imodel.stream(messages=[{"role": "user", "content": "hi"}]):
+                    if chunk and not isinstance(chunk, APICalling):
+                        seen.append(chunk)
+        # partial content was delivered, but the failure still surfaced
+        assert seen  # got the partial chunk before the error
+
+    @pytest.mark.asyncio
+    async def test_pre_first_byte_failure_raises_at_boundary(self):
+        imodel = self._imodel()
+
+        async def failing_stream():
+            raise RuntimeError("401 before first byte")
+            yield  # pragma: no cover -- makes this an async generator
+
+        with patch.object(imodel.endpoint, "stream", return_value=failing_stream()):
+            with pytest.raises(ValueError, match="401 before first byte"):
+                async for _ in imodel.stream(messages=[{"role": "user", "content": "hi"}]):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_successful_stream_does_not_raise(self):
+        imodel = self._imodel()
+
+        async def ok_stream():
+            for i in range(3):
+                yield {"choices": [{"delta": {"content": f"c{i}"}}]}
+
+        chunks = []
+        with patch.object(imodel.endpoint, "stream", return_value=ok_stream()):
+            async for chunk in imodel.stream(messages=[{"role": "user", "content": "hi"}]):
+                if chunk and not isinstance(chunk, APICalling):
+                    chunks.append(chunk)
+        assert len(chunks) >= 3

--- a/tests/service/test_imodel_hooks.py
+++ b/tests/service/test_imodel_hooks.py
@@ -623,3 +623,27 @@ class TestiModelStreamFailurePropagation:
                 if chunk and not isinstance(chunk, APICalling):
                     chunks.append(chunk)
         assert len(chunks) >= 3
+
+    @pytest.mark.asyncio
+    async def test_failure_raises_through_concurrency_sem_branch(self):
+        """concurrency_limit routes stream() through the semaphore branch; the
+        terminal failure must still surface there."""
+        # concurrency_limit routes stream() through the semaphore branch once the
+        # executor starts and builds the processor with a non-None _concurrency_sem.
+        imodel = iModel(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="test-key",
+            concurrency_limit=1,
+        )
+
+        async def failing_stream():
+            yield {"choices": [{"delta": {"content": "x"}}]}
+            raise RuntimeError("sem-branch transport failure")
+
+        with patch.object(imodel.endpoint, "stream", return_value=failing_stream()):
+            with pytest.raises(ValueError, match="sem-branch transport failure"):
+                async for _ in imodel.stream(messages=[{"role": "user", "content": "hi"}]):
+                    pass
+        # confirm this run actually exercised the semaphore branch
+        assert imodel.executor.processor._concurrency_sem is not None


### PR DESCRIPTION
## What

Two streaming-boundary correctness fixes so a consumer sees the true outcome of a stream — both failures and provider-reported usage.

### #2392 — stream failures no longer look like a clean end

`iModel.stream()` delivered transport/provider failures as ordinary iterator exhaustion. `Event.stream()` records a failure as `FAILED` and stops yielding rather than re-raising — deliberately, so the shared `Processor` can fire events concurrently (via a task group) without one failure cancelling the whole batch. That left `iModel.stream()`'s existing `except Exception -> raise ValueError` wrapper **unreachable**, so `async for chunk in imodel.stream(...)` terminated normally even on a 401, a dropped connection, or a malformed SSE.

Fix at the public boundary only: after the iteration completes, inspect the terminal status and raise there, chaining the captured cause. `Event.stream()`'s capture contract and the processor's fault isolation are **unchanged** (verified against the event-lifecycle and processor test suites).

### #2399 — usage-only terminal event is a result chunk, not a system chunk

A Chat Completions usage-only terminal event (`{"choices": [], "usage": {...}}`, sent under `stream_options.include_usage`) fell through the non-empty-choices handling to a `"system"` chunk, so consumers that read terminal accounting from `result` chunks skipped the provider usage. Add an explicit branch that normalizes it to a `result` chunk carrying the usage under `metadata["usage"]`.

## Tests

- Pre-first-byte and mid-stream failure propagation raise at `imodel.stream()`; a successful stream stays non-raising.
- Usage-only normalization at the unit level (`_event_to_stream_chunk`) and through the full aiohttp stream path; empty-choices-without-usage stays unchanged.
- Full service suite green except pre-existing environment-only failures (ollama/jsonschema/hypothesis optional deps not installed in the test venv); event-lifecycle + processor + resilience suites green.

Closes #2392
Closes #2399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
