### PR TITLE
fix(ci): disable xdist worker restart in the project pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,13 @@ ignore = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-q -ra --strict-config --strict-markers --tb=short --maxfail=5 -n auto --dist loadfile --benchmark-disable"
+# --max-worker-restart=0 belongs here rather than only in scripts/ci.sh: when a
+# worker crashes, xdist's default is to restart it, and the replacement is not
+# always scheduled -- the run then blocks in the controller's read() with no
+# timeout that can see it, because pytest-timeout is scoped to test bodies and
+# the controller is not inside one. Failing fast instead names the crashed test.
+# A CLI flag beats addopts, so callers that want restarts can still pass one.
+addopts = "-q -ra --strict-config --strict-markers --tb=short --maxfail=5 -n auto --dist loadfile --benchmark-disable --max-worker-restart=0"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,9 @@ ignore = [
 # always scheduled -- the run then blocks in the controller's read() with no
 # timeout that can see it, because pytest-timeout is scoped to test bodies and
 # the controller is not inside one. Failing fast instead names the crashed test.
-# A CLI flag beats addopts, so callers that want restarts can still pass one.
+# Here it reaches every caller that discovers this config, rather than only the
+# ones that go through the wrapper script. A CLI flag beats addopts, so callers
+# that want restarts can still pass one.
 addopts = "-q -ra --strict-config --strict-markers --tb=short --maxfail=5 -n auto --dist loadfile --benchmark-disable --max-worker-restart=0"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -209,19 +209,27 @@ def test_required_ci_wrapper_excludes_only_performance_and_quarantine() -> None:
 
     assert "not performance and not flaky_quarantine" in script
     # The wrapper keeps an explicit flag so MAX_WORKER_RESTART can raise the
-    # limit for a lane that wants restarts. It is an override of the default
+    # limit for a job that wants restarts. It is an override of the default
     # asserted below, not the thing that establishes the default.
     assert '--max-worker-restart="${MAX_WORKER_RESTART:-0}"' in script
     assert "pytest-rerunfailures" not in script
 
 
-def test_worker_restart_is_disabled_for_every_invocation(request: pytest.FixtureRequest) -> None:
+def test_worker_restart_is_disabled_by_the_project_config(request: pytest.FixtureRequest) -> None:
     # Read the effective ini configuration rather than the text of any one
     # file. A caller who never runs scripts/ci.sh -- `pytest tests/` typed by
     # hand, an editor's runner, a tool that shells out -- inherits addopts and
     # nothing else, so asserting the flag's presence in the wrapper proves
     # nothing about that caller. Going through pytest's own config also keeps
     # the assertion true if the settings move to another ini source.
+    #
+    # Scope, stated because the name would otherwise overpromise: this covers
+    # callers that discover the project's pytest configuration, which is every
+    # ordinary invocation from the repository. A caller that selects a different
+    # config with `pytest -c <file>` gets that file's addopts instead -- an
+    # empty list, and so xdist's restarting default. No setting here can reach
+    # such a caller; protecting one means putting the flag in the config it
+    # actually names.
     #
     # Without this, a crashed worker is restarted and the replacement may never
     # be scheduled, leaving the run blocked in the controller with no test name

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -226,10 +226,9 @@ def test_worker_restart_is_disabled_by_the_project_config(request: pytest.Fixtur
     # Scope, stated because the name would otherwise overpromise: this covers
     # callers that discover the project's pytest configuration, which is every
     # ordinary invocation from the repository. A caller that selects a different
-    # config with `pytest -c <file>` gets that file's addopts instead -- an
-    # empty list, and so xdist's restarting default. No setting here can reach
-    # such a caller; protecting one means putting the flag in the config it
-    # actually names.
+    # config with `pytest -c <file>` uses that file's addopts instead, so it is
+    # protected only if that file sets the flag itself; otherwise xdist's
+    # restarting default applies. Nothing set here can reach such a caller.
     #
     # Without this, a crashed worker is restarted and the replacement may never
     # be scheduled, leaving the run blocked in the controller with no test name

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -208,8 +208,26 @@ def test_required_ci_wrapper_excludes_only_performance_and_quarantine() -> None:
     script = CI_SCRIPT.read_text()
 
     assert "not performance and not flaky_quarantine" in script
+    # The wrapper keeps an explicit flag so MAX_WORKER_RESTART can raise the
+    # limit for a lane that wants restarts. It is an override of the default
+    # asserted below, not the thing that establishes the default.
     assert '--max-worker-restart="${MAX_WORKER_RESTART:-0}"' in script
     assert "pytest-rerunfailures" not in script
+
+
+def test_worker_restart_is_disabled_for_every_invocation(request: pytest.FixtureRequest) -> None:
+    # Read the effective ini configuration rather than the text of any one
+    # file. A caller who never runs scripts/ci.sh -- `pytest tests/` typed by
+    # hand, an editor's runner, a tool that shells out -- inherits addopts and
+    # nothing else, so asserting the flag's presence in the wrapper proves
+    # nothing about that caller. Going through pytest's own config also keeps
+    # the assertion true if the settings move to another ini source.
+    #
+    # Without this, a crashed worker is restarted and the replacement may never
+    # be scheduled, leaving the run blocked in the controller with no test name
+    # and no timeout able to fire: pytest-timeout watches test bodies, and a
+    # controller waiting on a worker channel is not inside one.
+    assert "--max-worker-restart=0" in request.config.getini("addopts")
 
 
 def test_docs_job_always_guard_survives_upstream_changes_failure() -> None:


### PR DESCRIPTION
## What breaks

When an xdist worker crashes, the default behaviour is to restart it. The
replacement is not always scheduled, and the run then blocks in the controller
waiting on a channel that will never deliver.

Nothing catches it. `pytest-timeout` is configured at 300s but watches test
bodies, and a controller waiting on a worker channel is not inside one, so the
run does not time out, does not name a test, and does not exit.

Observed on a full-suite run: 12 workers spawned on a 12-CPU machine, one
exited and was left unreaped, a 13th was spawned five minutes later as its
replacement, and the controller plus every worker sat blocked in `read()` at
0% CPU until the process tree was killed by hand. The unreaped worker is a
consequence of the same block, since a controller waiting on a channel never
reaches its `waitpid` loop.

## Why the existing guard did not cover it

`--max-worker-restart=0` already prevents this, and #1440 added it. It lives in
`scripts/ci.sh` only, so it applies to callers that go through the wrapper and
to nobody else. `pytest tests/`, an editor's test runner, and any tool that
shells out to pytest all inherit `addopts` and never read that script.

The contract test asserted the flag's presence in the wrapper's *text*. That
assertion passes forever while every caller who does not read the wrapper stays
unprotected, so the test was scoped to the file carrying the guard rather than
to the surface that needs it.

## The fix

- `--max-worker-restart=0` moves into `[tool.pytest.ini_options] addopts`, so
  every caller that discovers the project's pytest configuration inherits it.
- `scripts/ci.sh` keeps its explicit flag. A command-line option beats
  `addopts`, so `MAX_WORKER_RESTART` can still raise the limit for a lane that
  wants restarts.
- The contract test now asserts the **effective ini configuration** through
  pytest's own `config.getini("addopts")` rather than matching text in a file.
  It stays correct if the settings move to another ini source.

## Scope, stated because the change could be read as stronger than it is

This reaches every ordinary invocation from the repository. It does not reach a
caller that selects a different configuration with `pytest -c <file>`: pytest
then uses that file's `addopts`, so such a caller is protected only if that file
sets the flag itself, and otherwise gets xdist's restarting default. No setting
in `pyproject.toml` can reach it either way.

The test is named for what it establishes rather than for the stronger claim,
and the boundary is written into the comment beside it.

## Verification

Effective configuration read directly, before and after:

| invocation | `maxworkerrestart` |
|---|---|
| bare `pytest`, before | `None` (unlimited restarts) |
| bare `pytest`, after | `'0'` |
| `pytest --max-worker-restart=3`, after | `'3'` (override intact) |

The new test was also run against a reverted `addopts` to confirm it fails
there. A guard that cannot fail is what allowed this gap in the first place.

Follow-up to #1440.
