### PR TITLE
feat(mcp): prompt-file input for submit_agent and implementation identity in job_status

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -172,6 +172,43 @@ def _notify_template(run_id: str, notify_target: str | None, notify_command: str
     return " ".join(parts)
 
 
+def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -> None:
+    """Refuse a command line the OS will not accept, before anything is spawned.
+
+    ``exec`` limits the combined size of the argument vector and the environment.
+    Exceeding it raises ``OSError: [Errno 7] Argument list too long`` from the
+    spawn, which is late and hard to read; refusing here names the cause and the
+    limit instead.
+    """
+    try:
+        limit = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):  # pragma: no cover — platform without the knob
+        return
+    if not isinstance(limit, int) or limit <= 0:  # pragma: no cover — unset knob
+        return
+
+    # Each entry is stored with a terminator, and the kernel also keeps a pointer
+    # table and alignment padding that is not worth modelling exactly, so leave
+    # headroom rather than approving a command line that only just fits.
+    used = sum(len(a.encode()) + 1 for a in argv)
+    used += sum(len(k.encode()) + len(v.encode()) + 2 for k, v in env.items())
+    headroom = 8192
+    if used + headroom <= limit:
+        return
+
+    detail = (
+        "the instruction is passed on the command line for this kind of run"
+        if kind != "agent"
+        else "the command line is too long"
+    )
+    raise ValueError(
+        f"cannot submit this {kind} run: {detail}, and it needs {used} bytes of "
+        f"argument vector plus environment against an OS limit of {limit}. "
+        "Shorten the instruction, or use submit_agent, which hands the "
+        "instruction to the run in a file instead of on the command line."
+    )
+
+
 # --- public API ----------------------------------------------------------------
 
 
