### PR TITLE
fix(cli): li kill records the cancellation for a process that exited but was not reaped

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -74,63 +74,61 @@ def _cmdline_is_lionagi(cmdline: list[str], expected_cmd: str) -> bool:
     return False
 
 
+_IdentityVerdict = Literal["ours", "not_ours", "unverifiable", "zombie"]
+
+
+def _pid_is_zombie(pid: int) -> bool:
+    """True if *pid* has exited and is waiting for its parent to reap it.
+
+    `pid_alive` answers "does the OS still know this pid", and a zombie
+    satisfies that: it keeps its slot until it is reaped, so `kill -0` keeps
+    succeeding and signals keep being accepted with no effect. Anything that
+    reads "still there" as "still working" will wait out a grace period that
+    can never end and then escalate onto a process that is already dead.
+    """
+    if pid <= 1:
+        return False
+    try:
+        return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except psutil.ZombieProcess:
+        return True
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+
+
 def _check_pid_identity(
     pid: int,
     expected_cmd: str,
     *,
     expected_session_id: str | None = None,
     expected_create_time: float | None = None,
-) -> bool:
-    """Return True iff the live process at *pid* is the lionagi run we recorded."""
-    try:
-        proc = psutil.Process(pid)
-        create_time_ok: bool | None = None
-        if expected_create_time is not None:
-            create_time_ok = (
-                abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
-            )
-            if not create_time_ok:
-                return False
-
-        if expected_session_id is not None:
-            try:
-                marker = proc.environ().get("LIONAGI_SESSION_ID")
-            except (psutil.AccessDenied, NotImplementedError):
-                marker = None
-            if marker is not None:
-                return marker == expected_session_id
-            # Without env marker, require BOTH create_time match AND lionagi cmdline.
-            return create_time_ok is True and _cmdline_is_lionagi(proc.cmdline(), expected_cmd)
-
-        cmdline = proc.cmdline()
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        return False
-
-    return _cmdline_is_lionagi(cmdline, expected_cmd)
-
-
-_IdentityVerdict = Literal["ours", "not_ours", "unverifiable"]
-
-
-def _check_pid_identity_tristate(
-    pid: int,
-    expected_cmd: str,
-    *,
-    expected_session_id: str | None = None,
-    expected_create_time: float | None = None,
 ) -> _IdentityVerdict:
-    """Sweep-only identity check that separates "definitely not ours" from
-    "cannot tell" (permission denied reading process details).
+    """Classify the process at *pid* against the run we recorded.
 
