### PR TITLE
fix(cli): return a resumed session to running so its close announces itself

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -968,6 +968,59 @@ async def _flush_pending_message_events(ctx: dict) -> None:
         await retry_queue.flush()
 
 
+async def _reopen_session_for_resume(db, session_id: str, existing_session: dict | None) -> bool:
+    """Return a resumed session to ``running`` so its next close is a real change.
+
+    A session's closing transition only announces itself when the status
+    actually changes. A resume adopts a session an earlier leg already took
+    terminal, so writing that same terminal status at the end is not a change:
+    the leg finishes without announcing anything, the completion notice never
+    arrives, and the job record never closes. Reopening first restores the
+    invariant the rest of the system reads off this column, which is that a
+    session marked terminal is not currently executing.
+
+    Reopening is the only sanctioned exit from a terminal status, so it carries
+    an override. That is not a formality to satisfy the guard: it is what makes
+    each reopening attributable. Declaring a terminal-to-running edge in the
+    session policy would have satisfied the guard too, and would have permitted
+    terminal exit for every writer in the system, while finality is exactly what
+    the reapers, the teardown guard and ``li wait`` all rest on.
+    """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+    from lionagi.state.reasons import SessionReasons
+
+    if not existing_session or existing_session.get("status") not in SESSION_TERMINAL_STATUSES:
+        # Not terminal: a resume racing a live leg on the same branch. The row
+        # already describes the session correctly, so there is nothing to reopen.
+        return False
+
+    applied = await db.update_status(
+        "session",
+        session_id,
+        new_status="running",
+        reason_code=SessionReasons.REOPENED_BY_RESUME,
+        reason_summary="branch resumed by a new leg",
+        source="executor",
+        actor=session_id,
+        expected_statuses=SESSION_TERMINAL_STATUSES,
+        extra_fields={"ended_at": None},
+        override=True,
+        override_actor="cli.resume",
+        override_justification="branch resumed by a new leg; the session is executing again",
+    )
+    if not applied:
+        # A resumed leg must not fail because its bookkeeping lost a race, but
+        # the consequence is worth saying out loud: this leg will finish without
+        # announcing itself, and from the outside that is indistinguishable from
+        # a leg that is still running.
+        _log.warning(
+            "session %s was not reopened for resume; another writer moved it "
+            "first, so this leg will close without emitting a terminal notice",
+            session_id,
+        )
+    return applied
+
+
 async def setup_agent_persist(
     branch: Branch,
     *,
@@ -998,6 +1051,7 @@ async def setup_agent_persist(
         if existing_branch:
             session_id = existing_branch["session_id"]
             existing_session = await db.get_session(session_id)
+            await _reopen_session_for_resume(db, session_id, existing_session)
             session_prog_id = existing_session["progression_id"]
             branch_prog_id = existing_branch["progression_id"]
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1018,7 +1018,26 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
             "first, so this leg will close without emitting a terminal notice",
             session_id,
         )
-    return applied
+        return False
+
+    # Liveness is judged from the process markers on the row, and until now a
+    # reopened session carried the markers of the leg that already exited. A
+    # terminal session is never checked for liveness, so those markers were
+    # harmless while they were stale; a running one is, so leaving them would
+    # describe this live leg by a dead process and invite the phantom reaper to
+    # take a working session to failed. Written after the reopen wins, never
+    # before: on a lost race the row belongs to another leg, and stamping our
+    # markers on it would make that leg's liveness answer for our process.
+    from lionagi.cli.kill import current_pid_markers
+
+    node_metadata = existing_session.get("node_metadata") or {}
+    if isinstance(node_metadata, str):
+        node_metadata = json.loads(node_metadata)
+    await db.update_session(
+        session_id,
+        node_metadata=json.dumps({**node_metadata, **current_pid_markers()}),
+    )
+    return True
 
 
 async def setup_agent_persist(

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1003,9 +1003,18 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
     # transaction as the status: the sweeps select on status and then answer
     # "is it alive" from these markers, so a row that is running for even an
     # instant with the previous leg's markers is a row they can cancel.
-    node_metadata = existing_session.get("node_metadata") or {}
+    # Anything that is not a JSON object is dropped rather than raised on: every
+    # reader of this column already ignores what it cannot read as one, and a
+    # resume must not fail on its own bookkeeping. The markers are the part that
+    # has to be right.
+    node_metadata = existing_session.get("node_metadata")
     if isinstance(node_metadata, str):
-        node_metadata = json.loads(node_metadata)
+        try:
+            node_metadata = json.loads(node_metadata)
+        except ValueError:
+            node_metadata = None
+    if not isinstance(node_metadata, dict):
+        node_metadata = {}
 
     applied = await db.update_status(
         "session",

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1016,23 +1016,39 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
     if not isinstance(node_metadata, dict):
         node_metadata = {}
 
-    applied = await db.update_status(
-        "session",
-        session_id,
-        new_status="running",
-        reason_code=SessionReasons.REOPENED_BY_RESUME,
-        reason_summary="branch resumed by a new leg",
-        source="executor",
-        actor=session_id,
-        expected_statuses=SESSION_TERMINAL_STATUSES,
-        extra_fields={
-            "ended_at": None,
-            "node_metadata": json.dumps({**node_metadata, **current_pid_markers()}),
-        },
-        override=True,
-        override_actor="cli.resume",
-        override_justification="branch resumed by a new leg; the session is executing again",
-    )
+    try:
+        applied = await db.update_status(
+            "session",
+            session_id,
+            new_status="running",
+            reason_code=SessionReasons.REOPENED_BY_RESUME,
+            reason_summary="branch resumed by a new leg",
+            source="executor",
+            actor=session_id,
+            expected_statuses=SESSION_TERMINAL_STATUSES,
+            extra_fields={
+                "ended_at": None,
+                "node_metadata": json.dumps({**node_metadata, **current_pid_markers()}),
+            },
+            override=True,
+            override_actor="cli.resume",
+            override_justification="branch resumed by a new leg; the session is executing again",
+        )
+    except LookupError:
+        # update_status reports a missing row this way. The row was read a
+        # moment ago and is gone now: maintenance removes old terminal sessions
+        # and holds each candidate for the length of its transaction, so a
+        # resume that arrives just before one starts is let through only after
+        # it commits, to find nothing there. That is a legitimate outcome
+        # rather than a failure of this leg — there is no session to reopen,
+        # and the caller falls back to starting one.
+        _log.warning(
+            "session %s no longer exists and was not reopened for resume; "
+            "this leg will record itself under a new session",
+            session_id,
+        )
+        return False
+
     if not applied:
         # A resumed leg must not fail because its bookkeeping lost a race, but
         # the consequence is worth saying out loud: this leg will finish without
@@ -1075,10 +1091,28 @@ async def setup_agent_persist(
         db = await _open_shared_db()
 
         existing_branch = await db.get_branch(branch_id)
+        existing_session = None
+        if existing_branch:
+            existing_session = await db.get_session(existing_branch["session_id"])
+            if existing_session is not None and not await _reopen_session_for_resume(
+                db, existing_branch["session_id"], existing_session
+            ):
+                # The reopen declines for three reasons and one of them is that
+                # the session is no longer there — maintenance removes old
+                # terminal sessions, and a resume can arrive as one commits.
+                # Confirm the row before reading anything else out of a copy of
+                # it that may describe a row that no longer exists.
+                existing_session = await db.get_session(existing_branch["session_id"])
+
+            if existing_session is None:
+                # Nothing to resume into. Branches are removed with their
+                # session, so this leg records itself the way a branch nobody
+                # has seen before does, rather than persisting against ids that
+                # no longer resolve.
+                existing_branch = None
+
         if existing_branch:
             session_id = existing_branch["session_id"]
-            existing_session = await db.get_session(session_id)
-            await _reopen_session_for_resume(db, session_id, existing_session)
             session_prog_id = existing_session["progression_id"]
             branch_prog_id = existing_branch["progression_id"]
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -986,6 +986,7 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
     terminal exit for every writer in the system, while finality is exactly what
     the reapers, the teardown guard and ``li wait`` all rest on.
     """
+    from lionagi.cli.kill import current_pid_markers
     from lionagi.state.db import SESSION_TERMINAL_STATUSES
     from lionagi.state.reasons import SessionReasons
 
@@ -993,6 +994,18 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
         # Not terminal: a resume racing a live leg on the same branch. The row
         # already describes the session correctly, so there is nothing to reopen.
         return False
+
+    # Liveness is judged from the process markers on the row, and a reopened
+    # session used to carry the markers of the leg that already exited. A
+    # terminal session is never checked for liveness, so those markers were
+    # harmless while it was terminal; a running one is checked, so leaving them
+    # would describe this live leg by a dead process. They move in the same
+    # transaction as the status: the sweeps select on status and then answer
+    # "is it alive" from these markers, so a row that is running for even an
+    # instant with the previous leg's markers is a row they can cancel.
+    node_metadata = existing_session.get("node_metadata") or {}
+    if isinstance(node_metadata, str):
+        node_metadata = json.loads(node_metadata)
 
     applied = await db.update_status(
         "session",
@@ -1003,7 +1016,10 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
         source="executor",
         actor=session_id,
         expected_statuses=SESSION_TERMINAL_STATUSES,
-        extra_fields={"ended_at": None},
+        extra_fields={
+            "ended_at": None,
+            "node_metadata": json.dumps({**node_metadata, **current_pid_markers()}),
+        },
         override=True,
         override_actor="cli.resume",
         override_justification="branch resumed by a new leg; the session is executing again",
@@ -1020,23 +1036,6 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
         )
         return False
 
-    # Liveness is judged from the process markers on the row, and until now a
-    # reopened session carried the markers of the leg that already exited. A
-    # terminal session is never checked for liveness, so those markers were
-    # harmless while they were stale; a running one is, so leaving them would
-    # describe this live leg by a dead process and invite the phantom reaper to
-    # take a working session to failed. Written after the reopen wins, never
-    # before: on a lost race the row belongs to another leg, and stamping our
-    # markers on it would make that leg's liveness answer for our process.
-    from lionagi.cli.kill import current_pid_markers
-
-    node_metadata = existing_session.get("node_metadata") or {}
-    if isinstance(node_metadata, str):
-        node_metadata = json.loads(node_metadata)
-    await db.update_session(
-        session_id,
-        node_metadata=json.dumps({**node_metadata, **current_pid_markers()}),
-    )
     return True
 
 

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -591,12 +591,18 @@ async def _doctor(
 
     from sqlalchemy import text
 
+    from lionagi.cli._util import pid_alive
+    from lionagi.cli.kill import _read_pid_from_entity
+
     async with StateDB() as db:
         async with db._read() as conn:
             rows = (
                 (
                     await conn.execute(
-                        text("SELECT id, started_at FROM sessions WHERE status = 'running'")
+                        text(
+                            "SELECT id, started_at, node_metadata, artifacts_path "
+                            "FROM sessions WHERE status = 'running'"
+                        )
                     )
                 )
                 .mappings()
@@ -607,10 +613,25 @@ async def _doctor(
         skipped = 0
         for row in rows:
             started = row["started_at"]
-            if started is None or started < cutoff:
-                victims.append(row["id"])
-            else:
+            if started is not None and started >= cutoff:
                 skipped += 1
+                continue
+            # Age answers "how long since this session first started", which is
+            # the same question as "how long has this process been running" only
+            # for a session that ran once. A branch picked up again keeps the
+            # start time of the session while the process is new, so the command
+            # asks the process itself before calling anything stuck.
+            entity = dict(row)
+            if isinstance(entity.get("node_metadata"), str):
+                try:
+                    entity["node_metadata"] = json.loads(entity["node_metadata"])
+                except ValueError:
+                    entity["node_metadata"] = None
+            pid = _read_pid_from_entity(entity)
+            if pid is not None and pid_alive(pid):
+                skipped += 1
+                continue
+            victims.append(row["id"])
 
         swept_count = 0
         if dry_run:
@@ -941,10 +962,11 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
             "A SIGKILL or unclean exit between session-open and teardown "
             "leaves the session row at status='running' forever. This "
             "command resets such rows (older than --stale-hours, default "
-            "24) to --new-status (default 'aborted'). Conservative: only "
-            "sessions whose started_at is older than the threshold are "
-            "swept, so an actively-running CLI process is left alone. "
-            "Use --dry-run first."
+            "24) to --new-status (default 'aborted'). Conservative: a "
+            "session is swept only if its started_at is older than the "
+            "threshold AND its recorded process is not running, so an "
+            "actively-running CLI process is left alone even when the "
+            "session it resumed started long ago. Use --dry-run first."
         ),
     )
     doctor.add_argument(

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -592,7 +592,7 @@ async def _doctor(
     from sqlalchemy import text
 
     from lionagi.cli._util import pid_alive
-    from lionagi.cli.kill import _read_pid_from_entity
+    from lionagi.cli.kill import _check_pid_identity_tristate, _read_pid_from_entity
 
     async with StateDB() as db:
         async with db._read() as conn:
@@ -622,15 +622,37 @@ async def _doctor(
             # start time of the session while the process is new, so the command
             # asks the process itself before calling anything stuck.
             entity = dict(row)
-            if isinstance(entity.get("node_metadata"), str):
+            meta = entity.get("node_metadata")
+            if isinstance(meta, str):
                 try:
-                    entity["node_metadata"] = json.loads(entity["node_metadata"])
+                    meta = json.loads(meta)
                 except ValueError:
-                    entity["node_metadata"] = None
+                    meta = None
+            entity["node_metadata"] = meta if isinstance(meta, dict) else None
             pid = _read_pid_from_entity(entity)
             if pid is not None and pid_alive(pid):
-                skipped += 1
-                continue
+                # A live PID is not by itself proof: the OS can hand a dead
+                # session's number to an unrelated process, which would protect
+                # a genuinely stuck row for as long as that process lives. The
+                # stale-kill sweep already answers this, so it answers it here
+                # too rather than a second, weaker rule being written.
+                raw_ct = (entity["node_metadata"] or {}).get("pid_create_time")
+                try:
+                    expected_create_time = float(raw_ct) if raw_ct is not None else None
+                except (TypeError, ValueError):
+                    expected_create_time = None
+                verdict = _check_pid_identity_tristate(
+                    pid,
+                    "lionagi",
+                    expected_session_id=row["id"],
+                    expected_create_time=expected_create_time,
+                )
+                # "unverifiable" means the process could not be inspected, not
+                # that it is gone; skipping it leaves a row for the next run
+                # rather than reaping one out from under a worker.
+                if verdict in ("ours", "unverifiable"):
+                    skipped += 1
+                    continue
             victims.append(row["id"])
 
         swept_count = 0

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -321,8 +321,11 @@ TEAM_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["team"]
 # same transaction as the status/status_transitions write — keeps a caller
 # from splitting a status change and a dependent column (e.g. ended_at) into
 # two transactions that a crash between them could leave inconsistent.
+# node_metadata is here for the same reason: it carries the process markers
+# the sweeps use to answer "is this still alive", a question they only ask of
+# rows their status filter already selected.
 EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
-    "session": frozenset({"ended_at"}),
+    "session": frozenset({"ended_at", "node_metadata"}),
     "invocation": frozenset({"ended_at"}),
 }
 

--- a/lionagi/state/lifecycle/policy.py
+++ b/lionagi/state/lifecycle/policy.py
@@ -189,7 +189,18 @@ def build_default_registry() -> PolicyRegistry:
     )
     session_edges = _edges(("running", _to(*sorted(session_terminal))))
     session_patch_fields = frozenset(
-        {"ended_at", "input_tokens", "output_tokens", "total_cost_usd", "num_turns", "duration_ms"}
+        {
+            "ended_at",
+            "input_tokens",
+            "output_tokens",
+            "total_cost_usd",
+            "num_turns",
+            "duration_ms",
+            # The process markers a sweep reads to decide whether a row its
+            # status filter selected is still alive. Status and markers have to
+            # agree at every instant a sweep could look, so they move together.
+            "node_metadata",
+        }
     )
     registry.register(
         LifecyclePolicy(

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -138,6 +138,11 @@ class SessionReasons:
     HEALTH_PHANTOM_PROCESS_DEAD = "session.phantom.process_dead"
     HEALTH_PHANTOM_MISSING_ARTIFACTS = "session.phantom.missing_artifacts"
 
+    # A resumed branch puts its session back into execution. This is the only
+    # sanctioned exit from a terminal status, and it carries an override so the
+    # reopening is attributable rather than an ordinary write.
+    REOPENED_BY_RESUME = "session.reopened.by_resume"
+
 
 class PlayReasons:
     """Show-play lifecycle reasons (ADR-0057 play vocabulary)."""

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -169,6 +169,20 @@ async def prune_old_data(
             if session_ids:
                 session_ids = sorted(set(session_ids))
 
+                # A session can leave a terminal status after this selection:
+                # resuming a branch returns its session to running. Re-read the
+                # status immediately before anything destructive and drop any
+                # row that came back to life, so the batch is never assembled
+                # around a session with a live leg on it.
+                rows = await _fetch_chunked(
+                    conn,
+                    f"SELECT id FROM sessions WHERE status IN ({sess_ph}) AND id",  # noqa: S608
+                    session_ids,
+                    _TERMINAL_SESSION_STATUSES,
+                )
+                session_ids = sorted({r[0] for r in rows})
+
+            if session_ids:
                 # Capture child ids BEFORE deleting anything.
                 rows = await _fetch_chunked(
                     conn,
@@ -247,8 +261,15 @@ async def prune_old_data(
                     session_ids,
                 )
                 # branches cascade automatically via FK ON DELETE CASCADE
+                # The status predicate rides the delete itself, not only the
+                # read above it: on a backend where concurrent transactions can
+                # commit between the two, the statement that removes the row is
+                # the only place the condition is guaranteed to still hold.
                 sessions_pruned = await _exec_chunked(
-                    conn, "DELETE FROM sessions WHERE id", session_ids
+                    conn,
+                    f"DELETE FROM sessions WHERE status IN ({sess_ph}) AND id",  # noqa: S608
+                    session_ids,
+                    _TERMINAL_SESSION_STATUSES,
                 )
 
                 # Targeted orphan cleanup scoped to pruned lineage only — avoids a

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -12,6 +12,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
+from lionagi._errors import LionError
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 _log = logging.getLogger(__name__)
@@ -66,6 +67,16 @@ async def _fetch_chunked(
         )
         results.extend(result.fetchall())
     return results
+
+
+class PruneRaceError(LionError):
+    """A session stopped being terminal partway through pruning its history.
+
+    The prune holds every candidate row locked for the length of its
+    transaction, so this cannot happen through the lock; it is raised as a
+    post-condition, and raising it abandons the transaction rather than
+    committing a session that kept its row and lost its associations.
+    """
 
 
 # Statuses that are safe to prune (process is definitively done).
@@ -173,11 +184,29 @@ async def prune_old_data(
             if session_ids:
                 session_ids = sorted(set(session_ids))
 
-                # A session can leave a terminal status after this selection:
-                # resuming a branch returns its session to running. Re-read the
-                # status immediately before anything destructive and drop any
-                # row that came back to life, so the batch is never assembled
-                # around a session with a live leg on it.
+                # Lock every candidate row for the rest of the transaction
+                # before its status is read. A write to a row is what takes the
+                # lock on both backends: postgresql locks the rows themselves,
+                # sqlite escalates the whole transaction to a write, which is
+                # the same guarantee at a coarser grain. The value is left
+                # exactly as it was — this statement exists for the lock.
+                #
+                # Reading the status without holding the rows would only move
+                # the window rather than close it. A session can leave a
+                # terminal status at any time (resuming a branch returns it to
+                # running), so a resume that commits after an unlocked read is
+                # still free to land between two of the destructive statements
+                # below, which is how a session ends up keeping its row and
+                # losing the associations already cleared for it.
+                await _exec_chunked(
+                    conn,
+                    "UPDATE sessions SET updated_at = updated_at WHERE id",
+                    session_ids,
+                )
+
+                # Now that the rows are held, re-read the status and drop any
+                # that came back to life before the lock, so the batch is never
+                # assembled around a session with a live leg on it.
                 rows = await _fetch_chunked(
                     conn,
                     f"SELECT id FROM sessions WHERE status IN ({sess_ph}) AND id",  # noqa: S608
@@ -282,6 +311,24 @@ async def prune_old_data(
                     session_ids,
                     _TERMINAL_SESSION_STATUSES,
                 )
+
+                # The delete is where a session that reopened mid-sequence
+                # would show up: its row survives while the statements above
+                # have already cleared its history and associations. The lock
+                # taken before the re-read is what prevents that, and this is
+                # the check that it held. Raising abandons the transaction,
+                # so the pass either applies whole or leaves the row exactly as
+                # it was; the next pass drops the resumed session at selection.
+                survivors = await _fetch_chunked(
+                    conn, "SELECT id FROM sessions WHERE id", session_ids
+                )
+                if survivors:
+                    raise PruneRaceError(
+                        "session(s) "
+                        + ", ".join(sorted(str(r[0]) for r in survivors))
+                        + " stopped being terminal while their history was being removed; "
+                        "nothing was pruned"
+                    )
 
                 # Targeted orphan cleanup scoped to pruned lineage only — avoids a
                 # newborn-orphan race where _persist.py commits a progression before

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -30,17 +30,21 @@ async def _exec_chunked(
     sql_prefix: str,
     ids: Sequence[str],
     extra_params: Sequence[Any] = (),
+    suffix: str = "",
+    suffix_params: Sequence[Any] = (),
 ) -> int:
-    """Execute *sql_prefix* + ' IN (?,?,...)' for *ids* in chunks of _CHUNK.
+    """Execute *sql_prefix* + ' IN (?,?,...)' + *suffix* for *ids* in chunks.
 
-    *sql_prefix* must end just before the IN clause. Returns total rowcount.
+    *sql_prefix* must end just before the IN clause. *suffix* is appended after
+    it, for a condition that has to be part of the statement itself rather than
+    checked beforehand. Returns total rowcount.
     """
     total = 0
     for i in range(0, len(ids), _CHUNK):
         chunk = ids[i : i + _CHUNK]
         ph = ", ".join("?" * len(chunk))
         result = await conn.execute(
-            *_q(f"{sql_prefix} IN ({ph})", (*extra_params, *chunk))  # noqa: S608
+            *_q(f"{sql_prefix} IN ({ph}){suffix}", (*extra_params, *chunk, *suffix_params))  # noqa: S608
         )
         total += result.rowcount
     return total
@@ -236,29 +240,36 @@ async def prune_old_data(
                     {*coll_msg_ids, *session_first_ids, *session_last_ids, *branch_sys_ids}
                 )
 
+                # Every destructive statement carries the terminal condition
+                # itself. Checking it once above and then running a sequence of
+                # writes would protect only whichever statement happens to be
+                # last: a session that reopens partway through would keep its
+                # row and lose the history and associations already removed,
+                # which is a worse outcome than the one being prevented.
+                still_terminal = (
+                    f" AND session_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
+                )
+
                 # Nullify soft FKs (no CASCADE) before deleting sessions.
-                await _exec_chunked(
-                    conn, "UPDATE artifacts SET session_id = NULL WHERE session_id", session_ids
-                )
-                await _exec_chunked(
-                    conn, "UPDATE plays SET session_id = NULL WHERE session_id", session_ids
-                )
-                await _exec_chunked(
-                    conn,
-                    "UPDATE team_messages SET session_id = NULL WHERE session_id",
-                    session_ids,
-                )
-                # dispatch_outbox.session_id is a plain FK (no CASCADE) — nullify
-                # before the parent DELETE or the prune aborts on the FK constraint.
-                await _exec_chunked(
-                    conn,
-                    "UPDATE dispatch_outbox SET session_id = NULL WHERE session_id",
-                    session_ids,
-                )
+                for table in ("artifacts", "plays", "team_messages", "dispatch_outbox"):
+                    # dispatch_outbox.session_id is a plain FK (no CASCADE) —
+                    # nullify before the parent DELETE or the prune aborts on
+                    # the FK constraint.
+                    await _exec_chunked(
+                        conn,
+                        f"UPDATE {table} SET session_id = NULL WHERE session_id",  # noqa: S608
+                        session_ids,
+                        suffix=still_terminal,
+                        suffix_params=_TERMINAL_SESSION_STATUSES,
+                    )
                 await _exec_chunked(
                     conn,
                     "DELETE FROM status_transitions WHERE entity_type = 'session' AND entity_id",
                     session_ids,
+                    suffix=(
+                        f" AND entity_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
+                    ),
+                    suffix_params=_TERMINAL_SESSION_STATUSES,
                 )
                 # branches cascade automatically via FK ON DELETE CASCADE
                 # The status predicate rides the delete itself, not only the

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -203,46 +203,37 @@ def test_prune_removes_old_terminal_sessions_only(tmp_path, monkeypatch):
 
 
 def _reopen_before_call(monkeypatch, maint, session_id: str, *, call: int) -> None:
-    """Return *session_id* to running just before the *call*-th chunked read.
+    """Return *session_id* to running just before the *call*-th chunked write.
 
     Resuming a branch puts a terminal session back to running, so a session
-    selected for pruning can stop being prunable while the prune is still
-    assembling the batch. The seam lets that happen at a chosen point instead
-    of waiting for the interleaving to occur on its own.
+    selected for pruning can stop being prunable while the prune is running.
+    The seam lets that happen at a chosen point instead of waiting for the
+    interleaving to occur on its own. Writing on the prune's own connection is
+    how a committed write from another transaction looks to the statements that
+    follow it, which is what the backends this runs on actually allow.
+
+    Call 1 is the statement that takes the lock, so ``call=1`` is a reopen that
+    beats the lock and ``call>=2`` is one that would have to defeat it.
     """
     from sqlalchemy import text
 
-    real = maint._fetch_chunked
+    real = maint._exec_chunked
     seen = {"n": 0}
 
-    async def wrapper(conn, sql_prefix, ids, extra_params=()):
+    async def wrapper(conn, sql_prefix, ids, extra_params=(), suffix="", suffix_params=()):
         seen["n"] += 1
         if seen["n"] == call:
             await conn.execute(
                 text("UPDATE sessions SET status = 'running' WHERE id = :sid"),
                 {"sid": session_id},
             )
-        return await real(conn, sql_prefix, ids, extra_params)
+        return await real(conn, sql_prefix, ids, extra_params, suffix, suffix_params)
 
-    monkeypatch.setattr(maint, "_fetch_chunked", wrapper)
+    monkeypatch.setattr(maint, "_exec_chunked", wrapper)
 
 
-@pytest.mark.parametrize("call", [1, 2, 3, 4])
-def test_prune_leaves_a_session_that_stopped_being_terminal(tmp_path, monkeypatch, call):
-    """A session picked up by a resume mid-prune must survive it whole.
-
-    Surviving as a row is not enough. The prune nullifies associations and
-    deletes transition history before it deletes the session, so a check made
-    once at the top protects only the last statement under it: the leg keeps a
-    session whose history and links are gone. The parametrization moves the
-    reopen through those statements, and each case asserts everything, so a
-    guard that covers one statement and not the next fails here.
-    """
-    from lionagi.studio.services import db_maintenance as maint
-
-    db_path = tmp_path / "state.db"
-    _patch_db(monkeypatch, db_path)
-    old_ts = time.time() - 40 * 86400
+def _seed_session_with_history(db_path: Path, old_ts: float) -> str:
+    """One old terminal session carrying a transition record and an artifact."""
 
     async def seed():
         async with StateDB(db_path) as db:
@@ -262,12 +253,11 @@ def test_prune_leaves_a_session_that_stopped_being_terminal(tmp_path, monkeypatc
             )
         return sid
 
-    sid = run_async(seed())
-    _reopen_before_call(monkeypatch, maint, sid, call=call)
+    return run_async(seed())
 
-    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
 
-    async def survivors():
+def _session_and_its_history(db_path: Path, sid: str):
+    async def read():
         async with StateDB(db_path) as db:
             return (
                 await db.fetch_one("SELECT id, status FROM sessions WHERE id = ?", (sid,)),
@@ -275,11 +265,105 @@ def test_prune_leaves_a_session_that_stopped_being_terminal(tmp_path, monkeypatc
                 await db.fetch_all("SELECT id FROM artifacts WHERE session_id = ?", (sid,)),
             )
 
-    row, transitions, artifacts = run_async(survivors())
+    return run_async(read())
+
+
+def test_the_candidate_rows_are_held_before_their_status_is_read(tmp_path, monkeypatch):
+    """The prune must write to its candidates before it reads their status.
+
+    The read is what decides the batch, and on both backends it is a write that
+    holds a row against other transactions. Reading first and writing later
+    leaves the decision resting on a value that anyone may change in between,
+    so the order here is the whole guarantee, not a detail of it.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _seed_session_with_history(db_path, time.time() - 40 * 86400)
+
+    order: list[tuple[str, str]] = []
+    real_exec, real_fetch = maint._exec_chunked, maint._fetch_chunked
+
+    async def exec_spy(conn, sql_prefix, ids, extra_params=(), suffix="", suffix_params=()):
+        order.append(("write", sql_prefix))
+        return await real_exec(conn, sql_prefix, ids, extra_params, suffix, suffix_params)
+
+    async def fetch_spy(conn, sql_prefix, ids, extra_params=()):
+        order.append(("read", sql_prefix))
+        return await real_fetch(conn, sql_prefix, ids, extra_params)
+
+    monkeypatch.setattr(maint, "_exec_chunked", exec_spy)
+    monkeypatch.setattr(maint, "_fetch_chunked", fetch_spy)
+
+    run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    against_sessions = [step for step in order if " sessions " in f" {step[1]} "]
+    assert against_sessions, "the prune never touched the sessions table"
+    kind, sql = against_sessions[0]
+    assert kind == "write", f"the first statement against sessions was a read: {sql}"
+    assert "UPDATE sessions" in sql
+
+
+def test_prune_leaves_a_session_that_reopened_before_the_lock(tmp_path, monkeypatch):
+    """A session that comes back to life before the lock is simply not pruned.
+
+    This is the reachable case, and it has to stay quiet: resuming a branch
+    while a maintenance pass happens to be running is ordinary, so it ends in a
+    zero count rather than an error, with the session and everything attached
+    to it untouched.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    sid = _seed_session_with_history(db_path, time.time() - 40 * 86400)
+    _reopen_before_call(monkeypatch, maint, sid, call=1)
+
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    row, transitions, artifacts = _session_and_its_history(db_path, sid)
     assert row is not None and row["status"] == "running"
     assert len(transitions) == 1, "the reopened session lost its transition history"
     assert len(artifacts) == 1, "the reopened session lost its artifact association"
     assert result["sessions_pruned"] == 0
+
+
+@pytest.mark.parametrize("call", [2, 3, 4, 5, 6, 7])
+def test_a_session_that_reopens_past_the_lock_takes_the_whole_pass_down(
+    tmp_path, monkeypatch, call
+):
+    """Nothing may be committed for a session that reopened mid-sequence.
+
+    The prune clears associations and deletes transition history before it
+    deletes the session, so a per-statement condition protects each statement
+    on its own and still lets the sequence land half-applied: the earlier
+    writes are already done when the reopen arrives, and the delete then skips
+    the row, leaving a live session whose history and links are gone. The lock
+    is what keeps this from being reachable; the parametrization drives the
+    reopen past it at each step, and every case asserts the session survives
+    whole, so nothing short of abandoning the pass passes here.
+
+    The reopen rides the prune's own transaction here, so it is rolled back
+    along with everything else and the status reads terminal again afterwards.
+    A real resume commits on its own and would keep its status; what this
+    checks is the part that is the same either way, which is that none of the
+    prune's writes reached the database.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    sid = _seed_session_with_history(db_path, time.time() - 40 * 86400)
+    _reopen_before_call(monkeypatch, maint, sid, call=call)
+
+    with pytest.raises(maint.PruneRaceError):
+        run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    row, transitions, artifacts = _session_and_its_history(db_path, sid)
+    assert row is not None, "the reopened session lost its row"
+    assert len(transitions) == 1, "the reopened session lost its transition history"
+    assert len(artifacts) == 1, "the reopened session lost its artifact association"
 
 
 def test_prune_respects_fk_branches_cascade(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -227,16 +227,17 @@ def _reopen_before_call(monkeypatch, maint, session_id: str, *, call: int) -> No
     monkeypatch.setattr(maint, "_fetch_chunked", wrapper)
 
 
-@pytest.mark.parametrize(
-    ("call", "what_it_pins"),
-    [(1, "the re-read before anything destructive"), (2, "the predicate on the delete itself")],
-)
-def test_prune_leaves_a_session_that_stopped_being_terminal(
-    tmp_path, monkeypatch, call, what_it_pins
-):
-    """A session picked up by a resume mid-prune must survive it. Deleting one
-    would take a live leg's session, branches and messages out from under it,
-    and the leg would keep running against state that no longer exists."""
+@pytest.mark.parametrize("call", [1, 2, 3, 4])
+def test_prune_leaves_a_session_that_stopped_being_terminal(tmp_path, monkeypatch, call):
+    """A session picked up by a resume mid-prune must survive it whole.
+
+    Surviving as a row is not enough. The prune nullifies associations and
+    deletes transition history before it deletes the session, so a check made
+    once at the top protects only the last statement under it: the leg keeps a
+    session whose history and links are gone. The parametrization moves the
+    reopen through those statements, and each case asserts everything, so a
+    guard that covers one statement and not the next fails here.
+    """
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
@@ -245,20 +246,39 @@ def test_prune_leaves_a_session_that_stopped_being_terminal(
 
     async def seed():
         async with StateDB(db_path) as db:
-            return await _make_session(db, status="completed", started_at=old_ts)
+            sid = await _make_session(db, status="completed", started_at=old_ts)
+            await db.execute(
+                "INSERT INTO status_transitions"
+                " (id, entity_type, entity_id, previous_status, status, reason_code,"
+                "  source, created_at)"
+                " VALUES (?, 'session', ?, 'running', 'completed', 'run.completed.ok',"
+                "  'executor', ?)",
+                (str(uuid.uuid4()), sid, old_ts),
+            )
+            await db.execute(
+                "INSERT INTO artifacts (id, session_id, created_at, updated_at, kind, name,"
+                " content) VALUES (?, ?, ?, ?, 'file', 'a.txt', '{}')",
+                (str(uuid.uuid4()), sid, old_ts, old_ts),
+            )
+        return sid
 
     sid = run_async(seed())
     _reopen_before_call(monkeypatch, maint, sid, call=call)
 
     result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
 
-    async def remaining():
+    async def survivors():
         async with StateDB(db_path) as db:
-            return await db.fetch_one("SELECT id, status FROM sessions WHERE id = ?", (sid,))
+            return (
+                await db.fetch_one("SELECT id, status FROM sessions WHERE id = ?", (sid,)),
+                await db.fetch_all("SELECT id FROM status_transitions WHERE entity_id = ?", (sid,)),
+                await db.fetch_all("SELECT id FROM artifacts WHERE session_id = ?", (sid,)),
+            )
 
-    row = run_async(remaining())
-    assert row is not None, what_it_pins
-    assert row["status"] == "running"
+    row, transitions, artifacts = run_async(survivors())
+    assert row is not None and row["status"] == "running"
+    assert len(transitions) == 1, "the reopened session lost its transition history"
+    assert len(artifacts) == 1, "the reopened session lost its artifact association"
     assert result["sessions_pruned"] == 0
 
 

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -202,6 +202,66 @@ def test_prune_removes_old_terminal_sessions_only(tmp_path, monkeypatch):
     assert recent_completed in rem
 
 
+def _reopen_before_call(monkeypatch, maint, session_id: str, *, call: int) -> None:
+    """Return *session_id* to running just before the *call*-th chunked read.
+
+    Resuming a branch puts a terminal session back to running, so a session
+    selected for pruning can stop being prunable while the prune is still
+    assembling the batch. The seam lets that happen at a chosen point instead
+    of waiting for the interleaving to occur on its own.
+    """
+    from sqlalchemy import text
+
+    real = maint._fetch_chunked
+    seen = {"n": 0}
+
+    async def wrapper(conn, sql_prefix, ids, extra_params=()):
+        seen["n"] += 1
+        if seen["n"] == call:
+            await conn.execute(
+                text("UPDATE sessions SET status = 'running' WHERE id = :sid"),
+                {"sid": session_id},
+            )
+        return await real(conn, sql_prefix, ids, extra_params)
+
+    monkeypatch.setattr(maint, "_fetch_chunked", wrapper)
+
+
+@pytest.mark.parametrize(
+    ("call", "what_it_pins"),
+    [(1, "the re-read before anything destructive"), (2, "the predicate on the delete itself")],
+)
+def test_prune_leaves_a_session_that_stopped_being_terminal(
+    tmp_path, monkeypatch, call, what_it_pins
+):
+    """A session picked up by a resume mid-prune must survive it. Deleting one
+    would take a live leg's session, branches and messages out from under it,
+    and the leg would keep running against state that no longer exists."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return await _make_session(db, status="completed", started_at=old_ts)
+
+    sid = run_async(seed())
+    _reopen_before_call(monkeypatch, maint, sid, call=call)
+
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    async def remaining():
+        async with StateDB(db_path) as db:
+            return await db.fetch_one("SELECT id, status FROM sessions WHERE id = ?", (sid,))
+
+    row = run_async(remaining())
+    assert row is not None, what_it_pins
+    assert row["status"] == "running"
+    assert result["sessions_pruned"] == 0
+
+
 def test_prune_respects_fk_branches_cascade(tmp_path, monkeypatch):
     """Branches attached to pruned sessions are removed via CASCADE."""
     from lionagi.studio.services import db_maintenance as maint

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -863,15 +863,22 @@ async def test_teardown_already_terminal_session_reports_attempted_status(
     status masquerade as this invocation's outcome: a later leg's genuine
     'failed' must not be silently reported back as the old 'completed'. The
     rejection must still protect the DB row (ADR-0035 unchanged) — only the
-    caller-visible return value differs, and it's logged at warning level."""
+    caller-visible return value differs, and it's logged at warning level.
+
+    Setup now reopens a resumed session before the leg runs, so by the time
+    this teardown reads the row it is running rather than terminal and the
+    write lands. The stale status can no longer masquerade as this leg's
+    outcome because it is no longer there to do so, and the earlier leg's
+    outcome is kept in the transition history rather than on the row.
+    """
     branch = Branch(name="b1")
     ctx1 = await _setup_live_persist(branch)
     first = await _teardown_live_persist(ctx1, status="completed")
     assert first == "completed"
 
-    # A later leg attaches to the SAME session/branch row, which is already
-    # terminal by the time this teardown even starts (mirrors a resume/
-    # follow-up reusing a branch whose session an earlier run finalized).
+    # A later leg attaches to the SAME session/branch row, which the earlier
+    # leg already took terminal (mirrors a resume/follow-up reusing a branch
+    # whose session an earlier run finalized).
     ctx2 = await _setup_live_persist(branch)
     assert ctx2 is not None
     assert ctx2["session_id"] == ctx1["session_id"]
@@ -880,15 +887,29 @@ async def test_teardown_already_terminal_session_reports_attempted_status(
         second = await _teardown_live_persist(ctx2, status="failed", exception=RuntimeError("boom"))
 
     assert second == "failed"  # this invocation's honest outcome, not "completed"
-    assert any(
-        rec.levelno >= logging.WARNING and "completed" in rec.message and "failed" in rec.message
+    assert not any(
+        rec.levelno >= logging.WARNING and "already terminal" in rec.message
         for rec in caplog.records
     )
 
-    # The DB record itself is untouched — ADR-0035 still protects it.
     async with StateDB() as db:
         s = await db.get_session(ctx1["session_id"])
-    assert s["status"] == "completed"
+        history = await db.fetch_all(
+            "SELECT previous_status, status FROM status_transitions "
+            "WHERE entity_type = 'session' AND entity_id = ? ORDER BY created_at",
+            (ctx1["session_id"],),
+        )
+
+    # The row now describes the leg that just ran.
+    assert s["status"] == "failed"
+    # And the earlier leg is not erased by that: reopening is recorded as a
+    # transition like any other, so the whole sequence stays readable.
+    assert [(r["previous_status"], r["status"]) for r in history] == [
+        (None, "running"),
+        ("running", "completed"),
+        ("completed", "running"),
+        ("running", "failed"),
+    ]
 
 
 async def test_teardown_concurrent_race_non_terminal_entry_returns_winner_status(

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Resuming a branch puts its session back into execution.
+
+A session's closing transition only announces itself when the status actually
+changes. A resume adopts a session an earlier leg already took terminal, so
+writing that same terminal status at the end is not a change: the leg finishes
+silently, its completion notice never arrives, and anything waiting on that
+notice cannot tell the leg apart from one still running.
+
+The reopen is also the only sanctioned exit from a terminal status, which the
+transition service refuses without an override. That refusal is silent from the
+caller's side and produces exactly the symptom the reopen exists to remove, so
+it is pinned here separately from the notice it enables.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli._runs import _reopen_session_for_resume
+from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB
+from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+from lionagi.state.reasons import RunReasons
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+# The teardown's own status-to-reason mapping, so a session closed as timed_out
+# in a test carries the reason a real one would.
+_REASON_FOR = {
+    "completed": RunReasons.COMPLETED_OK,
+    "completed_empty": RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+    "failed": RunReasons.FAILED_EXCEPTION,
+    "timed_out": RunReasons.TIMED_OUT_DEADLINE,
+    "aborted": RunReasons.CANCELLED_SIGINT,
+    "cancelled": RunReasons.CANCELLED_SYSTEM,
+}
+
+
+async def _running_session(db: StateDB) -> str:
+    sid = uuid.uuid4().hex[:12]
+    prog = str(uuid.uuid4())
+    await db.create_progression(prog)
+    await db.create_session(
+        {
+            "id": sid,
+            "name": "agent",
+            "invocation_kind": "agent",
+            "progression_id": prog,
+            "status": "running",
+            "started_at": 1000.0,
+        }
+    )
+    return sid
+
+
+async def _finished_session(db: StateDB, *, status: str = "completed") -> str:
+    """A session an earlier leg already closed."""
+    sid = await _running_session(db)
+    await db.update_status(
+        "session",
+        sid,
+        new_status=status,
+        reason_code=_REASON_FOR[status],
+        source="executor",
+        actor=sid,
+        extra_fields={"ended_at": 2000.0},
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_session_is_reopened_rather_than_refused(temp_db_path):
+    """The session policy declares one edge, running to terminal, and refuses
+    any exit from terminal without an override. Without one this write is
+    rejected and the resume proceeds on a session still marked finished."""
+    async with StateDB() as db:
+        sid = await _finished_session(db)
+
+        applied = await _reopen_session_for_resume(db, sid, await db.get_session(sid))
+
+        assert applied is True
+        assert (await db.get_session(sid))["status"] == "running"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", sorted(SESSION_TERMINAL_STATUSES))
+async def test_every_terminal_status_can_be_reopened(temp_db_path, status):
+    """Not just the happy one. A leg resumed after a timeout or an abort has
+    the same claim on announcing itself as one resumed after a clean finish."""
+    async with StateDB() as db:
+        sid = await _finished_session(db, status=status)
+
+        assert await _reopen_session_for_resume(db, sid, await db.get_session(sid)) is True
+
+
+@pytest.mark.asyncio
+async def test_the_close_after_a_reopen_is_a_real_change(temp_db_path):
+    """The payoff. Closing a session that was never reopened writes the same
+    status it already held, which is not a change, so no terminal event is
+    emitted and nothing downstream hears the leg finish."""
+    emitted: list[str] = []
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        "test-observer", lambda env: emitted.append(env.entity.id), kinds=["session"]
+    )
+    try:
+        async with StateDB() as db:
+            sid = await _finished_session(db)
+            await _reopen_session_for_resume(db, sid, await db.get_session(sid))
+
+            await db.update_status(
+                "session",
+                sid,
+                new_status="completed",
+                reason_code=RunReasons.COMPLETED_OK,
+                source="executor",
+                actor=sid,
+            )
+
+        assert sid in emitted
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister("test-observer")
+
+
+@pytest.mark.asyncio
+async def test_a_running_session_is_left_alone(temp_db_path):
+    """A resume racing a live leg on the same branch. The row already describes
+    the session correctly, and reopening it would be a write with nothing to
+    say."""
+    async with StateDB() as db:
+        sid = await _running_session(db)
+        before = await db.get_session(sid)
+
+        assert await _reopen_session_for_resume(db, sid, before) is False
+        assert (await db.get_session(sid))["updated_at"] == before["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_reopening_clears_the_end_time_and_keeps_the_start(temp_db_path):
+    """A session cannot both have finished and be executing. Leaving a stale
+    end time on a running session is the same defect one column over, and the
+    start time belongs to the session rather than to whichever leg is running."""
+    async with StateDB() as db:
+        sid = await _finished_session(db)
+
+        await _reopen_session_for_resume(db, sid, await db.get_session(sid))
+
+        row = await db.get_session(sid)
+        assert row["ended_at"] is None
+        assert row["started_at"] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_a_reopen_leaves_a_record_of_what_did_it(temp_db_path):
+    """Reopening is the system's one exception to terminal finality, so it is
+    written down rather than passed off as an ordinary status write."""
+    async with StateDB() as db:
+        sid = await _finished_session(db)
+
+        await _reopen_session_for_resume(db, sid, await db.get_session(sid))
+
+        rows = await db.fetch_all(
+            "SELECT action, details FROM admin_events WHERE target_id = ?", (sid,)
+        )
+
+    assert any(r["action"] == "status_transition_override" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_a_missing_session_row_is_not_an_error(temp_db_path):
+    """get_session returns None for a branch whose session was pruned. The
+    resume should carry on rather than fail on its own bookkeeping."""
+    async with StateDB() as db:
+        assert await _reopen_session_for_resume(db, "gone", None) is False

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -16,6 +16,8 @@ it is pinned here separately from the notice it enables.
 
 from __future__ import annotations
 
+import json
+import os
 import uuid
 from pathlib import Path
 
@@ -108,13 +110,19 @@ async def test_the_close_after_a_reopen_is_a_real_change(temp_db_path):
     """The payoff. Closing a session that was never reopened writes the same
     status it already held, which is not a change, so no terminal event is
     emitted and nothing downstream hears the leg finish."""
-    emitted: list[str] = []
+    emitted: list = []
     DEFAULT_TERMINAL_CALLBACKS.register(
-        "test-observer", lambda env: emitted.append(env.entity.id), kinds=["session"]
+        "test-observer", lambda env: emitted.append(env), kinds=["session"]
     )
     try:
         async with StateDB() as db:
             sid = await _finished_session(db)
+            # The first leg's own close emits. Asserting on the accumulated list
+            # would then pass with the reopen removed, which is the vacuous
+            # version of this test: only what happens AFTER this point is
+            # evidence about the reopen.
+            emitted.clear()
+
             await _reopen_session_for_resume(db, sid, await db.get_session(sid))
 
             await db.update_status(
@@ -126,7 +134,9 @@ async def test_the_close_after_a_reopen_is_a_real_change(temp_db_path):
                 actor=sid,
             )
 
-        assert sid in emitted
+        assert [(e.entity.id, e.previous_status, e.terminal_status) for e in emitted] == [
+            (sid, "running", "completed")
+        ]
     finally:
         DEFAULT_TERMINAL_CALLBACKS.unregister("test-observer")
 
@@ -173,6 +183,57 @@ async def test_a_reopen_leaves_a_record_of_what_did_it(temp_db_path):
         )
 
     assert any(r["action"] == "status_transition_override" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_reopening_takes_over_the_liveness_markers(temp_db_path):
+    """Liveness is judged from the process markers on the row. A terminal
+    session is never checked for liveness, so markers left by the leg that
+    already exited were harmless; a running one is checked, so keeping them
+    would describe this live leg by a dead process and let the phantom reaper
+    take a working session to failed."""
+    async with StateDB() as db:
+        sid = await _running_session(db)
+        await db.update_session(sid, node_metadata=json.dumps({"pid": 999999, "keep": "me"}))
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            source="executor",
+            actor=sid,
+        )
+
+        await _reopen_session_for_resume(db, sid, await db.get_session(sid))
+
+        meta = (await db.get_session(sid))["node_metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+    assert meta["pid"] == os.getpid()
+    assert meta["keep"] == "me"  # unrelated metadata is merged, not replaced
+
+
+@pytest.mark.asyncio
+async def test_a_lost_reopen_race_does_not_take_over_another_leg_s_markers(temp_db_path):
+    """On a lost race the row belongs to a different leg. Stamping our markers
+    on it would make that leg's liveness answer for our process, which is the
+    same defect one owner over."""
+    async with StateDB() as db:
+        sid = await _running_session(db)
+        await db.update_session(sid, node_metadata=json.dumps({"pid": 999999}))
+        stale = await db.get_session(sid)  # snapshot taken while terminal...
+        stale = {**stale, "status": "completed"}  # ...as this leg believed it to be
+
+        # The row is actually running (another leg owns it), so the guarded
+        # reopen finds nothing to move.
+        assert await _reopen_session_for_resume(db, sid, stale) is False
+
+        meta = (await db.get_session(sid))["node_metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+    assert meta["pid"] == 999999
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -215,6 +215,40 @@ async def test_reopening_takes_over_the_liveness_markers(temp_db_path):
 
 
 @pytest.mark.asyncio
+async def test_the_status_and_the_markers_move_together(temp_db_path):
+    """Splitting them leaves a window where the row reads running while still
+    carrying the previous leg's markers. The sweeps select on status and then
+    ask these markers whether the row is alive, so a row that is running for
+    even an instant with a dead process recorded is a row they can cancel."""
+    async with StateDB() as db:
+        sid = await _running_session(db)
+        await db.update_session(sid, node_metadata=json.dumps({"pid": 999999}))
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            source="executor",
+            actor=sid,
+        )
+
+        async def _no_second_write(*args, **kwargs):
+            raise AssertionError("markers were written outside the status transaction")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(db, "update_session", _no_second_write)
+            assert await _reopen_session_for_resume(db, sid, await db.get_session(sid)) is True
+
+        row = await db.get_session(sid)
+        meta = row["node_metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+    assert row["status"] == "running"
+    assert meta["pid"] == os.getpid()
+
+
+@pytest.mark.asyncio
 async def test_a_lost_reopen_race_does_not_take_over_another_leg_s_markers(temp_db_path):
     """On a lost race the row belongs to a different leg. Stamping our markers
     on it would make that leg's liveness answer for our process, which is the

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -215,9 +215,13 @@ async def test_reopening_takes_over_the_liveness_markers(temp_db_path):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("stored", ["legacy", '"a string"', "[1, 2]", "{not json"])
+@pytest.mark.parametrize("stored", ["null", "legacy", '"a string"', "[1, 2]", "{not json"])
 async def test_metadata_that_is_not_an_object_does_not_stop_the_resume(temp_db_path, stored):
-    """The column has held plain strings, and reading one as an object raises.
+    """Values that are not objects do occur in this column; a JSON `null` is
+    the ordinary one, from a session that never recorded metadata, and it reads
+    back as nothing at all. The shapes that raise are text that is not JSON and
+    a JSON scalar or list, which raise in different places: the first when it is
+    read, the second when it is merged.
     Every other reader of it ignores what it cannot read as an object; a resume
     that raised here would lose the leg all of its state persistence, which is a
     far worse outcome than dropping a value nothing else consults."""

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -215,6 +215,26 @@ async def test_reopening_takes_over_the_liveness_markers(temp_db_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stored", ["legacy", '"a string"', "[1, 2]", "{not json"])
+async def test_metadata_that_is_not_an_object_does_not_stop_the_resume(temp_db_path, stored):
+    """The column has held plain strings, and reading one as an object raises.
+    Every other reader of it ignores what it cannot read as an object; a resume
+    that raised here would lose the leg all of its state persistence, which is a
+    far worse outcome than dropping a value nothing else consults."""
+    async with StateDB() as db:
+        sid = await _finished_session(db)
+        await db.execute("UPDATE sessions SET node_metadata = ? WHERE id = ?", (stored, sid))
+
+        assert await _reopen_session_for_resume(db, sid, await db.get_session(sid)) is True
+
+        meta = (await db.get_session(sid))["node_metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+    assert meta["pid"] == os.getpid()
+
+
+@pytest.mark.asyncio
 async def test_the_status_and_the_markers_move_together(temp_db_path):
     """Splitting them leaves a window where the row reads running while still
     carrying the previous leg's markers. The sweeps select on status and then

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -300,3 +300,66 @@ async def test_a_missing_session_row_is_not_an_error(temp_db_path):
     resume should carry on rather than fail on its own bookkeeping."""
     async with StateDB() as db:
         assert await _reopen_session_for_resume(db, "gone", None) is False
+
+
+@pytest.mark.asyncio
+async def test_a_session_deleted_while_the_resume_waited_is_not_an_error(temp_db_path):
+    """The row can be read as terminal and be gone by the time it is written.
+
+    Maintenance removes old terminal sessions and holds each candidate for the
+    length of its transaction, so a resume that arrives just before one starts
+    is released only after it commits. Nothing is left to reopen, and treating
+    that as a failure would stop the leg over bookkeeping it does not need.
+    """
+    async with StateDB() as db:
+        sid = await _finished_session(db)
+        snapshot = await db.get_session(sid)
+        await db.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+
+        assert await _reopen_session_for_resume(db, sid, snapshot) is False
+
+
+@pytest.mark.asyncio
+async def test_a_resume_whose_session_is_pruned_mid_setup_still_records_itself(
+    temp_db_path, monkeypatch
+):
+    """Persistence reads the branch and its session as two separate reads.
+
+    A maintenance pass can commit between them, so the branch is read as
+    present and its session comes back missing. Reading the rest of the
+    resume out of the branch's copy of a row that no longer exists takes the
+    whole run down to no persistence at all, which is a much larger loss than
+    the session that went away. The leg records itself under a new session
+    instead, the same way a branch nobody has seen before does.
+    """
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+
+    branch = Branch(name="resumed")
+    async with StateDB() as db:
+        first = await setup_agent_persist(branch, agent_name="implementer")
+        assert first is not None
+        await teardown_agent_persist(first, status="completed")
+        pruned_id = first["session_id"]
+
+    real_get_session = StateDB.get_session
+
+    async def get_session_after_a_prune(self, session_id):
+        row = await real_get_session(self, session_id)
+        if row is not None and session_id == pruned_id:
+            # The maintenance pass commits here, between the two reads.
+            await self.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            return None
+        return row
+
+    # Scoped to this patch alone: undoing every patch would also put back the
+    # database path this test is redirected away from.
+    with monkeypatch.context() as mp:
+        mp.setattr(StateDB, "get_session", get_session_after_a_prune)
+        second = await setup_agent_persist(branch, agent_name="implementer")
+
+    assert second is not None, "the resumed leg was left with no persistence at all"
+    assert second["session_id"] != pruned_id
+
+    async with StateDB() as db:
+        assert await db.get_session(second["session_id"]) is not None

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import contextlib
+import json
+import os
 import time
 import uuid
 from pathlib import Path
@@ -435,6 +437,31 @@ async def test_doctor_sweeps_stale_running_sessions_to_aborted(
     assert s_stale["status"] == "aborted"
     assert s_stale["ended_at"] is not None
     assert s_recent["status"] == "running"
+
+
+async def test_doctor_leaves_an_old_session_whose_process_is_still_running(
+    temp_db_path: Path,
+):
+    """Age answers how long since the session first started, which is how long
+    the process has been running only for a session that ran once. A branch
+    picked up again keeps its original start time while the process is new, so
+    the command asks the process before calling the session stuck."""
+    old = time.time() - (48 * 3600)
+    async with StateDB() as db:
+        alive = await _seed_session(db, status="running")
+        dead = await _seed_session(db, status="running")
+        for sid, pid in ((alive, os.getpid()), (dead, 999999)):
+            await db.execute(
+                "UPDATE sessions SET started_at = ?, node_metadata = ? WHERE id = ?",
+                (old, json.dumps({"pid": pid}), sid),
+            )
+
+    result = await _doctor(stale_hours=24, dry_run=False)
+    assert (result["swept"], result["skipped"]) == (1, 1)
+
+    async with StateDB() as db:
+        assert (await db.get_session(alive))["status"] == "running"
+        assert (await db.get_session(dead))["status"] == "aborted"
 
 
 async def test_doctor_handles_null_started_at_as_stale(temp_db_path: Path):

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -464,6 +464,26 @@ async def test_doctor_leaves_an_old_session_whose_process_is_still_running(
         assert (await db.get_session(dead))["status"] == "aborted"
 
 
+async def test_doctor_sweeps_a_session_whose_pid_was_recycled(temp_db_path: Path):
+    """A live PID is not proof on its own. The OS hands a dead session's number
+    to an unrelated process eventually, and a sweep that stopped there would
+    protect a genuinely stuck row for as long as that process lived."""
+    old = time.time() - (48 * 3600)
+    async with StateDB() as db:
+        sid = await _seed_session(db, status="running")
+        await db.execute(
+            "UPDATE sessions SET started_at = ?, node_metadata = ? WHERE id = ?",
+            # This process is alive, but it started at a different moment than
+            # the session recorded, so the number belongs to someone else now.
+            (old, json.dumps({"pid": os.getpid(), "pid_create_time": 1.0}), sid),
+        )
+
+    assert (await _doctor(stale_hours=24, dry_run=False))["swept"] == 1
+
+    async with StateDB() as db:
+        assert (await db.get_session(sid))["status"] == "aborted"
+
+
 async def test_doctor_handles_null_started_at_as_stale(temp_db_path: Path):
     """A 'running' row with NULL started_at is treated as stale regardless of the threshold."""
     async with StateDB() as db:


### PR DESCRIPTION
Implements ADR-0105 (D1 and D3).

## The defect

A session's closing transition only announces itself when the status actually changes. Resuming a branch adopts a session an earlier leg already took terminal, so writing that same terminal status at the end is not a change: the leg finishes silently, its completion notice never arrives, and the job record never closes. From the outside, a resumed leg that finished is indistinguishable from one still running.

## The fix

Resume returns the session to `running` before the leg executes, through `update_status` rather than a direct write, so the closing transition is a genuine change.

Reopening is the only sanctioned exit from a terminal status, so it carries an override. That is not a formality to satisfy the guard. Declaring a `terminal → running` edge in the session policy would satisfy it too, and would permit terminal exit for every session writer in the system, while finality is what the reapers, the teardown guard and `li wait` all rest on. The override keeps the exception to the one caller that earned it and, because it requires an actor and a justification and emits an admin event, makes each reopening attributable.

Without the override the write does not merely fail. `update_status` raises, `setup_agent_persist` catches `Exception` broadly and returns `None`, and that disables persistence for the entire run behind one warning line. The regression that pins this fails at the write rather than three steps downstream at the notice.

## A second defect falls out

Teardown skipped its status write when the session was already terminal on entry, which silently dropped a resumed leg's outcome. The session is now `running` at teardown, so that outcome is recorded. The earlier leg is not lost: reopening is a transition like any other, so the full sequence stays readable in the transition history. The existing test for the old behaviour was rewritten to assert that history end to end rather than to flip its expectation.

## Consumer sweep

Every live reader of session terminal-status and `ended_at` was enumerated by grep and read at its call site, since `completed → running → completed` is a transition no consumer has seen before. Thirteen consumers; none breaks. The table and the reasoning are in the ADR. Two behaviours change and are stated there rather than left to be discovered: the teardown skip above, and a reopened session becoming eligible for phantom reaping if its leg dies silently.

A second sweep covered a different question: whether any consumer treats "once completed" as a stable fact and would mis-run or double-run if the row later reads `failed`. It does not.

- Every consumer keyed specifically on `completed` is read-only: exit codes, outcome display, stats buckets, success predicates, and child-status aggregation. All recompute from the current row, so a later value changes what is reported, which is correct, and re-reading is idempotent.
- The teardown's own artifact-verification and escalation steps key on a per-leg local status, not on the persisted row.
- The one destructive consumer is retention pruning, which selects on session status and age. It treats all six terminal statuses identically, so a `completed → failed` flip does not change prune eligibility; and while a session is reopened it is `running` and therefore not prune-eligible at all, which is strictly more conservative than before.
- There is no finalization or archival step gated on a session having once been `completed`.

Separately and pre-existing: retention keys on `started_at`, which resume preserves by design, so a repeatedly-resumed session becomes prune-eligible on age since it first started rather than age since it last ran. Not introduced here and not changed here, recorded because this change makes resume more visible.

## Tests

Twelve new regressions, including one parametrized across all six terminal statuses (a leg resumed after a timeout has the same claim on announcing itself as one resumed after a clean finish), one asserting the terminal callback actually fires rather than that a callback was registered, and one asserting the override leaves an audit record. Each was proven to fail before the fix.

`tests/cli` and `tests/state`: 2821 passed, 8 failed, all eight from optional extras absent locally (Postgres driver, and one test that reads the machine's own agent profiles). Each was confirmed to fail identically with the changed files reverted to `main`.


## The markers travel with the status

A session's process markers are how the sweeps answer "is this row still alive", a question they only ask of rows their status filter already selected. So status and markers are read together and have to agree at every instant a sweep could look.

Reopening writes both in one guarded transaction, which is what the same-row status-write allowlist exists for. `node_metadata` is added to that allowlist and to the session policy's patch fields. Splitting them would leave a window where the row reads `running` while still carrying the markers of the leg that already exited, which is the exact shape `li kill --all-stale` cancels; and writing them on a lost reopen would stamp this process onto a row that belongs to another leg, making that leg's liveness answer for ours. The single guarded write either wins and installs both, or loses and touches nothing.

## `li state doctor` gets the process check it always described

The command sweeps sessions stuck at `status='running'` whose `started_at` is past a threshold, and its help text promised that an actively-running CLI process is left alone. Age answers *how long since this session first started*, which equals *how long this process has been running* only for a session that ran once. A resumed session keeps its original start time while its process is new, so a live resumed leg was sweepable the moment it went back to `running`.

It now requires both the age and the recorded process being gone, the same veto the stale-kill sweep already applied. Sessions with no recorded PID are unchanged, so a crash that never wrote markers is still reapable, and the help text states the predicate it enforces.

The pre-existing retention behaviour noted above is filed as #2474.

## Reading the metadata, and trusting a process number

Two smaller corrections in the same family.

Reopening read `node_metadata` as an object unconditionally, and a value that does not read as an object raises — which the caller catches broadly and turns into a run with no state persistence at all, a much larger failure than the field that caused it. Anything that does not read as a JSON object is now dropped, matching `_read_pid_from_entity` and `process_liveness`, which both already ignore what they cannot read as one.

The sweep's new liveness veto also trusted a live process number on its own. The OS hands a dead session's number to an unrelated process eventually, and a veto that stopped there would protect a genuinely stuck row for as long as that number stayed in use. It now uses the same identity check the stale-kill sweep does: correlate the recorded start time and session marker, sweep when the number has been recycled, and leave the row alone when the process cannot be inspected at all, since an unattended sweep must not reap a worker it merely lacks permission to see.
