### PR TITLE
fix(service): identify plugin activation entries by provenance, not defining module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The built-in provider collision filter no longer misses a plugin entry whose endpoint class
+  comes from a helper module. `_reject_builtin_collisions` identified an activation's entries by
+  requiring the class to be defined in the activated provider module, but a provider module may
+  register a class supplied by a helper or generated module. Such an entry carries the same
+  provenance `register` already records while its `__module__` differs, so it stayed registered
+  and silently took over a provider name a built-in serves, with no rejection diagnostic. The
+  filter now identifies activation entries by that recorded provenance alone.
+
+## [0.30.2] - 2026-07-23
+
+### Fixed
+
 - `to_list(..., unique=True)` no longer drops unequal items whose structural hashes collide.
   When the input holds an unhashable value, deduplication falls back to hashing; that fallback
   compared by hash alone, so two unequal mappings with colliding hashes (e.g. `{"x": -1}` and

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -564,7 +564,7 @@ class EndpointRegistry:
                         if module_name is not None and entry.cls.__module__ == module_name:
                             entry.plugin_name = plugin_name
                             entry.plugin_target = module
-                    cls._reject_builtin_collisions(plugin_name, module, module_name)
+                    cls._reject_builtin_collisions(plugin_name, module)
                     imported = True
                 except PluginActivationError:
                     continue
@@ -588,18 +588,19 @@ class EndpointRegistry:
         return imported
 
     @classmethod
-    def _reject_builtin_collisions(
-        cls, plugin_name: str, module: str, module_name: str | None
-    ) -> None:
+    def _reject_builtin_collisions(cls, plugin_name: str, module: str) -> None:
         """ADR-0088 D6: a plugin provider must never silently take over a
         provider name a built-in already serves. Drop (and log) any entry
         this activation just added whose provider name (or provider alias)
         matches an already-registered built-in entry -- the built-in stays
         authoritative and the plugin entry is rejected.
-        """
-        if module_name is None:
-            return
 
+        Activation entries are identified by the provenance ``register``
+        already recorded, not by where the endpoint class was defined: a
+        provider module may register a class supplied by a helper or
+        generated module, and such an entry carries the same provenance
+        while its ``__module__`` differs.
+        """
         builtin_names: set[str] = set()
         for entry in cls._entries:
             if entry.plugin_name is None:
@@ -610,11 +611,7 @@ class EndpointRegistry:
 
         rejected: list[_RegistryEntry] = []
         for entry in cls._entries:
-            is_this_activation = (
-                entry.plugin_name == plugin_name
-                and entry.plugin_target == module
-                and entry.cls.__module__ == module_name
-            )
+            is_this_activation = entry.plugin_name == plugin_name and entry.plugin_target == module
             collides = entry.meta.provider in builtin_names or any(
                 alias in builtin_names for alias in entry.meta.provider_aliases
             )

--- a/tests/service/connections/test_registry.py
+++ b/tests/service/connections/test_registry.py
@@ -233,7 +233,6 @@ class TestConcurrentRegistrationAndRemoval:
         EndpointRegistry._reject_builtin_collisions(
             "rejected-plugin",
             "rejected-plugin:_RejectedPluginEndpoint",
-            _RejectedPluginEndpoint.__module__,
         )
 
         assert entry not in EndpointRegistry._entries
@@ -251,6 +250,31 @@ class TestConcurrentRegistrationAndRemoval:
             pass
 
         assert EndpointRegistry._alias_owners["orphan-alias-f2359"] == "replacement-provider-f2359"
+
+    def test_builtin_collision_rejection_covers_helper_module_registration(self):
+        """A provider module may register an endpoint class that a helper or
+        generated module supplies. The entry carries the activation's
+        provenance but a different ``__module__``, and the built-in must
+        still win."""
+
+        class _HelperSuppliedEndpoint(Endpoint):
+            pass
+
+        _HelperSuppliedEndpoint.__module__ = "helper_plugin._generated_endpoints"
+        EndpointRegistry.register(
+            provider="openai",
+            endpoint="chat",
+            provider_aliases=["orphan-alias-a71c4"],
+        )(_HelperSuppliedEndpoint)
+
+        entry = next(e for e in EndpointRegistry._entries if e.cls is _HelperSuppliedEndpoint)
+        entry.plugin_name = "helper-plugin"
+        entry.plugin_target = "helper_plugin.providers"
+
+        EndpointRegistry._reject_builtin_collisions("helper-plugin", "helper_plugin.providers")
+
+        assert entry not in EndpointRegistry._entries
+        assert "orphan-alias-a71c4" not in EndpointRegistry._alias_owners
 
 
 class TestOptionalDependencyPreflight:


### PR DESCRIPTION
## Problem

The built-in provider collision filter (`EndpointRegistry._reject_builtin_collisions`) decided
which registry entries belonged to the activation it was filtering by requiring three things to
match: the entry's `plugin_name`, its `plugin_target`, and that the endpoint class was **defined
in** the activated provider module (`entry.cls.__module__ == module_name`).

That last predicate is stricter than the provenance the registry already records. `register()`
stamps `(plugin_name, plugin_target)` from the activation thread-local for whatever class is
being registered, with no requirement that the class be defined in the activated module. A
provider module may legitimately register an endpoint class supplied by a helper or generated
module. Such an entry has correct provenance but a different `__module__`, so the filter skipped
it: it stayed registered, silently taking over a provider name a built-in serves, and emitted no
rejection diagnostic.

The existing tests only covered a class defined in the provider module, so this path was
untested.

## Change

Identify an activation's entries by the recorded provenance alone. The now-unused `module_name`
parameter goes with it, which also removes an early `return` that disabled the whole filter
whenever the activated object had no `__name__`.

## Verification

Adds a regression test that registers a colliding endpoint class whose `__module__` is a helper
module. Confirmed it fails against the previous predicate and passes with the fix. Full suite run
locally shows no new failures.

Closes #2340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
