### PR TITLE
perf(state): index the foreign keys a delete searches through

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -746,6 +746,33 @@ produced nothing.
 
 ---
 
+## `li lifecycle`
+
+Report what the lifecycle store records about one CLI run.
+
+```bash
+li lifecycle <run-id> --machine
+```
+
+This is the one path from a run id to the rows the lifecycle writers actually
+write. A normal teardown records an end; so does `li kill`, which writes the
+row and signals the process without touching the MCP job record or the run
+manifest. A caller holding only a run id and reading only those two would see a
+dead process with no recorded end, which is what an orphaned run looks like.
+
+The answer is read-only and carries its own availability. An established answer
+with `found: false` means no session was ever recorded under this id. An
+unavailable one means the store could not be read at all, which is not a
+statement about the run. A caller that collapsed the two would report a run as
+finished, or as never started, on the strength of a database it never opened.
+
+The store consulted is the one `LIONAGI_STATE_DB_URL` names when it is set, and
+the default otherwise — including for the question of whether a store exists at
+all, so a configured store is never reported missing because the default path
+is absent.
+
+---
+
 ## Machine mode: `--machine`
 
 Any command that reaches the dispatcher accepts `--machine`, which turns its

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -38,6 +38,7 @@ __all__ = (
     "save_last_branch_pointer",
     "list_runs",
     "current_run_id",
+    "active_run_id",
     "resolve_run_reason",
     "setup_agent_persist",
     "teardown_persist",
@@ -57,6 +58,23 @@ def _new_run_id() -> str:
 def current_run_id() -> str | None:
     """Return the run_id inherited from the environment (subprocess case)."""
     return os.environ.get(_RUN_ID_ENV_VAR) or None
+
+
+# The run this process most recently allocated. Kept here rather than in the
+# environment because allocate_run() reads the environment to *inherit* an id,
+# so exporting one would make a second allocation in the same process silently
+# reuse the first run's directory.
+_ALLOCATED_RUN_ID: str | None = None
+
+
+def active_run_id() -> str | None:
+    """The run_id of the run this process is recording under, if any.
+
+    The run this process allocated, falling back to one inherited from a
+    parent. None when nothing has allocated a run yet — an embedded caller,
+    or the window before ``allocate_run`` runs.
+    """
+    return _ALLOCATED_RUN_ID or current_run_id()
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:
@@ -209,7 +227,10 @@ def allocate_run(
     run_id: str | None = None,
 ) -> RunDir:
     """Allocate a run dir, inheriting run_id from LIONAGI_RUN_ID env var if set (subprocess handoff)."""
+    global _ALLOCATED_RUN_ID
+
     rid = run_id or current_run_id() or _new_run_id()
+    _ALLOCATED_RUN_ID = rid
     state_root = RUNS_ROOT / rid
 
     if save_dir is not None:
@@ -1173,6 +1194,7 @@ async def setup_agent_persist(
             await db.create_session(
                 {
                     "id": session_id,
+                    "run_id": active_run_id(),
                     "created_at": session_dict["created_at"],
                     "node_metadata": _node_meta,
                     "name": session_dict.get("name"),

--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import argparse
 import time
+from typing import Any
 
 __all__ = (
     "add_dispatch_subparser",
     "run_dispatch",
+    "machine_result",
 )
 
 
@@ -259,3 +261,105 @@ def run_dispatch(args: argparse.Namespace) -> int:
             _cmd_purge_bulk(status=args.status, before=args.before, dry_run=args.dry_run)
         )
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# A listing reports the routing and delivery bookkeeping of each row. The
+# payload itself is not here: it is unbounded caller data and a listing of fifty
+# rows would carry fifty of them. `dispatch show` names one row and returns it.
+_LIST_FIELDS = (
+    "id",
+    "kind",
+    "deliver_to",
+    "dedup_key",
+    "status",
+    "attempt",
+    "max_attempts",
+    "next_attempt_at",
+    "ack_required",
+    "session_id",
+    "schedule_run_id",
+    "last_error",
+    "created_at",
+    "expires_at",
+    "updated_at",
+)
+
+# One row in full, plus the payload. `ack_token` is included: it is the value a
+# caller needs to acknowledge the row, `li dispatch show` is where a human reads
+# it, and withholding it here while printing it there would be a difference
+# between the two surfaces that neither one states.
+_SHOW_FIELDS = (*_LIST_FIELDS, "ack_token", "payload")
+
+
+async def _machine_ls_data(*, status: str | None, limit: int) -> dict[str, Any]:
+    from lionagi.dispatch import list_dispatches
+
+    from .machine import available, readonly_state_db
+
+    result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            result["dispatches"] = why
+            return result
+        rows = await list_dispatches(db, status=status, limit=limit)
+    result["dispatches"] = available(
+        [{field: row.get(field) for field in _LIST_FIELDS} for row in rows]
+    )
+    return result
+
+
+async def _machine_show_data(dispatch_id: str) -> dict[str, Any]:
+    from lionagi.dispatch import get_dispatch
+
+    from .machine import MachineError, readonly_state_db, store_unreachable
+
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            raise store_unreachable(why, f"no dispatch {dispatch_id!r}")
+        row = await get_dispatch(db, dispatch_id)
+    if row is None:
+        raise MachineError("not_found", f"no dispatch with id {dispatch_id!r}")
+    return {"dispatch": {field: row.get(field) for field in _SHOW_FIELDS}}
+
+
+def _machine_ls(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch ls")
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--limit", type=int, default=50, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_ls_data(status=args.status, limit=args.limit))
+
+
+def _machine_show(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch show")
+    parser.add_argument("id", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return run_async(_machine_show_data(args.id))
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li dispatch <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "dispatch",
+        argv,
+        {"ls": _machine_ls, "show": _machine_show},
+        without_seam={
+            "ack": "it acknowledges a delivery, which is a write to the outbox",
+            "retry": "it re-queues a row for delivery, which is a write to the outbox",
+            "purge": "it deletes rows from the outbox",
+        },
+    )

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import time
 import uuid
+from typing import Any
 
 from ._logging import hint, log_error
 
@@ -252,3 +253,74 @@ def run_invoke(args: argparse.Namespace) -> int:
         return 0
 
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# What a listing reports about one invocation. `node_metadata` is deliberately
+# not here: the store holds it as a JSON document for some rows and as the text
+# of one for others, so a caller could not tell which it had been handed without
+# guessing, and a listing is not where that ambiguity should be settled.
+_INVOCATION_FIELDS = (
+    "id",
+    "skill",
+    "plugin",
+    "status",
+    "prompt",
+    "started_at",
+    "ended_at",
+    "updated_at",
+    "session_count",
+    "project",
+    "project_source",
+)
+
+
+async def _machine_list_data(
+    *, skill: str | None, status: str | None, limit: int
+) -> dict[str, Any]:
+    from .machine import available, readonly_state_db
+
+    result: dict[str, Any] = {
+        "filters": {"skill": skill, "status": status},
+        "limit": limit,
+    }
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            result["invocations"] = why
+            return result
+        rows = await db.list_invocations(skill=skill, status=status, limit=limit)
+    result["invocations"] = available(
+        [{field: row.get(field) for field in _INVOCATION_FIELDS} for row in rows]
+    )
+    return result
+
+
+def _machine_list(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li invoke list")
+    parser.add_argument("--skill", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--limit", type=int, default=20, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_list_data(skill=args.skill, status=args.status, limit=args.limit))
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li invoke <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "invoke",
+        argv,
+        {"list": _machine_list},
+        without_seam={
+            "start": "it opens an invocation record, which is a write to the store",
+            "end": "it closes an invocation record, which is a write to the store",
+        },
+    )

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -74,63 +74,61 @@ def _cmdline_is_lionagi(cmdline: list[str], expected_cmd: str) -> bool:
     return False
 
 
+_IdentityVerdict = Literal["ours", "not_ours", "unverifiable", "zombie"]
+
+
+def _pid_is_zombie(pid: int) -> bool:
+    """True if *pid* has exited and is waiting for its parent to reap it.
+
+    `pid_alive` answers "does the OS still know this pid", and a zombie
+    satisfies that: it keeps its slot until it is reaped, so `kill -0` keeps
+    succeeding and signals keep being accepted with no effect. Anything that
+    reads "still there" as "still working" will wait out a grace period that
+    can never end and then escalate onto a process that is already dead.
+    """
+    if pid <= 1:
+        return False
+    try:
+        return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except psutil.ZombieProcess:
+        return True
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+
+
 def _check_pid_identity(
     pid: int,
     expected_cmd: str,
     *,
     expected_session_id: str | None = None,
     expected_create_time: float | None = None,
-) -> bool:
-    """Return True iff the live process at *pid* is the lionagi run we recorded."""
-    try:
-        proc = psutil.Process(pid)
-        create_time_ok: bool | None = None
-        if expected_create_time is not None:
-            create_time_ok = (
-                abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
-            )
-            if not create_time_ok:
-                return False
-
-        if expected_session_id is not None:
-            try:
-                marker = proc.environ().get("LIONAGI_SESSION_ID")
-            except (psutil.AccessDenied, NotImplementedError):
-                marker = None
-            if marker is not None:
-                return marker == expected_session_id
-            # Without env marker, require BOTH create_time match AND lionagi cmdline.
-            return create_time_ok is True and _cmdline_is_lionagi(proc.cmdline(), expected_cmd)
-
-        cmdline = proc.cmdline()
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        return False
-
-    return _cmdline_is_lionagi(cmdline, expected_cmd)
-
-
-_IdentityVerdict = Literal["ours", "not_ours", "unverifiable"]
-
-
-def _check_pid_identity_tristate(
-    pid: int,
-    expected_cmd: str,
-    *,
-    expected_session_id: str | None = None,
-    expected_create_time: float | None = None,
 ) -> _IdentityVerdict:
-    """Sweep-only identity check that separates "definitely not ours" from
-    "cannot tell" (permission denied reading process details).
+    """Classify the process at *pid* against the run we recorded.
 
-    The direct-kill path (`_check_pid_identity`) collapses AccessDenied to a
-    refusal, which is the safe default when a human explicitly asked to kill
-    one entity. The stale sweep runs unattended over many rows; if it reused
-    that same collapse, a live worker we simply lack permission to inspect
-    would be swept and its row marked cancelled while the process keeps
-    running. Callers must treat "unverifiable" as still-alive, not as dead.
+    Four answers, and every caller has to say which of them it accepts:
+
+    - "ours": positively identified as the run in the row.
+    - "not_ours": the pid is gone, or a different process holds it now. Killing
+      it would hit a stranger, which is the whole reason this check exists.
+    - "unverifiable": the process is there but could not be inspected (usually
+      permission denied). Callers must read this as still-alive, not as dead:
+      an unattended sweep that read it as dead would cancel the row of a worker
+      it merely lacks permission to look at, while that worker keeps running.
+    - "zombie": our process has exited and has not been reaped yet. A zombie
+      cannot be a recycled pid, because the OS does not hand a pid out again
+      until it is reaped, and it cannot be killed again either. It is a
+      finished termination, not an unidentifiable process, and callers that
+      fold it into "not_ours" refuse to record a cancellation that already
+      happened.
+
+    A recorded create_time still rules first: it is readable on a zombie, so a
+    pid that was reaped, recycled, and died again is reported "not_ours" rather
+    than being mistaken for our own corpse.
     """
     try:
         proc = psutil.Process(pid)
+    except psutil.ZombieProcess:
+        return "zombie"
     except psutil.NoSuchProcess:
         return "not_ours"
     except psutil.AccessDenied:
@@ -141,6 +139,8 @@ def _check_pid_identity_tristate(
             create_time_ok = (
                 abs(proc.create_time() - expected_create_time) <= _CREATE_TIME_TOLERANCE
             )
+        except psutil.ZombieProcess:
+            return "zombie"
         except psutil.NoSuchProcess:
             return "not_ours"
         except psutil.AccessDenied:
@@ -151,6 +151,10 @@ def _check_pid_identity_tristate(
     if expected_session_id is not None:
         try:
             marker = proc.environ().get("LIONAGI_SESSION_ID")
+        except psutil.ZombieProcess:
+            # A zombie has no environment left to read, which is exactly how
+            # this case used to disappear into "cannot identify it".
+            return "zombie"
         except psutil.NoSuchProcess:
             # The process died between the liveness check and here: the row
             # is genuinely stale, and letting this escape would abort the
@@ -168,6 +172,8 @@ def _check_pid_identity_tristate(
 
     try:
         cmdline = proc.cmdline()
+    except psutil.ZombieProcess:
+        return "zombie"
     except psutil.NoSuchProcess:
         return "not_ours"
     except psutil.AccessDenied:
@@ -188,13 +194,26 @@ def _terminate_pid(
     if not _pid_alive(pid):
         return "already_dead"
 
-    if expected_cmd is not None and not _check_pid_identity(
-        pid,
-        expected_cmd,
-        expected_session_id=expected_session_id,
-        expected_create_time=expected_create_time,
-    ):
-        return "identity_mismatch"
+    if _pid_is_zombie(pid):
+        # Exited already, just not reaped by whoever started it. There is
+        # nothing left to signal, and no other process can be holding this pid
+        # until the reap happens, so this is a termination that is already
+        # complete rather than a process we failed to identify.
+        return "already_dead"
+
+    if expected_cmd is not None:
+        verdict = _check_pid_identity(
+            pid,
+            expected_cmd,
+            expected_session_id=expected_session_id,
+            expected_create_time=expected_create_time,
+        )
+        if verdict == "zombie":
+            return "already_dead"
+        # "unverifiable" refuses too: when a human named one entity to kill,
+        # not being able to confirm the target is a reason to stop.
+        if verdict != "ours":
+            return "identity_mismatch"
 
     try:
         os.kill(pid, signal.SIGTERM)
@@ -209,12 +228,15 @@ def _terminate_pid(
     deadline = time.monotonic() + grace_seconds
     interval = 0.1
     while time.monotonic() < deadline:
-        if not _pid_alive(pid):
+        # A process whose parent never reaps it stays visible to `kill -0`
+        # forever, so waiting on liveness alone would sit out the whole grace
+        # window for a process that obeyed the SIGTERM immediately.
+        if not _pid_alive(pid) or _pid_is_zombie(pid):
             return "sigterm"
         time.sleep(interval)
         interval = min(interval * 2, 0.5)
 
-    if not _pid_alive(pid):
+    if not _pid_alive(pid) or _pid_is_zombie(pid):
         return "sigterm"
 
     # Re-check identity before escalating. The check above this function's
@@ -225,13 +247,19 @@ def _terminate_pid(
     # chance to identify itself, so the one thing this must not do is escalate
     # onto a stranger. A pid that now belongs to a different process is
     # reported the same way a mismatch at entry is.
-    if expected_cmd is not None and not _check_pid_identity(
-        pid,
-        expected_cmd,
-        expected_session_id=expected_session_id,
-        expected_create_time=expected_create_time,
-    ):
-        return "identity_mismatch"
+    if expected_cmd is not None:
+        verdict = _check_pid_identity(
+            pid,
+            expected_cmd,
+            expected_session_id=expected_session_id,
+            expected_create_time=expected_create_time,
+        )
+        if verdict == "zombie":
+            # It exited between the last poll and this check: the SIGTERM
+            # worked, and escalating would be aiming at a corpse.
+            return "sigterm"
+        if verdict != "ours":
+            return "identity_mismatch"
 
     try:
         os.kill(pid, signal.SIGKILL)
@@ -654,7 +682,7 @@ async def _do_kill_all_stale(
                     except (TypeError, ValueError):
                         expected_create_time = None
 
-                    verdict = _check_pid_identity_tristate(
+                    verdict = _check_pid_identity(
                         pid,
                         "lionagi",
                         expected_session_id=expected_session_id,
@@ -680,8 +708,10 @@ async def _do_kill_all_stale(
                                 "identity unverifiable (permission denied) — treated as live"
                             )
                         continue
-                    # verdict == "not_ours": pid was recycled by an unrelated
-                    # process, fall through and sweep the row.
+                    # "not_ours" (the pid was recycled by an unrelated process)
+                    # and "zombie" (our process exited and nobody reaped it)
+                    # both mean the recorded run is gone: fall through and
+                    # sweep the row.
 
                 if dry_run:
                     print(

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -52,6 +52,9 @@ __all__ = (
     "run_handshake",
     "add_runs_subparser",
     "run_runs",
+    "lifecycle_data",
+    "add_lifecycle_subparser",
+    "run_lifecycle",
 )
 
 # The one place the current contract version lives. Incremented only by a change
@@ -336,6 +339,133 @@ def runs_data(limit: int = _DEFAULT_RUNS_LIMIT) -> dict[str, Any]:
     return {"runs": available(entries), "truncated": truncated, "limit": limit}
 
 
+# Session statuses that mean the run was stopped on purpose, and the one that
+# means the work came out right. Both are read off the lifecycle vocabulary the
+# StateDB owns; everything else terminal is a failure. This mapping lives here,
+# on the side that owns the vocabulary, so a consumer never keeps a copy.
+_CANCELLED_SESSION_STATUSES = frozenset({"cancelled", "aborted"})
+_SUCCEEDED_SESSION_STATUSES = frozenset({"completed"})
+
+
+def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold a run's session rows into one answer about the run.
+
+    `found` and `terminal` are separate questions and stay separate: no rows
+    means nothing was ever recorded, which is not the same fact as rows that
+    record no end. `terminal` needs every row to have ended, because a run that
+    persisted two sessions is over only when both are.
+    """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+    sessions = [
+        {
+            "session_id": row.get("id"),
+            "status": row.get("status"),
+            "terminal": row.get("status") in SESSION_TERMINAL_STATUSES,
+            "started_at": row.get("started_at"),
+            "ended_at": row.get("ended_at"),
+            "reason_code": row.get("status_reason_code"),
+            "reason_summary": row.get("status_reason_summary"),
+        }
+        for row in rows
+    ]
+    if not sessions:
+        return {
+            "found": False,
+            "terminal": False,
+            "status": None,
+            "outcome": None,
+            "reason_code": None,
+            "reason_summary": None,
+            "ended_at": None,
+            "sessions": [],
+        }
+
+    terminal = all(entry["terminal"] for entry in sessions)
+    if not terminal:
+        governing = next(entry for entry in sessions if not entry["terminal"])
+        return {
+            "found": True,
+            "terminal": False,
+            "status": governing["status"],
+            "outcome": None,
+            "reason_code": governing["reason_code"],
+            "reason_summary": governing["reason_summary"],
+            "ended_at": None,
+            "sessions": sessions,
+        }
+
+    statuses = {entry["status"] for entry in sessions}
+    if statuses & _CANCELLED_SESSION_STATUSES:
+        outcome = "cancelled"
+        governing = next(
+            entry for entry in sessions if entry["status"] in _CANCELLED_SESSION_STATUSES
+        )
+    elif statuses <= _SUCCEEDED_SESSION_STATUSES:
+        outcome = "succeeded"
+        governing = sessions[-1]
+    else:
+        outcome = "failed"
+        governing = next(
+            entry for entry in sessions if entry["status"] not in _SUCCEEDED_SESSION_STATUSES
+        )
+    ends = [entry["ended_at"] for entry in sessions if entry["ended_at"] is not None]
+    return {
+        "found": True,
+        "terminal": True,
+        "status": governing["status"],
+        "outcome": outcome,
+        "reason_code": governing["reason_code"],
+        "reason_summary": governing["reason_summary"],
+        "ended_at": max(ends) if ends else None,
+        "sessions": sessions,
+    }
+
+
+def lifecycle_data(run_id: str) -> dict[str, Any]:
+    """What the lifecycle store records about CLI run *run_id*.
+
+    This is the one machine-qualified path from a run_id to the rows the
+    lifecycle writers — a normal teardown, and `li kill` — actually write. It
+    reads only; nothing here changes a run.
+
+    `lifecycle` carries its own availability, and the distinction is the whole
+    point: an established answer with `found: false` means no session was ever
+    recorded under this id, while an unavailable one means the store could not
+    be read at all. A caller that collapsed the two would report a run as
+    finished, or as never started, on the strength of a database it never
+    opened.
+    """
+    from lionagi.ln.concurrency import run_async
+    from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
+
+    if state_db_known_absent():
+        # No store at all is not evidence about one run: it is the absence of
+        # every record, including the ones that would answer this question.
+        #
+        # Asked of the store this read will actually open, not of the default
+        # path. `LIONAGI_STATE_DB_URL` moves the store, and a check against the
+        # default would then report every run in a configured store as
+        # unreadable while the reader beside it opens that store and finds them.
+        return {
+            "run_id": run_id,
+            "lifecycle": unavailable(REASON_NOT_FOUND, f"{state_db_file()} does not exist"),
+        }
+
+    async def _read() -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.get_sessions_for_run(run_id)
+
+    try:
+        rows = run_async(_read())
+    except Exception as exc:  # noqa: BLE001 — an unreadable store is an answer, not a crash
+        return {
+            "run_id": run_id,
+            "lifecycle": unavailable(REASON_UNREADABLE, f"{type(exc).__name__}: {exc}"),
+        }
+    return {"run_id": run_id, "lifecycle": available(_lifecycle_summary(rows))}
+
+
 # ── Machine dispatch ────────────────────────────────────────────────────────
 
 
@@ -368,6 +498,21 @@ def _machine_runs(argv: list[str]) -> dict[str, Any]:
     return runs_data(known.limit)
 
 
+def _machine_lifecycle(argv: list[str]) -> dict[str, Any]:
+    parser = argparse.ArgumentParser(prog="li lifecycle", add_help=False)
+    parser.add_argument(
+        "run_id",
+        nargs="?",
+        help="The run id to report the recorded lifecycle state of.",
+    )
+    known, extras = parser.parse_known_args(argv)
+    if extras:
+        raise MachineError("invalid_input", f"unrecognized arguments: {' '.join(extras)}")
+    if not known.run_id or not known.run_id.strip():
+        raise MachineError("invalid_input", "li lifecycle needs a run id")
+    return lifecycle_data(known.run_id.strip())
+
+
 def _reject_extra_arguments(name: str, argv: list[str]) -> None:
     if argv:
         raise MachineError("invalid_input", f"li {name} takes no arguments: {' '.join(argv)}")
@@ -377,6 +522,7 @@ _MACHINE_COMMANDS: dict[str, Callable[[list[str]], dict[str, Any]]] = {
     "handshake": _machine_handshake,
     "doctor": _machine_doctor,
     "runs": _machine_runs,
+    "lifecycle": _machine_lifecycle,
 }
 
 
@@ -503,4 +649,42 @@ def run_runs(args: argparse.Namespace) -> int:
         print(f"{entry['run_id']}  {summary}")
     if data["truncated"]:
         print(f"(truncated at {data['limit']}; pass --limit for more)")
+    return 0
+
+
+def add_lifecycle_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "lifecycle",
+        help="Report the recorded lifecycle state of a run.",
+        description=(
+            "Read-only: what the lifecycle store records about one run id — whether a "
+            "session was ever recorded for it, whether every one of them has ended, and "
+            "with what outcome. A run stopped by `li kill` reads as cancelled here. "
+            "Add --machine for the contract envelope on stdout."
+        ),
+    )
+    p.add_argument("run_id", help="The run id to report on.")
+    p.add_argument("--machine", action="store_true", help="Emit the machine-result envelope.")
+
+
+def run_lifecycle(args: argparse.Namespace) -> int:
+    from ._logging import log_error
+
+    data = lifecycle_data(args.run_id)
+    state = data["lifecycle"]
+    if not state["available"]:
+        log_error(f"could not read the lifecycle store ({state['reason_code']}): {state['detail']}")
+        return 1
+    value = state["value"]
+    if not value["found"]:
+        print(f"{data['run_id']}: no session recorded for this run")
+        return 1
+    print(f"{data['run_id']}: {value['status']}")
+    print(f"terminal: {value['terminal']}")
+    if value["terminal"]:
+        print(f"outcome: {value['outcome']}")
+    if value["reason_code"]:
+        print(f"reason: {value['reason_code']} — {value['reason_summary'] or ''}".rstrip(" —"))
+    for entry in value["sessions"]:
+        print(f"  session {entry['session_id']}  {entry['status']}")
     return 0

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -28,8 +28,9 @@ import argparse
 import json
 import os
 import sys
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,12 @@ __all__ = (
     "unavailable",
     "read_json_file",
     "list_directory",
+    "machine_parser",
+    "parse_machine_argv",
+    "machine_subcommand",
+    "readonly_state_db",
+    "state_db_absent",
+    "store_unreachable",
     "reserve_stdout",
     "dispatch_machine",
     "handshake_data",
@@ -191,6 +198,147 @@ def list_directory(path: Path, *, missing_is_empty: bool = False) -> dict[str, A
     except OSError as exc:
         return unavailable(REASON_UNREADABLE, f"{path}: {exc.strerror or exc}")
     return available(names)
+
+
+# ── argument parsing on the machine channel ─────────────────────────────────
+
+
+class _MachineArgumentParser(argparse.ArgumentParser):
+    """An argparse parser that refuses inside the envelope instead of exiting.
+
+    ``ArgumentParser.error`` prints usage and raises ``SystemExit``, which no
+    ``except Exception`` catches — the process would end having written a usage
+    message to stderr and no envelope at all, which reads to a machine caller as
+    a command that stopped answering rather than one that refused.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        raise MachineError("invalid_input", message)
+
+
+def machine_parser(prog: str) -> argparse.ArgumentParser:
+    """A parser for one machine command's arguments.
+
+    Deliberately separate from the human-facing parser the same command
+    registers: this one is reached with ``--machine`` already stripped and
+    answers only what the machine path honours, so a flag that shapes the human
+    printout is refused here rather than accepted and ignored.
+    """
+    return _MachineArgumentParser(prog=prog, add_help=False)
+
+
+def parse_machine_argv(parser: argparse.ArgumentParser, argv: list[str]) -> argparse.Namespace:
+    known, extras = parser.parse_known_args(argv)
+    if extras:
+        raise MachineError("invalid_input", f"unrecognized arguments: {' '.join(extras)}")
+    return known
+
+
+def machine_subcommand(
+    command: str,
+    argv: list[str],
+    handlers: Mapping[str, Callable[[list[str]], dict[str, Any]]],
+    *,
+    without_seam: Mapping[str, str],
+) -> dict[str, Any]:
+    """Route ``li <command> <sub>`` to the subcommand's machine payload.
+
+    Three answers, kept apart: a name that is not a subcommand of this command
+    is bad input, a real subcommand with no machine result is unavailable and
+    says why, and a qualified one runs. Collapsing the middle case into "no such
+    subcommand" would tell a caller the capability does not exist when what is
+    missing is only this surface's route to it.
+
+    *without_seam* carries a reason per subcommand rather than a list of names,
+    because the reasons differ — one command prints prose, the next writes to
+    the store — and one sentence covering both would be true of neither.
+    """
+    if not argv:
+        raise MachineError(
+            "invalid_input",
+            f"li {command} needs a subcommand; these answer on the machine "
+            f"channel: {', '.join(sorted(handlers))}",
+        )
+    sub, rest = argv[0], argv[1:]
+    handler = handlers.get(sub)
+    if handler is not None:
+        return handler(rest)
+    reason = without_seam.get(sub)
+    if reason is not None:
+        raise MachineError(
+            "unavailable",
+            f"`li {command} {sub}` has no machine result in contract version "
+            f"{CONTRACT_VERSION}: {reason}",
+        )
+    raise MachineError("invalid_input", f"no such subcommand: {command} {sub}")
+
+
+# ── the lifecycle store, opened for reading only ────────────────────────────
+
+
+@asynccontextmanager
+async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] | None]]:
+    """The lifecycle store open for reading, paired with why it is not.
+
+    Read-only at the connection, not by convention: the ordinary open reconciles
+    the schema, so a reporting command that used it would write to the store it
+    is reporting on.
+
+    Exactly one of the two is set. The reason travels with the ``None`` rather
+    than being reconstructed by the caller, because there is more than one way
+    to arrive here: the store may not exist yet, which is a definitive statement
+    that nothing has been recorded, or it may exist and refuse to open, which
+    says nothing at all about what it holds. A caller handed only ``None`` has
+    to guess between those, and every one of them guessed "absent".
+
+    A failure to open is a fact about the store, so it is reported rather than
+    raised. The guard covers the open alone — the caller's own body runs outside
+    it, and a bug in a reader still surfaces as the crash it is.
+    """
+    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+    if not DEFAULT_DB_PATH.exists():
+        yield None, state_db_absent()
+        return
+    async with AsyncExitStack() as stack:
+        try:
+            db = await stack.enter_async_context(StateDB(readonly=True))
+            # The engine is lazy: it connects on the first statement, so without
+            # this the store's refusal would surface in the middle of a caller's
+            # query, where it is indistinguishable from that query being wrong.
+            # One trivial statement moves the failure to the moment this seam
+            # claims the store is open, which is what the claim has to mean.
+            await db.fetch_all("SELECT 1")
+        except Exception as exc:  # noqa: BLE001 — an unopenable store is an answer, not a crash
+            yield None, unavailable(REASON_UNREADABLE, f"{DEFAULT_DB_PATH}: {type(exc).__name__}")
+            return
+        yield db, None
+
+
+def state_db_absent() -> dict[str, Any]:
+    """The unavailability every store-backed reader reports when there is no store."""
+    from lionagi.state.db import DEFAULT_DB_PATH
+
+    return unavailable(
+        REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist; nothing has been recorded yet"
+    )
+
+
+def store_unreachable(why: dict[str, Any], subject: str) -> MachineError:
+    """The refusal a detail read makes when it never reached the store.
+
+    A detail read answers about one record, so it has no availability wrapper to
+    put this in and has to refuse. `not_found` stays `not_found` — with no store
+    there is definitively no such record — but a store that would not open is
+    `unavailable`, because the record may well be sitting in it.
+    """
+    reason = why.get("reason_code")
+    detail = why.get("detail")
+    if reason == REASON_NOT_FOUND:
+        return MachineError("not_found", f"{subject}: {detail}")
+    return MachineError(
+        "unavailable", f"{subject}: the lifecycle store could not be read ({detail})"
+    )
 
 
 # ── stdout reservation ──────────────────────────────────────────────────────
@@ -525,6 +673,23 @@ _MACHINE_COMMANDS: dict[str, Callable[[list[str]], dict[str, Any]]] = {
     "lifecycle": _machine_lifecycle,
 }
 
+# Commands whose machine result is defined beside the command it mirrors rather
+# than here, because a payload that lives in another file drifts from the
+# printout it is supposed to be the machine form of. Each module exposes
+# ``machine_result(argv)`` and routes its own subcommands. The alias spellings
+# are registered too: `li mon --machine` reaches the same parser `li mon` does,
+# so it must reach the same result.
+_MACHINE_MODULES: dict[str, str] = {
+    "monitor": ".monitor",
+    "mon": ".monitor",
+    "stats": ".stats",
+    "invoke": ".invoke",
+    "dispatch": ".dispatch",
+    "state": ".state",
+    "team": ".team",
+    "plugin": ".plugin",
+}
+
 
 def strip_machine_flag(argv: list[str]) -> list[str]:
     """Remove `--machine` from the tokens the dispatcher routes on.
@@ -588,6 +753,10 @@ def _run_machine_command(argv: list[str]) -> dict[str, Any]:
     handler = _MACHINE_COMMANDS.get(name)
     if handler is not None:
         return handler(rest)
+
+    module_name = _MACHINE_MODULES.get(name)
+    if module_name is not None:
+        return import_module(module_name, __package__).machine_result(rest)
 
     from .main import _COMMAND_BY_NAME
 

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -241,6 +241,13 @@ _COMMAND_REGISTRY = (
         "run_runs",
     ),
     _CommandSpec(
+        "lifecycle",
+        "Report the recorded lifecycle state of a run.",
+        _load_machine,
+        "add_lifecycle_subparser",
+        "run_lifecycle",
+    ),
+    _CommandSpec(
         "mcp",
         "Serve the lionagi MCP server (background job submit/query) over stdio.",
         _load_mcp,
@@ -337,6 +344,10 @@ def run_handshake(args: argparse.Namespace) -> int:
 
 def run_runs(args: argparse.Namespace) -> int:
     return _load_machine().run_runs(args)
+
+
+def run_lifecycle(args: argparse.Namespace) -> int:
+    return _load_machine().run_lifecycle(args)
 
 
 def run_hooks(args: argparse.Namespace) -> int:

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -621,8 +621,6 @@ def _get_version() -> str:
 
 
 def _run(argv: list[str] | None = None) -> int:
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
     # Resolve verbose before any CLI code emits (argparse hasn't run yet).
     _argv = argv if argv is not None else sys.argv[1:]
     # Scan only before the '--' sentinel so a scheduled action_prompt
@@ -643,6 +641,24 @@ def _run(argv: list[str] | None = None) -> int:
     if "--machine" in _pre_sentinel:
         machine = _load_machine()
         return machine.dispatch_machine(machine.strip_machine_flag(_argv))
+
+    # From here on the reader is a person, usually with a pager: `li ... | head`
+    # should stop quietly rather than print a BrokenPipeError traceback, which
+    # is what the default disposition buys.
+    #
+    # The machine path above is deliberately left with the interpreter's own
+    # setting, where SIGPIPE is ignored and EPIPE arrives as a catchable OSError.
+    # Its caller reads the whole stream, so there is no pager to be quiet for,
+    # and this surface promises exactly one thing: every call answers with an
+    # envelope. Under the default disposition that promise is not ours to keep —
+    # any EPIPE anywhere in the process kills it outright, with no envelope and
+    # nothing on stderr, and not every write is one the command made. A database
+    # driver's worker thread signalling a result to an event loop that is closing
+    # underneath it writes to that loop's own wakeup socket, and if the loop got
+    # there first the write is on a socket whose other end is already gone. That
+    # is a routine internal race the interpreter absorbs; only the default
+    # disposition turns it into a command that stopped answering.
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     # Same pre-argparse scan, so a project-scoped .lionagi/settings.yaml
     # next to a `--cwd DIR` target isn't missed in favor of the shell's cwd.

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -751,15 +751,20 @@ def _show_project_matches(show: dict[str, Any], project: str) -> bool:
     return derived == project
 
 
-async def _gather_table_rows(
+async def _gather_entities(
     db: Any,
     *,
     since: float | None,
     entity_type: str | None,
     project: str | None,
-) -> list[dict[str, Any]]:
-    """Collect entity rows across all tables and convert to table-row dicts."""
-    rows: list[dict[str, Any]] = []
+) -> list[tuple[str, dict[str, Any]]]:
+    """Every in-flight row the views draw from, each paired with its kind.
+
+    Selection lives here and rendering lives in the callers, so the table and
+    the machine result answer with the same set of entities rather than with two
+    independently maintained ideas of what is running.
+    """
+    rows: list[tuple[str, dict[str, Any]]] = []
 
     sessions: list[dict[str, Any]] = []
     if entity_type in (None, "session", "agent", "play_session", "play"):
@@ -778,21 +783,41 @@ async def _gather_table_rows(
         play_session_ids = {p["session_id"] for p in plays if p.get("session_id")}
         sessions = [s for s in sessions if s["id"] not in play_session_ids]
 
-    rows.extend(_session_to_row(s) for s in sessions)
+    rows.extend(("session", s) for s in sessions)
 
     if entity_type in (None, "invocation"):
         invocations = await _query_running_invocations(db, since=since)
-        rows.extend(_invocation_to_row(i) for i in invocations)
+        rows.extend(("invocation", i) for i in invocations)
 
     if entity_type in (None, "show"):
         shows = await _query_active_shows(db, since=since)
         if project:
             shows = [s for s in shows if _show_project_matches(s, project)]
-        rows.extend(_show_to_row(s) for s in shows)
+        rows.extend(("show", s) for s in shows)
 
-    rows.extend(_play_to_row(p) for p in plays)
+    rows.extend(("play", p) for p in plays)
 
     return rows
+
+
+_ROW_BUILDERS = {
+    "session": _session_to_row,
+    "invocation": _invocation_to_row,
+    "show": _show_to_row,
+    "play": _play_to_row,
+}
+
+
+async def _gather_table_rows(
+    db: Any,
+    *,
+    since: float | None,
+    entity_type: str | None,
+    project: str | None,
+) -> list[dict[str, Any]]:
+    """Collect entity rows across all tables and convert to table-row dicts."""
+    entities = await _gather_entities(db, since=since, entity_type=entity_type, project=project)
+    return [_ROW_BUILDERS[kind](row) for kind, row in entities]
 
 
 # ── Async main routines ───────────────────────────────────────────────────────
@@ -1688,3 +1713,94 @@ def run_monitor(args: argparse.Namespace) -> int:
 
     print(output)
     return 0
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+# Every entity carries these; a caller reads `kind` and knows which of the
+# per-kind blocks below it also has. Timestamps are epoch seconds exactly as the
+# store holds them — an elapsed string would be this module's arithmetic against
+# a clock the caller cannot see, and `observed_at` lets the caller do that sum
+# itself against a moment it was told.
+_ENTITY_CORE = ("id", "status", "started_at", "ended_at", "updated_at")
+
+_ENTITY_EXTRA: dict[str, tuple[str, ...]] = {
+    "session": (
+        "project",
+        "invocation_kind",
+        "agent_name",
+        "playbook_name",
+        "current_phase",
+        "branch_count",
+    ),
+    "invocation": ("skill", "plugin"),
+    "show": ("repo", "topic"),
+    "play": ("name", "session_id", "show_id", "session_project", "branch_count"),
+}
+
+
+def _machine_entity(kind: str, row: dict[str, Any]) -> dict[str, Any]:
+    entity: dict[str, Any] = {"kind": kind}
+    for field in (*_ENTITY_CORE, *_ENTITY_EXTRA[kind]):
+        entity[field] = row.get(field)
+    return entity
+
+
+async def _machine_monitor_data(
+    *, since_window: str | None, entity_type: str | None, project: str | None
+) -> dict[str, Any]:
+    from .machine import available as _available
+    from .machine import readonly_state_db
+
+    since = _since_timestamp(since_window) if since_window else None
+    filters = {
+        "since": since_window,
+        "since_epoch": since,
+        "type": entity_type,
+        "project": project,
+    }
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            return {
+                "entities": why,
+                "filters": filters,
+                "observed_at": time.time(),
+            }
+        entities = await _gather_entities(db, since=since, entity_type=entity_type, project=project)
+    return {
+        "entities": _available([_machine_entity(kind, row) for kind, row in entities]),
+        "filters": filters,
+        "observed_at": time.time(),
+    }
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li monitor --machine` — the in-flight table, one entity per entry.
+
+    The detail view is not reachable here: it answers about one entity with a
+    different shape entirely, and a payload whose fields depend on whether an id
+    was passed is one a caller cannot branch on. It stays a separate decision.
+    """
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li monitor")
+    parser.add_argument("--since", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--type", dest="entity_type", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--project", "-p", default=None, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+
+    if args.entity_type is not None and args.entity_type not in _ENTITY_EXTRA:
+        raise MachineError(
+            "invalid_input",
+            f"--type must be one of {', '.join(sorted(_ENTITY_EXTRA))}; got {args.entity_type!r}",
+        )
+    try:
+        return run_async(
+            _machine_monitor_data(
+                since_window=args.since, entity_type=args.entity_type, project=args.project
+            )
+        )
+    except ValueError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -47,6 +47,9 @@ from .._runs import (
     save_last_branch_pointer,
     teardown_persist,
 )
+from .._runs import (
+    active_run_id as _active_run_id,
+)
 from .._util import validate_cwd_exists
 
 __all__ = (
@@ -1059,6 +1062,7 @@ async def setup_orchestration_persist(
         await db.create_session(
             {
                 "id": session_id,
+                "run_id": _active_run_id(),
                 "created_at": session_dict["created_at"],
                 "node_metadata": _node_meta,
                 "name": session_dict.get("name"),

--- a/lionagi/cli/plugin.py
+++ b/lionagi/cli/plugin.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import Any
 
 from ._logging import log_error
 
@@ -249,3 +250,81 @@ def run_plugin(args: argparse.Namespace) -> int:
         return _run_set_enabled(args.name, enabled=False)
     log_error(f"unknown plugin subcommand: {args.plugin_command!r}")
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_info_data(name: str) -> dict[str, Any]:
+    from lionagi.plugins import PluginRegistry
+    from lionagi.plugins.trust import build_trust_disclosure
+
+    from .machine import MachineError
+
+    PluginRegistry.reset()
+    record = PluginRegistry.get(name)
+    if record is None:
+        raise MachineError("not_found", f"no plugin named {name!r}")
+
+    plugin: dict[str, Any] = {
+        "name": record.name,
+        "version": record.version,
+        "state": record.state.value,
+        "bundle_dir": str(record.bundle_dir),
+        "error": record.error,
+        # None, not an empty disclosure: a bundle whose manifest did not parse
+        # declares nothing that can be read, which is a different fact from a
+        # manifest that declares nothing.
+        "declares": None,
+    }
+    if record.manifest is None:
+        return {"plugin": plugin}
+
+    disclosure = build_trust_disclosure(record)
+    plugin["declares"] = {
+        "description": disclosure["description"],
+        "lionagi": disclosure["lionagi"],
+        "tools": disclosure["tools"],
+        "hooks_external": disclosure["hooks_external"],
+        "agents": disclosure["agents"],
+        "playbooks": disclosure["playbooks"],
+        "providers": disclosure["providers"],
+        "packs": disclosure["packs"],
+    }
+    return {"plugin": plugin}
+
+
+def _machine_info(argv: list[str]) -> dict[str, Any]:
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li plugin info")
+    parser.add_argument("name", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return _machine_info_data(args.name)
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li plugin <sub> --machine`.
+
+    `list` is not routed here. It garbage-collects trust records as part of
+    listing — it deletes the record of any plugin whose bundle directory is
+    gone — so it writes to user settings, and what it writes to is the trust
+    surface this whole surface is fenced away from. `trust` is fenced outright.
+    """
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "plugin",
+        argv,
+        {"info": _machine_info},
+        without_seam={
+            "list": (
+                "listing garbage-collects trust records — it deletes the record of "
+                "any plugin whose bundle directory is gone — so it writes to user "
+                "settings, and what it writes to is the trust surface"
+            ),
+            "trust": "recording trust is a human-at-a-terminal operation",
+            "enable": "it writes an enabled flag to user settings",
+            "disable": "it writes an enabled flag to user settings",
+        },
+    )

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -658,7 +658,7 @@ async def _doctor(
     from sqlalchemy import text
 
     from lionagi.cli._util import pid_alive
-    from lionagi.cli.kill import _check_pid_identity_tristate, _read_pid_from_entity
+    from lionagi.cli.kill import _check_pid_identity, _read_pid_from_entity
 
     async with StateDB() as db:
         async with db._read() as conn:
@@ -707,7 +707,7 @@ async def _doctor(
                     expected_create_time = float(raw_ct) if raw_ct is not None else None
                 except (TypeError, ValueError):
                     expected_create_time = None
-                verdict = _check_pid_identity_tristate(
+                verdict = _check_pid_identity(
                     pid,
                     "lionagi",
                     expected_session_id=row["id"],
@@ -715,7 +715,9 @@ async def _doctor(
                 )
                 # "unverifiable" means the process could not be inspected, not
                 # that it is gone; skipping it leaves a row for the next run
-                # rather than reaping one out from under a worker.
+                # rather than reaping one out from under a worker. "zombie" is
+                # the opposite: the process has exited and is only waiting to
+                # be reaped, so the row is stale and belongs in the sweep.
                 if verdict in ("ours", "unverifiable"):
                     skipped += 1
                     continue

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -36,6 +36,7 @@ __all__ = [
     # CLI entrypoints
     "add_state_subparser",
     "run_state",
+    "machine_result",
 ]
 
 
@@ -299,43 +300,94 @@ def _format_bytes(n: int) -> str:
     return f"{n:.1f} TiB"
 
 
+async def _collect_sessions(db: Any, *, limit: int, status: str | None) -> list[dict[str, Any]]:
+    """Sessions newest-first, each with its branch and message counts.
+
+    The one query the listing runs, so the printed table and the machine result
+    report the same rows and the same counts rather than two readings of the
+    store taken by two pieces of code.
+    """
+    from sqlalchemy import text
+
+    async with db._read() as conn:
+        if status:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, name, status, updated_at FROM sessions "
+                            "WHERE status = :st ORDER BY updated_at DESC LIMIT :lim"
+                        ),
+                        {"st": status, "lim": limit},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        else:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, name, status, updated_at FROM sessions "
+                            "ORDER BY updated_at DESC LIMIT :lim"
+                        ),
+                        {"lim": limit},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+    collected: list[dict[str, Any]] = []
+    for row in rows:
+        sid = row["id"]
+        async with db._read() as conn:
+            bc = (
+                (
+                    await conn.execute(
+                        text("SELECT COUNT(*) AS n FROM branches WHERE session_id = :sid"),
+                        {"sid": sid},
+                    )
+                )
+                .mappings()
+                .first()["n"]
+            )
+
+            prog_row = (
+                (
+                    await conn.execute(
+                        text("SELECT progression_id FROM sessions WHERE id = :id"),
+                        {"id": sid},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        msg_count = 0
+        if prog_row and prog_row["progression_id"]:
+            prog_data = await db.get_progression(prog_row["progression_id"])
+            msg_count = len(prog_data)
+        collected.append(
+            {
+                "id": sid,
+                "name": row["name"],
+                "status": row["status"],
+                "updated_at": row["updated_at"],
+                "branch_count": bc,
+                "message_count": msg_count,
+            }
+        )
+    return collected
+
+
 async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
     import time
-
-    from sqlalchemy import text
 
     from lionagi.state.db import StateDB
 
     async with StateDB() as db:
-        async with db._read() as conn:
-            if status:
-                rows = (
-                    (
-                        await conn.execute(
-                            text(
-                                "SELECT id, name, status, updated_at FROM sessions "
-                                "WHERE status = :st ORDER BY updated_at DESC LIMIT :lim"
-                            ),
-                            {"st": status, "lim": limit},
-                        )
-                    )
-                    .mappings()
-                    .all()
-                )
-            else:
-                rows = (
-                    (
-                        await conn.execute(
-                            text(
-                                "SELECT id, name, status, updated_at FROM sessions "
-                                "ORDER BY updated_at DESC LIMIT :lim"
-                            ),
-                            {"lim": limit},
-                        )
-                    )
-                    .mappings()
-                    .all()
-                )
+        rows = await _collect_sessions(db, limit=limit, status=status)
 
         if not rows:
             print("(no sessions in state.db)")
@@ -348,117 +400,131 @@ async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
         print(header)
         print("-" * len(header))
         for row in rows:
-            sid = row["id"]
             name = (row["name"] or "")[:16]
             sstat = (row["status"] or "")[:10]
             updated = row["updated_at"]
             updated_str = (
                 time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(updated)) if updated else ""
             )
+            print(
+                f"{row['id']:<36}  {name:<16}  {sstat:<10}  "
+                f"{row['branch_count']:>8}  {row['message_count']:>8}  {updated_str:<20}"
+            )
 
-            async with db._read() as conn:
-                bc = (
-                    (
-                        await conn.execute(
-                            text("SELECT COUNT(*) AS n FROM branches WHERE session_id = :sid"),
-                            {"sid": sid},
-                        )
+
+# The tables a size report counts, and the pragmas it reads, in the order both
+# are printed. Named once so the machine result and the printout cannot come to
+# describe different databases.
+_STATS_TABLES = (
+    "messages",
+    "progressions",
+    "sessions",
+    "branches",
+    "definitions",
+    "shows",
+    "plays",
+)
+
+_STATS_PRAGMAS = (
+    "journal_mode",
+    "wal_autocheckpoint",
+    "busy_timeout",
+    "synchronous",
+    "foreign_keys",
+)
+
+
+def _db_sizes() -> dict[str, Any]:
+    from lionagi.state.db import DEFAULT_DB_PATH
+
+    wal_path = DEFAULT_DB_PATH.with_name(DEFAULT_DB_PATH.name + "-wal")
+    return {
+        "path": str(DEFAULT_DB_PATH),
+        "exists": DEFAULT_DB_PATH.exists(),
+        "size_bytes": DEFAULT_DB_PATH.stat().st_size if DEFAULT_DB_PATH.exists() else 0,
+        "wal_size_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
+    }
+
+
+async def _collect_stats(db: Any) -> dict[str, Any]:
+    """Row counts, the session status distribution, and the SQLite pragmas."""
+    from sqlalchemy import text
+
+    counts: dict[str, int] = {}
+    for table in _STATS_TABLES:
+        async with db._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(f"SELECT COUNT(*) AS n FROM {table}")  # noqa: S608
                     )
-                    .mappings()
-                    .first()["n"]
                 )
+                .mappings()
+                .first()
+            )
+        counts[table] = row["n"]
 
-                prog_row = (
-                    (
-                        await conn.execute(
-                            text("SELECT progression_id FROM sessions WHERE id = :id"),
-                            {"id": sid},
-                        )
+    async with db._read() as conn:
+        status_rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT status AS s, COUNT(*) AS n "
+                        "FROM sessions GROUP BY status ORDER BY n DESC"
                     )
-                    .mappings()
-                    .first()
                 )
-            msg_count = 0
-            if prog_row and prog_row["progression_id"]:
-                prog_data = await db.get_progression(prog_row["progression_id"])
-                msg_count = len(prog_data)
+            )
+            .mappings()
+            .all()
+        )
 
-            print(f"{sid:<36}  {name:<16}  {sstat:<10}  {bc:>8}  {msg_count:>8}  {updated_str:<20}")
+    pragmas: dict[str, Any] = {}
+    for pragma in _STATS_PRAGMAS:
+        async with db._read() as conn:
+            row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
+        pragmas[pragma] = row[0] if row else None
+
+    return {
+        "row_counts": counts,
+        # A list of pairs, not an object: a session whose status was never
+        # recorded is a null key, and the printout's "(null)" placeholder for it
+        # would be indistinguishable from a status literally spelled that way.
+        "sessions_by_status": [{"status": r["s"], "count": r["n"]} for r in status_rows],
+        "pragmas": pragmas,
+    }
 
 
 async def _print_stats() -> None:
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
-    db_path = DEFAULT_DB_PATH
-    db_size = db_path.stat().st_size if db_path.exists() else 0
-    wal_path = db_path.with_name(db_path.name + "-wal")
-    wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+    sizes = _db_sizes()
 
-    print(f"state.db path:   {db_path}")
-    print(f"state.db size:   {_format_bytes(db_size)}")
-    print(f"state.db-wal:    {_format_bytes(wal_size)}")
+    print(f"state.db path:   {DEFAULT_DB_PATH}")
+    print(f"state.db size:   {_format_bytes(sizes['size_bytes'])}")
+    print(f"state.db-wal:    {_format_bytes(sizes['wal_size_bytes'])}")
     print()
 
-    if not db_path.exists():
+    if not sizes["exists"]:
         print("(no state.db yet — first run will create it)")
         return
 
-    from sqlalchemy import text
-
     async with StateDB() as db:
-        print("Row counts:")
-        for table in (
-            "messages",
-            "progressions",
-            "sessions",
-            "branches",
-            "definitions",
-            "shows",
-            "plays",
-        ):
-            async with db._read() as conn:
-                row = (
-                    (
-                        await conn.execute(
-                            text(f"SELECT COUNT(*) AS n FROM {table}")  # noqa: S608
-                        )
-                    )
-                    .mappings()
-                    .first()
-                )
-            print(f"  {table:<14} {row['n']:>10}")
-        print()
+        collected = await _collect_stats(db)
 
-        async with db._read() as conn:
-            rows = (
-                (
-                    await conn.execute(
-                        text(
-                            "SELECT COALESCE(status, '(null)') AS s, COUNT(*) AS n "
-                            "FROM sessions GROUP BY status ORDER BY n DESC"
-                        )
-                    )
-                )
-                .mappings()
-                .all()
-            )
-        print("Sessions by status:")
-        for row in rows:
-            print(f"  {row['s']:<14} {row['n']:>10}")
-        print()
+    print("Row counts:")
+    for table, n in collected["row_counts"].items():
+        print(f"  {table:<14} {n:>10}")
+    print()
 
-        print("PRAGMAs:")
-        for pragma in (
-            "journal_mode",
-            "wal_autocheckpoint",
-            "busy_timeout",
-            "synchronous",
-            "foreign_keys",
-        ):
-            async with db._read() as conn:
-                row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
-            val = row[0] if row else "?"
-            print(f"  {pragma:<22} {val}")
+    print("Sessions by status:")
+    for entry in collected["sessions_by_status"]:
+        label = "(null)" if entry["status"] is None else entry["status"]
+        print(f"  {label:<14} {entry['count']:>10}")
+    print()
+
+    print("PRAGMAs:")
+    for pragma, value in collected["pragmas"].items():
+        print(f"  {pragma:<22} {'?' if value is None else value}")
 
 
 async def _checkpoint(mode: str) -> str:
@@ -1096,3 +1162,89 @@ def run_state(args: argparse.Namespace) -> int:
         return 0
 
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+async def _machine_ls_data(*, limit: int, status: str | None) -> dict[str, Any]:
+    from .machine import available, readonly_state_db
+
+    result: dict[str, Any] = {"filters": {"status": status}, "limit": limit}
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            result["sessions"] = why
+            return result
+        rows = await _collect_sessions(db, limit=limit, status=status)
+    result["sessions"] = available(rows)
+    return result
+
+
+async def _machine_stats_data() -> dict[str, Any]:
+    from .machine import available, readonly_state_db
+
+    sizes = _db_sizes()
+    result: dict[str, Any] = {"database": sizes}
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            absent = why
+            result["row_counts"] = absent
+            result["sessions_by_status"] = absent
+            result["journal_mode"] = absent
+            return result
+        collected = await _collect_stats(db)
+    result["row_counts"] = available(collected["row_counts"])
+    result["sessions_by_status"] = available(collected["sessions_by_status"])
+    # Only the one pragma that describes the database rather than the connection
+    # that asked. busy_timeout, synchronous and the rest are settings of whichever
+    # connection reads them, so reporting them here would hand a caller this
+    # reader's configuration under a name that reads like the store's.
+    result["journal_mode"] = available(collected["pragmas"]["journal_mode"])
+    return result
+
+
+def _machine_ls(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li state ls")
+    parser.add_argument("--limit", type=int, default=50, help=argparse.SUPPRESS)
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    if args.limit < 1:
+        raise MachineError("invalid_input", "--limit must be at least 1")
+    return run_async(_machine_ls_data(limit=args.limit, status=args.status))
+
+
+def _machine_stats(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError
+
+    if argv:
+        raise MachineError("invalid_input", f"li state stats takes no arguments: {' '.join(argv)}")
+    return run_async(_machine_stats_data())
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li state <sub> --machine`.
+
+    `migrate` is not among the subcommands routed here and is not reachable from
+    the MCP surface at all; it rewrites the store every other reader reports on.
+    """
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "state",
+        argv,
+        {"ls": _machine_ls, "stats": _machine_stats},
+        without_seam={
+            "import": "it loads run directories into the store, which is a write",
+            "import-teams": "it loads team files into the store, which is a write",
+            "checkpoint": "it checkpoints the write-ahead log",
+            "vacuum": "it rebuilds the database file",
+            "prune": "it deletes rows",
+            "doctor": "it sweeps stale rows to a new status, which is a write",
+        },
+    )

--- a/lionagi/cli/stats.py
+++ b/lionagi/cli/stats.py
@@ -86,13 +86,18 @@ async def _query_run_stats(
 
 
 async def _run_stats_runs(*, since: float, group_by: list[str]) -> list[dict[str, Any]]:
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    # readonly: a reporting command must never write to the DB it reports on,
+    # even implicitly via schema-reconcile. See docs/internals/cli.md.
+    from .machine import REASON_NOT_FOUND, readonly_state_db
 
-    if not DEFAULT_DB_PATH.exists():
-        return []
-    # readonly=True: a reporting command must never write to the DB it
-    # reports on, even implicitly via schema-reconcile. See docs/internals/cli.md.
-    async with StateDB(readonly=True) as db:
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            if why["reason_code"] == REASON_NOT_FOUND:
+                return []
+            # The human surface has nowhere to put an availability wrapper, and
+            # an empty table is the one thing it must not print here: it reads
+            # as "no runs" for a store that was never opened.
+            raise RuntimeError(f"the run store could not be read: {why['detail']}")
         return await _query_run_stats(db, since=since, group_by=group_by)
 
 
@@ -210,3 +215,72 @@ def run_stats(args: argparse.Namespace) -> int:
     else:
         print(_format_stats_table(rows, group_by))
     return 0
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_rows(rows: list[dict[str, Any]], group_by: list[str]) -> list[dict[str, Any]]:
+    """One aggregate per group, timestamps left as the epoch seconds stored.
+
+    The group keys stay nullable and stay null: a row whose project column is
+    empty is a run that recorded no project, which is a different fact from a
+    run in a project literally named "(none)", and the table's placeholder for
+    it is a rendering choice that must not reach a machine caller.
+    """
+    return [
+        {
+            "group": {key: row.get(key) for key in group_by},
+            "run_count": row["run_count"],
+            "completed": row["completed"] or 0,
+            "failed": row["failed"] or 0,
+            "first_at": row["first_at"],
+            "last_at": row["last_at"],
+        }
+        for row in rows
+    ]
+
+
+async def _machine_stats_runs_data(*, since_window: str, group_by: list[str]) -> dict[str, Any]:
+    from .machine import available, readonly_state_db
+
+    since = _since_timestamp(since_window)
+    result: dict[str, Any] = {
+        "group_by": group_by,
+        "since": since_window,
+        "since_epoch": since,
+    }
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            result["groups"] = why
+            return result
+        rows = await _query_run_stats(db, since=since, group_by=group_by)
+    result["groups"] = available(_machine_rows(rows, group_by))
+    return result
+
+
+def _machine_runs(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li stats runs")
+    parser.add_argument("--since", default="7d", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--group-by", dest="group_by", default=_DEFAULT_GROUP_BY, help=argparse.SUPPRESS
+    )
+    args = parse_machine_argv(parser, argv)
+
+    try:
+        group_by = _validate_group_by(args.group_by)
+        _reject_non_positive_since(args.since)
+        return run_async(_machine_stats_runs_data(since_window=args.since, group_by=group_by))
+    except ValueError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li stats <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand("stats", argv, {"runs": _machine_runs}, without_seam={})

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -633,3 +633,67 @@ def run_team(args: argparse.Namespace) -> int:
         return cmd_receive(args)
     log_error(f"Unknown team command: {cmd}")
     return 1
+
+
+# ── machine result ────────────────────────────────────────────────────────────
+
+
+def _machine_list_data() -> dict[str, Any]:
+    from .machine import REASON_UNREADABLE, available, list_directory, unavailable
+
+    # Read without creating: the human path ensures the directory exists as a
+    # side effect of being about to write to it, and a listing has nothing to
+    # write. A directory that was never created is a definitive zero teams,
+    # which is what the human path also reports once it has made one.
+    listing = list_directory(TEAMS_DIR, missing_is_empty=True)
+    if not listing["available"]:
+        return {"teams": listing, "unreadable": []}
+
+    teams: list[dict[str, Any]] = []
+    unreadable: list[dict[str, Any]] = []
+    for path in sorted(TEAMS_DIR.glob("*.json")):
+        data = read_team_json(path)
+        if data is None:
+            # The printed listing skips these silently. A machine caller is told,
+            # because "four teams" and "four teams and one file I could not read"
+            # are different answers and only one of them is complete.
+            unreadable.append(unavailable(REASON_UNREADABLE, str(path)))
+            continue
+        teams.append(
+            {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "members": data.get("members") or [],
+                "created_at": data.get("created_at"),
+                "message_count": len(data.get("messages") or []),
+                "path": str(path),
+            }
+        )
+    teams.sort(key=lambda t: (t["name"] or "", t["id"] or ""))
+    return {"teams": available(teams), "unreadable": unreadable}
+
+
+def _machine_list(argv: list[str]) -> dict[str, Any]:
+    from .machine import MachineError
+
+    if argv:
+        raise MachineError("invalid_input", f"li team list takes no arguments: {' '.join(argv)}")
+    return _machine_list_data()
+
+
+def machine_result(argv: list[str]) -> dict[str, Any]:
+    """`li team <sub> --machine`."""
+    from .machine import machine_subcommand
+
+    return machine_subcommand(
+        "team",
+        argv,
+        {"list": _machine_list, "ls": _machine_list},
+        without_seam={
+            "create": "it writes a new team file",
+            "show": "it prints a team's messages for a human reader",
+            "send": "it appends a message to a team file",
+            "receive": "it marks the messages it returns as read, which is a write",
+            "recv": "it marks the messages it returns as read, which is a write",
+        },
+    )

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -18,6 +18,15 @@ open vocabulary passed through verbatim, so a caller never needs — and must ne
 keep — a copy of lionagi's status names to tell a finished run from a running one
 or a success from a failure. All of these resolve through one path, ``status()``,
 so no two calls can disagree about the same run at the same moment.
+
+A run's end reaches that path from two writers. The terminal hook the CLI runs
+on ``--notify`` writes it into this package's own job record. A run stopped by
+``li kill`` never reaches that hook — the kill transitions the lifecycle row and
+signals the process, and writes nothing here — so when the process is gone and
+the job record shows no end, the state is read from the CLI itself, via
+``li lifecycle <run_id> --machine``, and cached back onto the job record. A read
+that cannot be made concludes nothing: the run is classified exactly as it would
+have been without it.
 """
 
 from __future__ import annotations
@@ -60,12 +69,26 @@ _KIND_ARGV: dict[str, list[str]] = {
 # stale success list is a timeout or an empty completion read back as a success.
 _SUCCEEDED_STATUSES = frozenset({"completed"})
 
+# Statuses that mean the run was stopped on purpose. Separated from failure
+# because "someone cancelled this" and "this went wrong" call for different
+# things from a caller, and reporting a cancellation as a failure invites a
+# retry of work that was deliberately abandoned.
+_CANCELLED_STATUSES = frozenset({"cancelled", "aborted"})
+
 # Short advisory qualifiers for a terminal outcome. A caller may surface one; it
 # never needs one to decide `outcome`.
 _REASON_BY_STATUS = {
     "completed_empty": "no_artifacts",
 }
 _SPAWN_FAILED_REASON = "spawn_failed"
+
+# The lifecycle read is a control-plane query against a local store; anything
+# slower than this is treated as unavailable rather than waited on, because it
+# is consulted from inside a caller's own poll.
+LIFECYCLE_TIMEOUT_SECONDS = 20.0
+
+# The most the lifecycle command may write on its result channel.
+_LIFECYCLE_OUTPUT_LIMIT = 1_000_000
 
 # Bounds for wait(). The maximum sits below ordinary MCP client timeouts so a
 # bounded observation returns partial results rather than being cut off mid-call.
@@ -122,6 +145,52 @@ def _read_job(run_id: str) -> dict[str, Any] | None:
         return json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
+    """Ask the CLI what the lifecycle store records about *run_id*.
+
+    Spawned as ``li lifecycle <run_id> --machine``, the same way every other
+    non-job verb reaches the CLI. Going through the command rather than opening
+    the database here keeps one reader of a schema this package does not own.
+
+    Returns the summary the command established, or None when it could not be
+    established for any reason at all — the command missing, refusing, timing
+    out, or answering that the store was unreadable. None is not "no record":
+    a caller must treat it as "did not learn anything" and fall back to what it
+    already knew, because the alternative is calling a run finished on the
+    strength of a read that never happened.
+    """
+    argv = [*config.li_command(), "lifecycle", run_id, "--machine"]
+    try:
+        completed = subprocess.run(  # noqa: S603 — resolved li command plus one run id, no shell
+            argv,
+            capture_output=True,
+            timeout=LIFECYCLE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if len(completed.stdout) > _LIFECYCLE_OUTPUT_LIMIT:
+        return None
+    text = completed.stdout.decode("utf-8", "replace").strip()
+    if not text:
+        return None
+    try:
+        envelope = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(envelope, dict) or not envelope.get("ok"):
+        return None
+    data = envelope.get("data")
+    if not isinstance(data, dict):
+        return None
+    state = data.get("lifecycle")
+    if not isinstance(state, dict) or not state.get("available"):
+        return None
+    value = state.get("value")
+    return value if isinstance(value, dict) else None
 
 
 def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
@@ -322,17 +391,43 @@ class SpawnError(RuntimeError):
         self.record = record
 
 
-def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
+def _outcome_for(status: Any) -> str:
+    """How a terminal run came out, from the status the CLI recorded.
+
+    Used only once a run has been established terminal by a recorded end, never
+    to decide whether it ended. A status this build has never heard of is a
+    failure, because the failure mode of a stale success list is a timeout or an
+    empty completion read back as a success.
+    """
+    if status in _SUCCEEDED_STATUSES:
+        return "succeeded"
+    if status in _CANCELLED_STATUSES:
+        return "cancelled"
+    return "failed"
+
+
+def _derive(
+    job: dict[str, Any] | None,
+    alive: bool,
+    lifecycle: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Classify a job record into the fields a caller is allowed to branch on.
 
     ``status`` is an open vocabulary: whatever the CLI recorded is passed through
     verbatim and is never matched against a local set to decide anything.
 
     ``terminal`` answers "stop waiting" and comes only from a recorded end — a
-    ``finished_at`` written by the terminal hook or by ``kill``, or a spawn
-    failure the producer caught and wrote down. It is never inferred from the
-    status string and never from a missing pid: between the pre-spawn write and
-    the write that attaches the pid, a perfectly healthy child has no pid yet.
+    ``finished_at`` written by the terminal hook or by ``kill``, a spawn failure
+    the producer caught and wrote down, or an end recorded in the lifecycle
+    store, which is where a run stopped by ``li kill`` leaves its only trace. It
+    is never inferred from the status string and never from a missing pid:
+    between the pre-spawn write and the write that attaches the pid, a perfectly
+    healthy child has no pid yet.
+
+    *lifecycle* is the summary ``li lifecycle`` established for this run, or None
+    when nothing could be established. None never terminalises anything: a read
+    that failed leaves the classification exactly as it was before this argument
+    existed.
 
     ``outcome`` answers "did the work come out right" and is null whenever
     ``terminal`` is false — including for a run whose process is gone with no end
@@ -365,8 +460,11 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
         return {
             "status": recorded,
             "terminal": True,
-            "outcome": "succeeded" if recorded in _SUCCEEDED_STATUSES else "failed",
-            "reason_code": _REASON_BY_STATUS.get(recorded),
+            "outcome": _outcome_for(recorded),
+            # A reason carried on the record wins: it came from the lifecycle
+            # store, which knows why the run ended, while the status-derived one
+            # is only what the status alone can say.
+            "reason_code": job.get("reason_code") or _REASON_BY_STATUS.get(recorded),
             "spawn_state": spawn_state,
             "possibly_orphaned": False,
         }
@@ -377,6 +475,21 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
             "terminal": False,
             "outcome": None,
             "reason_code": None,
+            "spawn_state": spawn_state,
+            "possibly_orphaned": False,
+        }
+
+    # The process is gone (or was never there) and the sidecar records no end.
+    # The lifecycle store is the other place an end gets written, and the only
+    # place a cancellation does: `li kill` transitions the row and signals the
+    # pid, and writes nothing here.
+    if lifecycle is not None and lifecycle.get("terminal"):
+        lifecycle_status = lifecycle.get("status", recorded)
+        return {
+            "status": lifecycle_status,
+            "terminal": True,
+            "outcome": _outcome_for(lifecycle_status),
+            "reason_code": lifecycle.get("reason_code"),
             "spawn_state": spawn_state,
             "possibly_orphaned": False,
         }
@@ -395,10 +508,10 @@ def _derive(job: dict[str, Any] | None, alive: bool) -> dict[str, Any]:
             "possibly_orphaned": False,
         }
 
-    # A recorded pid that is gone with no end recorded: an orphan. Advisory only.
-    # Nothing here terminalises it — liveness is an observation about a pid, which
-    # can be reused or denied, and two readers of one unchanged record may see it
-    # differently. It stays non-terminal.
+    # A recorded pid that is gone, with no end recorded anywhere: an orphan.
+    # Advisory only. Nothing here terminalises it — liveness is an observation
+    # about a pid, which can be reused or denied, and two readers of one
+    # unchanged record may see it differently. It stays non-terminal.
     return {
         "status": "exited",
         "terminal": False,
@@ -593,6 +706,61 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
     return SpawnError(run_id, record, f"could not spawn run {run_id}: {exc}")
 
 
+def _needs_lifecycle_read(job: dict[str, Any] | None, alive: bool) -> bool:
+    """Whether this observation has to go and ask the lifecycle store.
+
+    Only when the sidecar cannot already answer: there is a job, its process is
+    not running, and nothing has recorded an end for it. Those are exactly the
+    records `_derive` would otherwise classify from a dead pid alone. A run
+    whose process is alive, or whose end is already on the record, is answered
+    from the record — so the ordinary poll of a healthy run spawns nothing, and
+    a run observed repeatedly after it ended asks once.
+    """
+    if job is None or alive:
+        return False
+    return job.get("finished_at") is None and job.get("spawn_state") != "failed"
+
+
+def _cache_lifecycle_end(
+    job: dict[str, Any] | None, lifecycle: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Copy a lifecycle-recorded end onto the sidecar record, once.
+
+    The sidecar is a cache of the end, not a second opinion about it: the
+    lifecycle store and the terminal hook are the two writers, and whichever
+    gets there first is what the record then says. Writing it back is what keeps
+    the next observation from spawning the read again, and what keeps two
+    observations of one unchanged run from answering differently.
+
+    A failed write is not an error here — the record is a cache, so the next
+    observation simply asks again — and the in-memory record is returned either
+    way so this call is what the caller classifies.
+    """
+    if job is None or lifecycle is None or not lifecycle.get("terminal"):
+        return job
+    ended = lifecycle.get("ended_at")
+    updated = {
+        **job,
+        "status": lifecycle.get("status", job.get("status")),
+        "finished_at": _iso_from_epoch(ended) or _now_iso(),
+        "reason_code": lifecycle.get("reason_code"),
+        "terminal_source": "lifecycle",
+    }
+    try:
+        _write_job(updated)
+    except OSError:
+        pass
+    return updated
+
+
+def _iso_from_epoch(value: Any) -> str | None:
+    """The store keeps epoch seconds; the sidecar keeps ISO-8601 strings."""
+    try:
+        return datetime.fromtimestamp(float(value), timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 def _server_identity() -> dict[str, str]:
     """Which implementation answered this call.
 
@@ -623,9 +791,15 @@ def status(run_id: str) -> dict[str, Any]:
     it, display it, do not match it against a list. Branch on ``terminal`` ("stop
     waiting") and ``outcome`` ("did the work come out right", null while
     ``terminal`` is false) instead; both are derived here so a caller never has to
-    keep a copy of the status vocabulary. ``run`` is the raw CLI manifest,
-    advisory only — its own ``status`` stays ``running`` until the CLI finalizes
-    it in the StateDB, so read ``status`` here, not ``run["status"]``.
+    keep a copy of the status vocabulary. ``run`` is the raw CLI manifest. Its
+    ``status`` is not advisory in the sense of being unreliable — for a run that
+    reaches its own teardown, the manifest is rewritten with the terminal status
+    and an ``ended_at``, and that write happens after the CLI has finalized the
+    run in the StateDB, so a manifest that says a run ended is telling the truth.
+    What it cannot do is say a run ended when the run's own process did not live
+    to write it: a killed or crashed run leaves a manifest still reading
+    ``running`` forever. It is one-directional evidence, so read ``status`` here,
+    not ``run["status"]``.
     ``possibly_orphaned`` flags a run whose process is gone with no end recorded;
     it is advisory and never makes the run terminal.
     ``notify_delivery`` reports whether the terminal notice was delivered.
@@ -636,7 +810,13 @@ def status(run_id: str) -> dict[str, Any]:
     manifest = _read_run_manifest(run_id)
     pid = job.get("pid") if job else None
     alive = _pid_alive(pid)
-    derived = _derive(job, alive)
+
+    lifecycle = None
+    if _needs_lifecycle_read(job, alive):
+        lifecycle = _read_lifecycle(run_id)
+        job = _cache_lifecycle_end(job, lifecycle)
+
+    derived = _derive(job, alive, lifecycle)
 
     return {
         "run_id": run_id,

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -75,10 +75,10 @@ FENCED_PATHS = ("state migrate", "plugin trust", "hooks trust")
 # never a truncation that would run some of a caller's batch and report success.
 MAX_OPS = 8
 
-# The reason every long-tail command shares today: `--machine` answers for three
-# commands, and the rest print for a human reader. The fix belongs in the CLI —
-# the command gains a machine-result seam — not in a parser of its console text,
-# which would make its wording an API contract.
+# The reason the remaining long-tail commands share: `--machine` answers for the
+# commands registered above, and the rest print for a human reader. The fix
+# belongs in the CLI — the command gains a machine-result seam — not in a parser
+# of its console text, which would make its wording an API contract.
 _NO_MACHINE_SEAM = (
     "the CLI path emits no versioned machine result (`li <path> --machine`), so "
     "there is nothing to return that is not scraped console text"
@@ -411,6 +411,93 @@ _REGISTERED: tuple[Verb, ...] = (
         cli_path="runs",
         admits=("limit",),
     ),
+    # ── observability reads ──────────────────────────────────────────────────
+    # Each of these admits only the parameters its machine path honours. A flag
+    # that shapes a human printout is left out: the parser would take it and the
+    # machine dispatcher would then refuse it, so admitting it advertises a
+    # parameter that cannot work.
+    Verb(
+        name="monitor",
+        summary="Entities in flight right now: sessions, invocations, shows, plays.",
+        executor="machine",
+        cli_path="monitor",
+        admits=("since", "entity_type", "project"),
+        refuses={
+            "id": (
+                "opens the detail view, whose result is a different shape entirely; "
+                "this verb answers with the table"
+            ),
+            "watch": "redraws a terminal until interrupted",
+            "refresh": "paces a redraw this verb does not do",
+            "run_ids": "waits for schedule runs to finish; use job.wait for a bounded wait",
+            "interval": "paces the wait this verb does not do",
+            "follow": "keeps a wait open indefinitely",
+            "chain": "shapes the wait this verb does not do",
+            "max_wait": "bounds the wait this verb does not do",
+        },
+    ),
+    Verb(
+        name="stats.runs",
+        summary="Run counts and first/last timestamps, grouped by project/kind/agent/model/status.",
+        executor="machine",
+        cli_path="stats runs",
+        admits=("since", "group_by"),
+        refuses={
+            "json": (
+                "shapes the human printout only; the machine result is already the "
+                "envelope and carries the same rows"
+            )
+        },
+    ),
+    Verb(
+        name="invoke.list",
+        summary="Recent skill-level invocations, newest first.",
+        executor="machine",
+        cli_path="invoke list",
+        admits=("skill", "status", "limit"),
+    ),
+    Verb(
+        name="dispatch.ls",
+        summary="Rows in the durable dispatch outbox, newest first, without their payloads.",
+        executor="machine",
+        cli_path="dispatch ls",
+        admits=("status", "limit"),
+    ),
+    Verb(
+        name="dispatch.show",
+        summary="One dispatch row in full, including its payload and ack token.",
+        executor="machine",
+        cli_path="dispatch show",
+        admits=("id",),
+    ),
+    Verb(
+        name="state.ls",
+        summary="Sessions in the lifecycle store with their branch and message counts.",
+        executor="machine",
+        cli_path="state ls",
+        admits=("limit", "status"),
+    ),
+    Verb(
+        name="state.stats",
+        summary="Store and write-ahead-log size, per-table row counts, session status spread.",
+        executor="machine",
+        cli_path="state stats",
+        admits=(),
+    ),
+    Verb(
+        name="team.list",
+        summary="Teams on disk with their members and message counts.",
+        executor="machine",
+        cli_path="team list",
+        admits=(),
+    ),
+    Verb(
+        name="plugin.info",
+        summary="One plugin's version, trust state, and everything its manifest declares.",
+        executor="machine",
+        cli_path="plugin info",
+        admits=("name",),
+    ),
 )
 
 
@@ -443,28 +530,32 @@ ABSENT: tuple[AbsentVerb, ...] = (
     ),
     *_absent(
         "team",
-        ("create", "list", "show", "send", "receive"),
+        ("create", "show", "send", "receive"),
         "Messaging between agents working as a team.",
     ),
     *_absent(
         "state",
-        ("ls", "stats", "doctor"),
+        ("doctor",),
         "Read-only inspection of the lifecycle store.",
     ),
     *_absent(
         "dispatch",
-        ("ls", "show", "ack", "retry", "purge"),
+        ("ack", "retry", "purge"),
         "The outbound dispatch queue.",
     ),
     AbsentVerb(
-        name="monitor",
-        summary="What is running right now, across sessions and invocations.",
-        reason=_NO_MACHINE_SEAM,
-    ),
-    AbsentVerb(
-        name="stats",
-        summary="Aggregate run counts and durations.",
-        reason=_NO_MACHINE_SEAM,
+        name="plugin.list",
+        summary="Installed plugin bundles and their trust state.",
+        # Not a missing seam: the listing garbage-collects trust records as part
+        # of listing, deleting the record of any plugin whose bundle directory
+        # has gone. That is a write, and what it writes to is the trust surface
+        # this surface is fenced away from, so a read-only variant of it would
+        # be a second command wearing the name of this one.
+        reason=(
+            "listing prunes trust records for plugins whose bundle directory is "
+            "gone, so it writes to user settings on the trust surface; a listing "
+            "that skipped the prune would not be this command"
+        ),
     ),
 )
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -115,6 +115,49 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+
+def state_db_file() -> Path | None:
+    """The local file a default ``StateDB()`` would open, if it opens one at all.
+
+    Resolved the same way ``StateDB.__init__`` resolves it, so the two cannot
+    disagree about which store is in play. Returns None when the configured
+    store is not a local file — a server, or an in-memory database — because
+    then there is no path to report and nothing a filesystem check can say
+    about it.
+    """
+    raw = settings.LIONAGI_STATE_DB_URL
+    if raw is None:
+        raw = DEFAULT_DB_PATH
+    url = normalize_state_db_url(raw)
+    if dialect_of(url) != "sqlite":
+        return None
+    from sqlalchemy.engine import make_url
+
+    database = make_url(url).database
+    if not database or database == ":memory:":
+        return None
+    return Path(database)
+
+
+def state_db_known_absent() -> bool:
+    """Whether the store a default ``StateDB()`` would open is known not to exist.
+
+    Callers use this to tell "there is no store, so there is no record of
+    anything" apart from "the store is there and something went wrong reading
+    it". Those are different answers and a caller acts differently on each, so
+    the check has to be about the store that will actually be opened. Testing
+    ``DEFAULT_DB_PATH`` instead asks about a file that need not be involved:
+    ``LIONAGI_STATE_DB_URL`` moves the store elsewhere, and then the default
+    path is absent while every row being asked about exists.
+
+    Only a positive answer is confident. Where existence is not a filesystem
+    question this reports False and leaves the open attempt to give the real
+    answer.
+    """
+    path = state_db_file()
+    return path is not None and not path.exists()
+
+
 # The single definition of which schedule_run statuses count as "fired and
 # resolved" for budget bookkeeping (max_runs, one-shot auto-disable). The
 # scheduler service layer must observe the same set — both its defaults and
@@ -988,6 +1031,7 @@ class StateDB:
                             CREATE TABLE sessions_new (
                               id              TEXT    PRIMARY KEY,
                               cc_session_id   TEXT,
+                              run_id          TEXT,
                               created_at      REAL    NOT NULL,
                               node_metadata   JSON,
                               name            TEXT,
@@ -1913,7 +1957,7 @@ class StateDB:
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
-                    """INSERT INTO sessions (id, cc_session_id, created_at, node_metadata, name, "user",
+                    """INSERT INTO sessions (id, cc_session_id, run_id, created_at, node_metadata, name, "user",
                        progression_id, first_msg_id, last_msg_id, updated_at,
                        playbook_name, agent_name, invocation_kind, show_topic,
                        show_play_name, artifacts_path, artifact_contract_json,
@@ -1921,7 +1965,7 @@ class StateDB:
                        status, started_at, ended_at, last_message_at, invocation_id,
                        model, provider, effort, agent_hash,
                        project, project_source)
-                       VALUES (:id, :cc_session_id, :created_at, :node_metadata, :name, :user,
+                       VALUES (:id, :cc_session_id, :run_id, :created_at, :node_metadata, :name, :user,
                                :progression_id, :first_msg_id, :last_msg_id, :updated_at,
                                :playbook_name, :agent_name, :invocation_kind, :show_topic,
                                :show_play_name, :artifacts_path, :artifact_contract_json,
@@ -1938,6 +1982,7 @@ class StateDB:
                 {
                     "id": session["id"],
                     "cc_session_id": session.get("cc_session_id"),
+                    "run_id": session.get("run_id"),
                     "created_at": session.get("created_at", now),
                     "node_metadata": session.get("node_metadata"),
                     "name": session.get("name"),
@@ -2008,6 +2053,29 @@ class StateDB:
                 .first()
             )
         return self._row_to_dict(row) if row else None
+
+    async def get_sessions_for_run(self, run_id: str) -> list[dict[str, Any]]:
+        """Every session recorded against CLI run *run_id*, oldest first.
+
+        A list rather than one row: one run can persist more than one session,
+        and a caller deciding whether the run is over has to see all of them.
+        An empty list means no session was ever recorded under this run id.
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT * FROM sessions WHERE run_id = :run_id "
+                            "ORDER BY created_at ASC, id ASC"
+                        ),
+                        {"run_id": run_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        return [self._row_to_dict(row) for row in rows]
 
     async def get_session_by_cc_id(self, cc_session_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -107,6 +107,9 @@ CREATE INDEX IF NOT EXISTS idx_run_tags_tag ON run_tags(tag);
 CREATE TABLE IF NOT EXISTS sessions (
   id              TEXT    PRIMARY KEY,
   cc_session_id   TEXT,
+  -- The CLI run this session belongs to. NULL for a session no run started,
+  -- and for rows written before this column existed.
+  run_id          TEXT,
   created_at      REAL    NOT NULL,
   node_metadata   JSON,
   name            TEXT,
@@ -209,6 +212,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_project
   ON sessions(project) WHERE project IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_cc_session
   ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_run_id
+  ON sessions(run_id) WHERE run_id IS NOT NULL;
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -214,6 +214,21 @@ CREATE INDEX IF NOT EXISTS idx_sessions_cc_session
   ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_run_id
   ON sessions(run_id) WHERE run_id IS NOT NULL;
+-- first_msg_id / last_msg_id are child keys of messages(id). Deleting a
+-- message makes sqlite look for rows here that still point at it, and with
+-- no index on the column that search is a scan of the whole table, once per
+-- deleted row -- a cost that is a function of the store rather than of the
+-- delete. Measured on a 3.9 GB store, indexing these two columns and
+-- branches(system_msg_id) took a message delete from 8.47 ms/row to
+-- 0.86 ms/row. Not partial: the search sqlite runs for a foreign key is not
+-- the query planner's, and only a plain index is certain to serve it.
+CREATE INDEX IF NOT EXISTS idx_sessions_first_msg_id
+  ON sessions(first_msg_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_msg_id
+  ON sessions(last_msg_id);
+-- Same shape one level up: progressions(id) is this column's parent.
+CREATE INDEX IF NOT EXISTS idx_sessions_progression_id
+  ON sessions(progression_id);
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,
@@ -244,6 +259,11 @@ CREATE TABLE IF NOT EXISTS branches (
 
 CREATE INDEX IF NOT EXISTS idx_branches_session
   ON branches(session_id);
+-- Child keys of messages(id) / progressions(id); see idx_sessions_first_msg_id.
+CREATE INDEX IF NOT EXISTS idx_branches_system_msg_id
+  ON branches(system_msg_id);
+CREATE INDEX IF NOT EXISTS idx_branches_progression_id
+  ON branches(progression_id);
 
 -- ── Definitions (versioned agent + playbook files) ───────────────────────────
 -- Disk files remain source of truth; this table tracks edit history.

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -209,6 +209,21 @@ CREATE INDEX IF NOT EXISTS idx_sessions_project
   ON sessions(project) WHERE project IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_cc_session
   ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL;
+-- first_msg_id / last_msg_id are child keys of messages(id). Deleting a
+-- message makes sqlite look for rows here that still point at it, and with
+-- no index on the column that search is a scan of the whole table, once per
+-- deleted row -- a cost that is a function of the store rather than of the
+-- delete. Measured on a 3.9 GB store, indexing these two columns and
+-- branches(system_msg_id) took a message delete from 8.47 ms/row to
+-- 0.86 ms/row. Not partial: the search sqlite runs for a foreign key is not
+-- the query planner's, and only a plain index is certain to serve it.
+CREATE INDEX IF NOT EXISTS idx_sessions_first_msg_id
+  ON sessions(first_msg_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_msg_id
+  ON sessions(last_msg_id);
+-- Same shape one level up: progressions(id) is this column's parent.
+CREATE INDEX IF NOT EXISTS idx_sessions_progression_id
+  ON sessions(progression_id);
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,
@@ -239,6 +254,11 @@ CREATE TABLE IF NOT EXISTS branches (
 
 CREATE INDEX IF NOT EXISTS idx_branches_session
   ON branches(session_id);
+-- Child keys of messages(id) / progressions(id); see idx_sessions_first_msg_id.
+CREATE INDEX IF NOT EXISTS idx_branches_system_msg_id
+  ON branches(system_msg_id);
+CREATE INDEX IF NOT EXISTS idx_branches_progression_id
+  ON branches(progression_id);
 
 -- ── Definitions (versioned agent + playbook files) ───────────────────────────
 -- Disk files remain source of truth; this table tracks edit history.

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -215,6 +215,11 @@ sessions = Table(
     Column("duration_ms", Float),
 )
 
+# first_msg_id / last_msg_id are child keys of messages(id): these serve the
+# search sqlite runs when a message row is deleted, not any query.
+Index("idx_sessions_first_msg_id", sessions.c.first_msg_id)
+Index("idx_sessions_last_msg_id", sessions.c.last_msg_id)
+Index("idx_sessions_progression_id", sessions.c.progression_id)
 Index("idx_sessions_updated", sessions.c.updated_at)
 Index("idx_sessions_status_updated", sessions.c.status, sessions.c.updated_at)
 Index(
@@ -271,6 +276,8 @@ branches = Table(
 )
 
 Index("idx_branches_session", branches.c.session_id)
+Index("idx_branches_system_msg_id", branches.c.system_msg_id)
+Index("idx_branches_progression_id", branches.c.progression_id)
 
 # ── definitions ───────────────────────────────────────────────────────────────
 

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -219,6 +219,11 @@ sessions = Table(
     Column("duration_ms", Float),
 )
 
+# first_msg_id / last_msg_id are child keys of messages(id): these serve the
+# search sqlite runs when a message row is deleted, not any query.
+Index("idx_sessions_first_msg_id", sessions.c.first_msg_id)
+Index("idx_sessions_last_msg_id", sessions.c.last_msg_id)
+Index("idx_sessions_progression_id", sessions.c.progression_id)
 Index("idx_sessions_updated", sessions.c.updated_at)
 Index("idx_sessions_status_updated", sessions.c.status, sessions.c.updated_at)
 Index(
@@ -275,6 +280,8 @@ branches = Table(
 )
 
 Index("idx_branches_session", branches.c.session_id)
+Index("idx_branches_system_msg_id", branches.c.system_msg_id)
+Index("idx_branches_progression_id", branches.c.progression_id)
 
 # ── definitions ───────────────────────────────────────────────────────────────
 

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -151,6 +151,10 @@ sessions = Table(
     metadata,
     Column("id", Text, primary_key=True),
     Column("cc_session_id", Text),
+    # The CLI run this session belongs to, recorded at creation. Without it a
+    # run_id cannot reach the lifecycle row, so nothing that writes only the
+    # row (a kill, for one) is visible to a reader holding a run_id.
+    Column("run_id", Text),
     Column("created_at", Float, nullable=False),
     Column("node_metadata", JSON),
     Column("name", Text),

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -46,9 +46,17 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("total_cost_usd", "REAL"),
         ("num_turns", "INTEGER"),
         ("duration_ms", "REAL"),
+        # Reconciled here so the indexes below have columns to be built on;
+        # a store old enough to predate them must still open.
+        ("first_msg_id", "TEXT"),
+        ("last_msg_id", "TEXT"),
+        ("progression_id", "TEXT"),
     ],
     "branches": [
         ("system_msg_id", "TEXT"),
+        # Reconciled here so the index below it has a column to be built on;
+        # a store old enough to predate the column must still open.
+        ("progression_id", "TEXT"),
         # Per-branch provenance.
         ("model", "TEXT"),
         ("provider", "TEXT"),
@@ -194,17 +202,32 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
 
 # metadata.create_all() skips indexes when their table already exists. Keep
 # dialect-specific, idempotent DDL here for indexes introduced after deployment.
+# Child keys of messages(id). Without an index on the referring column,
+# deleting a message costs a scan of the referring table per deleted row, so
+# a prune pays for the whole store once per message it removes. These exist
+# for that search, not for any query. See schema.sql for the measurement.
+_MESSAGE_POINTER_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_sessions_first_msg_id ON sessions(first_msg_id)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_last_msg_id ON sessions(last_msg_id)",
+    "CREATE INDEX IF NOT EXISTS idx_branches_system_msg_id ON branches(system_msg_id)",
+    # Same shape one level up: progressions(id) is the parent of these two.
+    "CREATE INDEX IF NOT EXISTS idx_sessions_progression_id ON sessions(progression_id)",
+    "CREATE INDEX IF NOT EXISTS idx_branches_progression_id ON branches(progression_id)",
+)
+
 MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
     "sqlite": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        *_MESSAGE_POINTER_INDEXES,
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        *_MESSAGE_POINTER_INDEXES,
     ),
 }

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -9,6 +9,9 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
     "sessions": [
         ("updated_at", "REAL"),
         ("cc_session_id", "TEXT"),
+        # The CLI run this session belongs to; NULL on rows created before
+        # this migration and on sessions that were not started by a run.
+        ("run_id", "TEXT"),
         ("playbook_name", "TEXT"),
         ("agent_name", "TEXT"),
         ("invocation_kind", "TEXT"),
@@ -200,11 +203,15 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
+        "ON sessions(run_id) WHERE run_id IS NOT NULL",
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
         "ON sessions(cc_session_id) WHERE cc_session_id IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_schedules_owner_key "
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
+        "ON sessions(run_id) WHERE run_id IS NOT NULL",
     ),
 }

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -49,9 +49,17 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("total_cost_usd", "REAL"),
         ("num_turns", "INTEGER"),
         ("duration_ms", "REAL"),
+        # Reconciled here so the indexes below have columns to be built on;
+        # a store old enough to predate them must still open.
+        ("first_msg_id", "TEXT"),
+        ("last_msg_id", "TEXT"),
+        ("progression_id", "TEXT"),
     ],
     "branches": [
         ("system_msg_id", "TEXT"),
+        # Reconciled here so the index below it has a column to be built on;
+        # a store old enough to predate the column must still open.
+        ("progression_id", "TEXT"),
         # Per-branch provenance.
         ("model", "TEXT"),
         ("provider", "TEXT"),
@@ -197,6 +205,19 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
 
 # metadata.create_all() skips indexes when their table already exists. Keep
 # dialect-specific, idempotent DDL here for indexes introduced after deployment.
+# Child keys of messages(id). Without an index on the referring column,
+# deleting a message costs a scan of the referring table per deleted row, so
+# a prune pays for the whole store once per message it removes. These exist
+# for that search, not for any query. See schema.sql for the measurement.
+_MESSAGE_POINTER_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_sessions_first_msg_id ON sessions(first_msg_id)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_last_msg_id ON sessions(last_msg_id)",
+    "CREATE INDEX IF NOT EXISTS idx_branches_system_msg_id ON branches(system_msg_id)",
+    # Same shape one level up: progressions(id) is the parent of these two.
+    "CREATE INDEX IF NOT EXISTS idx_sessions_progression_id ON sessions(progression_id)",
+    "CREATE INDEX IF NOT EXISTS idx_branches_progression_id ON branches(progression_id)",
+)
+
 MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
     "sqlite": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
@@ -205,6 +226,7 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
         "ON sessions(run_id) WHERE run_id IS NOT NULL",
+        *_MESSAGE_POINTER_INDEXES,
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
@@ -213,5 +235,6 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "ON schedules(owner_key) WHERE owner_key IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
         "ON sessions(run_id) WHERE run_id IS NOT NULL",
+        *_MESSAGE_POINTER_INDEXES,
     ),
 }

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -142,6 +142,7 @@ TOP_LEVEL_COMMANDS = [
     "hooks",
     "invoke",
     "kill",
+    "lifecycle",
     "mcp",
     "mirror",
     "mon",

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
+import subprocess
 import sys
 import time
 import uuid
@@ -12,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import psutil
 import pytest
 import yaml
 
@@ -216,6 +220,9 @@ def test_terminate_pid_identity_mismatch_no_signal_sent(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     result = _terminate_pid(42, grace_seconds=0.1, expected_cmd="lionagi")
@@ -237,12 +244,165 @@ def test_terminate_pid_identity_match_sends_signal(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     result = _terminate_pid(42, grace_seconds=0.01, expected_cmd="lionagi")
     # SIGTERM must have been sent
     assert any(sig == __import__("signal").SIGTERM for _, sig in kill_calls)
     assert result in ("sigterm", "sigkill")
+
+
+# ── A real, unreaped child ────────────────────────────────────────────────────
+#
+# Everything below uses a process this test actually started. A SIGTERMed child
+# whose parent has not called wait() is a zombie: it holds its pid, so `kill -0`
+# keeps reporting it present, but it has no command line, no environment and no
+# way to be killed again. That is a third answer next to "this is our process"
+# and "this pid belongs to something else", and the kill path has to record the
+# cancellation for it instead of refusing.
+
+
+def _spawn_marked_child(session_id: str) -> subprocess.Popen:
+    """Start a sleeper carrying the session marker `li kill` identifies runs by."""
+    return subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(300)"],
+        env={**os.environ, "LIONAGI_SESSION_ID": session_id},
+    )
+
+
+def _await(predicate, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _is_zombie(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except psutil.ZombieProcess:
+        return True
+    except psutil.NoSuchProcess:
+        return False
+
+
+@pytest.mark.skipif(os.name != "posix", reason="zombies are a POSIX process state")
+async def test_kill_cancels_session_whose_child_is_an_unreaped_zombie(
+    temp_db_path: Path,
+):
+    """`li kill` against a SIGTERMed-but-unreaped child must persist the cancel.
+
+    This is the window a caller opens by starting a run and never waiting on
+    it: the process is gone, nobody has reaped it, and the row is still
+    'running'. Refusing here loses the cancellation for a run that has in fact
+    stopped.
+    """
+    sid = str(uuid.uuid4())
+    child = _spawn_marked_child(sid)
+    assert child.pid > 1
+
+    try:
+        assert _await(
+            lambda: _check_pid_identity(child.pid, "lionagi", expected_session_id=sid) == "ours"
+        ), "child never came up carrying its session marker"
+        create_time = psutil.Process(child.pid).create_time()
+
+        # While it is alive the identity check accepts it. Nothing about the
+        # arguments changes below, so whatever answer comes back after the
+        # SIGTERM differs only because the process died without being reaped.
+        assert (
+            _check_pid_identity(
+                child.pid,
+                "lionagi",
+                expected_session_id=sid,
+                expected_create_time=create_time,
+            )
+            == "ours"
+        )
+
+        async with StateDB() as db:
+            prog = str(uuid.uuid4())
+            await db.create_progression(prog)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": prog,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "node_metadata": {"pid": child.pid, "pid_create_time": create_time},
+                }
+            )
+
+        os.kill(child.pid, signal.SIGTERM)
+        # Deliberately no child.wait()/poll(): an unreaped exit is the state
+        # under test, and reaping it here would test a pid that is simply gone.
+        assert _await(lambda: _is_zombie(child.pid)), (
+            "child did not become a zombie — this environment reaps children "
+            "on its own and cannot exercise the window"
+        )
+        assert _pid_alive(child.pid) is True, "a zombie still answers kill -0"
+        assert (
+            _check_pid_identity(
+                child.pid,
+                "lionagi",
+                expected_session_id=sid,
+                expected_create_time=create_time,
+            )
+            == "zombie"
+        )
+
+        rc = await _do_kill(sid, grace_seconds=0.5)
+        assert rc == 0, "a run that has already stopped is not a blocked kill"
+
+        async with StateDB() as db:
+            row = await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,))
+        assert row is not None
+        assert row["status"] == "cancelled", (
+            "the process is dead and the row must say so; leaving it 'running' "
+            "loses the cancellation"
+        )
+    finally:
+        if child.poll() is None and child.pid > 1:
+            child.kill()
+        child.wait()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="a zombie is a POSIX process state")
+def test_terminate_pid_reports_an_unreaped_process_dead_with_no_identity_to_check():
+    """The same window, reached where there is nothing to identify the pid by.
+
+    `_terminate_pid` is also called with no expected command — killing by pid,
+    and every liveness poll inside the grace loop. On that path the identity
+    classifier never runs, so its verdict cannot be what saves this: with only
+    `kill -0` to go on, an unreaped process looks alive forever and the caller
+    would SIGTERM a corpse and then sit out the whole grace window waiting for
+    a flag that can never flip.
+    """
+    sid = str(uuid.uuid4())
+    child = _spawn_marked_child(sid)
+    assert child.pid > 1
+
+    try:
+        assert _await(lambda: _pid_alive(child.pid)), "child never started"
+        os.kill(child.pid, signal.SIGTERM)
+        assert _await(lambda: _is_zombie(child.pid)), (
+            "child did not become a zombie — this environment reaps children "
+            "on its own and cannot exercise the window"
+        )
+        assert _pid_alive(child.pid) is True, "a zombie still answers kill -0"
+
+        started = time.monotonic()
+        assert _terminate_pid(child.pid, grace_seconds=5.0) == "already_dead"
+        assert time.monotonic() - started < 1.0, "it waited out a grace window for a dead process"
+    finally:
+        if child.poll() is None and child.pid > 1:
+            child.kill()
+        child.wait()
 
 
 def _mock_psutil(
@@ -265,6 +425,9 @@ def _mock_psutil(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
     return kill_calls
 
@@ -287,13 +450,13 @@ def test_identity_rejects_path_substring(monkeypatch: pytest.MonkeyPatch):
 def test_identity_accepts_dash_m_module(monkeypatch: pytest.MonkeyPatch):
     """``python -m lionagi.cli.main`` is a genuine invocation and is accepted."""
     _mock_psutil(monkeypatch, cmdline=["/usr/bin/python3", "-m", "lionagi.cli.main"])
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_accepts_li_entrypoint(monkeypatch: pytest.MonkeyPatch):
     """The ``li`` console-script entrypoint is accepted by executable basename."""
     _mock_psutil(monkeypatch, cmdline=["/opt/venv/bin/li", "kill", "abc123"])
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
@@ -302,7 +465,7 @@ def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
         monkeypatch,
         cmdline=["/opt/.venv/bin/python3", "/opt/.venv/bin/li", "play", "abc123"],
     )
-    assert _check_pid_identity(42, "lionagi") is True
+    assert _check_pid_identity(42, "lionagi") == "ours"
 
 
 def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.MonkeyPatch):
@@ -311,7 +474,7 @@ def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.Mon
         monkeypatch,
         cmdline=["/usr/bin/python3", "/usr/local/bin/olia-tool", "run"],
     )
-    assert _check_pid_identity(42, "lionagi") is False
+    assert _check_pid_identity(42, "lionagi") == "not_ours"
 
 
 def test_identity_session_marker_match(monkeypatch: pytest.MonkeyPatch):
@@ -321,7 +484,7 @@ def test_identity_session_marker_match(monkeypatch: pytest.MonkeyPatch):
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         environ={"LIONAGI_SESSION_ID": "run-123"},
     )
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is True
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "ours"
 
 
 def test_identity_session_marker_mismatch_rejected(monkeypatch: pytest.MonkeyPatch):
@@ -335,7 +498,7 @@ def test_identity_session_marker_mismatch_rejected(monkeypatch: pytest.MonkeyPat
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         environ={"LIONAGI_SESSION_ID": "other-run"},
     )
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is False
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "not_ours"
 
 
 def test_identity_absent_marker_requires_create_time_match(monkeypatch: pytest.MonkeyPatch):
@@ -353,18 +516,18 @@ def test_identity_absent_marker_requires_create_time_match(monkeypatch: pytest.M
         create_time=500.0,
     )
     # No create_time recorded → cannot prove this run → skip.
-    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") is False
+    assert _check_pid_identity(42, "lionagi", expected_session_id="run-123") == "unverifiable"
     # create_time matches AND cmdline is lionagi → positively identified.
     assert (
         _check_pid_identity(
             42, "lionagi", expected_session_id="run-123", expected_create_time=500.0
         )
-        is True
+        == "ours"
     )
     # create_time differs → recycled PID → skip.
     assert (
         _check_pid_identity(42, "lionagi", expected_session_id="run-123", expected_create_time=1.0)
-        is False
+        == "not_ours"
     )
 
 
@@ -384,7 +547,7 @@ def test_identity_absent_marker_rejects_nonlionagi_cmdline(monkeypatch: pytest.M
         _check_pid_identity(
             42, "lionagi", expected_session_id="run-123", expected_create_time=500.0
         )
-        is False
+        == "not_ours"
     )
 
 
@@ -438,11 +601,11 @@ def test_identity_create_time_mismatch_rejected(monkeypatch: pytest.MonkeyPatch)
         cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
         create_time=100.0,
     )
-    assert _check_pid_identity(42, "lionagi", expected_create_time=999.0) is False
+    assert _check_pid_identity(42, "lionagi", expected_create_time=999.0) == "not_ours"
     # 0.5s apart → different process → reject (was accepted under the old 2s gate).
-    assert _check_pid_identity(42, "lionagi", expected_create_time=100.5) is False
+    assert _check_pid_identity(42, "lionagi", expected_create_time=100.5) == "not_ours"
     # within tick-rounding tolerance → accepted.
-    assert _check_pid_identity(42, "lionagi", expected_create_time=100.05) is True
+    assert _check_pid_identity(42, "lionagi", expected_create_time=100.05) == "ours"
 
 
 # ── current_pid_markers (launch-time recording) ───────────────────────────────
@@ -763,7 +926,7 @@ async def test_do_kill_all_stale_skips_live_pid(
 ):
     """Running session with a LIVE, identity-matching PID is not touched."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "ours")
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "ours")
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -784,9 +947,7 @@ async def test_do_kill_all_stale_sweeps_reused_pid(
     """A live PID that no longer identifies as the tracked process (reused
     after the original died) must still be swept, not treated as live."""
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
-    monkeypatch.setattr(
-        "lionagi.cli.kill._check_pid_identity_tristate", lambda *a, **kw: "not_ours"
-    )
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "not_ours")
 
     old_start = time.time() - 7200
     async with StateDB() as db:
@@ -875,6 +1036,9 @@ async def test_do_kill_all_stale_recycled_pid_swept_with_correlation(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     old_start = time.time() - 7200
@@ -916,6 +1080,9 @@ async def test_do_kill_all_stale_matching_correlation_skips_live(
     fake_psutil.Process.return_value = fake_proc
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    # Mirrors psutil: ZombieProcess is a NoSuchProcess subclass, so a double
+    # that omits it lets the code under test claim a distinction it never made.
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
     old_start = time.time() - 7200
@@ -948,10 +1115,9 @@ async def test_do_kill_all_stale_access_denied_not_cancelled(
     """A live pid we cannot inspect (psutil.AccessDenied) must be treated as
     still alive by the sweep, not cancelled out from under a running worker.
 
-    Discrimination: on unfixed code the sweep's bare `_check_pid_identity`
-    call collapses AccessDenied to False ("not ours"), so the row gets
-    cancelled while the process keeps running. Post-fix the tri-state check
-    reports "unverifiable" and the sweep skips it.
+    Discrimination: an identity check that collapses AccessDenied into "not
+    ours" gets the row cancelled while the process keeps running. The verdict
+    reports "unverifiable" instead and the sweep skips it.
     """
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: True)
 
@@ -959,6 +1125,7 @@ async def test_do_kill_all_stale_access_denied_not_cancelled(
     fake_psutil = MagicMock()
     fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
     fake_psutil.AccessDenied = fake_access_denied
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_psutil.NoSuchProcess,), {})
     fake_psutil.Process.side_effect = fake_access_denied("no access")
     monkeypatch.setattr("lionagi.cli.kill.psutil", fake_psutil)
 
@@ -988,6 +1155,7 @@ async def test_do_kill_all_stale_process_vanishing_mid_check_does_not_abort_swee
     fake_psutil = MagicMock()
     fake_psutil.NoSuchProcess = fake_no_such
     fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    fake_psutil.ZombieProcess = type("ZombieProcess", (fake_no_such,), {})
     fake_proc = MagicMock()
     fake_proc.environ.side_effect = fake_no_such("gone")
     fake_proc.cmdline.side_effect = fake_no_such("gone")
@@ -1483,9 +1651,6 @@ async def test_do_kill_all_stale_does_NOT_touch_play_at_all(
         assert row["status"] == "running"
 
 
-import signal  # noqa: E402
-
-
 class TestTerminatePidIdentityRevalidation:
     """SIGKILL is not survivable and gives the target no chance to identify
     itself, so escalation re-checks that the pid still belongs to the process
@@ -1501,7 +1666,7 @@ class TestTerminatePidIdentityRevalidation:
             identity_calls.append(pid)
             # first call (pre-SIGTERM) matches, later calls do not: the pid was
             # recycled while we waited out the grace window
-            return len(identity_calls) == 1
+            return "ours" if len(identity_calls) == 1 else "not_ours"
 
         monkeypatch.setattr(kill_mod, "_check_pid_identity", _identity)
 
@@ -1528,7 +1693,7 @@ class TestTerminatePidIdentityRevalidation:
         monkeypatch.setattr(kill_mod.os, "kill", lambda pid, sig: sent.append(sig))
         monkeypatch.setattr(kill_mod, "_pid_alive", lambda pid: True)
         monkeypatch.setattr(kill_mod.time, "sleep", lambda s: None)
-        monkeypatch.setattr(kill_mod, "_check_pid_identity", lambda *a, **kw: True)
+        monkeypatch.setattr(kill_mod, "_check_pid_identity", lambda *a, **kw: "ours")
 
         result = kill_mod._terminate_pid(4242, expected_cmd="li agent", grace_seconds=0.01)
 

--- a/tests/cli/test_machine_envelope.py
+++ b/tests/cli/test_machine_envelope.py
@@ -15,6 +15,7 @@ import errno
 import importlib
 import json
 import os
+import signal
 import subprocess
 import sys
 import textwrap
@@ -435,3 +436,54 @@ def test_78_survives_end_to_end_under_the_machine_flag():
 
     assert proc.returncode == EXIT_CODE_ENVIRONMENT_ERROR, proc.stderr
     assert proc.stdout.strip() == ""
+
+
+# ── the machine path leaves SIGPIPE where the interpreter put it ────────────
+
+
+def _sigpipe_disposition_after(*argv: str) -> str:
+    script = textwrap.dedent(
+        """
+        import signal, sys
+
+        from lionagi.cli.main import _run
+
+        _run(sys.argv[1:])
+        print(
+            "SIG_DFL" if signal.getsignal(signal.SIGPIPE) is signal.SIG_DFL else "ignored",
+            file=sys.stderr,
+        )
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script, *argv],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stderr.strip().splitlines()[-1]
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="no SIGPIPE on this platform")
+def test_a_machine_call_never_runs_with_a_signal_that_can_kill_it_silently():
+    """A command under the default SIGPIPE disposition can stop mid-answer.
+
+    The default kills the process on any EPIPE, from any thread, with no
+    envelope and nothing on stderr — and not every write is one the command
+    made. A database driver's worker thread reporting a result to an event loop
+    that is shutting down writes to the loop's own wakeup socket, and loses that
+    race often enough to be a routine outcome rather than a rare one. The
+    interpreter's own setting turns that into a catchable error; this surface
+    needs it, because its whole contract is that a call always answers.
+    """
+    assert _sigpipe_disposition_after("handshake", "--machine") == "ignored"
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="no SIGPIPE on this platform")
+def test_the_human_path_still_ends_quietly_when_its_reader_goes_away():
+    # The reason the default is set at all: `li ... | head` should stop, not
+    # print a traceback about a pipe the person closed on purpose.
+    assert _sigpipe_disposition_after("handshake") == "SIG_DFL"

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -182,7 +182,7 @@ async def test_do_kill_all_stale_does_not_sweep_play_with_live_session(
     # lionagi CLI invocation, so the real cmdline check would (correctly)
     # reject it -- here it stands in for a live, identity-matching session.
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: pid == own_pid)
-    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: True)
+    monkeypatch.setattr("lionagi.cli.kill._check_pid_identity", lambda *a, **kw: "ours")
 
     old_time = time.time() - 7200
     async with StateDB() as db:

--- a/tests/mcp/golden_projections/dispatch__show.json
+++ b/tests/mcp/golden_projections/dispatch__show.json
@@ -1,0 +1,22 @@
+{
+  "path": "dispatch show",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the dispatch row to show, as listed by `li dispatch ls`.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "dispatch show",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/invoke__list.json
+++ b/tests/mcp/golden_projections/invoke__list.json
@@ -1,0 +1,27 @@
+{
+  "path": "invoke list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "limit": {
+        "default": 20,
+        "description": "Maximum rows to print, newest first (default 20).",
+        "type": "integer",
+        "x-flag": "--limit"
+      },
+      "skill": {
+        "description": "Show only invocations of this skill name, matched exactly.",
+        "type": "string",
+        "x-flag": "--skill"
+      },
+      "status": {
+        "description": "Show only invocations in this status: running, completed, failed, timed_out, aborted or cancelled.",
+        "type": "string",
+        "x-flag": "--status"
+      }
+    },
+    "title": "invoke list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/plugin__info.json
+++ b/tests/mcp/golden_projections/plugin__info.json
@@ -1,0 +1,22 @@
+{
+  "path": "plugin info",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "description": "Plugin to describe \u2014 its manifest `name:`, as listed by `li plugin list`.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "plugin info",
+    "type": "object",
+    "x-positional-order": [
+      "name"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/state__stats.json
+++ b/tests/mcp/golden_projections/state__stats.json
@@ -1,0 +1,11 @@
+{
+  "path": "state stats",
+  "schema": {
+    "additionalProperties": false,
+    "description": "Report state.db + state.db-wal sizes, per-table row counts, session status distribution, and SQLite PRAGMAs (journal_mode, wal_autocheckpoint, busy_timeout). Use to spot growth and lock contention.",
+    "properties": {},
+    "title": "state stats",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__list.json
+++ b/tests/mcp/golden_projections/team__list.json
@@ -1,0 +1,10 @@
+{
+  "path": "team list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "team list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -82,7 +82,7 @@ def test_help_for_a_verb_returns_the_projected_schema():
 
 
 def test_help_for_an_unavailable_verb_says_why_instead_of_failing():
-    answer = call(help="monitor")
+    answer = call(help="state.doctor")
     assert answer["available"] is False and answer["reason"]
 
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -23,6 +23,11 @@ def sandbox(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
     monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    # Popen is doubled for the whole module here, and subprocess.run goes
+    # through Popen — so the lifecycle read cannot run in this file at all.
+    # Stubbed to the answer a failed read gives ("learned nothing"), which is
+    # what these tests assume; the read itself is covered in test_lifecycle.py.
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
     return tmp_path
 
 

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -1,0 +1,476 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The lifecycle read: a run stopped by `li kill` has to read as terminal.
+
+The kill path writes the StateDB row and signals the process. It does not write
+the MCP job record and it does not write the CLI run manifest, so before this
+seam existed a killed run was indistinguishable from an orphan — a dead pid with
+no recorded end — and `job.wait` sat on it for its whole window.
+
+The first test here is end to end on purpose: a real submit, a real child that
+persists a real session row, a real `li kill`, and a real `jobs.wait`. A unit
+test over `_derive` with a hand-built record would only assert its own fixture,
+and the defect lived in the gap between the writers, not in the classifier.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.mcp import config, jobs
+
+# A stand-in for the installed console script. Named `li` because the kill
+# path verifies a pid's identity from its command line before signalling it,
+# and a shebang-launched console script is `<python> <.../li>`.
+#
+# It forwards to the real CLI for everything except the run itself: `agent`
+# becomes a child that persists a session row through the production path and
+# then stays alive, which is what a run being killed looks like without needing
+# a model behind it.
+_LI_SHIM = """
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] != "agent":
+    from lionagi.cli.main import main
+
+    sys.exit(main(sys.argv[1:]))
+
+import time
+
+import anyio
+
+from lionagi import Branch
+from lionagi.cli._runs import allocate_run, setup_agent_persist
+
+
+async def _main():
+    allocate_run()
+    live = await setup_agent_persist(Branch(), agent_name="lifecycle-e2e")
+    print("SESSION " + live["session_id"], flush=True)
+    while True:
+        time.sleep(0.05)
+
+
+anyio.run(_main)
+"""
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path):
+    """A whole lionagi home of our own, for this process and every child."""
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    # Children are launched by absolute script path, so their `sys.path[0]` is
+    # the directory that script sits in, and this checkout is not on it. They
+    # then import whichever `lionagi` the interpreter's environment resolves,
+    # which is the same one only when the installed distribution happens to
+    # point here. Develop in a second checkout — a worktree, say — and it points
+    # at the first, so these end-to-end tests exercise a CLI that is not the one
+    # being changed, and do it silently.
+    #
+    # To see the difference, run any script by absolute path with and without
+    # this variable and print `lionagi.__file__`.
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
+    monkeypatch.delenv("LIONAGI_SESSION_ID", raising=False)
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    shim = tmp_path / "li"
+    shim.write_text(_LI_SHIM)
+    monkeypatch.setattr(config, "li_command", lambda: [sys.executable, str(shim)])
+    return tmp_path
+
+
+def _await_session_id(run_id: str, timeout: float = 90.0) -> str:
+    """Read the session id the child prints once its row is persisted."""
+    deadline = time.monotonic() + timeout
+    log = config.job_dir(run_id) / "console.log"
+    while time.monotonic() < deadline:
+        if log.exists():
+            for line in log.read_text(errors="replace").splitlines():
+                if line.startswith("SESSION "):
+                    return line.split(" ", 1)[1].strip()
+        time.sleep(0.2)
+    tail = log.read_text(errors="replace")[-2000:] if log.exists() else "<no console log>"
+    raise AssertionError(f"child never persisted a session row. console:\n{tail}")
+
+
+def _li(home_dir: Path, *argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603 — the test's own shim, no shell
+        [sys.executable, str(home_dir / "li"), *argv],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+def _li_kill(home_dir: Path, session_id: str, child_pid: int) -> subprocess.CompletedProcess:
+    """Run `li kill` while reaping the submitted child, as a server would.
+
+    The child is spawned detached but is still this process's child, so once it
+    exits on SIGTERM it lingers as a zombie until someone waits on it — and a
+    zombie has no readable command line, which `li kill` reads back to confirm
+    it is not escalating SIGKILL onto a recycled pid. A live server polls
+    ``status()`` throughout a run and reaps there; this loop stands in for that
+    poll so the kill sees the process actually go away.
+    """
+    proc = subprocess.Popen(  # noqa: S603 — the test's own shim, no shell
+        [sys.executable, str(home_dir / "li"), "kill", session_id],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    while proc.poll() is None:
+        jobs._pid_alive(child_pid)  # reaps the child once it exits
+        time.sleep(0.05)
+    out, err = proc.communicate()
+    return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
+# --- end to end ----------------------------------------------------------------
+
+
+@pytest.mark.slow
+async def test_a_killed_run_reads_terminal_end_to_end(home):
+    """Submit, kill by the path a person uses, and stop waiting.
+
+    Nothing is stubbed between the submit and the verdict: `li kill` writes only
+    the StateDB row, and that has to be enough for `wait` to return.
+    """
+    handle = jobs.submit("agent", [], prompt="stay up")
+    run_id = handle["run_id"]
+    session_id = _await_session_id(run_id)
+
+    killed = _li_kill(home, session_id, jobs._read_job(run_id)["pid"])
+    assert killed.returncode == 0, killed.stderr
+
+    started = time.monotonic()
+    result = await jobs.wait([run_id], max_wait=60.0, poll_interval=0.5)
+    elapsed = time.monotonic() - started
+
+    entry = result["runs"][0]
+    assert entry["terminal"] is True, entry
+    assert entry["outcome"] == "cancelled"
+    assert entry["status"] == "cancelled"
+    assert entry["reason_code"] in (
+        "run.cancelled.manual_kill",
+        "run.cancelled.force_kill",
+    )
+    assert result["all_terminal"] is True
+    assert result["timed_out"] is False
+    # "promptly" is the whole point: the defect was waiting out the window.
+    assert elapsed < 30.0
+
+
+@pytest.mark.slow
+async def test_the_lifecycle_end_is_cached_onto_the_job_record(home):
+    """The second observation of a killed run answers from the record.
+
+    The sidecar becomes a cache of the end, so a caller polling a finished run
+    does not spawn a CLI read per poll — and, more importantly, two observations
+    of one unchanged run cannot answer differently.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+    assert _li_kill(home, session_id, jobs._read_job(run_id)["pid"]).returncode == 0
+
+    first = await jobs.wait([run_id], max_wait=60.0, poll_interval=0.5)
+    assert first["runs"][0]["terminal"] is True
+
+    record = jobs._read_job(run_id)
+    assert record["finished_at"] is not None
+    assert record["status"] == "cancelled"
+
+    calls: list[str] = []
+
+    def _must_not_be_called(rid: str) -> None:
+        calls.append(rid)
+        raise AssertionError("the cached end should have answered this")
+
+    original = jobs._read_lifecycle
+    jobs._read_lifecycle = _must_not_be_called
+    try:
+        second = jobs.status(run_id)
+    finally:
+        jobs._read_lifecycle = original
+
+    assert calls == []
+    assert second["terminal"] is True
+    assert second["outcome"] == "cancelled"
+    assert second["reason_code"] == first["runs"][0]["reason_code"]
+
+
+@pytest.mark.slow
+async def test_a_run_that_completes_normally_still_reads_succeeded(home):
+    """The ordinary path is unchanged with the new read in place.
+
+    The terminal hook records the end first, so nothing is asked of the
+    lifecycle store at all — and the answer is a success, not a cancellation.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+
+    # What the notify hook does on a clean finish, then stop the child.
+    jobs.mark_terminal(run_id, "completed")
+    assert _li_kill(home, session_id, jobs._read_job(run_id)["pid"]).returncode == 0
+
+    result = await jobs.wait([run_id], max_wait=30.0, poll_interval=0.5)
+    entry = result["runs"][0]
+    assert entry["terminal"] is True
+    assert entry["outcome"] == "succeeded"
+    assert entry["status"] == "completed"
+
+
+# --- the windows where a recorded end does not exist ---------------------------
+
+
+@pytest.mark.slow
+async def test_a_kill_in_the_pre_spawn_window_does_not_terminalise(home):
+    """Before the child persists anything, there is no row to have cancelled.
+
+    A run recorded as preparing, with no pid, must stay non-terminal: the
+    lifecycle store answers definitively that it knows of no session, and
+    "no record" is not "ended".
+    """
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": None,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "preparing",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+
+    # The store is real and readable; it simply has nothing under this run id.
+    assert _li(home, "lifecycle", run_id, "--machine").returncode == 0
+
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["spawn_state"] == "preparing"
+
+
+@pytest.mark.slow
+async def test_a_run_whose_pid_was_already_gone_still_reads_the_cancellation(home):
+    """The kill signals a pid that is not there, and records the row anyway.
+
+    Liveness cannot answer this: the process was gone before the kill. What
+    makes it terminal is the recorded cancellation, not the dead pid.
+    """
+    run_id = jobs.submit("agent", [], prompt="stay up")["run_id"]
+    session_id = _await_session_id(run_id)
+
+    # Stop the child ourselves, so the kill finds nothing to signal.
+    record = jobs._read_job(run_id)
+    assert _li_kill(home, session_id, record["pid"]).returncode == 0
+    deadline = time.monotonic() + 30.0
+    while jobs._pid_alive(record["pid"]) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert not jobs._pid_alive(record["pid"])
+
+    st = jobs.status(run_id)
+    assert st["alive"] is False
+    assert st["terminal"] is True
+    assert st["outcome"] == "cancelled"
+    assert st["possibly_orphaned"] is False
+
+
+# --- degradation ---------------------------------------------------------------
+
+
+def test_a_lifecycle_read_that_fails_leaves_the_run_where_it_was(home, monkeypatch):
+    """A read that cannot be made concludes nothing.
+
+    The command is replaced by one that exits non-zero with no envelope. The
+    run must come back exactly as it did before this seam existed — orphaned
+    and not terminal — never as a terminal it never earned.
+    """
+    monkeypatch.setattr(config, "li_command", lambda: [sys.executable, "-c", "raise SystemExit(3)"])
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    st = jobs.status(run_id)
+    assert st["status"] == "exited"
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["possibly_orphaned"] is True
+    # Nothing was cached, so a later read that succeeds is still free to answer.
+    assert jobs._read_job(run_id)["finished_at"] is None
+
+
+def test_a_lifecycle_read_that_times_out_leaves_the_run_where_it_was(home, monkeypatch):
+    """A command that never answers is a read that was not made."""
+    monkeypatch.setattr(jobs, "LIFECYCLE_TIMEOUT_SECONDS", 0.5)
+    monkeypatch.setattr(
+        config, "li_command", lambda: [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
+def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypatch):
+    """ "The store could not be read" must not arrive as "the run never ran".
+
+    The command answers with a well-formed envelope whose lifecycle value is
+    unavailable. That is a refusal to state a fact, and nothing may be
+    concluded from it.
+    """
+    envelope = {
+        "ok": True,
+        "contract_version": 1,
+        "data": {
+            "run_id": "x",
+            "lifecycle": {
+                "available": False,
+                "value": None,
+                "reason_code": "unreadable",
+                "detail": "disk on fire",
+            },
+        },
+        "error": None,
+    }
+    monkeypatch.setattr(
+        config,
+        "li_command",
+        lambda: [sys.executable, "-c", f"print({json.dumps(json.dumps(envelope))})"],
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    assert jobs._read_lifecycle(run_id) is None
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
+def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):
+    """The read is only made where the record cannot already answer.
+
+    A poll of a live run must not spawn a CLI process — a `wait` over several
+    running ids polls every second, and paying a subprocess per id per poll
+    would be a real cost for an answer the record already has.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        jobs,
+        "_read_lifecycle",
+        lambda run_id: pytest.fail("a live run must be answered from the record"),
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 4242,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+
+    assert jobs.status(run_id)["status"] == "running"
+
+
+# --- which store the read opens -------------------------------------------------
+
+
+async def test_a_run_in_a_configured_store_is_found_there(home, monkeypatch):
+    """`LIONAGI_STATE_DB_URL` moves the store, and the read has to follow it.
+
+    The reader opens whatever `StateDB()` resolves, which is the configured URL
+    when one is set. A precondition asked of the default path instead is asking
+    about a file that need not be involved at all: with the store configured
+    elsewhere the default is absent, so every run in the configured store reads
+    back as `unavailable`, and a caller that cannot distinguish "no store" from
+    "no such run" gets neither. The run below exists and is finished; the only
+    reason it could be missed is that the answer came from the wrong file.
+    """
+    from lionagi.state.db import StateDB
+
+    configured = home / "elsewhere" / "configured.db"
+    configured.parent.mkdir(parents=True)
+    run_id = "20260725T120000-c0ffee"
+
+    async with StateDB(configured) as db:
+        progression_id = uuid.uuid4().hex
+        await db.create_progression(progression_id)
+        await db.create_session(
+            {
+                "id": uuid.uuid4().hex[:12],
+                "progression_id": progression_id,
+                "run_id": run_id,
+                "status": "completed",
+                "invocation_kind": "agent",
+                "started_at": time.time(),
+                "ended_at": time.time(),
+            }
+        )
+
+    assert not (home / "state.db").exists(), "the default store must stay absent"
+    monkeypatch.setenv("LIONAGI_STATE_DB_URL", str(configured))
+
+    result = _li(home, "lifecycle", run_id, "--machine")
+    assert result.returncode == 0, result.stderr
+    envelope = json.loads(result.stdout)
+
+    lifecycle = envelope["data"]["lifecycle"]
+    assert lifecycle["available"] is True, lifecycle
+    assert lifecycle["value"]["found"] is True, lifecycle

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The observability verbs, end to end through the real subprocess.
+
+Nothing here mocks the child. The whole point of this surface is the composition
+between the argv the server renders and what the CLI's own parser makes of it,
+so a test that stubbed the subprocess would assert on the one half that cannot
+be wrong. Each test spawns the real ``li``, with ``LIONAGI_HOME`` pointed at a
+temporary directory so what it reads is a store this test made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+
+import pytest
+
+from lionagi.mcp import config, dispatch, verbs
+
+# Every verb in the tranche that answers with no arguments, so one parametrized
+# call covers the whole set the same way a caller would reach it.
+NO_ARGUMENT_VERBS = (
+    "monitor",
+    "stats.runs",
+    "invoke.list",
+    "dispatch.ls",
+    "state.ls",
+    "state.stats",
+    "team.list",
+)
+
+# Where each verb's payload puts the thing it read, so the availability wrapper
+# can be asserted on without a second list of names to keep in step.
+AVAILABILITY_KEY = {
+    "monitor": "entities",
+    "stats.runs": "groups",
+    "invoke.list": "invocations",
+    "dispatch.ls": "dispatches",
+    "state.ls": "sessions",
+    "state.stats": "row_counts",
+    "team.list": "teams",
+}
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A LIONAGI_HOME the child inherits, so no test reads a real store."""
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    return tmp_path
+
+
+def call(**kwargs):
+    return asyncio.run(dispatch.request(**kwargs))
+
+
+def run_op(op: str, args: dict | None = None) -> dict:
+    answer = call(ops=[{"op": op, "args": args or {}}])
+    return answer["ops"][0]
+
+
+def li(*argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*config.li_command(), *argv], capture_output=True, text=True, check=False, timeout=120
+    )
+
+
+def seed_invocation(skill: str = "observability-test") -> str:
+    """One invocation row, created the way anything else creates one."""
+    done = li("invoke", "start", "--skill", skill)
+    assert done.returncode == 0, done.stderr
+    return done.stdout.strip()
+
+
+# ── every verb answers the contract, through the real command ────────────────
+
+
+@pytest.mark.parametrize("verb", NO_ARGUMENT_VERBS)
+def test_a_verb_answers_with_the_versioned_envelope(home, verb):
+    op = run_op(verb)
+    assert op["ok"] is True, op
+    assert op["result"]["contract_version"] == 1
+    assert isinstance(op["result"]["data"], dict)
+
+
+@pytest.mark.parametrize("verb", NO_ARGUMENT_VERBS)
+def test_every_read_a_verb_makes_carries_whether_it_was_established(home, verb):
+    data = run_op(verb)["result"]["data"]
+    wrapper = data[AVAILABILITY_KEY[verb]]
+    assert set(wrapper) == {"available", "value", "reason_code", "detail"}
+
+
+@pytest.mark.parametrize(
+    "verb", ["monitor", "stats.runs", "invoke.list", "dispatch.ls", "state.ls", "state.stats"]
+)
+def test_a_store_that_does_not_exist_is_not_reported_as_zero_rows(home, verb):
+    # The distinction the whole availability wrapper exists for: a caller that
+    # has never run anything must not be told there are zero sessions in a
+    # database that was never created.
+    wrapper = run_op(verb)["result"]["data"][AVAILABILITY_KEY[verb]]
+    assert wrapper["available"] is False
+    assert wrapper["reason_code"] == "not_found"
+    assert str(home) in wrapper["detail"]
+
+
+def test_no_team_directory_at_all_is_a_definitive_zero(home):
+    # The opposite case, and why it is not the one above: a team file is only
+    # ever written by `li team create`, so nothing having been written is the
+    # complete answer rather than a read that failed.
+    teams = run_op("team.list")["result"]["data"]["teams"]
+    assert teams["available"] is True
+    assert teams["value"] == []
+
+
+# ── the rows a seeded store actually holds ───────────────────────────────────
+
+
+def test_a_listing_returns_the_row_the_cli_just_created(home):
+    invocation_id = seed_invocation()
+    invocations = run_op("invoke.list")["result"]["data"]["invocations"]
+    assert invocations["available"] is True
+    assert [row["id"] for row in invocations["value"]] == [invocation_id]
+    row = invocations["value"][0]
+    assert row["skill"] == "observability-test"
+    assert row["status"] == "running"
+    assert isinstance(row["started_at"], float)
+
+
+def test_the_running_row_is_what_monitor_reports_in_flight(home):
+    invocation_id = seed_invocation()
+    data = run_op("monitor")["result"]["data"]
+    entities = data["entities"]["value"]
+    assert [e["id"] for e in entities if e["kind"] == "invocation"] == [invocation_id]
+    # The caller is told the moment the observation was taken, so it can compute
+    # an elapsed time itself rather than be handed one against an unseen clock.
+    assert data["observed_at"] >= entities[0]["started_at"]
+
+
+def test_a_filter_reaches_the_child_parser_and_narrows_the_result(home):
+    seed_invocation("kept")
+    seed_invocation("dropped")
+    kept = run_op("invoke.list", {"skill": "kept"})["result"]["data"]["invocations"]["value"]
+    assert [row["skill"] for row in kept] == ["kept"]
+
+
+def test_a_store_that_exists_reports_its_size_and_journal_mode(home):
+    seed_invocation()
+    data = run_op("state.stats")["result"]["data"]
+    assert data["database"]["exists"] is True
+    assert data["database"]["size_bytes"] > 0
+    assert data["row_counts"]["available"] is True
+    assert set(data["row_counts"]["value"]) >= {"sessions", "branches", "messages"}
+    assert data["journal_mode"]["available"] is True
+
+
+def test_a_status_is_a_pair_and_never_a_placeholder_string(home):
+    seed_invocation()
+    spread = run_op("state.stats")["result"]["data"]["sessions_by_status"]["value"]
+    assert all(set(entry) == {"status", "count"} for entry in spread)
+
+
+# ── refusals arrive inside the envelope ──────────────────────────────────────
+
+
+def test_an_id_with_no_row_is_a_refusal_and_not_a_crash(home):
+    op = run_op("dispatch.show", {"id": "no-such-dispatch"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "not_found"
+    assert "no-such-dispatch" in op["error"]["message"]
+
+
+def test_a_plugin_nobody_installed_is_a_refusal_naming_it(home):
+    op = run_op("plugin.info", {"name": "no-such-plugin"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "not_found"
+
+
+def test_a_flag_that_only_shapes_the_printout_is_refused_with_its_reason(home):
+    # The trap the doctor verb documents: `--json` is real to the parser and
+    # meaningless past it, so admitting it would be accepted here and refused
+    # by the machine dispatcher one process later.
+    op = run_op("stats.runs", {"json": True})
+    assert op["ok"] is False
+    assert "shapes the human printout" in op["error"]["message"]
+
+
+def test_the_detail_view_is_refused_rather_than_changing_the_payload_shape(home):
+    op = run_op("monitor", {"id": "whatever"})
+    assert op["ok"] is False
+    assert "detail view" in op["error"]["message"]
+
+
+@pytest.mark.parametrize("verb", ["monitor", "state.ls", "invoke.list"])
+def test_a_parameter_nobody_declared_is_refused_by_name(home, verb):
+    op = run_op(verb, {"noSuchParameter": 1})
+    assert op["ok"] is False
+    assert "noSuchParameter" in op["error"]["message"]
+
+
+def test_a_window_that_cannot_be_parsed_is_refused_inside_the_envelope(home):
+    op = run_op("stats.runs", {"since": "yesterday"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "invalid_input"
+
+
+# ── what the surface deliberately does not reach ─────────────────────────────
+
+
+def test_the_plugin_listing_is_named_and_refused_with_why(home):
+    entry = next(e for e in call(help=True)["verbs"] if e["verb"] == "plugin.list")
+    assert entry["available"] is False
+    assert "trust" in entry["reason"]
+    op = run_op("plugin.list")
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "unavailable"
+
+
+def test_the_listing_that_prunes_trust_never_runs_from_this_surface(home):
+    # Reached the way it would be if someone registered it, straight at the CLI,
+    # to prove the refusal is in the command and not only in the registry.
+    done = li("plugin", "list", "--machine")
+    envelope = json.loads(done.stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "unavailable"
+    assert not (home / "settings.yaml").exists()
+
+
+@pytest.mark.parametrize(
+    ("command", "sub"),
+    [("state", "prune"), ("dispatch", "purge"), ("team", "send"), ("invoke", "start")],
+)
+def test_a_subcommand_that_writes_says_so_instead_of_running(home, command, sub):
+    done = li(command, sub, "--machine")
+    envelope = json.loads(done.stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "unavailable"
+
+
+def test_a_subcommand_nobody_has_is_bad_input_not_an_absent_seam(home):
+    envelope = json.loads(li("state", "not-a-subcommand", "--machine").stdout)
+    assert envelope["error"]["kind"] == "invalid_input"
+
+
+# ── one envelope on stdout, whatever the command wanted to print ─────────────
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("monitor", "--machine"),
+        ("state", "stats", "--machine"),
+        ("team", "list", "--machine"),
+        ("stats", "runs", "--machine"),
+    ],
+)
+def test_stdout_carries_exactly_one_json_object(home, argv):
+    done = li(*argv)
+    assert done.returncode == 0, done.stderr
+    envelope = json.loads(done.stdout)
+    assert done.stdout.strip().count("\n") == 0
+    assert envelope["contract_version"] == 1
+    assert envelope["ok"] is True
+
+
+def test_the_alias_reaches_the_same_result_as_the_command(home):
+    assert json.loads(li("mon", "--machine").stdout)["ok"] is True
+
+
+# ── the registry says what it can do ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", [*NO_ARGUMENT_VERBS, "dispatch.show", "plugin.info"])
+def test_the_verb_admits_only_parameters_its_machine_path_honours(verb):
+    registered = verbs.VERBS[verb]
+    schema = dispatch.verb_schema(registered)
+    assert registered.admits is not None, f"{verb} admits every projected parameter"
+    assert set(schema["properties"]) <= set(registered.admits)
+
+
+# ── a store that exists but will not open ────────────────────────────────────
+
+
+@pytest.fixture
+def unreadable_store(home):
+    """A real state.db this process cannot open, restored on the way out."""
+    seed_invocation()
+    store = home / "state.db"
+    assert store.exists(), "the seed did not create a store"
+    original = store.stat().st_mode
+    store.chmod(0o000)
+    try:
+        try:
+            store.open("rb").close()
+        except OSError:
+            pass
+        else:
+            pytest.skip("this process can read a mode-000 file, so there is nothing to test")
+        yield store
+    finally:
+        store.chmod(original)
+
+
+@pytest.mark.parametrize(
+    "verb", ["monitor", "stats.runs", "invoke.list", "dispatch.ls", "state.ls", "state.stats"]
+)
+def test_a_store_that_will_not_open_is_not_an_implementation_crash(unreadable_store, verb):
+    """Existing-but-unopenable is a third answer, and it is the store's, not ours.
+
+    `internal` is this contract's word for our own bug, and a consumer is
+    entitled to treat it as one — to stop, to report the tool as broken. A
+    permission or a lock is none of those things: it is a routine condition of
+    reading someone else's file, the caller can act on it, and it says nothing
+    about whether the rows exist. Reporting it as `internal` also puts a driver
+    exception string into a versioned contract, where the next release of that
+    driver quietly changes it.
+    """
+    op = run_op(verb)
+    assert op["ok"] is True, op
+    wrapper = op["result"]["data"][AVAILABILITY_KEY[verb]]
+    assert wrapper["available"] is False, wrapper
+    assert wrapper["reason_code"] == "unreadable", wrapper
+
+
+def test_a_detail_read_refuses_rather_than_claiming_the_record_is_missing(unreadable_store):
+    """`not_found` would be a claim about the record. We never reached it.
+
+    A detail read has no availability wrapper to put this in, so it has to
+    refuse — but the refusal a caller acts on differently is `unavailable`. Told
+    `not_found`, a caller stops looking for a dispatch that may be sitting in
+    the store it could not open.
+    """
+    op = run_op("dispatch.show", {"id": "whatever"})
+    assert op["ok"] is False, op
+    assert op["error"]["kind"] == "unavailable", op["error"]

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -46,6 +46,15 @@ REVIEWED_PATHS = frozenset(
         "orchestrate fanout",
         "orchestrate flow",
         "runs",
+        "dispatch ls",
+        "dispatch show",
+        "invoke list",
+        "monitor",
+        "plugin info",
+        "state ls",
+        "state stats",
+        "stats runs",
+        "team list",
     }
 )
 

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -50,6 +50,14 @@ GOLDEN_VERBS = (
     "stats runs",
     "studio start",
     "team send",
+    # The observability reads: every one of these is a path the surface now
+    # dispatches, so an argparse change under it must fail here rather than
+    # quietly reshape a schema a caller validated against.
+    "dispatch show",
+    "invoke list",
+    "plugin info",
+    "state stats",
+    "team list",
 )
 
 # Everything the MCP surface is a candidate to dispatch. `mirror` is

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -53,7 +53,8 @@ def _record(rid: str, **fields) -> None:
         ("completed", "succeeded", None),
         ("completed_empty", "failed", "no_artifacts"),
         ("timed_out", "failed", None),
-        ("cancelled", "failed", None),
+        ("cancelled", "cancelled", None),
+        ("aborted", "cancelled", None),
         ("a_status_this_build_never_heard_of", "failed", None),
     ],
 )


### PR DESCRIPTION
## The defect

Five columns in the state schema are foreign-key children with no index on them. Three point at `messages(id)` (`sessions.first_msg_id`, `sessions.last_msg_id`, `branches.system_msg_id`) and two at `progressions(id)`.

When a parent row is deleted, SQLite has to look for child rows still pointing at it. Without an index that search is a full scan of the referring table, and it happens once per deleted row. So the cost of a delete scales with the size of the store rather than with the number of rows being deleted — the shape that turns a small maintenance action into a long write-lock hold.

## Measurement

A 3.9 GB store (12,900 sessions, 941,584 messages), deleting the same 2,000 messages from byte-identical APFS clones so each run starts from the same state:

| configuration | wall clock | per row |
|---|---|---|
| foreign keys on, unindexed | 16.94s | 8.47 ms |
| foreign keys off | 1.48s | 0.74 ms |
| foreign keys on, indexed | 1.72s | 0.86 ms |

Enforcement against unindexed columns was roughly 90% of the work, and indexing recovers essentially all of it.

Downstream, on a batch delete of 100 sessions' worth of history: the message delete falls from 32.49s to 1.23s. A second process taking `BEGIN IMMEDIATE` alongside that delete, under the same five second busy timeout the daemon uses, went from 33 lock-outs in 270 attempts to **zero in 500**.

These numbers were taken on a loaded machine and are inflated in absolute terms; the ratios are the part worth relying on.

## Two deliberate choices

**Plain indexes, not partial ones.** The search SQLite runs to enforce a foreign key does not go through the query planner, so a partial index is not certain to serve it. The rows a `WHERE ... IS NOT NULL` predicate would exclude are few enough here that there is nothing to gain by finding out.

**The three session columns join the reconciled column set.** An index cannot be built on a column that does not exist yet, and schema application aborts rather than skipping it, so without this a store old enough to predate those columns would stop opening entirely. An existing migration test covers exactly that case: removing the reconciliation entry makes it fail with a foreign-key error while the rest of the suite stays green.

## Scope

Schema only — no behaviour change, no query rewritten, no caller touched. Indexes are transparent to every reader.

`tests/state tests/studio tests/apps_studio_server`: 2592 passed. (`test_dual_backend.py` and `test_metadata_create_all_postgres` are deselected for a missing `asyncpg` in this environment, which is unrelated and pre-existing.)
