### PR TITLE
fix(studio): record which timezone each cron schedule was resolved in

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2655,6 +2655,7 @@ class StateDB:
                 project, threshold_config, last_alert_at,
                 spec_version, managed_by, owner_key, authored_spec,
                 resolved_target, resolved_digest, resolved_timezone,
+                effective_timezone, effective_timezone_source,
                 notify_on, notify_command,
                 created_at, updated_at)
                VALUES (:id, :name, :description, :enabled, :trigger_type,
@@ -2669,6 +2670,7 @@ class StateDB:
                        :project, :threshold_config, :last_alert_at,
                        :spec_version, :managed_by, :owner_key, :authored_spec,
                        :resolved_target, :resolved_digest, :resolved_timezone,
+                       :effective_timezone, :effective_timezone_source,
                        :notify_on, :notify_command,
                        :created_at, :updated_at)"""
         ).bindparams(
@@ -2726,6 +2728,8 @@ class StateDB:
             "resolved_target": schedule.get("resolved_target"),
             "resolved_digest": schedule.get("resolved_digest"),
             "resolved_timezone": schedule.get("resolved_timezone"),
+            "effective_timezone": schedule.get("effective_timezone"),
+            "effective_timezone_source": schedule.get("effective_timezone_source"),
             "notify_on": schedule.get("notify_on"),
             "notify_command": schedule.get("notify_command"),
             "created_at": schedule.get("created_at", now),
@@ -2875,6 +2879,8 @@ class StateDB:
             "resolved_target",
             "resolved_digest",
             "resolved_timezone",
+            "effective_timezone",
+            "effective_timezone_source",
             "notify_on",
             "notify_command",
         }

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -487,6 +487,17 @@ CREATE TABLE IF NOT EXISTS schedules (
   resolved_target     JSON,
   resolved_digest     TEXT,
   resolved_timezone   TEXT,
+  -- The zone this schedule's cron expression was last actually interpreted
+  -- in, and how that zone was arrived at (declared on this row, the
+  -- process-wide configured default and its own provenance, or a UTC
+  -- fallback). Written by the scheduler whenever it resolves a fire time and
+  -- never read back when resolving, so it records the outcome without being
+  -- able to change it. The name alone is not diagnostic -- a requested UTC
+  -- and a fallback UTC are the same string -- which is why the source is
+  -- stored beside it. NULL for triggers that resolve no wall-clock fields
+  -- (interval/at/github_poll) and for cron rows not yet armed or fired.
+  effective_timezone        TEXT,
+  effective_timezone_source TEXT,
   -- Terminal notification (declaration-layer `notify`): registers the
   -- existing run terminal-callback machinery on the invocation this
   -- schedule spawns, filtered to notify_on. Replaces on_fail for

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -552,6 +552,11 @@ schedules = Table(
     Column("resolved_target", JSON),
     Column("resolved_digest", Text),
     Column("resolved_timezone", Text),
+    # The zone this schedule's cron was last resolved in, and its provenance
+    # (declared / configured default / UTC fallback). Recorded by the
+    # scheduler at resolve time; never read back when resolving.
+    Column("effective_timezone", Text),
+    Column("effective_timezone_source", Text),
     # Terminal notification: registers the existing run terminal-callback
     # machinery on the spawned invocation, filtered to notify_on. NULL means
     # no callback.

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -121,6 +121,11 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("resolved_target", "JSON"),
         ("resolved_digest", "TEXT"),
         ("resolved_timezone", "TEXT"),
+        # The zone a cron schedule was last actually resolved in, plus how
+        # that zone was arrived at. NULL on rows not resolved since this
+        # migration; the scheduler stamps them at startup and at each fire.
+        ("effective_timezone", "TEXT"),
+        ("effective_timezone_source", "TEXT"),
         # Terminal notification: filtered callback on the spawned invocation.
         ("notify_on", "JSON"),
         ("notify_command", "TEXT"),

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -24,6 +24,19 @@ TZ_SOURCE_SCHEDULER_ENV = "env:LIONAGI_SCHEDULER_TZ"
 TZ_SOURCE_TZ_ENV = "env:TZ"
 TZ_SOURCE_SYSTEM_LOCALTIME = "system:localtime"
 TZ_SOURCE_UTC_FALLBACK = "fallback:utc"
+# A schedule row that names its own zone (the declarative layer's
+# ``resolved_timezone``) is resolved in that zone rather than the process-wide
+# default, so the two are different provenances for the same effective name.
+TZ_SOURCE_SCHEDULE_DECLARED = "schedule:resolved_timezone"
+# The requested name — from either of the two sources above — is not a zone
+# this host can load, so cron fields are being interpreted in UTC instead of
+# the zone that was asked for. Every other UTC in this vocabulary is a UTC
+# somebody chose; this one is the only one that means the request was lost.
+TZ_SOURCE_UTC_UNLOADABLE_NAME = "fallback:utc:unloadable-name"
+
+# The two sources that mean "UTC because nothing else could be resolved", as
+# opposed to "UTC because that is what was asked for".
+TZ_UTC_FALLBACK_SOURCES = frozenset({TZ_SOURCE_UTC_FALLBACK, TZ_SOURCE_UTC_UNLOADABLE_NAME})
 
 
 class SystemTimezoneUnreadableError(RuntimeError):

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -191,20 +192,63 @@ class _ThresholdCooldownClaim:
         self._engine._threshold_pending.discard(self._schedule_id)
 
 
-def _resolve_scheduler_tzinfo(tz_name: str) -> ZoneInfo:
-    """Resolve the configured scheduler timezone name to a ZoneInfo.
+@dataclass(frozen=True)
+class ScheduleTimezone:
+    """The zone one schedule's cron fields are interpreted in, plus its provenance.
 
-    Falls back to UTC (with a warning) if the configured name isn't a valid
-    IANA zone — an invalid config must never crash cron resolution.
+    ``name`` alone is not diagnostic. A UTC an operator asked for and a UTC
+    that is all the resolver could produce are the same three letters, and
+    only the second one means every cron row is firing on an hour nobody
+    chose. ``source`` is what tells them apart -- see the ``TZ_SOURCE_*``
+    vocabulary in ``lionagi.studio.config``.
     """
