### PR TITLE
fix(mcp): a run stopped by `li kill` reads as terminal, not as an orphan

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -746,6 +746,33 @@ produced nothing.
 
 ---
 
+## `li lifecycle`
+
+Report what the lifecycle store records about one CLI run.
+
+```bash
+li lifecycle <run-id> --machine
+```
+
+This is the one path from a run id to the rows the lifecycle writers actually
+write. A normal teardown records an end; so does `li kill`, which writes the
+row and signals the process without touching the MCP job record or the run
+manifest. A caller holding only a run id and reading only those two would see a
+dead process with no recorded end, which is what an orphaned run looks like.
+
+The answer is read-only and carries its own availability. An established answer
+with `found: false` means no session was ever recorded under this id. An
+unavailable one means the store could not be read at all, which is not a
+statement about the run. A caller that collapsed the two would report a run as
+finished, or as never started, on the strength of a database it never opened.
+
+The store consulted is the one `LIONAGI_STATE_DB_URL` names when it is set, and
+the default otherwise — including for the question of whether a store exists at
+all, so a configured store is never reported missing because the default path
+is absent.
+
+---
+
 ## Machine mode: `--machine`
 
 Any command that reaches the dispatcher accepts `--machine`, which turns its

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -38,6 +38,7 @@ __all__ = (
     "save_last_branch_pointer",
     "list_runs",
     "current_run_id",
+    "active_run_id",
     "resolve_run_reason",
     "setup_agent_persist",
     "teardown_persist",
@@ -57,6 +58,23 @@ def _new_run_id() -> str:
 def current_run_id() -> str | None:
     """Return the run_id inherited from the environment (subprocess case)."""
     return os.environ.get(_RUN_ID_ENV_VAR) or None
+
+
+# The run this process most recently allocated. Kept here rather than in the
+# environment because allocate_run() reads the environment to *inherit* an id,
+# so exporting one would make a second allocation in the same process silently
+# reuse the first run's directory.
+_ALLOCATED_RUN_ID: str | None = None
+
+
+def active_run_id() -> str | None:
+    """The run_id of the run this process is recording under, if any.
+
+    The run this process allocated, falling back to one inherited from a
+    parent. None when nothing has allocated a run yet — an embedded caller,
+    or the window before ``allocate_run`` runs.
+    """
+    return _ALLOCATED_RUN_ID or current_run_id()
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:
@@ -209,7 +227,10 @@ def allocate_run(
     run_id: str | None = None,
 ) -> RunDir:
     """Allocate a run dir, inheriting run_id from LIONAGI_RUN_ID env var if set (subprocess handoff)."""
+    global _ALLOCATED_RUN_ID
+
     rid = run_id or current_run_id() or _new_run_id()
+    _ALLOCATED_RUN_ID = rid
     state_root = RUNS_ROOT / rid
 
     if save_dir is not None:
@@ -1173,6 +1194,7 @@ async def setup_agent_persist(
             await db.create_session(
                 {
                     "id": session_id,
+                    "run_id": active_run_id(),
                     "created_at": session_dict["created_at"],
                     "node_metadata": _node_meta,
                     "name": session_dict.get("name"),

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -437,14 +437,19 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
     opened.
     """
     from lionagi.ln.concurrency import run_async
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         # No store at all is not evidence about one run: it is the absence of
         # every record, including the ones that would answer this question.
+        #
+        # Asked of the store this read will actually open, not of the default
+        # path. `LIONAGI_STATE_DB_URL` moves the store, and a check against the
+        # default would then report every run in a configured store as
+        # unreadable while the reader beside it opens that store and finds them.
         return {
             "run_id": run_id,
-            "lifecycle": unavailable(REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist"),
+            "lifecycle": unavailable(REASON_NOT_FOUND, f"{state_db_file()} does not exist"),
         }
 
     async def _read() -> list[dict[str, Any]]:

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -52,6 +52,9 @@ __all__ = (
     "run_handshake",
     "add_runs_subparser",
     "run_runs",
+    "lifecycle_data",
+    "add_lifecycle_subparser",
+    "run_lifecycle",
 )
 
 # The one place the current contract version lives. Incremented only by a change
@@ -336,6 +339,128 @@ def runs_data(limit: int = _DEFAULT_RUNS_LIMIT) -> dict[str, Any]:
     return {"runs": available(entries), "truncated": truncated, "limit": limit}
 
 
+# Session statuses that mean the run was stopped on purpose, and the one that
+# means the work came out right. Both are read off the lifecycle vocabulary the
+# StateDB owns; everything else terminal is a failure. This mapping lives here,
+# on the side that owns the vocabulary, so a consumer never keeps a copy.
+_CANCELLED_SESSION_STATUSES = frozenset({"cancelled", "aborted"})
+_SUCCEEDED_SESSION_STATUSES = frozenset({"completed"})
+
+
+def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold a run's session rows into one answer about the run.
+
+    `found` and `terminal` are separate questions and stay separate: no rows
+    means nothing was ever recorded, which is not the same fact as rows that
+    record no end. `terminal` needs every row to have ended, because a run that
+    persisted two sessions is over only when both are.
+    """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+    sessions = [
+        {
+            "session_id": row.get("id"),
+            "status": row.get("status"),
+            "terminal": row.get("status") in SESSION_TERMINAL_STATUSES,
+            "started_at": row.get("started_at"),
+            "ended_at": row.get("ended_at"),
+            "reason_code": row.get("status_reason_code"),
+            "reason_summary": row.get("status_reason_summary"),
+        }
+        for row in rows
+    ]
+    if not sessions:
+        return {
+            "found": False,
+            "terminal": False,
+            "status": None,
+            "outcome": None,
+            "reason_code": None,
+            "reason_summary": None,
+            "ended_at": None,
+            "sessions": [],
+        }
+
+    terminal = all(entry["terminal"] for entry in sessions)
+    if not terminal:
+        governing = next(entry for entry in sessions if not entry["terminal"])
+        return {
+            "found": True,
+            "terminal": False,
+            "status": governing["status"],
+            "outcome": None,
+            "reason_code": governing["reason_code"],
+            "reason_summary": governing["reason_summary"],
+            "ended_at": None,
+            "sessions": sessions,
+        }
+
+    statuses = {entry["status"] for entry in sessions}
+    if statuses & _CANCELLED_SESSION_STATUSES:
+        outcome = "cancelled"
+        governing = next(
+            entry for entry in sessions if entry["status"] in _CANCELLED_SESSION_STATUSES
+        )
+    elif statuses <= _SUCCEEDED_SESSION_STATUSES:
+        outcome = "succeeded"
+        governing = sessions[-1]
+    else:
+        outcome = "failed"
+        governing = next(
+            entry for entry in sessions if entry["status"] not in _SUCCEEDED_SESSION_STATUSES
+        )
+    ends = [entry["ended_at"] for entry in sessions if entry["ended_at"] is not None]
+    return {
+        "found": True,
+        "terminal": True,
+        "status": governing["status"],
+        "outcome": outcome,
+        "reason_code": governing["reason_code"],
+        "reason_summary": governing["reason_summary"],
+        "ended_at": max(ends) if ends else None,
+        "sessions": sessions,
+    }
+
+
+def lifecycle_data(run_id: str) -> dict[str, Any]:
+    """What the lifecycle store records about CLI run *run_id*.
+
+    This is the one machine-qualified path from a run_id to the rows the
+    lifecycle writers — a normal teardown, and `li kill` — actually write. It
+    reads only; nothing here changes a run.
+
+    `lifecycle` carries its own availability, and the distinction is the whole
+    point: an established answer with `found: false` means no session was ever
+    recorded under this id, while an unavailable one means the store could not
+    be read at all. A caller that collapsed the two would report a run as
+    finished, or as never started, on the strength of a database it never
+    opened.
+    """
+    from lionagi.ln.concurrency import run_async
+    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+    if not DEFAULT_DB_PATH.exists():
+        # No store at all is not evidence about one run: it is the absence of
+        # every record, including the ones that would answer this question.
+        return {
+            "run_id": run_id,
+            "lifecycle": unavailable(REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist"),
+        }
+
+    async def _read() -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.get_sessions_for_run(run_id)
+
+    try:
+        rows = run_async(_read())
+    except Exception as exc:  # noqa: BLE001 — an unreadable store is an answer, not a crash
+        return {
+            "run_id": run_id,
+            "lifecycle": unavailable(REASON_UNREADABLE, f"{type(exc).__name__}: {exc}"),
+        }
+    return {"run_id": run_id, "lifecycle": available(_lifecycle_summary(rows))}
+
+
 # ── Machine dispatch ────────────────────────────────────────────────────────
 
 
@@ -368,6 +493,21 @@ def _machine_runs(argv: list[str]) -> dict[str, Any]:
     return runs_data(known.limit)
 
 
+def _machine_lifecycle(argv: list[str]) -> dict[str, Any]:
+    parser = argparse.ArgumentParser(prog="li lifecycle", add_help=False)
+    parser.add_argument(
+        "run_id",
+        nargs="?",
+        help="The run id to report the recorded lifecycle state of.",
+    )
+    known, extras = parser.parse_known_args(argv)
+    if extras:
+        raise MachineError("invalid_input", f"unrecognized arguments: {' '.join(extras)}")
+    if not known.run_id or not known.run_id.strip():
+        raise MachineError("invalid_input", "li lifecycle needs a run id")
+    return lifecycle_data(known.run_id.strip())
+
+
 def _reject_extra_arguments(name: str, argv: list[str]) -> None:
     if argv:
         raise MachineError("invalid_input", f"li {name} takes no arguments: {' '.join(argv)}")
@@ -377,6 +517,7 @@ _MACHINE_COMMANDS: dict[str, Callable[[list[str]], dict[str, Any]]] = {
     "handshake": _machine_handshake,
     "doctor": _machine_doctor,
     "runs": _machine_runs,
+    "lifecycle": _machine_lifecycle,
 }
 
 
@@ -503,4 +644,42 @@ def run_runs(args: argparse.Namespace) -> int:
         print(f"{entry['run_id']}  {summary}")
     if data["truncated"]:
         print(f"(truncated at {data['limit']}; pass --limit for more)")
+    return 0
+
+
+def add_lifecycle_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "lifecycle",
+        help="Report the recorded lifecycle state of a run.",
+        description=(
+            "Read-only: what the lifecycle store records about one run id — whether a "
+            "session was ever recorded for it, whether every one of them has ended, and "
+            "with what outcome. A run stopped by `li kill` reads as cancelled here. "
+            "Add --machine for the contract envelope on stdout."
+        ),
+    )
+    p.add_argument("run_id", help="The run id to report on.")
+    p.add_argument("--machine", action="store_true", help="Emit the machine-result envelope.")
+
+
+def run_lifecycle(args: argparse.Namespace) -> int:
+    from ._logging import log_error
+
+    data = lifecycle_data(args.run_id)
+    state = data["lifecycle"]
+    if not state["available"]:
+        log_error(f"could not read the lifecycle store ({state['reason_code']}): {state['detail']}")
+        return 1
+    value = state["value"]
+    if not value["found"]:
+        print(f"{data['run_id']}: no session recorded for this run")
+        return 1
+    print(f"{data['run_id']}: {value['status']}")
+    print(f"terminal: {value['terminal']}")
+    if value["terminal"]:
+        print(f"outcome: {value['outcome']}")
+    if value["reason_code"]:
+        print(f"reason: {value['reason_code']} — {value['reason_summary'] or ''}".rstrip(" —"))
+    for entry in value["sessions"]:
+        print(f"  session {entry['session_id']}  {entry['status']}")
     return 0

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -241,6 +241,13 @@ _COMMAND_REGISTRY = (
         "run_runs",
     ),
     _CommandSpec(
+        "lifecycle",
+        "Report the recorded lifecycle state of a run.",
+        _load_machine,
+        "add_lifecycle_subparser",
+        "run_lifecycle",
+    ),
+    _CommandSpec(
         "mcp",
         "Serve the lionagi MCP server (background job submit/query) over stdio.",
         _load_mcp,
@@ -337,6 +344,10 @@ def run_handshake(args: argparse.Namespace) -> int:
 
 def run_runs(args: argparse.Namespace) -> int:
     return _load_machine().run_runs(args)
+
+
+def run_lifecycle(args: argparse.Namespace) -> int:
+    return _load_machine().run_lifecycle(args)
 
 
 def run_hooks(args: argparse.Namespace) -> int:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -47,6 +47,9 @@ from .._runs import (
     save_last_branch_pointer,
     teardown_persist,
 )
+from .._runs import (
+    active_run_id as _active_run_id,
+)
 from .._util import validate_cwd_exists
 
 __all__ = (
@@ -1059,6 +1062,7 @@ async def setup_orchestration_persist(
         await db.create_session(
             {
                 "id": session_id,
+                "run_id": _active_run_id(),
                 "created_at": session_dict["created_at"],
                 "node_metadata": _node_meta,
                 "name": session_dict.get("name"),

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -18,6 +18,15 @@ open vocabulary passed through verbatim, so a caller never needs — and must ne
 keep — a copy of lionagi's status names to tell a finished run from a running one
 or a success from a failure. All of these resolve through one path, ``status()``,
 so no two calls can disagree about the same run at the same moment.
+
+A run's end reaches that path from two writers. The terminal hook the CLI runs
+on ``--notify`` writes it into this package's own job record. A run stopped by
+``li kill`` never reaches that hook — the kill transitions the lifecycle row and
+signals the process, and writes nothing here — so when the process is gone and
+the job record shows no end, the state is read from the CLI itself, via
+``li lifecycle <run_id> --machine``, and cached back onto the job record. A read
+that cannot be made concludes nothing: the run is classified exactly as it would
+have been without it.
 """
 
 from __future__ import annotations
@@ -60,12 +69,26 @@ _KIND_ARGV: dict[str, list[str]] = {
 # stale success list is a timeout or an empty completion read back as a success.
 _SUCCEEDED_STATUSES = frozenset({"completed"})
 
+# Statuses that mean the run was stopped on purpose. Separated from failure
+# because "someone cancelled this" and "this went wrong" call for different
+# things from a caller, and reporting a cancellation as a failure invites a
+# retry of work that was deliberately abandoned.
+_CANCELLED_STATUSES = frozenset({"cancelled", "aborted"})
+
 # Short advisory qualifiers for a terminal outcome. A caller may surface one; it
 # never needs one to decide `outcome`.
 _REASON_BY_STATUS = {
     "completed_empty": "no_artifacts",
 }
 _SPAWN_FAILED_REASON = "spawn_failed"
+
+# The lifecycle read is a control-plane query against a local store; anything
+# slower than this is treated as unavailable rather than waited on, because it
+# is consulted from inside a caller's own poll.
+LIFECYCLE_TIMEOUT_SECONDS = 20.0
+
+# The most the lifecycle command may write on its result channel.
+_LIFECYCLE_OUTPUT_LIMIT = 1_000_000
 
 # Bounds for wait(). The maximum sits below ordinary MCP client timeouts so a
 # bounded observation returns partial results rather than being cut off mid-call.
@@ -122,6 +145,52 @@ def _read_job(run_id: str) -> dict[str, Any] | None:
         return json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
+    """Ask the CLI what the lifecycle store records about *run_id*.
+
+    Spawned as ``li lifecycle <run_id> --machine``, the same way every other
+    non-job verb reaches the CLI. Going through the command rather than opening
+    the database here keeps one reader of a schema this package does not own.
+
+    Returns the summary the command established, or None when it could not be
+    established for any reason at all — the command missing, refusing, timing
+    out, or answering that the store was unreadable. None is not "no record":
+    a caller must treat it as "did not learn anything" and fall back to what it
+    already knew, because the alternative is calling a run finished on the
+    strength of a read that never happened.
+    """
+    argv = [*config.li_command(), "lifecycle", run_id, "--machine"]
+    try:
+        completed = subprocess.run(  # noqa: S603 — resolved li command plus one run id, no shell
+            argv,
+            capture_output=True,
+            timeout=LIFECYCLE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if len(completed.stdout) > _LIFECYCLE_OUTPUT_LIMIT:
+        return None
+    text = completed.stdout.decode("utf-8", "replace").strip()
+    if not text:
+        return None
+    try:
+        envelope = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(envelope, dict) or not envelope.get("ok"):
+        return None
+    data = envelope.get("data")
+    if not isinstance(data, dict):
+        return None
+    state = data.get("lifecycle")
+    if not isinstance(state, dict) or not state.get("available"):
+        return None
+    value = state.get("value")
+    return value if isinstance(value, dict) else None
 
 
 def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
@@ -322,17 +391,43 @@ class SpawnError(RuntimeError):
         self.record = record
 
 
-def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
+def _outcome_for(status: Any) -> str:
+    """How a terminal run came out, from the status the CLI recorded.
+
+    Used only once a run has been established terminal by a recorded end, never
+    to decide whether it ended. A status this build has never heard of is a
+    failure, because the failure mode of a stale success list is a timeout or an
+    empty completion read back as a success.
+    """
+    if status in _SUCCEEDED_STATUSES:
+        return "succeeded"
+    if status in _CANCELLED_STATUSES:
+        return "cancelled"
+    return "failed"
+
+
+def _derive(
+    job: dict[str, Any] | None,
+    alive: bool,
+    lifecycle: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Classify a job record into the fields a caller is allowed to branch on.
 
     ``status`` is an open vocabulary: whatever the CLI recorded is passed through
     verbatim and is never matched against a local set to decide anything.
 
     ``terminal`` answers "stop waiting" and comes only from a recorded end — a
-    ``finished_at`` written by the terminal hook or by ``kill``, or a spawn
-    failure the producer caught and wrote down. It is never inferred from the
-    status string and never from a missing pid: between the pre-spawn write and
-    the write that attaches the pid, a perfectly healthy child has no pid yet.
+    ``finished_at`` written by the terminal hook or by ``kill``, a spawn failure
+    the producer caught and wrote down, or an end recorded in the lifecycle
+    store, which is where a run stopped by ``li kill`` leaves its only trace. It
+    is never inferred from the status string and never from a missing pid:
+    between the pre-spawn write and the write that attaches the pid, a perfectly
+    healthy child has no pid yet.
+
+    *lifecycle* is the summary ``li lifecycle`` established for this run, or None
+    when nothing could be established. None never terminalises anything: a read
+    that failed leaves the classification exactly as it was before this argument
+    existed.
 
     ``outcome`` answers "did the work come out right" and is null whenever
     ``terminal`` is false — including for a run whose process is gone with no end
@@ -365,8 +460,11 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
         return {
             "status": recorded,
             "terminal": True,
-            "outcome": "succeeded" if recorded in _SUCCEEDED_STATUSES else "failed",
-            "reason_code": _REASON_BY_STATUS.get(recorded),
+            "outcome": _outcome_for(recorded),
+            # A reason carried on the record wins: it came from the lifecycle
+            # store, which knows why the run ended, while the status-derived one
+            # is only what the status alone can say.
+            "reason_code": job.get("reason_code") or _REASON_BY_STATUS.get(recorded),
             "spawn_state": spawn_state,
             "possibly_orphaned": False,
         }
@@ -377,6 +475,21 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
             "terminal": False,
             "outcome": None,
             "reason_code": None,
+            "spawn_state": spawn_state,
+            "possibly_orphaned": False,
+        }
+
+    # The process is gone (or was never there) and the sidecar records no end.
+    # The lifecycle store is the other place an end gets written, and the only
+    # place a cancellation does: `li kill` transitions the row and signals the
+    # pid, and writes nothing here.
+    if lifecycle is not None and lifecycle.get("terminal"):
+        lifecycle_status = lifecycle.get("status", recorded)
+        return {
+            "status": lifecycle_status,
+            "terminal": True,
+            "outcome": _outcome_for(lifecycle_status),
+            "reason_code": lifecycle.get("reason_code"),
             "spawn_state": spawn_state,
             "possibly_orphaned": False,
         }
@@ -395,10 +508,10 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
             "possibly_orphaned": False,
         }
 
-    # A recorded pid that is gone with no end recorded: an orphan. Advisory only.
-    # Nothing here terminalises it — liveness is an observation about a pid, which
-    # can be reused or denied, and two readers of one unchanged record may see it
-    # differently. It stays non-terminal.
+    # A recorded pid that is gone, with no end recorded anywhere: an orphan.
+    # Advisory only. Nothing here terminalises it — liveness is an observation
+    # about a pid, which can be reused or denied, and two readers of one
+    # unchanged record may see it differently. It stays non-terminal.
     return {
         "status": "exited",
         "terminal": False,
@@ -593,6 +706,61 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
     return SpawnError(run_id, record, f"could not spawn run {run_id}: {exc}")
 
 
+def _needs_lifecycle_read(job: dict[str, Any] | None, alive: bool) -> bool:
+    """Whether this observation has to go and ask the lifecycle store.
+
+    Only when the sidecar cannot already answer: there is a job, its process is
+    not running, and nothing has recorded an end for it. Those are exactly the
+    records `_derive` would otherwise classify from a dead pid alone. A run
+    whose process is alive, or whose end is already on the record, is answered
+    from the record — so the ordinary poll of a healthy run spawns nothing, and
+    a run observed repeatedly after it ended asks once.
+    """
+    if job is None or alive:
+        return False
+    return job.get("finished_at") is None and job.get("spawn_state") != "failed"
+
+
+def _cache_lifecycle_end(
+    job: dict[str, Any] | None, lifecycle: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Copy a lifecycle-recorded end onto the sidecar record, once.
+
+    The sidecar is a cache of the end, not a second opinion about it: the
+    lifecycle store and the terminal hook are the two writers, and whichever
+    gets there first is what the record then says. Writing it back is what keeps
+    the next observation from spawning the read again, and what keeps two
+    observations of one unchanged run from answering differently.
+
+    A failed write is not an error here — the record is a cache, so the next
+    observation simply asks again — and the in-memory record is returned either
+    way so this call is what the caller classifies.
+    """
+    if job is None or lifecycle is None or not lifecycle.get("terminal"):
+        return job
+    ended = lifecycle.get("ended_at")
+    updated = {
+        **job,
+        "status": lifecycle.get("status", job.get("status")),
+        "finished_at": _iso_from_epoch(ended) or _now_iso(),
+        "reason_code": lifecycle.get("reason_code"),
+        "terminal_source": "lifecycle",
+    }
+    try:
+        _write_job(updated)
+    except OSError:
+        pass
+    return updated
+
+
+def _iso_from_epoch(value: Any) -> str | None:
+    """The store keeps epoch seconds; the sidecar keeps ISO-8601 strings."""
+    try:
+        return datetime.fromtimestamp(float(value), timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 def _server_identity() -> dict[str, str]:
     """Which implementation answered this call.
 
@@ -623,9 +791,15 @@ def status(run_id: str) -> dict[str, Any]:
     it, display it, do not match it against a list. Branch on ``terminal`` ("stop
     waiting") and ``outcome`` ("did the work come out right", null while
     ``terminal`` is false) instead; both are derived here so a caller never has to
-    keep a copy of the status vocabulary. ``run`` is the raw CLI manifest,
-    advisory only — its own ``status`` stays ``running`` until the CLI finalizes
-    it in the StateDB, so read ``status`` here, not ``run["status"]``.
+    keep a copy of the status vocabulary. ``run`` is the raw CLI manifest. Its
+    ``status`` is not advisory in the sense of being unreliable — for a run that
+    reaches its own teardown, the manifest is rewritten with the terminal status
+    and an ``ended_at``, and that write happens after the CLI has finalized the
+    run in the StateDB, so a manifest that says a run ended is telling the truth.
+    What it cannot do is say a run ended when the run's own process did not live
+    to write it: a killed or crashed run leaves a manifest still reading
+    ``running`` forever. It is one-directional evidence, so read ``status`` here,
+    not ``run["status"]``.
     ``possibly_orphaned`` flags a run whose process is gone with no end recorded;
     it is advisory and never makes the run terminal.
     ``notify_delivery`` reports whether the terminal notice was delivered.
@@ -636,7 +810,13 @@ def status(run_id: str) -> dict[str, Any]:
     manifest = _read_run_manifest(run_id)
     pid = job.get("pid") if job else None
     alive = _pid_alive(pid)
-    derived = _derive(job, alive)
+
+    lifecycle = None
+    if _needs_lifecycle_read(job, alive):
+        lifecycle = _read_lifecycle(run_id)
+        job = _cache_lifecycle_end(job, lifecycle)
+
+    derived = _derive(job, alive, lifecycle)
 
     return {
         "run_id": run_id,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1913,7 +1913,7 @@ class StateDB:
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
-                    """INSERT INTO sessions (id, cc_session_id, created_at, node_metadata, name, "user",
+                    """INSERT INTO sessions (id, cc_session_id, run_id, created_at, node_metadata, name, "user",
                        progression_id, first_msg_id, last_msg_id, updated_at,
                        playbook_name, agent_name, invocation_kind, show_topic,
                        show_play_name, artifacts_path, artifact_contract_json,
@@ -1921,7 +1921,7 @@ class StateDB:
                        status, started_at, ended_at, last_message_at, invocation_id,
                        model, provider, effort, agent_hash,
                        project, project_source)
-                       VALUES (:id, :cc_session_id, :created_at, :node_metadata, :name, :user,
+                       VALUES (:id, :cc_session_id, :run_id, :created_at, :node_metadata, :name, :user,
                                :progression_id, :first_msg_id, :last_msg_id, :updated_at,
                                :playbook_name, :agent_name, :invocation_kind, :show_topic,
                                :show_play_name, :artifacts_path, :artifact_contract_json,
@@ -1938,6 +1938,7 @@ class StateDB:
                 {
                     "id": session["id"],
                     "cc_session_id": session.get("cc_session_id"),
+                    "run_id": session.get("run_id"),
                     "created_at": session.get("created_at", now),
                     "node_metadata": session.get("node_metadata"),
                     "name": session.get("name"),
@@ -2008,6 +2009,29 @@ class StateDB:
                 .first()
             )
         return self._row_to_dict(row) if row else None
+
+    async def get_sessions_for_run(self, run_id: str) -> list[dict[str, Any]]:
+        """Every session recorded against CLI run *run_id*, oldest first.
+
+        A list rather than one row: one run can persist more than one session,
+        and a caller deciding whether the run is over has to see all of them.
+        An empty list means no session was ever recorded under this run id.
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT * FROM sessions WHERE run_id = :run_id "
+                            "ORDER BY created_at ASC, id ASC"
+                        ),
+                        {"run_id": run_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        return [self._row_to_dict(row) for row in rows]
 
     async def get_session_by_cc_id(self, cc_session_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -115,6 +115,49 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+
+def state_db_file() -> Path | None:
+    """The local file a default ``StateDB()`` would open, if it opens one at all.
+
+    Resolved the same way ``StateDB.__init__`` resolves it, so the two cannot
+    disagree about which store is in play. Returns None when the configured
+    store is not a local file — a server, or an in-memory database — because
+    then there is no path to report and nothing a filesystem check can say
+    about it.
+    """
+    raw = settings.LIONAGI_STATE_DB_URL
+    if raw is None:
+        raw = DEFAULT_DB_PATH
+    url = normalize_state_db_url(raw)
+    if dialect_of(url) != "sqlite":
+        return None
+    from sqlalchemy.engine import make_url
+
+    database = make_url(url).database
+    if not database or database == ":memory:":
+        return None
+    return Path(database)
+
+
+def state_db_known_absent() -> bool:
+    """Whether the store a default ``StateDB()`` would open is known not to exist.
+
+    Callers use this to tell "there is no store, so there is no record of
+    anything" apart from "the store is there and something went wrong reading
+    it". Those are different answers and a caller acts differently on each, so
+    the check has to be about the store that will actually be opened. Testing
+    ``DEFAULT_DB_PATH`` instead asks about a file that need not be involved:
+    ``LIONAGI_STATE_DB_URL`` moves the store elsewhere, and then the default
+    path is absent while every row being asked about exists.
+
+    Only a positive answer is confident. Where existence is not a filesystem
+    question this reports False and leaves the open attempt to give the real
+    answer.
+    """
+    path = state_db_file()
+    return path is not None and not path.exists()
+
+
 # The single definition of which schedule_run statuses count as "fired and
 # resolved" for budget bookkeeping (max_runs, one-shot auto-disable). The
 # scheduler service layer must observe the same set — both its defaults and

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1031,6 +1031,7 @@ class StateDB:
                             CREATE TABLE sessions_new (
                               id              TEXT    PRIMARY KEY,
                               cc_session_id   TEXT,
+                              run_id          TEXT,
                               created_at      REAL    NOT NULL,
                               node_metadata   JSON,
                               name            TEXT,

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -107,6 +107,9 @@ CREATE INDEX IF NOT EXISTS idx_run_tags_tag ON run_tags(tag);
 CREATE TABLE IF NOT EXISTS sessions (
   id              TEXT    PRIMARY KEY,
   cc_session_id   TEXT,
+  -- The CLI run this session belongs to. NULL for a session no run started,
+  -- and for rows written before this column existed.
+  run_id          TEXT,
   created_at      REAL    NOT NULL,
   node_metadata   JSON,
   name            TEXT,
@@ -209,6 +212,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_project
   ON sessions(project) WHERE project IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_cc_session
   ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_run_id
+  ON sessions(run_id) WHERE run_id IS NOT NULL;
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -151,6 +151,10 @@ sessions = Table(
     metadata,
     Column("id", Text, primary_key=True),
     Column("cc_session_id", Text),
+    # The CLI run this session belongs to, recorded at creation. Without it a
+    # run_id cannot reach the lifecycle row, so nothing that writes only the
+    # row (a kill, for one) is visible to a reader holding a run_id.
+    Column("run_id", Text),
     Column("created_at", Float, nullable=False),
     Column("node_metadata", JSON),
     Column("name", Text),

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -9,6 +9,9 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
     "sessions": [
         ("updated_at", "REAL"),
         ("cc_session_id", "TEXT"),
+        # The CLI run this session belongs to; NULL on rows created before
+        # this migration and on sessions that were not started by a run.
+        ("run_id", "TEXT"),
         ("playbook_name", "TEXT"),
         ("agent_name", "TEXT"),
         ("invocation_kind", "TEXT"),
@@ -200,11 +203,15 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
+        "ON sessions(run_id) WHERE run_id IS NOT NULL",
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
+        "ON sessions(run_id) WHERE run_id IS NOT NULL",
     ),
 }

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -142,6 +142,7 @@ TOP_LEVEL_COMMANDS = [
     "hooks",
     "invoke",
     "kill",
+    "lifecycle",
     "mcp",
     "mirror",
     "mon",

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -23,6 +23,11 @@ def sandbox(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
     monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    # Popen is doubled for the whole module here, and subprocess.run goes
+    # through Popen — so the lifecycle read cannot run in this file at all.
+    # Stubbed to the answer a failed read gives ("learned nothing"), which is
+    # what these tests assume; the read itself is covered in test_lifecycle.py.
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
     return tmp_path
 
 

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The lifecycle read: a run stopped by `li kill` has to read as terminal.
+
+The kill path writes the StateDB row and signals the process. It does not write
+the MCP job record and it does not write the CLI run manifest, so before this
+seam existed a killed run was indistinguishable from an orphan — a dead pid with
+no recorded end — and `job.wait` sat on it for its whole window.
+
+The first test here is end to end on purpose: a real submit, a real child that
+persists a real session row, a real `li kill`, and a real `jobs.wait`. A unit
+test over `_derive` with a hand-built record would only assert its own fixture,
+and the defect lived in the gap between the writers, not in the classifier.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from lionagi.mcp import config, jobs
+
+# A stand-in for the installed console script. Named `li` because the kill
+# path verifies a pid's identity from its command line before signalling it,
+# and a shebang-launched console script is `<python> <.../li>`.
+#
+# It forwards to the real CLI for everything except the run itself: `agent`
+# becomes a child that persists a session row through the production path and
+# then stays alive, which is what a run being killed looks like without needing
+# a model behind it.
+_LI_SHIM = """
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] != "agent":
+    from lionagi.cli.main import main
+
+    sys.exit(main(sys.argv[1:]))
+
+import time
+
+import anyio
+
+from lionagi import Branch
+from lionagi.cli._runs import allocate_run, setup_agent_persist
+
+
+async def _main():
+    allocate_run()
+    live = await setup_agent_persist(Branch(), agent_name="lifecycle-e2e")
+    print("SESSION " + live["session_id"], flush=True)
+    while True:
+        time.sleep(0.05)
+
+
+anyio.run(_main)
+"""
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path):
+    """A whole lionagi home of our own, for this process and every child."""
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    monkeypatch.delenv("LIONAGI_SESSION_ID", raising=False)
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    shim = tmp_path / "li"
+    shim.write_text(_LI_SHIM)
+    monkeypatch.setattr(config, "li_command", lambda: [sys.executable, str(shim)])
+    return tmp_path
+
+
+def _await_session_id(run_id: str, timeout: float = 90.0) -> str:
+    """Read the session id the child prints once its row is persisted."""
+    deadline = time.monotonic() + timeout
+    log = config.job_dir(run_id) / "console.log"
+    while time.monotonic() < deadline:
+        if log.exists():
+            for line in log.read_text(errors="replace").splitlines():
+                if line.startswith("SESSION "):
+                    return line.split(" ", 1)[1].strip()
+        time.sleep(0.2)
+    tail = log.read_text(errors="replace")[-2000:] if log.exists() else "<no console log>"
+    raise AssertionError(f"child never persisted a session row. console:\n{tail}")
+
+
+def _li(home_dir: Path, *argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603 — the test's own shim, no shell
+        [sys.executable, str(home_dir / "li"), *argv],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+def _li_kill(home_dir: Path, session_id: str, child_pid: int) -> subprocess.CompletedProcess:
+    """Run `li kill` while reaping the submitted child, as a server would.
+
+    The child is spawned detached but is still this process's child, so once it
+    exits on SIGTERM it lingers as a zombie until someone waits on it — and a
+    zombie has no readable command line, which `li kill` reads back to confirm
+    it is not escalating SIGKILL onto a recycled pid. A live server polls
+    ``status()`` throughout a run and reaps there; this loop stands in for that
+    poll so the kill sees the process actually go away.
+    """
+    proc = subprocess.Popen(  # noqa: S603 — the test's own shim, no shell
+        [sys.executable, str(home_dir / "li"), "kill", session_id],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    while proc.poll() is None:
+        jobs._pid_alive(child_pid)  # reaps the child once it exits
+        time.sleep(0.05)
+    out, err = proc.communicate()
+    return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
+# --- end to end ----------------------------------------------------------------
+
+
+@pytest.mark.slow
+async def test_a_killed_run_reads_terminal_end_to_end(home):
+    """Submit, kill by the path a person uses, and stop waiting.
+
+    Nothing is stubbed between the submit and the verdict: `li kill` writes only
+    the StateDB row, and that has to be enough for `wait` to return.
+    """
+    handle = jobs.submit("agent", [], prompt="stay up")
+    run_id = handle["run_id"]
+    session_id = _await_session_id(run_id)
+
+    killed = _li_kill(home, session_id, jobs._read_job(run_id)["pid"])
+    assert killed.returncode == 0, killed.stderr
+
+    started = time.monotonic()
+    result = await jobs.wait([run_id], max_wait=60.0, poll_interval=0.5)
+    elapsed = time.monotonic() - started
+
+    entry = result["runs"][0]
+    assert entry["terminal"] is True, entry
+    assert entry["outcome"] == "cancelled"
+    assert entry["status"] == "cancelled"
+    assert entry["reason_code"] in (
+        "run.cancelled.manual_kill",
+        "run.cancelled.force_kill",
+    )
+    assert result["all_terminal"] is True
+    assert result["timed_out"] is False
+    # "promptly" is the whole point: the defect was waiting out the window.
+    assert elapsed < 30.0
+
+
+@pytest.mark.slow
+async def test_the_lifecycle_end_is_cached_onto_the_job_record(home):
+    """The second observation of a killed run answers from the record.
+
+    The sidecar becomes a cache of the end, so a caller polling a finished run
+    does not spawn a CLI read per poll — and, more importantly, two observations
+    of one unchanged run cannot answer differently.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+    assert _li_kill(home, session_id, jobs._read_job(run_id)["pid"]).returncode == 0
+
+    first = await jobs.wait([run_id], max_wait=60.0, poll_interval=0.5)
+    assert first["runs"][0]["terminal"] is True
+
+    record = jobs._read_job(run_id)
+    assert record["finished_at"] is not None
+    assert record["status"] == "cancelled"
+
+    calls: list[str] = []
+
+    def _must_not_be_called(rid: str) -> None:
+        calls.append(rid)
+        raise AssertionError("the cached end should have answered this")
+
+    original = jobs._read_lifecycle
+    jobs._read_lifecycle = _must_not_be_called
+    try:
+        second = jobs.status(run_id)
+    finally:
+        jobs._read_lifecycle = original
+
+    assert calls == []
+    assert second["terminal"] is True
+    assert second["outcome"] == "cancelled"
+    assert second["reason_code"] == first["runs"][0]["reason_code"]
+
+
+@pytest.mark.slow
+async def test_a_run_that_completes_normally_still_reads_succeeded(home):
+    """The ordinary path is unchanged with the new read in place.
+
+    The terminal hook records the end first, so nothing is asked of the
+    lifecycle store at all — and the answer is a success, not a cancellation.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+
+    # What the notify hook does on a clean finish, then stop the child.
+    jobs.mark_terminal(run_id, "completed")
+    assert _li_kill(home, session_id, jobs._read_job(run_id)["pid"]).returncode == 0
+
+    result = await jobs.wait([run_id], max_wait=30.0, poll_interval=0.5)
+    entry = result["runs"][0]
+    assert entry["terminal"] is True
+    assert entry["outcome"] == "succeeded"
+    assert entry["status"] == "completed"
+
+
+# --- the windows where a recorded end does not exist ---------------------------
+
+
+@pytest.mark.slow
+async def test_a_kill_in_the_pre_spawn_window_does_not_terminalise(home):
+    """Before the child persists anything, there is no row to have cancelled.
+
+    A run recorded as preparing, with no pid, must stay non-terminal: the
+    lifecycle store answers definitively that it knows of no session, and
+    "no record" is not "ended".
+    """
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": None,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "preparing",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+
+    # The store is real and readable; it simply has nothing under this run id.
+    assert _li(home, "lifecycle", run_id, "--machine").returncode == 0
+
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["spawn_state"] == "preparing"
+
+
+@pytest.mark.slow
+async def test_a_run_whose_pid_was_already_gone_still_reads_the_cancellation(home):
+    """The kill signals a pid that is not there, and records the row anyway.
+
+    Liveness cannot answer this: the process was gone before the kill. What
+    makes it terminal is the recorded cancellation, not the dead pid.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+
+    # Stop the child ourselves, so the kill finds nothing to signal.
+    record = jobs._read_job(run_id)
+    assert _li_kill(home, session_id, record["pid"]).returncode == 0
+    deadline = time.monotonic() + 30.0
+    while jobs._pid_alive(record["pid"]) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert not jobs._pid_alive(record["pid"])
+
+    st = jobs.status(run_id)
+    assert st["alive"] is False
+    assert st["terminal"] is True
+    assert st["outcome"] == "cancelled"
+    assert st["possibly_orphaned"] is False
+
+
+# --- degradation ---------------------------------------------------------------
+
+
+def test_a_lifecycle_read_that_fails_leaves_the_run_where_it_was(home, monkeypatch):
+    """A read that cannot be made concludes nothing.
+
+    The command is replaced by one that exits non-zero with no envelope. The
+    run must come back exactly as it did before this seam existed — orphaned
+    and not terminal — never as a terminal it never earned.
+    """
+    monkeypatch.setattr(config, "li_command", lambda: [sys.executable, "-c", "raise SystemExit(3)"])
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    st = jobs.status(run_id)
+    assert st["status"] == "exited"
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["possibly_orphaned"] is True
+    # Nothing was cached, so a later read that succeeds is still free to answer.
+    assert jobs._read_job(run_id)["finished_at"] is None
+
+
+def test_a_lifecycle_read_that_times_out_leaves_the_run_where_it_was(home, monkeypatch):
+    """A command that never answers is a read that was not made."""
+    monkeypatch.setattr(jobs, "LIFECYCLE_TIMEOUT_SECONDS", 0.5)
+    monkeypatch.setattr(
+        config, "li_command", lambda: [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
+def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypatch):
+    """ "The store could not be read" must not arrive as "the run never ran".
+
+    The command answers with a well-formed envelope whose lifecycle value is
+    unavailable. That is a refusal to state a fact, and nothing may be
+    concluded from it.
+    """
+    envelope = {
+        "ok": True,
+        "contract_version": 1,
+        "data": {
+            "run_id": "x",
+            "lifecycle": {
+                "available": False,
+                "value": None,
+                "reason_code": "unreadable",
+                "detail": "disk on fire",
+            },
+        },
+        "error": None,
+    }
+    monkeypatch.setattr(
+        config,
+        "li_command",
+        lambda: [sys.executable, "-c", f"print({json.dumps(json.dumps(envelope))})"],
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    assert jobs._read_lifecycle(run_id) is None
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
+def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):
+    """The read is only made where the record cannot already answer.
+
+    A poll of a live run must not spawn a CLI process — a `wait` over several
+    running ids polls every second, and paying a subprocess per id per poll
+    would be a real cost for an answer the record already has.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        jobs,
+        "_read_lifecycle",
+        lambda run_id: pytest.fail("a live run must be answered from the record"),
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 4242,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+
+    assert jobs.status(run_id)["status"] == "running"

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -19,6 +19,7 @@ import json
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,12 @@ anyio.run(_main)
 def home(monkeypatch, tmp_path):
     """A whole lionagi home of our own, for this process and every child."""
     monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    # Children are launched by absolute script path, so their `sys.path[0]` is
+    # the directory that script sits in and the checkout under test is not on
+    # it. Without this they import whatever `lionagi` the interpreter's
+    # environment already has installed, which is a different tree — and then
+    # the end-to-end tests here run a CLI that is not the one being changed.
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
     monkeypatch.delenv("LIONAGI_SESSION_ID", raising=False)
     monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")
     monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
@@ -415,3 +422,50 @@ def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):
     )
 
     assert jobs.status(run_id)["status"] == "running"
+
+
+# --- which store the read opens -------------------------------------------------
+
+
+async def test_a_run_in_a_configured_store_is_found_there(home, monkeypatch):
+    """`LIONAGI_STATE_DB_URL` moves the store, and the read has to follow it.
+
+    The reader opens whatever `StateDB()` resolves, which is the configured URL
+    when one is set. A precondition asked of the default path instead is asking
+    about a file that need not be involved at all: with the store configured
+    elsewhere the default is absent, so every run in the configured store reads
+    back as `unavailable`, and a caller that cannot distinguish "no store" from
+    "no such run" gets neither. The run below exists and is finished; the only
+    reason it could be missed is that the answer came from the wrong file.
+    """
+    from lionagi.state.db import StateDB
+
+    configured = home / "elsewhere" / "configured.db"
+    configured.parent.mkdir(parents=True)
+    run_id = "20260725T120000-c0ffee"
+
+    async with StateDB(configured) as db:
+        progression_id = uuid.uuid4().hex
+        await db.create_progression(progression_id)
+        await db.create_session(
+            {
+                "id": uuid.uuid4().hex[:12],
+                "progression_id": progression_id,
+                "run_id": run_id,
+                "status": "completed",
+                "invocation_kind": "agent",
+                "started_at": time.time(),
+                "ended_at": time.time(),
+            }
+        )
+
+    assert not (home / "state.db").exists(), "the default store must stay absent"
+    monkeypatch.setenv("LIONAGI_STATE_DB_URL", str(configured))
+
+    result = _li(home, "lifecycle", run_id, "--machine")
+    assert result.returncode == 0, result.stderr
+    envelope = json.loads(result.stdout)
+
+    lifecycle = envelope["data"]["lifecycle"]
+    assert lifecycle["available"] is True, lifecycle
+    assert lifecycle["value"]["found"] is True, lifecycle

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -67,10 +67,15 @@ def home(monkeypatch, tmp_path):
     """A whole lionagi home of our own, for this process and every child."""
     monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
     # Children are launched by absolute script path, so their `sys.path[0]` is
-    # the directory that script sits in and the checkout under test is not on
-    # it. Without this they import whatever `lionagi` the interpreter's
-    # environment already has installed, which is a different tree — and then
-    # the end-to-end tests here run a CLI that is not the one being changed.
+    # the directory that script sits in, and this checkout is not on it. They
+    # then import whichever `lionagi` the interpreter's environment resolves,
+    # which is the same one only when the installed distribution happens to
+    # point here. Develop in a second checkout — a worktree, say — and it points
+    # at the first, so these end-to-end tests exercise a CLI that is not the one
+    # being changed, and do it silently.
+    #
+    # To see the difference, run any script by absolute path with and without
+    # this variable and print `lionagi.__file__`.
     monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
     monkeypatch.delenv("LIONAGI_SESSION_ID", raising=False)
     monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -53,7 +53,8 @@ def _record(rid: str, **fields) -> None:
         ("completed", "succeeded", None),
         ("completed_empty", "failed", "no_artifacts"),
         ("timed_out", "failed", None),
-        ("cancelled", "failed", None),
+        ("cancelled", "cancelled", None),
+        ("aborted", "cancelled", None),
         ("a_status_this_build_never_heard_of", "failed", None),
     ],
 )


### PR DESCRIPTION
`job.wait` never noticed a killed run. A run terminated by `li kill` waited out its entire
window and then reported a non-terminal result.

## Why

`_derive` terminalised on two conditions: a spawn the producer caught failing, or a
`finished_at` written by the terminal hook that `submit` installs. `li kill` transitions the
lifecycle rows and signals the pid; it writes neither the job record nor the CLI run manifest.
So a killed run arrived with a dead pid and no recorded end, and classified as an orphan.

That classification is right for a genuine orphan and stays: liveness is an observation about a
pid, which can be reused, so a pid that is simply gone does not make a run terminal. It is wrong
only for a run whose cancellation is recorded somewhere the reader was not looking.

## What changes

There was no way to get from a run id to the row `li kill` writes — `sessions` has no `run_id`
column. It gains one, written at creation from the run the process allocated, with a partial
index, through the repository's existing migration mechanism rather than a new one.

The read is a command: `li lifecycle <run_id> --machine`, answering in the versioned envelope
beside `runs` and `handshake`. Three outcomes stay three encodings and are never collapsed: the
store could not be read, the store was read and holds no such run, and the run ended with this
outcome. `_derive` consults it when the local record has no end, and the job record becomes a
cache of what it learns.

A lifecycle read that fails, times out, or answers unavailable leaves the run exactly where it
was. The surface degrades to the old behaviour, never to a false terminal.

## Verification

`tests/cli tests/mcp`: 2448 passed, 2 skipped, and one failure that reproduces on untouched
`main`. The end-to-end tests stub nothing between the submit and the verdict — `li kill` and
`li lifecycle` are the real commands, and only the model is absent. Stubbing the lifecycle read
turns three of them red.

Two things found on the way, neither fixed here:

- `li kill` can refuse to escalate inside the zombie window. A child that has taken SIGTERM but
  has not been reaped has no readable command line, the pid-identity check reports a mismatch,
  and the cancellation is never persisted. It predates this change and lives in the escalation
  path.
- The `jobs.status()` docstring claimed the run manifest was advisory because its status stays
  `running` until the CLI finalizes it. Measured over recent runs, the manifest does carry a
  terminal record for ordinary completion; the docstring is corrected to what is true.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

## Second round

A review found that the seam asked whether the *default* `state.db` existed and then opened whatever `StateDB()` resolves, which is `LIONAGI_STATE_DB_URL` when one is set. With the store configured elsewhere the two disagree: the default path is absent, so every run in the configured store answered `unavailable` while the reader beside it would have opened that store and found the rows. A caller cannot tell that from a store it genuinely cannot read, which is the one distinction the availability wrapper exists to preserve.

`state_db_file()` and `state_db_known_absent()` now resolve exactly the way `StateDB.__init__` does, so the precondition and the read cannot disagree about which store is in play. Existence is only claimed where it is a filesystem question — for a server or an in-memory database the check reports nothing and the open attempt gives the real answer.

A test writes a terminal session into a store at a configured non-default path, with the default path absent, and asserts `li lifecycle --machine` finds it. Reverting the resolution turns it red, and the failure is worth seeing: the reverted code reports the *configured* path in its detail string while having decided on the *default* one.

**The end-to-end tests in this branch were not exercising this branch.** They launch child CLI processes by absolute script path, so `sys.path[0]` is the script's directory and the working tree is not on it — the children imported whichever `lionagi` the interpreter already had installed. Four of the five were failing and had not been run. They now carry the checkout explicitly: `tests/mcp/test_lifecycle.py` is 10 passed in 15s, where the same file previously took 132s to fail four of five.