### PR TITLE
feat(cli): add `li mcp` — serve background li runs as an MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.30.2] - 2026-07-23
+### Added
+
+- `li mcp` serves an MCP server (over stdio) that submits `li` runs — agent, flow, and fanout —
+  as detached background jobs and exposes tools to query, tail, and stop them. Each `submit_*`
+  tool mirrors a `li` command but returns a `run_id` immediately while the run continues in its
+  own process group, so it survives an MCP-server restart. `fastmcp` stays behind the optional
+  `[mcp]` extra; importing `lionagi` never pulls it, and the job engine plus terminal notify hook
+  are standard-library only. Terminal notices are delivered through a configured command
+  (lionagi's own `notify.on_terminal` setting, a per-submit override, or an environment default),
+  never a hardcoded one, and the delivery outcome is recorded on the job and surfaced in
+  `job_status`. See `docs/cli-reference.md` for the tool list and `.mcp.json` registration.
 
 ### Fixed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,6 +43,7 @@ worker.
 | `li dispatch {ls,show,ack,retry,purge}` | Operate the durable dispatch outbox |
 | `li stats runs` | Aggregate run reporting from StateDB |
 | `li mirror` | Mirror Claude Code transcripts into StateDB/Studio |
+| `li mcp` | Serve an MCP server that submits `li` runs as background jobs ([details](#li-mcp)) |
 | `li doctor` | Check installation, dependencies, Studio reachability, and writable state |
 
 `play`, `skill`, and `wait` are compatibility-friendly top-level conveniences handled
@@ -628,6 +629,73 @@ li hooks trust --yes                     # record trust without the prompt
 |------------|-------|-------|
 | `import SOURCE [PATH]` | `--cwd` | `SOURCE` is `claude` or `codex`; `PATH` defaults to `.claude/settings.json` or `.codex/hooks.json` |
 | `trust` | `--cwd`, `--yes` | Lists pending imported hook commands and records approval (content-hashed argv) |
+
+---
+
+## `li mcp`
+
+Serve an [MCP](https://modelcontextprotocol.io) server over stdio that submits
+`li` runs as **detached background jobs** and exposes tools to query, tail, and
+stop them. Each `submit_*` tool mirrors a `li` command but returns a `run_id`
+immediately instead of blocking; the run keeps going in its own process group,
+so it survives an MCP-server restart. Requires the `mcp` extra
+(`pip install 'lionagi[mcp]'`). Source: `lionagi/mcp/`.
+
+```bash
+li mcp            # serve over stdio (same as: python -m lionagi.mcp)
+```
+
+Register it with any MCP client (e.g. an `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "lionagi": { "command": "li", "args": ["mcp"] }
+  }
+}
+```
+
+| Tool | Purpose |
+|------|---------|
+| `submit_agent` | Background `li agent` — returns `{run_id, pid, status}` |
+| `submit_flow` | Background `li o flow` (DAG orchestration) |
+| `submit_fanout` | Background `li o fanout` (flat parallel workers) |
+| `job_status RUN_ID` | Liveness + authoritative terminal status + CLI manifest |
+| `job_output RUN_ID` | Console (an agent's final response) + artifacts |
+| `job_kill RUN_ID` | Signal the run's whole process group |
+| `jobs_list` | Recent jobs, newest first; optional `status` filter |
+
+Job records live under `~/.lionagi/mcp/jobs/<run_id>/`; the authoritative run
+state is the CLI's own `~/.lionagi/runs/<run_id>/`. In `job_status`, the
+top-level `status` is authoritative — the embedded `run` manifest is advisory
+and its own `status` may lag.
+
+### Terminal notices
+
+When a background run finishes, the server records its terminal status and, if a
+delivery command is configured, runs it — on **every** terminal state, including
+failure and kill. Nothing is configured out of the box, so the default is no
+notice. The command is an argv list run directly (never through a shell); the
+placeholders `{run_id}`, `{status}`, `{label}`, and `{target}` are substituted
+into its arguments, and the same fields are offered as a JSON object on stdin.
+
+Configure the command once via lionagi's own `notify.on_terminal` setting
+(`~/.lionagi/settings.yaml` or a project `.lionagi/settings.yaml`):
+
+```yaml
+notify:
+  on_terminal:
+    adapter:
+      kind: exec
+      argv: ["/usr/local/bin/notify-run", "{run_id}", "{status}", "{target}"]
+```
+
+Or per submit: `notify` overrides the delivery command for one run (a JSON argv
+list), and `notify_seat` fills the `{target}` placeholder. The environment
+variables `LIONAGI_MCP_NOTIFY_COMMAND` and `LIONAGI_MCP_NOTIFY_TARGET` set a
+process-wide default. Delivery outcome is recorded on the job and surfaced in
+`job_status` (`notify_delivery`), so a notice that failed to send is visible
+rather than silently lost.
 
 ---
 

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -47,6 +47,10 @@ def _load_kill() -> ModuleType:
     return import_module(".kill", __package__)
 
 
+def _load_mcp() -> ModuleType:
+    return import_module(".mcp", __package__)
+
+
 def _load_mirror() -> ModuleType:
     return import_module(".mirror", __package__)
 
@@ -211,6 +215,13 @@ _COMMAND_REGISTRY = (
         "add_hooks_subparser",
         "run_hooks",
     ),
+    _CommandSpec(
+        "mcp",
+        "Serve the lionagi MCP server (background job submit/query) over stdio.",
+        _load_mcp,
+        "add_mcp_subparser",
+        "run_mcp",
+    ),
 )
 _COMMAND_BY_NAME = {
     command_name: spec for spec in _COMMAND_REGISTRY for command_name in (spec.name, *spec.aliases)
@@ -268,6 +279,10 @@ def run_invoke(args: argparse.Namespace) -> int:
 
 def run_kill(args: argparse.Namespace) -> int:
     return _load_kill().run_kill(args)
+
+
+def run_mcp(args: argparse.Namespace) -> int:
+    return _load_mcp().run_mcp(args)
 
 
 def run_mirror(args: argparse.Namespace) -> int:

--- a/lionagi/cli/mcp.py
+++ b/lionagi/cli/mcp.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li mcp` — serve the lionagi MCP server over stdio.
+
+The server submits ``li`` runs (agent/flow/fanout) as detached background jobs
+and exposes tools to query, tail, and stop them. It needs the optional ``mcp``
+extra (``pip install lionagi[mcp]``).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from ._logging import log_error
+
+__all__ = ("add_mcp_subparser", "run_mcp")
+
+
+def add_mcp_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register `li mcp` with argparse."""
+    p = subparsers.add_parser(
+        "mcp",
+        help="Serve the lionagi MCP server (background job submit/query) over stdio.",
+        description=(
+            "Serve the lionagi MCP server over stdio. It submits li runs as "
+            "detached background jobs (submit_agent/submit_flow/submit_fanout) "
+            "and exposes job_status/job_output/job_kill/jobs_list. Requires the "
+            "'mcp' extra: pip install 'lionagi[mcp]'."
+        ),
+    )
+    p.add_argument(
+        "action",
+        nargs="?",
+        default="serve",
+        choices=["serve"],
+        help="serve the server over stdio (default).",
+    )
+
+
+def run_mcp(args: argparse.Namespace) -> int:
+    if getattr(args, "action", "serve") != "serve":
+        log_error(f"unknown mcp action: {args.action}")
+        return 2
+    try:
+        from lionagi.mcp import serve
+    except ImportError as exc:
+        log_error(str(exc))
+        return 1
+    serve()
+    return 0

--- a/lionagi/mcp/__init__.py
+++ b/lionagi/mcp/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""lionagi MCP server — submit ``li`` runs as background jobs and query them.
+
+The server itself lives in :mod:`lionagi.mcp.server` and needs the optional
+``mcp`` extra (``pip install lionagi[mcp]``). Importing this package never pulls
+that dependency: the job engine (:mod:`lionagi.mcp.jobs`) and paths
+(:mod:`lionagi.mcp.config`) are stdlib-only, so the terminal hook the CLI runs
+imports cleanly even where the server dependency is absent.
+
+Serve it with ``li mcp`` (or ``python -m lionagi.mcp``).
+"""
+
+from __future__ import annotations
+
+__all__ = ("serve",)
+
+
+def serve() -> None:
+    """Run the MCP server over stdio. Requires the ``mcp`` extra."""
+    try:
+        from .server import main
+    except ImportError as exc:  # pragma: no cover - exercised via the CLI path
+        raise ImportError(
+            "the lionagi MCP server requires the 'mcp' extra; "
+            "install it with: pip install 'lionagi[mcp]'"
+        ) from exc
+    main()

--- a/lionagi/mcp/__main__.py
+++ b/lionagi/mcp/__main__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""``python -m lionagi.mcp`` — run the MCP server over stdio."""
+
+from __future__ import annotations
+
+from . import serve
+
+if __name__ == "__main__":
+    serve()

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Terminal hook for background MCP jobs, invoked by the CLI via ``--notify``.
+
+The CLI runs this once a background run reaches a terminal status. It does two
+things, both best-effort (the run has already finished, so nothing here may
+raise into the CLI's terminal path):
+
+1. Records the terminal status on the MCP job record, so ``job_status`` /
+   ``jobs_list`` report an authoritative ``completed`` / ``failed`` / ``killed``
+   / ``timeout`` instead of only inferring ``exited`` from a gone pid.
+
+2. Delivers a terminal notice through a *configured command*, never a
+   hardcoded one. The command comes from (in order) an explicit ``--command``
+   override or lionagi's own ``notify.on_terminal`` setting; ``{run_id}``,
+   ``{status}``, ``{label}`` and ``{target}`` are substituted into its argv and
+   the same fields are also offered as a JSON payload on stdin. With nothing
+   configured there is no delivery — the out-of-the-box default is silence.
+
+The command is run by absolute argv (never through a shell), so a caller wires
+whatever notifier they use (a webhook client, a messaging CLI) without this
+package knowing anything about it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from typing import Any
+
+# The CLI runs this file's module by absolute interpreter path; lionagi is on
+# the path because that interpreter is the one lionagi is installed in.
+from . import jobs
+
+# A configured notifier's stdout/stderr is free text that can carry a
+# credential the command obtained anywhere, so it is never captured or logged:
+# the child inherits DEVNULL and this hook keeps nothing.
+_DELIVERY_TIMEOUT_S = 30
+
+
+def _resolve_command(override: str | None, *, cwd: str | None) -> list[str] | None:
+    """The delivery argv template, or None when nothing is configured.
+
+    *override* (a JSON argv list) wins outright. Otherwise lionagi's own
+    ``notify.on_terminal`` setting is reused as the single delivery-config
+    surface — its ``exec`` adapter's argv is the template. Any resolution
+    failure yields None (no delivery), never an exception.
+    """
+    if override:
+        try:
+            parsed = json.loads(override)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, list) and all(isinstance(tok, str) for tok in parsed) and parsed:
+            return parsed
+        return None
+
+    try:
+        from lionagi.state.lifecycle.notify_settings import resolve_notify_config
+
+        resolved = resolve_notify_config(project_dir=cwd)
+    except Exception:  # noqa: BLE001 — a settings problem must never break the terminal path
+        return None
+    if resolved is None or resolved.argv is None:
+        return None
+    return list(resolved.argv)
+
+
+def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
+    """Replace ``{run_id}``/``{status}``/``{label}``/``{target}`` per token."""
+    out: list[str] = []
+    for tok in argv:
+        for key, value in fields.items():
+            tok = tok.replace("{" + key + "}", value)
+        out.append(tok)
+    return out
+
+
+def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
+    """Run the delivery command best-effort; return its outcome for the record.
+
+    The outcome is recorded on the job so a dead completion notice surfaces in
+    ``job_status`` instead of vanishing silently — a completion signal that can
+    fail silently would cost the detached-spawn pattern its reliability. Only
+    the exit code is kept: the command's stdout/stderr is free text that can
+    carry a credential, so it goes to DEVNULL and is never captured.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv is the operator-configured delivery command, no shell
+            argv,
+            input=json.dumps(payload),
+            text=True,
+            timeout=_DELIVERY_TIMEOUT_S,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        # never fail the run's terminal path; record the failure instead
+        return {"attempted": True, "ok": False, "exit_code": None, "error": type(exc).__name__}
+    return {
+        "attempted": True,
+        "ok": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "error": None,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="lionagi.mcp._notify_hook")
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--status", default="completed")
+    ap.add_argument("--target", default=None, help="value for the {target} placeholder")
+    ap.add_argument("--command", default=None, help="delivery argv override (JSON list)")
+    args = ap.parse_args(argv)
+
+    job = jobs.mark_terminal(args.run_id, args.status)
+
+    target = args.target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
+    label = (job or {}).get("label") or (job or {}).get("kind") or "run"
+    template = _resolve_command(
+        args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
+        cwd=(job or {}).get("cwd"),
+    )
+    if template:
+        fields = {
+            "run_id": args.run_id,
+            "status": args.status,
+            "label": label,
+            "target": target,
+        }
+        outcome = _deliver(_substitute(template, fields), fields)
+    else:
+        outcome = {"attempted": False}  # nothing configured — not a failure
+    jobs.record_notify_delivery(args.run_id, outcome)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lionagi/mcp/config.py
+++ b/lionagi/mcp/config.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Paths and CLI resolution for the lionagi MCP server.
+
+The server is a thin control plane over the ``li`` CLI. It never re-implements a
+run; it spawns the same command a human would type, then reads the run state
+lionagi already persists under ``LIONAGI_HOME/runs/{run_id}/``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from lionagi._paths import LIONAGI_HOME, RUNS_ROOT
+
+# Authoritative per-run state written by the CLI (run.json, branches, artifacts).
+RUNS_DIR = RUNS_ROOT
+
+# The MCP server's own per-job records (pid, argv, console log) — data the CLI
+# does not keep because it never needed a background handle before.
+JOBS_DIR = LIONAGI_HOME / "mcp" / "jobs"
+
+# The env var the CLI reads to inherit a caller-chosen run_id (subprocess
+# handoff, lionagi/cli/_runs.py). Setting it lets submit() name the run before
+# the child starts, so the id we return is race-free.
+RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"
+
+# Explicit override for the argv prefix that invokes the ``li`` CLI, split on
+# whitespace. Rarely needed: the server runs inside lionagi's own environment,
+# so the interpreter running it already resolves the CLI (see li_command).
+LI_BIN_ENV_VAR = "LIONAGI_MCP_LI_BIN"
+
+
+def li_command() -> list[str]:
+    """Return the argv prefix that invokes the ``li`` CLI.
+
+    The server runs inside lionagi's own environment, so the CLI it spawns is
+    the one installed alongside the running interpreter — no working-tree
+    hunting, no dependency resync on spawn. Resolution order:
+
+      1. ``LIONAGI_MCP_LI_BIN`` (explicit override, split on whitespace).
+      2. The ``li`` console script next to ``sys.executable`` (same venv/bin),
+         invoked by absolute path so it never depends on ``PATH``.
+      3. ``<this-interpreter> -m lionagi.cli`` as a last resort.
+    """
+    override = os.environ.get(LI_BIN_ENV_VAR)
+    if override:
+        return override.split()
+
+    bin_li = Path(sys.executable).resolve().parent / "li"
+    if bin_li.exists():
+        return [str(bin_li)]
+
+    return [sys.executable, "-m", "lionagi.cli"]
+
+
+def run_dir(run_id: str) -> Path:
+    """Directory of authoritative CLI state for *run_id*."""
+    return RUNS_DIR / run_id
+
+
+def run_manifest(run_id: str) -> Path:
+    """The run.json the CLI writes for *run_id*."""
+    return run_dir(run_id) / "run.json"
+
+
+def job_dir(run_id: str) -> Path:
+    """The MCP server's own record directory for *run_id*."""
+    return JOBS_DIR / run_id

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -36,8 +36,6 @@ _KIND_ARGV: dict[str, list[str]] = {
     "fanout": ["orchestrate", "fanout"],
 }
 
-_TERMINAL_STATES = {"completed", "failed", "killed", "timeout", "exited"}
-
 # The terminal hook module, invoked by the CLI's --notify by absolute
 # interpreter path so it runs regardless of PATH in the CLI's environment.
 _NOTIFY_MODULE = "lionagi.mcp._notify_hook"
@@ -210,6 +208,28 @@ def submit(
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
     env[config.RUN_ID_ENV_VAR] = run_id
 
+    # Persist the record BEFORE spawning, so the child's terminal --notify hook
+    # always finds a record to mark. mark_terminal no-ops on a missing record, so
+    # a child that reaches a terminal in the window between spawn and this write
+    # would otherwise lose its status and delivery outcome. pid is filled in right
+    # after the spawn; that follow-up write only attaches the pid and never
+    # rewrites status, so a terminal the hook may already have recorded survives.
+    record = {
+        "run_id": run_id,
+        "pid": None,
+        "kind": kind,
+        "argv": argv,
+        "cwd": cwd,
+        "label": label,
+        "notify_command": notify_command,
+        "notify_target": notify_target,
+        "submitted_at": _now_iso(),
+        "finished_at": None,
+        "status": "running",
+        "log": str(log_path),
+    }
+    _write_job(record)
+
     log_f = open(log_path, "wb")
     try:
         proc = subprocess.Popen(  # noqa: S603 — argv is the resolved li_command + CLI flags, no shell
@@ -224,23 +244,13 @@ def submit(
     finally:
         log_f.close()  # child holds its own fd; parent drops its copy
 
-    record = {
-        "run_id": run_id,
-        "pid": proc.pid,
-        "kind": kind,
-        "argv": argv,
-        "cwd": cwd,
-        "label": label,
-        "notify_command": notify_command,
-        "notify_target": notify_target,
-        "submitted_at": _now_iso(),
-        "finished_at": None,
-        "status": "running",
-        "log": str(log_path),
-    }
-    _write_job(record)
+    # Attach the pid without rewriting status: if the hook already recorded a
+    # terminal in the (tiny) spawn window, re-reading here preserves it.
+    latest = _read_job(run_id) or record
+    latest["pid"] = proc.pid
+    _write_job(latest)
 
-    return {"run_id": run_id, "pid": proc.pid, "status": "running", "log": str(log_path)}
+    return {"run_id": run_id, "pid": proc.pid, "status": latest["status"], "log": str(log_path)}
 
 
 def status(run_id: str) -> dict[str, Any]:
@@ -258,10 +268,15 @@ def status(run_id: str) -> dict[str, Any]:
     alive = _pid_alive(pid)
 
     recorded = (job or {}).get("status", "unknown")
+    finished = job is not None and job.get("finished_at") is not None
     if alive:
         state = "running"
-    elif recorded in _TERMINAL_STATES:
-        state = recorded  # authoritative terminal from the notify hook
+    elif finished:
+        # A terminal was recorded (notify hook or kill()). The CLI's own status
+        # string is authoritative and reported verbatim — never re-classified
+        # against a local vocabulary here, which is how "timed_out" once became
+        # a false "completed".
+        state = recorded
     elif job is not None:
         state = "exited"  # pid gone, no terminal record captured
     else:
@@ -354,11 +369,20 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
 
 
 def mark_terminal(run_id: str, cli_status: str) -> dict[str, Any] | None:
-    """Record a terminal status for *run_id* (called by the CLI notify hook)."""
+    """Record a terminal status for *run_id* (called by the CLI notify hook).
+
+    The CLI's terminal status string is authoritative and recorded verbatim. An
+    earlier version matched it against a local set and fell through to
+    ``"completed"`` on any miss, which silently turned every status the set did
+    not list — ``timed_out`` (the CLI's spelling for a timeout), ``cancelled``,
+    ``aborted``, ``completed_empty`` — into a false success. The hook fires only
+    on a genuine terminal, so the incoming status is trusted as-is and
+    ``finished_at`` marks the record terminal.
+    """
     job = _read_job(run_id)
     if job is None:
         return None
-    job["status"] = cli_status if cli_status in _TERMINAL_STATES else "completed"
+    job["status"] = cli_status
     job["cli_status"] = cli_status
     job["finished_at"] = _now_iso()
     _write_job(job)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Background job engine for the lionagi MCP server.
+
+``submit()`` spawns a ``li`` command as a detached process and returns immediately
+with the run_id. The id is pre-assigned via ``LIONAGI_RUN_ID`` so it is known
+before the child starts (no polling to discover it). ``status()`` / ``output()`` /
+``kill()`` / ``list_jobs()`` then operate on that id by reading the run state the
+CLI persists plus the MCP server's own small per-job record.
+
+The detached child gets its own session/pgid (``start_new_session``), so it
+survives an MCP-server restart and can still be signalled as a group. That is why
+job state lives on disk rather than in server memory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from . import config
+
+# li subcommand for each job kind. "orchestrate" is the canonical parser name
+# (the `o` alias also works); flow and fanout live under it.
+_KIND_ARGV: dict[str, list[str]] = {
+    "agent": ["agent"],
+    "flow": ["orchestrate", "flow"],
+    "fanout": ["orchestrate", "fanout"],
+}
+
+_TERMINAL_STATES = {"completed", "failed", "killed", "timeout", "exited"}
+
+# The terminal hook module, invoked by the CLI's --notify by absolute
+# interpreter path so it runs regardless of PATH in the CLI's environment.
+_NOTIFY_MODULE = "lionagi.mcp._notify_hook"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_run_id() -> str:
+    """Mint a run_id in the CLI's own format: ``YYYYMMDDTHHMMSS-<6hex>``."""
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    return f"{ts}-{uuid4().hex[:6]}"
+
+
+# --- record I/O ----------------------------------------------------------------
+
+
+def _write_job(record: dict[str, Any]) -> None:
+    d = config.job_dir(record["run_id"])
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "job.json").write_text(json.dumps(record, indent=2))
+
+
+def _read_job(run_id: str) -> dict[str, Any] | None:
+    p = config.job_dir(run_id) / "job.json"
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
+    p = config.run_manifest(run_id)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# --- process + log helpers -----------------------------------------------------
+
+
+def _pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 1:
+        return False
+    # A detached child is still OUR child, so once it exits unreaped it lingers
+    # as a zombie and `kill -0` would report it alive. Reap it first: waitpid
+    # returns (pid, _) if it just exited, (0, 0) if still running, and raises
+    # ChildProcessError when it is not our child (e.g. after an MCP-server
+    # restart, where init reaps it and a direct probe is authoritative).
+    try:
+        reaped, _ = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return False
+        if reaped == 0:
+            return True
+    except ChildProcessError:
+        pass
+    except OSError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _tail(path: str | None, limit: int = 4000) -> str | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        data = p.read_text(errors="replace")
+    except OSError:
+        return None
+    return data[-limit:] if len(data) > limit else data
+
+
+def _list_artifacts(run_id: str) -> list[str]:
+    adir = config.run_dir(run_id) / "artifacts"
+    if not adir.exists():
+        return []
+    return sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
+
+
+def _notify_template(run_id: str, notify_target: str | None, notify_command: str | None) -> str:
+    """Command the CLI runs on terminal status (records finished_at + delivery).
+
+    Invokes the terminal hook module by absolute interpreter path with a
+    ``{status}`` placeholder the CLI substitutes (a bareword, so it survives
+    the CLI's own shlex-split before being replaced). ``--target`` carries the
+    ``{target}`` value; ``--command`` carries an optional per-submit delivery
+    override.
+    """
+    parts = [
+        shlex.quote(sys.executable),
+        "-m",
+        _NOTIFY_MODULE,
+        "--run-id",
+        shlex.quote(run_id),
+        "--status",
+        "{status}",
+    ]
+    if notify_target:
+        parts += ["--target", shlex.quote(notify_target)]
+    if notify_command:
+        parts += ["--command", shlex.quote(notify_command)]
+    return " ".join(parts)
+
+
+# --- public API ----------------------------------------------------------------
+
+
+def submit(
+    kind: str,
+    flags: list[str],
+    *,
+    prompt: str | None = None,
+    cwd: str | None = None,
+    label: str | None = None,
+    notify_command: str | None = None,
+    notify_target: str | None = None,
+) -> dict[str, Any]:
+    """Spawn a ``li`` run in the background and return its handle immediately.
+
+    *flags* are the already-built CLI flags (everything except the prompt).
+    *prompt*, when given, is handed to an agent via ``--prompt-file`` (robust for
+    long text) or appended as the flow/fanout positional.
+
+    On terminal, the run records its status and — if a delivery command is
+    configured — sends a terminal notice. *notify_command* is an optional
+    per-submit delivery-argv override (JSON list); *notify_target* fills the
+    ``{target}`` placeholder in the configured command. With neither and no
+    configured default, the run simply records its status and delivers nothing.
+    """
+    if kind not in _KIND_ARGV:
+        raise ValueError(f"unknown job kind {kind!r}; expected one of {sorted(_KIND_ARGV)}")
+
+    run_id = new_run_id()
+    d = config.job_dir(run_id)
+    d.mkdir(parents=True, exist_ok=True)
+    log_path = d / "console.log"
+
+    tail = list(flags)
+    if prompt is not None:
+        if kind == "agent":
+            pf = d / "prompt.txt"
+            pf.write_text(prompt)
+            tail += ["--prompt-file", str(pf)]
+        else:
+            tail.append(prompt)  # flow/fanout take the prompt as a positional
+
+    # Wire the CLI's terminal hook back to the MCP server so we record a reliable
+    # finished_at/status (and fire the configured delivery) even across a restart.
+    tail = ["--notify", _notify_template(run_id, notify_target, notify_command), *tail]
+
+    argv = [*config.li_command(), *_KIND_ARGV[kind], *tail]
+
+    # Drop the parent harness marker so the detached child does not inherit an
+    # environment that claims it is running under an interactive harness.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    env[config.RUN_ID_ENV_VAR] = run_id
+
+    log_f = open(log_path, "wb")
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — argv is the resolved li_command + CLI flags, no shell
+            argv,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            cwd=cwd or None,
+            env=env,
+            start_new_session=True,  # own session/pgid: survives restart, killable as a group
+        )
+    finally:
+        log_f.close()  # child holds its own fd; parent drops its copy
+
+    record = {
+        "run_id": run_id,
+        "pid": proc.pid,
+        "kind": kind,
+        "argv": argv,
+        "cwd": cwd,
+        "label": label,
+        "notify_command": notify_command,
+        "notify_target": notify_target,
+        "submitted_at": _now_iso(),
+        "finished_at": None,
+        "status": "running",
+        "log": str(log_path),
+    }
+    _write_job(record)
+
+    return {"run_id": run_id, "pid": proc.pid, "status": "running", "log": str(log_path)}
+
+
+def status(run_id: str) -> dict[str, Any]:
+    """Current state of *run_id*.
+
+    ``status`` is the single authoritative field (the MCP record's terminal
+    status, corrected by pid liveness). ``run`` is the raw CLI manifest,
+    advisory only — its own ``status`` stays ``running`` until the CLI finalizes
+    it in the StateDB, so read ``status`` here, not ``run["status"]``.
+    ``notify_delivery`` reports whether the terminal notice was delivered.
+    """
+    job = _read_job(run_id)
+    manifest = _read_run_manifest(run_id)
+    pid = job.get("pid") if job else None
+    alive = _pid_alive(pid)
+
+    recorded = (job or {}).get("status", "unknown")
+    if alive:
+        state = "running"
+    elif recorded in _TERMINAL_STATES:
+        state = recorded  # authoritative terminal from the notify hook
+    elif job is not None:
+        state = "exited"  # pid gone, no terminal record captured
+    else:
+        state = "unknown"
+
+    return {
+        "run_id": run_id,
+        "kind": (job or {}).get("kind"),
+        "label": (job or {}).get("label"),
+        "status": state,
+        "alive": alive,
+        "pid": pid,
+        "submitted_at": (job or {}).get("submitted_at"),
+        "finished_at": (job or {}).get("finished_at"),
+        "notify_delivery": (job or {}).get("notify_delivery"),
+        "run": manifest,
+        "log_tail": _tail((job or {}).get("log")),
+        "known": job is not None,
+    }
+
+
+def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
+    """Terminal output of *run_id*: the console (an agent's final response prints
+    here) plus any persisted artifacts."""
+    job = _read_job(run_id)
+    if job is None:
+        return {"run_id": run_id, "known": False, "error": "no such job"}
+    st = status(run_id)
+    return {
+        "run_id": run_id,
+        "known": True,
+        "status": st["status"],
+        "console": _tail(job.get("log"), limit=tail_chars),
+        "artifacts": _list_artifacts(run_id),
+        "run_dir": str(config.run_dir(run_id)),
+    }
+
+
+def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
+    """Signal the whole process group of *run_id*."""
+    job = _read_job(run_id)
+    if job is None:
+        return {"run_id": run_id, "killed": False, "reason": "no such job"}
+    pid = job.get("pid")
+    if not pid or pid <= 1:  # never signal pgid 0/1 (self/init)
+        return {"run_id": run_id, "killed": False, "reason": "no pid on record"}
+    if not _pid_alive(pid):
+        return {"run_id": run_id, "killed": False, "reason": "already exited"}
+
+    reason: str | None = None
+    try:
+        os.killpg(os.getpgid(pid), sig)
+        killed = True
+    except ProcessLookupError:
+        killed, reason = False, "process gone"
+    except PermissionError as e:
+        killed, reason = False, f"permission denied: {e}"
+
+    if killed:
+        job["status"] = "killed"
+        job["finished_at"] = _now_iso()
+        _write_job(job)
+    return {"run_id": run_id, "killed": killed, "reason": reason, "pid": pid}
+
+
+def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[str, Any]]:
+    """Recent jobs, newest first (run_id sorts by timestamp)."""
+    if not config.JOBS_DIR.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for d in sorted(config.JOBS_DIR.iterdir(), reverse=True):
+        if not d.is_dir():
+            continue
+        st = status(d.name)
+        if status_filter and st["status"] != status_filter:
+            continue
+        out.append(
+            {
+                "run_id": st["run_id"],
+                "kind": st["kind"],
+                "label": st["label"],
+                "status": st["status"],
+                "submitted_at": st["submitted_at"],
+                "finished_at": st["finished_at"],
+            }
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def mark_terminal(run_id: str, cli_status: str) -> dict[str, Any] | None:
+    """Record a terminal status for *run_id* (called by the CLI notify hook)."""
+    job = _read_job(run_id)
+    if job is None:
+        return None
+    job["status"] = cli_status if cli_status in _TERMINAL_STATES else "completed"
+    job["cli_status"] = cli_status
+    job["finished_at"] = _now_iso()
+    _write_job(job)
+    return job
+
+
+def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> None:
+    """Record whether the terminal notice was delivered (called by the notify hook).
+
+    Surfaced by ``status`` so a completion notice that failed to send is visible
+    rather than silently lost — the detached-spawn pattern relies on that signal.
+    """
+    job = _read_job(run_id)
+    if job is None:
+        return
+    job["notify_delivery"] = outcome
+    _write_job(job)

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""lionagi MCP server.
+
+Every ``submit_*`` tool mirrors a ``li`` command; the only difference from the
+CLI is that it returns a run_id immediately instead of blocking until the run
+finishes. ``job_status`` / ``job_output`` / ``job_kill`` / ``jobs_list`` operate
+on that id by reading the state the CLI already persists.
+
+The submit tools deliberately expose the common flags as typed parameters (so
+callers do not have to remember CLI syntax) plus an ``extra_args`` escape hatch
+for the long tail of flags, so the surface never drifts out of reach of the CLI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from . import jobs
+
+mcp = FastMCP("lionagi")
+
+
+# --- submit tools (mirror the CLI) --------------------------------------------
+
+
+@mcp.tool
+def submit_agent(
+    prompt: str | None = None,
+    model: str | None = None,
+    agent: str | None = None,
+    effort: str | None = None,
+    cwd: str | None = None,
+    timeout: int | None = None,
+    resume: str | None = None,
+    continue_last: bool = False,
+    yolo: bool = False,
+    bypass: bool = False,
+    project: str | None = None,
+    resume_on_timeout: bool = False,
+    context_from: list[str] | None = None,
+    context_budget: int | None = None,
+    notify: str | None = None,
+    notify_seat: str | None = None,
+    label: str | None = None,
+    extra_args: list[str] | None = None,
+) -> dict[str, Any]:
+    """Submit a one-shot agent run in the background (mirrors ``li agent``).
+
+    Returns ``{run_id, pid, status}`` right away. Poll with ``job_status``, read
+    the final response with ``job_output``, stop it with ``job_kill``.
+
+    ``model`` is a spec like ``claude/opus`` or ``codex``; omit it when ``agent``
+    (a profile) or ``resume``/``continue_last`` already supplies one. ``agent``
+    loads a profile from ``.lionagi/agents/``.
+
+    On terminal the run records its status. If a delivery command is configured
+    (``notify`` here, or lionagi's ``notify.on_terminal`` setting) it also sends
+    a terminal notice; ``notify_seat`` fills that command's ``{target}``
+    placeholder. With nothing configured the run delivers nothing.
+    """
+    flags: list[str] = []
+    if model:
+        flags.append(model)  # leading positional model spec
+    if agent:
+        flags += ["-a", agent]
+    if resume:
+        flags += ["-r", resume]
+    if continue_last:
+        flags.append("-c")
+    if effort:
+        flags += ["--effort", effort]
+    if cwd:
+        flags += ["--cwd", cwd]
+    if timeout is not None:
+        flags += ["--timeout", str(timeout)]
+    if project:
+        flags += ["--project", project]
+    if resume_on_timeout:
+        flags.append("--resume-on-timeout")
+    for ref in context_from or []:
+        flags += ["--context-from", ref]
+    if context_budget is not None:
+        flags += ["--context-budget", str(context_budget)]
+    if yolo:
+        flags.append("--yolo")
+    if bypass:
+        flags.append("--bypass")
+    if extra_args:
+        flags += list(extra_args)
+
+    return jobs.submit(
+        "agent",
+        flags,
+        prompt=prompt,
+        cwd=cwd,
+        label=label,
+        notify_command=notify,
+        notify_target=notify_seat,
+    )
+
+
+@mcp.tool
+def submit_flow(
+    prompt: str | None = None,
+    model: str | None = None,
+    agent: str | None = None,
+    file: str | None = None,
+    playbook: str | None = None,
+    effort: str | None = None,
+    cwd: str | None = None,
+    timeout: int | None = None,
+    max_concurrent: int | None = None,
+    reactive: str | None = None,
+    with_synthesis: str | bool | None = None,
+    save: str | None = None,
+    yolo: bool = False,
+    bypass: bool = False,
+    project: str | None = None,
+    notify: str | None = None,
+    notify_seat: str | None = None,
+    label: str | None = None,
+    extra_args: list[str] | None = None,
+) -> dict[str, Any]:
+    """Submit an orchestrated flow in the background (mirrors ``li o flow``).
+
+    The orchestrator composes a DAG of agents and runs it with automatic
+    parallelism. Prompt may come from ``prompt``, ``file`` (-f), or ``playbook``
+    (-p). ``with_synthesis`` may be a model spec or ``True`` for the default.
+    """
+    flags: list[str] = []
+    if model:
+        flags.append(model)
+    if agent:
+        flags += ["-a", agent]
+    if file:
+        flags += ["-f", file]
+    if playbook:
+        flags += ["-p", playbook]
+    if effort:
+        flags += ["--effort", effort]
+    if cwd:
+        flags += ["--cwd", cwd]
+    if timeout is not None:
+        flags += ["--timeout", str(timeout)]
+    if max_concurrent is not None:
+        flags += ["--max-concurrent", str(max_concurrent)]
+    if reactive:
+        flags += ["--reactive", reactive]
+    if with_synthesis is not None:
+        if isinstance(with_synthesis, str):
+            flags += ["--with-synthesis", with_synthesis]
+        elif with_synthesis:
+            flags.append("--with-synthesis")
+    if save:
+        flags += ["--save", save]
+    if project:
+        flags += ["--project", project]
+    if yolo:
+        flags.append("--yolo")
+    if bypass:
+        flags.append("--bypass")
+    if extra_args:
+        flags += list(extra_args)
+
+    return jobs.submit(
+        "flow",
+        flags,
+        prompt=prompt,
+        cwd=cwd,
+        label=label,
+        notify_command=notify,
+        notify_target=notify_seat,
+    )
+
+
+@mcp.tool
+def submit_fanout(
+    prompt: str | None = None,
+    model: str | None = None,
+    agent: str | None = None,
+    num_workers: int | None = None,
+    workers: str | None = None,
+    pack: str | None = None,
+    max_concurrent: int | None = None,
+    with_synthesis: str | bool | None = None,
+    synthesis_prompt: str | None = None,
+    save: str | None = None,
+    cwd: str | None = None,
+    timeout: int | None = None,
+    yolo: bool = False,
+    bypass: bool = False,
+    project: str | None = None,
+    notify: str | None = None,
+    notify_seat: str | None = None,
+    label: str | None = None,
+    extra_args: list[str] | None = None,
+) -> dict[str, Any]:
+    """Submit a flat parallel fan-out in the background (mirrors ``li o fanout``).
+
+    ``num_workers`` copies of one worker, or ``workers`` as a comma-separated
+    list of model specs (M1,M2,...). ``synthesis_prompt`` drives an optional
+    synthesis pass over the workers' results.
+    """
+    flags: list[str] = []
+    if model:
+        flags.append(model)
+    if agent:
+        flags += ["-a", agent]
+    if num_workers is not None:
+        flags += ["--num-workers", str(num_workers)]
+    if workers:
+        flags += ["--workers", workers]
+    if pack:
+        flags += ["--pack", pack]
+    if max_concurrent is not None:
+        flags += ["--max-concurrent", str(max_concurrent)]
+    if with_synthesis is not None:
+        if isinstance(with_synthesis, str):
+            flags += ["--with-synthesis", with_synthesis]
+        elif with_synthesis:
+            flags.append("--with-synthesis")
+    if synthesis_prompt:
+        flags += ["--synthesis-prompt", synthesis_prompt]
+    if save:
+        flags += ["--save", save]
+    if cwd:
+        flags += ["--cwd", cwd]
+    if timeout is not None:
+        flags += ["--timeout", str(timeout)]
+    if project:
+        flags += ["--project", project]
+    if yolo:
+        flags.append("--yolo")
+    if bypass:
+        flags.append("--bypass")
+    if extra_args:
+        flags += list(extra_args)
+
+    return jobs.submit(
+        "fanout",
+        flags,
+        prompt=prompt,
+        cwd=cwd,
+        label=label,
+        notify_command=notify,
+        notify_target=notify_seat,
+    )
+
+
+# --- query tools --------------------------------------------------------------
+
+
+@mcp.tool
+def job_status(run_id: str) -> dict[str, Any]:
+    """Current state of a background run: liveness, MCP record, CLI manifest."""
+    return jobs.status(run_id)
+
+
+@mcp.tool
+def job_output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
+    """Terminal output of a run: console (an agent's final response) + artifacts."""
+    return jobs.output(run_id, tail_chars=tail_chars)
+
+
+@mcp.tool
+def job_kill(run_id: str) -> dict[str, Any]:
+    """Stop a running background job (signals its whole process group)."""
+    return jobs.kill(run_id)
+
+
+@mcp.tool
+def jobs_list(limit: int = 50, status: str | None = None) -> list[dict[str, Any]]:
+    """List recent background jobs, newest first; optionally filter by status."""
+    return jobs.list_jobs(limit=limit, status_filter=status)
+
+
+def main() -> None:
+    """Console entrypoint: run the server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,10 @@ mcp = [
     "starlette>=1.3.1",
     # fastmcp only requires mcp>=1.24.0,<2.0, which predates the advisories,
     # so pull the patched release forward here for the same dependency-hygiene
-    # reason as starlette above. lionagi
-    # uses MCP as a client only, so this floors the version we resolve rather
-    # than turning on any server-side transport protection.
+    # reason as starlette above. This extra covers both lionagi's MCP client use
+    # and the `li mcp` server, which serves over stdio (not an HTTP transport),
+    # so this floors the version we resolve rather than turning on any
+    # server-side transport protection.
     "mcp>=1.28.1",
 ]
 

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -141,6 +141,7 @@ TOP_LEVEL_COMMANDS = [
     "hooks",
     "invoke",
     "kill",
+    "mcp",
     "mirror",
     "mon",
     "monitor",

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for li CLI resolution (config.li_command).
+
+The server runs inside lionagi's own environment, so the CLI it spawns is the
+one installed next to the running interpreter — no working-tree hunting and no
+dependency resync on spawn.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from lionagi.mcp import config
+
+
+def test_li_bin_override_wins(monkeypatch):
+    monkeypatch.setenv("LIONAGI_MCP_LI_BIN", "/usr/bin/li --flag")
+    assert config.li_command() == ["/usr/bin/li", "--flag"]
+
+
+def test_prefers_li_next_to_interpreter(monkeypatch, tmp_path):
+    monkeypatch.delenv("LIONAGI_MCP_LI_BIN", raising=False)
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "python").write_text("#!/bin/sh\n")
+    li = bindir / "li"
+    li.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "executable", str(bindir / "python"))
+    assert config.li_command() == [str(li)]
+
+
+def test_module_fallback_when_no_sibling_li(monkeypatch, tmp_path):
+    monkeypatch.delenv("LIONAGI_MCP_LI_BIN", raising=False)
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "python").write_text("#!/bin/sh\n")  # no sibling `li`
+    monkeypatch.setattr(sys, "executable", str(bindir / "python"))
+    cmd = config.li_command()
+    assert cmd == [str(bindir / "python"), "-m", "lionagi.cli"]

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the background job engine.
+
+Popen is mocked throughout so no real `li` process is spawned; the tests assert
+on the argv/env the engine builds and on the on-disk job records it reads back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.mcp import config, jobs
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    """Point job/run state at a tmp dir so tests never touch the real ~/.lionagi."""
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    return tmp_path
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+def test_new_run_id_format():
+    rid = jobs.new_run_id()
+    ts, dash, suffix = rid.partition("-")
+    assert dash == "-"
+    assert len(ts) == len("YYYYMMDDTHHMMSS") and "T" in ts
+    assert len(suffix) == 6
+
+
+def test_submit_records_and_returns_handle(sandbox, monkeypatch):
+    captured: dict = {}
+
+    def fake_popen(argv, **kw):
+        captured["argv"] = argv
+        captured["kw"] = kw
+        return _FakeProc(4242)
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+
+    res = jobs.submit(
+        "agent",
+        ["-a", "reviewer"],
+        prompt="do the thing",
+        label="t1",
+        notify_target="downstream",
+    )
+    rid = res["run_id"]
+
+    assert res["pid"] == 4242 and res["status"] == "running"
+    # run_id handed to the child via env (race-free naming)
+    assert captured["kw"]["env"][config.RUN_ID_ENV_VAR] == rid
+    # detached into its own session
+    assert captured["kw"]["start_new_session"] is True
+    # CLAUDECODE stripped from the child env
+    assert "CLAUDECODE" not in captured["kw"]["env"]
+    # prompt via --prompt-file, notify wired, profile flag present
+    argv = captured["argv"]
+    assert "--prompt-file" in argv and "--notify" in argv and "-a" in argv
+    # record persisted
+    rec = jobs._read_job(rid)
+    assert rec["kind"] == "agent"
+    assert rec["status"] == "running"
+    assert rec["notify_target"] == "downstream"
+
+
+def _capture_popen(captured: dict):
+    def fake_popen(argv, **kw):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    return fake_popen
+
+
+def test_notify_template_bakes_hook_and_target(sandbox, monkeypatch):
+    """The --notify value invokes the terminal hook by interpreter -m, carries a
+    substitutable {status}, and bakes --target when a target is given."""
+    captured: dict = {}
+    monkeypatch.setattr(jobs.subprocess, "Popen", _capture_popen(captured))
+
+    jobs.submit("agent", ["-a", "reviewer"], prompt="x", notify_target="downstream")
+    argv = captured["argv"]
+    template = argv[argv.index("--notify") + 1]
+    assert "-m lionagi.mcp._notify_hook" in template
+    assert "--status {status}" in template
+    assert "--target downstream" in template
+
+
+def test_notify_template_no_target_no_command_when_absent(sandbox, monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(jobs.subprocess, "Popen", _capture_popen(captured))
+
+    res = jobs.submit("agent", ["-a", "reviewer"], prompt="x")  # no notify target/command
+    argv = captured["argv"]
+    template = argv[argv.index("--notify") + 1]
+    assert "--target" not in template
+    assert "--command" not in template
+    rec = jobs._read_job(res["run_id"])
+    assert rec["notify_target"] is None
+    assert rec["notify_command"] is None
+
+
+def test_notify_template_bakes_command_override(sandbox, monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(jobs.subprocess, "Popen", _capture_popen(captured))
+
+    jobs.submit(
+        "agent",
+        ["-a", "reviewer"],
+        prompt="x",
+        notify_command='["notify-send", "{status}"]',
+    )
+    argv = captured["argv"]
+    template = argv[argv.index("--notify") + 1]
+    assert "--command" in template
+
+
+def test_flow_prompt_is_positional(sandbox, monkeypatch):
+    captured: dict = {}
+
+    def fake_popen(argv, **kw):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+    jobs.submit("flow", ["-a", "orchestrator"], prompt="build the DAG")
+    argv = captured["argv"]
+    assert "--prompt-file" not in argv  # flow takes the prompt as a positional
+    assert argv[-1] == "build the DAG"
+
+
+def test_submit_rejects_unknown_kind(sandbox):
+    with pytest.raises(ValueError):
+        jobs.submit("bogus", [])
+
+
+def test_status_running_then_terminal(sandbox, monkeypatch):
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(999_999))
+    rid = jobs.submit("agent", [], prompt="x")["run_id"]
+
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    assert jobs.status(rid)["status"] == "running"
+
+    # pid gone, no terminal record captured -> exited
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    assert jobs.status(rid)["status"] == "exited"
+
+    # authoritative terminal recorded by the notify hook
+    jobs.mark_terminal(rid, "completed")
+    assert jobs.status(rid)["status"] == "completed"
+
+
+def test_pid_alive_reaps_zombie_child():
+    """A detached child that exited must not read as alive via kill -0 (zombie)."""
+    import subprocess
+    import time
+
+    p = subprocess.Popen(["sleep", "0.05"], start_new_session=True)
+    time.sleep(0.35)  # exited, but an unreaped zombie of this process
+    assert jobs._pid_alive(p.pid) is False
+
+
+def test_kill_guards_low_pid(sandbox):
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": 1, "kind": "agent", "status": "running", "log": None})
+    out = jobs.kill(rid)
+    assert out["killed"] is False and "no pid" in out["reason"]
+
+
+def test_kill_unknown_job(sandbox):
+    out = jobs.kill("nope")
+    assert out["killed"] is False and out["reason"] == "no such job"
+
+
+def test_mark_terminal_and_list(sandbox, monkeypatch):
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(4242))
+    rid = jobs.submit("agent", [], prompt="x")["run_id"]
+
+    job = jobs.mark_terminal(rid, "failed")
+    assert job["status"] == "failed" and job["finished_at"]
+    assert job["cli_status"] == "failed"
+
+    listed = jobs.list_jobs()
+    assert listed and listed[0]["run_id"] == rid
+    assert jobs.list_jobs(status_filter="failed")[0]["run_id"] == rid
+    assert jobs.list_jobs(status_filter="running") == []

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -179,6 +179,50 @@ def test_kill_unknown_job(sandbox):
     assert out["killed"] is False and out["reason"] == "no such job"
 
 
+@pytest.mark.parametrize("cli_status", ["timed_out", "cancelled", "aborted", "completed_empty"])
+def test_mark_terminal_records_cli_status_verbatim(sandbox, monkeypatch, cli_status):
+    """The CLI's terminal status is authoritative and recorded verbatim.
+
+    The CLI spells a timeout ``timed_out`` (agent/flow) and also emits
+    ``cancelled`` / ``aborted`` / ``completed_empty`` — none of which mean
+    success. A prior version matched against a local set and fell through to
+    ``completed`` on a miss, so a timed-out run reported success. Each real
+    terminal status must round-trip unchanged.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    rid = jobs.submit("agent", [], prompt="x")["run_id"]
+    jobs.mark_terminal(rid, cli_status)
+
+    assert jobs._read_job(rid)["status"] == cli_status
+    assert jobs.status(rid)["status"] == cli_status
+
+
+def test_submit_preserves_terminal_recorded_during_spawn(sandbox, monkeypatch):
+    """A terminal recorded in the spawn window is not clobbered back to running.
+
+    submit() persists the record before spawning, so the child's --notify hook
+    can mark it terminal immediately; the post-spawn write must only attach the
+    pid, never reset the status the hook set.
+    """
+
+    def racing_popen(argv, **kw):
+        # The child fires its terminal hook the instant it starts. The record
+        # already exists (persisted before spawn), so mark_terminal succeeds.
+        rid = kw["env"][config.RUN_ID_ENV_VAR]
+        jobs.mark_terminal(rid, "failed")
+        return _FakeProc(4321)
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", racing_popen)
+
+    res = jobs.submit("agent", [], prompt="x")
+    rec = jobs._read_job(res["run_id"])
+    assert rec["status"] == "failed"  # terminal survived the pid-attach write
+    assert rec["pid"] == 4321  # pid still attached
+    assert rec["finished_at"] is not None
+
+
 def test_mark_terminal_and_list(sandbox, monkeypatch):
     monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(4242))
     rid = jobs.submit("agent", [], prompt="x")["run_id"]

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the terminal notify hook.
+
+The hook is best-effort: it always records the terminal status on the job, then
+delivers a notice only through a *configured* command (never a hardcoded one),
+substituting run fields into its argv. The delivery outcome is recorded on the
+job so a dead notice is visible, not silently lost. subprocess.run is mocked so
+no real command is spawned.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp import _notify_hook, config, jobs
+
+
+@pytest.fixture
+def job(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_TARGET", raising=False)
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 4242,
+            "kind": "agent",
+            "label": "t1",
+            "cwd": None,
+            "status": "running",
+            "log": None,
+        }
+    )
+    return rid
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+
+
+def _no_settings_notifier(monkeypatch):
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **_kw: None,
+    )
+
+
+def test_marks_terminal_without_delivery(job, monkeypatch):
+    """No command configured: the status is recorded and nothing is spawned."""
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append((a, k)))
+    _no_settings_notifier(monkeypatch)  # lionagi's notify.on_terminal resolves to nothing
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+    assert rc == 0
+    rec = jobs._read_job(job)
+    assert rec["status"] == "completed"
+    assert calls == []  # nothing delivered
+    assert rec["notify_delivery"] == {"attempted": False}
+
+
+def test_command_override_substitutes_and_delivers(job, monkeypatch):
+    captured: dict = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["input"] = kw.get("input")
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+
+    command = json.dumps(["notify", "{run_id}", "{status}", "{label}", "{target}"])
+    rc = _notify_hook.main(
+        ["--run-id", job, "--status", "failed", "--target", "downstream", "--command", command]
+    )
+    assert rc == 0
+    rec = jobs._read_job(job)
+    assert rec["status"] == "failed"
+    assert captured["argv"] == ["notify", job, "failed", "t1", "downstream"]
+    # the same fields are offered as a JSON payload on stdin
+    payload = json.loads(captured["input"])
+    assert payload == {"run_id": job, "status": "failed", "label": "t1", "target": "downstream"}
+    assert rec["notify_delivery"] == {
+        "attempted": True,
+        "ok": True,
+        "exit_code": 0,
+        "error": None,
+    }
+
+
+def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
+    """A dead completion notice surfaces on the record, never a silent drop."""
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+
+    command = json.dumps(["notify", "{status}"])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+    assert rc == 0
+    assert jobs._read_job(job)["notify_delivery"] == {
+        "attempted": True,
+        "ok": False,
+        "exit_code": 7,
+        "error": None,
+    }
+
+
+def test_delivery_spawn_error_is_recorded(job, monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("no such command")
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", boom)
+
+    command = json.dumps(["nonexistent-notifier", "{status}"])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+    assert rc == 0
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["attempted"] is True and outcome["ok"] is False
+    assert outcome["error"] == "OSError"
+
+
+def test_malformed_command_override_delivers_nothing(job, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    _no_settings_notifier(monkeypatch)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
+    assert rc == 0
+    assert calls == []
+    assert jobs._read_job(job)["notify_delivery"] == {"attempted": False}
+
+
+def test_unknown_run_id_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    _no_settings_notifier(monkeypatch)
+    # No job record on disk: mark_terminal returns None, delivery still resolves
+    # to nothing, and the hook exits cleanly.
+    rc = _notify_hook.main(["--run-id", "nope", "--status", "completed"])
+    assert rc == 0
+    assert calls == []


### PR DESCRIPTION
## Summary

Adds `li mcp` — an MCP server (served over stdio) that submits `li` runs as detached background
jobs and exposes tools to query, tail, and stop them. It lets an MCP client fire off long-running
`li agent` / `li o flow` / `li o fanout` work without blocking, then poll for status and output.

Each `submit_*` tool mirrors a `li` command but returns a `run_id` immediately. The run keeps
going in its own process group (`start_new_session=True`), so it survives an MCP-server restart and
can still be signalled as a group.

## Tools

| Tool | Purpose |
|------|---------|
| `submit_agent` | Start a background `li agent` run; returns `run_id` + `pid`. |
| `submit_flow` | Start a background `li o flow` run. |
| `submit_fanout` | Start a background `li o fanout` run. |
| `job_status` | Authoritative status (corrected by pid liveness) + run manifest + log tail. |
| `job_output` | Console output (an agent's final response) + persisted artifacts. |
| `job_kill` | Signal the whole process group of a run. |
| `jobs_list` | Recent jobs, newest first, optionally filtered by status. |

## Design

- **Optional dependency.** `fastmcp` stays behind the existing `[mcp]` extra. Importing `lionagi`
  never pulls it, and the job engine + terminal notify hook are standard-library only, so the CLI's
  `--notify` terminal path runs even without the extra installed. `li mcp` raises a clean
  "install with `pip install 'lionagi[mcp]'`" if the extra is missing.
- **Authoritative state.** The run manifest under `~/.lionagi/runs/` stays the source of truth for
  run state; the server keeps a small per-job record under `~/.lionagi/mcp/jobs/` for the terminal
  status and delivery bookkeeping the manifest doesn't carry. `job_status` reads the job record's
  terminal status corrected by pid liveness, not the manifest's `status` field.
- **Configured terminal notices.** On terminal, a run records its status and — only if a delivery
  command is configured — sends a terminal notice. The command comes from lionagi's own
  `notify.on_terminal` setting, a per-submit override, or an env default; it is never hardcoded and
  is run by absolute argv, never through a shell. The delivery outcome is recorded on the job and
  surfaced in `job_status`, so a failed completion notice is visible rather than silently lost.

## Registration

```json
{
  "mcpServers": {
    "lionagi": { "command": "li", "args": ["mcp"] }
  }
}
```

## Tests

- `tests/mcp/test_config.py` — path + `li` command resolution.
- `tests/mcp/test_jobs.py` — the job engine (submit argv, status/liveness, kill guards, terminal marking).
- `tests/mcp/test_notify_hook.py` — the terminal hook records status, delivers only through a
  configured command, and records the delivery outcome.
- CLI surface golden updated to include `mcp`.

Docs: a `li mcp` section in `docs/cli-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
