### PR TITLE
fix(cli): reject ambiguous short id prefixes instead of silently picking one

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from lionagi._paths import RUNS_ROOT, ensure_lionagi_dir
+from lionagi.cli._util import AmbiguousIdError
 from lionagi.libs.path_safety import validate_path_component
 from lionagi.ln._utils import now_utc
 from lionagi.providers._provider_errors import ProviderError
@@ -232,36 +233,59 @@ def allocate_run(
 # ── Branch lookup (canonical + legacy fallback) ─────────────────────────
 
 
-def find_branch(branch_id: str) -> tuple[str | None, Path]:
-    """Locate a branch JSON; returns (run_id, path), run_id=None for legacy logs/agents/ storage."""
-    if RUNS_ROOT.exists():
-        # Prefer an exact hit, fall back to prefix match (branch UUIDs may
-        # have been truncated by the user when resuming).
-        for run_dir in sorted(
-            RUNS_ROOT.iterdir(),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        ):
-            if not run_dir.is_dir():
-                continue
-            branches = run_dir / "branches"
-            if not branches.exists():
-                continue
-            exact = branches / f"{branch_id}.json"
-            if exact.exists():
-                return run_dir.name, exact
-            for match in branches.glob(f"{branch_id}*.json"):
-                return run_dir.name, match
+def _branch_dirs() -> list[tuple[str | None, Path, str]]:
+    """Every directory that can hold a branch file, with its run id and suffix.
 
+    Newest run first, so an exact hit is found in the order a caller expects.
+    """
+    places: list[tuple[str | None, Path, str]] = []
+    if RUNS_ROOT.exists():
+        for run_dir in sorted(RUNS_ROOT.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+            branches = run_dir / "branches"
+            if run_dir.is_dir() and branches.exists():
+                places.append((run_dir.name, branches, ".json"))
     if _LEGACY_AGENTS_ROOT.exists():
-        for provider_dir in sorted(_LEGACY_AGENTS_ROOT.iterdir()):
-            if not provider_dir.is_dir():
-                continue
-            exact = provider_dir / branch_id
-            if exact.exists():
-                return None, exact
-            for match in provider_dir.glob(f"{branch_id}*"):
-                return None, match
+        places.extend(
+            (None, provider_dir, "")
+            for provider_dir in sorted(_LEGACY_AGENTS_ROOT.iterdir())
+            if provider_dir.is_dir()
+        )
+    return places
+
+
+def find_branch(branch_id: str) -> tuple[str | None, Path]:
+    """Locate a branch JSON; returns (run_id, path), run_id=None for legacy logs/agents/ storage.
+
+    Branch ids may be given truncated, so a prefix is accepted. It is resolved
+    in two passes over every place a branch can live rather than one pass that
+    accepts whatever it finds first: an exact id is a complete answer and must
+    win wherever it lives, and a prefix that fits more than one branch has no
+    correct winner. Resuming acts, so picking one of several would silently put
+    a new leg on a branch the caller did not name.
+    """
+    places = _branch_dirs()
+
+    for run_id, directory, suffix in places:
+        exact = directory / f"{branch_id}{suffix}"
+        if exact.exists():
+            return run_id, exact
+
+    matches: list[tuple[str | None, Path]] = []
+    for run_id, directory, suffix in places:
+        # startswith re-checks the glob: a case-insensitive filesystem matches
+        # names the id does not actually prefix.
+        matches.extend(
+            (run_id, match)
+            for match in sorted(directory.glob(f"{branch_id}*{suffix}"))
+            if match.name.startswith(branch_id)
+        )
+
+    if len(matches) > 1:
+        raise AmbiguousIdError(
+            branch_id, "branch", [m.name.removesuffix(".json") for _, m in matches]
+        )
+    if matches:
+        return matches[0]
 
     raise FileNotFoundError(f"No branch log found for id {branch_id!r}")
 

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -89,22 +89,83 @@ _TABLE_TO_ENTITY_TYPE = {
     "shows": "show",
 }
 
+# How many colliding ids an ambiguity message lists before it truncates.
+_CANDIDATES_SHOWN = 5
+
+
+class AmbiguousIdError(ValueError):
+    """A short id prefix matched more than one row in one table.
+
+    Carries the colliding ids so every CLI surface can tell the user what to
+    disambiguate between instead of silently acting on one of them.
+    """
+
+    def __init__(self, id_or_short: str, table: str, candidates: list[str]) -> None:
+        self.id_or_short = id_or_short
+        self.table = table
+        self.candidates = list(candidates)
+        shown = self.candidates[:_CANDIDATES_SHOWN]
+        listed = ", ".join(shown)
+        if len(self.candidates) > len(shown):
+            listed += ", ..."
+        super().__init__(
+            f"ambiguous id prefix {id_or_short!r} — matches more than one "
+            f"{table} record ({listed}); use a longer prefix or the full id"
+        )
+
+
+def _like_prefix_pattern(id_or_short: str) -> str:
+    """Escape LIKE metacharacters so a prefix is matched literally."""
+    escaped = id_or_short.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return escaped + "%"
+
+
+async def fetch_unique_row(db: Any, table: str, id_or_short: str) -> dict[str, Any] | None:
+    """Resolve one id (or short prefix) to a single row of *table*.
+
+    Exact id wins outright — it is the primary key, so it cannot be ambiguous.
+    Otherwise the value is treated as a prefix, and a prefix matching more than
+    one row raises `AmbiguousIdError` rather than picking one: a `LIKE` query
+    plus a fetch-one has no cardinality check and no ordering rule, so the row
+    it returns is whichever the engine happens to yield first. Rows are ordered
+    by id so the candidate list an error reports is stable.
+
+    Returns the raw row dict (JSON columns still encoded); callers that need
+    decoded columns pass it through `db._row_to_dict`.
+    """
+    id_or_short = id_or_short.strip()
+    if not id_or_short:
+        return None
+
+    row = await db.fetch_one(
+        f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
+        (id_or_short,),
+    )
+    if row is not None:
+        return row
+
+    rows = await db.fetch_all(
+        f"SELECT * FROM {table} WHERE id LIKE ? ESCAPE '\\' "  # noqa: S608
+        f"ORDER BY id LIMIT {_CANDIDATES_SHOWN + 1}",
+        (_like_prefix_pattern(id_or_short),),
+    )
+    if not rows:
+        return None
+    if len(rows) > 1:
+        raise AmbiguousIdError(id_or_short, table, [r["id"] for r in rows])
+    return rows[0]
+
 
 async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str, Any]] | None:
-    id_or_short = id_or_short.strip()
-    is_prefix = len(id_or_short) < 36
+    """Sweep the entity tables in order for the first one holding *id_or_short*.
 
+    Raises `AmbiguousIdError` when the prefix collides inside a table. A prefix
+    that matches one row in each of two different tables still resolves to the
+    earlier table in `_SEARCH_ORDER` — that shadowing is the documented
+    search-order contract, not a cardinality failure.
+    """
     for table in _SEARCH_ORDER:
-        if is_prefix:
-            row = await db.fetch_one(
-                f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-                (id_or_short + "%",),
-            )
-        else:
-            row = await db.fetch_one(
-                f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-                (id_or_short,),
-            )
+        row = await fetch_unique_row(db, table, id_or_short)
         if row is not None:
             entity_type = _TABLE_TO_ENTITY_TYPE[table]
             return table, entity_type, db._row_to_dict(row)

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -176,10 +177,12 @@ async def _fetch_prefix_rows(db: Any, table: str, id_or_short: str) -> list[dict
     )
 
 
-async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str, Any]] | None:
+async def resolve_entity(
+    db: Any, id_or_short: str, tables: Sequence[str] = _SEARCH_ORDER
+) -> tuple[str, str, dict[str, Any]] | None:
     """Find the one record holding *id_or_short*, across every entity kind.
 
-    An exact id is a primary key and settles it outright, in `_SEARCH_ORDER`.
+    An exact id is a primary key and settles it outright, in *tables* order.
     A prefix does not: it is a guess, and a guess that fits a session and an
     invocation equally well has no correct winner. Search order cannot break
     that tie, because ordering is about where to look first, not about which of
@@ -188,18 +191,23 @@ async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str,
     as a collision inside one does. The alternative is a resolver that rejects
     ambiguity in one direction and silently picks in the other, which teaches
     callers to trust a prefix that resolves.
+
+    *tables* narrows which kinds are considered, for callers that answer about
+    a subset. It is the kinds a caller searches, not the policy it searches
+    them under: a caller with its own list still gets the same exact-first,
+    refuse-a-collision behaviour, which is the whole point of it living here.
     """
     id_or_short = id_or_short.strip()
     if not id_or_short:
         return None
 
-    for table in _SEARCH_ORDER:
+    for table in tables:
         row = await _fetch_exact_row(db, table, id_or_short)
         if row is not None:
             return table, _TABLE_TO_ENTITY_TYPE[table], db._row_to_dict(row)
 
     hits: list[tuple[str, dict[str, Any]]] = []
-    for table in _SEARCH_ORDER:
+    for table in tables:
         hits.extend((table, row) for row in await _fetch_prefix_rows(db, table, id_or_short))
 
     if not hits:

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -94,13 +94,15 @@ _CANDIDATES_SHOWN = 5
 
 
 class AmbiguousIdError(ValueError):
-    """A short id prefix matched more than one row in one table.
+    """A short id prefix matched more than one record.
 
     Carries the colliding ids so every CLI surface can tell the user what to
