### PR TITLE
fix(scheduler): resolve the host timezone when the zoneinfo directory carries a suffix

### DIFF
--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -2,67 +2,95 @@ from __future__ import annotations
 
 import logging
 import os
+import zoneinfo
 from pathlib import Path
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 _logger = logging.getLogger(__name__)
 
 SYSTEM_LOCALTIME_LINK = Path("/etc/localtime")
 
 
-def _zone_name_from_path(path: Path) -> str | None:
-    """Extract an IANA zone name from a path pointing into a zoneinfo tree.
+def _tz_search_roots() -> list[Path]:
+    """The zoneinfo directories a zone name is resolved against.
 
-    The tree's directory is conventionally named ``zoneinfo``, but some hosts
-    use a suffixed variant — macOS resolves through ``zoneinfo.default`` — so
-    the directory is matched on its prefix rather than by equality. Matching
-    on equality alone silently yields no zone on those hosts.
+    ``zoneinfo.TZPATH`` is the authority here: it is where the stdlib itself
+    looks, so a name expressed relative to one of these roots is a name that
+    will actually load. Each entry is included both as written and as it
+    resolves, because these are commonly symlinks — on macOS
+    ``/usr/share/zoneinfo`` points at ``/usr/share/zoneinfo.default``, and a
+    path resolved through the link matches only the second form.
     """
-    parts = path.parts
-    for idx, part in enumerate(parts):
-        if part == "zoneinfo" or part.startswith("zoneinfo."):
-            return "/".join(parts[idx + 1 :]) or None
+    roots: list[Path] = []
+    for entry in zoneinfo.TZPATH:
+        candidate = Path(entry)
+        for form in (candidate, _resolved(candidate)):
+            if form is not None and form not in roots:
+                roots.append(form)
+    return roots
+
+
+def _resolved(path: Path) -> Path | None:
+    """``path.resolve()``, or None when the filesystem refuses to answer.
+
+    Symlink loops surface as RuntimeError on some Python versions and OSError
+    on others, so both are treated as "no answer". This is called while
+    computing a module constant at import, where an escaping exception makes
+    the package unimportable rather than merely mis-zoned.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _zone_name_from_path(path: Path, roots: list[Path]) -> str | None:
+    """Express *path* as a zone name relative to whichever root contains it."""
+    for root in roots:
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        name = "/".join(relative.parts)
+        if name:
+            return name
     return None
 
 
 def _system_local_tz_name() -> str:
     """Best-effort resolution of the system's IANA timezone name.
 
-    Checks ``$TZ`` first, then reads the ``/etc/localtime`` symlink (the
-    standard way Unix hosts point at their zoneinfo entry). Both the raw link
-    target and the fully resolved path are considered: a host may chain
-    through a second symlink into a directory whose name no longer identifies
-    the zoneinfo tree, and either form alone can be the one that carries the
-    zone name.
+    Checks ``$TZ`` first, then reads the ``/etc/localtime`` symlink — the
+    standard way Unix hosts point at their zoneinfo entry — and expresses it
+    relative to the zoneinfo roots the stdlib searches.
+
+    Deriving the name from the search roots rather than from a directory name
+    is what makes this reliable: the tree is called ``zoneinfo`` on most hosts
+    and something else on others, so any test against the name either misses
+    real trees or accepts directories that merely look like one and yields a
+    loadable but wrong zone. Containment in a search root has neither failure.
 
     Returns "UTC" if nothing resolves to a loadable zone. The daemon still
-    runs correctly in that case, but cron expressions are interpreted in UTC
-    rather than local time, so the fallback is logged — an unrequested UTC is
+    runs correctly then, but cron expressions are interpreted in UTC rather
+    than local time, so the fallback is logged: an unrequested UTC is
     otherwise indistinguishable from a configured one.
     """
     tz_env = os.environ.get("TZ")
     if tz_env:
         return tz_env
 
