### PR TITLE
docs(agent): how to prove a guard is covered

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -53,9 +53,13 @@ When editing `session/`, `operations/`, or `cli/orchestrate/`: preserve these co
 - `lionagi/protocols/*` → `tests/protocols/*`
 - `lionagi/service/*` → `tests/service/*`
 - `lionagi/ln/*` → `tests/libs/concurrency/*`, `tests/ln/*`
-- `lionagi/cli/*` → smoke with `li o flow ... --dry-run` for structure or `--bare --yolo` for a short real run; add smoke assertions in `tests/docs/` when changing user-facing output shape.
+- `lionagi/cli/*` → `tests/cli/*`; additionally smoke with `li o flow ... --dry-run` for structure or `--bare --yolo` for a short real run, and add smoke assertions in `tests/docs/` when changing user-facing output shape.
 
-CLI has no dedicated unit test suite.
+### Proving a guard is actually covered
+
+A test that fails when you revert the whole fix proves only that *some* part of it matters. When a change has more than one part, revert each part on its own and check that the test still fails. Parts frequently reach the same outcome by different paths, and a part that stays green when reverted alone is pinned by nothing.
+
+A part that is individually redundant is not necessarily wrong — redundancy across entry points is often deliberate. What is wrong is the belief that a test covers it. Find the caller where that part is *not* redundant and pin it there.
 
 ## Coding Standards
 


### PR DESCRIPTION
Adds a short rule to the testing section of `AGENT.md`.

A test that fails when you revert a whole fix proves only that *some* part of it
matters. When a change has more than one part, each part has to be reverted on its
own. Parts frequently reach the same outcome by different paths, and a part that
stays green when reverted alone is pinned by nothing.

This came out of the exit-78 work. That change classified a missing optional extra
in two places, and reverting the whole thing failed the test as expected. Reverting
either half on its own left it green, because three paths reach exit 78: the local
handler at the CLI boundary, and the entry point's handler catching whatever
escapes. Flattening the exception type back to a plain `ImportError` would have left
the entire suite passing while `python -m lionagi.mcp` lost the distinction between
an uninstalled extra and a broken one, on the one entry point with no other signal.

The rule includes the part that is easy to drop: a part that is individually
redundant is not necessarily wrong, because redundancy across entry points is often
deliberate. The defect is in the coverage claim, not the code, and the fix is to pin
the part at the caller where it is not redundant.

Also corrects "CLI has no dedicated unit test suite" in the same section, which has
not been true for some time — `tests/cli` holds 78 test modules plus
`tests/cli/orchestrate`.

Docs only; no code paths touched.