### PR TITLE
fix(mcp): distinguish a broken notifier from an unconfigured one

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -555,6 +555,15 @@ async def _run_agent(
             register_flow_notify_scope,
             unregister_flow_notify_scope,
         )
+        from lionagi.state.lifecycle.notify_settings import (
+            record_notify_rejection_to_run,
+        )
+
+        def _notify_override_refused(reason: str) -> None:
+            # This run explicitly asked for a notifier and will not get one.
+            # Recording it here is what keeps a refusal distinguishable from
+            # never having configured one; both otherwise register nothing.
+            record_notify_rejection_to_run(run, reason)
 
         _notify_scope_name = register_flow_notify_scope(
             override=notify,
@@ -566,6 +575,7 @@ async def _run_agent(
             save_dir=str(run.artifact_root),
             cwd=cwd or os.getcwd(),
             started_at=run_manifest["started_at"],
+            on_rejection=_notify_override_refused,
         )
 
     # notify.on_terminal (settings-driven, independent of --notify) outcome

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -72,7 +72,9 @@ def register_flow_notify_scope(
     ``unregister_flow_notify_scope`` in a ``finally`` block), or ``None`` if
     *override* resolved to disabled (never raised).
     """
-    resolved = resolve_notify_config(override=override)
+    # A rejected override is already reported through the resolver's warning;
+    # this registration only needs to know whether there is something to launch.
+    resolved = resolve_notify_config(override=override).handler
     if resolved is None:
         return None
     payload_fn = _legacy_payload_builder(

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -8,6 +8,7 @@ adapter for this run's entity. See docs/internals/cli.md.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 from lionagi.cli.status import _classify
 from lionagi.state.lifecycle.callbacks import (
@@ -66,15 +67,25 @@ def register_flow_notify_scope(
     save_dir: str | None,
     cwd: str,
     started_at: float,
+    on_rejection: Callable[[str], None] | None = None,
 ) -> str | None:
     """Register the `--notify` legacy-payload adapter scoped to this run's
     own terminal entity. Returns the registration name (pass to
     ``unregister_flow_notify_scope`` in a ``finally`` block), or ``None`` if
     *override* resolved to disabled (never raised).
+
+    *on_rejection*, if given, is called with a stable reason when an override
+    was asked for and refused, whether the spec itself was rejected or the
+    handler could not be built from it. A caller bound to a run passes this to
+    record the refusal; without it, asking for a notifier and being refused
+    looks exactly like never having asked, since both return ``None``.
     """
-    # A rejected override is already reported through the resolver's warning;
-    # this registration only needs to know whether there is something to launch.
-    resolved = resolve_notify_config(override=override).handler
+    resolution = resolve_notify_config(override=override)
+    if resolution.reason is not None:
+        if on_rejection is not None:
+            on_rejection(resolution.reason)
+        return None
+    resolved = resolution.handler
     if resolved is None:
         return None
     payload_fn = _legacy_payload_builder(
@@ -104,7 +115,13 @@ def register_flow_notify_scope(
             _INVOCATION_ID_ENV: invocation_id or "",
         }
 
-    handler = build_handler(resolved, payload_fn=payload_fn, argv_fn=_argv_fn, env_fn=_env_fn)
+    handler = build_handler(
+        resolved,
+        payload_fn=payload_fn,
+        argv_fn=_argv_fn,
+        env_fn=_env_fn,
+        on_build_failure=on_rejection,
+    )
     if handler is None:
         return None
     name = f"notify.flow.{entity_kind}.{entity_id}"

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -8,6 +8,7 @@ adapter for this run's entity. See docs/internals/cli.md.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 
 from lionagi.cli.status import _classify
@@ -22,6 +23,8 @@ from lionagi.state.lifecycle.notify_settings import (
 )
 
 __all__ = ("register_flow_notify_scope", "unregister_flow_notify_scope")
+
+logger = logging.getLogger(__name__)
 
 _PAYLOAD_ENV = "LIONAGI_NOTIFY_PAYLOAD"
 _STATUS_ENV = "LIONAGI_NOTIFY_STATUS"
@@ -80,10 +83,21 @@ def register_flow_notify_scope(
     record the refusal; without it, asking for a notifier and being refused
     looks exactly like never having asked, since both return ``None``.
     """
+
+    def _report(reason: str) -> None:
+        # Bookkeeping about a refusal must never turn into a second failure:
+        # the caller's notifier is already not going to fire, and aborting
+        # registration here would lose the reason as well.
+        if on_rejection is None:
+            return
+        try:
+            on_rejection(reason)
+        except Exception:  # noqa: BLE001 -- bookkeeping must never affect the run
+            logger.debug("failed to record notify override rejection", exc_info=True)
+
     resolution = resolve_notify_config(override=override)
     if resolution.reason is not None:
-        if on_rejection is not None:
-            on_rejection(resolution.reason)
+        _report(resolution.reason)
         return None
     resolved = resolution.handler
     if resolved is None:
@@ -120,7 +134,7 @@ def register_flow_notify_scope(
         payload_fn=payload_fn,
         argv_fn=_argv_fn,
         env_fn=_env_fn,
-        on_build_failure=on_rejection,
+        on_build_failure=_report,
     )
     if handler is None:
         return None

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -133,6 +133,16 @@ async def _run_fanout(
     # records are finalized externally and would never fire.
     _notify_scope_name: str | None = None
     if notify:
+        from lionagi.state.lifecycle.notify_settings import (
+            record_notify_rejection_to_run,
+        )
+
+        def _notify_override_refused(reason: str) -> None:
+            # This run explicitly asked for a notifier and will not get one.
+            # Recording it here is what keeps a refusal distinguishable from
+            # never having configured one; both otherwise register nothing.
+            record_notify_rejection_to_run(env.run, reason)
+
         _notify_scope_name = register_flow_notify_scope(
             override=notify,
             entity_kind="session",
@@ -143,6 +153,7 @@ async def _run_fanout(
             save_dir=save_dir,
             cwd=cwd or os.getcwd(),
             started_at=_started_at,
+            on_rejection=_notify_override_refused,
         )
 
     inner_kw = dict(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1747,6 +1747,16 @@ async def _run_flow(
     _notify_entity_kind = "invocation" if invocation_id else "session"
     _notify_entity_id = invocation_id if invocation_id else str(env.session.id)
     if notify:
+        from lionagi.state.lifecycle.notify_settings import (
+            record_notify_rejection_to_run,
+        )
+
+        def _notify_override_refused(reason: str) -> None:
+            # This run explicitly asked for a notifier and will not get one.
+            # Recording it here is what keeps a refusal distinguishable from
+            # never having configured one; both otherwise register nothing.
+            record_notify_rejection_to_run(env.run, reason)
+
         _notify_scope_name = register_flow_notify_scope(
             override=notify,
             entity_kind=_notify_entity_kind,
@@ -1757,6 +1767,7 @@ async def _run_flow(
             save_dir=save_dir,
             cwd=cwd or os.getcwd(),
             started_at=_started_at,
+            on_rejection=_notify_override_refused,
         )
 
     # notify.on_terminal (settings-driven, independent of --notify) outcome

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -16,6 +16,8 @@ raise into the CLI's terminal path):
    ``{status}``, ``{label}`` and ``{target}`` are substituted into its argv and
    the same fields are also offered as a JSON payload on stdin. With nothing
    configured there is no delivery — the out-of-the-box default is silence.
+   A notifier that *is* configured but cannot be used is recorded as a delivery
+   failure with a named reason, so it never passes for that default silence.
 
 The command is run by absolute argv (never through a shell), so a caller wires
 whatever notifier they use (a webhook client, a messaging CLI) without this
@@ -40,32 +42,53 @@ from . import jobs
 _DELIVERY_TIMEOUT_S = 30
 
 
-def _resolve_command(override: str | None, *, cwd: str | None) -> list[str] | None:
-    """The delivery argv template, or None when nothing is configured.
+def _resolve_command(
+    override: str | None, *, cwd: str | None
+) -> tuple[list[str] | None, str | None]:
+    """The delivery argv template, paired with why there is none.
+
+    Returns ``(argv, None)`` when a template resolved, ``(None, None)`` when
+    nothing is configured, and ``(None, reason)`` when something *was*
+    configured but cannot be used.
+
+    That third case is why this returns a pair. "Nobody asked for a notice" and
+    "a notice was asked for and this hook cannot send it" are opposite
+    situations, and reporting both as no-delivery makes a broken notifier
+    indistinguishable from an unconfigured one — which for a detached run is the
+    worst outcome available, because the caller is waiting on a notice that will
+    never come and nothing anywhere says so. Silence is only ever correct when
+    it was chosen.
 
     *override* (a JSON argv list) wins outright. Otherwise lionagi's own
     ``notify.on_terminal`` setting is reused as the single delivery-config
-    surface — its ``exec`` adapter's argv is the template. Any resolution
-    failure yields None (no delivery), never an exception.
+    surface — its ``exec`` adapter's argv is the template. Nothing here raises:
+    the run has already finished, so a resolution failure is reported through
+    the returned reason, never thrown into the CLI's terminal path.
     """
     if override:
         try:
             parsed = json.loads(override)
         except json.JSONDecodeError:
-            return None
-        if isinstance(parsed, list) and all(isinstance(tok, str) for tok in parsed) and parsed:
-            return parsed
-        return None
+            return None, "delivery_command_is_not_valid_json"
+        if not isinstance(parsed, list) or not all(isinstance(tok, str) for tok in parsed):
+            return None, "delivery_command_is_not_a_list_of_strings"
+        if not parsed:
+            return None, "delivery_command_is_empty"
+        return parsed, None
 
     try:
         from lionagi.state.lifecycle.notify_settings import resolve_notify_config
 
         resolved = resolve_notify_config(project_dir=cwd)
-    except Exception:  # noqa: BLE001 — a settings problem must never break the terminal path
-        return None
-    if resolved is None or resolved.argv is None:
-        return None
-    return list(resolved.argv)
+    except Exception as exc:  # noqa: BLE001 — a settings problem must never break the terminal path
+        return None, f"notify_settings_unreadable:{type(exc).__name__}"
+    if resolved is None:
+        return None, None  # no notifier configured — silence by choice
+    if resolved.argv is None:
+        # A notifier is configured but is not an exec adapter, so it has no argv
+        # this hook can run. Configured-and-unusable, not unconfigured.
+        return None, "configured_notifier_has_no_delivery_command"
+    return list(resolved.argv), None
 
 
 def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
@@ -120,7 +143,7 @@ def main(argv: list[str] | None = None) -> int:
 
     target = args.target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
     label = (job or {}).get("label") or (job or {}).get("kind") or "run"
-    template = _resolve_command(
+    template, unusable = _resolve_command(
         args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
         cwd=(job or {}).get("cwd"),
     )
@@ -132,6 +155,11 @@ def main(argv: list[str] | None = None) -> int:
             "target": target,
         }
         outcome = _deliver(_substitute(template, fields), fields)
+    elif unusable:
+        # Configured but unusable. Recorded as a failure so job_status shows a
+        # notifier that cannot deliver, rather than the silence of one that was
+        # never asked to.
+        outcome = {"attempted": False, "ok": False, "exit_code": None, "error": unusable}
     else:
         outcome = {"attempted": False}  # nothing configured — not a failure
     jobs.record_notify_delivery(args.run_id, outcome)

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -79,9 +79,16 @@ def _resolve_command(
     try:
         from lionagi.state.lifecycle.notify_settings import resolve_notify_config
 
-        resolved = resolve_notify_config(project_dir=cwd)
+        resolution = resolve_notify_config(project_dir=cwd)
+        # Read inside the guard too: a settings problem must never break the
+        # terminal path, whichever step of the resolution it surfaces from.
+        reason, resolved = resolution.reason, resolution.handler
     except Exception as exc:  # noqa: BLE001 — a settings problem must never break the terminal path
         return None, f"notify_settings_unreadable:{type(exc).__name__}"
+    if reason is not None:
+        # Settings named a notifier and the resolver refused it — a misconfigured
+        # notifier, not an absent one. The reason is what tells the two apart.
+        return None, reason
     if resolved is None:
         return None, None  # no notifier configured — silence by choice
     if resolved.argv is None:

--- a/lionagi/state/lifecycle/notify_settings.py
+++ b/lionagi/state/lifecycle/notify_settings.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = (
+    "NotifyConfigResolution",
     "PayloadBuilder",
     "ResolvedNotifyHandler",
     "build_handler",
@@ -88,15 +89,47 @@ class ResolvedNotifyHandler:
     filter_ids: tuple[str, ...] | None = None
 
 
+@dataclass(frozen=True)
+class NotifyConfigResolution:
+    """The outcome of resolving ``notify.on_terminal``: a handler, or why not.
+
+    ``reason`` is set if and only if a notifier was asked for and rejected.
+    Chosen silence -- nothing configured, or notification explicitly turned
+    off -- carries no reason, because nothing was rejected. Collapsing the two
+    into a bare None is what makes a misconfigured notifier indistinguishable
+    from an absent one, and a detached caller then waits on a notice that will
+    never arrive with nothing anywhere saying so.
+
+    Reasons are short stable identifiers, never interpolated user data: they
+    are persisted and read back, so they are a contract. The offending value
+    goes in the matching warning instead.
+    """
+
+    handler: ResolvedNotifyHandler | None = None
+    reason: str | None = None
+
+
+# Nothing was configured, so there is nothing to report -- silence by choice.
+_NOT_CONFIGURED = NotifyConfigResolution()
+
+
+def _rejected(reason: str) -> NotifyConfigResolution:
+    """A notifier was configured and this resolution refused it."""
+    return NotifyConfigResolution(reason=reason)
+
+
 def resolve_notify_config(
     *,
     settings: dict[str, Any] | None = None,
     override: str | dict[str, Any] | None = None,
     project_dir: str | None = None,
-) -> ResolvedNotifyHandler | None:
-    """Resolve ``notify.on_terminal`` to a handler spec, or ``None`` (disabled).
+) -> NotifyConfigResolution:
+    """Resolve ``notify.on_terminal`` to a handler spec, or to why there is none.
     *override* wins outright when supplied; otherwise settings are loaded
     once (snapshot semantics) via the project-then-global merge.
+
+    Always returns a :class:`NotifyConfigResolution`; see it for how a rejected
+    notifier is distinguished from an unconfigured one.
     """
     if override is not None:
         return _resolve_shape(override, scope="override")
@@ -106,15 +139,15 @@ def resolve_notify_config(
             settings = load_settings(project_dir=project_dir)
         except Exception as exc:  # noqa: BLE001 -- malformed settings must never affect the run
             logger.warning("notify.on_terminal settings resolution failed: %s", exc)
-            return None
+            return _rejected("settings_load_failed")
     notify_cfg = settings.get("notify") if isinstance(settings, dict) else None
     source = notify_cfg.get("on_terminal") if isinstance(notify_cfg, dict) else None
     if source is None:
-        return None
+        return _NOT_CONFIGURED  # no notifier configured -- the documented default
     return _resolve_shape(source, scope="settings")
 
 
-def _resolve_shape(source: Any, *, scope: str) -> ResolvedNotifyHandler | None:
+def _resolve_shape(source: Any, *, scope: str) -> NotifyConfigResolution:
     if isinstance(source, str):
         return _resolve_string(source, scope=scope)
     if isinstance(source, dict):
@@ -125,16 +158,16 @@ def _resolve_shape(source: Any, *, scope: str) -> ResolvedNotifyHandler | None:
         type(source).__name__,
         source,
     )
-    return None
+    return _rejected("on_terminal_not_string_or_mapping")
 
 
-def _resolve_string(command: str, *, scope: str) -> ResolvedNotifyHandler | None:
+def _resolve_string(command: str, *, scope: str) -> NotifyConfigResolution:
     if not command.strip():
         _warn_empty_argv(scope)
-        return None
+        return _rejected("on_terminal_command_is_empty")
     if _looks_like_shell(command):
         _warn_shell_feature(command, scope)
-        return None
+        return _rejected("on_terminal_command_requires_shell_features")
     try:
         argv = shlex.split(command)
     except ValueError as exc:
@@ -146,16 +179,18 @@ def _resolve_string(command: str, *, scope: str) -> ResolvedNotifyHandler | None
             command,
             exc,
         )
-        return None
+        return _rejected("on_terminal_command_not_parseable")
     if not argv:
         _warn_empty_argv(scope)
-        return None
-    return ResolvedNotifyHandler(argv=tuple(argv))
+        return _rejected("on_terminal_command_is_empty")
+    return NotifyConfigResolution(handler=ResolvedNotifyHandler(argv=tuple(argv)))
 
 
-def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandler | None:
+def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> NotifyConfigResolution:
     if cfg.get("enabled") is False:
-        return None
+        # Notification was configured off. Nothing was rejected, so this is the
+        # chosen silence, not a failure to report back to the operator.
+        return _NOT_CONFIGURED
 
     filter_kinds: tuple[str, ...] | None = None
     filter_ids: tuple[str, ...] | None = None
@@ -168,7 +203,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                 scope,
                 filt,
             )
-            return None
+            return _rejected("filter_not_a_mapping")
 
         unknown_keys = tuple(key for key in filt if key not in {"kinds", "ids"})
         if unknown_keys:
@@ -178,7 +213,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                 scope,
                 unknown_keys,
             )
-            return None
+            return _rejected("filter_has_unknown_keys")
 
         if "kinds" in filt:
             kinds = filt["kinds"]
@@ -193,7 +228,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                     scope,
                     kinds,
                 )
-                return None
+                return _rejected("filter_kinds_not_a_list_of_strings")
             unsupported_kinds = tuple(kind for kind in kinds if kind not in EXECUTION_ENTITY_KINDS)
             if unsupported_kinds:
                 logger.warning(
@@ -203,7 +238,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                     unsupported_kinds,
                     tuple(sorted(EXECUTION_ENTITY_KINDS)),
                 )
-                return None
+                return _rejected("filter_kinds_unsupported")
             filter_kinds = tuple(kinds)
 
         if "ids" in filt:
@@ -219,7 +254,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                     scope,
                     ids,
                 )