-    candidates: list[Path] = []
-    try:
-        candidates.append(Path(os.readlink(SYSTEM_LOCALTIME_LINK)))
-    except OSError:
-        pass
-    try:
-        candidates.append(SYSTEM_LOCALTIME_LINK.resolve())
-    except OSError:
-        pass
-
-    for candidate in candidates:
-        name = _zone_name_from_path(candidate)
-        if not name:
-            continue
-        try:
-            ZoneInfo(name)
-        except (ZoneInfoNotFoundError, ValueError):
-            continue
-        return name
+    localtime = _resolved(SYSTEM_LOCALTIME_LINK)
+    if localtime is not None:
+        name = _zone_name_from_path(localtime, _tz_search_roots())
+        if name is not None:
+            try:
+                zoneinfo.ZoneInfo(name)
+            except Exception:  # noqa: BLE001
+                # This runs at import to compute a module constant, so nothing
+                # may escape: an unreadable or malformed tzfile would otherwise
+                # make the package unimportable rather than merely mis-zoned.
+                name = None
+            if name is not None:
+                return name
 
     _logger.warning(
         "Could not determine the system timezone from %s; scheduler times will "

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -43,15 +43,37 @@ def _resolved(path: Path) -> Path | None:
         return None
 
 
+def _zone_file_for_name(name: str) -> Path | None:
+    """The tzfile the stdlib will actually open for *name*.
+
+    ``ZoneInfo`` takes the first match in ``TZPATH`` order, so this walks the
+    roots in that same order rather than guessing.
+    """
+    for entry in zoneinfo.TZPATH:
+        candidate = Path(entry) / name
+        if candidate.is_file():
+            return _resolved(candidate)
+    return None
+
+
 def _zone_name_from_path(path: Path, roots: list[Path]) -> str | None:
-    """Express *path* as a zone name relative to whichever root contains it."""
+    """Express *path* as a zone name that reopens *path*.
+
+    Containment alone is not enough. When several roots are configured, an
+    earlier one holding the same key shadows a later one, so a name derived
+    from the root that happens to contain the file can load a different
+    tzfile with different rules — the same silent-wrong-zone failure this
+    resolver exists to prevent, one level in. A candidate is therefore
+    accepted only if resolving it the way the stdlib will arrives back at the
+    file we started from.
+    """
     for root in roots:
         try:
             relative = path.relative_to(root)
         except ValueError:
             continue
         name = "/".join(relative.parts)
-        if name:
+        if name and _zone_file_for_name(name) == path:
             return name
     return None
 
@@ -64,10 +86,13 @@ def _system_local_tz_name() -> str:
     relative to the zoneinfo roots the stdlib searches.
 
     Deriving the name from the search roots rather than from a directory name
-    is what makes this reliable: the tree is called ``zoneinfo`` on most hosts
-    and something else on others, so any test against the name either misses
-    real trees or accepts directories that merely look like one and yields a
-    loadable but wrong zone. Containment in a search root has neither failure.
+    removes a whole class of guessing: the tree is called ``zoneinfo`` on most
+    hosts and something else on others, so any test against the name either
+    misses real trees or accepts directories that merely look like one.
+    Containment has neither failure, but it is not sufficient on its own —
+    with several roots configured, a name the containing root justifies can
+    still reopen an earlier root's file, so the name is additionally required
+    to round-trip back to the same tzfile.
 
     Returns "UTC" if nothing resolves to a loadable zone. The daemon still
     runs correctly then, but cron expressions are interpreted in UTC rather

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -1,29 +1,75 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_logger = logging.getLogger(__name__)
+
+SYSTEM_LOCALTIME_LINK = Path("/etc/localtime")
+
+
+def _zone_name_from_path(path: Path) -> str | None:
+    """Extract an IANA zone name from a path pointing into a zoneinfo tree.
+
+    The tree's directory is conventionally named ``zoneinfo``, but some hosts
+    use a suffixed variant — macOS resolves through ``zoneinfo.default`` — so
+    the directory is matched on its prefix rather than by equality. Matching
+    on equality alone silently yields no zone on those hosts.
+    """
+    parts = path.parts
+    for idx, part in enumerate(parts):
+        if part == "zoneinfo" or part.startswith("zoneinfo."):
+            return "/".join(parts[idx + 1 :]) or None
+    return None
 
 
 def _system_local_tz_name() -> str:
     """Best-effort resolution of the system's IANA timezone name.
 
-    Checks ``$TZ`` first, then falls back to reading the ``/etc/localtime``
-    symlink (the standard way Unix hosts point at their zoneinfo entry).
-    Returns "UTC" if neither resolves — the daemon still runs correctly,
-    just without local-time cron semantics until LIONAGI_SCHEDULER_TZ or the
-    host's timezone is configured.
+    Checks ``$TZ`` first, then reads the ``/etc/localtime`` symlink (the
+    standard way Unix hosts point at their zoneinfo entry). Both the raw link
+    target and the fully resolved path are considered: a host may chain
+    through a second symlink into a directory whose name no longer identifies
+    the zoneinfo tree, and either form alone can be the one that carries the
+    zone name.
+
+    Returns "UTC" if nothing resolves to a loadable zone. The daemon still
+    runs correctly in that case, but cron expressions are interpreted in UTC
+    rather than local time, so the fallback is logged — an unrequested UTC is
+    otherwise indistinguishable from a configured one.
     """
     tz_env = os.environ.get("TZ")
     if tz_env:
         return tz_env
+
+    candidates: list[Path] = []
     try:
-        localtime = Path("/etc/localtime").resolve()
+        candidates.append(Path(os.readlink(SYSTEM_LOCALTIME_LINK)))
     except OSError:
-        return "UTC"
-    parts = localtime.parts
-    if "zoneinfo" in parts:
-        idx = parts.index("zoneinfo")
-        return "/".join(parts[idx + 1 :])
+        pass
+    try:
+        candidates.append(SYSTEM_LOCALTIME_LINK.resolve())
+    except OSError:
+        pass
+
+    for candidate in candidates:
+        name = _zone_name_from_path(candidate)
+        if not name:
+            continue
+        try:
+            ZoneInfo(name)
+        except (ZoneInfoNotFoundError, ValueError):
+            continue
+        return name
+
+    _logger.warning(
+        "Could not determine the system timezone from %s; scheduler times will "
+        "be interpreted as UTC. Set LIONAGI_SCHEDULER_TZ to an IANA zone name "
+        "(for example America/New_York) to choose one explicitly.",
+        SYSTEM_LOCALTIME_LINK,
+    )
     return "UTC"
 
 

--- a/tests/studio/test_config_timezone.py
+++ b/tests/studio/test_config_timezone.py
@@ -4,10 +4,13 @@ The scheduler interprets cron expressions in ``SCHEDULER_TZ``, which defaults
 to the host's local zone read off ``/etc/localtime``. A misread there is
 invisible: every fire still succeeds, just at the wrong hour, so these pin the
 read itself rather than the scheduler's use of the result.
+
+Fixtures build a zoneinfo tree under ``tmp_path`` and point the search roots at
+it. Zone names are real ones so that the loadability check, which consults the
+host's actual tzdata, exercises the same path it does in production.
 """
 
 import logging
-from pathlib import Path
 
 import pytest
 
@@ -15,72 +18,95 @@ from lionagi.studio import config
 
 
 @pytest.fixture
-def localtime_link(tmp_path, monkeypatch):
-    """Point the resolver at a symlink under tmp_path instead of /etc."""
+def tz_host(tmp_path, monkeypatch):
+    """A fake host: a localtime link, and control over the search roots."""
+    monkeypatch.delenv("TZ", raising=False)
     link = tmp_path / "localtime"
     monkeypatch.setattr(config, "SYSTEM_LOCALTIME_LINK", link)
-    monkeypatch.delenv("TZ", raising=False)
-    return link
+
+    def set_roots(*names):
+        monkeypatch.setattr(config.zoneinfo, "TZPATH", tuple(str(tmp_path / n) for n in names))
+
+    def zone_file(tree, zone="America/New_York"):
+        path = tmp_path / tree / zone
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"")
+        return path
+
+    return link, set_roots, zone_file
 
 
-def _zone_file(root: Path, tree: str) -> Path:
-    path = root / tree / "America" / "New_York"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b"")
-    return path
+def test_suffixed_zoneinfo_directory_resolves(tz_host):
+    """macOS points /etc/localtime at a tree resolving through
+    ``zoneinfo.default``. Deriving the name from the search roots means the
+    directory's name never has to be guessed at."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo.default"))
+    set_roots("zoneinfo.default")
+
+    assert config._system_local_tz_name() == "America/New_York"
 
 
-def test_suffixed_zoneinfo_directory_still_yields_the_zone(tmp_path, localtime_link):
-    """A zoneinfo tree whose directory carries a suffix must still resolve.
+def test_plain_zoneinfo_directory_resolves(tz_host):
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo"))
+    set_roots("zoneinfo")
 
-    macOS points /etc/localtime at a tree that resolves through
-    ``zoneinfo.default``. Requiring the directory to be named exactly
-    ``zoneinfo`` yields no zone there and silently falls back to UTC.
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_search_root_reached_through_a_symlink_resolves(tz_host, tmp_path):
+    """Search roots are commonly symlinks. A localtime path resolved through
+    the link matches only the resolved form of the root, so both are tried."""
+    link, set_roots, zone_file = tz_host
+    real = zone_file("zoneinfo.default")
+    (tmp_path / "zoneinfo").symlink_to(tmp_path / "zoneinfo.default")
+    link.symlink_to(real)
+    set_roots("zoneinfo")  # the root as configured is the link, not the target
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_directory_that_merely_looks_like_a_tree_is_not_one(tz_host):
+    """A directory named like a zoneinfo tree but not among the search roots
+    must not produce a zone. Matching on the name would accept it and return a
+    loadable but wrong zone, which is worse than returning nothing."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo.backup"))
+    set_roots("zoneinfo")
+
+    assert config._system_local_tz_name() == "UTC"
+
+
+def test_zone_follows_the_resolved_path_not_the_link_text(tz_host, tmp_path):
+    """When the link's text and where it lands disagree, where it lands wins.
+
+    Reading the name off the unresolved text would report the zone the path is
+    named after rather than the zone the host actually uses.
     """