+
+    name: str
+    source: str
+    tzinfo: ZoneInfo
+
+
+def resolve_schedule_timezone(schedule: dict) -> ScheduleTimezone:
+    """Resolve the zone *schedule*'s cron expression is interpreted in.
+
+    A row that names its own zone (``resolved_timezone``, set by the
+    declarative apply path) is resolved in that zone; a row that names none
+    falls back to the process-wide configured default, whose own provenance
+    (``SCHEDULER_TZ_SOURCE``) is carried through unchanged rather than
+    flattened into "configured". Either requested name that this host cannot
+    load resolves to UTC with a warning -- an unloadable name must never
+    crash cron resolution -- and that UTC is reported under its own source so
+    it stays distinguishable from a UTC that was actually requested.
+
+    Resolution is a pure read: nothing here consults or is influenced by the
+    ``effective_timezone``/``effective_timezone_source`` columns that record
+    its outcome, so recording the outcome cannot change it.
+    """
+    from lionagi.studio.config import (
+        SCHEDULER_TZ,
+        SCHEDULER_TZ_SOURCE,
+        TZ_SOURCE_SCHEDULE_DECLARED,
+        TZ_SOURCE_UTC_UNLOADABLE_NAME,
+    )
+
+    declared = schedule.get("resolved_timezone")
+    if declared:
+        requested, source = declared, TZ_SOURCE_SCHEDULE_DECLARED
+    else:
+        requested, source = SCHEDULER_TZ, SCHEDULER_TZ_SOURCE
     try:
-        return ZoneInfo(tz_name)
+        return ScheduleTimezone(requested, source, ZoneInfo(requested))
     except (ZoneInfoNotFoundError, ValueError):
         _log.warning(
-            "Invalid scheduler timezone %r (LIONAGI_SCHEDULER_TZ); falling back to UTC.",
-            tz_name,
+            "Schedule %s: timezone %r (from %s) is not a zone this host can "
+            "load; interpreting its cron expression in UTC instead. Every "
+            "fire time this schedule computes is shifted by the offset of "
+            "the zone that was asked for.",
+            schedule.get("id"),
+            requested,
+            source,
         )