-                return None
+                return _rejected("filter_ids_not_a_list_of_strings")
             filter_ids = tuple(ids)
 
     adapter = cfg.get("adapter")
@@ -230,7 +265,10 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                 "adapter configured; resolving to disabled.",
                 scope,
             )
-        return None
+            return _rejected("enabled_without_adapter")
+        # A mapping that never asked to be enabled and names no adapter asked
+        # for nothing; that is the chosen silence, not a rejected notifier.
+        return _NOT_CONFIGURED
 
     kind = adapter.get("kind")
     if kind == "exec":
@@ -242,12 +280,14 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                 scope,
                 argv,
             )
-            return None
+            return _rejected("exec_adapter_argv_not_a_list_of_strings")
         if not argv:
             _warn_empty_argv(scope)
-            return None
-        return ResolvedNotifyHandler(
-            argv=tuple(argv), filter_kinds=filter_kinds, filter_ids=filter_ids
+            return _rejected("on_terminal_command_is_empty")
+        return NotifyConfigResolution(
+            handler=ResolvedNotifyHandler(
+                argv=tuple(argv), filter_kinds=filter_kinds, filter_ids=filter_ids
+            )
         )
 
     if kind == "python":
@@ -259,9 +299,11 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
                 scope,
                 ref,
             )