-    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo.default"))
+    link, set_roots, zone_file = tz_host
+    london = zone_file("zoneinfo.default", "Europe/London")
+    named_new_york = tmp_path / "zoneinfo.default" / "America" / "New_York"
+    named_new_york.parent.mkdir(parents=True, exist_ok=True)
+    named_new_york.symlink_to(london)
+    link.symlink_to(named_new_york)
+    set_roots("zoneinfo.default")
 
-    assert config._system_local_tz_name() == "America/New_York"
-
-
-def test_plain_zoneinfo_directory_yields_the_zone(tmp_path, localtime_link):
-    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo"))
-
-    assert config._system_local_tz_name() == "America/New_York"
-
-
-def test_zone_is_read_through_a_chained_link(tmp_path, localtime_link):
-    """The link may chain through a directory that renames the tree.
-
-    Only the unresolved target carries the tree's name in that case, so both
-    the raw target and the fully resolved path have to be considered.
-    """
-    real = _zone_file(tmp_path, "zoneinfo.default")
-    alias = tmp_path / "zoneinfo"
-    alias.symlink_to(real.parent.parent)
-    localtime_link.symlink_to(alias / "America" / "New_York")
-
-    assert config._system_local_tz_name() == "America/New_York"
+    assert config._system_local_tz_name() == "Europe/London"
 
 
-def test_tz_environment_variable_takes_precedence(tmp_path, localtime_link, monkeypatch):
-    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo"))
+def test_tz_environment_variable_takes_precedence(tz_host, monkeypatch):
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo"))
+    set_roots("zoneinfo")
     monkeypatch.setenv("TZ", "Asia/Tokyo")
 
     assert config._system_local_tz_name() == "Asia/Tokyo"
 
 
