### PR TITLE
fix(studio): add canonical partial indexes to the fallback approvals table

### DIFF
--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -49,6 +49,10 @@ CREATE TABLE IF NOT EXISTS approvals (
   consumed_at   REAL,
   expires_at    REAL    NOT NULL
 );
+CREATE INDEX IF NOT EXISTS idx_approvals_status
+  ON approvals(status) WHERE status IN ('pending', 'granted');
+CREATE INDEX IF NOT EXISTS idx_approvals_session
+  ON approvals(session_id) WHERE session_id IS NOT NULL;
 """
 
 EVIDENCE_EVENT_TYPES = frozenset({"proposed", "granted", "denied", "consumed", "expired"})
@@ -265,8 +269,19 @@ async def verify_evidence_chain() -> dict[str, Any]:
 
     key = os.getenv("LIONAGI_STUDIO_EVIDENCE_HMAC_KEY")
     expected_previous = GENESIS_HASH
+    expected_sequence = 1
     for row in rows:
         total += 1
+        # The sequence column is untrusted metadata: the true order is fixed by the
+        # previous_hash -> chain_hash linkage below. A legitimate chain is always
+        # 1, 2, ..., N (each row takes tail+1, starting at 1), so pin sequence to its
+        # cryptographically-enforced position. Without this, renumbering every row by a
+        # uniform offset (1, 2 -> 101, 102) leaves all hash columns intact and slips
+        # past chain-continuity, forging a valid-looking but relabelled audit trail.
+        if row["sequence"] != expected_sequence:
+            errors.append(
+                f"sequence {row['sequence']}: expected contiguous sequence {expected_sequence}"
+            )
         payload = {
             "id": row["id"],
             "event_type": row["event_type"],
@@ -297,6 +312,7 @@ async def verify_evidence_chain() -> dict[str, Any]:
                 if not hmac.compare_digest(expected_sig, row["hmac_sig"]):
                     errors.append(f"sequence {row['sequence']}: hmac signature mismatch")
         expected_previous = row["chain_hash"]
+        expected_sequence += 1
 
     return {
         "valid": not errors,

--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -269,19 +269,8 @@ async def verify_evidence_chain() -> dict[str, Any]:
 
     key = os.getenv("LIONAGI_STUDIO_EVIDENCE_HMAC_KEY")
     expected_previous = GENESIS_HASH
-    expected_sequence = 1
     for row in rows:
         total += 1
-        # The sequence column is untrusted metadata: the true order is fixed by the
-        # previous_hash -> chain_hash linkage below. A legitimate chain is always
-        # 1, 2, ..., N (each row takes tail+1, starting at 1), so pin sequence to its
-        # cryptographically-enforced position. Without this, renumbering every row by a
-        # uniform offset (1, 2 -> 101, 102) leaves all hash columns intact and slips
-        # past chain-continuity, forging a valid-looking but relabelled audit trail.
-        if row["sequence"] != expected_sequence:
-            errors.append(
-                f"sequence {row['sequence']}: expected contiguous sequence {expected_sequence}"
-            )
         payload = {
             "id": row["id"],
             "event_type": row["event_type"],
@@ -312,7 +301,6 @@ async def verify_evidence_chain() -> dict[str, Any]:
                 if not hmac.compare_digest(expected_sig, row["hmac_sig"]):
                     errors.append(f"sequence {row['sequence']}: hmac signature mismatch")
         expected_previous = row["chain_hash"]
-        expected_sequence += 1
 
     return {
         "valid": not errors,

--- a/tests/apps_studio_server/test_approvals.py
+++ b/tests/apps_studio_server/test_approvals.py
@@ -918,3 +918,66 @@ def test_double_expire_read_race_writes_only_one_evidence_row(tmp_path, monkeypa
     verdict = _run(approvals_mod.verify_evidence_chain())
     assert verdict["valid"] is True
     assert verdict["errors"] == []
+
+
+def test_sequence_renumbering_detected_by_verify(tmp_path, monkeypatch):
+    """Renumbering every evidence row by a uniform offset (1, 2 -> 101, 102)
+    leaves all hash columns untouched, so it slips past content/chain/hmac checks.
+    Verification must still reject it: a genuine chain is contiguous from 1, so the
+    sequence column is pinned to its cryptographically-enforced position."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import approvals as approvals_mod
+    from lionagi.studio.services._db import open_db
+
+    row = _run(
+        approvals_mod.create_approval(action_kind="launch_playbook", params={"name": "demo"})
+    )
+    _run(approvals_mod.grant_approval(row["id"]))
+
+    before = _evidence_rows(db_path)
+    assert [r["sequence"] for r in before] == [1, 2]
+    # Every hash column is preserved; only the sequence labels shift.
+    hashes_before = [(r["content_hash"], r["chain_hash"], r["previous_hash"]) for r in before]
+
+    async def _renumber():
+        async with open_db(str(db_path)) as db:
+            await db.execute("UPDATE approval_evidence SET sequence = sequence + 100")
+            await db.commit()
+
+    _run(_renumber())
+
+    after = _evidence_rows(db_path)
+    assert [r["sequence"] for r in after] == [101, 102]
+    assert [
+        (r["content_hash"], r["chain_hash"], r["previous_hash"]) for r in after
+    ] == hashes_before
+
+    verdict = _run(approvals_mod.verify_evidence_chain())
+    assert verdict["valid"] is False
+    assert any("expected contiguous sequence" in e for e in verdict["errors"])
+
+
+def test_fallback_ensure_table_creates_status_and_session_indexes(tmp_path):
+    """The defensive `_ensure_table` fallback (used by direct module callers
+    outside the studio lifespan, which never applies the full StateDB schema)
+    must create the same partial indexes the canonical schema defines, so the
+    ledger is not left un-indexed on the status/session read paths."""
+    from lionagi.studio.services import approvals as approvals_mod
+    from lionagi.studio.services._db import open_db
+
+    db_path = tmp_path / "bare.db"
+
+    async def _indexes() -> set[str]:
+        async with open_db(str(db_path)) as db:
+            await approvals_mod._ensure_table(db)
+            cur = await db.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'approvals'"
+            )
+            return {r["name"] for r in await cur.fetchall()}
+
+    names = _run(_indexes())
+    assert "idx_approvals_status" in names
+    assert "idx_approvals_session" in names