@@ -202,15 +239,18 @@ def submit(
 
     run_id = new_run_id()
     d = config.job_dir(run_id)
-    d.mkdir(parents=True, exist_ok=True)
     log_path = d / "console.log"
 
+    # The whole command line is assembled before anything is created on disk, so a
+    # run that cannot be spawned leaves no trace. Creating the directory first
+    # would leave an empty one behind on a rejection, and that reads back as a job
+    # with no kind that never finishes.
     tail = list(flags)
+    prompt_path = None
     if prompt is not None:
         if kind == "agent":
-            pf = d / "prompt.txt"
-            pf.write_text(prompt)
-            tail += ["--prompt-file", str(pf)]
+            prompt_path = d / "prompt.txt"
+            tail += ["--prompt-file", str(prompt_path)]
         else:
             tail.append(prompt)  # flow/fanout take the prompt as a positional
 
@@ -224,6 +264,16 @@ def submit(
     # environment that claims it is running under an interactive harness.
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
     env[config.RUN_ID_ENV_VAR] = run_id
+
+    # Only "agent" hands the instruction over in a file; flow and fanout take it
+    # as a positional, so a long one has to fit in the process argument vector.
+    # Checked before anything is written, because Popen raising this late would
+    # leave a job recorded as "running" for a run that never started.
+    _reject_oversized_argv(argv, env, kind=kind)
+
+    d.mkdir(parents=True, exist_ok=True)
+    if prompt_path is not None:
+        prompt_path.write_text(prompt)
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
     # always finds a record to mark. mark_terminal no-ops on a missing record, so

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -172,13 +172,34 @@ def _notify_template(run_id: str, notify_target: str | None, notify_command: str
     return " ".join(parts)
 
 
+# Linux caps a single exec argument at MAX_ARG_STRLEN — 32 pages — independently of
+# the aggregate limit, and offers no sysconf for it.
+_MAX_SINGLE_ARG_BYTES = 32 * 4096
+# argv and envp are pointer arrays, so every entry costs a slot as well as its bytes.
+_POINTER_BYTES = 8
+# Small allowance for the aux vector and alignment the kernel adds on top.
+_EXEC_RESERVE_BYTES = 4096
+
+
 def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -> None:
     """Refuse a command line the OS will not accept, before anything is spawned.
 
-    ``exec`` limits the combined size of the argument vector and the environment.
-    Exceeding it raises ``OSError: [Errno 7] Argument list too long`` from the
-    spawn, which is late and hard to read; refusing here names the cause and the
-    limit instead.
+    ``exec`` rejects an oversized invocation with ``OSError: [Errno 7] Argument
+    list too long``, which arrives too late to be useful: by then the caller has a
+    run id for a process that never started. There are two independent limits and
+    both have to hold.
+
+    The *aggregate* limit covers argv and the environment together and is readable
+    as ``SC_ARG_MAX``. Alongside the strings themselves the kernel stores a
+    terminator and a pointer per entry, so entries are counted, not just bytes —
+    a flat reserve would be defeated by a long list of short arguments.
+
+    The *per-argument* limit applies to one string on its own. Linux enforces
+    ``MAX_ARG_STRLEN`` (32 pages, 128 KiB) and does not expose it through
+    ``sysconf``, so it is used as a constant on every platform. That is
+    deliberately conservative: a flow instruction between 128 KiB and the
+    aggregate limit runs on macOS and fails on Linux, and one predictable refusal
+    beats a limit that depends on where the server happens to be running.
     """
     try:
         limit = os.sysconf("SC_ARG_MAX")
@@ -187,13 +208,23 @@ def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -
     if not isinstance(limit, int) or limit <= 0:  # pragma: no cover — unset knob
         return
 
-    # Each entry is stored with a terminator, and the kernel also keeps a pointer
-    # table and alignment padding that is not worth modelling exactly, so leave
-    # headroom rather than approving a command line that only just fits.
-    used = sum(len(a.encode()) + 1 for a in argv)
-    used += sum(len(k.encode()) + len(v.encode()) + 2 for k, v in env.items())
-    headroom = 8192
-    if used + headroom <= limit:
+    advice = (
+        "Shorten the instruction, or use submit_agent, which hands the instruction "
+        "to the run in a file instead of on the command line."
+    )
+
+    for arg in argv:
+        n = len(arg.encode())
+        if n > _MAX_SINGLE_ARG_BYTES:
+            raise ValueError(
+                f"cannot submit this {kind} run: one argument is {n} bytes, over the "
+                f"{_MAX_SINGLE_ARG_BYTES}-byte limit an operating system places on a "
+                f"single argument regardless of the {limit}-byte total. {advice}"
+            )
+
+    used = sum(len(a.encode()) + 1 + _POINTER_BYTES for a in argv)
+    used += sum(len(k.encode()) + len(v.encode()) + 2 + _POINTER_BYTES for k, v in env.items())
+    if used + _EXEC_RESERVE_BYTES <= limit:
         return
 
     detail = (
@@ -203,9 +234,7 @@ def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -
     )
     raise ValueError(
         f"cannot submit this {kind} run: {detail}, and it needs {used} bytes of "
-        f"argument vector plus environment against an OS limit of {limit}. "
-        "Shorten the instruction, or use submit_agent, which hands the "
-        "instruction to the run in a file instead of on the command line."
+        f"argument vector plus environment against an OS limit of {limit}. {advice}"
     )
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -270,6 +270,29 @@ def submit(
     return {"run_id": run_id, "pid": proc.pid, "status": latest["status"], "log": str(log_path)}
 
 
+def _server_identity() -> dict[str, str]:
+    """Which implementation answered this call.
+
+    A server imports its code once, at startup, so a caller cannot tell which
+    build is answering from the file on disk: the process may predate it. The
+    tool list does not help either, because two separate implementations can
+    expose the same tool names and differ only in parameters and behaviour. That
+    combination makes a wrong answer look authoritative — a field described from
+    a newer source reads as missing rather than as unsupported, and a caller who
+    trusts the description writes down a rule the running server does not
+    implement.
+
+    Reporting the version and the directory actually imported turns that from an
+    inference into a readable fact. Resolved per call rather than cached at
+    import so it reflects the module that is genuinely loaded.
+    """
+    try:
+        from lionagi.version import __version__ as version
+    except Exception:  # noqa: BLE001 — identity is diagnostic; never fail a status read
+        version = "unknown"
+    return {"version": version, "module": str(Path(__file__).resolve().parent)}
+
+
 def status(run_id: str) -> dict[str, Any]:
     """Current state of *run_id*.
 
@@ -278,6 +301,8 @@ def status(run_id: str) -> dict[str, Any]:
     advisory only — its own ``status`` stays ``running`` until the CLI finalizes
     it in the StateDB, so read ``status`` here, not ``run["status"]``.
     ``notify_delivery`` reports whether the terminal notice was delivered.
+    ``server`` identifies the implementation that answered, so a caller can tell
+    which build it is talking to rather than inferring it from behaviour.
     """
     job = _read_job(run_id)
     manifest = _read_run_manifest(run_id)
@@ -312,6 +337,7 @@ def status(run_id: str) -> dict[str, Any]:
         "run": manifest,
         "log_tail": _tail((job or {}).get("log")),
         "known": job is not None,
+        "server": _server_identity(),
     }
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -172,13 +172,30 @@ def _notify_template(run_id: str, notify_target: str | None, notify_command: str
     return " ".join(parts)
 
 
-# Linux caps a single exec argument at MAX_ARG_STRLEN — 32 pages — independently of
-# the aggregate limit, and offers no sysconf for it.
-_MAX_SINGLE_ARG_BYTES = 32 * 4096
 # argv and envp are pointer arrays, so every entry costs a slot as well as its bytes.
 _POINTER_BYTES = 8
 # Small allowance for the aux vector and alignment the kernel adds on top.
 _EXEC_RESERVE_BYTES = 4096
+
+
+def _max_single_arg_bytes() -> int | None:
+    """The per-argument exec limit, or None where the platform imposes none.
+
+    Linux caps one argument at ``MAX_ARG_STRLEN`` (32 pages) independently of the
+    aggregate limit and exposes no ``sysconf`` for it, so it is derived from the
+    running page size. Other platforms — macOS among them — bound only the total,
+    and happily exec a single argument far larger than this; applying the Linux
+    number there would refuse work the OS would have accepted.
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        page = os.sysconf("SC_PAGESIZE")
+    except (ValueError, OSError):  # pragma: no cover — platform without the knob
+        page = 4096
+    if not isinstance(page, int) or page <= 0:  # pragma: no cover — unset knob
+        page = 4096
+    return 32 * page
 
 
 def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -> None:
@@ -194,12 +211,10 @@ def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -
     terminator and a pointer per entry, so entries are counted, not just bytes —
     a flat reserve would be defeated by a long list of short arguments.
 
-    The *per-argument* limit applies to one string on its own. Linux enforces
-    ``MAX_ARG_STRLEN`` (32 pages, 128 KiB) and does not expose it through
-    ``sysconf``, so it is used as a constant on every platform. That is
-    deliberately conservative: a flow instruction between 128 KiB and the
-    aggregate limit runs on macOS and fails on Linux, and one predictable refusal
-    beats a limit that depends on where the server happens to be running.
+    The *per-argument* limit applies to one string on its own, and only where the
+    platform imposes one — see :func:`_max_single_arg_bytes`. It is checked
+    separately because an argument can be under the aggregate limit and still be
+    refused on its own.
     """
     try:
         limit = os.sysconf("SC_ARG_MAX")
@@ -213,14 +228,16 @@ def _reject_oversized_argv(argv: list[str], env: dict[str, str], *, kind: str) -
         "to the run in a file instead of on the command line."
     )
 
-    for arg in argv:
-        n = len(arg.encode())
-        if n > _MAX_SINGLE_ARG_BYTES:
-            raise ValueError(
-                f"cannot submit this {kind} run: one argument is {n} bytes, over the "
-                f"{_MAX_SINGLE_ARG_BYTES}-byte limit an operating system places on a "
-                f"single argument regardless of the {limit}-byte total. {advice}"
-            )
+    per_arg = _max_single_arg_bytes()
+    if per_arg is not None:
+        for arg in argv:
+            n = len(arg.encode())
+            if n > per_arg:
+                raise ValueError(
+                    f"cannot submit this {kind} run: one argument is {n} bytes, over the "
+                    f"{per_arg}-byte limit this platform places on a single argument "
+                    f"regardless of the {limit}-byte total. {advice}"
+                )
 
     used = sum(len(a.encode()) + 1 + _POINTER_BYTES for a in argv)
     used += sum(len(k.encode()) + len(v.encode()) + 2 + _POINTER_BYTES for k, v in env.items())

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -47,9 +47,15 @@ def _resolve_prompt(prompt: str | None, prompt_file: str | None) -> str | None:
         raise ValueError("prompt_file cannot be '-': a background run has no stdin")
     path = Path(prompt_file).expanduser()
     if not path.is_absolute():
-        # Resolved against this server's working directory, which the caller does
-        # not know and did not choose.
-        raise ValueError(f"prompt_file must be an absolute path, got {prompt_file!r}")
+        # The file is opened here, in the server process, so a relative path would
+        # resolve against the server's working directory — NOT the ``cwd`` the
+        # caller passes for the run, which is the directory they would reasonably
+        # expect. Rather than resolve it against the wrong root, require an
+        # absolute path and say so.
+        raise ValueError(
+            f"prompt_file must be an absolute path, got {prompt_file!r}: it is read by "
+            "the server, so a relative path would not resolve against the run's cwd"
+        )
     try:
         text = path.read_text()
     except OSError as exc:

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -24,6 +24,41 @@ from . import jobs
 mcp = FastMCP("lionagi")
 
 
+def _resolve_prompt(prompt: str | None, prompt_file: str | None) -> str | None:
+    """Return the instruction text, given either inline text or a file holding it.
+
+    The file is read here rather than passed to the CLI as a path. That snapshots
+    the text at submit time: ``submit`` writes it into the job directory, so
+    editing the file afterwards cannot change what an already-submitted run goes
+    on to execute.
+
+    Bad input is rejected before anything is submitted, because otherwise it
+    reaches the CLI only after the job record is written and a process is
+    spawned, and the caller learns about a typo by going to read the console log
+    of a failed run.
+    """
+    if prompt_file is None:
+        return prompt
+    if prompt is not None:
+        raise ValueError("pass prompt or prompt_file, not both")
+    if prompt_file == "-":
+        # The CLI reads stdin for "-", but a background job is spawned with stdin
+        # at DEVNULL, so it would read an empty prompt and fail.
+        raise ValueError("prompt_file cannot be '-': a background run has no stdin")
+    path = Path(prompt_file).expanduser()
+    if not path.is_absolute():
+        # Resolved against this server's working directory, which the caller does
+        # not know and did not choose.
+        raise ValueError(f"prompt_file must be an absolute path, got {prompt_file!r}")
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise ValueError(f"could not read prompt_file {path}: {exc}") from exc
+    if not text.strip():
+        raise ValueError(f"prompt_file is empty: {path}")
+    return text
+
+
 # --- submit tools (mirror the CLI) --------------------------------------------
 
 
@@ -58,37 +93,18 @@ def submit_agent(
     (a profile) or ``resume``/``continue_last`` already supplies one. ``agent``
     loads a profile from ``.lionagi/agents/``.
 
-    Give the instruction as either ``prompt`` (text, written to a file before the
-    run so long text with quotes or code is safe — no shell is involved on this
-    path) or ``prompt_file`` (an absolute path to a file you already have), never
-    both.
+    Give the instruction as either ``prompt`` (text) or ``prompt_file`` (an
+    absolute path to a file holding it), never both. Either way the text is
+    written to a file before the run and the process is spawned with an argv list
+    and no shell, so long text containing quotes or code is safe.
 
     On terminal the run records its status. If a delivery command is configured
     (``notify`` here, or lionagi's ``notify.on_terminal`` setting) it also sends
     a terminal notice; ``notify_seat`` fills that command's ``{target}``
     placeholder. With nothing configured the run delivers nothing.
     """
+    prompt = _resolve_prompt(prompt, prompt_file)
     flags: list[str] = []
-    if prompt_file is not None:
-        # Validated here rather than left to the CLI: a bad path would otherwise
-        # surface as a failed run whose console output the caller has to go read,
-        # and the run would already have been recorded and spawned.
-        if prompt is not None:
-            raise ValueError("pass prompt or prompt_file, not both")
-        if prompt_file == "-":
-            # The CLI accepts "-" for stdin, but a background job is spawned with
-            # stdin at DEVNULL, so it would read an empty prompt and fail.
-            raise ValueError("prompt_file cannot be '-': a background run has no stdin")
-        pf = Path(prompt_file).expanduser()
-        if not pf.is_absolute():
-            # The run's cwd is the caller's cwd argument, not this server's, so a
-            # relative path resolves against a directory the caller did not pick.
-            raise ValueError(f"prompt_file must be an absolute path, got {prompt_file!r}")
-        if not pf.is_file():
-            raise ValueError(f"prompt_file does not exist or is not a file: {pf}")
-        if pf.stat().st_size == 0:
-            raise ValueError(f"prompt_file is empty: {pf}")
-        flags += ["--prompt-file", str(pf)]
     if model:
         flags.append(model)  # leading positional model spec
     if agent:
@@ -132,6 +148,7 @@ def submit_agent(
 @mcp.tool
 def submit_flow(
     prompt: str | None = None,
+    prompt_file: str | None = None,
     model: str | None = None,
     agent: str | None = None,
     file: str | None = None,
@@ -154,9 +171,11 @@ def submit_flow(
     """Submit an orchestrated flow in the background (mirrors ``li o flow``).
 
     The orchestrator composes a DAG of agents and runs it with automatic
-    parallelism. Prompt may come from ``prompt``, ``file`` (-f), or ``playbook``
-    (-p). ``with_synthesis`` may be a model spec or ``True`` for the default.
+    parallelism. Prompt may come from ``prompt``, ``prompt_file`` (an absolute
+    path to a file holding the text), ``file`` (-f), or ``playbook`` (-p).
+    ``with_synthesis`` may be a model spec or ``True`` for the default.
     """
+    prompt = _resolve_prompt(prompt, prompt_file)
     flags: list[str] = []
     if model:
         flags.append(model)
@@ -206,6 +225,7 @@ def submit_flow(
 @mcp.tool
 def submit_fanout(
     prompt: str | None = None,
+    prompt_file: str | None = None,
     model: str | None = None,
     agent: str | None = None,
     num_workers: int | None = None,
@@ -229,8 +249,10 @@ def submit_fanout(
 
     ``num_workers`` copies of one worker, or ``workers`` as a comma-separated
     list of model specs (M1,M2,...). ``synthesis_prompt`` drives an optional
-    synthesis pass over the workers' results.
+    synthesis pass over the workers' results. The worker instruction may be given
+    inline as ``prompt`` or as ``prompt_file`` (an absolute path).
     """
+    prompt = _resolve_prompt(prompt, prompt_file)
     flags: list[str] = []
     if model:
         flags.append(model)

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -14,6 +14,7 @@ for the long tail of flags, so the surface never drifts out of reach of the CLI.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
@@ -29,6 +30,7 @@ mcp = FastMCP("lionagi")
 @mcp.tool
 def submit_agent(
     prompt: str | None = None,
+    prompt_file: str | None = None,
     model: str | None = None,
     agent: str | None = None,
     effort: str | None = None,
@@ -56,12 +58,37 @@ def submit_agent(
     (a profile) or ``resume``/``continue_last`` already supplies one. ``agent``
     loads a profile from ``.lionagi/agents/``.
 
+    Give the instruction as either ``prompt`` (text, written to a file before the
+    run so long text with quotes or code is safe — no shell is involved on this
+    path) or ``prompt_file`` (an absolute path to a file you already have), never
+    both.
+
     On terminal the run records its status. If a delivery command is configured
     (``notify`` here, or lionagi's ``notify.on_terminal`` setting) it also sends
     a terminal notice; ``notify_seat`` fills that command's ``{target}``
     placeholder. With nothing configured the run delivers nothing.
     """
     flags: list[str] = []
+    if prompt_file is not None:
+        # Validated here rather than left to the CLI: a bad path would otherwise
+        # surface as a failed run whose console output the caller has to go read,
+        # and the run would already have been recorded and spawned.
+        if prompt is not None:
+            raise ValueError("pass prompt or prompt_file, not both")
+        if prompt_file == "-":
+            # The CLI accepts "-" for stdin, but a background job is spawned with
+            # stdin at DEVNULL, so it would read an empty prompt and fail.
+            raise ValueError("prompt_file cannot be '-': a background run has no stdin")
+        pf = Path(prompt_file).expanduser()
+        if not pf.is_absolute():
+            # The run's cwd is the caller's cwd argument, not this server's, so a
+            # relative path resolves against a directory the caller did not pick.
+            raise ValueError(f"prompt_file must be an absolute path, got {prompt_file!r}")
+        if not pf.is_file():
+            raise ValueError(f"prompt_file does not exist or is not a file: {pf}")
+        if pf.stat().st_size == 0:
+            raise ValueError(f"prompt_file is empty: {pf}")
+        flags += ["--prompt-file", str(pf)]
     if model:
         flags.append(model)  # leading positional model spec
     if agent:

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -318,11 +318,49 @@ def test_oversized_flow_prompt_is_refused_before_a_record_exists(sandbox):
     limit = os.sysconf("SC_ARG_MAX")
     huge = "x" * limit
 
-    with pytest.raises(ValueError, match="OS limit"):
+    # Refused for whichever limit it hits first; the point is that it is refused
+    # before anything is recorded, not which of the two bounds caught it.
+    with pytest.raises(ValueError, match="cannot submit this flow run"):
         jobs.submit("flow", [], prompt=huge)
 
     # Nothing was recorded, so nothing shows up as a job that never finishes.
     assert jobs.list_jobs() == []
+
+
+def test_one_oversized_argument_is_refused_even_when_the_total_would_fit(sandbox):
+    """A single argument has its own limit, below the aggregate one.
+
+    Linux caps one exec argument at MAX_ARG_STRLEN (32 pages) regardless of how
+    much aggregate room is left, and does not expose it via sysconf. A flow prompt
+    between that and SC_ARG_MAX spawns fine on macOS and dies with E2BIG on Linux,
+    so it has to be refused on both.
+    """
+    limit = os.sysconf("SC_ARG_MAX")
+    one_arg = "x" * (jobs._MAX_SINGLE_ARG_BYTES + 1)
+    assert len(one_arg) < limit, "must fit the aggregate limit, or this tests the wrong thing"
+
+    with pytest.raises(ValueError, match="single argument"):
+        jobs.submit("flow", [], prompt=one_arg)
+
+    assert jobs.list_jobs() == []
+
+
+def test_argument_count_is_charged_not_only_bytes():
+    """Entries cost a pointer slot each, so counting bytes alone is not enough.
+
+    Constructed so the strings themselves fit the aggregate limit with room to
+    spare and only the per-entry pointer cost pushes the invocation over. A
+    byte-only estimate with a flat reserve accepts this and then dies in exec.
+    """
+    limit = os.sysconf("SC_ARG_MAX")
+    argv = ["x"] * (limit // 8)
+    env = {"PATH": "/usr/bin"}
+
+    byte_total = sum(len(a.encode()) + 1 for a in argv)
+    assert byte_total * 2 < limit, "bytes alone must fit, or this tests the wrong thing"
+
+    with pytest.raises(ValueError, match="OS limit"):
+        jobs._reject_oversized_argv(argv, env, kind="flow")
 
 
 def test_an_ordinary_prompt_is_not_caught_by_the_size_guard(tmp_path, monkeypatch):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -9,6 +9,7 @@ on the argv/env the engine builds and on the on-disk job records it reads back.
 from __future__ import annotations
 
 import builtins
+import os
 from pathlib import Path
 
 import pytest
@@ -304,3 +305,30 @@ def test_status_stamp_survives_an_unreadable_version(sandbox, monkeypatch):
 
     assert st["server"]["version"] == "unknown"
     assert st["status"]  # the rest of the read is unaffected
+
+
+def test_oversized_flow_prompt_is_refused_before_a_record_exists(sandbox):
+    """A prompt too big for the argument vector must fail before anything is recorded.
+
+    flow and fanout pass the instruction as a positional argument, so a large one
+    hits the OS exec limit. If that surfaced from the spawn, the job record would
+    already be on disk and would sit at "running" forever for a run that never
+    started.
+    """
+    limit = os.sysconf("SC_ARG_MAX")
+    huge = "x" * limit
+
+    with pytest.raises(ValueError, match="OS limit"):
+        jobs.submit("flow", [], prompt=huge)
+
+    # Nothing was recorded, so nothing shows up as a job that never finishes.
+    assert jobs.list_jobs() == []
+
+
+def test_an_ordinary_prompt_is_not_caught_by_the_size_guard(tmp_path, monkeypatch):
+    """The guard must not fire on realistic input — it only bounds the extreme."""
+    argv = ["li", "o", "flow", "a normal instruction"]
+    env = {"PATH": "/usr/bin"}
+
+    # Returns rather than raising.
+    assert jobs._reject_oversized_argv(argv, env, kind="flow") is None

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -8,6 +8,9 @@ on the argv/env the engine builds and on the on-disk job records it reads back.
 
 from __future__ import annotations
 
+import builtins
+from pathlib import Path
+
 import pytest
 
 from lionagi.mcp import config, jobs
@@ -263,3 +266,41 @@ def test_write_job_publishes_atomically(sandbox, monkeypatch):
     assert jobs._read_job(rid) == good
     # and the failed publish cleaned up its staging file rather than orphaning it
     assert not list(config.job_dir(rid).glob(".job.json.*.tmp"))
+
+
+def test_status_reports_which_implementation_answered(sandbox, monkeypatch):
+    # Two same-named MCP surfaces can expose identical tool lists, and a server
+    # imports its code at startup, so neither the tool list nor the file on disk
+    # tells a caller which build is answering. The stamp makes it readable.
+    monkeypatch.setattr(
+        subprocess := __import__("subprocess"), "Popen", lambda *a, **k: _FakeProc()
+    )
+    handle = jobs.submit("agent", [], prompt="x")
+
+    st = jobs.status(handle["run_id"])
+
+    from lionagi.version import __version__
+
+    assert st["server"]["version"] == __version__
+    # The module path is the one actually imported, not a configured guess.
+    assert st["server"]["module"] == str(Path(jobs.__file__).resolve().parent)
+
+
+def test_status_stamp_survives_an_unreadable_version(sandbox, monkeypatch):
+    # Identity is diagnostic; a status read must never fail for want of it.
+    monkeypatch.setattr(
+        subprocess := __import__("subprocess"), "Popen", lambda *a, **k: _FakeProc()
+    )
+    handle = jobs.submit("agent", [], prompt="x")
+    real_import = builtins.__import__
+
+    def boom(name, *args, **kwargs):
+        if name == "lionagi.version":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", boom)
+    st = jobs.status(handle["run_id"])
+
+    assert st["server"]["version"] == "unknown"
+    assert st["status"]  # the rest of the read is unaffected

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -327,22 +327,48 @@ def test_oversized_flow_prompt_is_refused_before_a_record_exists(sandbox):
     assert jobs.list_jobs() == []
 
 
-def test_one_oversized_argument_is_refused_even_when_the_total_would_fit(sandbox):
-    """A single argument has its own limit, below the aggregate one.
+def test_one_oversized_argument_is_refused_where_the_platform_caps_one(sandbox, monkeypatch):
+    """A single argument has its own limit on Linux, below the aggregate one.
 
-    Linux caps one exec argument at MAX_ARG_STRLEN (32 pages) regardless of how
-    much aggregate room is left, and does not expose it via sysconf. A flow prompt
-    between that and SC_ARG_MAX spawns fine on macOS and dies with E2BIG on Linux,
-    so it has to be refused on both.
+    Linux caps one exec argument at MAX_ARG_STRLEN regardless of how much
+    aggregate room is left, so a flow prompt between that and SC_ARG_MAX would
+    otherwise pass the preflight and die in exec after the record was written.
+    The cap is forced on here rather than skipped off Linux, so the rule is
+    exercised wherever the tests run.
     """
+    monkeypatch.setattr(jobs, "_max_single_arg_bytes", lambda: 131072)
     limit = os.sysconf("SC_ARG_MAX")
-    one_arg = "x" * (jobs._MAX_SINGLE_ARG_BYTES + 1)
+    one_arg = "x" * 131073
     assert len(one_arg) < limit, "must fit the aggregate limit, or this tests the wrong thing"
 
     with pytest.raises(ValueError, match="single argument"):
         jobs.submit("flow", [], prompt=one_arg)
 
     assert jobs.list_jobs() == []
+
+
+def test_a_platform_without_a_per_argument_cap_is_bounded_only_by_the_total(sandbox, monkeypatch):
+    """Where the OS caps only the total, do not invent a per-argument refusal.
+
+    macOS execs a single argument far larger than Linux's MAX_ARG_STRLEN, so
+    applying that number there would reject work the OS would have accepted.
+    """
+    monkeypatch.setattr(jobs, "_max_single_arg_bytes", lambda: None)
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(4242))
+
+    # Comfortably over Linux's per-argument cap, comfortably under the aggregate.
+    accepted = jobs.submit("flow", [], prompt="x" * 200_000)
+
+    assert accepted["status"] == "running"
+
+
+def test_the_per_argument_cap_tracks_the_platform(monkeypatch):
+    """Linux derives it from the page size; elsewhere there is none to apply."""
+    monkeypatch.setattr(jobs.sys, "platform", "linux")
+    assert jobs._max_single_arg_bytes() == 32 * os.sysconf("SC_PAGESIZE")
+
+    monkeypatch.setattr(jobs.sys, "platform", "darwin")
+    assert jobs._max_single_arg_bytes() is None
 
 
 def test_argument_count_is_charged_not_only_bytes():

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MCP tool surface.
+
+``jobs.submit`` is stubbed so nothing spawns; these assert on the flags the tool
+builds and on the input it refuses before a run is ever recorded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The tool surface is defined with fastmcp, which lives in the ``mcp`` extra; the
+# rest of tests/mcp only touches the extra-free job plumbing. CI syncs all extras,
+# so these run there — a skip here means a bare local install, not a green check.
+pytest.importorskip("fastmcp", reason="requires the 'mcp' extra")
+
+from lionagi.mcp import server  # noqa: E402 — must follow the extra guard
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Replace jobs.submit with a recorder, so a call that reaches it is visible."""
+    seen: dict = {}
+
+    def fake_submit(kind, flags, **kwargs):
+        seen["kind"] = kind
+        seen["flags"] = list(flags)
+        seen.update(kwargs)
+        return {"run_id": "x", "pid": 1, "status": "running"}
+
+    monkeypatch.setattr(server.jobs, "submit", fake_submit)
+    return seen
+
+
+def test_prompt_file_is_passed_through_as_a_cli_flag(captured, tmp_path):
+    pf = tmp_path / "prompt.md"
+    pf.write_text("a long instruction with 'quotes' and `code`\n")
+
+    server.submit_agent(prompt_file=str(pf), agent="reviewer")
+
+    assert captured["flags"][:2] == ["--prompt-file", str(pf)]
+    # The text is not read here and not inlined: the path is handed to the CLI.
+    assert captured["prompt"] is None
+
+
+def test_prompt_file_accepts_a_tilde_path(captured, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pf = tmp_path / "prompt.md"
+    pf.write_text("body")
+
+    server.submit_agent(prompt_file="~/prompt.md")
+
+    assert captured["flags"] == ["--prompt-file", str(pf)]
+
+
+def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path):
+    pf = tmp_path / "prompt.md"
+    pf.write_text("body")
+
+    with pytest.raises(ValueError, match="not both"):
+        server.submit_agent(prompt="inline", prompt_file=str(pf))
+
+    assert captured == {}  # refused before anything was submitted
+
+
+def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path):
+    # Without this the path reaches the CLI, the job record is written, a process
+    # is spawned, and the caller learns about the typo only by reading a console
+    # log of a failed run.
+    with pytest.raises(ValueError, match="does not exist"):
+        server.submit_agent(prompt_file=str(tmp_path / "nope.md"))
+
+    assert captured == {}
+
+
+def test_empty_prompt_file_is_refused(captured, tmp_path):
+    # The CLI itself errors on an empty prompt file, so catching it here turns a
+    # failed run into a rejected call.
+    pf = tmp_path / "empty.md"
+    pf.write_text("")
+
+    with pytest.raises(ValueError, match="is empty"):
+        server.submit_agent(prompt_file=str(pf))
+
+    assert captured == {}
+
+
+def test_relative_prompt_file_is_refused(captured):
+    # The run's cwd is the caller's `cwd` argument, not this server's, so a
+    # relative path would resolve against a directory the caller never chose.
+    with pytest.raises(ValueError, match="absolute path"):
+        server.submit_agent(prompt_file="prompt.md", cwd="/tmp")
+
+    assert captured == {}
+
+
+def test_stdin_prompt_file_is_refused(captured):
+    # The CLI accepts "-" for stdin, but a background run is spawned with stdin at
+    # DEVNULL, so "-" would yield an empty prompt and a failed run.
+    with pytest.raises(ValueError, match="no stdin"):
+        server.submit_agent(prompt_file="-")
+
+    assert captured == {}
+
+
+def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path):
+    with pytest.raises(ValueError, match="not a file"):
+        server.submit_agent(prompt_file=str(tmp_path))
+
+    assert captured == {}
+
+
+def test_plain_prompt_still_goes_through_untouched(captured):
+    server.submit_agent(prompt="hello")
+
+    assert captured["prompt"] == "hello"
+    assert "--prompt-file" not in captured["flags"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -18,10 +18,16 @@ pytest.importorskip("fastmcp", reason="requires the 'mcp' extra")
 from lionagi.mcp import server  # noqa: E402 — must follow the extra guard
 
 # Every submit tool takes the instruction the same way, so the path handling is
-# checked against all three rather than only the one it was added for.
+# checked against all three rather than only the one it was added for. The kind is
+# carried alongside so each case can assert it reached the right run kind: without
+# that, a regression routing flow or fanout through "agent" would still pass.
 SUBMITTERS = pytest.mark.parametrize(
-    "submit",
-    [server.submit_agent, server.submit_flow, server.submit_fanout],
+    ("submit", "kind"),
+    [
+        (server.submit_agent, "agent"),
+        (server.submit_flow, "flow"),
+        (server.submit_fanout, "fanout"),
+    ],
     ids=["agent", "flow", "fanout"],
 )
 
@@ -42,7 +48,7 @@ def captured(monkeypatch):
 
 
 @SUBMITTERS
-def test_prompt_file_contents_are_submitted_as_the_prompt(captured, tmp_path, submit):
+def test_prompt_file_contents_are_submitted_as_the_prompt(captured, tmp_path, submit, kind):
     body = "a long instruction with 'quotes' and `code`\n"
     pf = tmp_path / "prompt.md"
     pf.write_text(body)
@@ -51,23 +57,25 @@ def test_prompt_file_contents_are_submitted_as_the_prompt(captured, tmp_path, su
 
     # The text is read here, so submit() snapshots it into the job directory. The
     # caller's path is deliberately not forwarded: see the snapshot test below.
+    assert captured["kind"] == kind
     assert captured["prompt"] == body
     assert "--prompt-file" not in captured["flags"]
     assert str(pf) not in captured["flags"]
 
 
 @SUBMITTERS
-def test_prompt_file_accepts_a_tilde_path(captured, tmp_path, monkeypatch, submit):
+def test_prompt_file_accepts_a_tilde_path(captured, tmp_path, monkeypatch, submit, kind):
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / "prompt.md").write_text("body")
 
     submit(prompt_file="~/prompt.md")
 
+    assert captured["kind"] == kind
     assert captured["prompt"] == "body"
 
 
 @SUBMITTERS
-def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path, submit):
+def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path, submit, kind):
     pf = tmp_path / "prompt.md"
     pf.write_text("body")
 
@@ -78,7 +86,7 @@ def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path, submit)
 
 
 @SUBMITTERS
-def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path, submit):
+def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path, submit, kind):
     # Without this the path reaches the CLI, the job record is written, a process
     # is spawned, and the caller learns about the typo only by reading a console
     # log of a failed run.
@@ -89,7 +97,7 @@ def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path, su
 
 
 @SUBMITTERS
-def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path, submit):
+def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path, submit, kind):
     with pytest.raises(ValueError, match="could not read"):
         submit(prompt_file=str(tmp_path))
 
@@ -98,7 +106,7 @@ def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path, submit
 
 @SUBMITTERS
 @pytest.mark.parametrize("body", ["", "   \n\t\n"], ids=["empty", "whitespace"])
-def test_a_prompt_file_with_no_instruction_in_it_is_refused(captured, tmp_path, submit, body):
+def test_a_prompt_file_with_no_instruction_in_it_is_refused(captured, tmp_path, submit, kind, body):
     # An agent handed a blank instruction burns a real run to produce nothing.
     pf = tmp_path / "empty.md"
     pf.write_text(body)
@@ -110,17 +118,17 @@ def test_a_prompt_file_with_no_instruction_in_it_is_refused(captured, tmp_path, 
 
 
 @SUBMITTERS
-def test_relative_prompt_file_is_refused(captured, submit):
-    # A relative path resolves against this server's working directory, which the
-    # caller does not know and did not choose.
+def test_relative_prompt_file_is_refused(captured, submit, kind):
+    # The file is read in the server process, so a relative path would resolve
+    # against the server's working directory rather than the run's cwd.
     with pytest.raises(ValueError, match="absolute path"):
-        submit(prompt_file="prompt.md", cwd="/tmp")
+        submit(prompt_file="prompt.md", cwd="/project")
 
     assert captured == {}
 
 
 @SUBMITTERS
-def test_stdin_prompt_file_is_refused(captured, submit):
+def test_stdin_prompt_file_is_refused(captured, submit, kind):
     # The CLI accepts "-" for stdin, but a background run is spawned with stdin at
     # DEVNULL, so "-" would yield an empty prompt and a failed run.
     with pytest.raises(ValueError, match="no stdin"):
@@ -130,18 +138,20 @@ def test_stdin_prompt_file_is_refused(captured, submit):
 
 
 @SUBMITTERS
-def test_plain_prompt_still_goes_through_untouched(captured, submit):
+def test_plain_prompt_still_goes_through_untouched(captured, submit, kind):
     submit(prompt="hello")
 
+    assert captured["kind"] == kind
     assert captured["prompt"] == "hello"
     assert "--prompt-file" not in captured["flags"]
 
 
 @SUBMITTERS
-def test_neither_prompt_nor_prompt_file_leaves_the_prompt_unset(captured, submit):
+def test_neither_prompt_nor_prompt_file_leaves_the_prompt_unset(captured, submit, kind):
     # Both are optional: a resumed or playbook-driven run supplies its own text.
     submit(agent="reviewer")
 
+    assert captured["kind"] == kind
     assert captured["prompt"] is None
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the MCP tool surface.
 
-``jobs.submit`` is stubbed so nothing spawns; these assert on the flags the tool
-builds and on the input it refuses before a run is ever recorded.
+``jobs.submit`` is stubbed so nothing spawns; these assert on what the tools hand
+it and on the input they refuse before a run is ever recorded.
 """
 
 from __future__ import annotations
@@ -16,6 +16,14 @@ import pytest
 pytest.importorskip("fastmcp", reason="requires the 'mcp' extra")
 
 from lionagi.mcp import server  # noqa: E402 — must follow the extra guard
+
+# Every submit tool takes the instruction the same way, so the path handling is
+# checked against all three rather than only the one it was added for.
+SUBMITTERS = pytest.mark.parametrize(
+    "submit",
+    [server.submit_agent, server.submit_flow, server.submit_fanout],
+    ids=["agent", "flow", "fanout"],
+)
 
 
 @pytest.fixture
@@ -33,86 +41,118 @@ def captured(monkeypatch):
     return seen
 
 
-def test_prompt_file_is_passed_through_as_a_cli_flag(captured, tmp_path):
+@SUBMITTERS
+def test_prompt_file_contents_are_submitted_as_the_prompt(captured, tmp_path, submit):
+    body = "a long instruction with 'quotes' and `code`\n"
     pf = tmp_path / "prompt.md"
-    pf.write_text("a long instruction with 'quotes' and `code`\n")
+    pf.write_text(body)
 
-    server.submit_agent(prompt_file=str(pf), agent="reviewer")
+    submit(prompt_file=str(pf))
 
-    assert captured["flags"][:2] == ["--prompt-file", str(pf)]
-    # The text is not read here and not inlined: the path is handed to the CLI.
-    assert captured["prompt"] is None
+    # The text is read here, so submit() snapshots it into the job directory. The
+    # caller's path is deliberately not forwarded: see the snapshot test below.
+    assert captured["prompt"] == body
+    assert "--prompt-file" not in captured["flags"]
+    assert str(pf) not in captured["flags"]
 
 
-def test_prompt_file_accepts_a_tilde_path(captured, tmp_path, monkeypatch):
+@SUBMITTERS
+def test_prompt_file_accepts_a_tilde_path(captured, tmp_path, monkeypatch, submit):
     monkeypatch.setenv("HOME", str(tmp_path))
-    pf = tmp_path / "prompt.md"
-    pf.write_text("body")
+    (tmp_path / "prompt.md").write_text("body")
 
-    server.submit_agent(prompt_file="~/prompt.md")
+    submit(prompt_file="~/prompt.md")
 
-    assert captured["flags"] == ["--prompt-file", str(pf)]
+    assert captured["prompt"] == "body"
 
 
-def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path):
+@SUBMITTERS
+def test_prompt_and_prompt_file_together_are_refused(captured, tmp_path, submit):
     pf = tmp_path / "prompt.md"
     pf.write_text("body")
 
     with pytest.raises(ValueError, match="not both"):
-        server.submit_agent(prompt="inline", prompt_file=str(pf))
+        submit(prompt="inline", prompt_file=str(pf))
 
     assert captured == {}  # refused before anything was submitted
 
 
-def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path):
+@SUBMITTERS
+def test_missing_prompt_file_is_refused_before_submitting(captured, tmp_path, submit):
     # Without this the path reaches the CLI, the job record is written, a process
     # is spawned, and the caller learns about the typo only by reading a console
     # log of a failed run.
-    with pytest.raises(ValueError, match="does not exist"):
-        server.submit_agent(prompt_file=str(tmp_path / "nope.md"))
+    with pytest.raises(ValueError, match="could not read"):
+        submit(prompt_file=str(tmp_path / "nope.md"))
 
     assert captured == {}
 
 
-def test_empty_prompt_file_is_refused(captured, tmp_path):
-    # The CLI itself errors on an empty prompt file, so catching it here turns a
-    # failed run into a rejected call.
+@SUBMITTERS
+def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path, submit):
+    with pytest.raises(ValueError, match="could not read"):
+        submit(prompt_file=str(tmp_path))
+
+    assert captured == {}
+
+
+@SUBMITTERS
+@pytest.mark.parametrize("body", ["", "   \n\t\n"], ids=["empty", "whitespace"])
+def test_a_prompt_file_with_no_instruction_in_it_is_refused(captured, tmp_path, submit, body):
+    # An agent handed a blank instruction burns a real run to produce nothing.
     pf = tmp_path / "empty.md"
-    pf.write_text("")
+    pf.write_text(body)
 
     with pytest.raises(ValueError, match="is empty"):
-        server.submit_agent(prompt_file=str(pf))
+        submit(prompt_file=str(pf))
 
     assert captured == {}
 
 
-def test_relative_prompt_file_is_refused(captured):
-    # The run's cwd is the caller's `cwd` argument, not this server's, so a
-    # relative path would resolve against a directory the caller never chose.
+@SUBMITTERS
+def test_relative_prompt_file_is_refused(captured, submit):
+    # A relative path resolves against this server's working directory, which the
+    # caller does not know and did not choose.
     with pytest.raises(ValueError, match="absolute path"):
-        server.submit_agent(prompt_file="prompt.md", cwd="/tmp")
+        submit(prompt_file="prompt.md", cwd="/tmp")
 
     assert captured == {}
 
 
-def test_stdin_prompt_file_is_refused(captured):
+@SUBMITTERS
+def test_stdin_prompt_file_is_refused(captured, submit):
     # The CLI accepts "-" for stdin, but a background run is spawned with stdin at
     # DEVNULL, so "-" would yield an empty prompt and a failed run.
     with pytest.raises(ValueError, match="no stdin"):
-        server.submit_agent(prompt_file="-")
+        submit(prompt_file="-")
 
     assert captured == {}
 
 
-def test_a_directory_is_refused_rather_than_passed_on(captured, tmp_path):
-    with pytest.raises(ValueError, match="not a file"):
-        server.submit_agent(prompt_file=str(tmp_path))
-
-    assert captured == {}
-
-
-def test_plain_prompt_still_goes_through_untouched(captured):
-    server.submit_agent(prompt="hello")
+@SUBMITTERS
+def test_plain_prompt_still_goes_through_untouched(captured, submit):
+    submit(prompt="hello")
 
     assert captured["prompt"] == "hello"
     assert "--prompt-file" not in captured["flags"]
+
+
+@SUBMITTERS
+def test_neither_prompt_nor_prompt_file_leaves_the_prompt_unset(captured, submit):
+    # Both are optional: a resumed or playbook-driven run supplies its own text.
+    submit(agent="reviewer")
+
+    assert captured["prompt"] is None
+
+
+def test_the_text_is_snapshotted_at_submit_time(captured, tmp_path):
+    # An editable prompt file must not be able to change what an already-submitted
+    # run executes. Reading at submit time is what guarantees that; forwarding the
+    # path would leave the text live until the CLI opened it.
+    pf = tmp_path / "prompt.md"
+    pf.write_text("original")
+
+    server.submit_agent(prompt_file=str(pf))
+    pf.write_text("edited after submitting")
+
+    assert captured["prompt"] == "original"


### PR DESCRIPTION
Two independent changes to the MCP tool surface: a way to give an agent its
instruction from a file, and a way to tell which server answered a status call.

## `prompt_file` on the submit tools

The submit tools only accepted the instruction as inline text, so a caller who
already had it in a file had to read the file and pass its contents. All three
tools now accept `prompt_file` as well; exactly one of `prompt` / `prompt_file`
may be given.

The file is **read at submit time** rather than forwarded as a path. `submit()`
already writes the prompt into the job directory, so reading it here snapshots
the instruction: editing the file afterwards cannot change what an
already-submitted run goes on to execute. Prompt files are routinely generated or
hand-edited between runs, which is exactly the case where a live path is a
hazard.

Bad input is refused before anything is submitted. Without that, it reaches the
CLI only after the job record is written and a process is spawned, so a typo
surfaces as a failed run whose console log the caller has to go read.

| Input | Why refused |
| --- | --- |
| both `prompt` and `prompt_file` | ambiguous |
| relative path | resolves against the server's working directory, which the caller does not know and did not choose |
| missing path, or a directory | not a readable instruction |
| file with only whitespace | a blank instruction burns a real run to produce nothing |
| `"-"` | the CLI reads stdin for it, but a background run is spawned with stdin at DEVNULL |

`~` is expanded. Inline `prompt` behaviour is unchanged.

Worth recording since it motivated the shape: inline `prompt` was already written
to a file before the run, and the spawn passes an argv list with no shell. Long
text containing quotes or code was never at risk on that path, so this is an
ergonomic addition rather than a correctness fix.

## Refusing a command line the OS cannot exec

Only `agent` hands the instruction over in a file; `flow` and `fanout` pass it as a
positional argument, so a large one has to fit in the process argument vector.
Accepting a prompt file made that easy to reach — a multi-megabyte file exceeds
`ARG_MAX` and the spawn fails with `OSError: [Errno 7] Argument list too long`.

The failure was late in a way that left damage behind: the job record is written
before the spawn, so a run that never started stayed recorded as `running`.

The command line is now assembled and size-checked before anything touches disk,
and the job directory is created only once the run is known to be spawnable, so a
rejection leaves nothing behind. (An earlier version of this guard ran *after* the
directory was created, which left an empty one that reads back as a job with no
kind that never finishes; the test covers that ordering specifically.) The error
names the size, the limit, and the fact that `submit_agent` passes the instruction
in a file instead.

`exec` applies two independent limits and the preflight models both:

- **Aggregate** — argv and the environment together, read from `SC_ARG_MAX`.
  Entries are charged a pointer slot as well as their bytes, because counting
  bytes against a flat reserve is defeated by a long list of *short* arguments.
- **Per argument** — one string on its own. Linux caps this at `MAX_ARG_STRLEN`
  (32 pages) independently of the aggregate limit and exposes no `sysconf` for
  it, so it is derived from the running page size. Platforms without such a limit
  get no synthetic one: macOS execs a 200 KiB single argument successfully, and
  refusing it would reject work the OS accepts. Verified on Darwin — a
  200,000-byte argument execs with status 0, a 2,000,000-byte one raises
  `[Errno 7]` and is caught by the aggregate check.

## Implementation identity in `job_status`

A server imports its code once at startup, so a running process can be older than
the checkout it was launched from, and two implementations can expose the same
tool names. When either happens, a field described by newer source reads as
*missing* rather than *unsupported*, and nothing in the response distinguishes
those two. `job_status` now reports the version and module directory that
answered it. The lookup is wrapped: identity is diagnostic, so an unreadable
version reports `"unknown"` rather than failing a status read.

## Tests

`tests/mcp` is 88 passed. Full suite with all extras: 14987 passed, 4 failed — the
failures reproduce identically on a tree without these changes (docling is not
installed in this environment), verified side by side rather than assumed. The path handling is parameterised over all three
submit tools rather than asserted once.

Both features were checked against negative controls, so the tests are not
passing vacuously:

- stripping the validation down to a bare read fails 5 of the new tests
- swapping the whitespace check back to a zero-size check fails the 3
  whitespace-only cases
- removing the identity stamp fails its 2 tests
- removing the argv size guard, and separately creating the job directory before
  validating, each fail the oversized-prompt test

`tests/mcp/test_server.py` is the first test module here to import the tool
surface, which needs the `mcp` extra, so it carries an `importorskip` guard. CI
syncs all extras and runs it; a skip locally means a bare install, not a green
check.