-def test_missing_link_falls_back_to_utc_with_a_warning(localtime_link, caplog):
-    with caplog.at_level(logging.WARNING, logger=config.__name__):
-        assert config._system_local_tz_name() == "UTC"
-
-    assert "LIONAGI_SCHEDULER_TZ" in caplog.text
-
-
-def test_path_outside_a_zoneinfo_tree_falls_back_to_utc(tmp_path, localtime_link, caplog):
-    target = tmp_path / "etc" / "America" / "New_York"
-    target.parent.mkdir(parents=True)
-    target.write_bytes(b"")
-    localtime_link.symlink_to(target)
+def test_missing_link_falls_back_to_utc_with_a_warning(tz_host, caplog):
+    _, set_roots, _ = tz_host
+    set_roots("zoneinfo")
 
     with caplog.at_level(logging.WARNING, logger=config.__name__):
         assert config._system_local_tz_name() == "UTC"
@@ -88,12 +114,23 @@ def test_path_outside_a_zoneinfo_tree_falls_back_to_utc(tmp_path, localtime_link
     assert "LIONAGI_SCHEDULER_TZ" in caplog.text
 
 
-def test_unloadable_zone_name_falls_back_to_utc(tmp_path, localtime_link):
-    """A parse that yields a name no tzdata knows must not be handed on.
+def test_symlink_loop_falls_back_instead_of_raising(tz_host, tmp_path):
+    """This runs at import to compute a module constant, so a hostile
+    filesystem must not make the package unimportable."""
+    link, set_roots, _ = tz_host
+    other = tmp_path / "other"
+    link.symlink_to(other)
+    other.symlink_to(link)
+    set_roots("zoneinfo")
 
-    Returning it would push the failure into the scheduler, which can only
-    report the bad name rather than the path it came from.
-    """
-    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo").parent / "Nowhere")
+    assert config._system_local_tz_name() == "UTC"
+
+
+def test_unloadable_zone_name_falls_back_to_utc(tz_host):
+    """A name derived from a real search root that no tzdata knows must not be
+    handed on; the scheduler could only report the name, not its origin."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo", "Mars/Olympus_Mons"))
+    set_roots("zoneinfo")
 
     assert config._system_local_tz_name() == "UTC"

--- a/tests/studio/test_config_timezone.py
+++ b/tests/studio/test_config_timezone.py
@@ -1,0 +1,99 @@
+"""System timezone resolution for the scheduler's default cron zone.
+
+The scheduler interprets cron expressions in ``SCHEDULER_TZ``, which defaults
+to the host's local zone read off ``/etc/localtime``. A misread there is
+invisible: every fire still succeeds, just at the wrong hour, so these pin the
+read itself rather than the scheduler's use of the result.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from lionagi.studio import config
+
+
+@pytest.fixture
+def localtime_link(tmp_path, monkeypatch):
+    """Point the resolver at a symlink under tmp_path instead of /etc."""
+    link = tmp_path / "localtime"
+    monkeypatch.setattr(config, "SYSTEM_LOCALTIME_LINK", link)
+    monkeypatch.delenv("TZ", raising=False)
+    return link
+
+
+def _zone_file(root: Path, tree: str) -> Path:
+    path = root / tree / "America" / "New_York"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
+
+
+def test_suffixed_zoneinfo_directory_still_yields_the_zone(tmp_path, localtime_link):
+    """A zoneinfo tree whose directory carries a suffix must still resolve.
+
+    macOS points /etc/localtime at a tree that resolves through
+    ``zoneinfo.default``. Requiring the directory to be named exactly
+    ``zoneinfo`` yields no zone there and silently falls back to UTC.
+    """
+    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo.default"))
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_plain_zoneinfo_directory_yields_the_zone(tmp_path, localtime_link):
+    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo"))
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_zone_is_read_through_a_chained_link(tmp_path, localtime_link):
+    """The link may chain through a directory that renames the tree.
+
+    Only the unresolved target carries the tree's name in that case, so both
+    the raw target and the fully resolved path have to be considered.
+    """
+    real = _zone_file(tmp_path, "zoneinfo.default")
+    alias = tmp_path / "zoneinfo"
+    alias.symlink_to(real.parent.parent)
+    localtime_link.symlink_to(alias / "America" / "New_York")
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_tz_environment_variable_takes_precedence(tmp_path, localtime_link, monkeypatch):
+    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo"))
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+
+    assert config._system_local_tz_name() == "Asia/Tokyo"
+
+
+def test_missing_link_falls_back_to_utc_with_a_warning(localtime_link, caplog):
+    with caplog.at_level(logging.WARNING, logger=config.__name__):
+        assert config._system_local_tz_name() == "UTC"
+
+    assert "LIONAGI_SCHEDULER_TZ" in caplog.text
+
+
+def test_path_outside_a_zoneinfo_tree_falls_back_to_utc(tmp_path, localtime_link, caplog):
+    target = tmp_path / "etc" / "America" / "New_York"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"")
+    localtime_link.symlink_to(target)
+
+    with caplog.at_level(logging.WARNING, logger=config.__name__):
+        assert config._system_local_tz_name() == "UTC"
+
+    assert "LIONAGI_SCHEDULER_TZ" in caplog.text
+
+
+def test_unloadable_zone_name_falls_back_to_utc(tmp_path, localtime_link):
+    """A parse that yields a name no tzdata knows must not be handed on.
+
+    Returning it would push the failure into the scheduler, which can only
+    report the bad name rather than the path it came from.
+    """
+    localtime_link.symlink_to(_zone_file(tmp_path, "zoneinfo").parent / "Nowhere")
+
+    assert config._system_local_tz_name() == "UTC"

