### PR TITLE
fix(state): rebuilt sessions table keeps its declared foreign keys

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -905,17 +905,33 @@ class StateDB:
         col_list = ", ".join(cols)
 
         async def _rebuild() -> None:
-            async with self._engine.begin() as conn:
-                await conn.execute(text("PRAGMA foreign_keys = OFF"))
+            async with self._engine.connect() as conn:
+                driver = (await conn.get_raw_connection()).driver_connection
+                await driver.execute("PRAGMA foreign_keys = OFF")
+                # Everything after the OFF pragma -- including the flush commit
+                # that makes it take effect -- sits inside the outer try so that
+                # ANY failure path restores enforcement in the finally block; a
+                # flush failure must not leave the pooled connection with
+                # foreign keys silently disabled. The pragma must run on the raw
+                # driver outside a transaction: open() installs BEGIN IMMEDIATE
+                # on every sqlite engine, so setting it through an engine-level
+                # begin() block leaves it a no-op and enforcement stays on for
+                # the whole rebuild.
                 try:
-                    # Create without FK references: the referenced tables (messages,
-                    # invocations) may not exist yet in a minimal legacy DB.
-                    # metadata.create_all() runs AFTER this rebuild and will not
-                    # re-create sessions (table already exists after rename).
-                    # FK enforcement relies on the PRAGMA which is already set up
-                    # by make_engine and applies to all DML after schema init.
-                    await conn.execute(
-                        text(
+                    await driver.commit()
+                    await driver.execute("BEGIN IMMEDIATE")
+                    try:
+                        # The foreign keys below are the ones the declared schema
+                        # carries, so a rebuilt table ends up with the same
+                        # constraints a freshly created one gets. They are what
+                        # makes the OFF pragma above load-bearing: sqlite accepts
+                        # a forward reference to a table that does not exist yet,
+                        # but with enforcement on, every statement against the
+                        # child fails while the parent is absent -- including the
+                        # copy below, and including rows whose FK column is NULL.
+                        # A minimal legacy DB has no messages or invocations table
+                        # until create_all() runs after this rebuild.
+                        await driver.execute(
                             """
                             CREATE TABLE sessions_new (
                               id              TEXT    PRIMARY KEY,
@@ -924,9 +940,9 @@ class StateDB:
                               node_metadata   JSON,
                               name            TEXT,
                               user            TEXT,
-                              progression_id  TEXT    NOT NULL,
-                              first_msg_id    TEXT,
-                              last_msg_id     TEXT,
+                              progression_id  TEXT    NOT NULL REFERENCES progressions(id),
+                              first_msg_id    TEXT    REFERENCES messages(id),
+                              last_msg_id     TEXT    REFERENCES messages(id),
                               updated_at      REAL    NOT NULL,
                               playbook_name   TEXT,
                               agent_name      TEXT,
@@ -947,7 +963,7 @@ class StateDB:
                               ended_at        REAL,
                               last_message_at REAL,
                               current_phase   TEXT,
-                              invocation_id   TEXT,
+                              invocation_id   TEXT    REFERENCES invocations(id),
                               model           TEXT,
                               provider        TEXT,
                               effort          TEXT,
@@ -967,26 +983,28 @@ class StateDB:
                             )
                             """
                         )
-                    )
-                    select_cols = []
-                    for c in cols:
-                        if c == "updated_at":
-                            select_cols.append(
-                                "COALESCE(updated_at, created_at, strftime('%s','now')) AS updated_at"
-                            )
-                        else:
-                            select_cols.append(c)
-                    select_list = ", ".join(select_cols)
-                    insert_sql = (
-                        f"INSERT INTO sessions_new ({col_list}) SELECT {select_list} FROM sessions"  # noqa: S608
-                    )
-                    await conn.execute(text(insert_sql))
-                    await conn.execute(text("DROP TABLE sessions"))
-                    await conn.execute(text("ALTER TABLE sessions_new RENAME TO sessions"))
-                    for idx_sql in index_sqls:
-                        await conn.execute(text(idx_sql))
+                        select_cols = []
+                        for c in cols:
+                            if c == "updated_at":
+                                select_cols.append(
+                                    "COALESCE(updated_at, created_at, strftime('%s','now')) AS updated_at"
+                                )
+                            else:
+                                select_cols.append(c)
+                        select_list = ", ".join(select_cols)
+                        insert_sql = f"INSERT INTO sessions_new ({col_list}) SELECT {select_list} FROM sessions"  # noqa: S608
+                        await driver.execute(insert_sql)
+                        await driver.execute("DROP TABLE sessions")
+                        await driver.execute("ALTER TABLE sessions_new RENAME TO sessions")
+                        for idx_sql in index_sqls:
+                            await driver.execute(idx_sql)
+                        await driver.commit()
+                    except BaseException:
+                        await driver.rollback()
+                        raise
                 finally:
-                    await conn.execute(text("PRAGMA foreign_keys = ON"))
+                    await driver.execute("PRAGMA foreign_keys = ON")
+                    await driver.commit()
 
         await self._rebuild_check_constraint(
             "sessions",

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -421,6 +421,41 @@ def _install_begin_immediate(sync_engine) -> None:
         conn.exec_driver_sql("BEGIN IMMEDIATE")
 
 
+async def _restore_foreign_keys(conn, driver) -> None:
+    """Turn foreign-key enforcement back on after a legacy table rebuild.
+
+    Every rebuild calls this from its ``finally``, so it runs on the failure
+    paths too, and those are the ones that need the care. Two things can leave a
+    pooled connection with enforcement silently off:
+
+    ``PRAGMA foreign_keys`` is a no-op while a transaction is open, so a rollback
+    that itself failed leaves its transaction alive and the pragma inert. Any
+    surviving transaction is therefore closed first.
+
+    And a write is not a result. The setting is read back rather than assumed,
+    and a connection whose enforcement cannot be confirmed is invalidated so it
+    is never handed out again.
+    """
+    try:
+        # No-op when the caller already ended its own transaction.
+        await driver.rollback()
+    except Exception:  # noqa: S110 -- not fatal on its own; the read-back below is
+        # what decides whether this connection is safe to hand out again.
+        pass
+
+    confirmed = False
+    try:
+        await driver.execute("PRAGMA foreign_keys = ON")
+        await driver.commit()
+        row = await (await driver.execute("PRAGMA foreign_keys")).fetchone()
+        confirmed = bool(row) and row[0] == 1
+    except Exception:
+        confirmed = False
+
+    if not confirmed:
+        await conn.invalidate()
+
+
 class StateDB:
     """Async SQLAlchemy state layer for sessions, branches, messages, and progressions."""
 
@@ -1003,8 +1038,7 @@ class StateDB:
                         await driver.rollback()
                         raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "sessions",
@@ -1117,8 +1151,7 @@ class StateDB:
                         await driver.rollback()
                         raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "schedules",
@@ -1236,8 +1269,7 @@ class StateDB:
                         await driver.rollback()
                         raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "schedules",
@@ -1318,8 +1350,7 @@ class StateDB:
                         await driver.rollback()
                         raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "schedules",
@@ -1440,8 +1471,7 @@ class StateDB:
                     await driver.rollback()
                     raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "invocations",
@@ -1637,8 +1667,7 @@ class StateDB:
                     await driver.rollback()
                     raise
                 finally:
-                    await driver.execute("PRAGMA foreign_keys = ON")
-                    await driver.commit()
+                    await _restore_foreign_keys(conn, driver)
 
         await self._rebuild_check_constraint(
             "schedule_runs",

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -20,7 +20,7 @@ from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 from lionagi.config import settings
 from lionagi.libs.path_safety import check_path_safe as _check_path_safe
 from lionagi.ln import json_dumps as _json_dumps
-from lionagi.ln.concurrency import CancelScope, Lock
+from lionagi.ln.concurrency import CancelScope, Lock, get_cancelled_exc_class, shield
 from lionagi.state.engine import (
     dialect_of,
     make_engine,
@@ -435,10 +435,21 @@ async def _restore_foreign_keys(conn, driver) -> None:
     And a write is not a result. The setting is read back rather than assumed,
     and a connection whose enforcement cannot be confirmed is invalidated so it
     is never handed out again.
+
+    Cancellation gets its own handling rather than falling through. It arrives as
+    a BaseException, so catching ``Exception`` would let it skip the read-back and
+    the invalidation both, which is the one outcome this function exists to
+    prevent. The invalidation is shielded so it completes, and the cancellation is
+    then re-raised untouched.
     """
+    cancelled_exc = get_cancelled_exc_class()
+
     try:
         # No-op when the caller already ended its own transaction.
         await driver.rollback()
+    except cancelled_exc:
+        await shield(conn.invalidate)
+        raise
     except Exception:  # noqa: S110 -- not fatal on its own; the read-back below is
         # what decides whether this connection is safe to hand out again.
         pass
@@ -449,11 +460,14 @@ async def _restore_foreign_keys(conn, driver) -> None:
         await driver.commit()
         row = await (await driver.execute("PRAGMA foreign_keys")).fetchone()
         confirmed = bool(row) and row[0] == 1
+    except cancelled_exc:
+        await shield(conn.invalidate)
+        raise
     except Exception:
         confirmed = False
 
     if not confirmed:
-        await conn.invalidate()
+        await shield(conn.invalidate)
 
 
 class StateDB:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -956,17 +956,20 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
-                # Everything after the OFF pragma -- including the flush commit
-                # that makes it take effect -- sits inside the outer try so that
-                # ANY failure path restores enforcement in the finally block; a
-                # flush failure must not leave the pooled connection with
-                # foreign keys silently disabled. The pragma must run on the raw
-                # driver outside a transaction: open() installs BEGIN IMMEDIATE
-                # on every sqlite engine, so setting it through an engine-level
-                # begin() block leaves it a no-op and enforcement stays on for
-                # the whole rebuild.
                 try:
+                    # The OFF pragma is inside this try, not above it, because it
+                    # takes effect at its own await with no flush required. That is
+                    # measured, not inferred from the commit that follows. Anything
+                    # interrupting after it -- cancellation included -- must still
+                    # reach the finally, or a pooled connection keeps foreign keys
+                    # disabled for every caller that borrows it next.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
+                    # The commit does not make the pragma effective; it closes any
+                    # open transaction so BEGIN IMMEDIATE starts cleanly. The pragma
+                    # must run on the raw driver: open() installs BEGIN IMMEDIATE on
+                    # every sqlite engine, so setting it through an engine-level
+                    # begin() block leaves it a no-op and enforcement stays on for
+                    # the whole rebuild.
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     try:
@@ -1143,13 +1146,14 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
-                # Everything after the OFF pragma — including the flush commit
-                # that makes it take effect — sits inside the outer try so that
-                # ANY failure path restores enforcement in the finally block; a
-                # flush failure must not leave the pooled connection with
-                # foreign keys silently disabled.
                 try:
+                    # Inside the try, not above it: the pragma takes effect at its
+                    # own await with no flush required, so anything interrupting
+                    # after it -- cancellation included -- must still reach the
+                    # finally or a pooled connection keeps foreign keys disabled.
+                    # The commit closes any open transaction rather than making the
+                    # pragma effective.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     try:
@@ -1261,13 +1265,14 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
-                # Everything after the OFF pragma — including the flush commit
-                # that makes it take effect — sits inside the outer try so that
-                # ANY failure path restores enforcement in the finally block; a
-                # flush failure must not leave the pooled connection with
-                # foreign keys silently disabled.
                 try:
+                    # Inside the try, not above it: the pragma takes effect at its
+                    # own await with no flush required, so anything interrupting
+                    # after it -- cancellation included -- must still reach the
+                    # finally or a pooled connection keeps foreign keys disabled.
+                    # The commit closes any open transaction rather than making the
+                    # pragma effective.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     try:
@@ -1347,8 +1352,14 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
                 try:
+                    # Inside the try, not above it: the pragma takes effect at its
+                    # own await with no flush required, so anything interrupting
+                    # after it -- cancellation included -- must still reach the
+                    # finally or a pooled connection keeps foreign keys disabled.
+                    # The commit closes any open transaction rather than making the
+                    # pragma effective.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     try:
@@ -1438,14 +1449,17 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
-                # Everything after the OFF pragma sits inside the outer try so
-                # ANY failure path restores enforcement in the finally block.
-                # The flush commit makes the pragma effective, then BEGIN
-                # IMMEDIATE makes the whole rebuild one atomic transaction —
-                # DDL autocommits per-statement otherwise, so a crash between
-                # DROP and RENAME would strand the data in invocations_new.
                 try:
+                    # Inside the try, not above it: the pragma takes effect at its
+                    # own await with no flush required, so anything interrupting
+                    # after it -- cancellation included -- must still reach the
+                    # finally or a pooled connection keeps foreign keys disabled.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
+                    # The commit closes any open transaction rather than making the
+                    # pragma effective, then BEGIN IMMEDIATE makes the whole rebuild
+                    # one atomic transaction — DDL autocommits per-statement
+                    # otherwise, so a crash between DROP and RENAME would strand the
+                    # data in invocations_new.
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     await driver.execute(
@@ -1604,12 +1618,16 @@ class StateDB:
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
-                await driver.execute("PRAGMA foreign_keys = OFF")
-                # Same shape as the invocations rebuild above: flush commit so
-                # the pragma takes effect, then one BEGIN IMMEDIATE transaction
-                # around the whole rebuild so a crash mid-sequence cannot
-                # strand the data in schedule_runs_new.
                 try:
+                    # Same shape as the invocations rebuild above. The pragma is
+                    # inside the try because it takes effect at its own await, so
+                    # anything interrupting after it -- cancellation included --
+                    # must still reach the finally.
+                    await driver.execute("PRAGMA foreign_keys = OFF")
+                    # The commit closes any open transaction rather than making the
+                    # pragma effective, then one BEGIN IMMEDIATE transaction wraps
+                    # the whole rebuild so a crash mid-sequence cannot strand the
+                    # data in schedule_runs_new.
                     await driver.commit()
                     await driver.execute("BEGIN IMMEDIATE")
                     await driver.execute(

--- a/tests/state/test_sessions_rebuild_integrity.py
+++ b/tests/state/test_sessions_rebuild_integrity.py
@@ -115,8 +115,12 @@ async def test_rebuild_survives_a_database_with_no_parent_tables(tmp_path: Path)
 
 
 async def test_foreign_key_enforcement_is_restored_after_the_rebuild(tmp_path: Path):
-    """The rebuild turns enforcement off. It has to come back on, or every write
-    for the rest of the process runs unchecked."""
+    """The rebuild turns enforcement off. On the ordinary path it has to come
+    back on, or every write for the rest of the process runs unchecked.
+
+    This covers the ordinary path only. What happens when the restore itself
+    fails is a different guarantee, pinned below.
+    """
     path = tmp_path / "restored.db"
     async with aiosqlite.connect(str(path)) as old:
         await old.execute(_LEGACY_SESSIONS_DDL)
@@ -131,3 +135,84 @@ async def test_foreign_key_enforcement_is_restored_after_the_rebuild(tmp_path: P
         assert enforced[0] == 1, "foreign key enforcement was left disabled after the rebuild"
     finally:
         await state.close()
+
+
+class _FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    async def fetchone(self):
+        return self._row
+
+
+class _FakeDriver:
+    """Enough of the aiosqlite driver surface for the restore helper."""
+
+    def __init__(self, *, rollback_raises=False, pragma_raises=False, readback=1):
+        self.rollback_raises = rollback_raises
+        self.pragma_raises = pragma_raises
+        self.readback = readback
+        self.executed: list[str] = []
+
+    async def rollback(self):
+        if self.rollback_raises:
+            raise RuntimeError("rollback failed")
+
+    async def commit(self):
+        return None
+
+    async def execute(self, sql):
+        self.executed.append(sql)
+        if self.pragma_raises:
+            raise RuntimeError("pragma failed")
+        if sql == "PRAGMA foreign_keys":
+            return _FakeCursor((self.readback,))
+        return _FakeCursor(None)
+
+
+class _FakeConn:
+    def __init__(self):
+        self.invalidated = False
+
+    async def invalidate(self):
+        self.invalidated = True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expect_invalidated", "why"),
+    [
+        ({}, False, "ordinary path: enforcement confirmed on, connection stays in the pool"),
+        (
+            {"readback": 0},
+            True,
+            "the write appeared to succeed but enforcement read back off, which is what "
+            "a pragma issued inside a surviving transaction looks like",
+        ),
+        ({"pragma_raises": True}, True, "the restore itself raised, so nothing was restored"),
+        (
+            {"rollback_raises": True},
+            False,
+            "a failed rollback alone is survivable: enforcement still read back on",
+        ),
+    ],
+)
+async def test_a_connection_with_unconfirmed_enforcement_is_never_reused(
+    kwargs, expect_invalidated, why
+):
+    """The guarantee is not that the restore always succeeds. It is that a
+    connection whose foreign-key enforcement cannot be CONFIRMED is invalidated
+    rather than returned to the pool.
+
+    Both failure modes here are the same defect the rebuild itself was fixed for:
+    a pragma is a no-op inside an open transaction, so writing it proves nothing
+    and only reading it back does.
+    """
+    from lionagi.state.db import _restore_foreign_keys
+
+    driver = _FakeDriver(**kwargs)
+    conn = _FakeConn()
+
+    await _restore_foreign_keys(conn, driver)
+
+    assert conn.invalidated is expect_invalidated, why
+    assert "PRAGMA foreign_keys = ON" in driver.executed

--- a/tests/state/test_sessions_rebuild_integrity.py
+++ b/tests/state/test_sessions_rebuild_integrity.py
@@ -254,3 +254,55 @@ async def test_cancellation_invalidates_before_it_propagates(fail_on):
         "cancellation reached the caller without invalidating a connection whose "
         "foreign-key enforcement was never confirmed"
     )
+
+
+async def test_cancellation_at_the_disable_still_reaches_cleanup(tmp_path: Path, monkeypatch):
+    """The disable itself has to be inside the try that installs the cleanup.
+
+    `PRAGMA foreign_keys = OFF` takes effect at its own await, with no flush
+    needed. So if it sat above the try, a cancellation arriving right after it
+    would leave enforcement off with no finally installed, and the connection
+    would go back to the pool disabled for whoever borrows it next. Interrupting
+    exactly that await is the only way to pin the ordering.
+    """
+    import aiosqlite
+
+    import lionagi.state.db as db_mod
+    from lionagi.ln.concurrency import get_cancelled_exc_class
+
+    cancelled_exc = get_cancelled_exc_class()
+
+    path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(str(path)) as old:
+        await old.execute(_LEGACY_SESSIONS_DDL)
+        await old.commit()
+
+    reached: list[bool] = []
+    real_restore = db_mod._restore_foreign_keys
+
+    async def _spy_restore(conn, driver):
+        reached.append(True)
+        return await real_restore(conn, driver)
+
+    monkeypatch.setattr(db_mod, "_restore_foreign_keys", _spy_restore)
+
+    real_execute = aiosqlite.Connection.execute
+
+    async def _cancel_on_disable(self, sql, *args, **kwargs):
+        if isinstance(sql, str) and sql.strip() == "PRAGMA foreign_keys = OFF":
+            raise cancelled_exc()
+        return await real_execute(self, sql, *args, **kwargs)
+
+    monkeypatch.setattr(aiosqlite.Connection, "execute", _cancel_on_disable)
+
+    state = StateDB(path)
+    with pytest.raises(BaseException) as excinfo:
+        await state.open()
+
+    assert isinstance(excinfo.value, cancelled_exc), (
+        f"expected the cancellation to propagate, got {type(excinfo.value).__name__}"
+    )
+    assert reached, (
+        "cancellation at the disable never reached the restore, so the pragma is "
+        "taking effect outside the try that installs cleanup"
+    )

--- a/tests/state/test_sessions_rebuild_integrity.py
+++ b/tests/state/test_sessions_rebuild_integrity.py
@@ -216,3 +216,41 @@ async def test_a_connection_with_unconfirmed_enforcement_is_never_reused(
 
     assert conn.invalidated is expect_invalidated, why
     assert "PRAGMA foreign_keys = ON" in driver.executed
+
+
+@pytest.mark.parametrize("fail_on", ["rollback", "pragma"])
+async def test_cancellation_invalidates_before_it_propagates(fail_on):
+    """Cancellation is the one path that must not silently skip invalidation.
+
+    It arrives as a BaseException, so an ``except Exception`` guard lets it past
+    both the read-back and the invalidation, returning a connection with
+    enforcement in an unknown state to the pool. The cancellation itself still
+    has to propagate untouched, so this pins both halves: invalidated, and still
+    raised.
+    """
+    from lionagi.ln.concurrency import get_cancelled_exc_class
+    from lionagi.state.db import _restore_foreign_keys
+
+    cancelled_exc = get_cancelled_exc_class()
+
+    class _CancellingDriver(_FakeDriver):
+        async def rollback(self):
+            if fail_on == "rollback":
+                raise cancelled_exc()
+
+        async def execute(self, sql):
+            self.executed.append(sql)
+            if fail_on == "pragma":
+                raise cancelled_exc()
+            return _FakeCursor((1,))
+
+    driver = _CancellingDriver()
+    conn = _FakeConn()
+
+    with pytest.raises(cancelled_exc):
+        await _restore_foreign_keys(conn, driver)
+
+    assert conn.invalidated, (
+        "cancellation reached the caller without invalidating a connection whose "
+        "foreign-key enforcement was never confirmed"
+    )

--- a/tests/state/test_sessions_rebuild_integrity.py
+++ b/tests/state/test_sessions_rebuild_integrity.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The legacy sessions rebuild must produce the constraints the declared schema
+carries, and must survive a database that has nothing but a sessions table."""
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.state.schema_meta import metadata
+
+pytestmark = pytest.mark.asyncio
+
+_LEGACY_SESSIONS_DDL = """
+    CREATE TABLE sessions (
+      id              TEXT    PRIMARY KEY,
+      created_at      REAL    NOT NULL,
+      node_metadata   JSON,
+      name            TEXT,
+      user            TEXT,
+      progression_id  TEXT    NOT NULL,
+      first_msg_id    TEXT,
+      last_msg_id     TEXT,
+      updated_at      REAL,
+      status          TEXT CHECK(
+                        status IS NULL
+                        OR status IN ('running', 'completed', 'failed', 'aborted')
+                      )
+    )
+"""
+
+
+def _declared_foreign_keys() -> set[tuple[str, str, str]]:
+    """(child column, parent table, parent column) for every FK the schema declares."""
+    return {
+        (fk.parent.name, fk.column.table.name, fk.column.name)
+        for fk in metadata.tables["sessions"].foreign_keys
+    }
+
+
+async def test_rebuilt_sessions_carries_the_declared_foreign_keys(tmp_path: Path):
+    """A rebuilt table must end up with the same foreign keys a freshly created
+    one gets. The rebuild writes its own DDL, so nothing but a check like this
+    keeps it from drifting away from the declared schema."""
+    path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(str(path)) as old:
+        await old.execute(_LEGACY_SESSIONS_DDL)
+        await old.execute(
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at, status) "
+            "VALUES ('s1', 1.0, 'p1', 1.0, 'running')"
+        )
+        await old.commit()
+
+    state = StateDB(path)
+    await state.open()
+    try:
+        assert (await state.get_session("s1")) is not None
+    finally:
+        await state.close()
+
+    async with aiosqlite.connect(str(path)) as db:
+        rows = await (await db.execute("PRAGMA foreign_key_list(sessions)")).fetchall()
+    # PRAGMA foreign_key_list columns: id, seq, table, from, to, ...
+    rebuilt = {(r[3], r[2], r[4]) for r in rows}
+
+    declared = _declared_foreign_keys()
+    assert declared, "the schema is expected to declare foreign keys on sessions"
+    assert rebuilt == declared, (
+        f"rebuilt table's foreign keys {sorted(rebuilt)} do not match the declared "
+        f"schema's {sorted(declared)}"
+    )
+
+
+async def test_rebuild_survives_a_database_with_no_parent_tables(tmp_path: Path):
+    """The population this rebuild exists to serve: a database old enough that
+    the tables sessions references do not exist yet.
+
+    SQLite accepts a forward reference in DDL, so creating the new table is fine.
+    Enforcement is what bites: with foreign keys on, every statement against the
+    child fails while a parent is missing, including the rebuild's own copy and
+    including rows whose foreign key column is NULL. The rebuild therefore has to
+    disable enforcement in a way that actually takes effect, which means on the
+    raw connection outside a transaction -- open() installs BEGIN IMMEDIATE, so
+    the pragma is a no-op if it is issued inside an engine-level begin() block.
+    """
+    path = tmp_path / "minimal.db"
+    async with aiosqlite.connect(str(path)) as old:
+        await old.execute(_LEGACY_SESSIONS_DDL)
+        await old.execute(
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at, status) "
+            "VALUES ('only', 1.0, 'p-gone', 1.0, 'running')"
+        )
+        await old.commit()
+        names = {
+            r[0]
+            for r in await (
+                await old.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            ).fetchall()
+        }
+    assert names == {"sessions"}, f"fixture must start minimal, found {sorted(names)}"
+
+    state = StateDB(path)
+    await state.open()  # the rebuild runs here; a live FK check makes it raise
+    try:
+        row = await state.get_session("only")
+        assert row is not None
+        assert row["status"] == "running"
+        # The row's foreign key values point at rows that do not exist. The
+        # rebuild must not have silently dropped them while copying.
+        assert row["progression_id"] == "p-gone"
+    finally:
+        await state.close()
+
+
+async def test_foreign_key_enforcement_is_restored_after_the_rebuild(tmp_path: Path):
+    """The rebuild turns enforcement off. It has to come back on, or every write
+    for the rest of the process runs unchecked."""
+    path = tmp_path / "restored.db"
+    async with aiosqlite.connect(str(path)) as old:
+        await old.execute(_LEGACY_SESSIONS_DDL)
+        await old.commit()
+
+    state = StateDB(path)
+    await state.open()
+    try:
+        async with state._engine.connect() as conn:
+            driver = (await conn.get_raw_connection()).driver_connection
+            enforced = await (await driver.execute("PRAGMA foreign_keys")).fetchone()
+        assert enforced[0] == 1, "foreign key enforcement was left disabled after the rebuild"
+    finally:
+        await state.close()


### PR DESCRIPTION
## Summary

The legacy CHECK-constraint rebuild for `sessions` hand-writes its `CREATE TABLE`, and that DDL had drifted from the declared schema: it omitted all four foreign keys `sessions` carries. A database that went through the rebuild lost constraints a freshly created one has. `PRAGMA foreign_keys` is on, so the loss is real rather than cosmetic.

The five sibling legacy rebuilds in the same module compile their DDL from the declared metadata. This is the only hand-written one, and the only one that drifted.

## Why the foreign keys could not simply be added back

SQLite accepts a forward reference to a table that does not exist yet, so the `CREATE TABLE` is fine. Enforcement is what bites: with foreign keys on, **every** statement against the child fails while a parent table is missing, including rows whose foreign key column is NULL.

```
CREATE TABLE t (id TEXT, m TEXT REFERENCES messages(id))   -- messages absent -> OK
INSERT INTO t VALUES ('a', 'm1')  -> OperationalError: no such table: main.messages
INSERT INTO t VALUES ('a', NULL)  -> OperationalError: no such table: main.messages
```

A minimal legacy database has no `messages` or `invocations` table until `create_all` runs, which happens *after* this rebuild. So the rebuild's own `INSERT ... SELECT` would have failed there, on exactly the population the rebuild exists to serve, and nowhere else. A fixture that starts from a full schema cannot see it.

## The disable that was not disabling

The rebuild turned enforcement off with a pragma issued inside an engine-level `begin()` block. `open()` installs `BEGIN IMMEDIATE` on every SQLite engine, and `PRAGMA foreign_keys` is a no-op inside a transaction, so that disable never took effect:

```
engine + BEGIN IMMEDIATE installed, pragma inside begin() -> PRAGMA foreign_keys reads back 1
```

It was harmless only because there were no foreign keys to disable. Declaring them makes it load-bearing. The rebuild now issues the pragma on the raw connection with the flush commit that makes it take effect, then opens its own transaction and restores enforcement on every exit path, matching the sibling rebuilds.

## Tests

Three, and each pins a different half:

| test | against current main | with the FK clauses but the old pragma placement | with this change |
|---|---|---|---|
| rebuilt table carries the declared foreign keys | **fails** (0 vs 4) | fails | passes |
| rebuild survives a database with no parent tables | passes (nothing to enforce) | **fails** (`no such table: main.invocations`) | passes |
| enforcement restored after the rebuild | passes | **fails** | passes |

The middle state is the one the DDL change alone would have produced, and it was reproduced by temporarily reordering the pragma to confirm the guards bite rather than assuming it.

`tests/state/`: 753 passed. One unrelated failure (`test_metadata_create_all_postgres`, missing optional `asyncpg`) fails identically on main.

## Follow-up, not in this PR

The deeper fix is to compile this rebuild's DDL from the declared metadata like its five siblings, which makes the next drift impossible rather than correcting this one. Left out to keep this change reviewable against the defect it fixes.