### PR TITLE
fix(studio): make the runs listing cost the page, not the store

### DIFF
--- a/benchmarks/studio_query_cost.py
+++ b/benchmarks/studio_query_cost.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Measure what a studio list endpoint costs on a large store.
+
+Answers three questions with numbers rather than inspection:
+
+1. What plan does the runs listing actually get, and is any part of it bounded
+   by the caller's page size?
+2. How long does the endpoint take end to end, split into SQL and Python?
+3. While it runs, can other requests still be served -- or does one expensive
+   read make the whole daemon unresponsive?
+
+Point it at a synthetic store built by ``tests.fixtures.synthetic_state_db``::
+
+    uv run python benchmarks/studio_query_cost.py /tmp/big.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sqlite3
+import statistics
+import time
+from pathlib import Path
+
+RUNS_LIST_SQL = """
+SELECT s.id, s.updated_at,
+       COUNT(DISTINCT b.id) AS branch_count,
+       COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
+FROM sessions s
+LEFT JOIN branches b ON b.session_id = s.id
+LEFT JOIN progressions p ON p.id = b.progression_id
+GROUP BY s.id
+ORDER BY s.updated_at DESC
+"""
+
+PAGE_SQL = """
+SELECT s.id, s.updated_at,
+       COUNT(DISTINCT b.id) AS branch_count,
+       COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
+FROM sessions s
+LEFT JOIN branches b ON b.session_id = s.id
+LEFT JOIN progressions p ON p.id = b.progression_id
+GROUP BY s.id
+ORDER BY s.updated_at DESC
+LIMIT 200
+"""
+
+WINDOWED_SQL = """
+WITH page AS (
+    SELECT id, updated_at FROM sessions ORDER BY updated_at DESC LIMIT 200
+)
+SELECT page.id, page.updated_at,
+       COUNT(DISTINCT b.id) AS branch_count,
+       COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
+FROM page
+LEFT JOIN branches b ON b.session_id = page.id
+LEFT JOIN progressions p ON p.id = b.progression_id
+GROUP BY page.id
+ORDER BY page.updated_at DESC
+"""
+
+
+def explain(db: sqlite3.Connection, sql: str) -> str:
+    rows = db.execute("EXPLAIN QUERY PLAN " + sql).fetchall()
+    return "\n".join("    " + " ".join(str(c) for c in r[3:]) for r in rows)
+
+
+def time_sql(path: Path, sql: str, repeats: int = 3) -> float:
+    samples = []
+    for _ in range(repeats):
+        db = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        started = time.perf_counter()
+        db.execute(sql).fetchall()
+        samples.append(time.perf_counter() - started)
+        db.close()
+    return min(samples)
+
+
+async def measure_endpoints(path: Path, concurrency: int) -> None:
+    import httpx
+
+    from lionagi.studio.app import create_app
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://localhost") as client:
+        for label, url, params in (
+            ("GET /api/runs/?per_page=200", "/api/runs/", {"per_page": 200}),
+            ("GET /api/sessions/", "/api/sessions/", {}),
+            ("GET /api/admin/health", "/api/admin/health", {}),
+            ("GET /api/runs/projects", "/api/runs/projects", {}),
+        ):
+            started = time.perf_counter()
+            resp = await client.get(url, params=params)
+            elapsed = time.perf_counter() - started
+            body = resp.json() if resp.status_code == 200 else {}
+            served = len(body.get("runs", body.get("sessions", []))) or ""
+            print(f"\n{label} -> {resp.status_code} in {elapsed:.2f}s  rows={served}")
+
+        # Does one expensive read make the rest of the daemon unresponsive?
+        # Probe with a cheap read that still touches the store, not with a
+        # stateless route -- a stateless route answers a different question.
+        for probe_label, probe_url in (
+            ("/health (stateless)", "/health"),
+            ("/api/runs/projects (store-backed)", "/api/runs/projects"),
+        ):
+            baseline = []
+            for _ in range(10):
+                t0 = time.perf_counter()
+                await client.get(probe_url)
+                baseline.append(time.perf_counter() - t0)
+
+            latencies: list[float] = []
+            done = asyncio.Event()
+
+            async def poll(url: str, out: list[float], stop: asyncio.Event) -> None:
+                while not stop.is_set():
+                    t0 = time.perf_counter()
+                    await client.get(url)
+                    out.append(time.perf_counter() - t0)
+
+            poller = asyncio.create_task(poll(probe_url, latencies, done))
+            heavy = [client.get("/api/runs/", params={"per_page": 200}) for _ in range(concurrency)]
+            t0 = time.perf_counter()
+            await asyncio.gather(*heavy)
+            heavy_elapsed = time.perf_counter() - t0
+            done.set()
+            await poller
+
+            print(
+                f"\n{probe_label} latency while {concurrency} concurrent "
+                f"runs listings run ({heavy_elapsed:.2f}s total):"
+            )
+            print(f"    idle   median {statistics.median(baseline) * 1000:.1f} ms")
+            if latencies:
+                print(
+                    f"    loaded median {statistics.median(latencies) * 1000:.1f} ms, "
+                    f"max {max(latencies) * 1000:.0f} ms, n={len(latencies)}"
+                )
+            else:
+                print("    loaded: NO probe completed while the listings ran")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--skip-endpoints", action="store_true")
+    parser.add_argument("--concurrency", type=int, default=4)
+    args = parser.parse_args(argv)
+
+    # Studio resolves the store from LIONAGI_HOME at import time, so the store
+    # must be named state.db and the home must be set before lionagi loads.
+    if args.path.name != "state.db":
+        parser.error("store must be named state.db (studio resolves it from LIONAGI_HOME)")
+    os.environ["LIONAGI_HOME"] = str(args.path.parent)
+
+    size_mb = args.path.stat().st_size / 1024 / 1024
+    db = sqlite3.connect(f"file:{args.path}?mode=ro", uri=True)
+    counts = {
+        t: db.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]  # noqa: S608
+        for t in ("sessions", "branches", "progressions", "messages")
+    }
+    print(f"store: {args.path} ({size_mb:.0f} MB)")
+    for name, n in counts.items():
+        print(f"    {name}: {n:,}")
+
+    for label, sql in (
+        ("runs listing, as shipped (no LIMIT)", RUNS_LIST_SQL),
+        ("same query with LIMIT 200 appended", PAGE_SQL),
+        ("page selected first, then joined", WINDOWED_SQL),
+    ):
+        print(f"\n{label}:")
+        print(explain(db, sql))
+        print(f"    wall: {time_sql(args.path, sql):.3f}s")
+    db.close()
+
+    if not args.skip_endpoints:
+        asyncio.run(measure_endpoints(args.path, args.concurrency))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -143,6 +143,13 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
         return result
     finally:
         if conn is not None:
+            # Shielded because closing is itself an await, and this one can run
+            # with a cancellation already active around it — a caller that gave
+            # up on the probe, a request the client abandoned, a shutting-down
+            # daemon. Unshielded it is cancelled before it reaches the
+            # connection, and the worker thread lives on holding an open
+            # database until the loop closes underneath it. The wait is bounded
+            # by the busy timeout already set above.
             with CancelScope(shield=True):
                 await conn.close()
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -82,6 +82,67 @@ def db_health() -> dict[str, int]:
     return {"size_bytes": size_bytes, "wal_bytes": wal_bytes, "wal_pending": wal_bytes}
 
 