--- a/tests/studio/test_config_timezone.py
+++ b/tests/studio/test_config_timezone.py
@@ -5,35 +5,62 @@ to the host's local zone read off ``/etc/localtime``. A misread there is
 invisible: every fire still succeeds, just at the wrong hour, so these pin the
 read itself rather than the scheduler's use of the result.
 
-Fixtures build a zoneinfo tree under ``tmp_path`` and point the search roots at
-it. Zone names are real ones so that the loadability check, which consults the
-host's actual tzdata, exercises the same path it does in production.
+Fixtures build a zoneinfo tree under ``tmp_path`` and point the search path at
+it with ``zoneinfo.reset_tzpath``. That is the seam that matters: it moves the
+private path the loader consults, not just the public constant, so both the
+name derivation and the loadability check run against the constructed tree
+instead of the host's. Trees are filled with real tzdata bytes for the same
+reason, which lets a test give two roots genuinely different rules under one
+key.
 """
 
 import logging
+import zoneinfo
+from pathlib import Path
 
 import pytest
 
 from lionagi.studio import config
 
+# Captured before any test moves the search path, so the real trees stay
+# reachable as a source of tzfile bytes.
+_HOST_TZPATH = tuple(zoneinfo.TZPATH)
+
+
+def _host_zone_bytes(zone: str) -> bytes:
+    for entry in _HOST_TZPATH:
+        candidate = Path(entry) / zone
+        if candidate.is_file():
+            return candidate.read_bytes()
+    raise AssertionError(
+        f"no tzfile for {zone} under {_HOST_TZPATH}; these tests build zone "
+        "trees from the host's tzdata and cannot run without it"
+    )
+
 
 @pytest.fixture
 def tz_host(tmp_path, monkeypatch):
-    """A fake host: a localtime link, and control over the search roots."""
+    """A fake host: a localtime link, and control over the search path."""
     monkeypatch.delenv("TZ", raising=False)
     link = tmp_path / "localtime"
     monkeypatch.setattr(config, "SYSTEM_LOCALTIME_LINK", link)
 
     def set_roots(*names):
-        monkeypatch.setattr(config.zoneinfo, "TZPATH", tuple(str(tmp_path / n) for n in names))
+        """Point the stdlib's zone search at these trees, in this order."""
+        zoneinfo.reset_tzpath(to=[str(tmp_path / n) for n in names])
+        zoneinfo.ZoneInfo.clear_cache()
 