-            return None
-        return ResolvedNotifyHandler(
-            python_ref=ref, filter_kinds=filter_kinds, filter_ids=filter_ids
+            return _rejected("python_adapter_ref_invalid")
+        return NotifyConfigResolution(
+            handler=ResolvedNotifyHandler(
+                python_ref=ref, filter_kinds=filter_kinds, filter_ids=filter_ids
+            )
         )
 
     logger.warning(
@@ -270,7 +312,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> ResolvedNotifyHandle
         scope,
         kind,
     )
-    return None
+    return _rejected("adapter_kind_unsupported")
 
 
 # Returns the path the adapter's stderr was captured to, or None.
@@ -565,7 +607,7 @@ def register_settings_terminal_callback(
     CLI entry point and Studio service startup each call this once per
     process). Returns ``True`` iff a handler was installed.
     """
-    resolved = resolve_notify_config(project_dir=project_dir)
+    resolved = resolve_notify_config(project_dir=project_dir).handler
     if resolved is None:
         registry.unregister(name)
         return False
@@ -602,7 +644,7 @@ def register_run_notify_outcome_scope(
     ``None`` if notify.on_terminal resolved to disabled or if this entity is
     excluded by the configured filter (never raises).
     """
-    resolved = resolve_notify_config(project_dir=project_dir)
+    resolved = resolve_notify_config(project_dir=project_dir).handler
     if resolved is None:
         return None
     # The scoped registration is an override, so it dispatches on its own

--- a/lionagi/state/lifecycle/notify_settings.py
+++ b/lionagi/state/lifecycle/notify_settings.py
@@ -356,6 +356,26 @@ def _record_notify_outcome_to_run(
     return stderr_path
 
 
+def _record_notify_rejection_to_run(run: RunDir, reason: str) -> None:
+    """Best-effort: record into *run*'s own notify_outcome.json that a notifier
+    was configured for this run and refused, so the run says which of the two
+    silences it is. A run with nothing configured writes no file at all; a run
+    whose notifier could not be resolved or built writes an unsuccessful
+    outcome carrying the stable reason. Without this, a caller waiting on a
+    terminal notice that can never arrive sees exactly what a caller that never
+    asked for one sees. Never raises.
+
+    ``exit_code`` and ``stderr_path`` are null because nothing was launched:
+    the adapter was refused before it could run.
+    """
+    try:
+        run.write_notify_outcome(
+            {"ok": False, "exit_code": None, "stderr_path": None, "reason": reason}
+        )
+    except Exception:  # noqa: BLE001 -- outcome bookkeeping must never affect the run
+        logger.debug("failed to record notify.on_terminal rejection", exc_info=True)
+
+
 def _warn_adapter_failure(msg: str) -> None:
     try:
         from lionagi.cli._logging import warn
@@ -559,6 +579,7 @@ def build_handler(
     argv_fn: ArgvBuilder | None = None,
     env_fn: EnvBuilder | None = None,
     outcome_fn: OutcomeFn | None = None,
+    on_build_failure: Callable[[str], None] | None = None,
 ) -> TerminalCallbackHandler | None:
     """Build the process-local handler for a resolved adapter spec, or
     ``None`` if the spec fails to build (never raises). A python adapter ref
@@ -570,6 +591,12 @@ def build_handler(
     when no specific run is bound to this handler; outcome recording is then
     skipped rather than guessing at a target run. Never applies to a python
     adapter (only the exec adapter's process outcome is tracked).
+
+    *on_build_failure*, if given, is called with a stable reason when the spec
+    is refused here. A spec that resolves and then fails to build is still a
+    configured notifier that will never fire, and this is the only place that
+    knows why; a caller that can record it (one bound to a run) passes this so
+    the failure does not reduce to the same ``None`` as nothing configured.
     """
     if resolved.python_ref is not None:
         try:
@@ -580,6 +607,11 @@ def build_handler(
                 resolved.python_ref,
                 exc,
             )
+            # One identifier covers a missing module and a missing attribute:
+            # the reason is the stable contract, and the warning above carries
+            # which of the two it was.
+            if on_build_failure is not None:
+                on_build_failure("python_adapter_unresolvable")
             return None
         if not callable(handler):
             logger.warning(
@@ -588,6 +620,8 @@ def build_handler(
                 resolved.python_ref,
                 type(handler).__name__,
             )
+            if on_build_failure is not None:
+                on_build_failure("python_adapter_not_callable")
             return None
         return handler
     assert resolved.argv is not None  # _resolve_* never returns an empty spec
@@ -607,6 +641,10 @@ def register_settings_terminal_callback(
     CLI entry point and Studio service startup each call this once per
     process). Returns ``True`` iff a handler was installed.
     """
+    # A rejected configuration is already reported through the resolver's
+    # warning; this registration is process-wide and bound to no run, so it has
+    # nowhere to record a reason and only needs to know whether there is
+    # something to install. The run-scoped registration is where a reason lands.
     resolved = resolve_notify_config(project_dir=project_dir).handler
     if resolved is None:
         registry.unregister(name)
@@ -643,8 +681,18 @@ def register_run_notify_outcome_scope(
     ``unregister_run_notify_outcome_scope`` in a ``finally`` block), or
     ``None`` if notify.on_terminal resolved to disabled or if this entity is
     excluded by the configured filter (never raises).
+
+    Returning ``None`` says only that nothing was registered, so a notifier
+    this run asked for and could not have is recorded onto the run before
+    returning: an unsuccessful outcome carrying the reason. The two benign
+    cases -- nothing configured, and this entity excluded by the filter --
+    write nothing, which is what tells them apart from a refusal.
     """
-    resolved = resolve_notify_config(project_dir=project_dir).handler
+    resolution = resolve_notify_config(project_dir=project_dir)
+    if resolution.reason is not None:
+        _record_notify_rejection_to_run(run, resolution.reason)
+        return None
+    resolved = resolution.handler
     if resolved is None:
         return None
     # The scoped registration is an override, so it dispatches on its own
@@ -662,7 +710,10 @@ def register_run_notify_outcome_scope(
             run, ok=ok, exit_code=exit_code, stderr_text=stderr_text
         )
 
-    handler = build_handler(resolved, outcome_fn=_outcome_fn)
+    def _build_failure(reason: str) -> None:
+        _record_notify_rejection_to_run(run, reason)
+
+    handler = build_handler(resolved, outcome_fn=_outcome_fn, on_build_failure=_build_failure)
     if handler is None:
         return None
     name = f"notify.settings.on_terminal.{entity_kind}.{entity_id}"

--- a/lionagi/state/lifecycle/notify_settings.py
+++ b/lionagi/state/lifecycle/notify_settings.py
@@ -356,7 +356,7 @@ def _record_notify_outcome_to_run(
     return stderr_path
 
 
-def _record_notify_rejection_to_run(run: RunDir, reason: str) -> None:
+def record_notify_rejection_to_run(run: RunDir, reason: str) -> None:
     """Best-effort: record into *run*'s own notify_outcome.json that a notifier
     was configured for this run and refused, so the run says which of the two
     silences it is. A run with nothing configured writes no file at all; a run
@@ -690,7 +690,7 @@ def register_run_notify_outcome_scope(
     """
     resolution = resolve_notify_config(project_dir=project_dir)
     if resolution.reason is not None:
-        _record_notify_rejection_to_run(run, resolution.reason)
+        record_notify_rejection_to_run(run, resolution.reason)
         return None
     resolved = resolution.handler
     if resolved is None:
@@ -711,7 +711,7 @@ def register_run_notify_outcome_scope(
         )
 
     def _build_failure(reason: str) -> None:
-        _record_notify_rejection_to_run(run, reason)
+        record_notify_rejection_to_run(run, reason)
 
     handler = build_handler(resolved, outcome_fn=_outcome_fn, on_build_failure=_build_failure)
     if handler is None:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -60,7 +60,10 @@ def _register_schedule_notify(
     """
     if not notify_on or not notify_command:
         return None
-    resolved = resolve_notify_config(override=notify_command)
+    # A rejected command is already reported through the resolver's warning; this
+    # registration has no run record to carry a reason onto, so it only needs to
+    # know whether there is something to launch.
+    resolved = resolve_notify_config(override=notify_command).handler
     if resolved is None:
         return None
     handler = build_handler(resolved)

--- a/tests/cli/orchestrate/test_notify.py
+++ b/tests/cli/orchestrate/test_notify.py
@@ -415,3 +415,81 @@ async def test_no_shell_ever_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     )
     await registry.emit(_envelope(eid="inv-1"))
     assert out_file.exists()  # ran fine via create_subprocess_exec, never the shell
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_reason"),
+    [
+        ("   ", "on_terminal_command_is_empty"),
+        ("echo hi && rm -rf /", "on_terminal_command_requires_shell_features"),
+        ('echo "unbalanced', "on_terminal_command_not_parseable"),
+    ],
+)
+def test_a_refused_override_reports_why_it_was_refused(override, expected_reason):
+    """A caller that asked for a notifier and was refused must be able to find
+    out, and asking is what separates this from the unconfigured case.
+
+    Registration returns None either way, so the return value alone cannot tell
+    a refusal from nothing having been configured. The callback is the only
+    thing that carries the difference out.
+    """
+    reasons: list[str] = []
+
+    name = register_flow_notify_scope(
+        TerminalCallbackRegistry(),
+        override=override,
+        entity_kind="session",
+        entity_id="s1",
+        invocation_id=None,
+        flow_kind="agent",
+        playbook=None,
+        save_dir=None,
+        cwd=".",
+        started_at=0.0,
+        on_rejection=reasons.append,
+    )
+
+    assert name is None
+    assert reasons == [expected_reason]
+
+
+def test_a_refused_override_without_a_listener_still_does_not_raise():
+    """The callback is optional. A caller with no run to record against passes
+    nothing and must keep the old behavior: refuse quietly, never raise."""
+    name = register_flow_notify_scope(
+        TerminalCallbackRegistry(),
+        override="   ",
+        entity_kind="session",
+        entity_id="s1",
+        invocation_id=None,
+        flow_kind="agent",
+        playbook=None,
+        save_dir=None,
+        cwd=".",
+        started_at=0.0,
+    )
+    assert name is None
+
+
+def test_an_accepted_override_reports_no_refusal():
+    """The negative case: a good override must not fire the refusal path.
+    Without this, a callback that fired unconditionally would pass every test
+    above while turning every successful run into a recorded failure."""
+    reasons: list[str] = []
+
+    name = register_flow_notify_scope(
+        TerminalCallbackRegistry(),
+        override=f"{shlex.quote(sys.executable)} -c pass",
+        entity_kind="session",
+        entity_id="s1",
+        invocation_id=None,
+        flow_kind="agent",
+        playbook=None,
+        save_dir=None,
+        cwd=".",
+        started_at=0.0,
+        on_rejection=reasons.append,
+    )
+
+    assert name is not None
+    assert reasons == []

--- a/tests/cli/orchestrate/test_notify.py
+++ b/tests/cli/orchestrate/test_notify.py
@@ -493,3 +493,27 @@ def test_an_accepted_override_reports_no_refusal():
 
     assert name is not None
     assert reasons == []
+
+
+def test_a_raising_rejection_callback_does_not_break_registration():
+    """The refusal is already bad news; bookkeeping about it must not become a
+    second, louder failure. A callback that raises is swallowed so the caller
+    still gets the ordinary None rather than an exception out of registration."""
+
+    def _boom(reason: str) -> None:
+        raise RuntimeError("recorder exploded")
+
+    name = register_flow_notify_scope(
+        TerminalCallbackRegistry(),
+        override="   ",
+        entity_kind="session",
+        entity_id="s1",
+        invocation_id=None,
+        flow_kind="agent",
+        playbook=None,
+        save_dir=None,
+        cwd=".",
+        started_at=0.0,
+        on_rejection=_boom,
+    )
+    assert name is None

--- a/tests/cli/test_agent_notify_flag.py
+++ b/tests/cli/test_agent_notify_flag.py
@@ -7,6 +7,7 @@ the run scope (mirrors the `li o flow` / `li o fanout` wiring)."""
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import patch
 
@@ -80,3 +81,81 @@ async def test_notify_scope_is_session_even_with_invocation_id(monkeypatch, tmp_
     assert captured["entity_kind"] == "session"
     assert captured["entity_id"] == "sess-notify-1"
     assert captured["invocation_id"] == "parent-inv-123"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_notify_override_is_recorded_on_the_run(monkeypatch, tmp_path):
+    """A `--notify` value the resolver refuses must leave a record on the run.
+
+    The run-scoped outcome recorder is skipped whenever `--notify` is given,
+    because the override owns the entity. So if the override is then refused,
+    nothing registers and nothing is written, and a caller reading the run
+    cannot tell "asked for a notifier and was refused" from "never asked".
+    That is the same collapse the settings path was fixed for, one layer up.
+
+    A real RunDir is used deliberately: the shared stub returns a namespace
+    with no outcome-writing methods, and the recorder swallows its own errors,
+    so this assertion would pass vacuously against the stub.
+    """
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli._runs import RunDir
+
+    _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=lambda i: "done",
+        session_ids=["sess-refused-1"],
+    )
+
+    run = RunDir(
+        run_id="r",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda *a, **kw: run)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude_code/sonnet",
+        "hello",
+        notify="echo hi && rm -rf /",  # shell features: refused by the resolver
+    )
+
+    assert run.notify_outcome_path.exists(), "a refused --notify override left no record on the run"
+    outcome = json.loads(run.notify_outcome_path.read_text())
+    assert outcome["ok"] is False
+    assert outcome["reason"] == "on_terminal_command_requires_shell_features"
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_notify_override_records_no_refusal(monkeypatch, tmp_path):
+    """The negative half: a good override must not write a refusal outcome.
+
+    Without this, a recorder wired to fire unconditionally would satisfy the
+    test above while marking every healthy run as failed.
+    """
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli._runs import RunDir
+
+    _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=lambda i: "done",
+        session_ids=["sess-accepted-1"],
+    )
+
+    run = RunDir(
+        run_id="r",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda *a, **kw: run)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("claude_code/sonnet", "hello", notify="true {status}")
+
+    if run.notify_outcome_path.exists():
+        outcome = json.loads(run.notify_outcome_path.read_text())
+        assert "reason" not in outcome, f"an accepted override recorded a refusal: {outcome}"

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -12,6 +12,7 @@ no real command is spawned.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -122,15 +123,68 @@ def test_delivery_spawn_error_is_recorded(job, monkeypatch):
     assert outcome["error"] == "OSError"
 
 
-def test_malformed_command_override_delivers_nothing(job, monkeypatch):
+@pytest.mark.parametrize(
+    ("override", "reason"),
+    [
+        ("not json [", "delivery_command_is_not_valid_json"),
+        (json.dumps({"cmd": "notify"}), "delivery_command_is_not_a_list_of_strings"),
+        (json.dumps(["notify", 7]), "delivery_command_is_not_a_list_of_strings"),
+        (json.dumps([]), "delivery_command_is_empty"),
+    ],
+)
+def test_unusable_command_override_is_recorded_as_a_failure(job, monkeypatch, override, reason):
+    """A configured-but-unusable notifier must not read as an unconfigured one.
+
+    Both deliver nothing, so the record is the only thing that tells them apart.
+    A caller waiting on a completion notice that can never arrive has to be able
+    to find out why, and the named reason is where it says so.
+    """
     calls: list = []
     monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
     _no_settings_notifier(monkeypatch)
 
-    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", override])
+    assert rc == 0  # the terminal path still never fails
+    assert calls == []  # and nothing is spawned
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["attempted"] is False
+    assert outcome["ok"] is False
+    assert outcome["error"] == reason
+    # The distinction that matters: this is not the shape a silent default takes.
+    assert outcome != {"attempted": False}
+
+
+def test_configured_notifier_without_a_command_is_recorded_as_a_failure(job, monkeypatch):
+    """A notifier this hook cannot run is configured, not absent."""
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **_kw: SimpleNamespace(argv=None),
+    )
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
     assert rc == 0
     assert calls == []
-    assert jobs._read_job(job)["notify_delivery"] == {"attempted": False}
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["error"] == "configured_notifier_has_no_delivery_command"
+
+
+def test_unreadable_notify_settings_are_recorded_as_a_failure(job, monkeypatch):
+    """Settings that raise must not be reported as no notifier configured."""
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+
+    def _boom(**_kw):
+        raise RuntimeError("settings file is corrupt")
+
+    monkeypatch.setattr("lionagi.state.lifecycle.notify_settings.resolve_notify_config", _boom)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+    assert rc == 0  # a broken settings file still cannot break the terminal path
+    assert calls == []
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["error"] == "notify_settings_unreadable:RuntimeError"
 
 
 def test_unknown_run_id_is_noop(monkeypatch, tmp_path):

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -12,11 +12,14 @@ no real command is spawned.
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
 
 import pytest
 
 from lionagi.mcp import _notify_hook, config, jobs
+from lionagi.state.lifecycle.notify_settings import (
+    NotifyConfigResolution,
+    ResolvedNotifyHandler,
+)
 
 
 @pytest.fixture
@@ -47,7 +50,7 @@ class _FakeCompleted:
 def _no_settings_notifier(monkeypatch):
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
-        lambda **_kw: None,
+        lambda **_kw: NotifyConfigResolution(),
     )
 
 
@@ -160,7 +163,9 @@ def test_configured_notifier_without_a_command_is_recorded_as_a_failure(job, mon
     monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
-        lambda **_kw: SimpleNamespace(argv=None),
+        lambda **_kw: NotifyConfigResolution(
+            handler=ResolvedNotifyHandler(python_ref="os.path:join")
+        ),
     )
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
@@ -185,6 +190,138 @@ def test_unreadable_notify_settings_are_recorded_as_a_failure(job, monkeypatch):
     assert calls == []
     outcome = jobs._read_job(job)["notify_delivery"]
     assert outcome["error"] == "notify_settings_unreadable:RuntimeError"
+
+
+def _settings_notifier(monkeypatch, on_terminal):
+    """Drive the real resolver with *on_terminal* as lionagi's own setting."""
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.load_settings",
+        lambda project_dir=None: {"notify": {"on_terminal": on_terminal}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("on_terminal", "reason"),
+    [
+        ("notify-hook | grep x", "on_terminal_command_requires_shell_features"),
+        ('notify-hook "unbalanced', "on_terminal_command_not_parseable"),
+        ("   ", "on_terminal_command_is_empty"),
+        (12345, "on_terminal_not_string_or_mapping"),
+        (
+            {"enabled": True, "adapter": {"kind": "exec", "argv": []}},
+            "on_terminal_command_is_empty",
+        ),
+        (
+            {"enabled": True, "adapter": {"kind": "exec", "argv": "notify-hook"}},
+            "exec_adapter_argv_not_a_list_of_strings",
+        ),
+        ({"enabled": True}, "enabled_without_adapter"),
+        (
+            {"enabled": True, "adapter": {"kind": "carrier-pigeon"}},
+            "adapter_kind_unsupported",
+        ),
+        (
+            {"enabled": True, "adapter": {"kind": "python", "ref": "no-colon"}},
+            "python_adapter_ref_invalid",
+        ),
+        (
+            {
+                "enabled": True,
+                "adapter": {"kind": "exec", "argv": ["notify-hook"]},
+                "filter": "session",
+            },
+            "filter_not_a_mapping",
+        ),
+        (
+            {
+                "enabled": True,
+                "adapter": {"kind": "exec", "argv": ["notify-hook"]},
+                "filter": {"unexpected": True},
+            },
+            "filter_has_unknown_keys",
+        ),
+        (
+            {
+                "enabled": True,
+                "adapter": {"kind": "exec", "argv": ["notify-hook"]},
+                "filter": {"kinds": 0},
+            },
+            "filter_kinds_not_a_list_of_strings",
+        ),
+        (
+            {
+                "enabled": True,
+                "adapter": {"kind": "exec", "argv": ["notify-hook"]},
+                "filter": {"kinds": ["not-a-terminal-entity"]},
+            },
+            "filter_kinds_unsupported",
+        ),
+        (
+            {
+                "enabled": True,
+                "adapter": {"kind": "exec", "argv": ["notify-hook"]},
+                "filter": {"ids": 1},
+            },
+            "filter_ids_not_a_list_of_strings",
+        ),
+    ],
+)
+def test_rejected_settings_notifier_is_recorded_as_a_failure(job, monkeypatch, on_terminal, reason):
+    """A notifier that was configured wrong is a failure, never the default silence.
+
+    Every one of these settings shapes asked for a notice. None of them can
+    deliver one. Reporting them the way an unconfigured notifier is reported
+    would tell the operator they configured nothing, when what they actually
+    have is a notice that will never arrive.
+    """
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    _settings_notifier(monkeypatch, on_terminal)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+    assert rc == 0  # the terminal path still never fails
+    assert calls == []  # and nothing is spawned
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["error"] == reason
+    assert outcome["ok"] is False
+    assert outcome != {"attempted": False}  # not the shape a silent default takes
+
+
+@pytest.mark.parametrize(
+    "on_terminal",
+    [
+        None,  # notify.on_terminal absent entirely
+        {"enabled": False, "adapter": {"kind": "exec", "argv": ["should-not-run"]}},
+        {"adapter": None},  # a mapping that never asked to be enabled
+    ],
+)
+def test_silence_by_choice_stays_silence(job, monkeypatch, on_terminal):
+    """The chosen-silence shapes must not become failures: nothing was asked for."""
+    calls: list = []
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    _settings_notifier(monkeypatch, on_terminal)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+    assert rc == 0
+    assert calls == []
+    assert jobs._read_job(job)["notify_delivery"] == {"attempted": False}
+
+
+def test_settings_notifier_resolves_and_delivers(job, monkeypatch):
+    """The happy path still resolves through settings and delivers."""
+    captured: dict = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    _settings_notifier(monkeypatch, "notify-hook {run_id} {status}")
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+    assert rc == 0
+    assert captured["argv"] == ["notify-hook", job, "completed"]
+    assert jobs._read_job(job)["notify_delivery"]["ok"] is True
 
 
 def test_unknown_run_id_is_noop(monkeypatch, tmp_path):

--- a/tests/state/lifecycle/test_notify_settings.py
+++ b/tests/state/lifecycle/test_notify_settings.py
@@ -25,6 +25,7 @@ from lionagi.state.lifecycle.callbacks import (
     TerminalCallbackRegistry,
 )
 from lionagi.state.lifecycle.notify_settings import (
+    NotifyConfigResolution,
     ResolvedNotifyHandler,
     build_handler,
     register_settings_terminal_callback,
@@ -48,15 +49,16 @@ def _envelope() -> RunTerminalEnvelope:
 
 def test_string_form_resolves_to_argv():
     resolved = resolve_notify_config(override="notify-hook --flag value")
-    assert resolved == ResolvedNotifyHandler(argv=("notify-hook", "--flag", "value"))
+    assert resolved.handler == ResolvedNotifyHandler(argv=("notify-hook", "--flag", "value"))
+    assert resolved.reason is None  # nothing was rejected
 
 
 def test_string_form_preserves_quoted_shell_metacharacters_as_literal_args():
     # A quoted "|" is a literal argument character, not shell syntax -- must
     # not be flagged.
     resolved = resolve_notify_config(override='notify-hook "a|b"')
-    assert resolved is not None
-    assert resolved.argv == ("notify-hook", "a|b")
+    assert resolved.handler is not None
+    assert resolved.handler.argv == ("notify-hook", "a|b")
 
 
 @pytest.mark.parametrize(
@@ -73,14 +75,16 @@ def test_string_form_preserves_quoted_shell_metacharacters_as_literal_args():
 def test_shell_feature_string_resolves_disabled_with_diagnostic(caplog, command):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(override=command)
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "on_terminal_command_requires_shell_features"
     assert any("shell features" in r.message for r in caplog.records)
 
 
 def test_unparseable_string_resolves_disabled_with_diagnostic(caplog):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(override='notify-hook "unbalanced')
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "on_terminal_command_not_parseable"
     assert any("failed to parse" in r.message for r in caplog.records)
 
 
@@ -98,14 +102,16 @@ def test_unparseable_string_resolves_disabled_with_diagnostic(caplog):
 def test_empty_argv_resolves_disabled_with_diagnostic(caplog, source):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(override=source)
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "on_terminal_command_is_empty"
     assert any("empty command" in r.message for r in caplog.records)
 
 
 def test_empty_argv_via_settings_path_also_disabled(caplog):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(settings={"notify": {"on_terminal": "   "}})
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "on_terminal_command_is_empty"
     assert any("empty command" in r.message for r in caplog.records)
 
 
@@ -120,7 +126,7 @@ def test_mapping_form_exec_adapter():
             "filter": {"kinds": ["invocation"], "ids": ["inv-1"]},
         }
     )
-    assert resolved == ResolvedNotifyHandler(
+    assert resolved.handler == ResolvedNotifyHandler(
         argv=("notify-hook", "--x"),
         filter_kinds=("invocation",),
         filter_ids=("inv-1",),
@@ -131,36 +137,91 @@ def test_mapping_form_python_adapter():
     resolved = resolve_notify_config(
         override={"enabled": True, "adapter": {"kind": "python", "ref": "os.path:join"}}
     )
-    assert resolved == ResolvedNotifyHandler(python_ref="os.path:join")
+    assert resolved.handler == ResolvedNotifyHandler(python_ref="os.path:join")
 
 
 def test_mapping_form_explicit_enabled_false_is_disabled():
     resolved = resolve_notify_config(
         override={"enabled": False, "adapter": {"kind": "exec", "argv": ["should-not-run"]}}
     )
-    assert resolved is None
+    assert resolved.handler is None
+    # Turning notification off is a choice being honored, not a rejection, so it
+    # carries no reason -- it must not be reported to an operator as a failure.
+    assert resolved.reason is None
+
+
+def test_mapping_form_enabled_without_adapter_is_a_rejection(caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_notify_config(override={"enabled": True})
+    assert resolved.handler is None
+    assert resolved.reason == "enabled_without_adapter"
+    assert any("no adapter configured" in r.message for r in caplog.records)
+
+
+def test_mapping_form_without_enabled_or_adapter_is_silence_not_rejection(caplog):
+    # No warning today and no reason now: this mapping asked for nothing.
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_notify_config(override={"adapter": None})
+    assert resolved.handler is None
+    assert resolved.reason is None
+    assert not caplog.records
 
 
 def test_mapping_form_unknown_adapter_kind_disabled(caplog):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(override={"adapter": {"kind": "carrier-pigeon"}})
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "adapter_kind_unsupported"
     assert any("must be 'exec' or 'python'" in r.message for r in caplog.records)
 
 
+def test_mapping_form_invalid_exec_argv_disabled(caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_notify_config(
+            override={"enabled": True, "adapter": {"kind": "exec", "argv": "notify-hook"}}
+        )
+    assert resolved.handler is None
+    assert resolved.reason == "exec_adapter_argv_not_a_list_of_strings"
+    assert any("requires an argv" in r.message for r in caplog.records)
+
+
+def test_mapping_form_invalid_python_ref_disabled(caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_notify_config(
+            override={"enabled": True, "adapter": {"kind": "python", "ref": "no-colon"}}
+        )
+    assert resolved.handler is None
+    assert resolved.reason == "python_adapter_ref_invalid"
+    assert any("'module:callable' ref" in r.message for r in caplog.records)
+
+
 @pytest.mark.parametrize(
-    ("filter_value", "diagnostic"),
+    ("filter_value", "diagnostic", "reason"),
     [
-        ("session", "filter must be a non-empty mapping"),
-        ({"unexpected": True}, "filter keys must be 'kinds' and/or 'ids'"),
-        ({"kinds": 0}, "filter.kinds must be a list of strings"),
+        ("session", "filter must be a non-empty mapping", "filter_not_a_mapping"),
+        (
+            {"unexpected": True},
+            "filter keys must be 'kinds' and/or 'ids'",
+            "filter_has_unknown_keys",
+        ),
+        (
+            {"kinds": 0},
+            "filter.kinds must be a list of strings",
+            "filter_kinds_not_a_list_of_strings",
+        ),
         (
             {"kinds": ["not-a-terminal-entity"]},
             "filter.kinds contains unsupported terminal entity kinds",
+            "filter_kinds_unsupported",
+        ),
+        (
+            {"ids": 1},
+            "filter.ids must be a list of strings",
+            "filter_ids_not_a_list_of_strings",
         ),
     ],
 )
-def test_mapping_form_invalid_filter_disables_handler(caplog, filter_value, diagnostic):
+def test_mapping_form_invalid_filter_disables_handler(caplog, filter_value, diagnostic, reason):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(
             override={
@@ -169,7 +230,8 @@ def test_mapping_form_invalid_filter_disables_handler(caplog, filter_value, diag
                 "filter": filter_value,
             }
         )
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == reason
     assert any(diagnostic in record.message for record in caplog.records)
 
 
@@ -190,7 +252,8 @@ def test_mapping_form_malformed_filter_kinds_disabled_not_raised(caplog, filter_
                 "filter": {"kinds": filter_value},
             }
         )  # must not raise
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "filter_kinds_not_a_list_of_strings"
     assert any("filter.kinds must be a list of strings" in r.message for r in caplog.records)
 
 
@@ -211,7 +274,8 @@ def test_mapping_form_malformed_filter_ids_disabled_not_raised(caplog, filter_va
                 "filter": {"ids": filter_value},
             }
         )  # must not raise
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "filter_ids_not_a_list_of_strings"
     assert any("filter.ids must be a list of strings" in r.message for r in caplog.records)
 
 
@@ -222,7 +286,10 @@ def test_malformed_settings_never_raises(caplog, monkeypatch):
     monkeypatch.setattr("lionagi.state.lifecycle.notify_settings.load_settings", _boom)
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config()  # must not raise
-    assert resolved is None
+    assert resolved.handler is None
+    # Settings that cannot be read may well have named a notifier; that is not
+    # the same as having configured none, so it is reported as a rejection.
+    assert resolved.reason == "settings_load_failed"
     assert any("settings resolution failed" in r.message for r in caplog.records)
 
 
@@ -232,13 +299,17 @@ def test_malformed_settings_never_raises(caplog, monkeypatch):
 def test_invalid_value_type_disabled(caplog):
     with caplog.at_level(logging.WARNING):
         resolved = resolve_notify_config(override=12345)
-    assert resolved is None
+    assert resolved.handler is None
+    assert resolved.reason == "on_terminal_not_string_or_mapping"
     assert any("must be a string or mapping" in r.message for r in caplog.records)
 
 
 def test_absent_notify_key_is_disabled():
-    assert resolve_notify_config(settings={}) is None
-    assert resolve_notify_config(settings={"notify": {}}) is None
+    """The one genuinely-unconfigured path: no handler and no reason."""
+    for settings in ({}, {"notify": {}}, {"notify": {"on_terminal": None}}):
+        resolved = resolve_notify_config(settings=settings)
+        assert resolved.handler is None
+        assert resolved.reason is None
 
 
 # ── Precedence: per-run override beats settings for its own scope only ───────
@@ -247,12 +318,12 @@ def test_absent_notify_key_is_disabled():
 def test_per_run_override_replaces_settings_handler():
     settings = {"notify": {"on_terminal": "settings-cmd"}}
     resolved_no_override = resolve_notify_config(settings=settings)
-    assert resolved_no_override is not None
-    assert resolved_no_override.argv == ("settings-cmd",)
+    assert resolved_no_override.handler is not None
+    assert resolved_no_override.handler.argv == ("settings-cmd",)
 
     resolved_with_override = resolve_notify_config(settings=settings, override="override-cmd")
-    assert resolved_with_override is not None
-    assert resolved_with_override.argv == ("override-cmd",)
+    assert resolved_with_override.handler is not None
+    assert resolved_with_override.handler.argv == ("override-cmd",)
 
 
 # ── No-shell safety: the exec adapter never launches via a shell ────────────
@@ -608,7 +679,7 @@ async def test_run_scoped_outcome_survives_a_later_run_allocation(monkeypatch, t
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
-        lambda **kw: ResolvedNotifyHandler(argv=("notify-hook",)),
+        lambda **kw: NotifyConfigResolution(handler=ResolvedNotifyHandler(argv=("notify-hook",))),
     )
 
     class _FakeProc:
@@ -672,7 +743,7 @@ async def test_unscoped_entity_records_nothing_never_last_writer_wins(monkeypatc
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
-        lambda **kw: ResolvedNotifyHandler(argv=("notify-hook",)),
+        lambda **kw: NotifyConfigResolution(handler=ResolvedNotifyHandler(argv=("notify-hook",))),
     )
 
     class _FakeProc:
@@ -696,7 +767,7 @@ async def test_unscoped_entity_records_nothing_never_last_writer_wins(monkeypatc
     # entity still gets a matching, non-attributing handler.
     from lionagi.state.lifecycle.notify_settings import build_handler, resolve_notify_config
 
-    default_handler = build_handler(resolve_notify_config())
+    default_handler = build_handler(resolve_notify_config().handler)
     registry.register("notify.settings.on_terminal", default_handler)
 
     other_envelope = RunTerminalEnvelope(
@@ -734,7 +805,7 @@ async def test_cancelled_exec_handler_still_kills_its_child_process_group(tmp_pa
         'time.sleep(30)" '
         f"{shlex.quote(str(pid_file))}"
     )
-    resolved = resolve_notify_config(override=cmd)
+    resolved = resolve_notify_config(override=cmd).handler
     assert resolved is not None
     handler = build_handler(resolved)
     assert handler is not None
@@ -962,8 +1033,10 @@ async def test_run_scoped_registration_honors_configured_filter(monkeypatch, tmp
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
-        lambda **kw: ResolvedNotifyHandler(
-            argv=("notify-hook",), filter_kinds=("play",), filter_ids=("play-allowed",)
+        lambda **kw: NotifyConfigResolution(
+            handler=ResolvedNotifyHandler(
+                argv=("notify-hook",), filter_kinds=("play",), filter_ids=("play-allowed",)
+            )
         ),
     )
 

--- a/tests/state/lifecycle/test_notify_settings.py
+++ b/tests/state/lifecycle/test_notify_settings.py
@@ -1108,6 +1108,120 @@ async def test_run_scoped_registration_honors_configured_filter(monkeypatch, tmp
     assert json.loads(run.notify_outcome_path.read_text())["ok"] is True
 
 
+# ── The two silences a run must not confuse ────────────────────────────────
+# Registration returns None both when nothing was configured and when a
+# configured notifier was refused. The run's own record is what tells them
+# apart: a refusal writes an unsuccessful outcome carrying the reason, chosen
+# silence writes no file. Without this, a caller waiting on a terminal notice
+# that can never arrive sees exactly what a caller that never asked for one
+# sees.
+
+
+def test_run_scoped_registration_records_a_settings_rejection(monkeypatch, tmp_path):
+    import lionagi.cli._runs as runs_mod
+    from lionagi.cli._runs import allocate_run
+    from lionagi.state.lifecycle.notify_settings import register_run_notify_outcome_scope
+
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+    registry = TerminalCallbackRegistry()
+
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **kw: NotifyConfigResolution(reason="on_terminal_command_is_empty"),
+    )
+    rejected = allocate_run(run_id="rejected-run")
+    assert (
+        register_run_notify_outcome_scope(
+            rejected, entity_kind="session", entity_id="s-1", registry=registry
+        )
+        is None
+    )
+    assert json.loads(rejected.notify_outcome_path.read_text()) == {
+        "ok": False,
+        "exit_code": None,
+        "stderr_path": None,
+        "reason": "on_terminal_command_is_empty",
+    }
+
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **kw: NotifyConfigResolution(),
+    )
+    unconfigured = allocate_run(run_id="unconfigured-run")
+    assert (
+        register_run_notify_outcome_scope(
+            unconfigured, entity_kind="session", entity_id="s-1", registry=registry
+        )
+        is None
+    )
+    assert not unconfigured.notify_outcome_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("ref", "reason"),
+    [
+        ("lionagi._no_such_module_here:handler", "python_adapter_unresolvable"),
+        ("json:no_such_attribute", "python_adapter_unresolvable"),
+        ("json:__doc__", "python_adapter_not_callable"),
+    ],
+)
+def test_run_scoped_registration_records_a_python_build_failure(monkeypatch, tmp_path, ref, reason):
+    """A python adapter that resolves and then fails to build is configured and
+    unusable. Only build_handler knows why, so a run-bound caller is handed the
+    reason instead of the same None it returns for nothing configured."""
+    import lionagi.cli._runs as runs_mod
+    from lionagi.cli._runs import allocate_run
+    from lionagi.state.lifecycle.notify_settings import register_run_notify_outcome_scope
+
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **kw: NotifyConfigResolution(handler=ResolvedNotifyHandler(python_ref=ref)),
+    )
+    registry = TerminalCallbackRegistry()
+    run = allocate_run(run_id=f"build-failure-{reason}")
+
+    assert (
+        register_run_notify_outcome_scope(
+            run, entity_kind="session", entity_id="s-1", registry=registry
+        )
+        is None
+    )
+    assert json.loads(run.notify_outcome_path.read_text()) == {
+        "ok": False,
+        "exit_code": None,
+        "stderr_path": None,
+        "reason": reason,
+    }
+
+
+def test_filtered_out_entity_is_chosen_silence_not_a_rejection(monkeypatch, tmp_path):
+    """An entity the operator excluded is silence by choice for that entity, so
+    it writes no record. Recording it would make an intentional exclusion look
+    like a broken notifier."""
+    import lionagi.cli._runs as runs_mod
+    from lionagi.cli._runs import allocate_run
+    from lionagi.state.lifecycle.notify_settings import register_run_notify_outcome_scope
+
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+    monkeypatch.setattr(
+        "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
+        lambda **kw: NotifyConfigResolution(
+            handler=ResolvedNotifyHandler(argv=("notify-hook",), filter_kinds=("play",))
+        ),
+    )
+    registry = TerminalCallbackRegistry()
+    run = allocate_run(run_id="filtered-out-run")
+
+    assert (
+        register_run_notify_outcome_scope(
+            run, entity_kind="session", entity_id="s-1", registry=registry
+        )
+        is None
+    )
+    assert not run.notify_outcome_path.exists()
+
+
 @pytest.mark.asyncio
 async def test_adapter_argument_values_echoed_on_stderr_are_redacted(monkeypatch, tmp_path, caplog):
     """The realistic leak path: an adapter fails and echoes its own invocation


### PR DESCRIPTION
The terminal notify hook reported "nothing configured" and "configured but unusable" identically, as a bare `{"attempted": False}` delivery record. Both deliver no notice, so the record was the only thing that could tell them apart, and it did not.

For a detached background job that is the worst of the three available outcomes. Silence is correct when nobody asked for a notice. When someone did ask and the notifier cannot run, the caller is waiting on something that will never arrive and no artifact anywhere says so.

A malformed delivery command was the easiest way to reach it: the override is parsed as a JSON argv list, and any parse failure returned before a delivery outcome was ever written.

## Change

`_resolve_command` now returns the reason alongside the template. Four configured-but-unusable cases record a named delivery failure instead of passing for silence:

- `delivery_command_is_not_valid_json`
- `delivery_command_is_not_a_list_of_strings`
- `delivery_command_is_empty`
- `configured_notifier_has_no_delivery_command`

Settings that raise while being read report `notify_settings_unreadable:<Type>` rather than resolving to "no notifier configured".

Nothing here raises. The run has already finished by the time the hook executes, so a resolution failure is reported through the record and never thrown into the CLI's terminal path.

## Tests

Six new tests, all confirmed failing against the prior code before the fix (`KeyError: 'ok'` and `KeyError: 'error'` — the old record had no field in which to say a notifier was broken).

An existing test asserted the defective shape verbatim, which is why nothing caught this. It is replaced by one that pins the distinction, including an explicit assertion that the outcome is *not* the shape a silent default takes.

`tests/mcp/`: 32 passed.