-    The direct-kill path (`_check_pid_identity`) collapses AccessDenied to a
-    refusal, which is the safe default when a human explicitly asked to kill
-    one entity. The stale sweep runs unattended over many rows; if it reused
-    that same collapse, a live worker we simply lack permission to inspect
-    would be swept and its row marked cancelled while the process keeps
-    running. Callers must treat "unverifiable" as still-alive, not as dead.
+    Four answers, and every caller has to say which of them it accepts:
+
+    - "ours": positively identified as the run in the row.
+    - "not_ours": the pid is gone, or a different process holds it now. Killing
+      it would hit a stranger, which is the whole reason this check exists.
+    - "unverifiable": the process is there but could not be inspected (usually
+      permission denied). Callers must read this as still-alive, not as dead:
+      an unattended sweep that read it as dead would cancel the row of a worker
+      it merely lacks permission to look at, while that worker keeps running.
+    - "zombie": our process has exited and has not been reaped yet. A zombie
+      cannot be a recycled pid, because the OS does not hand a pid out again
+      until it is reaped, and it cannot be killed again either. It is a
+      finished termination, not an unidentifiable process, and callers that
+      fold it into "not_ours" refuse to record a cancellation that already
+      happened.
+
+    A recorded create_time still rules first: it is readable on a zombie, so a
+    pid that was reaped, recycled, and died again is reported "not_ours" rather
+    than being mistaken for our own corpse.
     """
     try:
         proc = psutil.Process(pid)
+    except psutil.ZombieProcess:
+        return "zombie"
     except psutil.NoSuchProcess:
         return "not_ours"
     except psutil.AccessDenied:
@@ -141,6 +139,8 @@ def _check_pid_identity_tristate(
             create_time_ok = (
                 abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
             )
+        except psutil.ZombieProcess:
+            return "zombie"
         except psutil.NoSuchProcess:
             return "not_ours"
         except psutil.AccessDenied:
@@ -151,6 +151,10 @@ def _check_pid_identity_tristate(
     if expected_session_id is not None:
         try:
             marker = proc.environ().get("LIONAGI_SESSION_ID")
+        except psutil.ZombieProcess:
+            # A zombie has no environment left to read, which is exactly how
+            # this case used to disappear into "cannot identify it".
+            return "zombie"
         except psutil.NoSuchProcess:
             # The process died between the liveness check and here: the row
             # is genuinely stale, and letting this escape would abort the
@@ -168,6 +172,8 @@ def _check_pid_identity_tristate(
 
     try:
         cmdline = proc.cmdline()
+    except psutil.ZombieProcess:
+        return "zombie"
     except psutil.NoSuchProcess:
         return "not_ours"
     except psutil.AccessDenied:
@@ -188,13 +194,26 @@ def _terminate_pid(
     if not _pid_alive(pid):
         return "already_dead"
 
-    if expected_cmd is not None and not _check_pid_identity(
-        pid,
-        expected_cmd,
-        expected_session_id=expected_session_id,
-        expected_create_time=expected_create_time,
-    ):
-        return "identity_mismatch"
+    if _pid_is_zombie(pid):
+        # Exited already, just not reaped by whoever started it. There is
+        # nothing left to signal, and no other process can be holding this pid
+        # until the reap happens, so this is a termination that is already
+        # complete rather than a process we failed to identify.
+        return "already_dead"
+
+    if expected_cmd is not None:
+        verdict = _check_pid_identity(
+            pid,
+            expected_cmd,
+            expected_session_id=expected_session_id,
+            expected_create_time=expected_create_time,
+        )
+        if verdict == "zombie":
+            return "already_dead"
+        # "unverifiable" refuses too: when a human named one entity to kill,
+        # not being able to confirm the target is a reason to stop.
+        if verdict != "ours":
+            return "identity_mismatch"
 
     try:
         os.kill(pid, signal.SIGTERM)
@@ -209,12 +228,15 @@ def _terminate_pid(
     deadline = time.monotonic() + grace_seconds
     interval = 0.1
     while time.monotonic() < deadline:
-        if not _pid_alive(pid):
+        # A process whose parent never reaps it stays visible to `kill -0`
+        # forever, so waiting on liveness alone would sit out the whole grace
+        # window for a process that obeyed the SIGTERM immediately.
+        if not _pid_alive(pid) or _pid_is_zombie(pid):
             return "sigterm"
         time.sleep(interval)
         interval = min(interval * 2, 0.5)
 
-    if not _pid_alive(pid):
+    if not _pid_alive(pid) or _pid_is_zombie(pid):
         return "sigterm"
 
     # Re-check identity before escalating. The check above this function's
@@ -225,13 +247,19 @@ def _terminate_pid(
     # chance to identify itself, so the one thing this must not do is escalate
     # onto a stranger. A pid that now belongs to a different process is
     # reported the same way a mismatch at entry is.
-    if expected_cmd is not None and not _check_pid_identity(
-        pid,
-        expected_cmd,
-        expected_session_id=expected_session_id,
-        expected_create_time=expected_create_time,
-    ):
-        return "identity_mismatch"
+    if expected_cmd is not None:
+        verdict = _check_pid_identity(
+            pid,
+            expected_cmd,
+            expected_session_id=expected_session_id,
+            expected_create_time=expected_create_time,
+        )
+        if verdict == "zombie":
+            # It exited between the last poll and this check: the SIGTERM
+            # worked, and escalating would be aiming at a corpse.
+            return "sigterm"
+        if verdict != "ours":
+            return "identity_mismatch"
 
     try:
         os.kill(pid, signal.SIGKILL)
@@ -654,7 +682,7 @@ async def _do_kill_all_stale(
                     except (TypeError, ValueError):
                         expected_create_time = None
 
-                    verdict = _check_pid_identity_tristate(
+                    verdict = _check_pid_identity(
                         pid,
                         "lionagi",
                         expected_session_id=expected_session_id,
@@ -680,8 +708,10 @@ async def _do_kill_all_stale(
                                 "identity unverifiable (permission denied) — treated as live"
                             )
                         continue
-                    # verdict == "not_ours": pid was recycled by an unrelated
-                    # process, fall through and sweep the row.
+                    # "not_ours" (the pid was recycled by an unrelated process)
+                    # and "zombie" (our process exited and nobody reaped it)
+                    # both mean the recorded run is gone: fall through and
+                    # sweep the row.
 
                 if dry_run:
                     print(

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -592,7 +592,7 @@ async def _doctor(
     from sqlalchemy import text
 
     from lionagi.cli._util import pid_alive
-    from lionagi.cli.kill import _check_pid_identity_tristate, _read_pid_from_entity
+    from lionagi.cli.kill import _check_pid_identity, _read_pid_from_entity
 
     async with StateDB() as db:
         async with db._read() as conn:
@@ -641,7 +641,7 @@ async def _doctor(
                     expected_create_time = float(raw_ct) if raw_ct is not None else None
                 except (TypeError, ValueError):
                     expected_create_time = None
-                verdict = _check_pid_identity_tristate(
+                verdict = _check_pid_identity(
                     pid,
                     "lionagi",
                     expected_session_id=row["id"],
@@ -649,7 +649,9 @@ async def _doctor(
                 )
                 # "unverifiable" means the process could not be inspected, not
                 # that it is gone; skipping it leaves a row for the next run
-                # rather than reaping one out from under a worker.
+                # rather than reaping one out from under a worker. "zombie" is
+                # the opposite: the process has exited and is only waiting to
+                # be reaped, so the row is stale and belongs in the sweep.
                 if verdict in ("ours", "unverifiable"):
                     skipped += 1
                     continue

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -372,6 +372,39 @@ async def test_kill_cancels_session_whose_child_is_an_unreaped_zombie(
         child.wait()
 
 
+@pytest.mark.skipif(os.name != "posix", reason="a zombie is a POSIX process state")
+def test_terminate_pid_reports_an_unreaped_process_dead_with_no_identity_to_check():
+    """The same window, reached where there is nothing to identify the pid by.
+
+    `_terminate_pid` is also called with no expected command — killing by pid,
+    and every liveness poll inside the grace loop. On that path the identity
+    classifier never runs, so its verdict cannot be what saves this: with only
+    `kill -0` to go on, an unreaped process looks alive forever and the caller
+    would SIGTERM a corpse and then sit out the whole grace window waiting for
+    a flag that can never flip.
+    """
+    sid = str(uuid.uuid4())
+    child = _spawn_marked_child(sid)
+    assert child.pid > 1
+
+    try:
+        assert _await(lambda: _pid_alive(child.pid)), "child never started"
+        os.kill(child.pid, signal.SIGTERM)
+        assert _await(lambda: _is_zombie(child.pid)), (
+            "child did not become a zombie — this environment reaps children "
+            "on its own and cannot exercise the window"
+        )
+        assert _pid_alive(child.pid) is True, "a zombie still answers kill -0"
+
+        started = time.monotonic()
+        assert _terminate_pid(child.pid, grace_seconds=5.0) == "already_dead"
+        assert time.monotonic() - started < 1.0, "it waited out a grace window for a dead process"
+    finally:
+        if child.poll() is None and child.pid > 1:
+            child.kill()
+        child.wait()
+
+
 def _mock_psutil(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
+import subprocess
 import sys
 import time
 import uuid
@@ -12,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import psutil
 import pytest
 import yaml
 
@@ -216,6 +220,9 @@ def test_terminate_pid_identity_mismatch_no_signal_sent(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     result = _terminate_pid(42, grace_seconds=0.1, expected_cmd="lionagi")
@@ -237,12 +244,132 @@ def test_terminate_pid_identity_match_sends_signal(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     result = _terminate_pid(42, grace_seconds=0.01, expected_cmd="lionagi")
     # SIGTERM must have been sent
     assert any(sig == __import__("signal").SIGTERM for _, sig in kill_calls)
     assert result in ("sigterm", "sigkill")
+
+
+# ── A real, unreaped child ────────────────────────────────────────────────────
+#
+# Everything below uses a process this test actually started. A SIGTERMed child
+# whose parent has not called wait() is a zombie: it holds its pid, so `kill -0`
+# keeps reporting it present, but it has no command line, no environment and no
+# way to be killed again. That is a third answer next to "this is our process"
+# and "this pid belongs to something else", and the kill path has to record the
+# cancellation for it instead of refusing.
+
+
+def _spawn_marked_child(session_id: str) -> subprocess.Popen:
+    """Start a sleeper carrying the session marker `li kill` identifies runs by."""
+    return subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(300)"],
+        env={**os.environ, "LIONAGI_SESSION_ID": session_id},
+    )
+
+
+def _await(predicate, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _is_zombie(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except psutil.ZombieProcess:
+        return True
+    except psutil.NoSuchProcess:
+        return False
+
+
+@pytest.mark.skipif(os.name != "posix", reason="zombies are a POSIX process state")
+async def test_kill_cancels_session_whose_child_is_an_unreaped_zombie(
+    temp_db_path: Path,
+):
+    """`li kill` against a SIGTERMed-but-unreaped child must persist the cancel.
+
+    This is the window a caller opens by starting a run and never waiting on
+    it: the process is gone, nobody has reaped it, and the row is still
+    'running'. Refusing here loses the cancellation for a run that has in fact
+    stopped.
+    """
+    sid = str(uuid.uuid4())
+    child = _spawn_marked_child(sid)
+    assert child.pid > 1
+
+    try:
+        assert _await(
+            lambda: _check_pid_identity(child.pid, "lionagi", expected_session_id=sid) == "ours"
+        ), "child never came up carrying its session marker"
+        create_time = psutil.Process(child.pid).create_time()
+
+        # While it is alive the identity check accepts it. Nothing about the
+        # arguments changes below, so whatever answer comes back after the
+        # SIGTERM differs only because the process died without being reaped.
+        assert (
+            _check_pid_identity(
+                child.pid,
+                "lionagi",
+                expected_session_id=sid,
+                expected_create_time=create_time,
+            )
+            == "ours"
+        )
+
+        async with StateDB() as db:
+            prog = str(uuid.uuid4())
+            await db.create_progression(prog)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": prog,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "node_metadata": {"pid": child.pid, "pid_create_time": create_time},
+                }
+            )
+
+        os.kill(child.pid, signal.SIGTERM)
+        # Deliberately no child.wait()/poll(): an unreaped exit is the state
+        # under test, and reaping it here would test a pid that is simply gone.
+        assert _await(lambda: _is_zombie(child.pid)), (
+            "child did not become a zombie — this environment reaps children "
+            "on its own and cannot exercise the window"
+        )
+        assert _pid_alive(child.pid) is True, "a zombie still answers kill -0"
+        assert (
+            _check_pid_identity(
+                child.pid,
+                "lionagi",
+                expected_session_id=sid,
+                expected_create_time=create_time,
+            )
+            == "zombie"
+        )
+
+        rc = await _do_kill(sid, grace_seconds=0.5)
+        assert rc == 0, "a run that has already stopped is not a blocked kill"
+
+        async with StateDB() as db:
+            row = await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,))
+        assert row is not None
+        assert row["status"] == "cancelled", (
+            "the process is dead and the row must say so; leaving it 'running' "
+            "loses the cancellation"
+        )
+    finally:
+        if child.poll() is None and child.pid > 1:
+            child.kill()
+        child.wait()
 
 
 def _mock_psutil(
@@ -265,6 +392,9 @@ def _mock_psutil(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
     return kill_calls
 
@@ -287,13 +417,13 @@ def test_identity_rejects_path_substring(monkeypatch: pytest.MonkeyPatch):
 def test_identity_accepts_dash_m_module(monkeypatch: pytest.MonkeyPatch):
     """``python -m lionagi.cli.main`` is a genuine invocation and is accepted."""
     _mock_psutil(monkeypatch, cmdline=["/usr/bin/python3", "-m", "lionagi.cli.main"])
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_accepts_li_entrypoint(monkeypatch: pytest.MonkeyPatch):
     """The ``li`` console-script entrypoint is accepted by executable basename."""
     _mock_psutil(monkeypatch, cmdline=["/opt/venv/bin/li", "kill", "abc123"])
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
@@ -302,7 +432,7 @@ def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
         monkeypatch,
         cmdline=["/opt/.venv/bin/python3", "/opt/.venv/bin/li", "play", "abc123"],
     )
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.MonkeyPatch):
@@ -311,7 +441,7 @@ def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.Mon
         monkeypatch,
         cmdline=["/usr/bin/python3", "/usr/local/bin/olia-tool", "run"],
     )
-    assert _check_pid_identity(42, "lionagi") is False
+    assert _check_pid_identity(42, "lionagi") == "not_ours"
 
 
 def test_identity_session_marker_match(monkeypatch: pytest.MonkeyPatch):
@@ -321,7 +451,7 @@ def test_identity_session_marker_match(monkeypatch: pytest.MonkeyPatch):
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         environ={"LIONAGI_SESSION_ID": "run-123"},
     )
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is True
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "ours"
 
 
 def test_identity_session_marker_mismatch_rejected(monkeypatch: pytest.MonkeyPatch):
@@ -335,7 +465,7 @@ def test_identity_session_marker_mismatch_rejected(monkeypatch: pytest.MonkeyPat
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         environ={"LIONAGI_SESSION_ID": "other-run"},
     )
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is False
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "not_ours"
 
 
 def test_identity_absent_marker_requires_create_time_match(monkeypatch: pytest.MonkeyPatch):
@@ -353,18 +483,18 @@ def test_identity_absent_marker_requires_create_time_match(monkeypatch: pytest.M
         create_time=500.0,
     )
     # No create_time recorded → cannot prove this run → skip.
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is False
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "unverifiable"
     # create_time matches AND cmdline is lionagi → positively identified.
     assert (
         _check_pid_identity(
             42, "lionagi", expected_session_id="run-123", expected_create_time=500.0
         )
-        is True
+        == "ours"
     )
     # create_time differs → recycled PID → skip.
     assert (
         _check_pid_identity(42, "lionagi", expected_session_id="run-123", expected_create_time=1.0)
-        is False
+        == "not_ours"
     )
 
 
@@ -384,7 +514,7 @@ def test_identity_absent_marker_rejects_nonlionagi_cmdline(monkeypatch: pytest.M
         _check_pid_identity(
             42, "lionagi", expected_session_id="run-123", expected_create_time=500.0
         )
-        is False
+        == "not_ours"
     )
 
 
@@ -438,11 +568,11 @@ def test_identity_create_time_mismatch_rejected(monkeypatch: pytest.MonkeyPatch)
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         create_time=100.0,
     )
-    assert _check_pid_identity(42, "lionagi", expected_create_time=999.0) is False
+    assert _check_pid_identity(42, "lionagi", expected_create_time=999.0) == "not_ours"
     # 0.5s apart → different process → reject (was accepted under the old 2s gate).
-    assert _check_pid_identity(42, "lionagi", expected_create_time=100.5) is False
+    assert _check_pid_identity(42, "lionagi", expected_create_time=100.5) == "not_ours"
     # within tick-rounding tolerance → accepted.
-    assert _check_pid_identity(42, "lionagi", expected_create_time=100.05) is True
+    assert _check_pid_identity(42, "lionagi", expected_create_time=100.05) == "ours"
 
 
 # ── current_pid_markers (launch-time recording) ───────────────────────────────
@@ -763,7 +893,7 @@ async def test_do_kill_all_stale_skips_live_pid(
 ):
     """Running session with a LIVE, identity-matching PID is not touched."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "ours")
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "ours")
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -784,9 +914,7 @@ async def test_do_kill_all_stale_sweeps_reused_pid(
     """A live PID that no longer identifies as the tracked process (reused
     after the original died) must still be swept, not treated as live."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr(
-        "lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "not_ours"
-    )
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "not_ours")
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -875,6 +1003,9 @@ async def test_do_kill_all_stale_recycled_pid_swept_with_correlation(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     old_start = time.time() - 7200
@@ -916,6 +1047,9 @@ async def test_do_kill_all_stale_matching_correlation_skips_live(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     old_start = time.time() - 7200
@@ -948,10 +1082,9 @@ async def test_do_kill_all_stale_access_denied_not_cancelled(
     """A live pid we cannot inspect (psutil.AccessDenied) must be treated as
     still alive by the sweep, not cancelled out from under a running worker.
 
-    Discrimination: on unfixed code the sweep's bare `_check_pid_identity`
-    call collapses AccessDenied to False ("not ours"), so the row gets
-    cancelled while the process keeps running. Post-fix the tri-state check
-    reports "unverifiable" and the sweep skips it.
+    Discrimination: an identity check that collapses AccessDenied into "not
+    ours" gets the row cancelled while the process keeps running. The verdict
+    reports "unverifiable" instead and the sweep skips it.
     """
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
 
@@ -959,6 +1092,7 @@ async def test_do_kill_all_stale_access_denied_not_cancelled(
     fake_psutil = MagicMock()
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = fake_access_denied
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     fake_psutil.Process.side_effect = fake_access_denied("no access")
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
@@ -988,6 +1122,7 @@ async def test_do_kill_all_stale_process_vanishing_mid_check_does_not_abort_swee
     fake_psutil = MagicMock()
     fake_psutil.NoSuchProcess = fake_no_such
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_no_such,), {})
     fake_proc = MagicMock()
     fake_proc.environ.side_effect = fake_no_such("gone")
     fake_proc.cmdline.side_effect = fake_no_such("gone")
@@ -1483,9 +1618,6 @@ async def test_do_kill_all_stale_does_NOT_touch_play_at_all(
         assert row["status"] == "running"
 
 
-import signal  # noqa: E402
-
-
 class TestTerminatePidIdentityRevalidation:
     """SIGKILL is not survivable and gives the target no chance to identify
     itself, so escalation re-checks that the pid still belongs to the process
@@ -1501,7 +1633,7 @@ class TestTerminatePidIdentityRevalidation:
             identity_calls.append(pid)
             # first call (pre-SIGTERM) matches, later calls do not: the pid was
             # recycled while we waited out the grace window
-            return len(identity_calls) == 1
+            return "ours" if len(identity_calls) == 1 else "not_ours"
 
         monkeypatch.setattr(kill_mod, "_check_pid_identity", _identity)
 
@@ -1528,7 +1660,7 @@ class TestTerminatePidIdentityRevalidation:
         monkeypatch.setattr(kill_mod.os, "kill", lambda pid, sig: sent.append(sig))
         monkeypatch.setattr(kill_mod, "_pid_alive", lambda pid: True)
         monkeypatch.setattr(kill_mod.time, "sleep", lambda s: None)
-        monkeypatch.setattr(kill_mod, "_check_pid_identity", lambda *a, **kw: True)
+        monkeypatch.setattr(kill_mod, "_check_pid_identity", lambda *a, **kw: "ours")
 
         result = kill_mod._terminate_pid(4242, expected_cmd="li agent", grace_seconds=0.01)
 

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -182,7 +182,7 @@ async def test_do_kill_all_stale_does_not_sweep_play_with_live_session(
     # lionagi CLI invocation, so the real cmdline check would (correctly)
     # reject it -- here it stands in for a live, identity-matching session.
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: pid == own_pid)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: True)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "ours")
 
     old_time = time.time() - 7200
     async with StateDB() as db:


### PR DESCRIPTION
`li kill` refused to record the cancellation for a process that had already exited but had not yet been reaped, and the row stayed `running`.

## The window

A process that has received SIGTERM and has not been reaped is a zombie. `kill -0` still succeeds on it, so the liveness check reports it alive; `psutil.cmdline()` raises `ZombieProcess`, and `ZombieProcess` is a **subclass of `NoSuchProcess`**, so the identity check's `except (NoSuchProcess, AccessDenied): return False` swallowed it and reported a mismatch. Nothing in the code mentioned zombies — the collapse was inherited from psutil's exception hierarchy.

It costs more than the escalation: the entry identity check already fails, so `li kill` refuses before sending any signal when the process died first; and when it dies during the grace window, the liveness poll never flips, so the caller sits out the full grace period before refusing again.

A caller that starts a run and never waits on it leaves exactly this state behind.

## The change

A zombie is a third answer, distinct from both "this is our process" and "this pid belongs to something else": it is our process, already dead, not yet reaped. It cannot be signalled again and it cannot be a recycled pid, because a pid is not reused until it is reaped. So the cancellation is recorded rather than skipped, and the recycled-pid guard is not weakened at all — that path sends no signal.

Two near-identical classifiers existed side by side, one returning a bool and one returning three verdicts, with the more expressive one not on the kill path. A bool cannot carry a third answer, so they are now one function returning `ours` / `not_ours` / `unverifiable` / `zombie`, and every caller names which verdicts it accepts. Equivalence was checked first: for every input except a zombie, the old bool agrees with `verdict == "ours"`, including the `AccessDenied` case the direct-kill path depends on.