--- a/tests/apps_studio_server/test_approvals.py
+++ b/tests/apps_studio_server/test_approvals.py
@@ -920,46 +920,6 @@ def test_double_expire_read_race_writes_only_one_evidence_row(tmp_path, monkeypa
     assert verdict["errors"] == []
 
 
-def test_sequence_renumbering_detected_by_verify(tmp_path, monkeypatch):
-    """Renumbering every evidence row by a uniform offset (1, 2 -> 101, 102)
-    leaves all hash columns untouched, so it slips past content/chain/hmac checks.
-    Verification must still reject it: a genuine chain is contiguous from 1, so the
-    sequence column is pinned to its cryptographically-enforced position."""
-    db_path = tmp_path / "state.db"
-    _patch_db(monkeypatch, db_path)
-    _run(_init_db(db_path))
-
-    from lionagi.studio.services import approvals as approvals_mod
-    from lionagi.studio.services._db import open_db
-
-    row = _run(
-        approvals_mod.create_approval(action_kind="launch_playbook", params={"name": "demo"})
-    )
-    _run(approvals_mod.grant_approval(row["id"]))
-
-    before = _evidence_rows(db_path)
-    assert [r["sequence"] for r in before] == [1, 2]
-    # Every hash column is preserved; only the sequence labels shift.
-    hashes_before = [(r["content_hash"], r["chain_hash"], r["previous_hash"]) for r in before]
-
-    async def _renumber():
-        async with open_db(str(db_path)) as db:
-            await db.execute("UPDATE approval_evidence SET sequence = sequence + 100")
-            await db.commit()
-
-    _run(_renumber())
-
-    after = _evidence_rows(db_path)
-    assert [r["sequence"] for r in after] == [101, 102]
-    assert [
-        (r["content_hash"], r["chain_hash"], r["previous_hash"]) for r in after
-    ] == hashes_before
-
-    verdict = _run(approvals_mod.verify_evidence_chain())
-    assert verdict["valid"] is False
-    assert any("expected contiguous sequence" in e for e in verdict["errors"])
-
-
 def test_fallback_ensure_table_creates_status_and_session_indexes(tmp_path):
     """The defensive `_ensure_table` fallback (used by direct module callers
     outside the studio lifespan, which never applies the full StateDB schema)


### PR DESCRIPTION
## What

#2397 — the defensive `_ENSURE_TABLE_SQL` fallback in `lionagi/studio/services/approvals.py` (used by direct module callers outside the studio app's lifespan, which never applies the full StateDB schema) created the `approvals` table **without** the two partial indexes the canonical schema defines in `lionagi/state/schema_meta.py`:

- `idx_approvals_status` — `ON approvals(status) WHERE status IN ('pending', 'granted')`
- `idx_approvals_session` — `ON approvals(session_id) WHERE session_id IS NOT NULL`

so the status/session read paths were left unindexed on any DB created via the fallback. Added both as `CREATE INDEX IF NOT EXISTS`, which also reconciles an already-created table (the same pattern the evidence table's fallback at `_ENSURE_EVIDENCE_TABLE_SQL` already uses).

## Tests

- `test_fallback_ensure_table_creates_status_and_session_indexes`: the direct `_ensure_table` path creates both partial indexes on a bare DB.
- Full `tests/apps_studio_server/` + `tests/state/test_engine_schema.py` green.

Scope note: the sibling issue #2438 (evidence-chain sequence tamper-evidence) is fixed separately in #2456, so it is intentionally not touched here.

Closes #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
