### PR TITLE
feat(mcp): machine-qualify the observability reads

### DIFF
--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import argparse
 import time
+from typing import Any
 
 __all__ = (
     "add_dispatch_subparser",
     "run_dispatch",
+    "machine_result",
 )
 
 
@@ -259,3 +261,108 @@ def run_dispatch(args: argparse.Namespace) -> int:
             _cmd_purge_bulk(status=args.status, before=args.before, dry_run=args.dry_run)
         )
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# A listing reports the routing and delivery bookkeeping of each row. The
+# payload itself is not here: it is unbounded caller data and a listing of fifty
+# rows would carry fifty of them. `dispatch show` names one row and returns it.
+_LIST_FIELDS = (
+    "id",
+    "kind",
+    "deliver_to",
+    "dedup_key",
+    "status",
+    "attempt",
+    "max_attempts",
+    "next_attempt_at",
+    "ack_required",
+    "session_id",
+    "schedule_run_id",
+    "last_error",
+    "created_at",
+    "expires_at",
+    "updated_at",
+)
+
+# One row in full, plus the payload. `ack_token` is included: it is the value a
+# caller needs to acknowledge the row, `li dispatch show` is where a human reads
+# it, and withholding it here while printing it there would be a difference
+# between the two surfaces that neither one states.
+_SHOW_FIELDS = (*_LIST_FIELDS, "ack_token", "payload")
+
+
+async def _machine_ls_data(*, status: str | None, limit: int) -> dict[str, Any]:
+    from lionagi.dispatch import list_dispatches
+
+    from .machine import available, readonly_state_db, state_db_absent
+
+    result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
+    async with readonly_state_db() as db:
+        if db is None:
+            result["dispatches"] = state_db_absent()
+            return result
+        rows = await list_dispatches(db, status=status, limit=limit)
+    result["dispatches"] = available(
+        [{field: row.get(field) for field in _LIST_FIELDS} for row in rows]
+    )
+    return result
+
+
+async def _machine_show_data(dispatch_id: str) -> dict[str, Any]:
+    from lionagi.dispatch import get_dispatch
+
+    from .machine import MachineError, readonly_state_db
+
+    async with readonly_state_db() as db:
+        if db is None:
+            raise MachineError(
+                "not_found",
+                f"no dispatch {dispatch_id!r}: the lifecycle store does not exist yet",
+            )
+        row = await get_dispatch(db, dispatch_id)
+    if row is None:
+        raise MachineError("not_found", f"no dispatch with id {dispatch_id!r}")
+    return {"dispatch": {field: row.get(field) for field in _SHOW_FIELDS}}
+
+
+def _machine_ls(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch ls")
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--limit", type=int, default=50, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_ls_data(status=args.status, limit=args.limit))
+
+
+def _machine_show(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch show")
+    parser.add_argument("id", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return run_async(_machine_show_data(args.id))
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li dispatch <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "dispatch",
+        argv,
+        {"ls": _machine_ls, "show": _machine_show},
+        without_seam={
+            "ack": "it acknowledges a delivery, which is a write to the outbox",
+            "retry": "it re-queues a row for delivery, which is a write to the outbox",
+            "purge": "it deletes rows from the outbox",
+        },
+    )

--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -296,12 +296,12 @@ _SHOW_FIELDS = (*_LIST_FIELDS, "ack_token", "payload")
 async def _machine_ls_data(*, status: str | None, limit: int) -> dict[str, Any]:
     from lionagi.dispatch import list_dispatches
 
-    from .machine import available, readonly_state_db, state_db_absent
+    from .machine import available, readonly_state_db
 
     result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            result["dispatches"] = state_db_absent()
+            result["dispatches"] = why
             return result
         rows = await list_dispatches(db, status=status, limit=limit)
     result["dispatches"] = available(
@@ -313,14 +313,11 @@ async def _machine_ls_data(*, status: str | None, limit: int) -> dict[str, Any]:
 async def _machine_show_data(dispatch_id: str) -> dict[str, Any]:
     from lionagi.dispatch import get_dispatch
 
-    from .machine import MachineError, readonly_state_db
+    from .machine import MachineError, readonly_state_db, store_unreachable
 
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            raise MachineError(
-                "not_found",
-                f"no dispatch {dispatch_id!r}: the lifecycle store does not exist yet",
-            )
+            raise store_unreachable(why, f"no dispatch {dispatch_id!r}")
         row = await get_dispatch(db, dispatch_id)
     if row is None:
         raise MachineError("not_found", f"no dispatch with id {dispatch_id!r}")

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import time
 import uuid
+from typing import Any
 
 from ._logging import hint, log_error
 
@@ -252,3 +253,74 @@ def run_invoke(args: argparse.Namespace) -> int:
         return 0
 
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# What a listing reports about one invocation. `node_metadata` is deliberately
+# not here: the store holds it as a JSON document for some rows and as the text
+# of one for others, so a caller could not tell which it had been handed without
+# guessing, and a listing is not where that ambiguity should be settled.
+_INVOCATION_FIELDS = (
+    "id",
+    "skill",
+    "plugin",
+    "status",
+    "prompt",
+    "started_at",
+    "ended_at",
+    "updated_at",
+    "session_count",
+    "project",
+    "project_source",
+)
+
+
+async def _machine_list_data(
+    *, skill: str | None, status: str | None, limit: int
+) -> dict[str, Any]:
+    from .machine import available, readonly_state_db, state_db_absent
+
+    result: dict[str, Any] = {
+        "filters": {"skill": skill, "status": status},
+        "limit": limit,
+    }
+    async with readonly_state_db() as db:
+        if db is None:
+            result["invocations"] = state_db_absent()
+            return result
+        rows = await db.list_invocations(skill=skill, status=status, limit=limit)
+    result["invocations"] = available(
+        [{field: row.get(field) for field in _INVOCATION_FIELDS} for row in rows]
+    )
+    return result
+
+
+def _machine_list(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li invoke list")
+    parser.add_argument("--skill", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--limit", type=int, default=20, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_list_data(skill=args.skill, status=args.status, limit=args.limit))
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li invoke <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "invoke",
+        argv,
+        {"list": _machine_list},
+        without_seam={
+            "start": "it opens an invocation record, which is a write to the store",
+            "end": "it closes an invocation record, which is a write to the store",
+        },
+    )

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -279,15 +279,15 @@ _INVOCATION_FIELDS = (
 async def _machine_list_data(
     *, skill: str | None, status: str | None, limit: int
 ) -> dict[str, Any]:
-    from .machine import available, readonly_state_db, state_db_absent
+    from .machine import available, readonly_state_db
 
     result: dict[str, Any] = {
         "filters": {"skill": skill, "status": status},
         "limit": limit,
     }
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            result["invocations"] = state_db_absent()
+            result["invocations"] = why
             return result
         rows = await db.list_invocations(skill=skill, status=status, limit=limit)
     result["invocations"] = available(

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -29,7 +29,7 @@ import json
 import os
 import sys
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from importlib import import_module
 from pathlib import Path
 from typing import Any
@@ -51,6 +51,7 @@ __all__ = (
     "machine_subcommand",
     "readonly_state_db",
     "state_db_absent",
+    "store_unreachable",
     "reserve_stdout",
     "dispatch_machine",
     "handshake_data",
@@ -273,22 +274,42 @@ def machine_subcommand(
 
 
 @asynccontextmanager
-async def readonly_state_db() -> AsyncIterator[Any | None]:
-    """The lifecycle store open for reading, or ``None`` when it does not exist.
+async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] | None]]:
+    """The lifecycle store open for reading, paired with why it is not.
 
     Read-only at the connection, not by convention: the ordinary open reconciles
     the schema, so a reporting command that used it would write to the store it
-    is reporting on. ``None`` rather than an empty result, so a caller that has
-    never run anything is told the store is absent instead of being told there
-    are zero rows in a store that does not exist.
+    is reporting on.
+
+    Exactly one of the two is set. The reason travels with the ``None`` rather
+    than being reconstructed by the caller, because there is more than one way
+    to arrive here: the store may not exist yet, which is a definitive statement
+    that nothing has been recorded, or it may exist and refuse to open, which
+    says nothing at all about what it holds. A caller handed only ``None`` has
+    to guess between those, and every one of them guessed "absent".
+
+    A failure to open is a fact about the store, so it is reported rather than
+    raised. The guard covers the open alone — the caller's own body runs outside
+    it, and a bug in a reader still surfaces as the crash it is.
     """
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
     if not DEFAULT_DB_PATH.exists():
-        yield None
+        yield None, state_db_absent()
         return
-    async with StateDB(readonly=True) as db:
-        yield db
+    async with AsyncExitStack() as stack:
+        try:
+            db = await stack.enter_async_context(StateDB(readonly=True))
+            # The engine is lazy: it connects on the first statement, so without
+            # this the store's refusal would surface in the middle of a caller's
+            # query, where it is indistinguishable from that query being wrong.
+            # One trivial statement moves the failure to the moment this seam
+            # claims the store is open, which is what the claim has to mean.
+            await db.fetch_all("SELECT 1")
+        except Exception as exc:  # noqa: BLE001 — an unopenable store is an answer, not a crash
+            yield None, unavailable(REASON_UNREADABLE, f"{DEFAULT_DB_PATH}: {type(exc).__name__}")
+            return
+        yield db, None
 
 
 def state_db_absent() -> dict[str, Any]:
@@ -297,6 +318,23 @@ def state_db_absent() -> dict[str, Any]:
 
     return unavailable(
         REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist; nothing has been recorded yet"
+    )
+
+
+def store_unreachable(why: dict[str, Any], subject: str) -> MachineError:
+    """The refusal a detail read makes when it never reached the store.
+
+    A detail read answers about one record, so it has no availability wrapper to
+    put this in and has to refuse. `not_found` stays `not_found` — with no store
+    there is definitively no such record — but a store that would not open is
+    `unavailable`, because the record may well be sitting in it.
+    """
+    reason = why.get("reason_code")
+    detail = why.get("detail")
+    if reason == REASON_NOT_FOUND:
+        return MachineError("not_found", f"{subject}: {detail}")
+    return MachineError(
+        "unavailable", f"{subject}: the lifecycle store could not be read ({detail})"
     )
 
 

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -28,8 +28,9 @@ import argparse
 import json
 import os
 import sys
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,11 @@ __all__ = (
     "unavailable",
     "read_json_file",
     "list_directory",
+    "machine_parser",
+    "parse_machine_argv",
+    "machine_subcommand",
+    "readonly_state_db",
+    "state_db_absent",
     "reserve_stdout",
     "dispatch_machine",
     "handshake_data",
@@ -188,6 +194,110 @@ def list_directory(path: Path, *, missing_is_empty: bool = False) -> dict[str, A
     except OSError as exc:
         return unavailable(REASON_UNREADABLE, f"{path}: {exc.strerror or exc}")
     return available(names)
+
+
+# ── argument parsing on the machine channel ─────────────────────────────────
+
+
+class _MachineArgumentParser(argparse.ArgumentParser):
+    """An argparse parser that refuses inside the envelope instead of exiting.
+
+    ``ArgumentParser.error`` prints usage and raises ``SystemExit``, which no
+    ``except Exception`` catches — the process would end having written a usage
+    message to stderr and no envelope at all, which reads to a machine caller as
+    a command that stopped answering rather than one that refused.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        raise MachineError("invalid_input", message)
+
+
+def machine_parser(prog: str) -> argparse.ArgumentParser:
+    """A parser for one machine command's arguments.
+
+    Deliberately separate from the human-facing parser the same command
+    registers: this one is reached with ``--machine`` already stripped and
+    answers only what the machine path honours, so a flag that shapes the human
+    printout is refused here rather than accepted and ignored.
+    """
+    return _MachineArgumentParser(prog=prog, add_help=False)
+
+
+def parse_machine_argv(parser: argparse.ArgumentParser, argv: list[str]) -> argparse.Namespace:
+    known, extras = parser.parse_known_args(argv)
+    if extras:
+        raise MachineError("invalid_input", f"unrecognized arguments: {' '.join(extras)}")
+    return known
+
+
+def machine_subcommand(
+    command: str,
+    argv: list[str],
+    handlers: Mapping[str, Callable[[list[str]], dict[str, Any]]],
+    *,
+    without_seam: Mapping[str, str],
+) -> dict[str, Any]:
+    """Route ``li <command> <sub>`` to the subcommand's machine payload.
+
+    Three answers, kept apart: a name that is not a subcommand of this command
+    is bad input, a real subcommand with no machine result is unavailable and
+    says why, and a qualified one runs. Collapsing the middle case into "no such
+    subcommand" would tell a caller the capability does not exist when what is
+    missing is only this surface's route to it.
+
+    *without_seam* carries a reason per subcommand rather than a list of names,
+    because the reasons differ — one command prints prose, the next writes to
+    the store — and one sentence covering both would be true of neither.
+    """
+    if not argv:
+        raise MachineError(
+            "invalid_input",
+            f"li {command} needs a subcommand; these answer on the machine "
+            f"channel: {', '.join(sorted(handlers))}",
+        )
+    sub, rest = argv[0], argv[1:]
+    handler = handlers.get(sub)
+    if handler is not None:
+        return handler(rest)
+    reason = without_seam.get(sub)
+    if reason is not None:
+        raise MachineError(
+            "unavailable",
+            f"`li {command} {sub}` has no machine result in contract version "
+            f"{CONTRACT_VERSION}: {reason}",
+        )
+    raise MachineError("invalid_input", f"no such subcommand: {command} {sub}")
+
+
+# ── the lifecycle store, opened for reading only ────────────────────────────
+
+
+@asynccontextmanager
+async def readonly_state_db() -> AsyncIterator[Any | None]:
+    """The lifecycle store open for reading, or ``None`` when it does not exist.
+
+    Read-only at the connection, not by convention: the ordinary open reconciles
+    the schema, so a reporting command that used it would write to the store it
+    is reporting on. ``None`` rather than an empty result, so a caller that has
+    never run anything is told the store is absent instead of being told there
+    are zero rows in a store that does not exist.
+    """
+    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+    if not DEFAULT_DB_PATH.exists():
+        yield None
+        return
+    async with StateDB(readonly=True) as db:
+        yield db
+
+
+def state_db_absent() -> dict[str, Any]:
+    """The unavailability every store-backed reader reports when there is no store."""
+    from lionagi.state.db import DEFAULT_DB_PATH
+
+    return unavailable(
+        REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist; nothing has been recorded yet"
+    )
 
 
 # ── stdout reservation ──────────────────────────────────────────────────────
@@ -379,6 +489,23 @@ _MACHINE_COMMANDS: dict[str, Callable[[list[str]], dict[str, Any]]] = {
     "runs": _machine_runs,
 }
 
+# Commands whose machine result is defined beside the command it mirrors rather
+# than here, because a payload that lives in another file drifts from the
+# printout it is supposed to be the machine form of. Each module exposes
+# ``machine_result(argv)`` and routes its own subcommands. The alias spellings
+# are registered too: `li mon --machine` reaches the same parser `li mon` does,
+# so it must reach the same result.
+_MACHINE_MODULES: dict[str, str] = {
+    "monitor": ".monitor",
+    "mon": ".monitor",
+    "stats": ".stats",
+    "invoke": ".invoke",
+    "dispatch": ".dispatch",
+    "state": ".state",
+    "team": ".team",
+    "plugin": ".plugin",
+}
+
 
 def strip_machine_flag(argv: list[str]) -> list[str]:
     """Remove `--machine` from the tokens the dispatcher routes on.
@@ -442,6 +569,10 @@ def _run_machine_command(argv: list[str]) -> dict[str, Any]:
     handler = _MACHINE_COMMANDS.get(name)
     if handler is not None:
         return handler(rest)
+
+    module_name = _MACHINE_MODULES.get(name)
+    if module_name is not None:
+        return import_module(module_name, __package__).machine_result(rest)
 
     from .main import _COMMAND_BY_NAME
 

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -610,8 +610,6 @@ def _get_version() -> str:
 
 
 def _run(argv: list[str] | None = None) -> int:
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
     # Resolve verbose before any CLI code emits (argparse hasn't run yet).
     _argv = argv if argv is not None else sys.argv[1:]
     # Scan only before the '--' sentinel so a scheduled action_prompt
@@ -632,6 +630,24 @@ def _run(argv: list[str] | None = None) -> int:
     if "--machine" in _pre_sentinel:
         machine = _load_machine()
         return machine.dispatch_machine(machine.strip_machine_flag(_argv))
+
+    # From here on the reader is a person, usually with a pager: `li ... | head`
+    # should stop quietly rather than print a BrokenPipeError traceback, which
+    # is what the default disposition buys.
+    #
+    # The machine path above is deliberately left with the interpreter's own
+    # setting, where SIGPIPE is ignored and EPIPE arrives as a catchable OSError.
+    # Its caller reads the whole stream, so there is no pager to be quiet for,
+    # and this surface promises exactly one thing: every call answers with an
+    # envelope. Under the default disposition that promise is not ours to keep —
+    # any EPIPE anywhere in the process kills it outright, with no envelope and
+    # nothing on stderr, and not every write is one the command made. A database
+    # driver's worker thread signalling a result to an event loop that is closing
+    # underneath it writes to that loop's own wakeup socket, and if the loop got
+    # there first the write is on a socket whose other end is already gone. That
+    # is a routine internal race the interpreter absorbs; only the default
+    # disposition turns it into a command that stopped answering.
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     # Same pre-argparse scan, so a project-scoped .lionagi/settings.yaml
     # next to a `--cwd DIR` target isn't missed in favor of the shell's cwd.

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1750,7 +1750,7 @@ async def _machine_monitor_data(
     *, since_window: str | None, entity_type: str | None, project: str | None
 ) -> dict[str, Any]:
     from .machine import available as _available
-    from .machine import readonly_state_db, state_db_absent
+    from .machine import readonly_state_db
 
     since = _since_timestamp(since_window) if since_window else None
     filters = {
@@ -1759,10 +1759,10 @@ async def _machine_monitor_data(
         "type": entity_type,
         "project": project,
     }
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
             return {
-                "entities": state_db_absent(),
+                "entities": why,
                 "filters": filters,
                 "observed_at": time.time(),
             }

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -751,15 +751,20 @@ def _show_project_matches(show: dict[str, Any], project: str) -> bool:
     return derived == project
 
 
-async def _gather_table_rows(
+async def _gather_entities(
     db: Any,
     *,
     since: float | None,
     entity_type: str | None,
     project: str | None,
-) -> list[dict[str, Any]]:
-    """Collect entity rows across all tables and convert to table-row dicts."""
-    rows: list[dict[str, Any]] = []
+) -> list[tuple[str, dict[str, Any]]]:
+    """Every in-flight row the views draw from, each paired with its kind.
+
+    Selection lives here and rendering lives in the callers, so the table and
+    the machine result answer with the same set of entities rather than with two
+    independently maintained ideas of what is running.
+    """
+    rows: list[tuple[str, dict[str, Any]]] = []
 
     sessions: list[dict[str, Any]] = []
     if entity_type in (None, "session", "agent", "play_session", "play"):
@@ -778,21 +783,41 @@ async def _gather_table_rows(
         play_session_ids = {p["session_id"] for p in plays if p.get("session_id")}
         sessions = [s for s in sessions if s["id"] not in play_session_ids]
 
-    rows.extend(_session_to_row(s) for s in sessions)
+    rows.extend(("session", s) for s in sessions)
 
     if entity_type in (None, "invocation"):
         invocations = await _query_running_invocations(db, since=since)
-        rows.extend(_invocation_to_row(i) for i in invocations)
+        rows.extend(("invocation", i) for i in invocations)
 
     if entity_type in (None, "show"):
         shows = await _query_active_shows(db, since=since)
         if project:
             shows = [s for s in shows if _show_project_matches(s, project)]
-        rows.extend(_show_to_row(s) for s in shows)
+        rows.extend(("show", s) for s in shows)
 
-    rows.extend(_play_to_row(p) for p in plays)
+    rows.extend(("play", p) for p in plays)
 
     return rows
+
+
+_ROW_BUILDERS = {
+    "session": _session_to_row,
+    "invocation": _invocation_to_row,
+    "show": _show_to_row,
+    "play": _play_to_row,
+}
+
+
+async def _gather_table_rows(
+    db: Any,
+    *,
+    since: float | None,
+    entity_type: str | None,
+    project: str | None,
+) -> list[dict[str, Any]]:
+    """Collect entity rows across all tables and convert to table-row dicts."""
+    entities = await _gather_entities(db, since=since, entity_type=entity_type, project=project)
+    return [_ROW_BUILDERS[kind](row) for kind, row in entities]
 
 
 # ── Async main routines ───────────────────────────────────────────────────────
@@ -1688,3 +1713,94 @@ def run_monitor(args: argparse.Namespace) -> int:
 
     print(output)
     return 0
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# Every entity carries these; a caller reads `kind` and knows which of the
+# per-kind blocks below it also has. Timestamps are epoch seconds exactly as the
+# store holds them — an elapsed string would be this module's arithmetic against
+# a clock the caller cannot see, and `observed_at` lets the caller do that sum
+# itself against a moment it was told.
+_ENTITY_CORE = ("id", "status", "started_at", "ended_at", "updated_at")
+
+_ENTITY_EXTRA: dict[str, tuple[str, ...]] = {
+    "session": (
+        "project",
+        "invocation_kind",
+        "agent_name",
+        "playbook_name",
+        "current_phase",
+        "branch_count",
+    ),
+    "invocation": ("skill", "plugin"),
+    "show": ("repo", "topic"),
+    "play": ("name", "session_id", "show_id", "session_project", "branch_count"),
+}
+
+
+def _machine_entity(kind: str, row: dict[str, Any]) -> dict[str, Any]:
+    entity: dict[str, Any] = {"kind": kind}
+    for field in (*_ENTITY_CORE, *_ENTITY_EXTRA[kind]):
+        entity[field] = row.get(field)
+    return entity
+
+
+async def _machine_monitor_data(
+    *, since_window: str | None, entity_type: str | None, project: str | None
+) -> dict[str, Any]:
+    from .machine import available as _available
+    from .machine import readonly_state_db, state_db_absent
+
+    since = _since_timestamp(since_window) if since_window else None
+    filters = {
+        "since": since_window,
+        "since_epoch": since,
+        "type": entity_type,
+        "project": project,
+    }
+    async with readonly_state_db() as db:
+        if db is None:
+            return {
+                "entities": state_db_absent(),
+                "filters": filters,
+                "observed_at": time.time(),
+            }
+        entities = await _gather_entities(db, since=since, entity_type=entity_type, project=project)
+    return {
+        "entities": _available([_machine_entity(kind, row) for kind, row in entities]),
+        "filters": filters,
+        "observed_at": time.time(),
+    }
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li monitor --machine` — the in-flight table, one entity per entry.
+
+    The detail view is not reachable here: it answers about one entity with a
+    different shape entirely, and a payload whose fields depend on whether an id
+    was passed is one a caller cannot branch on. It stays a separate decision.
+    """
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li monitor")
+    parser.add_argument("--since", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--type", dest="entity_type", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--project", "-p", default=None, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+
+    if args.entity_type is not None and args.entity_type not in _ENTITY_EXTRA:
+        raise MachineError(
+            "invalid_input",
+            f"--type must be one of {', '.join(sorted(_ENTITY_EXTRA))}; got {args.entity_type!r}",
+        )
+    try:
+        return run_async(
+            _machine_monitor_data(
+                since_window=args.since, entity_type=args.entity_type, project=args.project
+            )
+        )
+    except ValueError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc

--- a/lionagi/cli/plugin.py
+++ b/lionagi/cli/plugin.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import Any
 
 from ._logging import log_error
 
@@ -249,3 +250,81 @@ def run_plugin(args: argparse.Namespace) -> int:
         return _run_set_enabled(args.name, enabled=False)
     log_error(f"unknown plugin subcommand: {args.plugin_command!r}")
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_info_data(name: str) -> dict[str, Any]:
+    from lionagi.plugins import PluginRegistry
+    from lionagi.plugins.trust import build_trust_disclosure
+
+    from .machine import MachineError
+
+    PluginRegistry.reset()
+    record = PluginRegistry.get(name)
+    if record is None:
+        raise MachineError("not_found", f"no plugin named {name!r}")
+
+    plugin: dict[str, Any] = {
+        "name": record.name,
+        "version": record.version,
+        "state": record.state.value,
+        "bundle_dir": str(record.bundle_dir),
+        "error": record.error,
+        # None, not an empty disclosure: a bundle whose manifest did not parse
+        # declares nothing that can be read, which is a different fact from a
+        # manifest that declares nothing.
+        "declares": None,
+    }
+    if record.manifest is None:
+        return {"plugin": plugin}
+
+    disclosure = build_trust_disclosure(record)
+    plugin["declares"] = {
+        "description": disclosure["description"],
+        "lionagi": disclosure["lionagi"],
+        "tools": disclosure["tools"],
+        "hooks_external": disclosure["hooks_external"],
+        "agents": disclosure["agents"],
+        "playbooks": disclosure["playbooks"],
+        "providers": disclosure["providers"],
+        "packs": disclosure["packs"],
+    }
+    return {"plugin": plugin}
+
+
+def _machine_info(argv: list[str]) -> dict[str, Any]:
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li plugin info")
+    parser.add_argument("name", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return _machine_info_data(args.name)
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li plugin <sub> --machine`.
+
+    `list` is not routed here. It garbage-collects trust records as part of
+    listing — it deletes the record of any plugin whose bundle directory is
+    gone — so it writes to user settings, and what it writes to is the trust
+    surface this whole surface is fenced away from. `trust` is fenced outright.
+    """
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "plugin",
+        argv,
+        {"info": _machine_info},
+        without_seam={
+            "list": (
+                "listing garbage-collects trust records — it deletes the record of "
+                "any plugin whose bundle directory is gone — so it writes to user "
+                "settings, and what it writes to is the trust surface"
+            ),
+            "trust": "recording trust is a human-at-a-terminal operation",
+            "enable": "it writes an enabled flag to user settings",
+            "disable": "it writes an enabled flag to user settings",
+        },
+    )

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -36,6 +36,7 @@ __all__ = [
     # CLI entrypoints
     "add_state_subparser",
     "run_state",
+    "machine_result",
 ]
 
 
@@ -299,43 +300,94 @@ def _format_bytes(n: int) -> str:
     return f"{n:.1f} TiB"
 
 
+async def _collect_sessions(db: Any, *, limit: int, status: str | None) -> list[dict[str, Any]]:
+    """Sessions newest-first, each with its branch and message counts.
+
+    The one query the listing runs, so the printed table and the machine result
+    report the same rows and the same counts rather than two readings of the
+    store taken by two pieces of code.
+    """
+    from sqlalchemy import text
+
+    async with db._read() as conn:
+        if status:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, name, status, updated_at FROM sessions "
+                            "WHERE status = :st ORDER BY updated_at DESC LIMIT :lim"
+                        ),
+                        {"st": status, "lim": limit},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        else:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, name, status, updated_at FROM sessions "
+                            "ORDER BY updated_at DESC LIMIT :lim"
+                        ),
+                        {"lim": limit},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+    collected: list[dict[str, Any]] = []
+    for row in rows:
+        sid = row["id"]
+        async with db._read() as conn:
+            bc = (
+                (
+                    await conn.execute(
+                        text("SELECT COUNT(*) AS n FROM branches WHERE session_id = :sid"),
+                        {"sid": sid},
+                    )
+                )
+                .mappings()
+                .first()["n"]
+            )
+
+            prog_row = (
+                (
+                    await conn.execute(
+                        text("SELECT progression_id FROM sessions WHERE id = :id"),
+                        {"id": sid},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        msg_count = 0
+        if prog_row and prog_row["progression_id"]:
+            prog_data = await db.get_progression(prog_row["progression_id"])
+            msg_count = len(prog_data)
+        collected.append(
+            {
+                "id": sid,
+                "name": row["name"],
+                "status": row["status"],
+                "updated_at": row["updated_at"],
+                "branch_count": bc,
+                "message_count": msg_count,
+            }
+        )
+    return collected
+
+
 async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
     import time
-
-    from sqlalchemy import text
 
     from lionagi.state.db import StateDB
 
     async with StateDB() as db:
-        async with db._read() as conn:
-            if status:
-                rows = (
-                    (
-                        await conn.execute(
-                            text(
-                                "SELECT id, name, status, updated_at FROM sessions "
-                                "WHERE status = :st ORDER BY updated_at DESC LIMIT :lim"
-                            ),
-                            {"st": status, "lim": limit},
-                        )
-                    )
-                    .mappings()
-                    .all()
-                )
-            else:
-                rows = (
-                    (
-                        await conn.execute(
-                            text(
-                                "SELECT id, name, status, updated_at FROM sessions "
-                                "ORDER BY updated_at DESC LIMIT :lim"
-                            ),
-                            {"lim": limit},
-                        )
-                    )
-                    .mappings()
-                    .all()
-                )
+        rows = await _collect_sessions(db, limit=limit, status=status)
 
         if not rows:
             print("(no sessions in state.db)")
@@ -348,117 +400,131 @@ async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
         print(header)
         print("-" * len(header))
         for row in rows:
-            sid = row["id"]
             name = (row["name"] or "")[:16]
             sstat = (row["status"] or "")[:10]
             updated = row["updated_at"]
             updated_str = (
                 time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(updated)) if updated else ""
             )
+            print(
+                f"{row['id']:<36}  {name:<16}  {sstat:<10}  "
+                f"{row['branch_count']:>8}  {row['message_count']:>8}  {updated_str:<20}"
+            )
 
-            async with db._read() as conn:
-                bc = (
-                    (
-                        await conn.execute(
-                            text("SELECT COUNT(*) AS n FROM branches WHERE session_id = :sid"),
-                            {"sid": sid},
-                        )
+
+# The tables a size report counts, and the pragmas it reads, in the order both
+# are printed. Named once so the machine result and the printout cannot come to
+# describe different databases.
+_STATS_TABLES = (
+    "messages",
+    "progressions",
+    "sessions",
+    "branches",
+    "definitions",
+    "shows",
+    "plays",
+)
+
+_STATS_PRAGMAS = (
+    "journal_mode",
+    "wal_autocheckpoint",
+    "busy_timeout",
+    "synchronous",
+    "foreign_keys",
+)
+
+
+def _db_sizes() -> dict[str, Any]:
+    from lionagi.state.db import DEFAULT_DB_PATH
+
+    wal_path = DEFAULT_DB_PATH.with_name(DEFAULT_DB_PATH.name + "-wal")
+    return {
+        "path": str(DEFAULT_DB_PATH),
+        "exists": DEFAULT_DB_PATH.exists(),
+        "size_bytes": DEFAULT_DB_PATH.stat().st_size if DEFAULT_DB_PATH.exists() else 0,
+        "wal_size_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
+    }
+
+
+async def _collect_stats(db: Any) -> dict[str, Any]:
+    """Row counts, the session status distribution, and the SQLite pragmas."""
+    from sqlalchemy import text
+
+    counts: dict[str, int] = {}
+    for table in _STATS_TABLES:
+        async with db._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(f"SELECT COUNT(*) AS n FROM {table}")  # noqa: S608
                     )
-                    .mappings()
-                    .first()["n"]
                 )
+                .mappings()
+                .first()
+            )
+        counts[table] = row["n"]
 
-                prog_row = (
-                    (
-                        await conn.execute(
-                            text("SELECT progression_id FROM sessions WHERE id = :id"),
-                            {"id": sid},
-                        )
+    async with db._read() as conn:
+        status_rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT status AS s, COUNT(*) AS n "
+                        "FROM sessions GROUP BY status ORDER BY n DESC"
                     )
-                    .mappings()
-                    .first()
                 )
-            msg_count = 0
-            if prog_row and prog_row["progression_id"]:
-                prog_data = await db.get_progression(prog_row["progression_id"])
-                msg_count = len(prog_data)
+            )
+            .mappings()
+            .all()
+        )
 
-            print(f"{sid:<36}  {name:<16}  {sstat:<10}  {bc:>8}  {msg_count:>8}  {updated_str:<20}")
+    pragmas: dict[str, Any] = {}
+    for pragma in _STATS_PRAGMAS:
+        async with db._read() as conn:
+            row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
+        pragmas[pragma] = row[0] if row else None
+
+    return {
+        "row_counts": counts,
+        # A list of pairs, not an object: a session whose status was never
+        # recorded is a null key, and the printout's "(null)" placeholder for it
+        # would be indistinguishable from a status literally spelled that way.
+        "sessions_by_status": [{"status": r["s"], "count": r["n"]} for r in status_rows],
+        "pragmas": pragmas,
+    }
 
 
 async def _print_stats() -> None:
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
-    db_path = DEFAULT_DB_PATH
-    db_size = db_path.stat().st_size if db_path.exists() else 0
-    wal_path = db_path.with_name(db_path.name + "-wal")
-    wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+    sizes = _db_sizes()
 
-    print(f"state.db path:   {db_path}")
-    print(f"state.db size:   {_format_bytes(db_size)}")
-    print(f"state.db-wal:    {_format_bytes(wal_size)}")
+    print(f"state.db path:   {DEFAULT_DB_PATH}")
+    print(f"state.db size:   {_format_bytes(sizes['size_bytes'])}")
+    print(f"state.db-wal:    {_format_bytes(sizes['wal_size_bytes'])}")
     print()
 
-    if not db_path.exists():
+    if not sizes["exists"]:
         print("(no state.db yet — first run will create it)")
         return
 
-    from sqlalchemy import text
-
     async with StateDB() as db:
-        print("Row counts:")
-        for table in (
-            "messages",
-            "progressions",
-            "sessions",
-            "branches",
-            "definitions",
-            "shows",
-            "plays",
-        ):
-            async with db._read() as conn:
-                row = (
-                    (
-                        await conn.execute(
-                            text(f"SELECT COUNT(*) AS n FROM {table}")  # noqa: S608
-                        )
-                    )
-                    .mappings()
-                    .first()
-                )
-            print(f"  {table:<14} {row['n']:>10}")
-        print()
+        collected = await _collect_stats(db)
 
-        async with db._read() as conn:
-            rows = (
-                (
-                    await conn.execute(
-                        text(
-                            "SELECT COALESCE(status, '(null)') AS s, COUNT(*) AS n "
-                            "FROM sessions GROUP BY status ORDER BY n DESC"
-                        )
-                    )
-                )
-                .mappings()
-                .all()
-            )
-        print("Sessions by status:")
-        for row in rows:
-            print(f"  {row['s']:<14} {row['n']:>10}")
-        print()
+    print("Row counts:")
+    for table, n in collected["row_counts"].items():
+        print(f"  {table:<14} {n:>10}")
+    print()
 
-        print("PRAGMAs:")
-        for pragma in (
-            "journal_mode",
-            "wal_autocheckpoint",
-            "busy_timeout",
-            "synchronous",
-            "foreign_keys",
-        ):
-            async with db._read() as conn:
-                row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
-            val = row[0] if row else "?"
-            print(f"  {pragma:<22} {val}")
+    print("Sessions by status:")
+    for entry in collected["sessions_by_status"]:
+        label = "(null)" if entry["status"] is None else entry["status"]
+        print(f"  {label:<14} {entry['count']:>10}")
+    print()
+
+    print("PRAGMAs:")
+    for pragma, value in collected["pragmas"].items():
+        print(f"  {pragma:<22} {'?' if value is None else value}")
 
 
 async def _checkpoint(mode: str) -> str:
@@ -1096,3 +1162,89 @@ def run_state(args: argparse.Namespace) -> int:
         return 0
 
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+async def _machine_ls_data(*, limit: int, status: str | None) -> dict[str, Any]:
+    from .machine import available, readonly_state_db, state_db_absent
+
+    result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
+    async with readonly_state_db() as db:
+        if db is None:
+            result["sessions"] = state_db_absent()
+            return result
+        rows = await _collect_sessions(db, limit=limit, status=status)
+    result["sessions"] = available(rows)
+    return result
+
+
+async def _machine_stats_data() -> dict[str, Any]:
+    from .machine import available, readonly_state_db, state_db_absent
+
+    sizes = _db_sizes()
+    result: dict[str, Any] = {"database": sizes}
+    async with readonly_state_db() as db:
+        if db is None:
+            absent = state_db_absent()
+            result["row_counts"] = absent
+            result["sessions_by_status"] = absent
+            result["journal_mode"] = absent
+            return result
+        collected = await _collect_stats(db)
+    result["row_counts"] = available(collected["row_counts"])
+    result["sessions_by_status"] = available(collected["sessions_by_status"])
+    # Only the one pragma that describes the database rather than the connection
+    # that asked. busy_timeout, synchronous and the rest are settings of whichever
+    # connection reads them, so reporting them here would hand a caller this
+    # reader's configuration under a name that reads like the store's.
+    result["journal_mode"] = available(collected["pragmas"]["journal_mode"])
+    return result
+
+
+def _machine_ls(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li state ls")
+    parser.add_argument("--limit", type=int, default=50, help=argparse.SUPPRESS)
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_ls_data(limit=args.limit, status=args.status))
+
+
+def _machine_stats(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError
+
+    if argv:
+        raise MachineError("invalid_input", f"li state stats takes no arguments: {' '.join(argv)}")
+    return run_async(_machine_stats_data())
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li state <sub> --machine`.
+
+    `migrate` is not among the subcommands routed here and is not reachable from
+    the MCP surface at all; it rewrites the store every other reader reports on.
+    """
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "state",
+        argv,
+        {"ls": _machine_ls, "stats": _machine_stats},
+        without_seam={
+            "import": "it loads run directories into the store, which is a write",
+            "import-teams": "it loads team files into the store, which is a write",
+            "checkpoint": "it checkpoints the write-ahead log",
+            "vacuum": "it rebuilds the database file",
+            "prune": "it deletes rows",
+            "doctor": "it sweeps stale rows to a new status, which is a write",
+        },
+    )

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -1168,12 +1168,12 @@ def run_state(args: argparse.Namespace) -> int:
 
 
 async def _machine_ls_data(*, limit: int, status: str | None) -> dict[str, Any]:
-    from .machine import available, readonly_state_db, state_db_absent
+    from .machine import available, readonly_state_db
 
     result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            result["sessions"] = state_db_absent()
+            result["sessions"] = why
             return result
         rows = await _collect_sessions(db, limit=limit, status=status)
     result["sessions"] = available(rows)
@@ -1181,13 +1181,13 @@ async def _machine_ls_data(*, limit: int, status: str | None) -> dict[str, Any]:
 
 
 async def _machine_stats_data() -> dict[str, Any]:
-    from .machine import available, readonly_state_db, state_db_absent
+    from .machine import available, readonly_state_db
 
     sizes = _db_sizes()
     result: dict[str, Any] = {"database": sizes}
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            absent = state_db_absent()
+            absent = why
             result["row_counts"] = absent
             result["sessions_by_status"] = absent
             result["journal_mode"] = absent

--- a/lionagi/cli/stats.py
+++ b/lionagi/cli/stats.py
@@ -86,13 +86,13 @@ async def _query_run_stats(
 
 
 async def _run_stats_runs(*, since: float, group_by: list[str]) -> list[dict[str, Any]]:
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    # readonly: a reporting command must never write to the DB it reports on,
+    # even implicitly via schema-reconcile. See docs/internals/cli.md.
+    from .machine import readonly_state_db
 
-    if not DEFAULT_DB_PATH.exists():
-        return []
-    # readonly=True: a reporting command must never write to the DB it
-    # reports on, even implicitly via schema-reconcile. See docs/internals/cli.md.
-    async with StateDB(readonly=True) as db:
+    async with readonly_state_db() as db:
+        if db is None:
+            return []
         return await _query_run_stats(db, since=since, group_by=group_by)
 
 
@@ -210,3 +210,72 @@ def run_stats(args: argparse.Namespace) -> int:
     else:
         print(_format_stats_table(rows, group_by))
     return 0
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_rows(rows: list[dict[str, Any]], group_by: list[str]) -> list[dict[str, Any]]:
+    """One aggregate per group, timestamps left as the epoch seconds stored.
+
+    The group keys stay nullable and stay null: a row whose project column is
+    empty is a run that recorded no project, which is a different fact from a
+    run in a project literally named "(none)", and the table's placeholder for
+    it is a rendering choice that must not reach a machine caller.
+    """
+    return [
+        {
+            "group": {key: row.get(key) for key in group_by},
+            "run_count": row["run_count"],
+            "completed": row["completed"] or 0,
+            "failed": row["failed"] or 0,
+            "first_at": row["first_at"],
+            "last_at": row["last_at"],
+        }
+        for row in rows
+    ]
+
+
+async def _machine_stats_runs_data(*, since_window: str, group_by: list[str]) -> dict[str, Any]:
+    from .machine import available, readonly_state_db, state_db_absent
+
+    since = _since_timestamp(since_window)
+    result: dict[str, Any] = {
+        "group_by": group_by,
+        "since": since_window,
+        "since_epoch": since,
+    }
+    async with readonly_state_db() as db:
+        if db is None:
+            result["groups"] = state_db_absent()
+            return result
+        rows = await _query_run_stats(db, since=since, group_by=group_by)
+    result["groups"] = available(_machine_rows(rows, group_by))
+    return result
+
+
+def _machine_runs(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li stats runs")
+    parser.add_argument("--since", default="7d", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--group-by", dest="group_by", default=_DEFAULT_GROUP_BY, help=argparse.SUPPRESS
+    )
+    args = parse_machine_argv(parser, argv)
+
+    try:
+        group_by = _validate_group_by(args.group_by)
+        _reject_non_positive_since(args.since)
+        return run_async(_machine_stats_runs_data(since_window=args.since, group_by=group_by))
+    except ValueError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li stats <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand("stats", argv, {"runs": _machine_runs}, without_seam={})

--- a/lionagi/cli/stats.py
+++ b/lionagi/cli/stats.py
@@ -88,11 +88,16 @@ async def _query_run_stats(
 async def _run_stats_runs(*, since: float, group_by: list[str]) -> list[dict[str, Any]]:
     # readonly: a reporting command must never write to the DB it reports on,
     # even implicitly via schema-reconcile. See docs/internals/cli.md.
-    from .machine import readonly_state_db
+    from .machine import REASON_NOT_FOUND, readonly_state_db
 
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            return []
+            if why["reason_code"] == REASON_NOT_FOUND:
+                return []
+            # The human surface has nowhere to put an availability wrapper, and
+            # an empty table is the one thing it must not print here: it reads
+            # as "no runs" for a store that was never opened.
+            raise RuntimeError(f"the run store could not be read: {why['detail']}")
         return await _query_run_stats(db, since=since, group_by=group_by)
 
 
@@ -237,7 +242,7 @@ def _machine_rows(rows: list[dict[str, Any]], group_by: list[str]) -> list[dict[
 
 
 async def _machine_stats_runs_data(*, since_window: str, group_by: list[str]) -> dict[str, Any]:
-    from .machine import available, readonly_state_db, state_db_absent
+    from .machine import available, readonly_state_db
 
     since = _since_timestamp(since_window)
     result: dict[str, Any] = {
@@ -245,9 +250,9 @@ async def _machine_stats_runs_data(*, since_window: str, group_by: list[str]) ->
         "since": since_window,
         "since_epoch": since,
     }
-    async with readonly_state_db() as db:
+    async with readonly_state_db() as (db, why):
         if db is None:
-            result["groups"] = state_db_absent()
+            result["groups"] = why
             return result
         rows = await _query_run_stats(db, since=since, group_by=group_by)
     result["groups"] = available(_machine_rows(rows, group_by))

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -633,3 +633,67 @@ def run_team(args: argparse.Namespace) -> int:
         return cmd_receive(args)
     log_error(f"Unknown team command: {cmd}")
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_list_data() -> dict[str, Any]:
+    from .machine import REASON_UNREADABLE, available, list_directory, unavailable
+
+    # Read without creating: the human path ensures the directory exists as a
+    # side effect of being about to write to it, and a listing has nothing to
+    # write. A directory that was never created is a definitive zero teams,
+    # which is what the human path also reports once it has made one.
+    listing = list_directory(TEAMS_DIR, missing_is_empty=True)
+    if not listing["available"]:
+        return {"teams": listing, "unreadable": []}
+
+    teams: list[dict[str, Any]] = []
+    unreadable: list[dict[str, Any]] = []
+    for path in sorted(TEAMS_DIR.glob("*.json")):
+        data = read_team_json(path)
+        if data is None:
+            # The printed listing skips these silently. A machine caller is told,
+            # because "four teams" and "four teams and one file I could not read"
+            # are different answers and only one of them is complete.
+            unreadable.append(unavailable(REASON_UNREADABLE, str(path)))
+            continue
+        teams.append(
+            {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "members": data.get("members") or [],
+                "created_at": data.get("created_at"),
+                "message_count": len(data.get("messages") or []),
+                "path": str(path),
+            }
+        )
+    teams.sort(key=lambda t: (t["name"] or "", t["id"] or ""))
+    return {"teams": available(teams), "unreadable": unreadable}
+
+
+def _machine_list(argv: list[str]) -> dict[str, Any]:
+    from .machine import MachineError
+
+    if argv:
+        raise MachineError("invalid_input", f"li team list takes no arguments: {' '.join(argv)}")
+    return _machine_list_data()
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li team <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "team",
+        argv,
+        {"list": _machine_list, "ls": _machine_list},
+        without_seam={
+            "create": "it writes a new team file",
+            "show": "it prints a team's messages for a human reader",
+            "send": "it appends a message to a team file",
+            "receive": "it marks the messages it returns as read, which is a write",
+            "recv": "it marks the messages it returns as read, which is a write",
+        },
+    )

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -75,10 +75,10 @@ FENCED_PATHS = ("state migrate", "plugin trust", "hooks trust")
 # never a truncation that would run some of a caller's batch and report success.
 MAX_OPS = 8
 
-# The reason every long-tail command shares today: `--machine` answers for three
-# commands, and the rest print for a human reader. The fix belongs in the CLI —
-# the command gains a machine-result seam — not in a parser of its console text,
-# which would make its wording an API contract.
+# The reason the remaining long-tail commands share: `--machine` answers for the
+# commands registered above, and the rest print for a human reader. The fix
+# belongs in the CLI — the command gains a machine-result seam — not in a parser
+# of its console text, which would make its wording an API contract.
 _NO_MACHINE_SEAM = (
     "the CLI path emits no versioned machine result (`li <path> --machine`), so "
     "there is nothing to return that is not scraped console text"
@@ -411,6 +411,93 @@ _REGISTERED: tuple[Verb, ...] = (
         cli_path="runs",
         admits=("limit",),
     ),
+    # ── observability reads ──────────────────────────────────────────────────
+    # Each of these admits only the parameters its machine path honours. A flag
+    # that shapes a human printout is left out: the parser would take it and the
+    # machine dispatcher would then refuse it, so admitting it advertises a
+    # parameter that cannot work.
+    Verb(
+        name="monitor",
+        summary="Entities in flight right now: sessions, invocations, shows, plays.",
+        executor="machine",
+        cli_path="monitor",
+        admits=("since", "entity_type", "project"),
+        refuses={
+            "id": (
+                "opens the detail view, whose result is a different shape entirely; "
+                "this verb answers with the table"
+            ),
+            "watch": "redraws a terminal until interrupted",
+            "refresh": "paces a redraw this verb does not do",
+            "run_ids": "waits for schedule runs to finish; use job.wait for a bounded wait",
+            "interval": "paces the wait this verb does not do",
+            "follow": "keeps a wait open indefinitely",
+            "chain": "shapes the wait this verb does not do",
+            "max_wait": "bounds the wait this verb does not do",
+        },
+    ),
+    Verb(
+        name="stats.runs",
+        summary="Run counts and first/last timestamps, grouped by project/kind/agent/model/status.",
+        executor="machine",
+        cli_path="stats runs",
+        admits=("since", "group_by"),
+        refuses={
+            "json": (
+                "shapes the human printout only; the machine result is already the "
+                "envelope and carries the same rows"
+            )
+        },
+    ),
+    Verb(
+        name="invoke.list",
+        summary="Recent skill-level invocations, newest first.",
+        executor="machine",
+        cli_path="invoke list",
+        admits=("skill", "status", "limit"),
+    ),
+    Verb(
+        name="dispatch.ls",
+        summary="Rows in the durable dispatch outbox, newest first, without their payloads.",
+        executor="machine",
+        cli_path="dispatch ls",
+        admits=("status", "limit"),
+    ),
+    Verb(
+        name="dispatch.show",
+        summary="One dispatch row in full, including its payload and ack token.",
+        executor="machine",
+        cli_path="dispatch show",
+        admits=("id",),
+    ),
+    Verb(
+        name="state.ls",
+        summary="Sessions in the lifecycle store with their branch and message counts.",
+        executor="machine",
+        cli_path="state ls",
+        admits=("limit", "status"),
+    ),
+    Verb(
+        name="state.stats",
+        summary="Store and write-ahead-log size, per-table row counts, session status spread.",
+        executor="machine",
+        cli_path="state stats",
+        admits=(),
+    ),
+    Verb(
+        name="team.list",
+        summary="Teams on disk with their members and message counts.",
+        executor="machine",
+        cli_path="team list",
+        admits=(),
+    ),
+    Verb(
+        name="plugin.info",
+        summary="One plugin's version, trust state, and everything its manifest declares.",
+        executor="machine",
+        cli_path="plugin info",
+        admits=("name",),
+    ),
 )
 
 
@@ -443,28 +530,32 @@ ABSENT: tuple[AbsentVerb, ...] = (
     ),
     *_absent(
         "team",
-        ("create", "list", "show", "send", "receive"),
+        ("create", "show", "send", "receive"),
         "Messaging between agents working as a team.",
     ),
     *_absent(
         "state",
-        ("ls", "stats", "doctor"),
+        ("doctor",),
         "Read-only inspection of the lifecycle store.",
     ),
     *_absent(
         "dispatch",
-        ("ls", "show", "ack", "retry", "purge"),
+        ("ack", "retry", "purge"),
         "The outbound dispatch queue.",
     ),
     AbsentVerb(
-        name="monitor",
-        summary="What is running right now, across sessions and invocations.",
-        reason=_NO_MACHINE_SEAM,
-    ),
-    AbsentVerb(
-        name="stats",
-        summary="Aggregate run counts and durations.",
-        reason=_NO_MACHINE_SEAM,
+        name="plugin.list",
+        summary="Installed plugin bundles and their trust state.",
+        # Not a missing seam: the listing garbage-collects trust records as part
+        # of listing, deleting the record of any plugin whose bundle directory
+        # has gone. That is a write, and what it writes to is the trust surface
+        # this surface is fenced away from, so a read-only variant of it would
+        # be a second command wearing the name of this one.
+        reason=(
+            "listing prunes trust records for plugins whose bundle directory is "
+            "gone, so it writes to user settings on the trust surface; a listing "
+            "that skipped the prune would not be this command"
+        ),
     ),
 )
 

--- a/tests/cli/test_machine_envelope.py
+++ b/tests/cli/test_machine_envelope.py
@@ -15,6 +15,7 @@ import errno
 import importlib
 import json
 import os
+import signal
 import subprocess
 import sys
 import textwrap
@@ -435,3 +436,54 @@ def test_78_survives_end_to_end_under_the_machine_flag():
 
     assert proc.returncode == EXIT_CODE_ENVIRONMENT_ERROR, proc.stderr
     assert proc.stdout.strip() == ""
+
+
+# ── the machine path leaves SIGPIPE where the interpreter put it ────────────
+
+
+def _sigpipe_disposition_after(*argv: str) -> str:
+    script = textwrap.dedent(
+        """
+        import signal, sys
+
+        from lionagi.cli.main import _run
+
+        _run(sys.argv[1:])
+        print(
+            "SIG_DFL" if signal.getsignal(signal.SIGPIPE) is signal.SIG_DFL else "ignored",
+            file=sys.stderr,
+        )
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script, *argv],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stderr.strip().splitlines()[-1]
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="no SIGPIPE on this platform")
+def test_a_machine_call_never_runs_with_a_signal_that_can_kill_it_silently():
+    """A command under the default SIGPIPE disposition can stop mid-answer.
+
+    The default kills the process on any EPIPE, from any thread, with no
+    envelope and nothing on stderr — and not every write is one the command
+    made. A database driver's worker thread reporting a result to an event loop
+    that is shutting down writes to the loop's own wakeup socket, and loses that
+    race often enough to be a routine outcome rather than a rare one. The
+    interpreter's own setting turns that into a catchable error; this surface
+    needs it, because its whole contract is that a call always answers.
+    """
+    assert _sigpipe_disposition_after("handshake", "--machine") == "ignored"
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="no SIGPIPE on this platform")
+def test_the_human_path_still_ends_quietly_when_its_reader_goes_away():
+    # The reason the default is set at all: `li ... | head` should stop, not
+    # print a traceback about a pipe the person closed on purpose.
+    assert _sigpipe_disposition_after("handshake") == "SIG_DFL"

--- a/tests/mcp/golden_projections/dispatch__show.json
+++ b/tests/mcp/golden_projections/dispatch__show.json
@@ -1,0 +1,22 @@
+{
+  "path": "dispatch show",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the dispatch row to show, as listed by `li dispatch ls`.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "dispatch show",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/invoke__list.json
+++ b/tests/mcp/golden_projections/invoke__list.json
@@ -1,0 +1,27 @@
+{
+  "path": "invoke list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "limit": {
+        "default": 20,
+        "description": "Maximum rows to print, newest first (default 20).",
+        "type": "integer",
+        "x-flag": "--limit"
+      },
+      "skill": {
+        "description": "Show only invocations of this skill name, matched exactly.",
+        "type": "string",
+        "x-flag": "--skill"
+      },
+      "status": {
+        "description": "Show only invocations in this status: running, completed, failed, timed_out, aborted or cancelled.",
+        "type": "string",
+        "x-flag": "--status"
+      }
+    },
+    "title": "invoke list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/plugin__info.json
+++ b/tests/mcp/golden_projections/plugin__info.json
@@ -1,0 +1,22 @@
+{
+  "path": "plugin info",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "description": "Plugin to describe \u2014 its manifest `name:`, as listed by `li plugin list`.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "plugin info",
+    "type": "object",
+    "x-positional-order": [
+      "name"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/state__stats.json
+++ b/tests/mcp/golden_projections/state__stats.json
@@ -1,0 +1,11 @@
+{
+  "path": "state stats",
+  "schema": {
+    "additionalProperties": false,
+    "description": "Report state.db + state.db-wal sizes, per-table row counts, session status distribution, and SQLite PRAGMAs (journal_mode, wal_autocheckpoint, busy_timeout). Use to spot growth and lock contention.",
+    "properties": {},
+    "title": "state stats",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__list.json
+++ b/tests/mcp/golden_projections/team__list.json
@@ -1,0 +1,10 @@
+{
+  "path": "team list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "team list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -82,7 +82,7 @@ def test_help_for_a_verb_returns_the_projected_schema():
 
 
 def test_help_for_an_unavailable_verb_says_why_instead_of_failing():
-    answer = call(help="monitor")
+    answer = call(help="state.doctor")
     assert answer["available"] is False and answer["reason"]
 
 

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -276,3 +276,60 @@ def test_the_verb_admits_only_parameters_its_machine_path_honours(verb):
     schema = dispatch.verb_schema(registered)
     assert registered.admits is not None, f"{verb} admits every projected parameter"
     assert set(schema["properties"]) <= set(registered.admits)
+
+
+# ── a store that exists but will not open ────────────────────────────────────
+
+
+@pytest.fixture
+def unreadable_store(home):
+    """A real state.db this process cannot open, restored on the way out."""
+    seed_invocation()
+    store = home / "state.db"
+    assert store.exists(), "the seed did not create a store"
+    original = store.stat().st_mode
+    store.chmod(0o000)
+    try:
+        try:
+            store.open("rb").close()
+        except OSError:
+            pass
+        else:
+            pytest.skip("this process can read a mode-000 file, so there is nothing to test")
+        yield store
+    finally:
+        store.chmod(original)
+
+
+@pytest.mark.parametrize(
+    "verb", ["monitor", "stats.runs", "invoke.list", "dispatch.ls", "state.ls", "state.stats"]
+)
+def test_a_store_that_will_not_open_is_not_an_implementation_crash(unreadable_store, verb):
+    """Existing-but-unopenable is a third answer, and it is the store's, not ours.
+
+    `internal` is this contract's word for our own bug, and a consumer is
+    entitled to treat it as one — to stop, to report the tool as broken. A
+    permission or a lock is none of those things: it is a routine condition of
+    reading someone else's file, the caller can act on it, and it says nothing
+    about whether the rows exist. Reporting it as `internal` also puts a driver
+    exception string into a versioned contract, where the next release of that
+    driver quietly changes it.
+    """
+    op = run_op(verb)
+    assert op["ok"] is True, op
+    wrapper = op["result"]["data"][AVAILABILITY_KEY[verb]]
+    assert wrapper["available"] is False, wrapper
+    assert wrapper["reason_code"] == "unreadable", wrapper
+
+
+def test_a_detail_read_refuses_rather_than_claiming_the_record_is_missing(unreadable_store):
+    """`not_found` would be a claim about the record. We never reached it.
+
+    A detail read has no availability wrapper to put this in, so it has to
+    refuse — but the refusal a caller acts on differently is `unavailable`. Told
+    `not_found`, a caller stops looking for a dispatch that may be sitting in
+    the store it could not open.
+    """
+    op = run_op("dispatch.show", {"id": "whatever"})
+    assert op["ok"] is False, op
+    assert op["error"]["kind"] == "unavailable", op["error"]

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The observability verbs, end to end through the real subprocess.
+
+Nothing here mocks the child. The whole point of this surface is the composition
+between the argv the server renders and what the CLI's own parser makes of it,
+so a test that stubbed the subprocess would assert on the one half that cannot
+be wrong. Each test spawns the real ``li``, with ``LIONAGI_HOME`` pointed at a
+temporary directory so what it reads is a store this test made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+
+import pytest
+
+from lionagi.mcp import config, dispatch, verbs
+
+# Every verb in the tranche that answers with no arguments, so one parametrized
+# call covers the whole set the same way a caller would reach it.
+NO_ARGUMENT_VERBS = (
+    "monitor",
+    "stats.runs",
+    "invoke.list",
+    "dispatch.ls",
+    "state.ls",
+    "state.stats",
+    "team.list",
+)
+
+# Where each verb's payload puts the thing it read, so the availability wrapper
+# can be asserted on without a second list of names to keep in step.
+AVAILABILITY_KEY = {
+    "monitor": "entities",
+    "stats.runs": "groups",
+    "invoke.list": "invocations",
+    "dispatch.ls": "dispatches",
+    "state.ls": "sessions",
+    "state.stats": "row_counts",
+    "team.list": "teams",
+}
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A LIONAGI_HOME the child inherits, so no test reads a real store."""
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    return tmp_path
+
+
+def call(**kwargs):
+    return asyncio.run(dispatch.request(**kwargs))
+
+
+def run_op(op: str, args: dict | None = None) -> dict:
+    answer = call(ops=[{"op": op, "args": args or {}}])
+    return answer["ops"][0]
+
+
+def li(*argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*config.li_command(), *argv], capture_output=True, text=True, check=False, timeout=120
+    )
+
+
+def seed_invocation(skill: str = "observability-test") -> str:
+    """One invocation row, created the way anything else creates one."""
+    done = li("invoke", "start", "--skill", skill)
+    assert done.returncode == 0, done.stderr
+    return done.stdout.strip()
+
+
+# ── every verb answers the contract, through the real command ────────────────
+
+
+@pytest.mark.parametrize("verb", NO_ARGUMENT_VERBS)
+def test_a_verb_answers_with_the_versioned_envelope(home, verb):
+    op = run_op(verb)
+    assert op["ok"] is True, op
+    assert op["result"]["contract_version"] == 1
+    assert isinstance(op["result"]["data"], dict)
+
+
+@pytest.mark.parametrize("verb", NO_ARGUMENT_VERBS)
+def test_every_read_a_verb_makes_carries_whether_it_was_established(home, verb):
+    data = run_op(verb)["result"]["data"]
+    wrapper = data[AVAILABILITY_KEY[verb]]
+    assert set(wrapper) == {"available", "value", "reason_code", "detail"}
+
+
+@pytest.mark.parametrize(
+    "verb", ["monitor", "stats.runs", "invoke.list", "dispatch.ls", "state.ls", "state.stats"]
+)
+def test_a_store_that_does_not_exist_is_not_reported_as_zero_rows(home, verb):
+    # The distinction the whole availability wrapper exists for: a caller that
+    # has never run anything must not be told there are zero sessions in a
+    # database that was never created.
+    wrapper = run_op(verb)["result"]["data"][AVAILABILITY_KEY[verb]]
+    assert wrapper["available"] is False
+    assert wrapper["reason_code"] == "not_found"
+    assert str(home) in wrapper["detail"]
+
+
+def test_no_team_directory_at_all_is_a_definitive_zero(home):
+    # The opposite case, and why it is not the one above: a team file is only
+    # ever written by `li team create`, so nothing having been written is the
+    # complete answer rather than a read that failed.
+    teams = run_op("team.list")["result"]["data"]["teams"]
+    assert teams["available"] is True
+    assert teams["value"] == []
+
+
+# ── the rows a seeded store actually holds ───────────────────────────────────
+
+
+def test_a_listing_returns_the_row_the_cli_just_created(home):
+    invocation_id = seed_invocation()
+    invocations = run_op("invoke.list")["result"]["data"]["invocations"]
+    assert invocations["available"] is True
+    assert [row["id"] for row in invocations["value"]] == [invocation_id]
+    row = invocations["value"][0]
+    assert row["skill"] == "observability-test"
+    assert row["status"] == "running"
+    assert isinstance(row["started_at"], float)
+
+
+def test_the_running_row_is_what_monitor_reports_in_flight(home):
+    invocation_id = seed_invocation()
+    data = run_op("monitor")["result"]["data"]
+    entities = data["entities"]["value"]
+    assert [e["id"] for e in entities if e["kind"] == "invocation"] == [invocation_id]
+    # The caller is told the moment the observation was taken, so it can compute
+    # an elapsed time itself rather than be handed one against an unseen clock.
+    assert data["observed_at"] >= entities[0]["started_at"]
+
+
+def test_a_filter_reaches_the_child_parser_and_narrows_the_result(home):
+    seed_invocation("kept")
+    seed_invocation("dropped")
+    kept = run_op("invoke.list", {"skill": "kept"})["result"]["data"]["invocations"]["value"]
+    assert [row["skill"] for row in kept] == ["kept"]
+
+
+def test_a_store_that_exists_reports_its_size_and_journal_mode(home):
+    seed_invocation()
+    data = run_op("state.stats")["result"]["data"]
+    assert data["database"]["exists"] is True
+    assert data["database"]["size_bytes"] > 0
+    assert data["row_counts"]["available"] is True
+    assert set(data["row_counts"]["value"]) >= {"sessions", "branches", "messages"}
+    assert data["journal_mode"]["available"] is True
+
+
+def test_a_status_is_a_pair_and_never_a_placeholder_string(home):
+    seed_invocation()
+    spread = run_op("state.stats")["result"]["data"]["sessions_by_status"]["value"]
+    assert all(set(entry) == {"status", "count"} for entry in spread)
+
+
+# ── refusals arrive inside the envelope ──────────────────────────────────────
+
+
+def test_an_id_with_no_row_is_a_refusal_and_not_a_crash(home):
+    op = run_op("dispatch.show", {"id": "no-such-dispatch"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "not_found"
+    assert "no-such-dispatch" in op["error"]["message"]
+
+
+def test_a_plugin_nobody_installed_is_a_refusal_naming_it(home):
+    op = run_op("plugin.info", {"name": "no-such-plugin"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "not_found"
+
+
+def test_a_flag_that_only_shapes_the_printout_is_refused_with_its_reason(home):
+    # The trap the doctor verb documents: `--json` is real to the parser and
+    # meaningless past it, so admitting it would be accepted here and refused
+    # by the machine dispatcher one process later.
+    op = run_op("stats.runs", {"json": True})
+    assert op["ok"] is False
+    assert "shapes the human printout" in op["error"]["message"]
+
+
+def test_the_detail_view_is_refused_rather_than_changing_the_payload_shape(home):
+    op = run_op("monitor", {"id": "whatever"})
+    assert op["ok"] is False
+    assert "detail view" in op["error"]["message"]
+
+
+@pytest.mark.parametrize("verb", ["monitor", "state.ls", "invoke.list"])
+def test_a_parameter_nobody_declared_is_refused_by_name(home, verb):
+    op = run_op(verb, {"noSuchParameter": 1})
+    assert op["ok"] is False
+    assert "noSuchParameter" in op["error"]["message"]
+
+
+def test_a_window_that_cannot_be_parsed_is_refused_inside_the_envelope(home):
+    op = run_op("stats.runs", {"since": "yesterday"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "invalid_input"
+
+
+# ── what the surface deliberately does not reach ─────────────────────────────
+
+
+def test_the_plugin_listing_is_named_and_refused_with_why(home):
+    entry = next(e for e in call(help=True)["verbs"] if e["verb"] == "plugin.list")
+    assert entry["available"] is False
+    assert "trust" in entry["reason"]
+    op = run_op("plugin.list")
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "unavailable"
+
+
+def test_the_listing_that_prunes_trust_never_runs_from_this_surface(home):
+    # Reached the way it would be if someone registered it, straight at the CLI,
+    # to prove the refusal is in the command and not only in the registry.
+    done = li("plugin", "list", "--machine")
+    envelope = json.loads(done.stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "unavailable"
+    assert not (home / "settings.yaml").exists()
+
+
+@pytest.mark.parametrize(
+    ("command", "sub"),
+    [("state", "prune"), ("dispatch", "purge"), ("team", "send"), ("invoke", "start")],
+)
+def test_a_subcommand_that_writes_says_so_instead_of_running(home, command, sub):
+    done = li(command, sub, "--machine")
+    envelope = json.loads(done.stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "unavailable"
+
+
+def test_a_subcommand_nobody_has_is_bad_input_not_an_absent_seam(home):
+    envelope = json.loads(li("state", "not-a-subcommand", "--machine").stdout)
+    assert envelope["error"]["kind"] == "invalid_input"
+
+
+# ── one envelope on stdout, whatever the command wanted to print ─────────────
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("monitor", "--machine"),
+        ("state", "stats", "--machine"),
+        ("team", "list", "--machine"),
+        ("stats", "runs", "--machine"),
+    ],
+)
+def test_stdout_carries_exactly_one_json_object(home, argv):
+    done = li(*argv)
+    assert done.returncode == 0, done.stderr
+    envelope = json.loads(done.stdout)
+    assert done.stdout.strip().count("\n") == 0
+    assert envelope["contract_version"] == 1
+    assert envelope["ok"] is True
+
+
+def test_the_alias_reaches_the_same_result_as_the_command(home):
+    assert json.loads(li("mon", "--machine").stdout)["ok"] is True
+
+
+# ── the registry says what it can do ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", [*NO_ARGUMENT_VERBS, "dispatch.show", "plugin.info"])
+def test_the_verb_admits_only_parameters_its_machine_path_honours(verb):
+    registered = verbs.VERBS[verb]
+    schema = dispatch.verb_schema(registered)
+    assert registered.admits is not None, f"{verb} admits every projected parameter"
+    assert set(schema["properties"]) <= set(registered.admits)

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -46,6 +46,15 @@ REVIEWED_PATHS = frozenset(
         "orchestrate fanout",
         "orchestrate flow",
         "runs",
+        "dispatch ls",
+        "dispatch show",
+        "invoke list",
+        "monitor",
+        "plugin info",
+        "state ls",
+        "state stats",
+        "stats runs",
+        "team list",
     }
 )
 

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -50,6 +50,14 @@ GOLDEN_VERBS = (
     "stats runs",
     "studio start",
     "team send",
+    # The observability reads: every one of these is a path the surface now
+    # dispatches, so an argparse change under it must fail here rather than
+    # quietly reshape a schema a caller validated against.
+    "dispatch show",
+    "invoke list",
+    "plugin info",
+    "state stats",
+    "team list",
 )
 
 # Everything the MCP surface is a candidate to dispatch. `mirror` is


### PR DESCRIPTION
The MCP surface reaches six CLI paths. The projector can read parsers for seventy-two. That gap
is the whole point of the surface: an agent is meant to discover a command by being handed its
schema, not by already knowing to ask for it. A surface covering six paths does not do that.

This is the observability tranche — nine read-only commands, machine-qualified and registered:
`monitor`, `stats runs`, `invoke list`, `dispatch ls`, `dispatch show`, `state ls`,
`state stats`, `team list`, `plugin info`.

Each emits exactly one versioned envelope on stdout and nothing else, following `runs` and
`handshake` rather than inventing a second style. Anything read from disk carries its
availability, so "there are none" and "could not establish whether there are any" stay
different answers.

Flags that shape a human printout are not admitted. A flag the parser accepts and the machine
dispatcher then refuses is worse than an absent parameter, because a caller reading the schema
has no way to tell.

## Verification

`tests/cli tests/mcp`: 2498 passed, 2 skipped, and one failure that reproduces on untouched
`main`. Every verb is exercised end to end through `request` with the real subprocess; nothing
mocks the child, because the assembly between rendering argv and what the child parses is where
this surface's defects live.

The privilege fence's reviewed-path list gains one line per path. That test diffs the reachable
set against a list a person wrote down, in both directions, so it fails until someone writes the
new path down — which is the point of it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

## Second round

A review found that an existing `state.db` which refuses to open — a permission, a lock — escaped every store-backed read and came back as `internal`. That is this contract's word for our own bug, and a consumer is entitled to treat it as one and stop. A file it cannot read right now is none of those things: the caller can act on it, and it says nothing about whether the rows exist. It also put a driver exception string into a versioned contract, where the next release of that driver quietly changes it.

`readonly_state_db` now yields the store paired with why it is not there, so the reason travels with the `None` instead of being reconstructed by each caller. There was always more than one way to arrive at that `None` — no store, which is a definitive statement that nothing has been recorded, or a store that would not open, which establishes nothing — and every caller guessed the first. Detail reads have no wrapper to put this in, so they refuse: still `not_found` when there is no store, `unavailable` when there is one we could not read, because the record may well be sitting in it.

The guard covers opening the store and one trivial statement against it, and nothing else. The engine connects lazily, so without that statement the refusal surfaced in the middle of a caller's query, where it is indistinguishable from that query being wrong. A caller's own body still runs outside the guard, so a bug in a reader surfaces as the crash it is.

Tests take a real store and remove read permission from it, then go through the real subprocess: six collection reads report `unreadable`, and the detail read refuses `unavailable` rather than `not_found`. Each half of the fix — the eager statement and the reporting — turns those red on its own when reverted separately.