-    disambiguate between instead of silently acting on one of them.
+    disambiguate between instead of silently acting on one of them. `table` is
+    None when the collision is across kinds rather than inside one, since the
+    candidates then name their own kind and a single table would misdescribe it.
     """
 
-    def __init__(self, id_or_short: str, table: str, candidates: list[str]) -> None:
+    def __init__(self, id_or_short: str, table: str | None, candidates: list[str]) -> None:
         self.id_or_short = id_or_short
         self.table = table
         self.candidates = list(candidates)
@@ -108,9 +110,10 @@ class AmbiguousIdError(ValueError):
         listed = ", ".join(shown)
         if len(self.candidates) > len(shown):
             listed += ", ..."
+        what = f"more than one {table} record" if table else "records of more than one kind"
         super().__init__(
-            f"ambiguous id prefix {id_or_short!r} — matches more than one "
-            f"{table} record ({listed}); use a longer prefix or the full id"
+            f"ambiguous id prefix {id_or_short!r} — matches {what} "
+            f"({listed}); use a longer prefix or the full id"
         )
 
 
@@ -137,18 +140,11 @@ async def fetch_unique_row(db: Any, table: str, id_or_short: str) -> dict[str, A
     if not id_or_short:
         return None
 
-    row = await db.fetch_one(
-        f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-        (id_or_short,),
-    )
+    row = await _fetch_exact_row(db, table, id_or_short)
     if row is not None:
         return row
 
-    rows = await db.fetch_all(
-        f"SELECT * FROM {table} WHERE id LIKE ? ESCAPE '\\' "  # noqa: S608
-        f"ORDER BY id LIMIT {_CANDIDATES_SHOWN + 1}",
-        (_like_prefix_pattern(id_or_short),),
-    )
+    rows = await _fetch_prefix_rows(db, table, id_or_short)
     if not rows:
         return None
     if len(rows) > 1:
@@ -156,18 +152,68 @@ async def fetch_unique_row(db: Any, table: str, id_or_short: str) -> dict[str, A
     return rows[0]
 
 
-async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str, Any]] | None:
-    """Sweep the entity tables in order for the first one holding *id_or_short*.
+async def _fetch_exact_row(db: Any, table: str, id_or_short: str) -> dict[str, Any] | None:
+    return await db.fetch_one(
+        f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
+        (id_or_short,),
+    )
 
-    Raises `AmbiguousIdError` when the prefix collides inside a table. A prefix
-    that matches one row in each of two different tables still resolves to the
-    earlier table in `_SEARCH_ORDER` — that shadowing is the documented
-    search-order contract, not a cardinality failure.
+
+async def _fetch_prefix_rows(db: Any, table: str, id_or_short: str) -> list[dict[str, Any]]:
+    """Rows of *table* whose id starts with *id_or_short*, case-sensitively.
+
+    LIKE alone is not enough: on the default backend it compares ASCII
+    case-insensitively, so an upper-cased prefix would match a lower-cased id
+    while the exact comparison beside it would not. It is kept as the first
+    predicate because it is the one an index on `id` can use; the substring
+    equality after it is what actually decides.
     """
-    for table in _SEARCH_ORDER:
-        row = await fetch_unique_row(db, table, id_or_short)
-        if row is not None:
-            entity_type = _TABLE_TO_ENTITY_TYPE[table]
-            return table, entity_type, db._row_to_dict(row)
+    return await db.fetch_all(
+        f"SELECT * FROM {table} WHERE id LIKE ? ESCAPE '\\' "  # noqa: S608
+        f"AND substr(id, 1, ?) = ? "
+        f"ORDER BY id LIMIT {_CANDIDATES_SHOWN + 1}",
+        (_like_prefix_pattern(id_or_short), len(id_or_short), id_or_short),
+    )
 
-    return None
+
+async def resolve_entity(db: Any, id_or_short: str) -> tuple[str, str, dict[str, Any]] | None:
+    """Find the one record holding *id_or_short*, across every entity kind.
+
+    An exact id is a primary key and settles it outright, in `_SEARCH_ORDER`.
+    A prefix does not: it is a guess, and a guess that fits a session and an
+    invocation equally well has no correct winner. Search order cannot break
+    that tie, because ordering is about where to look first, not about which of
+    two equally good matches the caller meant. So prefixes are gathered from
+    every kind and a collision across kinds raises `AmbiguousIdError`, exactly
+    as a collision inside one does. The alternative is a resolver that rejects
+    ambiguity in one direction and silently picks in the other, which teaches
+    callers to trust a prefix that resolves.
+    """
+    id_or_short = id_or_short.strip()
+    if not id_or_short:
+        return None
+
+    for table in _SEARCH_ORDER:
+        row = await _fetch_exact_row(db, table, id_or_short)
+        if row is not None:
+            return table, _TABLE_TO_ENTITY_TYPE[table], db._row_to_dict(row)
+
+    hits: list[tuple[str, dict[str, Any]]] = []
+    for table in _SEARCH_ORDER:
+        hits.extend((table, row) for row in await _fetch_prefix_rows(db, table, id_or_short))
+
+    if not hits:
+        return None
+    if len(hits) > 1:
+        kinds = {table for table, _ in hits}
+        raise AmbiguousIdError(
+            id_or_short,
+            _TABLE_TO_ENTITY_TYPE[next(iter(kinds))] if len(kinds) == 1 else None,
+            [
+                row["id"] if len(kinds) == 1 else f"{_TABLE_TO_ENTITY_TYPE[table]} {row['id']}"
+                for table, row in hits
+            ],
+        )
+
+    table, row = hits[0]
+    return table, _TABLE_TO_ENTITY_TYPE[table], db._row_to_dict(row)

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -16,7 +16,7 @@ import psutil
 from lionagi.state.db import PLAY_ACTIVE_STATUSES as _PLAY_ACTIVE_STATUSES
 
 from ._logging import log_error, warn
-from ._util import _TABLE_TO_ENTITY_TYPE
+from ._util import _TABLE_TO_ENTITY_TYPE, AmbiguousIdError
 from ._util import pid_alive as _pid_alive
 from ._util import resolve_entity as _resolve_entity
 