-    def zone_file(tree, zone="America/New_York"):
+    def zone_file(tree, zone="America/New_York", data_from=None):
+        """A real tzfile at *tree*/*zone*, carrying *data_from*'s rules."""
         path = tmp_path / tree / zone
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"")
+        path.write_bytes(_host_zone_bytes(data_from or zone))
         return path
 
-    return link, set_roots, zone_file
+    yield link, set_roots, zone_file
+
+    zoneinfo.reset_tzpath()
+    zoneinfo.ZoneInfo.clear_cache()
 
 
 def test_suffixed_zoneinfo_directory_resolves(tz_host):
@@ -59,18 +86,25 @@ def test_search_root_reached_through_a_symlink_resolves(tz_host, tmp_path):
     """Search roots are commonly symlinks. A localtime path resolved through
     the link matches only the resolved form of the root, so both are tried."""
     link, set_roots, zone_file = tz_host
-    real = zone_file("zoneinfo.default")
+    target = zone_file("zoneinfo.default")
     (tmp_path / "zoneinfo").symlink_to(tmp_path / "zoneinfo.default")
-    link.symlink_to(real)
-    set_roots("zoneinfo")  # the root as configured is the link, not the target
+    link.symlink_to(target)
+    set_roots("zoneinfo")
 
     assert config._system_local_tz_name() == "America/New_York"
 
 
