### PR TITLE
fix(hooks): run post-stream hook when a stream fails or ends early

### DIFF
--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -95,32 +95,43 @@ class HookedEvent(Event):
                 )
             await global_hook_logger.alog(h_ev)
 
-        async for chunk in self._core_stream():
-            yield chunk
+        # The post-stream hook is teardown: it must run whether the core stream
+        # completed, raised, or the consumer stopped early (which resumes this
+        # generator with GeneratorExit at the yield), so the loop is wrapped in
+        # try/finally rather than falling through on the happy path only.
+        try:
+            async for chunk in self._core_stream():
+                yield chunk
+        finally:
+            await self._run_post_stream_hook()
 
-        # Post-stream hook failure: data already sent, must not reraise — log at WARNING only.
-        # HookRegistry.post_invocation() records a handler's raised exception on the
-        # HookEvent (status FAILED/CANCELLED/ABORTED) rather than re-raising it out of
-        # invoke(), so the failure must be detected via status, not a try/except.
-        if h_ev := self._post_invoke_hook_event:
-            try:
-                await h_ev.invoke()
-                if h_ev.execution.status in (
-                    EventStatus.FAILED,
-                    EventStatus.CANCELLED,
-                    EventStatus.ABORTED,
-                ):
-                    _logger.warning(
-                        "Post-stream hook failed (data already sent): %s",
-                        h_ev.execution.error,
-                    )
-            except Exception as _hook_exc:
+    async def _run_post_stream_hook(self):
+        """Run the post-stream hook; failures are logged, never raised (data already sent).
+
+        HookRegistry.post_invocation() records a handler's raised exception on the
+        HookEvent (status FAILED/CANCELLED/ABORTED) rather than re-raising it out of
+        invoke(), so the failure must be detected via status, not a try/except.
+        """
+        if not (h_ev := self._post_invoke_hook_event):
+            return
+        try:
+            await h_ev.invoke()
+            if h_ev.execution.status in (
+                EventStatus.FAILED,
+                EventStatus.CANCELLED,
+                EventStatus.ABORTED,
+            ):
                 _logger.warning(
                     "Post-stream hook failed (data already sent): %s",
-                    _hook_exc,
-                    exc_info=True,
+                    h_ev.execution.error,
                 )
-            await global_hook_logger.alog(h_ev)
+        except Exception as _hook_exc:
+            _logger.warning(
+                "Post-stream hook failed (data already sent): %s",
+                _hook_exc,
+                exc_info=True,
+            )
+        await global_hook_logger.alog(h_ev)
 
     def create_pre_invoke_hook(
         self,

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -99,6 +99,12 @@ class HookedEvent(Event):
         # completed, raised, or the consumer stopped early (which resumes this
         # generator with GeneratorExit at the yield), so the loop is wrapped in
         # try/finally rather than falling through on the happy path only.
+        #
+        # Under cancellation the finally is entered via GeneratorExit when the
+        # generator is closed, not inside the cancelled await, so the hook's own
+        # awaits run to completion and the CancelledError still propagates to the
+        # consumer unchanged. `except Exception` in _run_post_stream_hook does not
+        # catch it, since the cancellation exception derives from BaseException.
         try:
             async for chunk in self._core_stream():
                 yield chunk

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -284,3 +284,53 @@ async def test_stream_post_hook_aborted_status_logs_warning(caplog):
 
     assert chunks == ["chunk1", "chunk2"]
     assert any("Post-stream hook failed" in r.message for r in caplog.records)
+
+
+class PartialFailingHooked(HookedEvent):
+    async def _core_stream(self):
+        yield "chunk1"
+        raise ValueError("core_stream_failed_midway")
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_core_stream_raises():
+    """A stream that fails partway through must still run post-hook teardown,
+    and the original exception must reach the caller unchanged."""
+    h = PartialFailingHooked()
+    hook = _fake_hook()
+    hook.invoked = False
+
+    async def _invoke():
+        hook.invoked = True
+
+    hook.invoke = _invoke
+    h._post_invoke_hook_event = hook
+
+    chunks = []
+    with pytest.raises(ValueError, match="core_stream_failed_midway"):
+        async for c in h._stream():
+            chunks.append(c)
+
+    assert chunks == ["chunk1"]
+    assert hook.invoked is True
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_consumer_stops_early():
+    """A consumer that breaks out of the stream must still run post-hook teardown."""
+    h = SimpleHooked()
+    hook = _fake_hook()
+    hook.invoked = False
+
+    async def _invoke():
+        hook.invoked = True
+
+    hook.invoke = _invoke
+    h._post_invoke_hook_event = hook
+
+    agen = h._stream()
+    async for _ in agen:
+        break
+    await agen.aclose()
+
+    assert hook.invoked is True

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -3,6 +3,7 @@
 
 """Tests for lionagi.service.hooks.hooked_event — HookedEvent._invoke() and _stream()."""
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -331,6 +332,49 @@ async def test_stream_post_hook_runs_when_consumer_stops_early():
     agen = h._stream()
     async for _ in agen:
         break
+    await agen.aclose()
+
+    assert hook.invoked is True
+
+
+class SlowHooked(HookedEvent):
+    async def _core_stream(self):
+        yield "chunk1"
+        await asyncio.sleep(10)
+        yield "chunk2"
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_propagates_and_runs_post_hook():
+    """Cancelling the consuming task must reach the caller as CancelledError,
+    and teardown still runs: the generator is closed outside the cancelled
+    await, so the hook's own awaits complete normally."""
+    h = SlowHooked()
+    hook = _fake_hook()
+    hook.invoked = False
+
+    async def _invoke():
+        await asyncio.sleep(0)
+        hook.invoked = True
+
+    hook.invoke = _invoke
+    h._post_invoke_hook_event = hook
+
+    started = asyncio.Event()
+    agen = h._stream()
+
+    async def consume():
+        async for _ in agen:
+            started.set()
+
+    task = asyncio.create_task(consume())
+    await started.wait()
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
     await agen.aclose()
 
     assert hook.invoked is True


### PR DESCRIPTION
Closes #2477

`HookedEvent._stream` ran the post-invocation hook only after the `async for` over `_core_stream()` ran to exhaustion, so teardown was skipped when the core stream raised or when a consumer broke out early (the generator is resumed with `GeneratorExit` at the `yield` and unwinds without reaching the block below the loop).

Wrapping the loop in `try/finally` (hook body extracted to `_run_post_stream_hook()`) makes the hook run on completion, failure, and early close alike. The original exception still propagates unchanged, and post-hook failures stay logged rather than raised since stream data has already been sent.

Two regression tests (core stream raising midway, consumer breaking after the first chunk) fail on main and pass with the fix; `tests/service/hooks` is 146 passed.
