### PR TITLE
feat(cli): report a broken environment as its own failure, not a failed run

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -253,20 +253,31 @@ the one-line summary is emitted last through the CLI error logger, so a caller k
 tail of stderr still receives the diagnosis. Callers distinguishing the two cases should test for
 78 specifically; every other exit code retains its existing meaning.
 
-A missing module reaches this state from two places, and both are covered:
+The wrapper in `main()` catches whatever escapes, but a `ModuleNotFoundError` absorbed by a broad
+handler on the way to dispatch never reaches it. Every such handler ahead of the wrapper must
+therefore split the missing-module case out and return 78 itself, keeping its existing handling for
+everything else; a discriminator absorbed upstream is not a discriminator. Two do so today: the
+lazy command-module loader, and the agent-profile load in `li play check`. Both keep their concise
+report rather than switching to a traceback, because a command that never started has no stack
+worth printing and naming the missing module is the whole diagnosis. Any new broad handler in that
+region needs the same split.
 
-- **While loading a command.** Command modules are imported lazily once one is selected, behind a
-  broad handler that reports a command-scoped error. A missing dependency is split out of that
-  handler and returns 78 with the same concise report — a traceback for a command that never
-  started is noise, and naming the module is the whole diagnosis at that point.
-- **Anywhere else before a run exists.** The wrapper in `main()` catches what escapes.
+The boundary in the wrapper is a run having been allocated. `allocate_run` sets a marker, and once
+it is set a `ModuleNotFoundError` is *not* reported as an environment fault: a run id, a run
+directory and a manifest exist on disk, so telling the caller nothing was executed would be the
+same misattribution pointed the other way. Such an error propagates and is reported the way any
+other failure during a run is. This is why a lazily imported provider extra going missing mid-run
+does not exit 78.
 
-The boundary on the second is a run having been allocated. `allocate_run` sets a process-level
-marker, and once it is set a `ModuleNotFoundError` is *not* reported as an environment fault: a run
-id, a run directory and a manifest exist on disk, so telling the caller nothing was executed would
-be the same misattribution pointed the other way. Such an error propagates and is reported the way
-any other failure during a run is. This is why a lazily imported provider extra going missing
-mid-run does not exit 78.
+The marker is process-wide by necessity, not by convenience. `run_async` drives each command's
+async body on its own thread with its own event loop, so allocation happens on a different thread,
+in a fresh context, from the one the entry point returns on — a thread-local or a `ContextVar`
+would be invisible to the reader and would claim no run started while one existed. The cost is
+precision when two invocations overlap in one process, which is not a supported entry point. That
+is handled by making the unsafe direction impossible rather than by pretending it cannot happen:
+seeing another invocation's allocation only re-raises, which is the behaviour that predates this
+code, while *losing* one would assert something false, so the reset on entry is skipped whenever
+another invocation is in flight.
 
 ## `dispatch.py` — dispatch outbox (ADR-0059)
 

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -279,6 +279,14 @@ seeing another invocation's allocation only re-raises, which is the behaviour th
 code, while *losing* one would assert something false, so the reset on entry is skipped whenever
 another invocation is in flight.
 
+The accepted limitation, stated so it is not rediscovered as a bug: while two invocations overlap,
+one that dies on a missing import before allocating anything can see the other's allocation and
+re-raise rather than reporting 78. Making that precise requires attributing an allocation to an
+invocation, and allocation happens on a thread the entry point did not create, so attribution means
+threading a token through `run_async` into every command's async body — a change to a shared
+concurrency primitive, for an entry point that is not supported, to turn an ambiguous report into a
+precise one. Revisit if concurrent in-process invocation ever becomes supported.
+
 ## `dispatch.py` — dispatch outbox (ADR-0059)
 
 Module docstring: `li dispatch` inspects and acknowledges durable `dispatch_outbox` rows.

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -239,6 +239,20 @@ surfaced as a UI note in `_detect_degraded`/`_audit_degraded` in that same modul
 not an internal failure — it lands in the same terminal bucket as a runtime-cancelled task
 (same reason class, same exit code 143) rather than a new status.
 
+**`EXIT_CODE_ENVIRONMENT_ERROR` (78)** — the installation cannot start. A `ModuleNotFoundError`
+reaching the top of `main()` means an import failed and nothing handled it, so no command ran at
+all. This is deliberately outside `EXIT_CODE_BY_STATUS`, because it is not a run status: there is
+no run. It exits 78 (`EX_CONFIG`) rather than 1 so that a caller can tell a broken environment
+from a run that started and failed, which both used to exit 1 with a traceback. A wrapper that
+reads only the exit status and the presence of an artifact would otherwise report a missing
+dependency as the agent's own empty or crashed result, and attribute an environment outage to
+whatever the agent had been asked to do.
+
+The traceback is printed first because it names the import chain that reached the missing module;
+the one-line summary is emitted last through the CLI error logger, so a caller keeping only the
+tail of stderr still receives the diagnosis. Callers distinguishing the two cases should test for
+78 specifically; every other exit code retains its existing meaning.
+
 ## `dispatch.py` — dispatch outbox (ADR-0059)
 
 Module docstring: `li dispatch` inspects and acknowledges durable `dispatch_outbox` rows.

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -253,6 +253,21 @@ the one-line summary is emitted last through the CLI error logger, so a caller k
 tail of stderr still receives the diagnosis. Callers distinguishing the two cases should test for
 78 specifically; every other exit code retains its existing meaning.
 
+A missing module reaches this state from two places, and both are covered:
+
+- **While loading a command.** Command modules are imported lazily once one is selected, behind a
+  broad handler that reports a command-scoped error. A missing dependency is split out of that
+  handler and returns 78 with the same concise report — a traceback for a command that never
+  started is noise, and naming the module is the whole diagnosis at that point.
+- **Anywhere else before a run exists.** The wrapper in `main()` catches what escapes.
+
+The boundary on the second is a run having been allocated. `allocate_run` sets a process-level
+marker, and once it is set a `ModuleNotFoundError` is *not* reported as an environment fault: a run
+id, a run directory and a manifest exist on disk, so telling the caller nothing was executed would
+be the same misattribution pointed the other way. Such an error propagates and is reported the way
+any other failure during a run is. This is why a lazily imported provider extra going missing
+mid-run does not exit 78.
+
 ## `dispatch.py` — dispatch outbox (ADR-0059)
 
 Module docstring: `li dispatch` inspects and acknowledges durable `dispatch_outbox` rows.

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from lionagi._paths import RUNS_ROOT, ensure_lionagi_dir
-from lionagi.cli._util import AmbiguousIdError
+from lionagi.cli._util import AmbiguousIdError, mark_run_allocated
 from lionagi.libs.path_safety import validate_path_component
 from lionagi.ln._utils import now_utc
 from lionagi.providers._provider_errors import ProviderError