+def test_multi_level_zone_name_keeps_all_its_parts(tz_host):
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo", "America/Indiana/Knox"))
+    set_roots("zoneinfo")
+
+    assert config._system_local_tz_name() == "America/Indiana/Knox"
+
+
 def test_directory_that_merely_looks_like_a_tree_is_not_one(tz_host):
-    """A directory named like a zoneinfo tree but not among the search roots
-    must not produce a zone. Matching on the name would accept it and return a
-    loadable but wrong zone, which is worse than returning nothing."""
+    """A path under some unrelated directory named ``zoneinfo.backup`` is not
+    a zone source. Only the configured search roots are."""
     link, set_roots, zone_file = tz_host
     link.symlink_to(zone_file("zoneinfo.backup"))
     set_roots("zoneinfo")
@@ -79,23 +113,69 @@ def test_directory_that_merely_looks_like_a_tree_is_not_one(tz_host):
 
 
 def test_zone_follows_the_resolved_path_not_the_link_text(tz_host, tmp_path):
-    """When the link's text and where it lands disagree, where it lands wins.
-
-    Reading the name off the unresolved text would report the zone the path is
-    named after rather than the zone the host actually uses.
-    """
+    """The link's text can name one zone while resolving to another. What the
+    host actually uses is where it resolves, so that is what is read."""
     link, set_roots, zone_file = tz_host
-    london = zone_file("zoneinfo.default", "Europe/London")
-    named_new_york = tmp_path / "zoneinfo.default" / "America" / "New_York"
-    named_new_york.parent.mkdir(parents=True, exist_ok=True)
-    named_new_york.symlink_to(london)
-    link.symlink_to(named_new_york)
-    set_roots("zoneinfo.default")
+    zone_file("zoneinfo", "Asia/Tokyo")
+    (tmp_path / "zoneinfo" / "America").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "zoneinfo" / "America" / "New_York").symlink_to(
+        tmp_path / "zoneinfo" / "Asia" / "Tokyo"
+    )
+    link.symlink_to(tmp_path / "zoneinfo" / "America" / "New_York")
+    set_roots("zoneinfo")
 
-    assert config._system_local_tz_name() == "Europe/London"
+    assert config._system_local_tz_name() == "Asia/Tokyo"
 
 
-def test_tz_environment_variable_takes_precedence(tz_host, monkeypatch):
+def test_shadowed_key_is_refused_rather_than_loading_another_zone(tz_host):
+    """Two roots can hold the same key with different rules. The name derived
+    from the root that contains localtime would be reopened from the earlier
+    root, so accepting it would schedule on rules the host does not use."""
+    link, set_roots, zone_file = tz_host
+    zone_file("first", "America/New_York", data_from="Asia/Tokyo")
+    link.symlink_to(zone_file("second", "America/New_York"))
+    set_roots("first", "second")
+
+    assert config._system_local_tz_name() == "UTC"
+
+
+def test_unshadowed_key_still_resolves_with_several_roots(tz_host):
+    """The refusal above is about a collision, not about having more than one
+    root: a key only the containing root holds still resolves."""
+    link, set_roots, zone_file = tz_host
+    zone_file("first", "Asia/Tokyo")
+    link.symlink_to(zone_file("second", "America/New_York"))
+    set_roots("first", "second")
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_unreadable_zone_data_falls_back_instead_of_raising(tz_host, tmp_path):
+    """The name is computed at import to build a module constant, so a
+    malformed tzfile must not make the package unimportable."""
+    link, set_roots, _zone_file = tz_host
+    path = tmp_path / "zoneinfo" / "America" / "New_York"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"not a tzfile")
+    link.symlink_to(path)
+    set_roots("zoneinfo")
+
+    assert config._system_local_tz_name() == "UTC"
+
+
+def test_symlink_loop_falls_back_instead_of_raising(tz_host, tmp_path):
+    """A looping localtime link raises from ``resolve()`` rather than
+    returning. At import that would take the whole package down."""
+    link, set_roots, _zone_file = tz_host
+    other = tmp_path / "loop_b"
+    link.symlink_to(other)
+    other.symlink_to(link)
+    set_roots("zoneinfo")
+
+    assert config._system_local_tz_name() == "UTC"
+
+
+def test_tz_environment_variable_wins(tz_host, monkeypatch):
     link, set_roots, zone_file = tz_host
     link.symlink_to(zone_file("zoneinfo"))
     set_roots("zoneinfo")
