### PR TITLE
fix(cli): heartbeat reports agent progress instead of mere liveness

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -242,6 +242,10 @@ class _ProgressReport:
     def __init__(self, branch, now: float):
         self._branch = branch
         self._start = now
+        # Read once, and never re-read if it failed. Nothing is writing to the
+        # branch yet at this point, so a failure here is structural rather than
+        # transient. Adopting a later baseline instead would silently discard
+        # whatever had already landed and report it as no progress at all.
         self._base = self._counts()
         self._last = self._base
         self._changed_at = now

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -21,6 +21,7 @@ from lionagi.ln.concurrency import (
     run_async,
 )
 from lionagi.protocols.generic.log import DataLoggerConfig
+from lionagi.protocols.messages import ActionRequest, AssistantResponse
 from lionagi.state import provenance as _provenance
 from lionagi.state.artifact_verifier import resolve_artifact_contract
 
@@ -227,6 +228,56 @@ def _form_to_context_block(form) -> str:
     for key, value in form.values.items():
         lines.append(f"  {key}: {value!r}")
     return "\n".join(lines)
+
+
+class _ProgressReport:
+    """Heartbeat text that distinguishes a working agent from a merely live one.
+
+    A bare elapsed-seconds timer reports that the event loop is scheduling, which
+    a reader takes as evidence that work is happening. Assistant responses and
+    action requests are added to the branch as the stream arrives, so counting
+    them says whether anything has actually landed since the run started.
+    """
+
+    def __init__(self, branch, now: float):
+        self._branch = branch
+        self._start = now
+        self._base = self._counts()
+        self._last = self._base
+        self._changed_at = now
+
+    def _counts(self) -> tuple[int, int, int] | None:
+        """(turns, tool calls, total messages), or None if they cannot be read."""
+        try:
+            messages = list(self._branch.msgs.messages)
+        except Exception:
+            return None
+        turns = sum(1 for m in messages if isinstance(m, AssistantResponse))
+        calls = sum(1 for m in messages if isinstance(m, ActionRequest))
+        return turns, calls, len(messages)
+
+    def line(self, now: float) -> str:
+        elapsed = int(now - self._start)
+        current = self._counts()
+        if self._base is None or current is None:
+            # Saying nothing here would leave the last reading standing as if it
+            # still applied, which is the failure this class exists to avoid.
+            return (
+                f"[progress] {elapsed}s elapsed — progress is not observable for "
+                "this engine; this line means alive, not working"
+            )
+        if current[2] != self._last[2]:
+            self._last = current
+            self._changed_at = now
+        turns = self._last[0] - self._base[0]
+        calls = self._last[1] - self._base[1]
+        if turns <= 0 and calls <= 0:
+            return f"[progress] {elapsed}s elapsed — no completed turn yet ({elapsed}s since start)"
+        return (
+            f"[progress] {elapsed}s elapsed — {turns} turn{'' if turns == 1 else 's'}, "
+            f"{calls} tool call{'' if calls == 1 else 's'}, "
+            f"last activity {int(now - self._changed_at)}s ago"
+        )
 
 
 async def _run_agent(
@@ -596,15 +647,12 @@ async def _run_agent(
         import asyncio as _asyncio
         import time as _hb_time
 
-        _hb_start = _hb_time.monotonic()
+        _hb_report = _ProgressReport(branch, _hb_time.monotonic())
 
         async def _heartbeat_loop():
             while True:
                 await _asyncio.sleep(60)
-                elapsed = int(_hb_time.monotonic() - _hb_start)
-                from lionagi.cli._logging import hint as _hint
-
-                _hint(f"[progress] {elapsed}s elapsed — agent still running…")
+                hint(_hb_report.line(_hb_time.monotonic()))
 
         try:
             _heartbeat_task = _asyncio.ensure_future(_heartbeat_loop())

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -259,12 +259,21 @@ class _ProgressReport:
     def line(self, now: float) -> str:
         elapsed = int(now - self._start)
         current = self._counts()
-        if self._base is None or current is None:
-            # Saying nothing here would leave the last reading standing as if it
-            # still applied, which is the failure this class exists to avoid.
+        # Two different unreadable states, kept apart because they license
+        # different claims. An unreadable baseline means the counts were never
+        # available here; a single unreadable snapshot may be one bad tick, and
+        # calling it an engine property claims more than was measured. Neither
+        # falls back to the previous reading, which would present a stale count
+        # as current.
+        if self._base is None:
             return (
                 f"[progress] {elapsed}s elapsed — progress is not observable for "
                 "this engine; this line means alive, not working"
+            )
+        if current is None:
+            return (
+                f"[progress] {elapsed}s elapsed — progress could not be read this "
+                "tick; this line means alive, not working"
             )
         if current[2] != self._last[2]:
             self._last = current

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -264,15 +264,16 @@ class _ProgressReport:
         elapsed = int(now - self._start)
         current = self._counts()
         # Two different unreadable states, kept apart because they license
-        # different claims. An unreadable baseline means the counts were never
-        # available here; a single unreadable snapshot may be one bad tick, and
-        # calling it an engine property claims more than was measured. Neither
+        # different claims. The baseline is taken once and never retried, so a
+        # baseline that failed to read means no delta is computable for the rest
+        # of this run; a single unreadable snapshot may be one bad tick, and
+        # widening it past this tick claims more than was measured. Neither
         # falls back to the previous reading, which would present a stale count
         # as current.
         if self._base is None:
             return (
                 f"[progress] {elapsed}s elapsed — progress is not observable for "
-                "this engine; this line means alive, not working"
+                "this run; this line means alive, not working"
             )
         if current is None:
             return (

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -242,10 +242,10 @@ class _ProgressReport:
     def __init__(self, branch, now: float):
         self._branch = branch
         self._start = now
-        # Read once, and never re-read if it failed. Nothing is writing to the
-        # branch yet at this point, so a failure here is structural rather than
-        # transient. Adopting a later baseline instead would silently discard
-        # whatever had already landed and report it as no progress at all.
+        # The only read taken before the run starts, so every later count is a
+        # delta from it. Do not retry it on failure: a baseline adopted once
+        # messages have arrived would take them as the starting point and report
+        # work already done as no progress at all.
         self._base = self._counts()
         self._last = self._base
         self._changed_at = now

--- a/tests/cli/test_agent_progress_report.py
+++ b/tests/cli/test_agent_progress_report.py
@@ -80,7 +80,7 @@ def test_unreadable_counts_report_unobservable_rather_than_working():
     report = _ProgressReport(_NoMessages(), now=0.0)
     line = report.line(60.0)
 
-    assert "not observable for this engine" in line
+    assert "not observable for this run" in line
     assert "alive, not working" in line
     assert "still running" not in line
 
@@ -120,7 +120,7 @@ def test_counts_becoming_unreadable_mid_run_does_not_leave_a_stale_claim():
     assert "1 turn" not in line
 
 
-def test_a_bad_tick_is_not_reported_as_a_property_of_the_engine():
+def test_a_bad_tick_is_not_reported_as_unobservable_for_the_whole_run():
     """The two unreadable states license different claims, so they read differently."""
     never_readable = _ProgressReport(_Holder(_Broken()), now=0.0).line(60.0)
 
@@ -128,8 +128,8 @@ def test_a_bad_tick_is_not_reported_as_a_property_of_the_engine():
     holder.msgs = _Broken()
     one_bad_tick = report.line(60.0)
 
-    assert "not observable for this engine" in never_readable
-    assert "not observable for this engine" not in one_bad_tick
+    assert "not observable for this run" in never_readable
+    assert "not observable for this run" not in one_bad_tick
     assert never_readable != one_bad_tick
 
 

--- a/tests/cli/test_agent_progress_report.py
+++ b/tests/cli/test_agent_progress_report.py
@@ -80,33 +80,57 @@ def test_unreadable_counts_report_unobservable_rather_than_working():
     report = _ProgressReport(_NoMessages(), now=0.0)
     line = report.line(60.0)
 
-    assert "not observable" in line
+    assert "not observable for this engine" in line
     assert "alive, not working" in line
     assert "still running" not in line
 
 
-def test_counts_becoming_unreadable_mid_run_does_not_leave_a_stale_claim():
-    class _Msgs:
-        def __init__(self, messages):
-            self.messages = messages
+class _Msgs:
+    def __init__(self, messages):
+        self.messages = messages
 
-    class _Broken:
-        @property
-        def messages(self):
-            raise RuntimeError("pile went away")
 
-    class _Holder:
-        def __init__(self, msgs):
-            self.msgs = msgs
+class _Broken:
+    @property
+    def messages(self):
+        raise RuntimeError("pile went away")
 
+
+class _Holder:
+    def __init__(self, msgs):
+        self.msgs = msgs
+
+
+def _report_that_breaks_mid_run() -> tuple[_ProgressReport, _Holder, Branch]:
     real = _branch()
     holder = _Holder(_Msgs(real.msgs.messages))
     report = _ProgressReport(holder, now=0.0)
+    return report, holder, real
+
+
+def test_counts_becoming_unreadable_mid_run_does_not_leave_a_stale_claim():
+    report, holder, real = _report_that_breaks_mid_run()
     real.msgs.add_message(assistant_response="one turn's worth")
     assert "1 turn," in report.line(60.0)
 
     holder.msgs = _Broken()
-    assert "not observable" in report.line(120.0)
+    line = report.line(120.0)
+    assert "could not be read this tick" in line
+    assert "alive, not working" in line
+    assert "1 turn" not in line
+
+
+def test_a_bad_tick_is_not_reported_as_a_property_of_the_engine():
+    """The two unreadable states license different claims, so they read differently."""
+    never_readable = _ProgressReport(_Holder(_Broken()), now=0.0).line(60.0)
+
+    report, holder, _ = _report_that_breaks_mid_run()
+    holder.msgs = _Broken()
+    one_bad_tick = report.line(60.0)
+
+    assert "not observable for this engine" in never_readable
+    assert "not observable for this engine" not in one_bad_tick
+    assert never_readable != one_bad_tick
 
 
 @pytest.mark.parametrize("count,expected", [(1, "1 turn,"), (2, "2 turns,")])

--- a/tests/cli/test_agent_progress_report.py
+++ b/tests/cli/test_agent_progress_report.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The agent heartbeat must report progress, or say it cannot see any.
+
+A timer that only proves the event loop is scheduling reads as "still working"
+to whoever is deciding whether to kill the leg. These pin the distinction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi import Branch
+from lionagi.cli.agent import _ProgressReport
+
+
+def _branch() -> Branch:
+    return Branch(system="s")
+
+
+def test_a_run_that_produces_nothing_never_implies_progress():
+    branch = _branch()
+    report = _ProgressReport(branch, now=0.0)
+
+    lines = [report.line(t) for t in (60.0, 120.0, 180.0)]
+
+    for line in lines:
+        assert "no completed turn yet" in line
+        assert "still running" not in line
+        assert "turn," not in line
+        assert "turns," not in line
+    assert lines[-1] == "[progress] 180s elapsed — no completed turn yet (180s since start)"
+
+
+def test_a_stalled_run_reports_a_stale_last_activity():
+    branch = _branch()
+    report = _ProgressReport(branch, now=0.0)
+
+    branch.msgs.add_message(assistant_response="one turn's worth")
+    first = report.line(60.0)
+    assert "1 turn," in first
+    assert "last activity 0s ago" in first
+
+    # Nothing further arrives. The line must age rather than repeat.
+    second = report.line(120.0)
+    third = report.line(180.0)
+    assert "last activity 60s ago" in second
+    assert "last activity 120s ago" in third
+    assert first != second != third
+
+
+def test_tool_calls_advance_the_marker_too():
+    branch = _branch()
+    report = _ProgressReport(branch, now=0.0)
+
+    branch.msgs.add_message(action_function="grep", action_arguments={"q": "x"})
+    line = report.line(60.0)
+
+    assert "0 turns" in line
+    assert "1 tool call," in line
+    assert "last activity 0s ago" in line
+
+
+def test_only_this_runs_messages_count_toward_progress():
+    """A resumed branch starts with history; that history is not progress."""
+    branch = _branch()
+    branch.msgs.add_message(assistant_response="from an earlier run")
+
+    report = _ProgressReport(branch, now=0.0)
+
+    assert "no completed turn yet" in report.line(60.0)
+
+
+def test_unreadable_counts_report_unobservable_rather_than_working():
+    class _NoMessages:
+        @property
+        def msgs(self):
+            raise AttributeError("this engine exposes no message pile")
+
+    report = _ProgressReport(_NoMessages(), now=0.0)
+    line = report.line(60.0)
+
+    assert "not observable" in line
+    assert "alive, not working" in line
+    assert "still running" not in line
+
+
+def test_counts_becoming_unreadable_mid_run_does_not_leave_a_stale_claim():
+    class _Msgs:
+        def __init__(self, messages):
+            self.messages = messages
+
+    class _Broken:
+        @property
+        def messages(self):
+            raise RuntimeError("pile went away")
+
+    class _Holder:
+        def __init__(self, msgs):
+            self.msgs = msgs
+
+    real = _branch()
+    holder = _Holder(_Msgs(real.msgs.messages))
+    report = _ProgressReport(holder, now=0.0)
+    real.msgs.add_message(assistant_response="one turn's worth")
+    assert "1 turn," in report.line(60.0)
+
+    holder.msgs = _Broken()
+    assert "not observable" in report.line(120.0)
+
+
+@pytest.mark.parametrize("count,expected", [(1, "1 turn,"), (2, "2 turns,")])
+def test_turn_count_reads_as_english(count, expected):
+    branch = _branch()
+    report = _ProgressReport(branch, now=0.0)
+    for _ in range(count):
+        branch.msgs.add_message(assistant_response="x")
+
+    assert expected in report.line(60.0)


### PR DESCRIPTION
## Problem

The `li agent` heartbeat printed elapsed seconds and "agent still running". That
proves the event loop is scheduling, nothing more. A stalled session and a healthy
long run produced identical output, so a caller reading the heartbeat could not
decide whether to kill the leg. Observed: 25 identical ticks over 1500s from a run
that completed zero turns on a task that finishes in about 30 seconds.

## Change

Assistant responses and action requests are added to the branch incrementally as
the stream arrives, so they are a usable progress marker. The heartbeat now
reports turns, tool calls, and seconds since the last change:

```
[progress] 180s elapsed — 4 turns, 11 tool calls, last activity 12s ago
```

A tick with no new messages says so instead of anything that reads as working:

```
[progress] 180s elapsed — no completed turn yet (180s since start)
```

Only messages added after the heartbeat starts count, so a resumed branch's
history is not reported as this run's progress.

When the counts cannot be read, the line says so rather than falling back to the
previous reading — a stale count presented as current is the same defect one
level down. Two unreadable states are kept apart, because they license different
claims:

```
[progress] 180s elapsed — progress is not observable for this run; this line means alive, not working
[progress] 180s elapsed — progress could not be read this tick; this line means alive, not working
```

The first is scoped to the run, not to the engine. The baseline is read once
and never retried, so once that read fails no delta is computable for the rest of
the run. The code cannot say more than that: the read is wrapped in a bare
`except`, so a failure there is indistinguishable from any other cause and
establishes nothing about what the engine can expose. The second may be a single
bad read after a readable baseline, and widening it past that tick would assert
more than was observed.

`run.stream_dir` looks like the obvious marker and is not usable: it stays empty
even for healthy completed CLI legs, so a check there would report every such leg
as stalled.

## Tests

`tests/cli/test_agent_progress_report.py`, 9 tests: a run producing nothing never
emits a line implying progress; a stalled run's last-activity ages across ticks
instead of repeating; tool calls advance the marker; a resumed branch's history
does not count; a never-readable baseline and a single unreadable tick produce
different lines; neither presents a stale count; and singular/plural read as
English.

Each was proved to bite by breaking the fix and confirming exactly the expected
tests failed:

| Break | Failed |
|---|---|
| last-activity timestamp updated every tick | stale-last-activity test |
| absolute counts instead of deltas from start | resumed-branch test |
| unreadable counts fall back to the old line | both unobservable tests |
| zero-delta tick returns the old line | produces-nothing and resumed-branch tests |
| the two unreadable states collapsed into one condition | mid-run and bad-tick tests |
| the run-scoped wording reverted to naming the engine | both unobservable tests |

`tests/cli`: 2129 passed, 1 failure (`test_pack_routing_shown_in_dry_run`) that
reproduces identically on clean `main` at the same base commit, so it is not from
this change.