@@ -220,6 +220,11 @@ def allocate_run(
     run = RunDir(run_id=rid, state_root=state_root, artifact_root=artifact_root)
     run.ensure_state_dirs()
     run.ensure_artifact_root()
+    # From here on there is durable state on disk under this run id, so a later
+    # failure is a failed run and must not be reported as an unusable
+    # environment. Marked here rather than at the call sites so every caller,
+    # including ones added later, is covered.
+    mark_run_allocated()
     run.write_manifest(
         {
             "status": "running",

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -42,32 +43,78 @@ EXIT_CODE_ENVIRONMENT_ERROR = 78
 # directory waiting to be read.
 #
 # The flag is set inside `allocate_run` rather than at each of its callers, so a
-# future caller is covered without having to know this exists. It is a
-# process-level fact because the exit status it guards is a process-level fact.
+# future caller is covered without having to know this exists.
+#
+# It is deliberately process-wide, and NOT a thread-local or a ContextVar, even
+# though the fact it records is invocation-scoped. `run_async` drives every
+# command's async body on its own thread with its own event loop, so allocation
+# happens on a different thread — and in a fresh context — from the one the
+# entry point returns on. Either narrower scope would therefore be invisible to
+# the reader and would report "no run was started" while a run exists, which is
+# precisely the false claim this guards against. The narrower scope looks safer
+# and is the more dangerous of the two.
+#
+# What process-wide state costs is precision when two invocations overlap inside
+# one process, which is not a supported entry point but also must not be allowed
+# to produce a lie. The two directions are not equally bad. Seeing another
+# invocation's allocation only re-raises, which is the behaviour that predates
+# this code: ambiguous, not untrue. Losing an allocation, on the other hand,
+# asserts that nothing ran when something did. So the reset is what needs
+# guarding, and it only happens when no other invocation is in flight; anything
+# less certain leaves the flag alone and degrades to the older behaviour.
+_allocation_lock = threading.Lock()
+_invocations_in_flight = 0
 _run_allocated = False
 
 
 def mark_run_allocated() -> None:
     """Record that a run directory now exists for this invocation."""
     global _run_allocated
-    _run_allocated = True
+    with _allocation_lock:
+        _run_allocated = True
+
+
+def begin_invocation() -> None:
+    """Enter an invocation, resetting the marker when it is safe to.
+
+    The question the flag answers is whether *this* invocation allocated a run,
+    so a process that calls the entry point more than once - the test suite
+    does, and so would any in-process embedding - must not carry the first run's
+    allocation into the second. Resetting unconditionally would do that, but it
+    would also let a second invocation erase a first one's allocation while the
+    first is still running, so the reset is skipped whenever anything else is in
+    flight.
+    """
+    global _invocations_in_flight, _run_allocated
+    with _allocation_lock:
+        if _invocations_in_flight == 0:
+            _run_allocated = False
+        _invocations_in_flight += 1
+
+
+def end_invocation() -> None:
+    """Leave an invocation, so a later one can reset the marker again."""
+    global _invocations_in_flight
+    with _allocation_lock:
+        if _invocations_in_flight > 0:
+            _invocations_in_flight -= 1
 
 
 def clear_run_allocation() -> None:
-    """Reset the marker at the start of an invocation.
+    """Reset both the marker and the in-flight count.
 
-    The question the flag answers is whether *this* invocation allocated a run,
-    so it has to start false every time. A process that calls the entry point
-    more than once - the test suite does, and so would any in-process embedding
-    of the CLI - would otherwise carry the first run's allocation forward and
-    misreport every later broken-environment exit as a failed run.
+    For tests and embeddings that need a known starting state, rather than for
+    the entry point, which goes through `begin_invocation`.
     """
-    global _run_allocated
-    _run_allocated = False
+    global _run_allocated, _invocations_in_flight
+    with _allocation_lock:
+        _run_allocated = False
+        _invocations_in_flight = 0
 
 
 def run_was_allocated() -> bool:
-    return _run_allocated
+    with _allocation_lock:
+        return _run_allocated
 
 
 def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> str | None:

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -30,6 +30,45 @@ EXIT_CODE_BY_STATUS: dict[str, int] = {
 # above.
 EXIT_CODE_ENVIRONMENT_ERROR = 78
 
+# Whether this invocation got as far as allocating a run.
+#
+# The code above may only be reported while this is false. A missing import can
+# surface at two very different moments: before anything started, where nothing
+# ran and the environment is the whole story, and part-way through a command
+# that already allocated a run, where a run id, a run directory and a manifest
+# exist on disk. Reporting the second as an unusable environment is the same
+# misattribution the exit code exists to prevent, pointed the other way: it
+# tells a caller nothing was executed while durable state is sitting in the runs
+# directory waiting to be read.
+#
+# The flag is set inside `allocate_run` rather than at each of its callers, so a
+# future caller is covered without having to know this exists. It is a
+# process-level fact because the exit status it guards is a process-level fact.
+_run_allocated = False
+
+
+def mark_run_allocated() -> None:
+    """Record that a run directory now exists for this invocation."""
+    global _run_allocated
+    _run_allocated = True
+
+
+def clear_run_allocation() -> None:
+    """Reset the marker at the start of an invocation.
+
+    The question the flag answers is whether *this* invocation allocated a run,
+    so it has to start false every time. A process that calls the entry point
+    more than once - the test suite does, and so would any in-process embedding
+    of the CLI - would otherwise carry the first run's allocation forward and
+    misreport every later broken-environment exit as a failed run.
+    """
+    global _run_allocated
+    _run_allocated = False
+
+
+def run_was_allocated() -> bool:
+    return _run_allocated
+
 
 def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> str | None:
     """Fail fast when a user-supplied working directory doesn't exist.

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -19,6 +19,17 @@ EXIT_CODE_BY_STATUS: dict[str, int] = {
     "cancelled": 143,
 }
 
+# A run never reaches a status when the environment cannot import what the CLI
+# needs, so this code deliberately sits outside the map above. It exists to be
+# distinguishable: an installation missing a dependency previously exited 1
+# with a traceback, which is the same thing a run that started and failed
+# reports, so a wrapper reading only the exit status could not tell a broken
+# environment from a genuine failure and would attribute the outage to whatever
+# the agent had been asked to do. 78 is EX_CONFIG from sysexits, meaning
+# something was found in an unconfigured state, and it collides with no status
+# above.
+EXIT_CODE_ENVIRONMENT_ERROR = 78
+
 
 def validate_cwd_exists(cwd: str | None, *, flag: str = "--cwd") -> str | None:
     """Fail fast when a user-supplied working directory doesn't exist.

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -62,6 +62,18 @@ EXIT_CODE_ENVIRONMENT_ERROR = 78
 # asserts that nothing ran when something did. So the reset is what needs
 # guarding, and it only happens when no other invocation is in flight; anything
 # less certain leaves the flag alone and degrades to the older behaviour.
+#
+# The remaining imprecision is stated rather than left to be rediscovered: while
+# two invocations overlap, one that dies on a missing import before allocating
+# anything can see the other's allocation and re-raise instead of reporting 78.
+# That is the degraded-to-older-behaviour direction, and it is accepted. Fixing
+# it needs the allocation to be attributable to an invocation, and allocation
+# happens on a thread this code did not create, so attribution means propagating
+# an invocation token through `run_async` into every command's async body. That
+# is a change to a shared concurrency primitive on behalf of an entry point that
+# is not supported, to convert an ambiguous report into a precise one. If
+# concurrent in-process invocation ever becomes supported, this is the thing to
+# revisit, and the token is the design to revisit it with.
 _allocation_lock = threading.Lock()
 _invocations_in_flight = 0
 _run_allocated = False

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -14,7 +14,11 @@ from importlib import import_module
 from types import ModuleType
 
 from ._logging import configure_cli_logging, log_error
-from ._util import EXIT_CODE_ENVIRONMENT_ERROR
+from ._util import (
+    EXIT_CODE_ENVIRONMENT_ERROR,
+    clear_run_allocation,
+    run_was_allocated,
+)
 
 
 def _load_agent() -> ModuleType:
@@ -623,8 +627,24 @@ def _run(argv: list[str] | None = None) -> int:
     selected = _COMMAND_BY_NAME.get(_argv[0]) if _argv else None
     try:
         parser, selected_parser = _build_parser(selected)
+    except ModuleNotFoundError as exc:
+        # A dependency missing from the environment is not a command-scoped
+        # error, even though it surfaces while loading one. Reported below it
+        # would exit 1, which is what a run that started and failed returns, so
+        # a caller could not tell an unusable environment from a real failure.
+        # Only the status changes here: the concise report stays, because a
+        # traceback for a command that never started was judged to be noise and
+        # naming the missing module is the whole diagnosis at this boundary.
+        # Nothing has run at this point — the parser is still being built.
+        missing = exc.name or "a required module"
+        log_error(
+            f"command {_argv[0]!r} cannot run: {missing} is not installed in this "
+            "environment. No run was started, so this is an unusable environment "
+            "rather than a failed run. Install the missing dependency, then re-run."
+        )
+        return EXIT_CODE_ENVIRONMENT_ERROR
     except Exception as exc:
-        # A lazy command module that fails to import surfaces here at
+        # Any other lazy command module that fails to import surfaces here at
         # dispatch; report it as a command-scoped error, not a traceback.
         log_error(f"command {_argv[0]!r} failed to load: {type(exc).__name__}: {exc}")
         return 1
@@ -727,11 +747,13 @@ def _report_broken_environment(exc: ModuleNotFoundError) -> int:
     """Report a missing import as an environment fault, not a failed run.
 
     A ``ModuleNotFoundError`` reaching the top of the CLI means some import
-    failed and nothing along the way handled it. Whatever the command was, it
-    never got the chance to run, so reporting it the way a failed run is
-    reported tells every caller the wrong thing: the command looks like it
-    executed and came back empty. That is how a dependency dropping out of an
+    failed and nothing along the way handled it. Reporting it the way a failed
+    run is reported tells every caller the wrong thing: the command looks like
+    it executed and came back empty. That is how a dependency dropping out of an
     environment reads downstream as a crashed agent.
+
+    Only called once it is established that no run was allocated, which is what
+    makes the message's claim true rather than merely likely. See ``main``.
 
     The traceback is printed first because it names the import chain and is the
     only thing that identifies which package went missing and from where. The
@@ -742,16 +764,30 @@ def _report_broken_environment(exc: ModuleNotFoundError) -> int:
     missing = exc.name or "a required module"
     log_error(
         f"cannot start: {missing} is not installed in this environment. "
-        "This is a broken installation, not a failed run - nothing was "
-        "executed. Reinstall lionagi in this environment, then re-run."
+        "No run was started, so this is an unusable environment rather than a "
+        "failed run. Install the missing dependency, then re-run."
     )
     return EXIT_CODE_ENVIRONMENT_ERROR
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``li`` console script.
+
+    Wraps the real implementation so that a missing dependency is reported as a
+    broken environment rather than as a failed run, but only where that is
+    actually true. A lazily imported module can go missing after a command has
+    already allocated a run, and there a run id, a run directory and a manifest
+    exist on disk; calling that an unusable environment would tell the caller
+    nothing was executed while durable state sits in the runs directory. So the
+    allocation marker decides, and once a run exists the error is left to
+    propagate and be reported the way any other failure during a run is.
+    """
+    clear_run_allocation()
     try:
         return _run(argv)
     except ModuleNotFoundError as exc:
+        if run_was_allocated():
+            raise
         return _report_broken_environment(exc)
 
 

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -16,7 +16,8 @@ from types import ModuleType
 from ._logging import configure_cli_logging, log_error
 from ._util import (
     EXIT_CODE_ENVIRONMENT_ERROR,
-    clear_run_allocation,
+    begin_invocation,
+    end_invocation,
     run_was_allocated,
 )
 
@@ -421,6 +422,19 @@ def _handle_play_check(argv: list[str]) -> int:
 
             profile = load_agent_profile(agent_name)
             agent_defaults = getattr(profile, "artifact_defaults", None)
+        except ModuleNotFoundError as exc:
+            # The profile is fine; this installation cannot load it. Nothing has
+            # run, so this is the environment, and returning the ordinary
+            # failure code here would make it indistinguishable from a check
+            # that found a genuinely broken playbook.
+            missing = exc.name or "a required module"
+            log_error(
+                f"playbook '{name}' references agent profile '{agent_name}', "
+                f"which needs {missing}, and it is not installed in this "
+                f"environment. Nothing was checked and no run was started. "
+                f"Install the missing dependency, then re-run."
+            )
+            return EXIT_CODE_ENVIRONMENT_ERROR
         except Exception as exc:  # noqa: BLE001 — match runtime behaviour
             log_error(
                 f"playbook '{name}' references agent profile "
@@ -782,13 +796,15 @@ def main(argv: list[str] | None = None) -> int:
     allocation marker decides, and once a run exists the error is left to
     propagate and be reported the way any other failure during a run is.
     """
-    clear_run_allocation()
+    begin_invocation()
     try:
         return _run(argv)
     except ModuleNotFoundError as exc:
         if run_was_allocated():
             raise
         return _report_broken_environment(exc)
+    finally:
+        end_invocation()
 
 
 if __name__ == "__main__":

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 import argparse
 import signal
 import sys
+import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module
 from types import ModuleType
 
 from ._logging import configure_cli_logging, log_error
+from ._util import EXIT_CODE_ENVIRONMENT_ERROR
 
 
 def _load_agent() -> ModuleType:
@@ -554,7 +556,7 @@ def _get_version() -> str:
     return __version__
 
 
-def main(argv: list[str] | None = None) -> int:
+def _run(argv: list[str] | None = None) -> int:
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     # Resolve verbose before any CLI code emits (argparse hasn't run yet).
@@ -719,6 +721,38 @@ def main(argv: list[str] | None = None) -> int:
 
     parser.print_help()
     return 1
+
+
+def _report_broken_environment(exc: ModuleNotFoundError) -> int:
+    """Report a missing import as an environment fault, not a failed run.
+
+    A ``ModuleNotFoundError`` reaching the top of the CLI means some import
+    failed and nothing along the way handled it. Whatever the command was, it
+    never got the chance to run, so reporting it the way a failed run is
+    reported tells every caller the wrong thing: the command looks like it
+    executed and came back empty. That is how a dependency dropping out of an
+    environment reads downstream as a crashed agent.
+
+    The traceback is printed first because it names the import chain and is the
+    only thing that identifies which package went missing and from where. The
+    single-line summary goes last so that a caller which keeps only the tail of
+    stderr still receives the diagnosis rather than the middle of a stack.
+    """
+    traceback.print_exc()
+    missing = exc.name or "a required module"
+    log_error(
+        f"cannot start: {missing} is not installed in this environment. "
+        "This is a broken installation, not a failed run - nothing was "
+        "executed. Reinstall lionagi in this environment, then re-run."
+    )
+    return EXIT_CODE_ENVIRONMENT_ERROR
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return _run(argv)
+    except ModuleNotFoundError as exc:
+        return _report_broken_environment(exc)
 
 
 if __name__ == "__main__":

--- a/lionagi/cli/mcp.py
+++ b/lionagi/cli/mcp.py
@@ -43,6 +43,14 @@ def run_mcp(args: argparse.Namespace) -> int:
         log_error(f"unknown mcp action: {args.action}")
         return 2
     try:
+        # `lionagi.mcp` is deliberately dependency-free, so importing it proves
+        # nothing about whether the server can run. The server module is what
+        # needs the extra, so it is imported here, explicitly and before
+        # serving. That keeps the classification below on the import, where
+        # "nothing was started" is true, rather than wrapping the serve loop,
+        # where a lazy import failing mid-session would be misreported as an
+        # installation that never started.
+        import lionagi.mcp.server  # noqa: F401
         from lionagi.mcp import serve
     except ModuleNotFoundError as exc:
         # The extra is not installed. The server never started and nothing ran,

--- a/lionagi/cli/mcp.py
+++ b/lionagi/cli/mcp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 
 from ._logging import log_error
+from ._util import EXIT_CODE_ENVIRONMENT_ERROR
 
 __all__ = ("add_mcp_subparser", "run_mcp")
 
@@ -43,7 +44,22 @@ def run_mcp(args: argparse.Namespace) -> int:
         return 2
     try:
         from lionagi.mcp import serve
+    except ModuleNotFoundError as exc:
+        # The extra is not installed. The server never started and nothing ran,
+        # so this is the environment rather than a failed command, and returning
+        # the ordinary failure code would leave a caller unable to tell an
+        # uninstalled extra from a server that started and died.
+        missing = exc.name or "a required module"
+        log_error(
+            f"cannot serve: {missing} is not installed in this environment. "
+            "The MCP server needs the 'mcp' extra: install lionagi[mcp], then "
+            "re-run. Nothing was started."
+        )
+        return EXIT_CODE_ENVIRONMENT_ERROR
     except ImportError as exc:
+        # The module is present but something in it could not be imported. That
+        # is a defect in what is installed, not a missing piece of it, so it
+        # keeps the ordinary failure code.
         log_error(str(exc))
         return 1
     serve()

--- a/lionagi/mcp/__init__.py
+++ b/lionagi/mcp/__init__.py
@@ -20,9 +20,21 @@ def serve() -> None:
     """Run the MCP server over stdio. Requires the ``mcp`` extra."""
     try:
         from .server import main
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised via the CLI path
+        # Re-raised as the same type, not as a plain ImportError. A caller
+        # deciding whether this installation is unusable or merely broken keys
+        # off the type, and flattening it here would discard exactly the fact
+        # that distinguishes "the extra is not installed" from "the extra is
+        # installed and something in it is wrong". `name` is carried through for
+        # the same reason: it is what a caller reports.
+        raise ModuleNotFoundError(
+            "the lionagi MCP server requires the 'mcp' extra; "
+            "install it with: pip install 'lionagi[mcp]'",
+            name=exc.name,
+        ) from exc
     except ImportError as exc:  # pragma: no cover - exercised via the CLI path
         raise ImportError(
-            "the lionagi MCP server requires the 'mcp' extra; "
-            "install it with: pip install 'lionagi[mcp]'"
+            "the lionagi MCP server could not be imported; the 'mcp' extra is "
+            "present but something in it failed to load"
         ) from exc
     main()

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -306,6 +306,42 @@ def test_the_marker_survives_allocation_on_another_thread(monkeypatch, reported)
     assert reported == []
 
 
+@pytest.mark.parametrize(
+    ("raised", "expected_code"),
+    [
+        (ModuleNotFoundError("No module named 'fastmcp'", name="fastmcp"), 78),
+        (ImportError("cannot import name 'serve'"), 1),
+    ],
+)
+def test_li_mcp_separates_a_missing_extra_from_a_broken_one(monkeypatch, raised, expected_code):
+    """`li mcp` imports an optional extra, and the two ways that fails differ.
+
+    An extra that is not installed means the server never started and nothing
+    ran. An extra that is installed but cannot be imported is a defect in what is
+    present. Reporting both with the ordinary failure code leaves a caller unable
+    to tell "install this" from "this installation is broken", and the handler
+    catches the wider of the two exception types, so the narrower one has to be
+    split out ahead of it.
+    """
+    import argparse
+
+    from lionagi.cli import mcp as cli_mcp
+
+    blocked = "lionagi.mcp"
+
+    class _RefuseOne:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == blocked or fullname.startswith(blocked + "."):
+                raise raised
+            return None
+
+    for name in [m for m in list(sys.modules) if m == blocked or m.startswith(blocked + ".")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_RefuseOne(), *sys.meta_path])
+
+    assert cli_mcp.run_mcp(argparse.Namespace(action="serve")) == expected_code
+
+
 def test_other_exceptions_are_not_swallowed(monkeypatch):
     """Only a missing module means the environment cannot start.
 

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -363,6 +363,73 @@ def test_li_mcp_separates_a_missing_extra_from_a_broken_one(raised, expected_cod
     assert proc.returncode == expected_code, proc.stderr
 
 
+@pytest.mark.parametrize(
+    ("raised", "expected_type", "expected_name"),
+    [
+        (
+            "ModuleNotFoundError(\"No module named 'fastmcp'\", name='fastmcp')",
+            "ModuleNotFoundError",
+            "fastmcp",
+        ),
+        ("ImportError(\"cannot import name 'FastMCP'\")", "ImportError", None),
+    ],
+)
+def test_serve_reports_a_missing_extra_as_a_missing_module(raised, expected_type, expected_name):
+    """`serve()` keeps the distinction in the exception type it raises.
+
+    `li mcp` does not depend on this: it imports the server module itself, so it
+    sees the original error before `serve()` is ever called. The caller that does
+    depend on it is `python -m lionagi.mcp`, which calls `serve()` directly and
+    has nothing else to key off. Without this test the type is pinned only where
+    it happens to be redundant, and flattening it to a plain ImportError would
+    leave every test passing while that entry point lost the distinction.
+
+    `name` is asserted too, because it is what a caller reports to a human and it
+    is dropped by the obvious wrong implementation.
+    """
+    script = textwrap.dedent(
+        f"""
+        import sys
+
+        BLOCKED = "fastmcp"
+
+        class _RefuseOne:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == BLOCKED or fullname.startswith(BLOCKED + "."):
+                    raise {raised}
+                return None
+
+        for name in [m for m in list(sys.modules)
+                     if m == BLOCKED or m.startswith(BLOCKED + ".")]:
+            del sys.modules[name]
+        sys.meta_path.insert(0, _RefuseOne())
+
+        from lionagi.mcp import serve
+
+        try:
+            serve()
+        except BaseException as exc:
+            print(type(exc).__name__)
+            print(getattr(exc, "name", None))
+            sys.exit(0)
+        sys.exit(1)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    seen_type, seen_name = proc.stdout.split()[:2]
+    assert seen_type == expected_type, proc.stdout
+    assert seen_name == str(expected_name), proc.stdout
+
+
 def test_other_exceptions_are_not_swallowed(monkeypatch):
     """Only a missing module means the environment cannot start.
 

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -25,8 +25,11 @@ import pytest
 from lionagi.cli._util import (
     EXIT_CODE_BY_STATUS,
     EXIT_CODE_ENVIRONMENT_ERROR,
+    begin_invocation,
     clear_run_allocation,
+    end_invocation,
     mark_run_allocated,
+    run_was_allocated,
 )
 
 # `from lionagi.cli import main` is not a handle on this module. What it yields
@@ -243,6 +246,64 @@ def test_a_previous_invocations_run_does_not_suppress_the_report(monkeypatch, re
 
     assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
     assert "sniffio" in "\n".join(reported)
+
+
+def test_an_overlapping_invocation_does_not_erase_an_allocation():
+    """The reset is the dangerous operation, so it only runs when nothing is in flight.
+
+    The two ways overlapping invocations can go wrong are not equally bad.
+    Seeing another invocation's allocation only re-raises, which is what
+    happened before any of this existed. Losing one asserts that nothing ran
+    while a run directory sits on disk, which is the false claim the exit code
+    exists to prevent, so that direction has to be impossible.
+    """
+    begin_invocation()
+    mark_run_allocated()
+
+    begin_invocation()  # a second invocation starts while the first is running
+    assert run_was_allocated(), "the second entry erased the first one's allocation"
+
+    end_invocation()
+    end_invocation()
+
+
+def test_a_finished_invocation_lets_the_next_one_reset():
+    """Guarding the reset must not disable it, or the marker latches on forever.
+
+    Once nothing is in flight the fact is stale, and a later broken environment
+    in the same process has to be reported as one.
+    """
+    begin_invocation()
+    mark_run_allocated()
+    end_invocation()
+
+    begin_invocation()
+    assert not run_was_allocated()
+    end_invocation()
+
+
+def test_the_marker_survives_allocation_on_another_thread(monkeypatch, reported):
+    """Allocation does not happen on the thread that returns the exit code.
+
+    `run_async` drives each command's async body on its own thread with its own
+    event loop, so a thread-local or a ContextVar would be invisible here and
+    would report that nothing ran while a run existed. This pins the property
+    that makes the process-wide marker the correct choice rather than the lazy
+    one.
+    """
+    import threading
+
+    def _boom(argv=None):
+        worker = threading.Thread(target=mark_run_allocated)
+        worker.start()
+        worker.join()
+        raise ModuleNotFoundError("No module named 'some_provider'", name="some_provider")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    with pytest.raises(ModuleNotFoundError):
+        cli_main.main([])
+    assert reported == []
 
 
 def test_other_exceptions_are_not_swallowed(monkeypatch):

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -14,16 +14,30 @@ never ran.
 from __future__ import annotations
 
 import importlib
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 
 import pytest
 
-from lionagi.cli._util import EXIT_CODE_BY_STATUS, EXIT_CODE_ENVIRONMENT_ERROR
+from lionagi.cli._util import (
+    EXIT_CODE_BY_STATUS,
+    EXIT_CODE_ENVIRONMENT_ERROR,
+    clear_run_allocation,
+    mark_run_allocated,
+)
 
-# `from lionagi.cli import main` would bind the re-exported main() function
-# rather than this module, because the package attribute shadows the submodule
-# of the same name, and monkeypatching an attribute on a function silently
-# patches nothing a caller reads.
+# `from lionagi.cli import main` is not a handle on this module. What it yields
+# depends on import order: the package's __getattr__ pins the re-exported
+# main() function, while importing the submodule binds the module onto the same
+# package attribute. Monkeypatching an attribute on whichever of the two is
+# bound may silently patch nothing a caller reads, so the module is taken by
+# name.
 cli_main = importlib.import_module("lionagi.cli.main")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_environment_code_collides_with_no_run_status() -> None:
@@ -36,7 +50,7 @@ def test_environment_code_collides_with_no_run_status() -> None:
     assert EXIT_CODE_ENVIRONMENT_ERROR not in set(EXIT_CODE_BY_STATUS.values())
 
 
-def test_missing_dependency_exits_with_the_environment_code(monkeypatch, caplog):
+def test_missing_dependency_exits_with_the_environment_code(monkeypatch, reported):
     def _boom(argv=None):
         raise ModuleNotFoundError("No module named 'sniffio'", name="sniffio")
 
@@ -44,11 +58,11 @@ def test_missing_dependency_exits_with_the_environment_code(monkeypatch, caplog)
 
     assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
 
-    # The summary goes through the CLI error logger, so it is captured here
-    # rather than in the stderr stream that carries the traceback.
-    summary = caplog.text
+    summary = "\n".join(reported)
     assert "sniffio" in summary
-    assert "not a failed run" in summary
+    # The claim a caller acts on: no run exists, so there is nothing to go and
+    # read and the environment is the whole story.
+    assert "No run was started" in summary
 
 
 def test_the_traceback_survives(monkeypatch, capsys):
@@ -70,7 +84,7 @@ def test_the_traceback_survives(monkeypatch, capsys):
     assert "ModuleNotFoundError" in err
 
 
-def test_a_nameless_module_error_still_reports(monkeypatch, caplog):
+def test_a_nameless_module_error_still_reports(monkeypatch, reported):
     """``exc.name`` is optional, and a crash while reporting a crash is worse
     than a vague message."""
 
@@ -80,7 +94,7 @@ def test_a_nameless_module_error_still_reports(monkeypatch, caplog):
     monkeypatch.setattr(cli_main, "_run", _boom)
 
     assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
-    assert "a required module" in caplog.text
+    assert "a required module" in "\n".join(reported)
 
 
 @pytest.mark.parametrize("code", [0, 1, 2, 124, 130])
@@ -89,6 +103,146 @@ def test_ordinary_exit_codes_pass_through(monkeypatch, code):
 
     monkeypatch.setattr(cli_main, "_run", lambda argv=None: code)
     assert cli_main.main([]) == code
+
+
+@pytest.fixture
+def reported(monkeypatch) -> list[str]:
+    """Collect what the CLI reports, without depending on logging configuration.
+
+    `configure_cli_logging` turns propagation off on the CLI logger, so whether
+    `caplog` sees a message depends on whether some earlier test in the session
+    already configured logging. Asserting through it made these tests pass or
+    fail on execution order rather than on behaviour. The message text is what
+    these tests are about; that it genuinely reaches stderr, last, is pinned by
+    the subprocess test below, which configures nothing and reads the real
+    stream.
+    """
+    messages: list[str] = []
+    monkeypatch.setattr(cli_main, "log_error", messages.append)
+    return messages
+
+
+@pytest.fixture(autouse=True)
+def _no_run_allocated():
+    """Keep the process-level allocation marker from leaking between tests.
+
+    Some tests here set it deliberately, and any other test in the session that
+    allocates a run sets it too. Left set, it would silently turn the assertions
+    below into their opposite.
+    """
+    clear_run_allocation()
+    yield
+    clear_run_allocation()
+
+
+def test_the_loader_boundary_does_not_absorb_a_missing_dependency(monkeypatch, reported):
+    """A missing dependency found while loading a command is still the environment.
+
+    Command modules are imported lazily when one is selected, and that import
+    sits behind a broad `except Exception` which reports a command-scoped error
+    and returns 1. A dependency missing from the environment would be caught
+    there and reported as an ordinary failure, which is exactly the collision
+    the distinct code exists to remove, so it has to reach the entry point
+    instead.
+    """
+
+    def _boom(selected):
+        raise ModuleNotFoundError("No module named 'somedep'", name="somedep")
+
+    monkeypatch.setattr(cli_main, "_build_parser", _boom)
+
+    assert cli_main.main(["doctor"]) == EXIT_CODE_ENVIRONMENT_ERROR
+    assert "somedep" in "\n".join(reported)
+
+
+def test_a_missing_command_module_reports_the_environment_end_to_end():
+    """The same path again, with nothing patched.
+
+    The test above pins the boundary but supplies the error itself. Here the
+    import genuinely fails: a meta-path finder refuses one command module, the
+    CLI is asked for that command, and the real lazy loader raises. This is the
+    configuration the feature exists for, so it is worth paying a subprocess
+    for.
+
+    A caller that keeps only the tail of stderr has to receive the diagnosis, so
+    the report is asserted to be the last thing written.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED = "lionagi.cli.doctor"
+
+        class _RefuseOne:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == BLOCKED:
+                    raise ModuleNotFoundError(
+                        f"No module named {fullname!r}", name=fullname
+                    )
+                return None
+
+        sys.modules.pop(BLOCKED, None)
+        sys.meta_path.insert(0, _RefuseOne())
+
+        from lionagi.cli.main import main
+
+        sys.exit(main(["doctor"]))
+        """
+    )
+    # Run from the source tree, so the subprocess imports the code under test.
+    # An installed lionagi may sit in the same interpreter and would otherwise
+    # answer instead, which makes the test report on a build nobody changed.
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+
+    assert proc.returncode == EXIT_CODE_ENVIRONMENT_ERROR, proc.stderr
+    last_line = [line for line in proc.stderr.splitlines() if line.strip()][-1]
+    assert "lionagi.cli.doctor" in last_line
+    assert "No run was started" in last_line
+
+
+def test_a_missing_import_after_a_run_was_allocated_is_not_an_environment_fault(monkeypatch):
+    """Once a run exists on disk, the same error means something different.
+
+    A run id, a run directory and a manifest are durable state a caller can go
+    and read. Reporting that as an unusable environment would claim nothing was
+    executed while the evidence says otherwise, which is the misattribution this
+    feature exists to prevent, running the other way. So it propagates and is
+    reported the way any other failure during a run is.
+    """
+
+    def _boom(argv=None):
+        mark_run_allocated()
+        raise ModuleNotFoundError("No module named 'some_provider'", name="some_provider")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    with pytest.raises(ModuleNotFoundError):
+        cli_main.main([])
+
+
+def test_a_previous_invocations_run_does_not_suppress_the_report(monkeypatch, reported):
+    """The marker answers a question about *this* invocation.
+
+    A process that runs the entry point more than once would otherwise carry the
+    first invocation's allocation forward, and every later broken environment
+    would be misreported as a failed run.
+    """
+    mark_run_allocated()
+
+    def _boom(argv=None):
+        raise ModuleNotFoundError("No module named 'sniffio'", name="sniffio")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
+    assert "sniffio" in "\n".join(reported)
 
 
 def test_other_exceptions_are_not_swallowed(monkeypatch):

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -310,36 +310,57 @@ def test_the_marker_survives_allocation_on_another_thread(monkeypatch, reported)
     ("raised", "expected_code"),
     [
         (ModuleNotFoundError("No module named 'fastmcp'", name="fastmcp"), 78),
-        (ImportError("cannot import name 'serve'"), 1),
+        (ImportError("cannot import name 'FastMCP'"), 1),
     ],
 )
-def test_li_mcp_separates_a_missing_extra_from_a_broken_one(monkeypatch, raised, expected_code):
-    """`li mcp` imports an optional extra, and the two ways that fails differ.
+def test_li_mcp_separates_a_missing_extra_from_a_broken_one(raised, expected_code):
+    """`li mcp` needs an optional extra, and the two ways that fails differ.
 
     An extra that is not installed means the server never started and nothing
     ran. An extra that is installed but cannot be imported is a defect in what is
-    present. Reporting both with the ordinary failure code leaves a caller unable
-    to tell "install this" from "this installation is broken", and the handler
-    catches the wider of the two exception types, so the narrower one has to be
-    split out ahead of it.
+    present rather than a missing piece of it. Reporting both with the ordinary
+    failure code leaves a caller unable to tell "install this" from "this
+    installation is broken".
+
+    The dependency blocked here is `fastmcp`, the package the extra actually
+    supplies, and the command is driven through `main()`. Blocking `lionagi.mcp`
+    instead would prove nothing: that package is deliberately dependency-free and
+    imports fine without the extra, so the real failure happens one level deeper
+    and would have been missed by a test that never reached it.
     """
-    import argparse
+    script = textwrap.dedent(
+        f"""
+        import sys
 
-    from lionagi.cli import mcp as cli_mcp
+        BLOCKED = "fastmcp"
+        RAISED = {raised!r}
 
-    blocked = "lionagi.mcp"
+        class _RefuseOne:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == BLOCKED or fullname.startswith(BLOCKED + "."):
+                    raise RAISED
+                return None
 
-    class _RefuseOne:
-        def find_spec(self, fullname, path=None, target=None):
-            if fullname == blocked or fullname.startswith(blocked + "."):
-                raise raised
-            return None
+        for name in [m for m in list(sys.modules)
+                     if m == BLOCKED or m.startswith(BLOCKED + ".")]:
+            del sys.modules[name]
+        sys.meta_path.insert(0, _RefuseOne())
 
-    for name in [m for m in list(sys.modules) if m == blocked or m.startswith(blocked + ".")]:
-        monkeypatch.delitem(sys.modules, name, raising=False)
-    monkeypatch.setattr(sys, "meta_path", [_RefuseOne(), *sys.meta_path])
+        from lionagi.cli.main import main
 
-    assert cli_mcp.run_mcp(argparse.Namespace(action="serve")) == expected_code
+        sys.exit(main(["mcp"]))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+
+    assert proc.returncode == expected_code, proc.stderr
 
 
 def test_other_exceptions_are_not_swallowed(monkeypatch):

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The CLI must report a broken environment as its own kind of failure.
+
+When a dependency is missing, every command dies during import and the CLI
+previously exited 1 with a traceback. A run that started and failed also exits
+1, so a caller reading the exit status could not tell the two apart, and a
+wrapper that expects an artifact would report the absent artifact as the
+command's own result. That misattribution is the thing these tests pin: the
+exit code must be distinct, and the last line of stderr must say the command
+never ran.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from lionagi.cli._util import EXIT_CODE_BY_STATUS, EXIT_CODE_ENVIRONMENT_ERROR
+
+# `from lionagi.cli import main` would bind the re-exported main() function
+# rather than this module, because the package attribute shadows the submodule
+# of the same name, and monkeypatching an attribute on a function silently
+# patches nothing a caller reads.
+cli_main = importlib.import_module("lionagi.cli.main")
+
+
+def test_environment_code_collides_with_no_run_status() -> None:
+    """The whole point is distinguishability, so a collision defeats it.
+
+    Asserted against the status map rather than a second literal: adding a
+    status that happens to use 78 would otherwise silently re-merge the two
+    cases this separation exists to keep apart.
+    """
+    assert EXIT_CODE_ENVIRONMENT_ERROR not in set(EXIT_CODE_BY_STATUS.values())
+
+
+def test_missing_dependency_exits_with_the_environment_code(monkeypatch, caplog):
+    def _boom(argv=None):
+        raise ModuleNotFoundError("No module named 'sniffio'", name="sniffio")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
+
+    # The summary goes through the CLI error logger, so it is captured here
+    # rather than in the stderr stream that carries the traceback.
+    summary = caplog.text
+    assert "sniffio" in summary
+    assert "not a failed run" in summary
+
+
+def test_the_traceback_survives(monkeypatch, capsys):
+    """The summary names the module; only the traceback names the import chain.
+
+    Which module is missing rarely identifies the cause on its own. What does
+    is the chain of module-level imports that reached it, so the summary must
+    add to the traceback rather than replace it.
+    """
+
+    def _boom(argv=None):
+        raise ModuleNotFoundError("No module named 'sniffio'", name="sniffio")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+    cli_main.main([])
+
+    err = capsys.readouterr().err
+    assert "Traceback" in err
+    assert "ModuleNotFoundError" in err
+
+
+def test_a_nameless_module_error_still_reports(monkeypatch, caplog):
+    """``exc.name`` is optional, and a crash while reporting a crash is worse
+    than a vague message."""
+
+    def _boom(argv=None):
+        raise ModuleNotFoundError("something went wrong")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    assert cli_main.main([]) == EXIT_CODE_ENVIRONMENT_ERROR
+    assert "a required module" in caplog.text
+
+
+@pytest.mark.parametrize("code", [0, 1, 2, 124, 130])
+def test_ordinary_exit_codes_pass_through(monkeypatch, code):
+    """The guard must not become a catch-all that rewrites real outcomes."""
+
+    monkeypatch.setattr(cli_main, "_run", lambda argv=None: code)
+    assert cli_main.main([]) == code
+
+
+def test_other_exceptions_are_not_swallowed(monkeypatch):
+    """Only a missing module means the environment cannot start.
+
+    Catching more than that would convert genuine failures into environment
+    reports, which is the same misattribution in the opposite direction.
+    """
+
+    def _boom(argv=None):
+        raise RuntimeError("a real failure")
+
+    monkeypatch.setattr(cli_main, "_run", _boom)
+
+    with pytest.raises(RuntimeError, match="a real failure"):
+        cli_main.main([])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -282,6 +282,46 @@ def test_play_check_playbook_with_contract(tmp_path, monkeypatch, capsys):
     assert "review" in out and "notes" in out
 
 
+@pytest.mark.parametrize(
+    ("raised", "expected_code", "expected_text"),
+    [
+        (ModuleNotFoundError("No module named 'thing'", name="thing"), 78, "thing"),
+        (RuntimeError("profile is malformed"), 1, "could not be loaded"),
+    ],
+)
+def test_play_check_separates_a_missing_module_from_a_bad_profile(
+    tmp_path, monkeypatch, caplog, raised, expected_code, expected_text
+):
+    """`li play check` loads the named agent profile, and that import can fail two ways.
+
+    A malformed profile is a real finding and the check should report it as a
+    failure. A profile this installation cannot import is not a finding at all:
+    nothing was checked, and returning the same code makes a broken environment
+    look like a playbook with a broken profile - which sends someone to edit a
+    file that is fine.
+    """
+    pb_path = tmp_path / "withagent.playbook.yaml"
+    pb_path.write_text("name: withagent\nmodel: claude/sonnet\nprompt: do z\nagent: someprofile\n")
+
+    from lionagi.cli import orchestrate as _orch
+
+    def fake_resolve(name):
+        return (pb_path, None) if name == "withagent" else _orch._resolve_playbook_path(name)
+
+    def fake_load(name):
+        raise raised
+
+    monkeypatch.setattr(_orch, "_resolve_playbook_path", fake_resolve)
+    monkeypatch.setattr("lionagi.cli.main._resolve_playbook_path", fake_resolve, raising=False)
+    monkeypatch.setattr("lionagi.cli._providers.load_agent_profile", fake_load)
+
+    with caplog.at_level("ERROR"):
+        result = _handle_play_shortcut(["play", "check", "withagent"])
+
+    assert result == expected_code
+    assert expected_text in caplog.text
+
+
 def test_play_check_playbook_without_contract(tmp_path, monkeypatch, capsys):
     """A playbook without `artifacts:` exits 0 and reports verification skipped."""
     pb_path = tmp_path / "plain.playbook.yaml"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 import yaml
 
+from lionagi.cli._util import EXIT_CODE_ENVIRONMENT_ERROR
 from lionagi.cli.main import _handle_play_shortcut, main
 from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
 
@@ -433,6 +434,42 @@ def test_broken_command_loader_reports_error_without_traceback(capsys, monkeypat
             "agent",
             "broken",
             lambda: __import__("missing_lionagi_command_module"),
+            "add_agent_subparser",
+            "run_agent",
+        ),
+    )
+    rc = main_module.main(["agent", "--help"])
+    # A module missing from the environment is reported as an unusable
+    # environment, not as a failed run: exit 1 here is what a run that started
+    # and failed returns, and a caller reading the status could not tell the two
+    # apart. The concise report is unchanged — only the status distinguishes.
+    assert rc == EXIT_CODE_ENVIRONMENT_ERROR
+    err = capsys.readouterr().err
+    assert "missing_lionagi_command_module" in err
+    assert "Traceback" not in err
+
+
+def test_a_command_loader_failing_for_another_reason_is_an_ordinary_failure(capsys, monkeypatch):
+    """Only a missing module means the environment is unusable.
+
+    The loader boundary splits on the exception type, so the other side of that
+    split needs its own case: a command module that imports fine but raises
+    while being set up is a defect in this installation's code, not a missing
+    piece of it, and reporting it as an unusable environment would send the
+    caller off to install something that is already there.
+    """
+    import lionagi.cli.main as main_module
+
+    def _explode():
+        raise RuntimeError("bad module")
+
+    monkeypatch.setitem(
+        main_module._COMMAND_BY_NAME,
+        "agent",
+        main_module._CommandSpec(
+            "agent",
+            "broken",
+            _explode,
             "add_agent_subparser",
             "run_agent",
         ),


### PR DESCRIPTION
## The problem

When a dependency is missing from the environment, every command dies during
import and the CLI exits 1 with a traceback. A run that started and failed
also exits 1. A caller reading the exit status cannot tell the two apart, so a
wrapper that expects an artifact sees a nonzero code and no artifact and
reports an environment fault as the agent's own crashed or empty result.

The consequence is that an outage gets attributed to whatever the agent had
been asked to do, and the environment is never suspected.

## The change

`main()` now delegates to `_run()` and converts a `ModuleNotFoundError` that
reaches the top into exit **78** (`EX_CONFIG`), with a line stating that
nothing was executed.

The code sits outside `EXIT_CODE_BY_STATUS` deliberately: no run reached a
status, because no run started. A test asserts it collides with none of the
status codes, so a future status cannot silently re-merge the two cases.

Only `ModuleNotFoundError` is converted. Catching more would turn genuine
failures into environment reports, which is the same misattribution running
the other way; a test pins that too.

The traceback prints first because it names the import chain that reached the
missing module, which is what identifies the cause. The one-line summary is
emitted last so a caller keeping only the tail of stderr still receives the
diagnosis.

## Verification

Measured on real installs rather than mocks. A core-only install of the parent
commit has no `sniffio`, which reproduces a broken environment:

| environment | command | before | after |
|---|---|---|---|
| missing dependency | `li --version` | exit 1, raw traceback | exit 78, traceback plus `error: cannot start: sniffio is not installed ... not a failed run` |
| healthy | `li --version` | exit 0 | exit 0 |
| healthy | unknown flag | exit 2 | exit 2 |
| healthy | unknown command | exit 2 | exit 2 |

Ten unit tests cover the exit code, the message, traceback survival, the
absent-`exc.name` path, pass-through of ordinary exit codes, and non-swallowing
of other exceptions. Removing the guard fails the suite, so it is not vacuous.

Exit codes are documented in `docs/internals/cli.md`, since a caller has to
know 78 exists in order to branch on it.