### PR TITLE
fix: attribute fan-out notify outcomes to their run, and select transport from the effective model

### DIFF
--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -145,6 +145,28 @@ async def _run_fanout(
             started_at=_started_at,
         )
 
+    # notify.on_terminal (settings-driven, independent of --notify) outcome
+    # attribution: bind this run into the handler at registration time so a
+    # late-arriving outcome for this entity lands here or nowhere -- never
+    # on a different run this process later allocates. Skipped when --notify
+    # already owns this same entity as an exclusive override (registering a
+    # second override for the same entity would fire the adapter twice).
+    from lionagi.state.lifecycle.notify_settings import (
+        register_run_notify_outcome_scope,
+        unregister_run_notify_outcome_scope,
+    )
+
+    _notify_outcome_scope_name = (
+        None
+        if notify
+        else register_run_notify_outcome_scope(
+            env.run,
+            entity_kind="session",
+            entity_id=str(env.session.id),
+            project_dir=cwd,
+        )
+    )
+
     inner_kw = dict(
         env=env,
         num_workers=num_workers,
@@ -187,6 +209,7 @@ async def _run_fanout(
                 _terminal_status = effective_status
             # Unregister after stop_live_persist fires the terminal transition.
             unregister_flow_notify_scope(_notify_scope_name)
+            unregister_run_notify_outcome_scope(_notify_outcome_scope_name)
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
 

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -228,7 +228,12 @@ async def operate(
             _pctx = _pctx.with_updates(response_format=response_fmt)
 
     if middle is None:
-        if isinstance(_cctx, RunParam) or getattr(branch.chat_model, "is_cli", False):
+        # A model carried on the chat param overrides the branch default for
+        # this call, so transport must follow the effective model's CLI flag
+        # rather than the branch's — otherwise a per-call CLI model on an API
+        # branch takes the non-streaming path.
+        effective_imodel = _cctx.imodel or branch.chat_model
+        if isinstance(_cctx, RunParam) or getattr(effective_imodel, "is_cli", False):
             from ..run.run import run_and_collect
 
             middle = run_and_collect

--- a/tests/cli/orchestrate/test_fanout_notify_outcome_scope.py
+++ b/tests/cli/orchestrate/test_fanout_notify_outcome_scope.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A settings-driven `notify.on_terminal` exec adapter fired by a fan-out run
+must have its outcome attributed to that run, matching the flow path."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from lionagi.cli.orchestrate import fanout as fanout_module
+from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
+
+from .test_fanout_artifacts import _fanout_env
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def _capture_command(out_file: Path) -> list[str]:
+    return shlex.split(
+        f"{shlex.quote(sys.executable)} -c "
+        '"import pathlib, sys; '
+        "data = sys.stdin.read(); "
+        'pathlib.Path(sys.argv[1]).write_text(data)" '
+        f"{shlex.quote(str(out_file))}"
+    )
+
+
+def _write_project_settings(project_dir: Path, argv: list[str]) -> None:
+    lionagi_dir = project_dir / ".lionagi"
+    lionagi_dir.mkdir(parents=True, exist_ok=True)
+    (lionagi_dir / "settings.yaml").write_text(
+        yaml.dump(
+            {
+                "notify": {
+                    "on_terminal": {
+                        "enabled": True,
+                        "adapter": {"kind": "exec", "argv": argv},
+                    }
+                }
+            }
+        )
+    )
+
+
+async def _run_settings_only_fanout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, notify: str | None = None
+):
+    """Fan-out with a settings-configured exec adapter and no `--notify`,
+    short-circuited to an empty plan so only the terminal path runs."""
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated_home"))
+    env, run, _session = _fanout_env(tmp_path)
+    out_file = tmp_path / "captured.json"
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _write_project_settings(repo_dir, _capture_command(out_file))
+
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=[]))
+
+    assert register_settings_terminal_callback(project_dir=str(repo_dir)) is True
+    try:
+        _result, status = await fanout_module._run_fanout(
+            "codex/model",
+            "prompt",
+            cwd=str(repo_dir),
+            notify=notify,
+        )
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister("notify.settings.on_terminal")
+    return env, run, out_file, status
+
+
+async def test_settings_only_fanout_records_adapter_outcome_against_its_run(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The adapter fires and its exec outcome lands in this run's own
+    notify_outcome.json — the run-bound scope is what attributes it."""
+    _env, run, out_file, status = await _run_settings_only_fanout(tmp_path, monkeypatch)
+
+    assert status == "completed"
+    payload = json.loads(out_file.read_text())
+    assert payload["entity"]["kind"] == "session"
+    assert run.notify_outcome_path.exists(), "adapter outcome was not attributed to the run"
+    outcome = json.loads(run.notify_outcome_path.read_text())
+    assert outcome["ok"] is True
+    assert outcome["exit_code"] == 0
+
+
+async def test_fanout_notify_override_owns_delivery_without_outcome_scope(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`--notify` is an exclusive override for the same entity, so the
+    run-bound settings scope is skipped and the settings adapter does not
+    fire — registering both would deliver twice for one event."""
+    hook_out = tmp_path / "hook.txt"
+    _env, run, out_file, status = await _run_settings_only_fanout(
+        tmp_path,
+        monkeypatch,
+        notify=f"{shlex.quote(sys.executable)} -c "
+        '"import pathlib, sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2])" '
+        f"{shlex.quote(str(hook_out))} {{status}}",
+    )
+
+    assert status == "completed"
+    assert hook_out.read_text() == "completed"
+    assert not out_file.exists()
+    assert not run.notify_outcome_path.exists()
+
+
+async def test_fanout_terminal_notify_scopes_are_unregistered_after_the_run(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Both scoped registrations are torn down, so a later run in the same
+    process can never inherit this run's outcome binding."""
+    env, _run, _out_file, _status = await _run_settings_only_fanout(tmp_path, monkeypatch)
+
+    session_id = str(env.session.id)
+    assert f"notify.settings.on_terminal.session.{session_id}" not in DEFAULT_TERMINAL_CALLBACKS
+    assert f"notify.flow.session.{session_id}" not in DEFAULT_TERMINAL_CALLBACKS

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -555,3 +555,82 @@ async def test_operate_reason_only_constructs_operative_with_reason_field():
         f"'reason' field missing from generated response_format {fmt}; "
         "Operative was not constructed or reason spec was dropped"
     )
+
+
+@pytest.mark.asyncio
+async def test_operate_transport_follows_per_call_model_override(monkeypatch):
+    """A CLI model supplied on the chat param overrides the branch default,
+    so transport selection must take the streaming path even though the
+    branch's own chat_model is an API model."""
+    from types import SimpleNamespace
+
+    from lionagi.operations.operate.operate import operate
+    from lionagi.operations.types import ChatParam
+
+    branch = make_mocked_branch_for_operate()
+    assert not getattr(branch.chat_model, "is_cli", False)
+
+    selected: list[str] = []
+
+    async def fake_run_and_collect(*args, **kwargs):
+        selected.append("run_and_collect")
+        return "ok"
+
+    async def fake_communicate(*args, **kwargs):
+        selected.append("communicate")
+        return "ok"
+
+    monkeypatch.setattr(
+        "lionagi.operations.run.run.run_and_collect", fake_run_and_collect, raising=True
+    )
+    monkeypatch.setattr(
+        "lionagi.operations.communicate.communicate.communicate", fake_communicate, raising=True
+    )
+
+    cli_model = SimpleNamespace(is_cli=True)
+    chat_param = ChatParam(imodel=cli_model)
+    await operate(
+        branch,
+        "per-call CLI model",
+        chat_param,
+        skip_validation=True,
+        invoke_actions=False,
+    )
+
+    assert selected == ["run_and_collect"]
+
+
+@pytest.mark.asyncio
+async def test_operate_transport_unchanged_without_a_model_override(monkeypatch):
+    """With no per-call override the branch default still decides, so an
+    API branch keeps the non-streaming transport."""
+    from lionagi.operations.operate.operate import operate
+    from lionagi.operations.types import ChatParam
+
+    branch = make_mocked_branch_for_operate()
+    selected: list[str] = []
+
+    async def fake_run_and_collect(*args, **kwargs):
+        selected.append("run_and_collect")
+        return "ok"
+
+    async def fake_communicate(*args, **kwargs):
+        selected.append("communicate")
+        return "ok"
+
+    monkeypatch.setattr(
+        "lionagi.operations.run.run.run_and_collect", fake_run_and_collect, raising=True
+    )
+    monkeypatch.setattr(
+        "lionagi.operations.communicate.communicate.communicate", fake_communicate, raising=True
+    )
+
+    await operate(
+        branch,
+        "no override",
+        ChatParam(),
+        skip_validation=True,
+        invoke_actions=False,
+    )
+
+    assert selected == ["communicate"]


### PR DESCRIPTION
Two independent dispatch defects, one commit each.

## Fan-out terminal notify outcome is dropped

A settings-driven `notify.on_terminal` exec adapter fires for fan-out runs, but fan-out never registered the run-bound outcome scope that attributes the adapter's exit status to a run. The outcome was produced and then discarded: a fan-out run's `notify_outcome.json` was never written, so a notify hook that failed left no trace on the run that triggered it.

The fix registers the scope exactly as the flow path already does, bound to this run's own session entity, and unregisters it in the same `finally` block after the terminal transition. It is skipped when `--notify` is present, because that flag is an exclusive override for the same entity and registering both would deliver twice for one terminal event.

Covered by three tests that drive a real exec adapter through `_run_fanout`: the outcome lands on the run, `--notify` suppresses the settings path without double-delivering, and both scoped registrations are torn down so a later run in the same process cannot inherit the binding.

## Transport ignored a per-call model override

`operate()` chose between the streaming and non-streaming transports by reading `is_cli` off `branch.chat_model`, ignoring a model supplied on the chat param for that call. A per-call CLI model on a branch whose default is an API model took the non-streaming path, which cannot accumulate a CLI stream. The fix resolves the effective model first and reads `is_cli` from that. Tested both directions: with an override, and without one so the branch default still decides.

## Verification

Both tests fail on the parent commit with the reported assertions and pass with the fixes. The suite is green apart from `test_pack_routing_shown_in_dry_run`, confirmed pre-existing by reproducing it on a branch containing none of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)