### PR TITLE
fix(protocols): make repeated next() on Pile and Progression advance

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -248,6 +248,9 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
     # may call @synchronized siblings while the wrapper already holds it.
     _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
     _async_lock: ConcurrencyLock = PrivateAttr(default_factory=ConcurrencyLock)
+    # Cursor backing __next__ so repeated next(pile) calls advance instead of
+    # restarting a fresh iterator each time.
+    _iterator: Any = PrivateAttr(default=None)
 
     @classmethod
     def _validate_before(cls, data: dict[str, Any]) -> dict[str, Any]:
@@ -427,9 +430,12 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
             yield self.collections[key]
 
     def __next__(self) -> T:
+        if self._iterator is None:
+            self._iterator = iter(self)
         try:
-            return next(iter(self))
+            return next(self._iterator)
         except StopIteration:
+            self._iterator = None
             raise StopIteration("End of pile") from None
 
     @synchronized

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -429,7 +429,14 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         for key in order:
             yield self.collections[key]
 
+    @synchronized
     def __next__(self) -> T:
+        # The cursor is created on the first next() and walks the order
+        # snapshot taken at that moment; it is not rebuilt per call. So
+        # interleaving next() with mutation traverses the order as it was
+        # when iteration started (item lookup stays live, as in __iter__).
+        # The cursor read/update runs under the same lock as the other sync
+        # methods, so concurrent next() calls do not race on it.
         if self._iterator is None:
             self._iterator = iter(self)
         try:
@@ -574,11 +581,14 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
             object.__setattr__(result, k, copy.deepcopy(v, memo))
         priv = {}
         for k, v in (self.__pydantic_private__ or {}).items():
-            if k in ("_lock", "_async_lock"):
+            # _iterator holds a live generator between next() calls and is
+            # not copyable; a copy should start with a fresh cursor anyway.
+            if k in ("_lock", "_async_lock", "_iterator"):
                 continue
             priv[k] = copy.deepcopy(v, memo)
         priv["_lock"] = threading.RLock()
         priv["_async_lock"] = ConcurrencyLock()
+        priv["_iterator"] = None
         object.__setattr__(result, "__pydantic_private__", priv)
         return result
 

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -38,6 +38,9 @@ class Progression(Element, Ordering[T], Generic[T]):
         description="A human-readable identifier for the progression.",
     )
     _members: set[UUID] = PrivateAttr(default_factory=set)
+    # Cursor backing __next__ so repeated next(progression) calls advance
+    # instead of restarting a fresh iterator each time.
+    _iterator: Any = PrivateAttr(default=None)
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
@@ -119,9 +122,12 @@ class Progression(Element, Ordering[T], Generic[T]):
         return iter(self.order)
 
     def __next__(self) -> UUID:
+        if self._iterator is None:
+            self._iterator = iter(self.order)
         try:
-            return next(iter(self.order))
+            return next(self._iterator)
         except StopIteration:
+            self._iterator = None
             raise StopIteration("No more items in the progression") from None
 
     def __list__(self) -> list[UUID]:

--- a/tests/protocols/generic/test_pile.py
+++ b/tests/protocols/generic/test_pile.py
@@ -696,3 +696,14 @@ def test_list_adapters_returns_registered_keys():
     adapters = Pile.list_adapters()
     assert "csv" in adapters
     assert "json" in adapters
+
+
+def test_repeated_next_advances(sample_pile, sample_elements):
+    """next() must walk the pile, not restart from the first item."""
+    assert [next(sample_pile) for _ in range(len(sample_elements))] == sample_elements
+
+    with pytest.raises(StopIteration):
+        next(sample_pile)
+
+    # Exhausting the cursor resets it, so the container stays reusable.
+    assert next(sample_pile) == sample_elements[0]

--- a/tests/protocols/generic/test_pile.py
+++ b/tests/protocols/generic/test_pile.py
@@ -707,3 +707,19 @@ def test_repeated_next_advances(sample_pile, sample_elements):
 
     # Exhausting the cursor resets it, so the container stays reusable.
     assert next(sample_pile) == sample_elements[0]
+
+
+def test_deepcopy_with_live_cursor(sample_pile, sample_elements):
+    """A pile stepped with next() must still be deepcopy-able."""
+    import copy
+
+    # Control: an untouched pile copies fine.
+    assert len(copy.deepcopy(sample_pile)) == len(sample_elements)
+
+    next(sample_pile)  # leave a live, unexhausted generator on the instance
+    clone = copy.deepcopy(sample_pile)
+
+    assert len(clone) == len(sample_elements)
+    # The copy starts with a fresh cursor rather than sharing the original's.
+    assert next(clone) == sample_elements[0]
+    assert next(sample_pile) == sample_elements[1]

--- a/tests/protocols/generic/test_progression.py
+++ b/tests/protocols/generic/test_progression.py
@@ -390,3 +390,16 @@ def test_progression_serialization_advanced():
     assert len(deserialized) == 5
     assert all(isinstance(elem, UUID) for elem in deserialized)  # IDs are UUIDs
     assert p == deserialized
+
+
+def test_repeated_next_advances(sample_elements):
+    """next() must walk the progression, not restart from the first item."""
+    p = Progression(order=sample_elements)
+
+    assert [next(p) for _ in range(len(sample_elements))] == [e.id for e in sample_elements]
+
+    with pytest.raises(StopIteration):
+        next(p)
+
+    # Exhausting the cursor resets it, so the container stays reusable.
+    assert next(p) == sample_elements[0].id


### PR DESCRIPTION
Closes #2414

`Pile.__next__` and `Progression.__next__` built a fresh iterator on every call, so `next(container)` returned the first item each time and later items were unreachable through the direct `next` interface. Both now keep a private cursor created on first use and cleared on exhaustion, so repeated `next()` walks the container and it stays reusable afterwards; `__iter__` is unchanged.

`test_repeated_next_advances` (added to both suites) fails on main and passes with the fix; `tests/protocols/generic/` is green (887 passed, 9 skipped).