+# How long the store probe waits before calling the store slow. Well under any
+# sensible caller timeout, so a slow verdict arrives as an answer rather than
+# as the caller's own timeout.
+STORE_PROBE_TIMEOUT_MS = 1000
+
+# One row off an index the store already maintains (idx_sessions_updated). The
+# probe must not be able to cause the failure it detects, so it reads no
+# content, joins nothing, and its cost does not grow with the store.
+_STORE_PROBE_SQL = "SELECT id FROM sessions ORDER BY updated_at DESC LIMIT 1"
+
+
+async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, Any]:
+    """Run a bounded indexed read against the store and report which of three
+    things is true: it answered, it did not answer in time, or it could not be
+    reached at all. Collapsing those into one boolean is what let a stalled
+    daemon keep reporting healthy."""
+    import aiosqlite
+
+    from lionagi.ln import move_on_after
+
+    result: dict[str, Any] = {
+        "status": "unavailable",
+        "detail": "",
+        "latency_ms": None,
+        "timeout_ms": timeout_ms,
+        "store_present": DEFAULT_DB_PATH.exists(),
+        "checked_at": now_utc().isoformat(),
+    }
+    if not result["store_present"]:
+        result["detail"] = f"no store at {DEFAULT_DB_PATH}"
+        return result
+
+    started = time.perf_counter()
+    timed_out = True
+    try:
+        with move_on_after(timeout_ms / 1000) as scope:
+            async with aiosqlite.connect(str(DEFAULT_DB_PATH)) as db:
+                # The shared connection helper waits 5s on a lock, which would
+                # outlast this probe's own deadline; the probe would rather
+                # report "slow" than sit in SQLite's retry loop.
+                await db.execute(f"PRAGMA busy_timeout = {timeout_ms}")
+                cur = await db.execute(_STORE_PROBE_SQL)
+                await cur.fetchone()
+            timed_out = False
+        if scope.cancelled_caught:
+            timed_out = True
+    except Exception as exc:  # noqa: BLE001
+        result["latency_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        result["detail"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result["latency_ms"] = round((time.perf_counter() - started) * 1000, 1)
+    if timed_out:
+        result["status"] = "slow"
+        result["detail"] = f"store did not answer a single indexed read within {timeout_ms} ms"
+    else:
+        result["status"] = "healthy"
+        result["detail"] = "store answered a bounded indexed read"
+    return result
+
+
 def _find_pid_file(root: Path) -> int | None:
     for name in ("session.pid", "run.pid", ".pid"):
         p = root / name
@@ -115,6 +176,11 @@ def _ps_snapshot() -> str:
 
 # Process start-time comparison tolerance (clock-tick rounding).
 _PID_CREATE_TIME_TOLERANCE = 1.0
+
+# Sessions the health report classifies per call, newest first. Bounds the
+# filesystem and process work the diagnostic does; the response discloses
+# how much of the store the number actually covers.
+HEALTH_SCAN_LIMIT = 500
 
 
 def process_liveness(
@@ -286,18 +352,32 @@ async def health_report() -> dict[str, Any]:
 
     now = time.time()
     async with _open_db(_DB) as db:
+        total_cur = await db.execute("SELECT COUNT(*) AS n FROM sessions")
+        total_row = await total_cur.fetchone()
+        total_sessions = int(total_row["n"]) if total_row else 0
+        # Classifying a session stats its artifact tree and can shell out to
+        # `ps`, so the pass is bounded to the most recent window and the
+        # response says how much of the store it covered. Reporting on every
+        # session would make this diagnostic the most expensive read in the
+        # daemon -- and a health check that can hurt a sick store is worse
+        # than no health check.
         cur = await db.execute(
             """
+            WITH page AS (
+                SELECT id AS page_id FROM sessions ORDER BY updated_at DESC LIMIT ?
+            )
             SELECT s.id, s.name, s.status, s.invocation_kind, s.agent_name,
                    s.playbook_name, s.started_at, s.ended_at, s.updated_at,
                    s.last_message_at, s.artifacts_path, s.node_metadata,
                    COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
-            FROM sessions s
+            FROM page
+            JOIN sessions s ON s.id = page.page_id
             LEFT JOIN branches b ON b.session_id = s.id
             LEFT JOIN progressions p ON p.id = b.progression_id
             GROUP BY s.id
             ORDER BY s.updated_at DESC
-            """
+            """,
+            (HEALTH_SCAN_LIMIT,),
         )
         rows = await cur.fetchall()
 
@@ -367,9 +447,12 @@ async def health_report() -> dict[str, Any]:
                 }
             )
 
+    scanned = sum(by_status.values())
     return {
         "sessions": {
-            "total": sum(by_status.values()),
+            "total": total_sessions,
+            "scanned": scanned,
+            "truncated": scanned < total_sessions,
             "by_status": dict(by_status),
             "by_health": dict(by_health),
             "unhealthy": unhealthy,
@@ -673,6 +756,26 @@ async def doctor_route(
 async def health_route() -> dict[str, Any]:
     """ADR-0057 D6: composite session health report."""
     return await health_report()
+
+
+@studio_route("/admin/readiness", method="GET", area="admin", name="readiness")
+async def readiness_route(
+    timeout_ms: int = Query(
+        default=STORE_PROBE_TIMEOUT_MS,
+        ge=50,
+        le=10_000,
+        description="How long the probe waits for the store before reporting slow",
+    ),
+) -> dict[str, Any]:
+    """Whether a query against the store will actually return.
+
+    Distinct from ``/health``, which answers only whether the process is up:
+    that stays true while every database-backed endpoint is unresponsive, which
+    is exactly the failure this reports. Never 5xx -- the verdict is in the
+    body, so a caller can tell "store unreachable" from "store slow" from
+    "healthy" instead of getting one boolean for all three.
+    """
+    return await store_probe(timeout_ms=timeout_ms)
 
 
 @studio_route("/admin/transition", method="POST", area="admin", name="transition")

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -125,9 +125,19 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
     # slow verdict is — so its cleanup is the one part that must not be.
     conn = None
     try:
-        with move_on_after(timeout_ms / 1000) as scope:
+        # Connecting is shielded and sits outside the deadline. Opening a SQLite
+        # file takes no database lock — the first statement does — so the connect
+        # is not what a slow store makes slow, and bounding it buys nothing. What
+        # bounding it costs is the only way out of the leak: a connect cancelled
+        # midway leaves the driver's worker thread running while the connection
+        # object it would be closed through is discarded, so the close below
+        # returns at once and the thread outlives the probe unreachable. The
+        # remaining way for this to hang is a filesystem that will not answer,
+        # which the `store_present` check above already stands in front of.
+        with CancelScope(shield=True):
             conn = aiosqlite.connect(str(DEFAULT_DB_PATH))
             db = await conn
+        with move_on_after(timeout_ms / 1000) as scope:
             # The shared connection helper waits 5s on a lock, which would
             # outlast this probe's own deadline; the probe would rather
             # report "slow" than sit in SQLite's retry loop.

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -101,6 +101,7 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
     import aiosqlite
 
     from lionagi.ln import move_on_after
+    from lionagi.ln.concurrency import CancelScope
 
     result: dict[str, Any] = {
         "status": "unavailable",
@@ -116,15 +117,23 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
 
     started = time.perf_counter()
     timed_out = True
+    # Closing is deliberately not left to `async with`. This connection runs a
+    # worker thread, and closing it is itself an await; inside a scope that has
+    # just been cancelled that await is cancelled too, so the thread survives
+    # holding an open database and then tries to complete against an event loop
+    # that has since closed. The probe exists to be cancelled — that is what a
+    # slow verdict is — so its cleanup is the one part that must not be.
+    conn = None
     try:
         with move_on_after(timeout_ms / 1000) as scope:
-            async with aiosqlite.connect(str(DEFAULT_DB_PATH)) as db:
-                # The shared connection helper waits 5s on a lock, which would
-                # outlast this probe's own deadline; the probe would rather
-                # report "slow" than sit in SQLite's retry loop.
-                await db.execute(f"PRAGMA busy_timeout = {timeout_ms}")
-                cur = await db.execute(_STORE_PROBE_SQL)
-                await cur.fetchone()
+            conn = aiosqlite.connect(str(DEFAULT_DB_PATH))
+            db = await conn
+            # The shared connection helper waits 5s on a lock, which would
+            # outlast this probe's own deadline; the probe would rather
+            # report "slow" than sit in SQLite's retry loop.
+            await db.execute(f"PRAGMA busy_timeout = {timeout_ms}")
+            cur = await db.execute(_STORE_PROBE_SQL)
+            await cur.fetchone()
             timed_out = False
         if scope.cancelled_caught:
             timed_out = True
@@ -132,6 +141,10 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
         result["latency_ms"] = round((time.perf_counter() - started) * 1000, 1)
         result["detail"] = f"{type(exc).__name__}: {exc}"
         return result
+    finally:
+        if conn is not None:
+            with CancelScope(shield=True):
+                await conn.close()
 
     result["latency_ms"] = round((time.perf_counter() - started) * 1000, 1)
     if timed_out:

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -169,9 +169,11 @@ def _all_tools() -> list:
 async def tool_list_runs(page: int = 1, per_page: int = 10) -> dict[str, Any]:
     """List recent studio runs (read-only)."""
     from lionagi.studio.services import runs as runs_svc
+    from lionagi.studio.services import sessions as sessions_svc
 
-    raw = await runs_svc.list_runs()
-    return runs_svc.paginate_runs(raw, page=page, per_page=per_page)
+    raw = await runs_svc.list_runs(limit=per_page, offset=(page - 1) * per_page)
+    total = await sessions_svc.count_sessions()
+    return runs_svc.paginate_runs(raw, page=page, per_page=per_page, total=total)
 
 
 async def tool_list_invocations(limit: int = 10, offset: int = 0) -> dict[str, Any]:
@@ -186,8 +188,8 @@ async def tool_list_sessions(limit: int = 10) -> dict[str, Any]:
     """List recent agent sessions (read-only)."""
     from lionagi.studio.services import sessions as sess_svc
 
-    rows = await sess_svc.list_sessions()
-    return {"sessions": rows[:limit]}
+    rows = await sess_svc.list_sessions(limit=limit)
+    return {"sessions": rows}
 
 
 async def tool_list_playbooks() -> dict[str, Any]:

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -508,27 +508,27 @@ async def list_runs(
     project: str | None = None,
     project_null: bool = False,
     tag: list[str] | None = None,
+    *,
+    limit: int = _sessions_svc.MAX_SESSION_PAGE,
+    offset: int = 0,
 ) -> list[dict[str, Any]]:
+    """One page of runs. Filters are applied in SQL so the page is selected
+    rather than sieved out of a whole-store read; per-row liveness and tag
+    hydration then touch only the rows actually being returned."""
     from . import run_tags
 
-    sessions = await _sessions_svc.list_sessions()
-    status_set = _normalize_status_filter(status)
-    tagged = await run_tags.session_ids_with_tags(tag) if (tag and sessions) else None
+    where = _sessions_svc.SessionFilter(
+        playbook=playbook,
+        statuses=_normalize_status_filter(status),
+        project=project,
+        project_null=project_null,
+        tags=tag,
+    )
+    sessions = await _sessions_svc.list_sessions(limit=limit, offset=offset, where=where)
     now = time.time()
     out = []
     snapshot: str | None = None
     for s in sessions:
-        if playbook and playbook.lower() not in (s.get("playbook_name") or "").lower():
-            continue
-        if project_null:
-            if s.get("project") is not None:
-                continue
-        elif project and s.get("project") != project:
-            continue
-        if status_set and s.get("status") not in status_set:
-            continue
-        if tagged is not None and s["id"] not in tagged:
-            continue
         alive: bool | None = None
         if s.get("status") == "running":
             if snapshot is None:
@@ -545,15 +545,16 @@ async def list_runs(
 
 
 def paginate_runs(
-    runs: list[dict[str, Any]],
+    page_runs: list[dict[str, Any]],
     *,
     page: int,
     per_page: int,
+    total: int,
 ) -> dict[str, Any]:
-    total = len(runs)
+    """Wrap an already-selected page in the listing envelope. `total` is counted
+    separately in SQL; it is never inferred from the length of the page, which
+    would report a bounded answer as a complete one."""
     total_pages = math.ceil(total / per_page) if total else 0
-    start = (page - 1) * per_page
-    page_runs = runs[start : start + per_page]
     return {
         "runs": page_runs,
         "page": page,
@@ -695,7 +696,14 @@ def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]]
 @studio_route("/runs/", method="GET", area="runs", name="list_runs")
 async def list_runs_route(
     page: int = Query(default=1, ge=1, description="1-based page number"),
-    per_page: int = Query(default=20, ge=1, le=5000, description="Rows per page"),
+    # Refused above the cap rather than served slowly: a caller can react to a
+    # 422 and ask for pages, but it cannot react to a daemon that stops answering.
+    per_page: int = Query(
+        default=20,
+        ge=1,
+        le=_sessions_svc.MAX_SESSION_PAGE,
+        description=f"Rows per page (max {_sessions_svc.MAX_SESSION_PAGE})",
+    ),
     status: list[str] | None = Query(default=None, description="Repeated status filter"),  # noqa: B008
     # ADR-0079: renamed from ?worker= to ?playbook= — "worker" is
     # not in lionagi's Studio vocabulary per ADR-0079.
@@ -708,14 +716,24 @@ async def list_runs_route(
         default=None, description="Repeated tag filter (AND-composed)"
     ),
 ) -> dict[str, Any]:
+    where = _sessions_svc.SessionFilter(
+        playbook=playbook,
+        statuses=_normalize_status_filter(status),
+        project=project,
+        project_null=project_null,
+        tags=tag,
+    )
     runs = await list_runs(
         playbook=playbook,
         status=status,
         project=project,
         project_null=project_null,
         tag=tag,
+        limit=per_page,
+        offset=(page - 1) * per_page,
     )
-    return paginate_runs(runs, page=page, per_page=per_page)
+    total = await _sessions_svc.count_sessions(where)
+    return paginate_runs(runs, page=page, per_page=per_page, total=total)
 
 
 # Registered before /runs/{run_id} so the literal path is not captured as a run id.

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -7,7 +7,7 @@ import time
 from typing import Any
 
 import aiosqlite
-from fastapi import HTTPException
+from fastapi import HTTPException, Query
 
 from lionagi._errors import NotFoundError
 from lionagi.state.claude_mirror import session_db_id
@@ -94,13 +94,109 @@ def _format_message(row: aiosqlite.Row | dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def list_sessions() -> list[dict[str, Any]]:
+# A listing whose SQL carries no LIMIT examines every session, every branch and
+# every progression regardless of how few rows the caller asked for -- appending
+# LIMIT to that statement does not help, because a limit bounds rows returned
+# and not rows examined. So the page is chosen first, from an indexed scan of
+# `sessions` alone, and only that page is joined against branches/progressions.
+# Callers that want a whole-store answer must ask for it a page at a time.
+MAX_SESSION_PAGE = 500
+
+
+class SessionFilter:
+    """Filters the runs/sessions listings share, pushed into SQL so they select
+    the page rather than discard rows after the whole store has been read."""
+
+    def __init__(
+        self,
+        *,
+        playbook: str | None = None,
+        statuses: set[str] | None = None,
+        project: str | None = None,
+        project_null: bool = False,
+        tags: list[str] | None = None,
+    ) -> None:
+        self.playbook = playbook
+        self.statuses = statuses
+        self.project = project
+        self.project_null = project_null
+        self.tags = list(dict.fromkeys(tags)) if tags else None
+
+    def where(self) -> tuple[str, list[Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if self.playbook:
+            clauses.append("LOWER(COALESCE(s.playbook_name, '')) LIKE '%' || LOWER(?) || '%'")
+            params.append(self.playbook)
+        if self.statuses:
+            ordered = sorted(self.statuses)
+            placeholders = ",".join("?" for _ in ordered)
+            # Legacy rows carry NULL status and read as "completed" everywhere else.
+            null_clause = " OR s.status IS NULL" if "completed" in self.statuses else ""
+            clauses.append(f"(COALESCE(s.status, 'completed') IN ({placeholders}){null_clause})")
+            params.extend(ordered)
+        if self.project_null:
+            clauses.append("s.project IS NULL")
+        elif self.project:
+            clauses.append("s.project = ?")
+            params.append(self.project)
+        if self.tags:
+            placeholders = ",".join("?" for _ in self.tags)
+            clauses.append(
+                f"s.id IN (SELECT session_id FROM run_tags WHERE tag IN ({placeholders})"  # noqa: S608
+                " GROUP BY session_id HAVING COUNT(DISTINCT tag) = ?)"
+            )
+            params.extend([*self.tags, len(self.tags)])
+        if not clauses:
+            return "", []
+        return "WHERE " + " AND ".join(clauses), params
+
+
+async def count_sessions(where: SessionFilter | None = None) -> int:
+    """Total matching sessions, without reading a single branch or progression."""
+    if not DEFAULT_DB_PATH.exists():
+        return 0
+    clause, params = (where or SessionFilter()).where()
+    async with _open_db(_DB) as db:
+        cur = await db.execute(
+            f"SELECT COUNT(*) AS n FROM sessions s {clause}",  # noqa: S608
+            params,
+        )
+        row = await cur.fetchone()
+    return int(row["n"]) if row else 0
+
+
+async def list_sessions(
+    *,
+    limit: int = MAX_SESSION_PAGE,
+    offset: int = 0,
+    where: SessionFilter | None = None,
+) -> list[dict[str, Any]]:
+    """One page of sessions, newest first. Cost is proportional to `limit`, not
+    to the size of the store."""
     if not DEFAULT_DB_PATH.exists():
         return []
 
+    limit = max(1, min(int(limit), MAX_SESSION_PAGE))
+    offset = max(0, int(offset))
+    clause, params = (where or SessionFilter()).where()
+
     async with _open_db(_DB) as db:
+        # run_tags is created lazily on first tag write, so a tag filter would
+        # fail on a store that has never been tagged.
+        if (where or SessionFilter()).tags:
+            from .run_tags import _ensure_table
+
+            await _ensure_table(db)
         cur = await db.execute(
-            """
+            f"""
+            WITH page AS (
+                SELECT s.id AS page_id
+                FROM sessions s
+                {clause}
+                ORDER BY s.updated_at DESC
+                LIMIT ? OFFSET ?
+            )
             SELECT
                 s.id,
                 s.name,
@@ -133,12 +229,14 @@ async def list_sessions() -> list[dict[str, Any]]:
                 COALESCE(SUM(
                     json_array_length(p.collection)
                 ), 0) AS message_count
-            FROM sessions s
+            FROM page
+            JOIN sessions s ON s.id = page.page_id
             LEFT JOIN branches b ON b.session_id = s.id
             LEFT JOIN progressions p ON p.id = b.progression_id
             GROUP BY s.id
             ORDER BY s.updated_at DESC
-            """
+            """,  # noqa: S608
+            [*params, limit, offset],
         )
         rows = await cur.fetchall()
 
@@ -775,8 +873,26 @@ def is_session_stream_done(state: dict[str, Any] | None, *, now: float) -> bool:
 
 
 @studio_route("/sessions/", method="GET", area="sessions", name="list_sessions")
-async def list_sessions_route() -> dict[str, Any]:
-    return {"sessions": await list_sessions()}
+async def list_sessions_route(
+    limit: int = Query(
+        default=MAX_SESSION_PAGE,
+        ge=1,
+        le=MAX_SESSION_PAGE,
+        description=f"Rows to return, newest first (max {MAX_SESSION_PAGE})",
+    ),
+    offset: int = Query(default=0, ge=0, description="Rows to skip, newest first"),
+) -> dict[str, Any]:
+    """One page of sessions. The response always reports `total` and
+    `truncated` so a bounded answer can never be mistaken for a complete one."""
+    sessions = await list_sessions(limit=limit, offset=offset)
+    total = await count_sessions()
+    return {
+        "sessions": sessions,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "truncated": offset + len(sessions) < total,
+    }
 
 
 @studio_route("/sessions/{session_id}", method="GET", area="sessions", name="get_session")

--- a/lionagi/studio/services/stats.py
+++ b/lionagi/studio/services/stats.py
@@ -220,7 +220,9 @@ async def get_stats() -> dict[str, Any]:
     return {
         "playbooks": len(playbooks_svc.list_playbooks()),
         "agents": len(agents_svc.list_agents()),
-        "runs": len(await sessions_svc.list_sessions()),
+        # Counted in SQL; materializing the rows just to take len() made the
+        # dashboard's cheapest number the most expensive query on the page.
+        "runs": await sessions_svc.count_sessions(),
         "shows": len(await shows_svc.list_shows()),
         "skills": len(skills_svc.list_skills()),
         "plugins": len(plugins_svc.list_plugins()),

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -68,6 +68,7 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/admin/doctor"),
     ("GET", "/api/admin/events"),
     ("GET", "/api/admin/health"),
+    ("GET", "/api/admin/readiness"),
     ("GET", "/api/agents/"),
     ("GET", "/api/agents/{name}"),
     ("GET", "/api/approvals/evidence/verify"),
@@ -235,7 +236,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 99
+    assert len(_GOLDEN_ROUTES) == 100
 
 
 def _compiled_match_shape(path_template: str) -> str:
@@ -577,7 +578,14 @@ def test_sessions_list_response_shape(tmp_path, monkeypatch):
 
     r = client.get("/api/sessions/")
     assert r.status_code == 200
-    assert sorted(r.json().keys()) == ["sessions"]
+    # The listing is bounded, so it also reports what it left out.
+    assert sorted(r.json().keys()) == [
+        "limit",
+        "offset",
+        "sessions",
+        "total",
+        "truncated",
+    ]
 
 
 def test_sessions_detail_response_shape(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -494,3 +494,35 @@ class TestStoreProbe:
         r = client.get("/health")
         assert r.status_code == 200
         assert r.json() == {"status": "ok"}
+
+    def test_this_file_runs_under_the_interpreter_default_sigpipe(self):
+        """The tests above must not inherit a ``SIG_DFL`` from an earlier test.
+
+        Several of them close an event loop while a database connection's
+        worker thread may still be finishing. Closing a loop closes the read
+        end of its self-pipe before the write end, so a thread handing back a
+        result in that window writes to a pipe whose peer is gone. Under the
+        interpreter default that is an ``OSError`` asyncio already swallows.
+        Under ``SIG_DFL`` the kernel kills the process first, and it dies with
+        its buffered output still buffered: no traceback, no failing
+        assertion, just a worker that stopped and a report blaming whichever
+        test it was holding.
+
+        The CLI sets ``SIG_DFL`` on entry, deliberately, because a command in
+        a pipeline should die quietly when its reader leaves. ``signal.signal``
+        is process-wide, so any test that drives the CLI in-process hands that
+        to every test after it. A fixture in ``tests/conftest.py`` puts it
+        back; this asserts the tests here actually got the benefit.
+
+        Order-dependent by nature: it can only catch the leak when something
+        that changes the policy ran earlier in this same process. Run this
+        file after ``tests/cli`` with ``-n 0`` to see it fail without that
+        fixture. Distributed across workers it may pass without proving
+        anything, which is why it is written to never fail falsely.
+        """
+        import signal
+
+        assert signal.getsignal(signal.SIGPIPE) is signal.SIG_IGN, (
+            "an earlier test left SIGPIPE at SIG_DFL; a closed-loop wakeup "
+            "here will kill the worker with no traceback"
+        )

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -275,12 +275,19 @@ class TestStoreProbe:
         import anyio
 
         class _SlowConnection:
-            async def __aenter__(self):
-                await anyio.sleep(5)
-                raise AssertionError("probe should have given up before this")
+            # Shaped like the real connection object, which is awaited to
+            # connect and closed explicitly. A double that only implemented
+            # `async with` would still pass while the code under test stopped
+            # using it.
+            def __await__(self):
+                async def _hang():
+                    await anyio.sleep(5)
+                    raise AssertionError("probe should have given up before this")
 
-            async def __aexit__(self, *exc):
-                return False
+                return _hang().__await__()
+
+            async def close(self):
+                return None
 
         import aiosqlite
 
@@ -290,6 +297,101 @@ class TestStoreProbe:
         assert body["timeout_ms"] == 100
         assert body["store_present"] is True
         assert "did not answer" in body["detail"]
+
+    def test_a_real_lock_leaves_no_connection_running_behind_the_timeout(self, seeded, monkeypatch):
+        """The probe gives up on a genuinely locked store and takes its thread with it.
+
+        A slow verdict is a cancellation, so the code that closes the connection
+        runs inside a scope that has already been cancelled. If that close is
+        awaited unprotected it is cancelled too, and the connection's worker
+        thread outlives the probe holding an open database — until the event
+        loop closes underneath it and it raises from a thread nobody is
+        watching. Nothing about the response body shows this, which is why the
+        assertion is on the thread rather than on the verdict.
+
+        The lock is a real one taken by another connection. A slow double can
+        be made to hang, but only a real lock produces the real connection, the
+        real worker thread and the real cleanup path that was wrong.
+        """
+        import asyncio
+        import threading
+
+        from aiosqlite.core import _connection_worker_thread
+
+        from lionagi.studio.services import admin as admin_svc
+
+        db_path, _ = seeded
+
+        def _workers() -> int:
+            return sum(
+                1
+                for t in threading.enumerate()
+                if getattr(t, "_target", None) is _connection_worker_thread
+            )
+
+        # The store runs in WAL, where an ordinary writer never blocks a reader.
+        # An exclusive locking mode does: it holds the file lock outright, so
+        # any other connection is refused until this one lets go.
+        blocker = sqlite3.connect(str(db_path), isolation_level=None)
+        blocker.execute("PRAGMA locking_mode = EXCLUSIVE")
+        blocker.execute("BEGIN IMMEDIATE")
+        blocker.execute("UPDATE sessions SET name = name")
+        try:
+            before = _workers()
+            body = asyncio.run(admin_svc.store_probe(timeout_ms=50))
+            assert body["status"] == "slow", body
+            assert _workers() == before, "a connection worker outlived the probe"
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+    def test_a_caller_that_gives_up_first_also_leaves_nothing_running(self, seeded):
+        """The same cleanup, with the cancellation coming from outside.
+
+        Readiness is served inside a request, and a request can be abandoned:
+        the client disconnects, the daemon shuts down, an outer deadline fires.
+        Then the probe's own cleanup runs with a cancellation already active
+        around it, and an unprotected close is cancelled before it reaches the
+        connection. The previous test cannot see this — there the probe absorbs
+        its own timeout, so by the time cleanup runs nothing is cancelling any
+        more and the close completes either way.
+        """
+        import threading
+
+        import anyio
+        from aiosqlite.core import _connection_worker_thread
+
+        from lionagi.studio.services import admin as admin_svc
+
+        db_path, _ = seeded
+
+        def _workers() -> int:
+            return sum(
+                1
+                for t in threading.enumerate()
+                if getattr(t, "_target", None) is _connection_worker_thread
+            )
+
+        blocker = sqlite3.connect(str(db_path), isolation_level=None)
+        blocker.execute("PRAGMA locking_mode = EXCLUSIVE")
+        blocker.execute("BEGIN IMMEDIATE")
+        blocker.execute("UPDATE sessions SET name = name")
+        try:
+            before = _workers()
+
+            async def _abandon():
+                with anyio.move_on_after(0.05):
+                    # Long enough that the caller's deadline is the one that fires.
+                    await admin_svc.store_probe(timeout_ms=5000)
+
+            anyio.run(_abandon)
+            deadline = time.monotonic() + 5
+            while _workers() > before and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert _workers() == before, "a connection worker outlived an abandoned probe"
+        finally:
+            blocker.rollback()
+            blocker.close()
 
     def test_probe_never_returns_5xx(self, client, monkeypatch):
         import aiosqlite

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The listing endpoints must do work proportional to the page, must refuse
+rather than serve an unbounded page, must say so when an answer is bounded,
+and the store probe must be able to go red."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lionagi.studio.app import create_app
+
+
+def _seed(db_path, *, sessions: int, branches_per_session: int = 1) -> list[str]:
+    from lionagi.state.db import _SCHEMA_PATH
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA_PATH.read_text())
+    now = time.time()
+    ids = []
+    for i in range(sessions):
+        sid = str(uuid.uuid4())
+        prog = str(uuid.uuid4())
+        ids.append(sid)
+        conn.execute(
+            "INSERT INTO progressions (id, created_at, collection) VALUES (?, ?, '[]')",
+            (prog, now),
+        )
+        conn.execute(
+            """INSERT INTO sessions
+               (id, created_at, progression_id, updated_at, name, status,
+                playbook_name, project)
+               VALUES (?,?,?,?,?,?,?,?)""",
+            (
+                sid,
+                now - i,
+                prog,
+                now - i,
+                f"run-{i}",
+                "completed" if i % 2 else "running",
+                f"book-{i % 3}",
+                "alpha" if i % 2 else None,
+            ),
+        )
+        for b in range(branches_per_session):
+            bprog = str(uuid.uuid4())
+            conn.execute(
+                "INSERT INTO progressions (id, created_at, collection) VALUES (?, ?, ?)",
+                (bprog, now, '["a","b","c"]'),
+            )
+            conn.execute(
+                """INSERT INTO branches (id, created_at, session_id, progression_id, name)
+                   VALUES (?,?,?,?,?)""",
+                (str(uuid.uuid4()), now, sid, bprog, f"b{b}"),
+            )
+    conn.commit()
+    conn.close()
+    return ids
+
+
+@pytest.fixture
+def seeded(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    ids = _seed(db_path, sessions=25)
+    for mod in ("sessions", "runs", "admin", "run_tags", "stats"):
+        module = pytest.importorskip(f"lionagi.studio.services.{mod}")
+        monkeypatch.setattr(module, "_DB", str(db_path), raising=False)
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    for mod in ("sessions", "runs", "admin", "run_tags"):
+        module = pytest.importorskip(f"lionagi.studio.services.{mod}")
+        if hasattr(module, "DEFAULT_DB_PATH"):
+            monkeypatch.setattr(module, "DEFAULT_DB_PATH", db_path)
+    return db_path, ids
+
+
+@pytest.fixture
+def client(seeded):
+    # The daemon rejects Host headers it doesn't recognise, and TestClient's
+    # default ("testserver") is not one of them.
+    with TestClient(create_app(), base_url="http://localhost") as c:
+        yield c
+
+
+class TestPageBoundsTheWork:
+    def test_rows_outside_the_page_are_never_examined(self, tmp_path, monkeypatch):
+        """A page size bounds rows *returned*; the defect was that it bounded
+        nothing *examined*. Poison every progression outside the first page with
+        JSON the aggregate cannot parse: a listing that reads the whole store
+        raises, one that reads only its page does not."""
+        import asyncio
+
+        db_path = tmp_path / "state.db"
+        ids = _seed(db_path, sessions=20)
+        conn = sqlite3.connect(str(db_path))
+        # Oldest 15 sessions -- outside a 5-row newest-first page.
+        for sid in ids[5:]:
+            conn.execute(
+                """UPDATE progressions SET collection = 'not json'
+                   WHERE id IN (SELECT progression_id FROM branches WHERE session_id = ?)""",
+                (sid,),
+            )
+        conn.commit()
+        conn.close()
+
+        import lionagi.state.db as db_mod
+        from lionagi.studio.services import sessions as sessions_svc
+
+        monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+        monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
+        monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
+
+        rows = asyncio.run(sessions_svc.list_sessions(limit=5))
+        assert [r["id"] for r in rows] == ids[:5]
+        assert all(r["message_count"] == 3 for r in rows)
+
+    def test_second_page_is_disjoint_and_ordered(self, seeded):
+        import asyncio
+
+        from lionagi.studio.services import sessions as sessions_svc
+
+        first = asyncio.run(sessions_svc.list_sessions(limit=5, offset=0))
+        second = asyncio.run(sessions_svc.list_sessions(limit=5, offset=5))
+        assert {r["id"] for r in first}.isdisjoint({r["id"] for r in second})
+        assert [r["updated_at"] for r in first] == sorted(
+            (r["updated_at"] for r in first), reverse=True
+        )
+        assert first[-1]["updated_at"] >= second[0]["updated_at"]
+
+    def test_limit_is_clamped_not_honoured_unbounded(self, seeded):
+        import asyncio
+
+        from lionagi.studio.services import sessions as sessions_svc
+
+        rows = asyncio.run(sessions_svc.list_sessions(limit=10_000))
+        assert len(rows) <= sessions_svc.MAX_SESSION_PAGE
+
+    def test_message_count_still_aggregates_over_branches(self, seeded):
+        import asyncio
+
+        from lionagi.studio.services import sessions as sessions_svc
+
+        rows = asyncio.run(sessions_svc.list_sessions(limit=3))
+        assert all(r["branch_count"] == 1 for r in rows)
+        assert all(r["message_count"] == 3 for r in rows)
+
+
+class TestFiltersApplyInSql:
+    def test_status_filter_matches_python_semantics(self, client):
+        r = client.get("/api/runs/", params={"status": "running", "per_page": 100})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["runs"]
+        assert all(run["status"] == "running" for run in body["runs"])
+        assert body["total"] == len(body["runs"])
+
+    def test_status_alias_expands(self, client):
+        aliased = client.get("/api/runs/", params={"status": "done", "per_page": 100}).json()
+        direct = client.get("/api/runs/", params={"status": "completed", "per_page": 100}).json()
+        assert aliased["total"] == direct["total"]
+
+    def test_project_null_filter(self, client):
+        body = client.get("/api/runs/", params={"project_null": True, "per_page": 100}).json()
+        assert body["runs"]
+        assert all(run["project"] is None for run in body["runs"])
+
+    def test_project_exact_filter(self, client):
+        body = client.get("/api/runs/", params={"project": "alpha", "per_page": 100}).json()
+        assert body["runs"]
+        assert all(run["project"] == "alpha" for run in body["runs"])
+
+    def test_playbook_filter_is_case_insensitive_contains(self, client):
+        body = client.get("/api/runs/", params={"playbook": "BOOK-1", "per_page": 100}).json()
+        assert body["runs"]
+        assert all("book-1" in run["playbook_name"] for run in body["runs"])
+
+    def test_tag_filter_and_composes(self, seeded, client):
+        _, ids = seeded
+        client.post(f"/api/sessions/{ids[0]}/tags", json={"tag": "keep"})
+        client.post(f"/api/sessions/{ids[0]}/tags", json={"tag": "urgent"})
+        client.post(f"/api/sessions/{ids[1]}/tags", json={"tag": "keep"})
+
+        one = client.get("/api/runs/", params={"tag": ["keep"], "per_page": 100}).json()
+        both = client.get("/api/runs/", params={"tag": ["keep", "urgent"], "per_page": 100}).json()
+        assert one["total"] == 2
+        assert both["total"] == 1
+        assert both["runs"][0]["run_id"] == ids[0]
+
+    def test_tag_filter_on_never_tagged_store(self, client):
+        """run_tags is created on first tag write; filtering before that must
+        return nothing, not raise."""
+        r = client.get("/api/runs/", params={"tag": ["nope"], "per_page": 100})
+        assert r.status_code == 200
+        assert r.json()["total"] == 0
+
+    def test_total_counts_the_filtered_set_not_the_page(self, client):
+        body = client.get("/api/runs/", params={"per_page": 5}).json()
+        assert len(body["runs"]) == 5
+        assert body["total"] == 25
+        assert body["total_pages"] == 5
+        assert body["has_next"] is True
+
+
+class TestBoundedAnswersSaySo:
+    def test_runs_pagination_envelope_is_honest(self, client):
+        body = client.get("/api/runs/", params={"page": 2, "per_page": 10}).json()
+        assert body["page"] == 2
+        assert body["total"] == 25
+        assert body["has_prev"] is True
+        assert body["has_next"] is True
+
+    def test_sessions_listing_reports_truncation(self, client, monkeypatch):
+        body = client.get("/api/sessions/", params={"limit": 10}).json()
+        assert len(body["sessions"]) == 10
+        assert body["total"] == 25
+        assert body["truncated"] is True
+
+    def test_sessions_listing_not_truncated_when_complete(self, client):
+        body = client.get("/api/sessions/", params={"limit": 100}).json()
+        assert len(body["sessions"]) == 25
+        assert body["truncated"] is False
+
+    def test_admin_health_reports_scan_coverage(self, client):
+        body = client.get("/api/admin/health").json()
+        assert body["sessions"]["total"] == 25
+        assert body["sessions"]["scanned"] == 25
+        assert body["sessions"]["truncated"] is False
+
+
+class TestOversizedPageIsRefused:
+    def test_per_page_above_cap_is_refused(self, client):
+        from lionagi.studio.services import sessions as sessions_svc
+
+        r = client.get("/api/runs/", params={"per_page": sessions_svc.MAX_SESSION_PAGE + 1})
+        assert r.status_code == 422
+
+    def test_per_page_at_cap_is_served(self, client):
+        from lionagi.studio.services import sessions as sessions_svc
+
+        r = client.get("/api/runs/", params={"per_page": sessions_svc.MAX_SESSION_PAGE})
+        assert r.status_code == 200
+
+    def test_sessions_limit_above_cap_is_refused(self, client):
+        from lionagi.studio.services import sessions as sessions_svc
+
+        r = client.get("/api/sessions/", params={"limit": sessions_svc.MAX_SESSION_PAGE + 1})
+        assert r.status_code == 422
+
+
+class TestStoreProbe:
+    def test_healthy_store_reports_healthy(self, client):
+        body = client.get("/api/admin/readiness").json()
+        assert body["status"] == "healthy"
+        assert body["store_present"] is True
+        assert body["latency_ms"] >= 0
+
+    def test_missing_store_reports_unavailable_not_healthy(self, client, tmp_path, monkeypatch):
+        from lionagi.studio.services import admin as admin_svc
+
+        monkeypatch.setattr(admin_svc, "DEFAULT_DB_PATH", tmp_path / "gone.db")
+        body = client.get("/api/admin/readiness").json()
+        assert body["status"] == "unavailable"
+        assert body["store_present"] is False
+
+    def test_slow_store_reports_slow_not_unavailable(self, client, monkeypatch):
+        """A store that answers, but not inside the probe's deadline, is a
+        distinct verdict from one that cannot be reached at all."""
+        import anyio
+
+        class _SlowConnection:
+            async def __aenter__(self):
+                await anyio.sleep(5)
+                raise AssertionError("probe should have given up before this")
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import aiosqlite
+
+        monkeypatch.setattr(aiosqlite, "connect", lambda *a, **kw: _SlowConnection())
+        body = client.get("/api/admin/readiness", params={"timeout_ms": 100}).json()
+        assert body["status"] == "slow"
+        assert body["timeout_ms"] == 100
+        assert body["store_present"] is True
+        assert "did not answer" in body["detail"]
+
+    def test_probe_never_returns_5xx(self, client, monkeypatch):
+        import aiosqlite
+
+        def _boom(*args, **kwargs):
+            raise sqlite3.OperationalError("database disk image is malformed")
+
+        monkeypatch.setattr(aiosqlite, "connect", _boom)
+        r = client.get("/api/admin/readiness")
+        assert r.status_code == 200
+        assert r.json()["status"] == "unavailable"
+        assert "malformed" in r.json()["detail"]
+
+    def test_liveness_endpoint_is_unchanged(self, client):
+        """Callers depending on /health must see exactly what they saw before."""
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -355,6 +355,14 @@ class TestStoreProbe:
         connection. The previous test cannot see this — there the probe absorbs
         its own timeout, so by the time cleanup runs nothing is cancelling any
         more and the close completes either way.
+
+        The assertion is deliberately immediate. Left alone the thread does go
+        away eventually: dropping the last reference to the connection runs a
+        finalizer that stops the worker once its statement gives up. Waiting for
+        that is what makes the difference invisible, and it is not the behaviour
+        being asked for — a finalizer completing a close against an event loop
+        that has since closed is the failure, not the recovery. What the probe
+        owes its caller is a connection already closed by the time it returns.
         """
         import threading
 
@@ -381,13 +389,12 @@ class TestStoreProbe:
 
             async def _abandon():
                 with anyio.move_on_after(0.05):
-                    # Long enough that the caller's deadline is the one that fires.
-                    await admin_svc.store_probe(timeout_ms=5000)
+                    # Long enough that the caller's deadline is the one that
+                    # fires, short enough that the cleanup's own bounded wait
+                    # for the locked read to give up does not dominate the test.
+                    await admin_svc.store_probe(timeout_ms=1000)
 
             anyio.run(_abandon)
-            deadline = time.monotonic() + 5
-            while _workers() > before and time.monotonic() < deadline:
-                time.sleep(0.05)
             assert _workers() == before, "a connection worker outlived an abandoned probe"
         finally:
             blocker.rollback()

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -271,7 +271,15 @@ class TestStoreProbe:
 
     def test_slow_store_reports_slow_not_unavailable(self, client, monkeypatch):
         """A store that answers, but not inside the probe's deadline, is a
-        distinct verdict from one that cannot be reached at all."""
+        distinct verdict from one that cannot be reached at all.
+
+        The double stalls on the first statement rather than on the connect,
+        because that is where a real store stalls: opening a SQLite file takes
+        no database lock, so a connect against a store held by someone else
+        still succeeds and it is the statement afterwards that waits. A double
+        that hung at the connect would be testing a deadline over a call that
+        cannot be slow for the reason this verdict exists.
+        """
         import anyio
 
         class _SlowConnection:
@@ -280,11 +288,14 @@ class TestStoreProbe:
             # `async with` would still pass while the code under test stopped
             # using it.
             def __await__(self):
-                async def _hang():
-                    await anyio.sleep(5)
-                    raise AssertionError("probe should have given up before this")
+                async def _connect():
+                    return self
 
-                return _hang().__await__()
+                return _connect().__await__()
+
+            async def execute(self, *args):
+                await anyio.sleep(5)
+                raise AssertionError("probe should have given up before this")
 
             async def close(self):
                 return None
@@ -399,6 +410,58 @@ class TestStoreProbe:
         finally:
             blocker.rollback()
             blocker.close()
+
+    def test_a_connect_is_never_abandoned_partway(self, seeded, monkeypatch):
+        """Whatever else is cancelled, the connect runs to completion.
+
+        This is the leak the two tests above cannot see. A connection is closed
+        through the object the connect returns, so a connect cancelled midway
+        leaves the driver's worker thread running with nothing left to reach it
+        by: the close that follows finds no connection and returns at once,
+        reporting success while the thread is still there. Later it completes
+        against an event loop that has closed, from a thread nobody is
+        watching.
+
+        Asserted on the connect rather than on a thread count because the
+        window is a race — it needs the caller to give up during the connect
+        specifically, which no test can schedule reliably against a real
+        connection. What can be pinned is the property that closes the window.
+        """
+        import anyio
+
+        finished = []
+
+        class _SlowToConnect:
+            def __await__(self):
+                async def _connect():
+                    await anyio.sleep(0.2)
+                    finished.append(True)
+                    return self
+
+                return _connect().__await__()
+
+            async def execute(self, *args):
+                return self
+
+            async def fetchone(self):
+                return (0,)
+
+            async def close(self):
+                return None
+
+        import aiosqlite
+
+        from lionagi.studio.services import admin as admin_svc
+
+        monkeypatch.setattr(aiosqlite, "connect", lambda *a, **kw: _SlowToConnect())
+
+        async def _abandon():
+            # Fires while the connect is still in flight.
+            with anyio.move_on_after(0.05):
+                await admin_svc.store_probe(timeout_ms=5000)
+
+        anyio.run(_abandon)
+        assert finished == [True], "the caller's cancellation reached the connect"
 
     def test_probe_never_returns_5xx(self, client, monkeypatch):
         import aiosqlite

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -64,6 +64,29 @@ def _seed(db_path, *, sessions: int, branches_per_session: int = 1) -> list[str]
     return ids
 
 
+def _hold_the_write_lock(db_path):
+    """A connection holding the store's write lock against every reader.
+
+    The store is created in WAL, where an ordinary writer deliberately does not
+    block readers, so a plain transaction cannot produce the condition these
+    tests need. The obvious lever, `PRAGMA locking_mode = EXCLUSIVE`, is the
+    wrong one: a second connection to the same WAL database in the same process
+    while another holds the shared-memory region exclusively is not a
+    configuration SQLite supports, and it can end the process rather than
+    return an error — a harness that aborts its own worker, with no traceback
+    to say why.
+
+    Moving the file to a rollback journal gets there within supported
+    behaviour: there a writer holding a transaction does block readers, which
+    is exactly the "store will not answer" the probe has to report as slow.
+    """
+    blocker = sqlite3.connect(str(db_path), isolation_level=None)
+    blocker.execute("PRAGMA journal_mode = DELETE")
+    blocker.execute("BEGIN EXCLUSIVE")
+    blocker.execute("UPDATE sessions SET name = name")
+    return blocker
+
+
 @pytest.fixture
 def seeded(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
@@ -340,13 +363,7 @@ class TestStoreProbe:
                 if getattr(t, "_target", None) is _connection_worker_thread
             )
 
-        # The store runs in WAL, where an ordinary writer never blocks a reader.
-        # An exclusive locking mode does: it holds the file lock outright, so
-        # any other connection is refused until this one lets go.
-        blocker = sqlite3.connect(str(db_path), isolation_level=None)
-        blocker.execute("PRAGMA locking_mode = EXCLUSIVE")
-        blocker.execute("BEGIN IMMEDIATE")
-        blocker.execute("UPDATE sessions SET name = name")
+        blocker = _hold_the_write_lock(db_path)
         try:
             before = _workers()
             body = asyncio.run(admin_svc.store_probe(timeout_ms=50))
@@ -391,10 +408,7 @@ class TestStoreProbe:
                 if getattr(t, "_target", None) is _connection_worker_thread
             )
 
-        blocker = sqlite3.connect(str(db_path), isolation_level=None)
-        blocker.execute("PRAGMA locking_mode = EXCLUSIVE")
-        blocker.execute("BEGIN IMMEDIATE")
-        blocker.execute("UPDATE sessions SET name = name")
+        blocker = _hold_the_write_lock(db_path)
         try:
             before = _workers()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,41 @@ def pytest_collection_modifyitems(items):
     apply_quarantine_markers(items, _QUARANTINE, pytest.mark.flaky_quarantine)
 
 
+@pytest.fixture(autouse=True)
+def _keep_the_interpreter_default_sigpipe():
+    """Stop one test's signal policy from following every later test.
+
+    The CLI sets ``SIGPIPE`` to ``SIG_DFL`` on entry, which is right for a
+    command in a pipeline: ``li ... | head`` should die quietly when head
+    leaves rather than spew a traceback. But ``signal.signal`` is
+    process-wide and permanent, and a test that drives the CLI in-process
+    hands that disposition to every test that runs after it in the same
+    worker.
+
+    Python's own default is ``SIG_IGN``, which turns a write to a broken pipe
+    into an ``OSError`` that the writer can catch. Several things running
+    under test rely on that, asyncio among them: closing an event loop
+    closes the read end of its self-pipe before the write end, so a thread
+    handing back a result in that window writes to a pipe whose peer is
+    already gone. Asyncio expects the ``OSError`` and swallows it. Under
+    ``SIG_DFL`` the kernel delivers the signal first and the process is gone
+    instead, taking its buffered output with it -- no traceback, no failing
+    assertion, just a worker that stopped, blamed on whichever test it
+    happened to be holding.
+
+    Restoring the disposition after each test costs nothing and keeps that
+    failure inside the test that actually changes the policy.
+    """
+    import signal
+
+    previous = signal.getsignal(signal.SIGPIPE)
+    try:
+        yield
+    finally:
+        if signal.getsignal(signal.SIGPIPE) is not previous:
+            signal.signal(signal.SIGPIPE, previous)
+
+
 # Hypothesis: coverage instrumentation (5-10x slowdown) makes the default
 # 200ms deadline trip on async property tests. Register a "ci" profile with
 # no deadline and load it whenever coverage is active or CI=true.

--- a/tests/fixtures/synthetic_state_db.py
+++ b/tests/fixtures/synthetic_state_db.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a large synthetic ``state.db`` so query cost can be measured at scale.
+
+A studio store grows to gigabytes in normal use, and several read paths change
+character only once the store is big -- a plan that looks fine over a hundred
+sessions parses hundreds of megabytes of JSON over ten thousand. This builds a
+store with the same shape and the same row counts, so those paths can be timed
+without ever touching a real one.
+
+Run it directly to write a store::
+
+    uv run python -m tests.fixtures.synthetic_state_db /tmp/big.db --scale 1.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+# Row counts observed on a store that had reached ~4 GB in ordinary use. Scale
+# 1.0 reproduces them; the shape, not the absolute size, is what matters.
+REFERENCE_SESSIONS = 12_900
+REFERENCE_BRANCHES_PER_SESSION = 1.3
+REFERENCE_MESSAGES_PER_BRANCH = 56
+REFERENCE_CONTENT_BYTES = 3_000
+
+_STATUSES = ("completed", "running", "failed", "timed_out", "aborted", "cancelled")
+_ROLES = ("user", "assistant", "system", "action")
+_LION_CLASSES = (2, 3, 1, 4)
+_PROJECTS = (None, "lionagi", "khive", "studio", "docs")
+
+
+@dataclass(frozen=True)
+class StoreSpec:
+    sessions: int
+    branches_per_session: float
+    messages_per_branch: int
+    content_bytes: int
+    write_messages: bool = True
+
+    @classmethod
+    def at_scale(cls, scale: float, *, write_messages: bool = True) -> StoreSpec:
+        return cls(
+            sessions=max(1, int(REFERENCE_SESSIONS * scale)),
+            branches_per_session=REFERENCE_BRANCHES_PER_SESSION,
+            messages_per_branch=REFERENCE_MESSAGES_PER_BRANCH,
+            content_bytes=REFERENCE_CONTENT_BYTES,
+            write_messages=write_messages,
+        )
+
+
+def _schema_sql() -> str:
+    from lionagi.state.db import _SCHEMA_PATH
+
+    return Path(_SCHEMA_PATH).read_text()
+
+
+def build_store(path: Path, spec: StoreSpec, *, seed: int = 7) -> dict[str, int]:
+    """Write a synthetic store at `path`. Returns the row counts written."""
+    rng = random.Random(seed)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    for suffix in ("-wal", "-shm"):
+        side = path.with_name(path.name + suffix)
+        if side.exists():
+            side.unlink()
+
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_schema_sql())
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = OFF")
+
+    now = time.time()
+    filler = "x" * spec.content_bytes
+    counts = {"sessions": 0, "branches": 0, "progressions": 0, "messages": 0}
+
+    for batch_start in range(0, spec.sessions, 200):
+        batch = range(batch_start, min(batch_start + 200, spec.sessions))
+        sessions: list[tuple] = []
+        branches: list[tuple] = []
+        progressions: list[tuple] = []
+        messages: list[tuple] = []
+
+        for i in batch:
+            session_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
+            session_prog_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
+            # Sessions age backwards from now so updated_at DESC is meaningful.
+            updated = now - i * 60.0
+            progressions.append((session_prog_id, updated, "[]"))
+
+            n_branches = 1 + (1 if rng.random() < (spec.branches_per_session - 1) else 0)
+            for _ in range(n_branches):
+                branch_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
+                prog_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
+                msg_ids = [
+                    str(uuid.UUID(int=rng.getrandbits(128), version=4))
+                    for _ in range(spec.messages_per_branch)
+                ]
+                progressions.append((prog_id, updated, json.dumps(msg_ids)))
+                branches.append(
+                    (
+                        branch_id,
+                        updated,
+                        None,
+                        None,
+                        f"agent-{i % 17}",
+                        session_id,
+                        prog_id,
+                        None,
+                        "claude/claude-sonnet-4-6",
+                        "claude",
+                        f"role-{i % 5}",
+                        "completed",
+                        updated,
+                        updated + 30,
+                    )
+                )
+                if spec.write_messages:
+                    for k, mid in enumerate(msg_ids):
+                        messages.append(
+                            (
+                                mid,
+                                updated + k,
+                                None,
+                                json.dumps({"instruction": filler}),
+                                None,
+                                f"agent-{i % 17}",
+                                None,
+                                None,
+                                _ROLES[k % len(_ROLES)],
+                                _LION_CLASSES[k % len(_LION_CLASSES)],
+                            )
+                        )
+
+            status = _STATUSES[i % len(_STATUSES)]
+            sessions.append(
+                (
+                    session_id,
+                    None,
+                    updated,
+                    json.dumps({"pid": 999999, "pid_create_time": updated}),
+                    f"run-{i}",
+                    None,
+                    session_prog_id,
+                    updated,
+                    f"playbook-{i % 11}",
+                    f"agent-{i % 17}",
+                    "agent",
+                    status,
+                    updated,
+                    updated + 120,
+                    updated + 100,
+                    "claude/claude-sonnet-4-6",
+                    "claude",
+                    "high",
+                    _PROJECTS[i % len(_PROJECTS)],
+                    "cwd" if _PROJECTS[i % len(_PROJECTS)] else None,
+                )
+            )
+
+        conn.executemany(
+            "INSERT INTO progressions (id, created_at, collection) VALUES (?, ?, ?)",
+            progressions,
+        )
+        conn.executemany(
+            """INSERT INTO sessions
+               (id, cc_session_id, created_at, node_metadata, name, user,
+                progression_id, updated_at, playbook_name, agent_name,
+                invocation_kind, status, started_at, ended_at, last_message_at,
+                model, provider, effort, project, project_source)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            sessions,
+        )
+        conn.executemany(
+            """INSERT INTO branches
+               (id, created_at, node_metadata, user, name, session_id,
+                progression_id, system_msg_id, model, provider, agent_name,
+                status, started_at, ended_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            branches,
+        )
+        if messages:
+            conn.executemany(
+                """INSERT INTO messages
+                   (id, created_at, node_metadata, content, embedding,
+                    sender, recipient, channel, role, lion_class)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                messages,
+            )
+        counts["sessions"] += len(sessions)
+        counts["branches"] += len(branches)
+        counts["progressions"] += len(progressions)
+        counts["messages"] += len(messages)
+        conn.commit()
+
+    conn.execute("ANALYZE")
+    conn.commit()
+    conn.close()
+    return counts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Where to write the synthetic store")
+    parser.add_argument(
+        "--scale",
+        type=float,
+        default=1.0,
+        help="Multiple of the reference session count (default 1.0 = ~12,900 sessions)",
+    )
+    parser.add_argument(
+        "--no-messages",
+        action="store_true",
+        help="Skip message rows; progressions still reference them (much faster to build)",
+    )
+    args = parser.parse_args(argv)
+
+    spec = StoreSpec.at_scale(args.scale, write_messages=not args.no_messages)
+    started = time.perf_counter()
+    counts = build_store(args.path, spec)
+    elapsed = time.perf_counter() - started
+    size_mb = args.path.stat().st_size / 1024 / 1024
+    print(f"wrote {args.path} ({size_mb:.0f} MB) in {elapsed:.1f}s")
+    for name, n in counts.items():
+        print(f"  {name}: {n:,}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reported from a machine running the studio daemon against a 3.96 GB `state.db`: a runs query
was followed by roughly two minutes in which every database-backed endpoint was unresponsive,
while `/docs` returned 200 and the socket stayed listening throughout.

## What was measured

A limit bounds rows returned, not rows examined. The runs listing did work proportional to the
whole store rather than to the page asked for, which is a real and reproducible defect and is
fixed here.

It is not by itself an explanation for a two-minute stall. Measured on a synthetic store built
to the same shape and row counts, the endpoint costs 0.43 s. The generator is in the tree and
reproducible; the reported store was read read-only for the plan and never copied anywhere.

What is established is the mechanism by which one expensive read makes the others unresponsive.
Reads do not serialize in SQLite, but the per-row work that follows each read runs on the event
loop with no await points, so it blocks every other request while it runs. Under sixteen
concurrent listings the store-backed probe peaked at 4.7 s while a stateless route still
answered in a median 4.9 ms — the reported symptom's shape, reproduced, at roughly a
twenty-fifth of the reported magnitude. Causation is therefore partial: the mechanism is proven
and the shape matches, the magnitude does not, and the remaining candidates are named rather
than assumed.

## What changes

The expensive paths are bounded, and a bounded answer says so rather than looking complete.

The health probe now touches the store: a bounded, indexed read with its own timeout. It
distinguishes a store that cannot be reached, one that is slow past the timeout, and a healthy
one, rather than collapsing all three into a boolean. It cannot itself cause the failure it
detects, and existing liveness behaviour is unchanged for callers that depend on it.

## Retention, measured but not touched here

Nothing in this change alters retention. The numbers are worth stating because they explain the
store size: `messages` is 77% of it, no message in the reported store is older than 16 days,
and ingest runs around 180 MB of message content per day. A prune function exists with a 30-day
default and is correct — nothing calls it on a timer. That is its own change.

`tests/cli tests/studio`: 2988 passed, 2 skipped, and one failure that reproduces on untouched
`main`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

## Second round

A review found that the readiness probe's connection was closed by `async with`, from inside the scope doing the cancelling. The probe exists to be cancelled — a slow verdict is what a cancellation means here — and closing that connection is itself an await, so the close was cancelled too. The worker thread survived holding an open database and later tried to complete against an event loop that had since closed, raising from a thread nobody is watching.

Cleanup now runs outside the timeout scope and is shielded. Both parts are load-bearing and each has its own test, because either one alone still looks correct in the other's test. When the probe absorbs its own deadline the scope has already exited by the time cleanup runs, so placement is enough and the shield changes nothing. When the caller gives up first — a client disconnects, the daemon shuts down, an outer deadline fires — the cancellation is still active around the cleanup, and only the shield gets the close through.

Both tests take a real exclusive lock with a second connection rather than substituting a slow connection object, and assert on the connection worker rather than on the response: nothing in the body distinguishes a probe that cleaned up from one that did not.

On the instrument: the unhandled-thread-exception warning is not usable for this. It depends on when the event loop happens to close, and it still appears with every probe test deselected, so something else in the studio test fixtures leaks a connection worker too. That is pre-existing and not addressed here.

The slow-connection double now matches the shape the code uses, which is a connection that is awaited and closed rather than entered as a context manager.