### PR TITLE
feat(mcp): the roster a caller can name, answered by the resolver a run uses

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -371,6 +371,17 @@ def _unreadable_symlink_target(path: Path) -> str | None:
         return "<unreadable>"
 
 
+def _profile_path_candidates(agents_dir: Path, name: str) -> tuple[Path, ...]:
+    """Where NAME may live in one agents dir, in the order resolution tries them.
+
+    Two layouts share a directory, so a root can hold more than one declaration
+    of the same name. Anything reporting which files declare a profile has to
+    walk the same candidates in the same order as the resolver, or it reports a
+    displaced file in one root while missing one in another.
+    """
+    return (agents_dir / name / f"{name}.md", agents_dir / f"{name}.md")
+
+
 def _resolve_profile_path(
     agents_dir: Path,
     name: str,
@@ -378,8 +389,7 @@ def _resolve_profile_path(
     unreadable_symlinks: list[tuple[Path, str]] | None = None,
 ) -> Path | None:
     """Return profile path for NAME, recording unreadable candidate symlinks."""
-    candidates = (agents_dir / name / f"{name}.md", agents_dir / f"{name}.md")
-    for candidate in candidates:
+    for candidate in _profile_path_candidates(agents_dir, name):
         if candidate.is_file():
             return candidate
         target = _unreadable_symlink_target(candidate)

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -56,6 +56,7 @@ __all__ = (
     "build_deadline_preamble",
     "list_agents",
     "load_agent_profile",
+    "profile_config",
     "_parse_profile",
     "_resolve_profile_path",
     "_validate_bare_name",
@@ -426,29 +427,32 @@ def list_agents() -> list[str]:
     return sorted(seen)
 
 
-def build_agent_profile_catalog() -> dict[str, dict[str, Any]]:
-    """Index discoverable profiles by name and resolved runtime configuration.
+def profile_config(profile: AgentProfile) -> dict[str, Any]:
+    """The runtime configuration a loaded profile contributes, as plain JSON values.
 
-    Prompt bodies are deliberately omitted: the catalog is a discovery surface,
-    not a second path for exposing or copying profile instructions.
+    The one place that decides which fields a discovery surface reports — and
+    which it withholds. Prompt bodies are deliberately absent: discovery is not a
+    second path for exposing or copying profile instructions. Every reader of the
+    roster goes through here so they cannot disagree about either half.
     """
-    catalog: dict[str, dict[str, Any]] = {}
-    for name in list_agents():
-        profile = load_agent_profile(name)
-        catalog[name] = {
-            "model": profile.model,
-            "effort": profile.effort,
-            "role": profile.extra.get("role"),
-            "pack": profile.extra.get("pack"),
-            "yolo": profile.yolo,
-            "bypass": profile.bypass,
-            "fast_mode": profile.fast_mode,
-            "lion_system": profile.lion_system,
-            "khive_injection": profile.khive_injection,
-            "timeout": profile.timeout,
-            "resume_on_timeout": profile.resume_on_timeout,
-        }
-    return catalog
+    return {
+        "model": profile.model,
+        "effort": profile.effort,
+        "role": profile.extra.get("role"),
+        "pack": profile.extra.get("pack"),
+        "yolo": profile.yolo,
+        "bypass": profile.bypass,
+        "fast_mode": profile.fast_mode,
+        "lion_system": profile.lion_system,
+        "khive_injection": profile.khive_injection,
+        "timeout": profile.timeout,
+        "resume_on_timeout": profile.resume_on_timeout,
+    }
+
+
+def build_agent_profile_catalog() -> dict[str, dict[str, Any]]:
+    """Index discoverable profiles by name and resolved runtime configuration."""
+    return {name: profile_config(load_agent_profile(name)) for name in list_agents()}
 
 
 def _resolve_plugin_profile_path(name: str) -> Path | None:

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from . import config, jobs, projection
+from . import config, jobs, projection, roster
 from .verbs import (
     ABSENT,
     MAX_OPS,
@@ -498,6 +498,31 @@ async def _run_job(verb: Verb, args: dict[str, Any]) -> dict[str, Any]:
     return _JOB_EXECUTORS[verb.name](args)
 
 
+def _run_roster(verb: Verb, args: dict[str, Any]) -> dict[str, Any]:
+    """Answer a roster verb through the resolver a run itself uses.
+
+    Called in this process rather than spawned, because there is nothing here to
+    drift from: the profile loader is one function, and it is the same one the
+    spawned `li agent` calls. The one thing the subprocess boundary would have
+    carried for free is the working directory, so that is taken as an argument
+    and checked here — a run submitted with a bad cwd fails at spawn, and a
+    roster read of the same cwd should not answer for a different directory.
+    """
+    cwd = args.get("cwd")
+    if cwd is not None and not Path(cwd).expanduser().is_dir():
+        raise OpError("invalid_input", f"cwd {cwd!r} is not a directory")
+    try:
+        if verb.name == "profile.list":
+            return roster.profile_list(cwd=cwd)
+        return roster.profile_show(args["name"], cwd=cwd)
+    except FileNotFoundError as exc:
+        # The loader's own miss already names every available profile; re-listing
+        # them here would be a second answer that could disagree with it.
+        raise OpError("not_found", str(exc)) from exc
+    except ValueError as exc:
+        raise OpError("invalid_input", str(exc)) from exc
+
+
 def _run_machine(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
     """Run the verb's CLI path as a subprocess and return its versioned envelope.
 
@@ -686,6 +711,8 @@ async def _run_one(entry: Any) -> dict[str, Any]:
             result = _run_spawn(verb, schema, args)
         elif verb.executor == "job":
             result = await _run_job(verb, args)
+        elif verb.executor == "roster":
+            result = _run_roster(verb, args)
         else:
             result = _run_machine(verb, schema, args)
     except OpError as exc:

--- a/lionagi/mcp/roster.py
+++ b/lionagi/mcp/roster.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The agent roster: which profile names exist here, and what one of them runs.
+
+``agent.submit`` takes ``agent=<name>`` and nothing on this surface said which
+names it would accept or what one of them would do. Finding out meant leaving the
+tool surface, listing ``~/.lionagi/agents/`` by hand, and guessing whether a
+project directory shadowed it. These two verbs answer both questions here.
+
+What makes the answer worth trusting is that it is not computed here. Both verbs
+call ``load_agent_profile`` and ``build_agent_profile_catalog`` from
+:mod:`lionagi.cli._providers` — the same functions the spawned ``li agent`` calls
+when it turns ``-a NAME`` into a model, an effort and a set of flags. A second
+reader of the same files would drift from the first, and the drift would be
+invisible in the worst way: the verb would report one model, the run would use
+another, and the caller would have no reason to doubt the verb.
+
+Two properties of that resolver shape what these verbs have to accept and report.
+
+Resolution reads the working directory live — git root, then the working
+directory and each parent, then ``~/.lionagi/`` — and a submitted run's working
+directory is the ``cwd`` argument, not this server's. So both verbs take the same
+``cwd`` and resolve under it; without it they would answer accurately about the
+server's roster and misleadingly about the run's.
+
+Precedence is whole-file. The first file found wins outright: a project profile
+does not merge its fields over a global one of the same name, it replaces it. So
+the winning file is reported as ``source`` and every displaced file as
+``shadowed``, rather than being merged into a single view that no code produces.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+__all__ = ("profile_list", "profile_show")
+
+
+@contextmanager
+def _resolving_under(cwd: str | None):
+    """Run the resolver with the working directory a submitted run would have.
+
+    The change is process-wide, which is safe here only because everything
+    between the two calls is synchronous: dispatch awaits one op at a time, and
+    an op that never awaits cannot interleave with another one.
+    """
+    if cwd is None:
+        yield
+        return
+    previous = os.getcwd()
+    os.chdir(Path(cwd).expanduser())
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _scope(lionagi_dir: Path) -> str:
+    return "global" if lionagi_dir == Path.home() / ".lionagi" else "project"
+
+
+def _roots() -> list[dict[str, Any]]:
+    """The agent directories the resolver would search, in the order it searches them.
+
+    A root with no ``agents/`` subdirectory is still listed, marked absent: that
+    is why a name a caller expected to find is missing, and dropping it silently
+    would leave the caller with an empty list and no explanation.
+    """
+    from lionagi._paths import find_lionagi_dirs
+
+    return [
+        {
+            "path": str(d / "agents"),
+            "scope": _scope(d),
+            "exists": (d / "agents").is_dir(),
+        }
+        for d in find_lionagi_dirs()
+    ]
+
+
+def _placement(name: str) -> dict[str, Any]:
+    """Every file declaring *name*, in resolution order — the first one is what runs.
+
+    Built from the same per-directory resolver ``load_agent_profile`` uses, and
+    walked in the same order, so the file named here is the file that was read.
+    """
+    from lionagi._paths import find_lionagi_dirs
+    from lionagi.cli._providers import _resolve_plugin_profile_path, _resolve_profile_path
+
+    found: list[dict[str, str]] = []
+    if "/" not in name:
+        for d in find_lionagi_dirs():
+            path = _resolve_profile_path(d / "agents", name)
+            if path is not None:
+                found.append({"path": str(path), "scope": _scope(d)})
+    plugin_path = _resolve_plugin_profile_path(name)
+    if plugin_path is not None:
+        found.append({"path": str(plugin_path), "scope": "plugin"})
+    return {"source": found[0] if found else None, "shadowed": found[1:]}
+
+
+def profile_list(*, cwd: str | None = None) -> dict[str, Any]:
+    """Every profile name ``agent.submit`` would accept here, and what each resolves to."""
+    from lionagi.cli._providers import build_agent_profile_catalog
+
+    with _resolving_under(cwd):
+        catalog = build_agent_profile_catalog()
+        profiles = [
+            {"name": name, **_placement(name), "resolved": config}
+            for name, config in sorted(catalog.items())
+        ]
+        return {
+            "cwd": os.getcwd(),
+            "roots": _roots(),
+            "profiles": profiles,
+            "count": len(profiles),
+        }
+
+
+def profile_show(name: str, *, cwd: str | None = None) -> dict[str, Any]:
+    """What one named profile resolves to, and which file it came from.
+
+    A name nothing declares raises ``FileNotFoundError`` from the loader itself,
+    carrying the loader's own list of what is available.
+    """
+    from lionagi.cli._providers import load_agent_profile, profile_config
+
+    with _resolving_under(cwd):
+        profile = load_agent_profile(name)
+        return {
+            "cwd": os.getcwd(),
+            "name": name,
+            **_placement(name),
+            "resolved": profile_config(profile),
+            # Frontmatter keys the loader recognised no runtime meaning for,
+            # by name only: enough to see that a profile declares something
+            # extra, without turning this into a second route to its contents.
+            "declared_extra_keys": sorted(profile.extra),
+        }

--- a/lionagi/mcp/roster.py
+++ b/lionagi/mcp/roster.py
@@ -88,14 +88,18 @@ def _placement(name: str) -> dict[str, Any]:
     walked in the same order, so the file named here is the file that was read.
     """
     from lionagi._paths import find_lionagi_dirs
-    from lionagi.cli._providers import _resolve_plugin_profile_path, _resolve_profile_path
+    from lionagi.cli._providers import _profile_path_candidates, _resolve_plugin_profile_path
 
     found: list[dict[str, str]] = []
     if "/" not in name:
         for d in find_lionagi_dirs():
-            path = _resolve_profile_path(d / "agents", name)
-            if path is not None:
-                found.append({"path": str(path), "scope": _scope(d)})
+            # Every candidate in the root, not just the winning one: the two
+            # layouts share a directory, so a single root can hold two
+            # declarations of the same name and the loser is displaced just as
+            # surely as one in a root further down.
+            for path in _profile_path_candidates(d / "agents", name):
+                if path.is_file():
+                    found.append({"path": str(path), "scope": _scope(d)})
     plugin_path = _resolve_plugin_profile_path(name)
     if plugin_path is not None:
         found.append({"path": str(plugin_path), "scope": "plugin"})

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -37,7 +37,8 @@ mcp = FastMCP(SERVER_NAME)
 _OPS_DESCRIPTION = (
     "Operations to run, each {'op': '<verb>', 'args': {...}}. Verbs are namespaced: "
     "agent.submit, flow.submit, fanout.submit, play.submit spawn background runs; "
-    "job.status, job.output, job.list, job.wait, job.kill observe and control them. "
+    "job.status, job.output, job.list, job.wait, job.kill observe and control them; "
+    "profile.list, profile.show say which agent profiles exist here and what one runs. "
     "Call with help=true first for the full catalog with each verb's required "
     "parameters. Ops run in order; a failing op returns ok=false and does not stop "
     "the ops beside it."

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -306,6 +306,35 @@ _JOB_WAIT_SCHEMA = _own(
 
 _SERVER_INFO_SCHEMA = _own({})
 
+# Profile resolution reads the working directory live, and a submitted run's
+# working directory is this same argument. Answering under the server's own
+# directory instead would be accurate about the wrong roster.
+_ROSTER_CWD = {
+    "type": "string",
+    "description": (
+        "Resolve as a run submitted with this cwd would: the search starts at its "
+        "git root, walks up from it, then reaches ~/.lionagi/. Omit it to answer "
+        "for the server's own directory, which is what a submit without cwd gets."
+    ),
+}
+
+_PROFILE_LIST_SCHEMA = _own({"cwd": _ROSTER_CWD})
+
+_PROFILE_SHOW_SCHEMA = _own(
+    {
+        "name": {
+            "type": "string",
+            "description": (
+                "The profile name, as it would be passed to agent.submit. A name "
+                "nothing declares is an error listing every name that is available "
+                "here, rather than an empty result."
+            ),
+        },
+        "cwd": _ROSTER_CWD,
+    },
+    ["name"],
+)
+
 
 # ── the registry ─────────────────────────────────────────────────────────────
 
@@ -380,6 +409,24 @@ _REGISTERED: tuple[Verb, ...] = (
         summary="Stop a background job by signalling the process group this server created.",
         executor="job",
         own_schema=_JOB_KILL_SCHEMA,
+    ),
+    Verb(
+        name="profile.list",
+        summary=(
+            "Agent profiles agent.submit would accept here, each with the file it "
+            "comes from and the configuration it resolves to."
+        ),
+        executor="roster",
+        own_schema=_PROFILE_LIST_SCHEMA,
+    ),
+    Verb(
+        name="profile.show",
+        summary=(
+            "What one agent profile name resolves to: its winning file, the files "
+            "it shadows, and its effective configuration."
+        ),
+        executor="roster",
+        own_schema=_PROFILE_SHOW_SCHEMA,
     ),
     Verb(
         name="server.info",

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The roster verbs: which agent profiles exist here, and what one of them runs.
+
+A caller submits a run by naming a profile, so the value of these verbs is
+entirely in whether their answer is the answer the run would get. That is what
+these assert: the same file wins, the reported configuration is the one the
+loader produced, and a name that does not exist comes back naming the ones that
+do rather than as an empty result.
+
+Every root here is a temp directory. Nothing in this file may read the real
+``~/.lionagi/agents/``, which is why HOME is redirected and the working directory
+moved before any resolution happens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli._providers import load_agent_profile
+from lionagi.mcp import dispatch
+
+
+def call(**kwargs):
+    return asyncio.run(dispatch.request(**kwargs))
+
+
+def op(name: str, args: dict | None = None) -> dict:
+    """Run one roster op and return its entry, which may be a failure."""
+    return call(ops=[{"op": name, "args": args or {}}])["ops"][0]
+
+
+def write_profile(agents_dir: Path, name: str, body: str) -> Path:
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / f"{name}.md"
+    path.write_text(body)
+    return path
+
+
+@pytest.fixture
+def roots(monkeypatch, tmp_path: Path):
+    """A global root and a project root, both under a temp directory.
+
+    HOME is redirected and the working directory moved into the project, because
+    the resolver reads both live and would otherwise walk up into whatever real
+    ``.lionagi/`` sits above the checkout.
+    """
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    global_agents = home / ".lionagi" / "agents"
+    project_agents = project / ".lionagi" / "agents"
+    global_agents.mkdir(parents=True)
+    project_agents.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.chdir(project)
+    # A temp directory is not a git repository, so the git-root probe finds
+    # nothing and the walk starts at the working directory.
+    return type(
+        "Roots",
+        (),
+        {"home": home, "project": project, "glob": global_agents, "proj": project_agents},
+    )()
+
+
+# ── the list ─────────────────────────────────────────────────────────────────
+
+
+def test_the_list_covers_both_roots_and_says_which_one_each_came_from(roots):
+    write_profile(roots.glob, "archivist", "---\nmodel: openai/gpt-4.1-mini\n---\nbody\n")
+    write_profile(roots.proj, "builder", "---\nmodel: anthropic/claude\n---\nbody\n")
+
+    result = op("profile.list")
+    assert result["ok"] is True, result
+    by_name = {p["name"]: p for p in result["result"]["profiles"]}
+
+    assert sorted(by_name) == ["archivist", "builder"]
+    assert by_name["archivist"]["source"]["scope"] == "global"
+    assert by_name["builder"]["source"]["scope"] == "project"
+    assert by_name["archivist"]["source"]["path"] == str(roots.glob / "archivist.md")
+    assert result["result"]["count"] == 2
+
+
+def test_the_list_names_the_roots_it_searched(roots):
+    # Without them, an empty list and a missing directory are the same answer.
+    scopes = [r["scope"] for r in op("profile.list")["result"]["roots"]]
+    assert scopes == ["project", "global"]
+
+
+def test_the_list_reports_what_the_loader_produced_not_what_the_file_says(roots):
+    # The file declares a timeout the loader rejects; reporting the declared
+    # value would tell a caller a run will do something it will not do.
+    write_profile(roots.proj, "builder", "---\nmodel: m\ntimeout: -5\n---\nbody\n")
+    entry = op("profile.list")["result"]["profiles"][0]
+    assert entry["resolved"]["timeout"] is None
+    assert entry["resolved"]["timeout"] == load_agent_profile("builder").timeout
+
+
+def test_the_list_withholds_the_prompt_body(roots):
+    write_profile(roots.proj, "builder", "---\nmodel: m\n---\nsecret instructions\n")
+    entry = op("profile.list")["result"]["profiles"][0]
+    assert "secret instructions" not in str(entry)
+
+
+# ── precedence ───────────────────────────────────────────────────────────────
+
+
+def test_a_name_in_both_roots_resolves_to_the_project_one(roots):
+    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\neffort: low\n---\nglobal\n")
+    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\n---\nproject\n")
+
+    result = op("profile.show", {"name": "reviewer"})
+    assert result["ok"] is True, result
+    shown = result["result"]
+
+    assert shown["source"]["path"] == str(roots.proj / "reviewer.md")
+    assert shown["source"]["scope"] == "project"
+    assert shown["resolved"]["model"] == "project-model"
+    # Whole-file precedence, not a field merge: the global file's effort is
+    # displaced, not inherited.
+    assert shown["resolved"]["effort"] is None
+    assert shown["shadowed"] == [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}]
+
+
+def test_the_verb_agrees_with_the_loader_a_run_would_use(roots):
+    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\n---\nglobal\n")
+    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\neffort: high\n---\np\n")
+
+    shown = op("profile.show", {"name": "reviewer"})["result"]["resolved"]
+    loaded = load_agent_profile("reviewer")
+    assert (shown["model"], shown["effort"]) == (loaded.model, loaded.effort)
+
+
+def test_an_unshadowed_name_reports_nothing_shadowed(roots):
+    write_profile(roots.glob, "archivist", "---\nmodel: m\n---\nbody\n")
+    shown = op("profile.show", {"name": "archivist"})["result"]
+    assert shown["shadowed"] == []
+    assert shown["source"]["scope"] == "global"
+
+
+# ── a name that is not there ─────────────────────────────────────────────────
+
+
+def test_an_unknown_name_is_an_error_naming_the_alternatives(roots):
+    write_profile(roots.glob, "archivist", "---\nmodel: m\n---\nbody\n")
+    write_profile(roots.proj, "builder", "---\nmodel: m\n---\nbody\n")
+
+    result = op("profile.show", {"name": "ghost"})
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "not_found"
+    message = result["error"]["message"]
+    assert "ghost" in message
+    assert "archivist" in message and "builder" in message
+
+
+def test_a_name_the_validator_refuses_is_invalid_input_not_a_miss(roots):
+    result = op("profile.show", {"name": "../escape"})
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "invalid_input"
+
+
+# ── the working directory the answer is about ────────────────────────────────
+
+
+def test_resolution_follows_the_cwd_a_run_would_be_submitted_with(roots, tmp_path: Path):
+    write_profile(roots.proj, "builder", "---\nmodel: here\n---\nbody\n")
+    elsewhere = tmp_path / "elsewhere"
+    write_profile(elsewhere / ".lionagi" / "agents", "builder", "---\nmodel: there\n---\nb\n")
+
+    assert op("profile.show", {"name": "builder"})["result"]["resolved"]["model"] == "here"
+    under = op("profile.show", {"name": "builder", "cwd": str(elsewhere)})["result"]
+    assert under["resolved"]["model"] == "there"
+    assert under["cwd"] == str(elsewhere)
+
+
+def test_the_working_directory_is_restored_after_a_cwd_scoped_read(roots, tmp_path: Path):
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / ".lionagi" / "agents").mkdir(parents=True)
+    before = Path.cwd()
+    op("profile.list", {"cwd": str(elsewhere)})
+    assert Path.cwd() == before
+
+
+def test_a_cwd_that_is_not_a_directory_is_refused_by_name(roots, tmp_path: Path):
+    result = op("profile.list", {"cwd": str(tmp_path / "nowhere")})
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "invalid_input"
+    assert "nowhere" in result["error"]["message"]
+
+
+# ── the shape of the surface ─────────────────────────────────────────────────
+
+
+def test_the_roster_verbs_are_in_the_catalog_with_their_signature():
+    entries = {e["verb"]: e for e in call(help=True)["verbs"]}
+    assert entries["profile.list"]["available"] is True
+    assert entries["profile.show"]["required"] == ["name"]
+
+
+def test_a_roster_read_needs_no_schema_fingerprint():
+    # Fingerprints gate the spawn verbs. A read that demanded one would cost a
+    # round-trip for nothing, and none of the job reads demand one either.
+    assert "schema_fingerprint" not in call(help="profile.show")
+
+
+def test_an_unknown_parameter_is_refused_by_name(roots):
+    result = op("profile.list", {"root": "/tmp"})
+    assert result["ok"] is False
+    assert "root" in result["error"]["message"]

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from lionagi.cli._providers import load_agent_profile
+from lionagi.cli._providers import load_agent_profile, profile_config
 from lionagi.mcp import dispatch
 
 
@@ -126,13 +126,59 @@ def test_a_name_in_both_roots_resolves_to_the_project_one(roots):
     assert shown["shadowed"] == [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}]
 
 
+def test_the_two_layouts_in_one_root_shadow_each_other_too(roots):
+    """A root holds two layouts, so it can hold two declarations of one name.
+
+    The loser here is displaced exactly as surely as a file in a root further
+    down, and it is easier to miss: reporting only the winning path per root
+    hides it, and the caller reads an empty shadowed list as "nothing else
+    declares this".
+    """
+    directory_layout = roots.proj / "reviewer" / "reviewer.md"
+    directory_layout.parent.mkdir(parents=True)
+    directory_layout.write_text("---\nmodel: directory-model\n---\ndirectory\n")
+    flat_layout = write_profile(roots.proj, "reviewer", "---\nmodel: flat-model\n---\nflat\n")
+
+    shown = op("profile.show", {"name": "reviewer"})["result"]
+
+    assert shown["source"]["path"] == str(directory_layout)
+    assert shown["resolved"]["model"] == "directory-model"
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
+
+
+def test_a_same_root_loser_is_listed_before_a_further_root(roots):
+    # Shadowed is in resolution order, so the file that came closest to winning
+    # comes first -- which is the one to delete if the wrong profile ran.
+    directory_layout = roots.proj / "reviewer" / "reviewer.md"
+    directory_layout.parent.mkdir(parents=True)
+    directory_layout.write_text("---\nmodel: directory-model\n---\ndirectory\n")
+    flat_layout = write_profile(roots.proj, "reviewer", "---\nmodel: flat-model\n---\nflat\n")
+    global_layout = write_profile(roots.glob, "reviewer", "---\nmodel: g\n---\nglobal\n")
+
+    shown = op("profile.show", {"name": "reviewer"})["result"]
+
+    assert [entry["path"] for entry in shown["shadowed"]] == [
+        str(flat_layout),
+        str(global_layout),
+    ]
+
+
 def test_the_verb_agrees_with_the_loader_a_run_would_use(roots):
-    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\n---\nglobal\n")
-    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\neffort: high\n---\np\n")
+    """Compared on a profile that declares almost nothing, and on every field.
+
+    Both halves are load-bearing. Two fields are not enough — a roster that
+    parsed a couple for itself would pass and disagree with the run about the
+    rest. And a profile with everything set is not enough either: a reader
+    supplying its own default only diverges where the file is silent, so a fully
+    populated fixture agrees with any defaulting logic at all.
+    """
+    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\neffort: high\n---\ng\n")
+    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\n---\nproject\n")
 
     shown = op("profile.show", {"name": "reviewer"})["result"]["resolved"]
-    loaded = load_agent_profile("reviewer")
-    assert (shown["model"], shown["effort"]) == (loaded.model, loaded.effort)
+    assert shown == profile_config(load_agent_profile("reviewer"))
+    assert shown["model"] == "project-model"
+    assert [key for key, value in shown.items() if value is None]
 
 
 def test_an_unshadowed_name_reports_nothing_shadowed(roots):


### PR DESCRIPTION
Submitting a run means naming an agent profile, and until now nothing on the MCP surface said which names exist or what one of them does. The way to find out was to leave the tool surface, list the agents directory by hand, and guess whether a project-local file shadowed the global one.

`profile.list` and `profile.show` close that gap.

## Why they can be trusted

Neither verb computes an answer of its own. Both call `load_agent_profile` and `build_agent_profile_catalog` — the same functions the spawned `li agent` calls when it turns `-a NAME` into a model and an effort. A second reader of the same files would eventually drift from the first, and the drift would be invisible in the worst way: the verb reporting one model while the run actually used another.

Submitting is unchanged. It never resolved the name in-process to begin with — it renders the argv and the spawned CLI resolves it — so both paths already met at one function and no code on the submit path was touched.

## Two properties of that resolver, surfaced rather than hidden

**Resolution reads the working directory live.** A run's working directory is the `cwd` argument, not the server's, so both verbs take the same `cwd` and echo back the roots they used. Asking about profiles from one directory and running from another would otherwise give a confident wrong answer.

**Precedence is whole-file, not a field merge.** The first file found wins outright: a project file carrying only `model:` does not inherit the global file's `effort:`. So the winning file is reported as `source` and every displaced file as `shadowed`, rather than being merged into a composite view that no code path actually produces.

## Shared field selection

The per-profile field selection moves out of `build_agent_profile_catalog` into `profile_config`, so the two readers cannot disagree about which fields a profile carries — or about the prompt bodies both deliberately withhold, since discovery is not a second route for copying instructions. Same keys, same values, same order.

## Tests

`tests/mcp/test_roster.py`, 15 tests. Each was proven able to fail by reverting exactly the change it guards, producing one distinct failure per property.

Suites: `tests/mcp tests/cli` — 2453 passed, 2 skipped, 1 failed. The failure is `test_pack_routing_shown_in_dry_run`, which depends on the contents of the developer's home directory and fails identically on a tree without these changes.