`--all-stale` and the session sweep are unchanged in behaviour — `zombie` falls through beside `not_ours` because both mean the recorded run is gone. What changed there is that the case no longer arrives mislabelled as a recycled pid.

## Tests

Both tests start a real child, SIGTERM it, deliberately never reap it, and run the real path against the real process state. No patched `psutil`, no `ZombieProcess` fixture — a mocked zombie would assert its own fixture.

- The kill path end to end: the row ends `cancelled`. The discriminator is that the identity arguments never change, so the only variable is the reaping state.
- The liveness check that runs with no identity to check. `_terminate_pid` takes its early exit twice over, and with both in place the second was unreachable in every test — removing it changed nothing that went red, while being the only guard on the path where a pid is killed with no expected command.

Reverting each part separately turns the relevant test red: the classifier verdict, and the liveness check.

## Not covered

- Skipped off POSIX.
- The narrower race where the child becomes a zombie *during* the grace window or between the last poll and the escalation re-check. Those paths are implemented and reachable by inspection, but landing a real process in that interleaving needs a stubbed clock, at which point the test asserts its own fixture.
- A pid reaped, recycled by a stranger, and then itself becoming a zombie. The recorded `create_time` rules it out and is readable on a zombie, but there is no test that constructs it.

`tests/cli tests/mcp`: 1 failed, 2258 passed, 2 skipped of 2261 collected. The failure is `test_pack_routing_shown_in_dry_run`, confirmed pre-existing by running it alone on untouched `main`, where it fails identically.