@@ -482,7 +482,13 @@ async def _do_kill(
     from lionagi.state.db import StateDB
 
     async with StateDB() as db:
-        resolved = await _resolve_entity(db, id_or_short)
+        try:
+            resolved = await _resolve_entity(db, id_or_short)
+        except AmbiguousIdError as exc:
+            # Killing "whichever row matched first" would signal a process the
+            # caller never named — refuse and show the candidates instead.
+            log_error(str(exc))
+            return 1
         if resolved is None:
             log_error(f"entity not found for id: {id_or_short!r}")
             return 1

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -217,6 +217,22 @@ def _terminate_pid(
     if not _pid_alive(pid):
         return "sigterm"
 
+    # Re-check identity before escalating. The check above this function's
+    # SIGTERM ran up to grace_seconds ago, and the whole reason we are here is
+    # that the process did not exit when asked -- which is indistinguishable
+    # from it having exited early and the OS having handed its pid to something
+    # else in the meantime. SIGKILL is not survivable and gives the target no
+    # chance to identify itself, so the one thing this must not do is escalate
+    # onto a stranger. A pid that now belongs to a different process is
+    # reported the same way a mismatch at entry is.
+    if expected_cmd is not None and not _check_pid_identity(
+        pid,
+        expected_cmd,
+        expected_session_id=expected_session_id,
+        expected_create_time=expected_create_time,
+    ):
+        return "identity_mismatch"
+
     try:
         os.kill(pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from ._project import detect_project
 from ._runs import RUNS_ROOT
+from ._util import AmbiguousIdError, fetch_unique_row
 from ._util import pid_alive as _pid_alive_int
 
 __all__ = (
@@ -234,7 +235,12 @@ async def _query_plays_for_show(db: Any, show_id: str) -> list[dict[str, Any]]:
 
 
 async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | None:
-    """Resolve entity_id across all entity tables; returns (entity_type, row) or None."""
+    """Resolve entity_id across all entity tables; returns (entity_type, row) or None.
+
+    Raises `AmbiguousIdError` when a short prefix matches more than one row in
+    a table, so a detail view can never be rendered for an arbitrarily chosen
+    run.
+    """
     searches = [
         ("session", "sessions"),
         ("invocation", "invocations"),
@@ -242,16 +248,7 @@ async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | 
         ("play", "plays"),
     ]
     for entity_type, table in searches:
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-            (entity_id,),
-        )
-        if row:
-            return entity_type, row
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-            (entity_id + "%",),
-        )
+        row = await fetch_unique_row(db, table, entity_id)
         if row:
             return entity_type, row
     return None
@@ -844,6 +841,10 @@ async def _run_detail(entity_id: str) -> str:
             if entity_type == "play":
                 return await _detail_play(db, entity_row)
             return _red(f"unknown entity type {entity_type!r}")
+    except AmbiguousIdError:
+        # Propagate: an ambiguous id is a user-input error the caller has to
+        # turn into a non-success exit code, not a rendered detail body.
+        raise
     except Exception as exc:  # noqa: BLE001
         return _red(f"error: {exc}")
 
@@ -866,7 +867,10 @@ def _watch_loop(
     project: str | None,
 ) -> int:
     """Repeatedly clear screen and reprint; exit cleanly on SIGINT/SIGTERM."""
-    from lionagi.ln.concurrency import run_async
+    from lionagi.ln.concurrency import SigtermInterrupt, run_async
+
+    from ._logging import log_error
+    from .status import EXIT_UNKNOWN
 
     interrupted = False
 
@@ -874,29 +878,53 @@ def _watch_loop(
         nonlocal interrupted
         interrupted = True
 
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
+    prior_sigint = signal.signal(signal.SIGINT, _handle_signal)
+    prior_sigterm = signal.signal(signal.SIGTERM, _handle_signal)
+    exit_code = 0
 
-    while not interrupted:
-        since = _since_timestamp(since_window) if since_window else None
-        if entity_id:
-            output = run_async(_run_detail(entity_id))
-        else:
-            output = run_async(_run_table(since=since, entity_type=entity_type, project=project))
-        _clear_screen()
-        ts = time.strftime("%H:%M:%S")
-        print(f"{_dim(f'Updated: {ts}  (refresh every {refresh_seconds}s, Ctrl-C to exit)')}")
-        print()
-        print(output)
-        # Sleep in small increments so SIGINT is responsive
-        for _ in range(refresh_seconds * 10):
-            if interrupted:
+    try:
+        while not interrupted:
+            since = _since_timestamp(since_window) if since_window else None
+            try:
+                if entity_id:
+                    output = run_async(_run_detail(entity_id))
+                else:
+                    output = run_async(
+                        _run_table(since=since, entity_type=entity_type, project=project)
+                    )
+            except (KeyboardInterrupt, SigtermInterrupt):
+                # run_async installs its own signal handlers for the duration
+                # of the refresh, so a signal arriving inside that window
+                # surfaces as an exception here instead of setting the flag
+                # above. Both derive from BaseException, so they must be named.
+                interrupted = True
                 break
-            time.sleep(0.1)
+            except AmbiguousIdError as exc:
+                # A longer prefix is the only fix; refreshing cannot resolve it.
+                log_error(str(exc))
+                exit_code = EXIT_UNKNOWN
+                break
+            _clear_screen()
+            ts = time.strftime("%H:%M:%S")
+            print(f"{_dim(f'Updated: {ts}  (refresh every {refresh_seconds}s, Ctrl-C to exit)')}")
+            print()
+            print(output)
+            # Sleep in small increments so SIGINT is responsive
+            for _ in range(refresh_seconds * 10):
+                if interrupted:
+                    break
+                time.sleep(0.1)
+    finally:
+        # The loop's handlers must not outlive the loop — restore whatever the
+        # process had before (None means the handler wasn't a Python callable).
+        if prior_sigint is not None:
+            signal.signal(signal.SIGINT, prior_sigint)
+        if prior_sigterm is not None:
+            signal.signal(signal.SIGTERM, prior_sigterm)
 
     if _IS_TTY:
         print()  # newline after Ctrl-C
-    return 0
+    return exit_code
 
 
 # ── Wait-for-terminal primitive (li monitor run / li monitor --run) ───────────
@@ -922,26 +950,21 @@ def _split_watched_ids(raw: list[str]) -> list[str]:
 
 
 async def _resolve_schedule_run(db: Any, raw_id: str) -> dict[str, Any] | None:
-    """Exact match then prefix match. schedule_run ids are 12-char hex, not
-    36-char UUIDs, so _util.py's length-36 prefix heuristic doesn't apply."""
+    """Exact match then unique-prefix match. schedule_run ids are 12-char hex,
+    not 36-char UUIDs, so any id length can be a prefix here."""
     row = await db.get_schedule_run(raw_id)
     if row:
         return row
-    return await db.fetch_one(
-        "SELECT * FROM schedule_runs WHERE id LIKE ?",
-        (raw_id + "%",),
-    )
+    return await fetch_unique_row(db, "schedule_runs", raw_id)
 
 
 async def _resolve_session_run(db: Any, raw_id: str) -> dict[str, Any] | None:
-    """Exact match then prefix match against the sessions table (agent/li agent run ids)."""
+    """Exact match then unique-prefix match against the sessions table
+    (agent/li agent run ids)."""
     row = await db.get_session(raw_id)
     if row:
         return row
-    return await db.fetch_one(
-        "SELECT * FROM sessions WHERE id LIKE ?",
-        (raw_id + "%",),
-    )
+    return await fetch_unique_row(db, "sessions", raw_id)
 
 
 def _format_session_wait_line(row: dict[str, Any]) -> str:
@@ -1318,7 +1341,12 @@ def _dispatch_wait(
         async with StateDB() as db:
             return await _resolve_watched_runs(db, ids)
 
-    resolved = _run_tick(_resolve())
+    try:
+        resolved = _run_tick(_resolve())
+    except AmbiguousIdError as exc:
+        # Nothing to wait on: the caller named a prefix, not a run.
+        log_error(str(exc))
+        return EXIT_UNKNOWN
     if resolved is None:
         # Interrupted before resolving completed — "still in progress",
         # not success or failure.
@@ -1615,7 +1643,14 @@ def run_monitor(args: argparse.Namespace) -> int:
         )
 
     if entity_id:
-        output = run_async(_run_detail(entity_id))
+        try:
+            output = run_async(_run_detail(entity_id))
+        except AmbiguousIdError as exc:
+            from ._logging import log_error
+            from .status import EXIT_UNKNOWN
+
+            log_error(str(exc))
+            return EXIT_UNKNOWN
     else:
         output = run_async(_run_table(since=since, entity_type=entity_type, project=project))
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -878,8 +878,22 @@ def _watch_loop(
         nonlocal interrupted
         interrupted = True
 
-    prior_sigint = signal.signal(signal.SIGINT, _handle_signal)
-    prior_sigterm = signal.signal(signal.SIGTERM, _handle_signal)
+    def _install(signum):
+        """Take over *signum* only if the handler can be given back.
+
+        A handler installed outside Python is reported as None and cannot be
+        reinstalled, so replacing one means keeping it forever. Leaving it
+        alone costs this loop its clean exit on that signal; taking it would
+        cost the whole process its handler, which is the larger harm.
+        """
+        prior = signal.getsignal(signum)
+        if prior is None:
+            return None
+        signal.signal(signum, _handle_signal)
+        return prior
+
+    prior_sigint = _install(signal.SIGINT)
+    prior_sigterm = _install(signal.SIGTERM)
     exit_code = 0
 
     try:
@@ -915,8 +929,8 @@ def _watch_loop(
                     break
                 time.sleep(0.1)
     finally:
-        # The loop's handlers must not outlive the loop — restore whatever the
-        # process had before (None means the handler wasn't a Python callable).
+        # The loop's handlers must not outlive the loop. None here means the
+        # signal was never taken over, so there is nothing to give back.
         if prior_sigint is not None:
             signal.signal(signal.SIGINT, prior_sigint)
         if prior_sigterm is not None:

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from ._project import detect_project
 from ._runs import RUNS_ROOT
-from ._util import AmbiguousIdError, fetch_unique_row
+from ._util import AmbiguousIdError, fetch_unique_row, resolve_entity
 from ._util import pid_alive as _pid_alive_int
 
 __all__ = (
@@ -237,21 +237,18 @@ async def _query_plays_for_show(db: Any, show_id: str) -> list[dict[str, Any]]:
 async def _find_entity(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | None:
     """Resolve entity_id across all entity tables; returns (entity_type, row) or None.
 
-    Raises `AmbiguousIdError` when a short prefix matches more than one row in
-    a table, so a detail view can never be rendered for an arbitrarily chosen
-    run.
+    Raises `AmbiguousIdError` when a short prefix matches more than one row,
+    whether the rows are of one kind or several, so a detail view can never be
+    rendered for an arbitrarily chosen run. Kinds are searched together for
+    that reason: taking the first kind that matches would answer a collision
+    across kinds by search order, which says where to look first and nothing
+    about which record the caller meant.
     """
-    searches = [
-        ("session", "sessions"),
-        ("invocation", "invocations"),
-        ("show", "shows"),
-        ("play", "plays"),
-    ]
-    for entity_type, table in searches:
-        row = await fetch_unique_row(db, table, entity_id)
-        if row:
-            return entity_type, row
-    return None
+    hit = await resolve_entity(db, entity_id, tables=("sessions", "invocations", "shows", "plays"))
+    if hit is None:
+        return None
+    _table, entity_type, row = hit
+    return entity_type, row
 
 
 def _stream_tail(run_dir: Path, branch_id: str, n_lines: int = 5) -> list[str]:

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -15,6 +15,7 @@ from lionagi._errors import LionError
 from lionagi._paths import RUNS_ROOT
 
 from .._runs import RunDir
+from .._util import AmbiguousIdError
 
 __all__ = (
     "CHECKPOINT_VERSION",
@@ -164,18 +165,29 @@ def load_checkpoint(path: Path) -> dict[str, Any]:
 
 
 def _find_run_dir_by_id(run_id: str) -> RunDir | None:
+    """Resolve a run id, or an unambiguous prefix of one, to its directory.
+
+    Taking the most recent of several prefix matches would answer a question
+    the caller did not ask: they named a run, not "the newest run starting
+    with this", and the commands built on this act on what comes back.
+    """
     exact = RUNS_ROOT / run_id
     if exact.is_dir():
         return RunDir(run_id=run_id, state_root=exact, artifact_root=exact / "artifacts")
-    if RUNS_ROOT.exists():
-        for match in sorted(
-            RUNS_ROOT.glob(f"{run_id}*"), key=lambda p: p.stat().st_mtime, reverse=True
-        ):
-            if match.is_dir():
-                return RunDir(
-                    run_id=match.name, state_root=match, artifact_root=match / "artifacts"
-                )
-    return None
+    if not RUNS_ROOT.exists():
+        return None
+
+    # startswith re-checks the glob: a case-insensitive filesystem matches
+    # names the id does not actually prefix.
+    matches = sorted(
+        p for p in RUNS_ROOT.glob(f"{run_id}*") if p.is_dir() and p.name.startswith(run_id)
+    )
+    if len(matches) > 1:
+        raise AmbiguousIdError(run_id, "run", [p.name for p in matches])
+    if not matches:
+        return None
+    match = matches[0]
+    return RunDir(run_id=match.name, state_root=match, artifact_root=match / "artifacts")
 
 
 async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]]:

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -20,6 +20,7 @@ import asyncio
 from typing import Any
 
 from .._logging import log_error
+from .._util import AmbiguousIdError
 from ..status import EXIT_UNKNOWN, _resolve_any_target, _resolve_primary_session
 
 __all__ = (
@@ -37,22 +38,6 @@ _DB_BUSY_TIMEOUT_S = 10.0
 # "flow", playbook runs set "play"); anything else has no consumer, so a
 # queued control would sit pending forever.
 _POLLER_KINDS = frozenset({"flow", "play"})
-
-
-async def _prefix_is_ambiguous(db: Any, entity_id: str) -> bool:
-    """True when a short prefix matches 2+ rows in the first table that
-    matches at all (same sessions→invocations→plays order the resolver
-    sweeps, so cross-table shadowing stays intentional)."""
-    if len(entity_id) >= 36:
-        return False
-    for table in ("sessions", "invocations", "plays"):
-        rows = await db.fetch_all(
-            f"SELECT id FROM {table} WHERE id LIKE ? LIMIT 2",  # noqa: S608
-            (entity_id + "%",),
-        )
-        if rows:
-            return len(rows) > 1
-    return False
 
 
 async def _resolve_session(db: Any, entity_id: str) -> dict[str, Any] | None:
@@ -75,13 +60,10 @@ async def _enqueue_control_inner(
 
     async with StateDB() as db:
         entity_id = entity_id.strip()
-        if await _prefix_is_ambiguous(db, entity_id):
-            return (
-                f"ambiguous id prefix {entity_id!r} — matches more than one "
-                "record; use a longer prefix or the full id",
-                EXIT_UNKNOWN,
-            )
-        session = await _resolve_session(db, entity_id)
+        try:
+            session = await _resolve_session(db, entity_id)
+        except AmbiguousIdError as exc:
+            return str(exc), EXIT_UNKNOWN
         if session is None:
             return f"no session/invocation/play found for id {entity_id!r}", EXIT_UNKNOWN
         session_id = session["id"]

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from ._logging import log_error
 from ._project import detect_project
+from ._util import AmbiguousIdError, fetch_unique_row
 
 __all__ = (
     "run_agent_status",
@@ -45,19 +46,14 @@ _DB_BUSY_TIMEOUT_S = 10.0
 
 
 async def _fetch_by_id(db: Any, table: str, id_or_short: str) -> dict[str, Any] | None:
-    """Exact-id fetch for full ids, prefix (LIKE) fetch for short ids, scoped
-    to one table (see _util.resolve_entity for the multi-table sweep)."""
-    id_or_short = id_or_short.strip()
-    if len(id_or_short) < 36:
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id LIKE ?",  # noqa: S608
-            (id_or_short + "%",),
-        )
-    else:
-        row = await db.fetch_one(
-            f"SELECT * FROM {table} WHERE id = ?",  # noqa: S608
-            (id_or_short,),
-        )
+    """Exact-id fetch, then unique-prefix fetch, scoped to one table (see
+    _util.resolve_entity for the multi-table sweep).
+
+    Raises `AmbiguousIdError` when a prefix matches more than one row; the
+    status entry points turn that into EXIT_UNKNOWN, never a status readout
+    for an arbitrarily chosen run.
+    """
+    row = await fetch_unique_row(db, table, id_or_short)
     return db._row_to_dict(row) if row is not None else None
 
 
@@ -407,12 +403,15 @@ async def _run_status_inner(
 
     async with StateDB() as db:
         project = detect_project(Path.cwd())[0]
-        if command == "agent":
-            target = await _resolve_agent_target(db, entity_id, project)
-        elif command == "play":
-            target = await _resolve_play_target(db, entity_id, project)
-        else:  # "ctl" — generic, id required (enforced by argparse), no kind scoping
-            target = await _resolve_any_target(db, entity_id) if entity_id else None
+        try:
+            if command == "agent":
+                target = await _resolve_agent_target(db, entity_id, project)
+            elif command == "play":
+                target = await _resolve_play_target(db, entity_id, project)
+            else:  # "ctl" — generic, id required (enforced by argparse), no kind scoping
+                target = await _resolve_any_target(db, entity_id) if entity_id else None
+        except AmbiguousIdError as exc:
+            return str(exc), EXIT_UNKNOWN
 
         if target is None:
             who = f"id {entity_id!r}" if entity_id else f"latest {command} run"

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from ._logging import log_error
 from ._project import detect_project
-from ._util import AmbiguousIdError, fetch_unique_row
+from ._util import AmbiguousIdError, fetch_unique_row, resolve_entity
 
 __all__ = (
     "run_agent_status",
@@ -87,14 +87,17 @@ async def _resolve_agent_target(
     db: Any, entity_id: str | None, project: str | None
 ) -> tuple[str, dict[str, Any]] | None:
     """`li agent status` resolution: session (any kind), invocation, or a
-    branch_id, by id; default-latest is scoped to agent-kind sessions."""
+    branch_id, by id; default-latest is scoped to agent-kind sessions.
+
+    Sessions and invocations are searched together: a prefix that fits one of
+    each is ambiguous, and reporting the session because it is looked at first
+    is search order deciding a question it cannot answer.
+    """
     if entity_id:
-        row = await _fetch_by_id(db, "sessions", entity_id)
-        if row is not None:
-            return "session", row
-        row = await _fetch_by_id(db, "invocations", entity_id)
-        if row is not None:
-            return "invocation", row
+        hit = await resolve_entity(db, entity_id, tables=("sessions", "invocations"))
+        if hit is not None:
+            _table, entity_type, row = hit
+            return entity_type, row
         row = await _resolve_session_by_branch_id(db, entity_id)
         if row is not None:
             return "session", row
@@ -106,19 +109,17 @@ async def _resolve_agent_target(
 async def _resolve_play_target(
     db: Any, entity_id: str | None, project: str | None
 ) -> tuple[str, dict[str, Any]] | None:
-    """`li play status` resolution: session, then invocation, then a show
-    sub-play row, by id; default-latest is scoped to play/flow-kind sessions.
+    """`li play status` resolution: session, invocation, or a show sub-play
+    row, by id; default-latest is scoped to play/flow-kind sessions.
+
+    The three kinds are searched together, for the same reason `li agent
+    status` searches its two together.
     """
     if entity_id:
-        row = await _fetch_by_id(db, "sessions", entity_id)
-        if row is not None:
-            return "session", row
-        row = await _fetch_by_id(db, "invocations", entity_id)
-        if row is not None:
-            return "invocation", row
-        row = await _fetch_by_id(db, "plays", entity_id)
-        if row is not None:
-            return "play", row
+        hit = await resolve_entity(db, entity_id, tables=("sessions", "invocations", "plays"))
+        if hit is not None:
+            _table, entity_type, row = hit
+            return entity_type, row
         return None
     row = await _latest_session(db, invocation_kinds=("play", "flow"), project=project)
     return ("session", row) if row is not None else None
@@ -126,16 +127,19 @@ async def _resolve_play_target(
 
 async def _resolve_any_target(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | None:
     """`li o ctl status <id>` resolution: no kind scoping, id required (no
-    latest). Falls back to branch_id last, after sessions/invocations/plays."""
-    row = await _fetch_by_id(db, "sessions", entity_id)
-    if row is not None:
-        return "session", row
-    row = await _fetch_by_id(db, "invocations", entity_id)
-    if row is not None:
-        return "invocation", row
-    row = await _fetch_by_id(db, "plays", entity_id)
-    if row is not None:
-        return "play", row
+    latest). Falls back to branch_id last, after sessions/invocations/plays.
+
+    The kinds are searched together rather than one after another. Trying each
+    in turn and keeping the first hit resolves a prefix that fits a session and
+    an invocation to whichever is looked at first, and the commands built on
+    this resolver act: `li o ctl pause` would queue a control for a flow the
+    caller never identified. The branch fallback stays last and applies only
+    when no entity matched at all.
+    """
+    hit = await resolve_entity(db, entity_id, tables=("sessions", "invocations", "plays"))
+    if hit is not None:
+        _table, entity_type, row = hit
+        return entity_type, row
     row = await _resolve_session_by_branch_id(db, entity_id)
     if row is not None:
         return "session", row

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -16,6 +16,7 @@ from typing import Any
 from uuid import uuid4
 
 from lionagi._paths import ensure_lionagi_dir
+from lionagi.cli._util import AmbiguousIdError
 from lionagi.ln._utils import now_utc
 from lionagi.utils import LIONAGI_HOME
 
@@ -53,15 +54,26 @@ def read_team_json(path: Path) -> dict[str, Any] | None:
 
 
 def _team_file(team_id: str) -> Path:
-    """Resolve a team by id/prefix/name to its JSON path."""
-    for p in _teams_dir().glob("*.json"):
+    """Resolve a team by id, name, or an unambiguous id prefix, to its JSON path.
+
+    An id and a name are both complete answers and settle it. A prefix is a
+    guess, so one that fits two teams is refused rather than resolved to
+    whichever file the directory listing happened to yield first.
+    """
+    prefix_hits: list[tuple[str, Path]] = []
+    for p in sorted(_teams_dir().glob("*.json")):
         data = read_team_json(p)
         if data is None:
             continue
-        if data.get("id") == team_id or data.get("id", "").startswith(team_id):
+        if data.get("id") == team_id or data.get("name") == team_id:
             return p
-        if data.get("name") == team_id:
-            return p
+        if data.get("id", "").startswith(team_id):
+            prefix_hits.append((data["id"], p))
+
+    if len(prefix_hits) > 1:
+        raise AmbiguousIdError(team_id, "team", [tid for tid, _ in prefix_hits])
+    if prefix_hits:
+        return prefix_hits[0][1]
     raise FileNotFoundError(f"No team found matching '{team_id}'")
 
 

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -17,6 +17,7 @@ from lionagi.state.db import TERMINAL_STATUSES_BY_ENTITY_TYPE
 from lionagi.state.reasons import VALID_REASON_CODES
 
 from ._logging import log_error
+from ._util import AmbiguousIdError
 from .monitor import _resolve_schedule_run, _split_watched_ids
 from .status import EXIT_RUNNING, EXIT_UNKNOWN, _resolve_any_target, _resolve_primary_session
 
@@ -135,7 +136,26 @@ async def wait_for_terminal(
 
     async with StateDB() as db:
         for raw_id in ids:
-            hit = await _resolve_wait_target(db, raw_id)
+            try:
+                hit = await _resolve_wait_target(db, raw_id)
+            except AmbiguousIdError as exc:
+                # One bad id doesn't abort the wait — it resolves to its own
+                # non-success outcome, like a not-found id does.
+                outcome = {
+                    "run_id": raw_id,
+                    "kind": None,
+                    "status": "ambiguous",
+                    "reason": _UNKNOWN_REASON,
+                    "artifact_dir": None,
+                    "exit_code": None,
+                    "success": False,
+                    "detail": str(exc),
+                }
+                outcomes[raw_id] = outcome
+                order.append(raw_id)
+                if on_result is not None:
+                    on_result(outcome)
+                continue
             if hit is None:
                 outcome = {
                     "run_id": raw_id,
@@ -239,6 +259,9 @@ def run_wait(argv: list[str]) -> int:
         if outcome["status"] == "not_found":
             log_error(f"run {outcome['run_id']!r} not found")
             return
+        if outcome["status"] == "ambiguous":
+            log_error(outcome["detail"])
+            return
         print(format_wait_line(outcome))
 
     # A still-in-progress wait (SIGINT/SIGTERM mid-wait) is neither success nor failure.
@@ -252,6 +275,6 @@ def run_wait(argv: list[str]) -> int:
 
     if interrupted or len(outcomes) < len(watched_ids):
         return EXIT_RUNNING
-    if any(o["status"] in ("not_found", "unknown") for o in outcomes):
+    if any(o["status"] in ("not_found", "unknown", "ambiguous") for o in outcomes):
         return EXIT_UNKNOWN
     return 0 if all(o["success"] for o in outcomes) else 1

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import logging
 import signal
 import threading
 from collections.abc import Awaitable, Callable
@@ -153,9 +154,21 @@ def run_async(coro: Awaitable[T]) -> T:
     try:
         thread.join()
     finally:
-        # Restore only what was installed above.
+        # Restore only what was installed above. Each restore stands alone: this
+        # runs in a finally, often while an exception is already propagating, and
+        # a failure on one signal must not strand the others with this runner's
+        # handler still installed. Failures are logged rather than raised, since
+        # raising here would replace whatever the caller was actually failing on.
         for signum, prior in installed:
-            signal.signal(signum, prior)
+            try:
+                signal.signal(signum, prior)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "could not restore the previous handler for signal %s; it "
+                    "remains overridden for the rest of this process",
+                    signum,
+                    exc_info=True,
+                )
 
     if _cancel_requested.is_set():
         raise KeyboardInterrupt

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -131,19 +131,31 @@ def run_async(coro: Awaitable[T]) -> T:
 
         return _handler
 
+    # Take over a signal only when the previous handler can be given back.
+    # getsignal() reports None for a handler installed outside Python, and
+    # signal.signal(signum, None) raises, so restoring one is impossible:
+    # taking it over would leave this runner's handler installed for the rest
+    # of the process. Abstaining per signal costs the caller's own cancellation
+    # wiring for that signal and keeps whatever was already there working.
+    installed: list[tuple[int, Any]] = []
     if in_main_thread:
-        old_sigint_handler = signal.getsignal(signal.SIGINT)
-        old_sigterm_handler = signal.getsignal(signal.SIGTERM)
-        signal.signal(signal.SIGINT, _make_handler(_cancel_requested, old_sigint_handler))
-        signal.signal(signal.SIGTERM, _make_handler(_term_requested, old_sigterm_handler))
+        for signum, requested in (
+            (signal.SIGINT, _cancel_requested),
+            (signal.SIGTERM, _term_requested),
+        ):
+            prior = signal.getsignal(signum)
+            if prior is None:
+                continue
+            signal.signal(signum, _make_handler(requested, prior))
+            installed.append((signum, prior))
 
     thread.start()
     try:
         thread.join()
     finally:
-        if in_main_thread:
-            signal.signal(signal.SIGINT, old_sigint_handler)
-            signal.signal(signal.SIGTERM, old_sigterm_handler)
+        # Restore only what was installed above.
+        for signum, prior in installed:
+            signal.signal(signum, prior)
 
     if _cancel_requested.is_set():
         raise KeyboardInterrupt

--- a/tests/cli/test_id_resolution.py
+++ b/tests/cli/test_id_resolution.py
@@ -268,3 +268,58 @@ def test_team_lookup_settles_on_an_id_or_a_name(teams_dir: Path):
 
     assert _team_file(FIRST) == first
     assert _team_file("two") == second
+
+
+# ── the resolvers the CLI surfaces actually call ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    [
+        "_resolve_any_target",
+        "_resolve_agent_target",
+        "_resolve_play_target",
+    ],
+)
+async def test_the_status_resolvers_refuse_a_prefix_that_fits_two_kinds(db_path: Path, resolver):
+    """The resolvers behind the commands, not only the shared helper.
+
+    Each of these used to try one table after another and keep the first hit,
+    so a prefix that fits a session and an invocation resolved to the session
+    because sessions are looked at first. `li o ctl pause` and the checkpoint
+    replay act on what comes back, so the pick is a control queued against a
+    flow the caller never identified.
+    """
+    from lionagi.cli import status
+
+    fn = getattr(status, resolver)
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        with pytest.raises(AmbiguousIdError):
+            await (fn(db, SHARED) if resolver == "_resolve_any_target" else fn(db, SHARED, None))
+
+
+async def test_the_monitor_detail_resolver_refuses_a_prefix_that_fits_two_kinds(db_path: Path):
+    from lionagi.cli.monitor import _find_entity
+
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        with pytest.raises(AmbiguousIdError):
+            await _find_entity(db, SHARED)
+
+
+async def test_the_status_resolvers_still_take_an_exact_id(db_path: Path):
+    """Aggregating prefixes must not disturb the answer an exact id gives."""
+    from lionagi.cli import status
+
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        assert (await status._resolve_any_target(db, FIRST))[0] == "session"
+        assert (await status._resolve_any_target(db, SECOND))[0] == "invocation"
+        assert (await status._resolve_agent_target(db, SECOND, None))[0] == "invocation"

--- a/tests/cli/test_id_resolution.py
+++ b/tests/cli/test_id_resolution.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Short ids are guesses, and every CLI resolver has to treat them as one.
+
+A full id is a primary key and settles the question. A prefix does not: it can
+fit several records, and there is no rule that makes one of them the right
+answer. Each of these resolvers feeds a command that acts — resuming a branch,
+killing a process, replaying a run — so picking a match is picking a target the
+caller never named. These tests hold all four to refusing instead.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli._util import AmbiguousIdError, fetch_unique_row, resolve_entity
+from lionagi.state.db import StateDB
+
+# Two ids of each kind that agree on their first six characters.
+SHARED = "abc123"
+FIRST = f"{SHARED}00-0000-4000-8000-000000000001"
+SECOND = f"{SHARED}00-0000-4000-8000-000000000002"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", path)
+    return path
+
+
+async def _seed_session(db: StateDB, session_id: str) -> None:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": session_id,
+            "progression_id": prog_id,
+            "status": "running",
+            "started_at": time.time(),
+        }
+    )
+
+
+async def _seed_invocation(db: StateDB, invocation_id: str) -> None:
+    await db.create_invocation(
+        {
+            "id": invocation_id,
+            "skill": "test",
+            "started_at": time.time(),
+            "status": "running",
+        }
+    )
+
+
+# ── across kinds ──────────────────────────────────────────────────────────────
+
+
+async def test_a_prefix_that_fits_two_kinds_is_refused(db_path: Path):
+    """Search order says where to look first, not who wins a tie.
+
+    A prefix that fits a session and an invocation equally well has no correct
+    winner, and taking the one whose table is searched earlier answers a
+    question about lookup order as if it were a question about intent.
+    """
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        with pytest.raises(AmbiguousIdError) as caught:
+            await resolve_entity(db, SHARED)
+
+    message = str(caught.value)
+    assert "session" in message and "invocation" in message
+    assert FIRST in message and SECOND in message
+
+
+async def test_a_full_id_resolves_even_when_its_prefix_is_ambiguous(db_path: Path):
+    """Refusing a prefix must not spread to the id it is a prefix of."""
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        table, entity_type, row = await resolve_entity(db, FIRST)
+
+    assert (table, entity_type) == ("sessions", "session")
+    assert row["id"] == FIRST
+
+
+async def test_an_unambiguous_prefix_still_resolves(db_path: Path):
+    """The refusal is about collisions, not about prefixes."""
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+
+        table, entity_type, row = await resolve_entity(db, SHARED)
+
+    assert (table, entity_type) == ("sessions", "session")
+    assert row["id"] == FIRST
+
+
+# ── inside one kind ───────────────────────────────────────────────────────────
+
+
+async def test_a_prefix_that_fits_two_rows_of_one_kind_is_refused(db_path: Path):
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_session(db, SECOND)
+
+        with pytest.raises(AmbiguousIdError) as caught:
+            await fetch_unique_row(db, "sessions", SHARED)
+
+    assert "session" in str(caught.value)
+
+
+# ── case ──────────────────────────────────────────────────────────────────────
+
+
+async def test_an_upper_cased_prefix_does_not_match_a_lower_cased_id(db_path: Path):
+    """LIKE compares ASCII case-insensitively on the default backend.
+
+    Left at that, a prefix would match ids it is not actually a prefix of,
+    while the exact comparison beside it would not — the same input resolving
+    one way as a whole id and another way as a prefix.
+    """
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+
+        assert await fetch_unique_row(db, "sessions", SHARED.upper()) is None
+        assert await resolve_entity(db, SHARED.upper()) is None
+
+
+# ── branch files ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr("lionagi.cli._runs.RUNS_ROOT", root)
+    monkeypatch.setattr("lionagi.cli._runs._LEGACY_AGENTS_ROOT", tmp_path / "absent")
+    return root
+
+
+def _write_branch(runs_root: Path, run_id: str, branch_id: str) -> Path:
+    branches = runs_root / run_id / "branches"
+    branches.mkdir(parents=True, exist_ok=True)
+    path = branches / f"{branch_id}.json"
+    path.write_text(json.dumps({"id": branch_id}))
+    return path
+
+
+def test_find_branch_refuses_a_prefix_that_fits_two_branches(runs_root: Path):
+    """Resuming acts, so the wrong branch is a new leg on someone else's work."""
+    from lionagi.cli._runs import find_branch
+
+    _write_branch(runs_root, "run-a", FIRST)
+    _write_branch(runs_root, "run-b", SECOND)
+
+    with pytest.raises(AmbiguousIdError) as caught:
+        find_branch(SHARED)
+
+    assert FIRST in str(caught.value) and SECOND in str(caught.value)
+
+
+def test_find_branch_takes_an_exact_id_from_an_older_run(runs_root: Path):
+    """An exact id is a complete answer and must win wherever it lives.
+
+    Directories are walked newest first, which is a reasonable place to start
+    looking and a bad reason to prefer one complete answer over another.
+    """
+    from lionagi.cli._runs import find_branch
+
+    older = _write_branch(runs_root, "run-old", FIRST)
+    _write_branch(runs_root, "run-new", SECOND)
+    newer_dir = runs_root / "run-new"
+    older_dir = runs_root / "run-old"
+    now = time.time()
+    import os
+
+    os.utime(older_dir, (now - 600, now - 600))
+    os.utime(newer_dir, (now, now))
+
+    run_id, path = find_branch(FIRST)
+
+    assert (run_id, path) == ("run-old", older)
+
+
+# ── run directories ───────────────────────────────────────────────────────────
+
+
+def test_run_dir_lookup_refuses_a_prefix_that_fits_two_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Taking the newest match answers "the newest run starting with this".
+
+    That is not the question the caller asked, and the commands built on this
+    resolver replay and inspect whatever comes back.
+    """
+    from lionagi.cli.orchestrate import _checkpoint
+
+    root = tmp_path / "runs"
+    (root / f"{SHARED}-aaaaaa").mkdir(parents=True)
+    (root / f"{SHARED}-bbbbbb").mkdir(parents=True)
+    monkeypatch.setattr(_checkpoint, "RUNS_ROOT", root)
+
+    with pytest.raises(AmbiguousIdError) as caught:
+        _checkpoint._find_run_dir_by_id(SHARED)
+
+    assert f"{SHARED}-aaaaaa" in str(caught.value)
+
+
+def test_run_dir_lookup_still_resolves_an_exact_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from lionagi.cli.orchestrate import _checkpoint
+
+    root = tmp_path / "runs"
+    exact = root / f"{SHARED}-aaaaaa"
+    exact.mkdir(parents=True)
+    (root / f"{SHARED}-aaaaaa-extended").mkdir(parents=True)
+    monkeypatch.setattr(_checkpoint, "RUNS_ROOT", root)
+
+    run_dir = _checkpoint._find_run_dir_by_id(f"{SHARED}-aaaaaa")
+
+    assert run_dir is not None
+    assert run_dir.state_root == exact
+
+
+# ── team files ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def teams_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "teams"
+    root.mkdir()
+    monkeypatch.setattr("lionagi.cli.team.TEAMS_DIR", root)
+    return root
+
+
+def _write_team(teams_dir: Path, team_id: str, name: str) -> Path:
+    path = teams_dir / f"{team_id}.json"
+    path.write_text(json.dumps({"id": team_id, "name": name, "members": [], "messages": []}))
+    return path
+
+
+def test_team_lookup_refuses_a_prefix_that_fits_two_teams(teams_dir: Path):
+    """Otherwise the team a message lands in depends on directory order."""
+    from lionagi.cli.team import _team_file
+
+    _write_team(teams_dir, FIRST, "one")
+    _write_team(teams_dir, SECOND, "two")
+
+    with pytest.raises(AmbiguousIdError) as caught:
+        _team_file(SHARED)
+
+    assert FIRST in str(caught.value) and SECOND in str(caught.value)
+
+
+def test_team_lookup_settles_on_an_id_or_a_name(teams_dir: Path):
+    """Both are complete answers, so neither is held up by a colliding prefix."""
+    from lionagi.cli.team import _team_file
+
+    first = _write_team(teams_dir, FIRST, "one")
+    second = _write_team(teams_dir, SECOND, "two")
+
+    assert _team_file(FIRST) == first
+    assert _team_file("two") == second

--- a/tests/cli/test_id_resolution.py
+++ b/tests/cli/test_id_resolution.py
@@ -323,3 +323,20 @@ async def test_the_status_resolvers_still_take_an_exact_id(db_path: Path):
         assert (await status._resolve_any_target(db, FIRST))[0] == "session"
         assert (await status._resolve_any_target(db, SECOND))[0] == "invocation"
         assert (await status._resolve_agent_target(db, SECOND, None))[0] == "invocation"
+
+
+async def test_the_monitor_detail_resolver_still_takes_an_exact_id(db_path: Path):
+    """The same guarantee where monitor gets it, which is by delegation.
+
+    Refusing an ambiguous prefix is only correct while an exact id still
+    answers. Monitor gets both from `resolve_entity` rather than stating them
+    itself, so the assertion is here to hold that delegation in place.
+    """
+    from lionagi.cli.monitor import _find_entity
+
+    async with StateDB(db_path) as db:
+        await _seed_session(db, FIRST)
+        await _seed_invocation(db, SECOND)
+
+        assert (await _find_entity(db, FIRST))[0] == "session"
+        assert (await _find_entity(db, SECOND))[0] == "invocation"

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -1534,3 +1534,55 @@ class TestTerminatePidIdentityRevalidation:
 
         assert result == "sigkill"
         assert sent == [signal.SIGTERM, signal.SIGKILL]
+
+
+# ── Ambiguous short-id prefixes ────────────────────────────────────────────────
+#
+# A prefix that matches two rows must never resolve to "whichever came first":
+# `li kill` would then signal a process the caller never named.
+
+
+async def _seed_session_with_id(db: StateDB, sid: str, *, pid: int | None = None) -> str:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "status": "running",
+            "started_at": time.time(),
+            "node_metadata": {"pid": pid} if pid is not None else {},
+        }
+    )
+    return sid
+
+
+async def test_resolve_entity_rejects_ambiguous_prefix(temp_db_path: Path):
+    from lionagi.cli._util import AmbiguousIdError
+
+    async with StateDB() as db:
+        first = await _seed_session_with_id(db, "abcde000-0000-0000-0000-000000000001")
+        second = await _seed_session_with_id(db, "abcde111-0000-0000-0000-000000000002")
+
+        with pytest.raises(AmbiguousIdError) as excinfo:
+            await _resolve_entity(db, "abcde")
+
+    assert set(excinfo.value.candidates) == {first, second}
+    assert "abcde" in str(excinfo.value)
+
+
+async def test_do_kill_ambiguous_prefix_signals_nothing_and_fails(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+):
+    async with StateDB() as db:
+        first = await _seed_session_with_id(db, "abcde000-0000-0000-0000-000000000001", pid=4242)
+        second = await _seed_session_with_id(db, "abcde111-0000-0000-0000-000000000002", pid=4243)
+
+    with patch("lionagi.cli.kill._kill_one") as kill_one:
+        with caplog.at_level("ERROR"):
+            rc = await _do_kill("abcde")
+
+    assert rc == 1, "an ambiguous prefix must not be a success exit code"
+    kill_one.assert_not_called()
+    assert "ambiguous" in caplog.text
+    assert first in caplog.text and second in caplog.text

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -1481,3 +1481,56 @@ async def test_do_kill_all_stale_does_NOT_touch_play_at_all(
         assert row is not None
         # Play must remain running — the sweep must not have touched it.
         assert row["status"] == "running"
+
+
+import signal  # noqa: E402
+
+
+class TestTerminatePidIdentityRevalidation:
+    """SIGKILL is not survivable and gives the target no chance to identify
+    itself, so escalation re-checks that the pid still belongs to the process
+    we meant to kill."""
+
+    def _patch(self, monkeypatch, *, alive, identity_calls):
+        from lionagi.cli import kill as kill_mod
+
+        monkeypatch.setattr(kill_mod, "_pid_alive", lambda pid: alive(pid))
+        monkeypatch.setattr(kill_mod.time, "sleep", lambda s: None)
+
+        def _identity(pid, expected_cmd, **kw):
+            identity_calls.append(pid)
+            # first call (pre-SIGTERM) matches, later calls do not: the pid was
+            # recycled while we waited out the grace window
+            return len(identity_calls) == 1
+
+        monkeypatch.setattr(kill_mod, "_check_pid_identity", _identity)
+
+    def test_recycled_pid_is_not_sigkilled(self, monkeypatch):
+        from lionagi.cli import kill as kill_mod
+
+        sent = []
+        monkeypatch.setattr(kill_mod.os, "kill", lambda pid, sig: sent.append(sig))
+        identity_calls: list[int] = []
+        self._patch(monkeypatch, alive=lambda pid: True, identity_calls=identity_calls)
+
+        result = kill_mod._terminate_pid(4242, expected_cmd="li agent", grace_seconds=0.01)
+
+        assert result == "identity_mismatch"
+        assert len(identity_calls) == 2, "identity must be re-checked before escalating"
+        assert signal.SIGKILL not in sent, "escalated onto a recycled pid"
+        assert sent == [signal.SIGTERM]
+
+    def test_same_process_still_escalates(self, monkeypatch):
+        """The re-check must not block escalation against the real target."""
+        from lionagi.cli import kill as kill_mod
+
+        sent = []
+        monkeypatch.setattr(kill_mod.os, "kill", lambda pid, sig: sent.append(sig))
+        monkeypatch.setattr(kill_mod, "_pid_alive", lambda pid: True)
+        monkeypatch.setattr(kill_mod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(kill_mod, "_check_pid_identity", lambda *a, **kw: True)
+
+        result = kill_mod._terminate_pid(4242, expected_cmd="li agent", grace_seconds=0.01)
+
+        assert result == "sigkill"
+        assert sent == [signal.SIGTERM, signal.SIGKILL]

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -1925,3 +1925,28 @@ def test_watch_loop_restores_prior_signal_handlers(monkeypatch: pytest.MonkeyPat
     finally:
         signal.signal(signal.SIGINT, saved[0])
         signal.signal(signal.SIGTERM, saved[1])
+
+
+def test_watch_loop_leaves_unrestorable_handlers_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A handler installed outside Python is reported as None and cannot be
+    reinstalled, so taking it over would mean keeping it forever. The loop must
+    decline to replace it rather than install a handler it can never remove."""
+    import lionagi.cli.monitor as monitor_mod
+    import lionagi.ln.concurrency as concurrency_mod
+    from lionagi.ln.concurrency.utils import SigtermInterrupt
+
+    monkeypatch.setattr(monitor_mod, "_clear_screen", lambda: None)
+
+    def sigterm_run_async(coro: Any) -> str:
+        coro.close()
+        raise SigtermInterrupt("SIGTERM during refresh")
+
+    monkeypatch.setattr(concurrency_mod, "run_async", sigterm_run_async)
+    monkeypatch.setattr(signal, "getsignal", lambda signum: None)
+
+    installed: list[int] = []
+    monkeypatch.setattr(signal, "signal", lambda signum, handler: installed.append(signum))
+
+    monitor_mod._watch_loop(1, None, since_window=None, entity_type=None, project=None)
+
+    assert installed == []

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -1739,3 +1739,189 @@ def test_watch_mode_sigint_clean(temp_db_path: Path, monkeypatch: pytest.MonkeyP
 
     assert signal.SIGINT in handlers
     assert exit_code == 0
+
+
+# ── Ambiguous short-id prefixes ───────────────────────────────────────────────
+
+
+async def _make_session_with_id(db: StateDB, sid: str) -> str:
+    prog_id = uuid.uuid4().hex
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "status": "running",
+            "invocation_kind": "agent",
+            "started_at": time.time(),
+        }
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_find_entity_rejects_ambiguous_prefix(temp_db_path: Path) -> None:
+    from lionagi.cli._util import AmbiguousIdError
+
+    async with StateDB() as db:
+        first = await _make_session_with_id(db, "abcde01")
+        second = await _make_session_with_id(db, "abcde02")
+
+        with pytest.raises(AmbiguousIdError) as excinfo:
+            await _find_entity(db, "abcde")
+
+    assert set(excinfo.value.candidates) == {first, second}
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_run_rejects_ambiguous_prefix(temp_db_path: Path) -> None:
+    from lionagi.cli._util import AmbiguousIdError
+    from lionagi.cli.monitor import _resolve_session_run
+
+    async with StateDB() as db:
+        await _make_session_with_id(db, "abcde01")
+        await _make_session_with_id(db, "abcde02")
+
+        with pytest.raises(AmbiguousIdError):
+            await _resolve_session_run(db, "abcde")
+
+
+@pytest.mark.asyncio
+async def test_run_detail_propagates_ambiguous_prefix(temp_db_path: Path) -> None:
+    """_run_detail's broad `except Exception` must not swallow the ambiguity
+    into a rendered detail body — the caller has to set the exit code."""
+    from lionagi.cli._util import AmbiguousIdError
+
+    async with StateDB() as db:
+        await _make_session_with_id(db, "abcde01")
+        await _make_session_with_id(db, "abcde02")
+
+    with pytest.raises(AmbiguousIdError):
+        await _run_detail("abcde")
+
+
+@pytest.mark.asyncio
+async def test_monitor_detail_ambiguous_prefix_exits_unknown(temp_db_path: Path) -> None:
+    import argparse
+
+    import lionagi.cli.monitor as monitor_mod
+    from lionagi.cli.status import EXIT_UNKNOWN
+
+    async with StateDB() as db:
+        await _make_session_with_id(db, "abcde01")
+        await _make_session_with_id(db, "abcde02")
+
+    args = argparse.Namespace(
+        run_ids=None,
+        since=None,
+        id="abcde",
+        entity_type=None,
+        project=None,
+        watch=False,
+        refresh=2,
+        interval=3.0,
+        follow=False,
+        chain=True,
+        max_wait=None,
+    )
+
+    assert monitor_mod.run_monitor(args) == EXIT_UNKNOWN
+
+
+def test_watch_loop_ambiguous_prefix_exits_unknown(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Watch mode can't refresh its way out of an ambiguous id — it stops."""
+    import lionagi.cli.monitor as monitor_mod
+    from lionagi.cli._util import AmbiguousIdError
+    from lionagi.cli.status import EXIT_UNKNOWN
+
+    monkeypatch.setattr(monitor_mod, "_clear_screen", lambda: None)
+
+    def raising_run_async(coro: Any) -> str:
+        coro.close()
+        raise AmbiguousIdError("abcde", "sessions", ["abcde01", "abcde02"])
+
+    import lionagi.ln.concurrency as concurrency_mod
+
+    monkeypatch.setattr(concurrency_mod, "run_async", raising_run_async)
+
+    saved = (signal.getsignal(signal.SIGINT), signal.getsignal(signal.SIGTERM))
+    try:
+        exit_code = monitor_mod._watch_loop(
+            1, "abcde", since_window=None, entity_type=None, project=None
+        )
+    finally:
+        signal.signal(signal.SIGINT, saved[0])
+        signal.signal(signal.SIGTERM, saved[1])
+
+    assert exit_code == EXIT_UNKNOWN
+
+
+# ── Watch mode: SIGTERM during a refresh ──────────────────────────────────────
+#
+# run_async installs its own signal handlers for the duration of the call, so a
+# signal delivered inside a refresh surfaces as SigtermInterrupt/KeyboardInterrupt
+# out of run_async rather than setting the loop's own flag. Both derive from
+# BaseException, so the loop has to name them.
+
+
+def test_watch_loop_exits_cleanly_on_sigterm_during_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lionagi.cli.monitor as monitor_mod
+    import lionagi.ln.concurrency as concurrency_mod
+    from lionagi.ln.concurrency.utils import SigtermInterrupt
+
+    monkeypatch.setattr(monitor_mod, "_clear_screen", lambda: None)
+
+    def sigterm_run_async(coro: Any) -> str:
+        coro.close()
+        raise SigtermInterrupt("SIGTERM during refresh")
+
+    monkeypatch.setattr(concurrency_mod, "run_async", sigterm_run_async)
+
+    saved = (signal.getsignal(signal.SIGINT), signal.getsignal(signal.SIGTERM))
+    try:
+        exit_code = monitor_mod._watch_loop(
+            1, None, since_window=None, entity_type=None, project=None
+        )
+    finally:
+        signal.signal(signal.SIGINT, saved[0])
+        signal.signal(signal.SIGTERM, saved[1])
+
+    assert exit_code == 0
+
+
+def test_watch_loop_restores_prior_signal_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loop's handlers must not outlive the loop, on any exit path."""
+    import lionagi.cli.monitor as monitor_mod
+    import lionagi.ln.concurrency as concurrency_mod
+    from lionagi.ln.concurrency.utils import SigtermInterrupt
+
+    monkeypatch.setattr(monitor_mod, "_clear_screen", lambda: None)
+
+    def sigterm_run_async(coro: Any) -> str:
+        coro.close()
+        raise SigtermInterrupt("SIGTERM during refresh")
+
+    monkeypatch.setattr(concurrency_mod, "run_async", sigterm_run_async)
+
+    def sentinel_sigint(signum: int, frame: Any) -> None:
+        pass
+
+    def sentinel_sigterm(signum: int, frame: Any) -> None:
+        pass
+
+    saved = (signal.getsignal(signal.SIGINT), signal.getsignal(signal.SIGTERM))
+    try:
+        signal.signal(signal.SIGINT, sentinel_sigint)
+        signal.signal(signal.SIGTERM, sentinel_sigterm)
+
+        monitor_mod._watch_loop(1, None, since_window=None, entity_type=None, project=None)
+
+        assert signal.getsignal(signal.SIGINT) is sentinel_sigint
+        assert signal.getsignal(signal.SIGTERM) is sentinel_sigterm
+    finally:
+        signal.signal(signal.SIGINT, saved[0])
+        signal.signal(signal.SIGTERM, saved[1])

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -1000,3 +1000,67 @@ def test_main_o_ctl_status_unknown_flag_is_argparse_error(temp_db_path: Path) ->
     with pytest.raises(SystemExit) as exc_info:
         main(["o", "ctl", "status", "some-id", "--jsonn"])
     assert exc_info.value.code == 2
+
+
+# ── Ambiguous short-id prefixes ─────────────────────────────────────────────
+#
+# Every status resolution stage (agent, play, generic) goes through the same
+# shared resolver, so a prefix matching two rows is reported, never guessed.
+
+
+async def _seed_session_with_id(db: StateDB, sid: str) -> str:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "status": "running",
+            "invocation_kind": "agent",
+            "started_at": time.time(),
+        }
+    )
+    return sid
+
+
+async def test_fetch_by_id_rejects_ambiguous_prefix(temp_db_path: Path) -> None:
+    from lionagi.cli._util import AmbiguousIdError
+    from lionagi.cli.status import _fetch_by_id
+
+    async with StateDB() as db:
+        first = await _seed_session_with_id(db, "abcde000-0000-0000-0000-000000000001")
+        second = await _seed_session_with_id(db, "abcde111-0000-0000-0000-000000000002")
+
+        with pytest.raises(AmbiguousIdError) as excinfo:
+            await _fetch_by_id(db, "sessions", "abcde")
+
+    assert set(excinfo.value.candidates) == {first, second}
+
+
+@pytest.mark.parametrize("command", ["agent", "play", "ctl"])
+async def test_status_ambiguous_prefix_reports_candidates_and_exits_unknown(
+    temp_db_path: Path, no_project: None, command: str
+) -> None:
+    async with StateDB() as db:
+        first = await _seed_session_with_id(db, "abcde000-0000-0000-0000-000000000001")
+        second = await _seed_session_with_id(db, "abcde111-0000-0000-0000-000000000002")
+
+    output, exit_code = await _run_status(command=command, entity_id="abcde", as_json=False)
+
+    assert exit_code == EXIT_UNKNOWN, "an ambiguous prefix must not be a success exit code"
+    assert "ambiguous" in output
+    assert first in output and second in output
+
+
+async def test_status_full_id_still_resolves_when_a_sibling_shares_a_prefix(
+    temp_db_path: Path, no_project: None
+) -> None:
+    """The guard is on prefixes only — an exact id is a primary key."""
+    async with StateDB() as db:
+        first = await _seed_session_with_id(db, "abcde000-0000-0000-0000-000000000001")
+        await _seed_session_with_id(db, "abcde111-0000-0000-0000-000000000002")
+
+    output, exit_code = await _run_status(command="agent", entity_id=first, as_json=True)
+
+    assert exit_code != EXIT_UNKNOWN
+    assert first in output

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -337,3 +337,59 @@ def test_run_wait_unknown_id_returns_exit_unknown(temp_db_path: Path) -> None:
 def test_run_wait_requires_at_least_one_id(temp_db_path: Path) -> None:
     with pytest.raises(SystemExit):
         run_wait([])
+
+
+# ── Ambiguous short-id prefixes ─────────────────────────────────────────────
+
+
+async def _make_session_with_id(db: StateDB, sid: str, *, status: str = "running") -> str:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": status})
+    return sid
+
+
+async def test_resolve_wait_target_rejects_ambiguous_prefix(temp_db_path: Path) -> None:
+    from lionagi.cli._util import AmbiguousIdError
+    from lionagi.cli.wait import _resolve_wait_target
+
+    async with StateDB() as db:
+        first = await _make_session_with_id(db, "abcde01")
+        second = await _make_session_with_id(db, "abcde02")
+
+        with pytest.raises(AmbiguousIdError) as excinfo:
+            await _resolve_wait_target(db, "abcde")
+
+    assert set(excinfo.value.candidates) == {first, second}
+
+
+async def test_wait_for_terminal_reports_ambiguous_id_without_waiting(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        first = await _make_session_with_id(db, "abcde01")
+        second = await _make_session_with_id(db, "abcde02")
+
+    outcomes = await wait_for_terminal(["abcde"], interval=0.01)
+
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome["status"] == "ambiguous"
+    assert outcome["success"] is False
+    assert first in outcome["detail"] and second in outcome["detail"]
+
+
+def test_run_wait_ambiguous_prefix_returns_exit_unknown(
+    temp_db_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def _seed() -> None:
+        async with StateDB() as db:
+            await _make_session_with_id(db, "abcde01")
+            await _make_session_with_id(db, "abcde02")
+
+    from lionagi.ln.concurrency import run_async
+
+    run_async(_seed())
+
+    assert run_wait(["abcde"]) == EXIT_UNKNOWN
+    assert "abcde01\tstatus=" not in capsys.readouterr().out

--- a/tests/libs/concurrency/test_run_async_signal_takeover.py
+++ b/tests/libs/concurrency/test_run_async_signal_takeover.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Which signals ``run_async`` takes over, and which it leaves alone.
+
+``run_async`` installs its own SIGINT/SIGTERM handlers so a signal cancels the
+inner task, and restores the previous ones when it returns. ``getsignal()``
+reports ``None`` for a handler installed outside Python, and
+``signal.signal(signum, None)`` raises, so a handler taken over in that state
+could never be given back: the restore would fail and this runner's handler
+would stay installed for the rest of the process, swallowing the signal a
+long-lived caller relies on.
+"""
+
+import signal as signal_module
+
+import pytest
+
+from lionagi.ln.concurrency.utils import run_async
+
+
+async def _work():
+    return 42
+
+
+@pytest.fixture
+def signal_probe(monkeypatch):
+    """Report ``None`` as the prior handler for chosen signals, and record
+    every takeover so the decision itself can be asserted."""
+    real_getsignal = signal_module.getsignal
+    real_signal = signal_module.signal
+    installed: list[int] = []
+
+    def probe(*unrestorable):
+        def fake_getsignal(signum):
+            return None if signum in unrestorable else real_getsignal(signum)
+
+        def fake_signal(signum, handler):
+            installed.append(signum)
+            return real_signal(signum, handler)
+
+        monkeypatch.setattr(signal_module, "getsignal", fake_getsignal)
+        monkeypatch.setattr(signal_module, "signal", fake_signal)
+
+    return probe, installed
+
+
+def test_abstains_from_a_signal_whose_handler_cannot_be_restored(signal_probe):
+    probe, installed = signal_probe
+    probe(signal_module.SIGINT)
+
+    assert run_async(_work()) == 42
+    assert signal_module.SIGINT not in installed
+
+
+def test_abstaining_is_per_signal_not_all_or_nothing(signal_probe):
+    """Only the signal that cannot be given back is skipped; cancellation
+    wiring for the other one is still worth having."""
+    probe, installed = signal_probe
+    probe(signal_module.SIGINT)
+
+    run_async(_work())
+
+    assert signal_module.SIGTERM in installed
+
+
+def test_the_signal_it_does_take_over_is_handed_back(signal_probe):
+    """Abstaining on one signal must not cost the restore of the other."""
+    probe, _installed = signal_probe
+    before = signal_module.getsignal(signal_module.SIGTERM)
+    probe(signal_module.SIGINT)
+
+    run_async(_work())
+
+    assert signal_module.getsignal(signal_module.SIGTERM) is before
+
+
+def test_both_signals_unrestorable_still_runs_the_work(signal_probe):
+    """Nothing about signal wiring is load-bearing for producing a result."""
+    probe, installed = signal_probe
+    probe(signal_module.SIGINT, signal_module.SIGTERM)
+
+    assert run_async(_work()) == 42
+    assert installed == []

--- a/tests/libs/concurrency/test_run_async_signal_takeover.py
+++ b/tests/libs/concurrency/test_run_async_signal_takeover.py
@@ -74,6 +74,32 @@ def test_the_signal_it_does_take_over_is_handed_back(signal_probe):
     assert signal_module.getsignal(signal_module.SIGTERM) is before
 
 
+def test_a_failed_restore_does_not_strand_the_other_signal(monkeypatch):
+    """Restores run in a finally, often while an exception is already
+    propagating. One of them failing must not leave the other signal still
+    overridden for the rest of the process."""
+    real_signal = signal_module.signal
+    original_sigint = signal_module.getsignal(signal_module.SIGINT)
+    restored: list[int] = []
+    calls = {"n": 0}
+
+    def flaky_signal(signum, handler):
+        calls["n"] += 1
+        if calls["n"] <= 2:  # the two installs
+            return real_signal(signum, handler)
+        if signum == signal_module.SIGINT:  # first restore fails
+            raise OSError("cannot restore")
+        restored.append(signum)
+        return real_signal(signum, handler)
+
+    monkeypatch.setattr(signal_module, "signal", flaky_signal)
+    try:
+        assert run_async(_work()) == 42
+        assert signal_module.SIGTERM in restored
+    finally:
+        real_signal(signal_module.SIGINT, original_sigint)
+
+
 def test_both_signals_unrestorable_still_runs_the_work(signal_probe):
     """Nothing about signal wiring is load-bearing for producing a result."""
     probe, installed = signal_probe


### PR DESCRIPTION
## Problem

Every CLI surface accepting a short id resolved it with a prefix `LIKE` query followed by a fetch-one. That has no cardinality check and no ordering rule, so a prefix matching several rows returned whichever the engine happened to yield first, with no signal that a choice had been made.

For `li kill` that means signalling a process the caller did not name. The regression test captures the old behaviour executing: `killed session abcde000-000`, `rc=0`.

Six sites each decided cardinality for themselves, and they disagreed about how. Three treated a value shorter than 36 characters as a prefix and three did not — wrong for tables whose ids are 12-char hex rather than UUIDs, as one of the removed docstrings noted explicitly. A sixth site in `li o ctl` carried its own private two-row probe with its own length rule. That disagreement is the reason the defect existed in six places rather than one.

## Fix

A single resolver in `_util.py`:

- An exact id wins outright. It is the primary key, so it cannot be ambiguous, and this replaces the length heuristic the sites disagreed about.
- Otherwise the value is a prefix, ordered so the reported candidate list is stable, fetching more than one row so cardinality is observable at all.
- More than one match raises with the colliding ids attached, so each surface can tell the user what to disambiguate between.
- `LIKE` metacharacters in the supplied value are escaped, so a prefix is matched literally rather than as a pattern.

All six sites route through it and the private probe is deleted.

Callers turn the rejection into a clean non-action rather than a traceback: the message names the candidates, no process is signalled, and no surface exits zero on an ambiguous prefix. `li wait` records the outcome per id so its other ids still resolve.

Cross-table shadowing is left as-is and documented: a prefix matching one row in each of two tables still resolves to the earlier table in the search order. That is the existing search-order contract, not a cardinality failure.

## Monitor watch loop — two separable defects

1. A signal arriving during a refresh surfaced as an exception from the async runner rather than setting the loop's flag, and derives from `BaseException`, so the surrounding handler could not catch it. Both interrupt types are now named explicitly and take the loop's existing clean exit path.
2. The loop replaced the SIGINT and SIGTERM handlers and returned without restoring them, leaving its own handlers installed on the process after the loop was gone. Prior handlers are captured and restored in a `finally` on every path.

## Tests

Red-then-green, proven by reverting the source and re-running. 14 of 16 new tests failed outright. The two `li wait` tests did not fail — they **hung**, because the unfixed `li wait` locks onto the first running match and polls it forever; both were run in isolation and killed by the faulthandler timeout.

Green: `279 passed`, against a `262` baseline. Verified independently of the run that produced the change.

One pre-existing flow-planning failure in `tests/cli/orchestrate` is unrelated and untouched.