### PR TITLE
fix(mcp): publish job records atomically (temp file + os.replace)

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -55,9 +55,17 @@ def new_run_id() -> str:
 
 
 def _write_job(record: dict[str, Any]) -> None:
+    # Publish atomically: write a unique temp file in the same directory, then
+    # os.replace() it into place. os.replace is atomic on the same filesystem, so
+    # a concurrent reader (status / list_jobs) never observes a torn file — and a
+    # failed write leaves the previous record intact instead of a partial one. The
+    # temp name is per-write-unique so two writers to the same run (the pid-attach
+    # write in submit() and the terminal hook) never collide on the temp itself.
     d = config.job_dir(record["run_id"])
     d.mkdir(parents=True, exist_ok=True)
-    (d / "job.json").write_text(json.dumps(record, indent=2))
+    tmp = d / f".job.json.{os.getpid()}.{uuid4().hex[:8]}.tmp"
+    tmp.write_text(json.dumps(record, indent=2))
+    os.replace(tmp, d / "job.json")
 
 
 def _read_job(run_id: str) -> dict[str, Any] | None:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -61,11 +61,20 @@ def _write_job(record: dict[str, Any]) -> None:
     # failed write leaves the previous record intact instead of a partial one. The
     # temp name is per-write-unique so two writers to the same run (the pid-attach
     # write in submit() and the terminal hook) never collide on the temp itself.
+    # This makes each publish all-or-nothing; it does not serialize two writers,
+    # so a read-modify-write pair can still lose an update (last replace wins).
     d = config.job_dir(record["run_id"])
     d.mkdir(parents=True, exist_ok=True)
     tmp = d / f".job.json.{os.getpid()}.{uuid4().hex[:8]}.tmp"
-    tmp.write_text(json.dumps(record, indent=2))
-    os.replace(tmp, d / "job.json")
+    try:
+        tmp.write_text(json.dumps(record, indent=2))
+        os.replace(tmp, d / "job.json")
+    except OSError:
+        # Do not leave the staging file behind: a run whose writes keep failing
+        # would otherwise accumulate orphans in its job dir. The original error
+        # still propagates.
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def _read_job(run_id: str) -> dict[str, Any] | None:

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -261,3 +261,5 @@ def test_write_job_publishes_atomically(sandbox, monkeypatch):
 
     # the previously published record is untouched — no partial write reached it
     assert jobs._read_job(rid) == good
+    # and the failed publish cleaned up its staging file rather than orphaning it
+    assert not list(config.job_dir(rid).glob(".job.json.*.tmp"))

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -235,3 +235,29 @@ def test_mark_terminal_and_list(sandbox, monkeypatch):
     assert listed and listed[0]["run_id"] == rid
     assert jobs.list_jobs(status_filter="failed")[0]["run_id"] == rid
     assert jobs.list_jobs(status_filter="running") == []
+
+
+def test_write_job_publishes_atomically(sandbox, monkeypatch):
+    """A failed write leaves the prior record intact, and a success leaves no temp.
+
+    _write_job stages a temp file then os.replace()s it into place, so a reader
+    never sees a torn file and a crash mid-write does not corrupt the existing
+    record.
+    """
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "status": "running", "pid": 7, "kind": "agent", "log": None})
+    good = jobs._read_job(rid)
+
+    # a successful publish renames the temp away — nothing lingers
+    assert not list(config.job_dir(rid).glob(".job.json.*.tmp"))
+
+    # simulate a crash during publish: the rename raises after the temp is written
+    def boom(_src, _dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(jobs.os, "replace", boom)
+    with pytest.raises(OSError):
+        jobs._write_job({"run_id": rid, "status": "failed", "pid": 7, "kind": "agent", "log": None})
+
+    # the previously published record is untouched — no partial write reached it
+    assert jobs._read_job(rid) == good


### PR DESCRIPTION
## Summary

Follow-up hardening for the `li mcp` background-job engine: `_write_job` now
publishes the per-job record atomically.

## Problem

`_write_job` wrote `job.json` in place with `write_text`. Two consequences:

- A concurrent reader (`job_status` / `jobs_list`) could observe a torn file
  mid-write. The reader catches `JSONDecodeError` and treats it as "no record",
  which loses the record for that call.
- A write that failed partway (e.g. a full disk) could leave a corrupt record on
  disk.

## Fix

`_write_job` stages a per-write-unique temp file in the same directory and
`os.replace()`s it into place. `os.replace` is atomic on a single filesystem, so:

- a reader never observes a partial file, and
- a failed write leaves the previous record intact rather than a partial one.

A failed publish also removes its staging file rather than orphaning it, so a run
whose writes keep failing does not accumulate temp files in its job directory.
The original error still propagates.

### Scope

This makes each publish all-or-nothing. It does **not** serialize two writers, so
a read-modify-write pair can still lose an update (last replace wins) — the
pid-attach write in `submit()` can still race the terminal hook's write between
its read and its replace. That window is narrowed, not closed; its outcome stays
benign and visible (a job reads as `exited`, never as a false success). Closing it
fully would require file locking, which the risk does not warrant.

## Tests

- `test_write_job_publishes_atomically`: a failed publish leaves the previously
  published record unchanged and leaves no staging file behind; a successful
  publish leaves no staging file either.

Full MCP suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