@@ -104,33 +184,13 @@ def test_tz_environment_variable_takes_precedence(tz_host, monkeypatch):
     assert config._system_local_tz_name() == "Asia/Tokyo"
 
 
-def test_missing_link_falls_back_to_utc_with_a_warning(tz_host, caplog):
-    _, set_roots, _ = tz_host
+def test_missing_localtime_falls_back_to_utc_with_a_warning(tz_host, caplog):
+    """An unrequested UTC is indistinguishable from a configured one, so the
+    fallback says so rather than being silent."""
+    _link, set_roots, _zone_file = tz_host
     set_roots("zoneinfo")
 
     with caplog.at_level(logging.WARNING, logger=config.__name__):
         assert config._system_local_tz_name() == "UTC"
 
     assert "LIONAGI_SCHEDULER_TZ" in caplog.text
-
-
-def test_symlink_loop_falls_back_instead_of_raising(tz_host, tmp_path):
-    """This runs at import to compute a module constant, so a hostile
-    filesystem must not make the package unimportable."""
-    link, set_roots, _ = tz_host
-    other = tmp_path / "other"
-    link.symlink_to(other)
-    other.symlink_to(link)
-    set_roots("zoneinfo")
-
-    assert config._system_local_tz_name() == "UTC"
-
-
-def test_unloadable_zone_name_falls_back_to_utc(tz_host):
-    """A name derived from a real search root that no tzdata knows must not be
-    handed on; the scheduler could only report the name, not its origin."""
-    link, set_roots, zone_file = tz_host
-    link.symlink_to(zone_file("zoneinfo", "Mars/Olympus_Mons"))
-    set_roots("zoneinfo")
-
-    assert config._system_local_tz_name() == "UTC"


### PR DESCRIPTION
## Problem

The scheduler interprets cron expressions in `SCHEDULER_TZ`, which defaults to the host's local zone read off the `/etc/localtime` symlink. The zone name was extracted by locating a path component named exactly `zoneinfo` and taking everything after it.

macOS resolves that link through a directory named `zoneinfo.default`:

```
/etc/localtime -> /var/db/timezone/zoneinfo/America/New_York
        resolves to /usr/share/zoneinfo.default/America/New_York
        parts ('/', 'usr', 'share', 'zoneinfo.default', 'America', 'New_York')
        'zoneinfo' in parts -> False
```

The exact-name test finds nothing and the function takes its documented UTC fallback. Every cron expression on such a host is then interpreted in UTC while appearing to be configured for local time.

The failure is silent in both directions. Nothing errors and no row is skipped: each fires successfully, just at the wrong hour. And because the fallback is also the correct behaviour for a host with no detectable zone, an unrequested UTC is indistinguishable from a chosen one.

## Fix

- Match the zoneinfo directory on its prefix, so a suffixed variant still yields the zone.
- Consider the raw symlink target as well as the fully resolved path. A host may chain through a second link into a directory whose name no longer identifies the tree, and either form alone can be the one carrying the zone name.
- Validate that the parsed name loads as a zone before returning it. A bad parse now falls back here rather than handing the scheduler a plausible-looking name it can only reject later, where the path it came from is no longer available to report.
- Log the UTC fallback and name the override in the message.

## Tests

Seven tests on the resolver, including the real macOS shape and the chained-link case.

The existing timezone tests all set `SCHEDULER_TZ` to a literal, so they covered the scheduler's use of the value and never the code that produces it. That gap is why a green suite coexisted with a host resolving every cron row in UTC.

Verified against a real daemon: pinning the zone and reloading moved fourteen daily and weekly rows by exactly the local offset, one six-hourly row to its correct next local boundary, and left non-cron rows untouched.

Full studio suite: 780 passed.