-        return ZoneInfo("UTC")
+        return ScheduleTimezone("UTC", TZ_SOURCE_UTC_UNLOADABLE_NAME, ZoneInfo("UTC"))
 
 
 class SchedulerCwdInheritRefusedError(RuntimeError):
@@ -446,9 +490,93 @@ class SchedulerEngine:
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
         self._stopping = False
+        self._log_scheduler_timezone()
         await self._backfill_action_cwd()
+        await self._stamp_effective_timezones()
         await self._recompute_armed_cron_schedules()
         self._task = asyncio.create_task(self._tick_loop())
+
+    def _log_scheduler_timezone(self) -> None:
+        """Say the effective cron timezone out loud, once, at startup.
+
+        The zone is resolved at import and frozen for the life of the
+        process, so nothing later in a daemon's lifetime restates it. A
+        resolution that fell back to UTC moved every cron schedule in the
+        process by the host's offset, which is a fleet-wide change with no
+        other symptom than jobs running early, so it is logged at warning
+        level rather than left for whoever goes looking.
+        """
+        from lionagi.studio.config import TZ_UTC_FALLBACK_SOURCES, scheduler_timezone_report
+
+        report = scheduler_timezone_report()
+        if report["source"] in TZ_UTC_FALLBACK_SOURCES:
+            _log.warning(
+                "Scheduler cron timezone FELL BACK to %s (source=%s, from=%s) -- "
+                "this is not a configured zone, and every cron schedule without "
+                "its own declared timezone is being interpreted in it. Set "
+                "LIONAGI_SCHEDULER_TZ to an IANA zone name to choose one.",
+                report["name"],
+                report["source"],
+                report["source_detail"],
+            )
+        else:
+            _log.info(
+                "Scheduler cron timezone: %s (source=%s, from=%s). Cron "
+                "schedules without their own declared timezone are "
+                "interpreted in this zone.",
+                report["name"],
+                report["source"],
+                report["source_detail"],
+            )
+
+    async def _stamp_effective_timezones(self) -> None:
+        """Record, on every cron schedule row, the zone it is actually being
+        interpreted in and how that zone was arrived at.
+
+        The startup log line says this once for the process default; this
+        says it per row, which is what makes it answerable after the fact
+        and per schedule -- a row carrying its own declared zone and a row
+        riding the process default resolve differently, and only the row
+        knows which it is. Rows are also stamped as they arm and as they
+        fire; this pass exists so a daemon that resolves its zone
+        differently from the previous run corrects every row at startup
+        rather than only the ones that happen to fire afterwards.
+
+        Idempotent: a row whose stamp already matches is left untouched, so
+        re-running this on every startup writes nothing once the fleet has
+        converged.
+        """
+        try:
+            schedules = await self._svc.list_schedules()
+        except Exception:
+            _log.exception("Failed to load schedules for startup timezone stamping")
+            return
+        for s in schedules:
+            fields = self._effective_timezone_fields(s)
+            if not fields or all(s.get(key) == value for key, value in fields.items()):
+                continue
+            try:
+                await self._svc.update_schedule(s["id"], **fields)
+            except Exception:
+                _log.exception("Failed to stamp effective timezone for schedule %s", s.get("id"))
+
+    def _effective_timezone_fields(self, schedule: dict) -> dict[str, str]:
+        """The columns recording how *schedule*'s fire times were resolved.
+
+        Empty for any trigger that resolves no wall-clock fields (interval,
+        at, github_poll): those compute a fire time from an offset, so there
+        is no zone in play and stamping one would invent a fact. Purely an
+        output -- ``resolve_schedule_timezone()`` never reads these back, so
+        merging them into a write cannot change what the next resolution
+        produces.
+        """
+        if schedule.get("trigger_type") != "cron" or not schedule.get("cron_expr"):
+            return {}
+        resolution = resolve_schedule_timezone(schedule)
+        return {
+            "effective_timezone": resolution.name,
+            "effective_timezone_source": resolution.source,
+        }
 
     async def _backfill_action_cwd(self) -> None:
         """One-shot startup backfill: give pre-migration schedules a persisted execution root.
@@ -582,7 +710,9 @@ class SchedulerEngine:
             return None
         if old is not None and abs(new - old) < 1e-6:
             return new
-        await self._svc.update_schedule(schedule["id"], next_fire_at=new)
+        await self._svc.update_schedule(
+            schedule["id"], next_fire_at=new, **self._effective_timezone_fields(schedule)
+        )
         if old is not None:
             from lionagi.studio.config import SCHEDULER_TZ
 
@@ -995,7 +1125,11 @@ class SchedulerEngine:
                     elif nfa is None:
                         next_at = self._compute_next_fire(s, now)
                         if next_at:
-                            await self._svc.update_schedule(s["id"], next_fire_at=next_at)
+                            await self._svc.update_schedule(
+                                s["id"],
+                                next_fire_at=next_at,
+                                **self._effective_timezone_fields(s),
+                            )
             except Exception:
                 _log.exception("Error evaluating schedule %s", s.get("name"))
 
@@ -2004,6 +2138,7 @@ class SchedulerEngine:
                 failed_schedule_fields.update(
                     self._threshold_alert_update_fields(schedule, chain_depth, now)
                 )
+                failed_schedule_fields.update(self._effective_timezone_fields(schedule))
                 if extra_schedule_fields:
                     failed_schedule_fields.update(extra_schedule_fields)
                 # Occurrence-insert + cursor-advance atomic even on this
@@ -2122,6 +2257,7 @@ class SchedulerEngine:
             update_fields: dict[str, Any] = {"last_fired_at": now}
             update_fields.update(self._next_fire_field(schedule, next_at))
             update_fields.update(self._threshold_alert_update_fields(schedule, chain_depth, now))
+            update_fields.update(self._effective_timezone_fields(schedule))
             if extra_schedule_fields:
                 update_fields.update(extra_schedule_fields)
 
@@ -2464,8 +2600,6 @@ class SchedulerEngine:
             try:
                 from croniter import croniter
 
-                from lionagi.studio.config import SCHEDULER_TZ
-
                 # Resolve the cron expression's wall-clock fields in the
                 # schedule's own declared timezone when it has one (set by
                 # the declarative apply path); legacy rows with no
@@ -2473,9 +2607,9 @@ class SchedulerEngine:
                 # default. croniter honors DST transitions when given a
                 # tz-aware start_time; get_next(float) still returns an
                 # absolute UTC epoch, which is what next_fire_at stores.
-                tz_name = schedule.get("resolved_timezone") or SCHEDULER_TZ
-                tz = _resolve_scheduler_tzinfo(tz_name)
-                start = datetime.fromtimestamp(ref_time, tz=tz)
+                start = datetime.fromtimestamp(
+                    ref_time, tz=resolve_schedule_timezone(schedule).tzinfo
+                )
                 return croniter(expr, start_time=start).get_next(float)
             except Exception:
                 _log.exception("Invalid cron expression: %s", expr)

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -637,6 +637,8 @@ _SCHEDULE_DETAIL_KEYS = sorted(
         "created_at",
         "cron_expr",
         "description",
+        "effective_timezone",
+        "effective_timezone_source",
         "enabled",
         "github_cursor",
         "github_filter",

--- a/tests/studio/test_schedule_effective_timezone.py
+++ b/tests/studio/test_schedule_effective_timezone.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The scheduler records which zone it resolved each cron schedule in.
+
+The failure these guard against is not a wrong zone -- it is a zone nobody
+could name after the fact. A resolution that quietly produced UTC moved every
+cron schedule in the process by the host's offset and left no trace on any
+row, so "firing an hour early" and "correct" looked identical in storage.
+
+So these assert on the *record*, not on the value: an unresolvable
+configuration must leave a row that says the zone was not resolvable, and a
+resolvable one must leave a row naming the zone that was actually used. The
+two UTCs -- one requested, one fallen back to -- must not read the same.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+pytest.importorskip("croniter", reason="studio extra not installed")
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test temp file DB. Both ``state.db`` and the schedules service
+    bind ``DEFAULT_DB_PATH`` by plain import, so both need patching."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def _pin_scheduler_tz(monkeypatch: pytest.MonkeyPatch, name: str, source: str) -> None:
+    """Pin the process-wide resolution the scheduler reads.
+
+    Both attributes are set together because they are two halves of one
+    answer: pinning only the name would leave the source describing how some
+    other name was arrived at, which is exactly the confusion under test.
+    """
+    import lionagi.studio.config as studio_config
+
+    monkeypatch.setattr(studio_config, "SCHEDULER_TZ", name)
+    monkeypatch.setattr(studio_config, "SCHEDULER_TZ_SOURCE", source)
+    monkeypatch.setattr(studio_config, "SCHEDULER_TZ_SOURCE_DETAIL", "test")
+
+
+async def _create_cron_schedule(name: str, **extra) -> str:
+    from lionagi.studio.services.schedules import create_schedule
+
+    created = await create_schedule(
+        {
+            "name": name,
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            **extra,
+        }
+    )
+    return created["id"]
+
+
+async def _stamp_and_read(schedule_id: str) -> dict:
+    """Run the scheduler's startup stamping pass and read the row back."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    await SchedulerEngine()._stamp_effective_timezones()
+    async with StateDB() as db:
+        return await db.get_schedule(schedule_id)
+
+
+@pytest.mark.asyncio
+async def test_unloadable_zone_is_recorded_as_unresolvable(temp_db_path, monkeypatch):
+    """A configuration naming a zone this host cannot load must produce a row
+    that says so -- not merely a row that happens to say UTC."""
+    from lionagi.studio.config import TZ_SOURCE_UTC_UNLOADABLE_NAME
+
+    _pin_scheduler_tz(monkeypatch, "Not/A_Real_Zone", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-unloadable")
+
+    row = await _stamp_and_read(sid)
+
+    assert row["effective_timezone_source"] == TZ_SOURCE_UTC_UNLOADABLE_NAME
+    assert row["effective_timezone"] == "UTC"
+
+
+@pytest.mark.asyncio
+async def test_resolvable_zone_is_recorded_by_name(temp_db_path, monkeypatch):
+    """A resolvable configuration must name the zone that was actually used,
+    and attribute it to where it came from."""
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-resolvable")
+
+    row = await _stamp_and_read(sid)
+
+    assert row["effective_timezone"] == "America/New_York"
+    assert row["effective_timezone_source"] == "env:LIONAGI_SCHEDULER_TZ"
+
+
+@pytest.mark.asyncio
+async def test_requested_utc_and_fallback_utc_are_distinguishable(temp_db_path, monkeypatch):
+    """The whole point of storing the source: three configurations that all
+    interpret cron in UTC must leave three different records."""
+    from lionagi.studio.config import (
+        TZ_SOURCE_SCHEDULER_ENV,
+        TZ_SOURCE_UTC_FALLBACK,
+        TZ_SOURCE_UTC_UNLOADABLE_NAME,
+    )
+
+    _pin_scheduler_tz(monkeypatch, "UTC", TZ_SOURCE_SCHEDULER_ENV)
+    asked_for = await _stamp_and_read(await _create_cron_schedule("tz-utc-asked-for"))
+
+    _pin_scheduler_tz(monkeypatch, "UTC", TZ_SOURCE_UTC_FALLBACK)
+    fell_back = await _stamp_and_read(await _create_cron_schedule("tz-utc-fell-back"))
+
+    _pin_scheduler_tz(monkeypatch, "Not/A_Real_Zone", TZ_SOURCE_SCHEDULER_ENV)
+    unloadable = await _stamp_and_read(await _create_cron_schedule("tz-utc-unloadable"))
+
+    names = {
+        asked_for["effective_timezone"],
+        fell_back["effective_timezone"],
+        unloadable["effective_timezone"],
+    }
+    assert names == {"UTC"}, "premise: all three interpret cron in UTC"
+
+    assert asked_for["effective_timezone_source"] == TZ_SOURCE_SCHEDULER_ENV
+    assert fell_back["effective_timezone_source"] == TZ_SOURCE_UTC_FALLBACK
+    assert unloadable["effective_timezone_source"] == TZ_SOURCE_UTC_UNLOADABLE_NAME
+
+
+@pytest.mark.asyncio
+async def test_declared_zone_on_the_row_wins_and_is_attributed_to_the_row(
+    temp_db_path, monkeypatch
+):
+    """A row carrying its own zone resolves in that zone, and the record says
+    the zone came from the row -- not from the process default it overrode."""
+    from lionagi.studio.config import TZ_SOURCE_SCHEDULE_DECLARED
+
+    _pin_scheduler_tz(monkeypatch, "UTC", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-declared", resolved_timezone="Europe/Berlin")
+
+    row = await _stamp_and_read(sid)
+
+    assert row["effective_timezone"] == "Europe/Berlin"
+    assert row["effective_timezone_source"] == TZ_SOURCE_SCHEDULE_DECLARED
+
+
+@pytest.mark.asyncio
+async def test_a_fire_stamps_the_row_too(temp_db_path, monkeypatch):
+    """Startup is not the only resolve point. A schedule armed by the tick
+    loop must carry the stamp as well, or a row created between restarts
+    stays unattributed until the daemon happens to bounce."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-armed-by-tick")
+
+    async with StateDB() as db:
+        await db.update_schedule(sid, next_fire_at=None)
+        schedule = await db.get_schedule(sid)
+
+    engine = SchedulerEngine()
+    await engine.recompute_next_fire(schedule)
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+
+    assert row["effective_timezone"] == "America/New_York"
+    assert row["effective_timezone_source"] == "env:LIONAGI_SCHEDULER_TZ"
+
+
+@pytest.mark.asyncio
+async def test_non_cron_schedules_are_not_stamped(temp_db_path, monkeypatch):
+    """An interval trigger computes its fire time from an offset, so no zone
+    is in play. Stamping one would record a fact that was never used."""
+    from lionagi.studio.services.schedules import create_schedule
+
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+    created = await create_schedule(
+        {
+            "name": "tz-interval",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+
+    row = await _stamp_and_read(created["id"])
+
+    assert row["effective_timezone"] is None
+    assert row["effective_timezone_source"] is None
+
+
+def test_startup_announces_the_resolved_zone(caplog, monkeypatch):
+    """The zone is resolved at import and frozen for the process, so if
+    startup does not say it, nothing does."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+
+    with caplog.at_level(logging.INFO, logger="lionagi.studio.scheduler.engine"):
+        SchedulerEngine()._log_scheduler_timezone()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("America/New_York" in m and "env:LIONAGI_SCHEDULER_TZ" in m for m in messages), (
+        f"startup said nothing naming the zone and its source: {messages}"
+    )
+
+
+def test_startup_announces_a_utc_fallback_at_warning_level(caplog, monkeypatch):
+    """A fallback moved every cron schedule in the process. It must not be
+    logged at the same level as an ordinary, chosen configuration."""
+    from lionagi.studio.config import TZ_SOURCE_UTC_FALLBACK
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    _pin_scheduler_tz(monkeypatch, "UTC", TZ_SOURCE_UTC_FALLBACK)
+
+    with caplog.at_level(logging.INFO, logger="lionagi.studio.scheduler.engine"):
+        SchedulerEngine()._log_scheduler_timezone()
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(TZ_SOURCE_UTC_FALLBACK in m for m in warnings), (
+        f"a fleet-wide UTC fallback was not warned about: {warnings}"
+    )

--- a/tests/studio/test_schedule_effective_timezone.py
+++ b/tests/studio/test_schedule_effective_timezone.py
@@ -151,7 +151,7 @@ async def test_declared_zone_on_the_row_wins_and_is_attributed_to_the_row(
 
 
 @pytest.mark.asyncio
-async def test_a_fire_stamps_the_row_too(temp_db_path, monkeypatch):
+async def test_a_rearm_by_the_tick_loop_stamps_the_row_too(temp_db_path, monkeypatch):
     """Startup is not the only resolve point. A schedule armed by the tick
     loop must carry the stamp as well, or a row created between restarts
     stays unattributed until the daemon happens to bounce."""
@@ -171,6 +171,87 @@ async def test_a_fire_stamps_the_row_too(temp_db_path, monkeypatch):
     async with StateDB() as db:
         row = await db.get_schedule(sid)
 
+    assert row["effective_timezone"] == "America/New_York"
+    assert row["effective_timezone_source"] == "env:LIONAGI_SCHEDULER_TZ"
+
+
+@pytest.mark.asyncio
+async def test_an_actual_fire_stamps_the_row_too(temp_db_path, monkeypatch):
+    """Re-arming and firing are different writes, and both compute a next
+    fire time.
+
+    A schedule that never restarts and never has its next fire recomputed by
+    the tick loop still passes through here on every occurrence, so a stamp
+    missing from this path leaves exactly the schedules that run most often
+    as the ones nobody can attribute. Asserted through a real fire against
+    the store rather than on the arguments to a mock, because the question is
+    what ends up on the row.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-fired")
+
+    async with StateDB() as db:
+        schedule = await db.get_schedule(sid)
+
+    engine = SchedulerEngine()
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-tz-001", trigger_context={"scheduled": True})
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+
+    assert row["last_fired_at"] is not None, "the fire path did not run"
+    assert row["effective_timezone"] == "America/New_York"
+    assert row["effective_timezone_source"] == "env:LIONAGI_SCHEDULER_TZ"
+
+
+@pytest.mark.asyncio
+async def test_a_fire_that_could_not_spawn_stamps_the_row_too(temp_db_path, monkeypatch):
+    """The failure path computes a next fire time as well, so it resolves a
+    zone as well, so it has to record which one.
+
+    A schedule whose action cannot be built fires, fails and re-arms on every
+    occurrence without ever reaching the normal path. Left unstamped it would
+    be the one class of schedule that is both permanently broken and
+    permanently unattributable, which is the combination least affordable
+    when someone is trying to work out why it runs when it does.
+    """
+    from unittest.mock import patch
+
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    _pin_scheduler_tz(monkeypatch, "America/New_York", "env:LIONAGI_SCHEDULER_TZ")
+    sid = await _create_cron_schedule("tz-unspawnable")
+
+    async with StateDB() as db:
+        schedule = await db.get_schedule(sid)
+
+    engine = SchedulerEngine()
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("action is not buildable"),
+    ):
+        await engine._fire(schedule, "run-tz-002", trigger_context={"scheduled": True})
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+
+    assert row["last_fired_at"] is not None, "the failure path did not run"
     assert row["effective_timezone"] == "America/New_York"
     assert row["effective_timezone_source"] == "env:LIONAGI_SCHEDULER_TZ"
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1173,7 +1173,7 @@ def test_invalid_scheduler_tz_falls_back_to_utc(monkeypatch, caplog):
     assert next_at is not None
     got_utc = datetime.fromtimestamp(next_at, tz=timezone.utc)
     assert got_utc == datetime(2026, 7, 2, 18, 0, 0, tzinfo=timezone.utc)
-    assert any("Invalid scheduler timezone" in r.message for r in caplog.records)
+    assert any("is not a zone this host can load" in r.getMessage() for r in caplog.records)
 
 
 def test_compute_next_fire_cron_prefers_resolved_timezone_over_scheduler_tz(monkeypatch):
@@ -1422,7 +1422,15 @@ async def test_recompute_next_fire_persists_and_logs_on_shift(monkeypatch, caplo
 
     assert new is not None
     assert new != 100.0
-    svc.update_schedule.assert_awaited_once_with(schedule["id"], next_fire_at=new)
+    # The same write also carries the zone the new value was resolved in, so
+    # a shifted fire time and the interpretation that produced it land
+    # together rather than as two separately-discoverable facts.
+    svc.update_schedule.assert_awaited_once_with(
+        schedule["id"],
+        next_fire_at=new,
+        effective_timezone="America/New_York",
+        effective_timezone_source=studio_config.SCHEDULER_TZ_SOURCE,
+    )
     shift_logs = [r for r in caplog.records if "next_fire_at shifted" in r.message]
     assert len(shift_logs) == 1
 


### PR DESCRIPTION
The scheduler resolves cron expressions in a timezone and recorded nothing about which one or how it got there. When resolution falls back to UTC, every cron row without its own declared zone fires by the host's offset early, and nothing anywhere says so — the fallback is indistinguishable from correct operation until someone reconstructs cron-versus-observed firing times by hand. That is the defect here. The fallback itself is fine; its silence is not.

## What changed

Two new columns on `schedules` record the outcome of resolution, and resolution never reads them back:

| column | meaning |
|---|---|
| `effective_timezone` | the zone the cron fields were actually interpreted in |
| `effective_timezone_source` | how that zone was arrived at |

`resolved_timezone` already existed and keeps its meaning. It is an **input** — the zone a row declared — and `_compute_next_fire()` reads it. Writing the effective zone into it would have frozen legacy rows to whatever one daemon happened to resolve, so a corrected configuration would never reach them again. That is the same class of silent behaviour change this is about, installed deliberately, so the outcome goes in columns of its own.

## Telling the two UTCs apart

Four configurations produce `effective_timezone = "UTC"` and they are not the same fact. `effective_timezone_source` draws from a closed vocabulary: `schedule:resolved_timezone`, `env:LIONAGI_SCHEDULER_TZ`, `env:TZ`, `system:localtime` all mean somebody chose UTC. `fallback:utc` and `fallback:utc:unloadable-name` mean the request was lost. The startup line branches on that second group and logs at WARNING with the words `FELL BACK`; an ordinary resolution logs at INFO. The zone is resolved at import and frozen for the process, so if startup does not say it, nothing does.

Rows are stamped at every point the engine resolves a fire time, including a startup pass over all schedules rather than only enabled ones, so a daemon that resolves differently from the previous run corrects every row immediately. The pass is idempotent — a converged fleet writes nothing. Interval, `at` and `github_poll` triggers are left unstamped: they compute from an offset with no wall-clock fields, so there is no zone in play.

## Resolution behaviour is unchanged

Same precedence, same fallback, same `ZoneInfo`. Every fire time this computes is what the previous code computed for the same input. Two existing tests changed because they pinned surface rather than behaviour: one the exact wording of the fallback warning, one the exact `update_schedule()` call.

## Verification

`tests/studio tests/state tests/apps_studio_server`: **2600 passed**, with `tests/state/test_dual_backend.py` ignored and `test_metadata_create_all_postgres` deselected — those six fail with `ModuleNotFoundError: No module named 'asyncpg'` on this branch and before it. Worth noting for anyone rerunning: without the deselect the run hits `--maxfail` and stops early, and the passing count it prints then is a truncated run rather than a result.

8 new tests in `tests/studio/test_schedule_effective_timezone.py` assert on the record rather than the value: three configurations that all interpret cron in UTC leave three different records; a row's own declared zone wins and is attributed to the row; a re-arm stamps too; a non-cron trigger is not stamped.

Revert probe: with the body of `_effective_timezone_fields()` replaced by `return {}` and everything else intact (file confirmed to still parse, so the red is an assertion and not a broken import), **5 of the 8 fail**. Of the three that stay green, two guard the startup log, which is a separate deliverable; the third asserts a NULL and is therefore vacuous under that revert — it guards against a future change that starts stamping interval rows, not against the stamp being absent. Recording that rather than counting it as coverage.

Migration checked by hand as well as by suite: a store created from `main`'s `schema.sql`, with a schedule row in it, opens under this branch with both columns present and the existing row preserved as NULL.

## Not covered

- **The migration list and the `db.py` insert have no parity test.** Both were updated, but only `schema.sql` and `schema_meta.py` are compared by an existing test. The other two were found by reading, and nothing would have caught a miss.
- **An unloadable name from the environment is not recorded on the row** — the row says `fallback:utc:unloadable-name` but not which name failed; that is in the warning and in the health report. Embedding it would have made the vocabulary open-ended.
- **No backfill.** Rows are stamped going forward. Schedules that fired during a silent period get no retroactive record.
- **Rows created between daemon restarts carry NULL until armed**, within one tick. Stamping at creation would mean a second resolution site.
- **Postgres unverified here.** The columns are plain nullable `Text` in the shared metadata, so the DDL derives from the same source, but `asyncpg` is not installed in this environment.
