### PR TITLE
fix(log): keep base64 image payloads out of the log files

### DIFF
--- a/lionagi/config.py
+++ b/lionagi/config.py
@@ -91,6 +91,11 @@ class AppSettings(BaseSettings, frozen=True):
     LOG_FILE_PREFIX: str = "log"
     LOG_AUTO_SAVE_ON_EXIT: bool = True
     LOG_CLEAR_AFTER_DUMP: bool = True
+    # Keep base64 image/audio payloads out of the log files; each entry keeps a
+    # placeholder naming the field, media type and byte length. Set false to log
+    # payloads verbatim, at the cost of log files as large as the media.
+    LOG_REDACT_BINARY: bool = True
+    LOG_REDACT_BINARY_THRESHOLD: int = 1024
 
     _instance: ClassVar[Any] = None
 
@@ -123,6 +128,8 @@ class AppSettings(BaseSettings, frozen=True):
             "file_prefix": self.LOG_FILE_PREFIX,
             "auto_save_on_exit": self.LOG_AUTO_SAVE_ON_EXIT,
             "clear_after_dump": self.LOG_CLEAR_AFTER_DUMP,
+            "redact_binary": self.LOG_REDACT_BINARY,
+            "redact_binary_threshold": self.LOG_REDACT_BINARY_THRESHOLD,
         }
 
 

--- a/lionagi/protocols/generic/log.py
+++ b/lionagi/protocols/generic/log.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +24,101 @@ __all__ = (
     "Log",
     "DataLogger",
     "LogManager",
+    "redact_binary_content",
 )
 
 logger = logging.getLogger(__name__)
+
+
+# A base64 data URI, e.g. "data:image/png;base64,iVBOR..." — the media type is
+# optional per RFC 2397 and further parameters may sit between it and ";base64".
+_DATA_URI_RE = re.compile(r"^data:([-\w.+]+/[-\w.+]+)?(?:;[-\w.+=]+)*;base64,")
+
+# Bare (not data-URI-wrapped) base64 is only redacted under keys that provider
+# schemas use for binary: Anthropic image blocks, Ollama multimodal messages,
+# OpenAI image generation, and audio input. Under any other key a base64-shaped
+# string is more likely to be an id or a token than an image.
+_BINARY_KEYS = frozenset({"data", "b64_json", "image", "images", "audio", "input_audio"})
+
+_BARE_B64_RE = re.compile(r"^[A-Za-z0-9+/]+={0,2}$")
+
+
+def _b64_decoded_size(payload: str) -> int:
+    """Decoded byte length of a base64 string, computed without decoding it."""
+    return max(0, len(payload) * 3 // 4 - payload.count("="))
+
+
+def _placeholder(key: str | None, media_type: str | None, size: int) -> str:
+    parts = ["<lionagi:redacted-binary"]
+    if key:
+        parts.append(f"field={key}")
+    if media_type:
+        parts.append(f"media_type={media_type}")
+    parts.append(f"bytes={size}>")
+    return " ".join(parts)
+
+
+def _redact_str(value: str, key: str | None, media_type: str | None, threshold: int) -> str:
+    # Cheap length gate first: nothing under the threshold can be redacted, and
+    # this keeps the regexes off the short strings that dominate a payload.
+    if len(value) * 3 // 4 < threshold:
+        return value
+
+    if match := _DATA_URI_RE.match(value):
+        payload = value[match.end() :]
+        size = _b64_decoded_size(payload)
+        if size >= threshold:
+            return _placeholder(key, match.group(1) or media_type, size)
+        return value
+
+    # Real base64 is padded to a multiple of 4; requiring that, plus an
+    # alphabet with no whitespace or punctuation, keeps prose out.
+    if key in _BINARY_KEYS and len(value) % 4 == 0 and _BARE_B64_RE.match(value):
+        size = _b64_decoded_size(value)
+        if size >= threshold:
+            return _placeholder(key, media_type, size)
+
+    return value
+
+
+def redact_binary_content(
+    data: Any,
+    *,
+    threshold: int = 1024,
+    _key: str | None = None,
+    _media_type: str | None = None,
+) -> Any:
+    """Return `data` with base64 binary payloads replaced by placeholders.
+
+    Never mutates its input: subtrees with nothing to redact are returned by
+    identity, so the caller's object -- including a payload already queued for a
+    provider -- is unchanged.
+    """
+    if isinstance(data, dict):
+        media_type = data.get("media_type") or data.get("mime_type") or _media_type
+        out = None
+        for k, v in data.items():
+            new = redact_binary_content(v, threshold=threshold, _key=k, _media_type=media_type)
+            if new is not v:
+                if out is None:
+                    out = dict(data)
+                out[k] = new
+        return data if out is None else out
+
+    if isinstance(data, list):
+        out = None
+        for i, v in enumerate(data):
+            new = redact_binary_content(v, threshold=threshold, _key=_key, _media_type=_media_type)
+            if new is not v:
+                if out is None:
+                    out = list(data)
+                out[i] = new
+        return data if out is None else out
+
+    if isinstance(data, str):
+        return _redact_str(data, _key, _media_type, threshold)
+
+    return data
 
 
 class DataLoggerConfig(BaseModel):
@@ -38,6 +131,12 @@ class DataLoggerConfig(BaseModel):
     hash_digits: int | None = Field(5, ge=0, le=10)
     auto_save_on_exit: bool = True
     clear_after_dump: bool = True
+    # Base64 binary (images, audio) is replaced by a placeholder naming the
+    # field, media type and byte length. On by default: a vision workload logs
+    # its payloads verbatim otherwise, and the bytes are unreadable in a log
+    # while being most of its size.
+    redact_binary: bool = True
+    redact_binary_threshold: int = Field(1024, ge=0)  # decoded bytes
 
     @field_validator("capacity", "hash_digits", mode="before")
     def _validate_non_negative(cls, value):
@@ -118,12 +217,29 @@ class DataLogger:
     def log(self, log_: Any) -> None:
         """Add a log entry; auto-dumps to file if capacity is reached."""
         log_ = Log.create(log_) if not isinstance(log_, Log) else log_
+        log_ = self._redact(log_)
         if self._config.capacity and len(self.logs) >= self._config.capacity:
             try:
                 self.dump(clear=self._config.clear_after_dump)
             except Exception as e:
                 logger.error(f"Failed to auto-dump logs: {e}")
         self.logs.include(log_)
+
+    def _redact(self, log_: Log) -> Log:
+        """Swap binary payloads for placeholders on the way into the store.
+
+        Works on the Log's own snapshot dict, never on the object that was
+        logged -- an APICalling's payload is still queued for the provider when
+        this runs, and rewriting it would change the request.
+        """
+        if not self._config.redact_binary:
+            return log_
+        content = redact_binary_content(
+            log_.content, threshold=self._config.redact_binary_threshold
+        )
+        if content is log_.content:
+            return log_
+        return Log.from_dict({**log_.to_dict(), "content": content})
 
     async def alog(self, log_: Any) -> None:
         """Async variant of log(); auto-dumps to file if capacity is reached."""

--- a/tests/protocols/generic/test_log_redaction.py
+++ b/tests/protocols/generic/test_log_redaction.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Binary payloads must not reach the log files, and the payload sent to the
+provider must be identical whether or not redaction is on."""
+
+import base64
+import copy
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from lionagi.protocols.generic.log import (
+    DataLogger,
+    DataLoggerConfig,
+    Log,
+    redact_binary_content,
+)
+
+IMAGE_BYTES = 48 * 1024
+B64 = base64.b64encode(os.urandom(IMAGE_BYTES)).decode("ascii")
+PNG_URI = f"data:image/png;base64,{B64}"
+
+
+def _vision_payload() -> dict:
+    return {
+        "model": "gpt-4.1-mini",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": PNG_URI, "detail": "auto"},
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _dump(logger: DataLogger, tmp_path: Path, name: str = "out.json") -> tuple[int, dict]:
+    fp = tmp_path / name
+    logger.dump(clear=False, persist_path=fp)
+    return fp.stat().st_size, json.loads(fp.read_text())
+
+
+# --- the reported case ------------------------------------------------------
+
+
+def test_image_payload_is_not_written_to_the_log_file(tmp_path):
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    logger.log({"payload": _vision_payload()})
+
+    size, data = _dump(logger, tmp_path)
+
+    assert B64 not in json.dumps(data)
+    # The 48 KiB image becomes a placeholder; the whole file stays far under
+    # the size of the raw payload it replaced.
+    assert size < IMAGE_BYTES // 8
+
+    url = data["content"]["payload"]["messages"][0]["content"][1]["image_url"]["url"]
+    assert url.startswith("<lionagi:redacted-binary")
+    assert "field=url" in url
+    assert "media_type=image/png" in url
+    assert f"bytes={IMAGE_BYTES}" in url
+
+
+def test_redaction_does_not_mutate_the_payload_sent_to_the_provider(tmp_path):
+    """The object the caller holds -- and hands to the endpoint -- is untouched."""
+    payload = _vision_payload()
+    before = copy.deepcopy(payload)
+
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    logger.log({"payload": payload})
+    _dump(logger, tmp_path)
+
+    assert payload == before
+    assert payload["messages"][0]["content"][1]["image_url"]["url"] == PNG_URI
+
+
+def test_redaction_survives_an_api_calling_event(tmp_path):
+    """End to end over the type actually logged by branch.emit_and_log()."""
+    from lionagi.service.connections.api_calling import APICalling
+    from lionagi.service.imodel import iModel
+
+    imodel = iModel(provider="openai", model="gpt-4.1-mini", api_key="dummy")
+    payload = _vision_payload()
+    call = APICalling(endpoint=imodel.endpoint, payload=payload, headers={})
+
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    logger.log(call)
+    size, data = _dump(logger, tmp_path)
+
+    assert B64 not in json.dumps(data)
+    assert size < IMAGE_BYTES // 8
+    # The live event still carries the real bytes for the request.
+    assert call.payload["messages"][0]["content"][1]["image_url"]["url"] == PNG_URI
+
+
+# --- the knob ---------------------------------------------------------------
+
+
+def test_redaction_is_on_by_default():
+    assert DataLoggerConfig().redact_binary is True
+
+
+def test_redaction_can_be_turned_off(tmp_path):
+    logger = DataLogger(
+        persist_dir=str(tmp_path),
+        auto_save_on_exit=False,
+        capacity=None,
+        redact_binary=False,
+    )
+    logger.log({"payload": _vision_payload()})
+    size, data = _dump(logger, tmp_path)
+
+    assert B64 in json.dumps(data)
+    assert size > IMAGE_BYTES
+
+
+def test_threshold_keeps_small_payloads(tmp_path):
+    small = base64.b64encode(b"x" * 64).decode("ascii")
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    logger.log({"url": f"data:image/png;base64,{small}"})
+    _, data = _dump(logger, tmp_path)
+
+    assert data["content"]["url"].endswith(small)
+
+
+def test_threshold_is_configurable(tmp_path):
+    small = base64.b64encode(b"x" * 64).decode("ascii")
+    logger = DataLogger(
+        persist_dir=str(tmp_path),
+        auto_save_on_exit=False,
+        capacity=None,
+        redact_binary_threshold=16,
+    )
+    logger.log({"url": f"data:image/png;base64,{small}"})
+    _, data = _dump(logger, tmp_path)
+
+    assert data["content"]["url"].startswith("<lionagi:redacted-binary")
+
+
+def test_settings_expose_the_knob():
+    from lionagi.config import settings
+
+    assert "redact_binary" in settings.LOG_CONFIG
+    assert "redact_binary_threshold" in settings.LOG_CONFIG
+
+
+def test_a_prebuilt_log_is_redacted_too(tmp_path):
+    """Redaction is a property of writing to disk, not of how the Log was made."""
+    log = Log.create({"payload": _vision_payload()})
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    logger.log(log)
+    _, data = _dump(logger, tmp_path)
+
+    assert B64 not in json.dumps(data)
+    # Identity is preserved across the rebuild, so the entry still correlates.
+    assert data["id"] == str(log.id)
+
+
+@pytest.mark.anyio
+async def test_async_dump_redacts(tmp_path):
+    logger = DataLogger(persist_dir=str(tmp_path), auto_save_on_exit=False, capacity=None)
+    await logger.alog({"payload": _vision_payload()})
+    fp = tmp_path / "async.json"
+    await logger.adump(clear=False, persist_path=fp)
+
+    assert B64 not in fp.read_text()
+
+
+# --- the predicate ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload,path",
+    [
+        # Anthropic content block
+        (
+            {
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/webp",
+                            "data": B64,
+                        },
+                    }
+                ]
+            },
+            lambda d: d["content"][0]["source"]["data"],
+        ),
+        # Ollama multimodal
+        ({"images": [B64]}, lambda d: d["images"][0]),
+        # OpenAI image generation response
+        ({"b64_json": B64}, lambda d: d["b64_json"]),
+        # A tool result carrying an inline image
+        (
+            {"media_type": "image/jpeg", "content": f"data:image/jpeg;base64,{B64}"},
+            lambda d: d["content"],
+        ),
+    ],
+)
+def test_known_binary_shapes_are_caught(payload, path):
+    out = redact_binary_content(payload, threshold=1024)
+    assert path(out).startswith("<lionagi:redacted-binary")
+    assert f"bytes={IMAGE_BYTES}" in path(out)
+
+
+def test_media_type_comes_from_a_sibling_when_the_string_has_none():
+    out = redact_binary_content(
+        {"source": {"type": "base64", "media_type": "image/gif", "data": B64}},
+        threshold=1024,
+    )
+    assert "media_type=image/gif" in out["source"]["data"]
+
+
+def test_large_text_is_kept():
+    """The predicate is 'base64-encoded binary', not 'large'. Prose stays."""
+    prose = "the quick brown fox jumps over the lazy dog. " * 5000
+    out = redact_binary_content({"data": prose, "text": prose}, threshold=1024)
+    assert out["data"] == prose
+    assert out["text"] == prose
+
+
+def test_base64_shaped_string_under_an_unrelated_key_is_kept():
+    out = redact_binary_content({"reasoning": B64}, threshold=1024)
+    assert out["reasoning"] == B64
+
+
+def test_unchanged_input_is_returned_as_is():
+    """No copying when there is nothing to redact -- redaction is on by default,
+    so the common no-image path must not pay for it."""
+    data = {"messages": [{"role": "user", "content": "hello"}]}
+    assert redact_binary_content(data, threshold=1024) is data


### PR DESCRIPTION
A vision workload writes its images into the log directory. `APICalling.payload` is a plain, non-excluded field, so `to_dict(mode="json")` serialises the entire provider request — including `content.payload.messages[i].content[j].image_url.url`, the whole base64 data URI. `capacity` bounds the number of entries per file, not their size, so a run of vision calls produces log files measured in tens of megabytes each and directories measured in gigabytes.

There was no knob for this. `DataLoggerConfig` had eight fields and `AppSettings` nine matching env vars, all about *where* and *when* to write, none about *what*.

## What changed

`DataLogger.log()` now swaps base64 binary for a placeholder on the way into the store:

```json
"image_url": {
  "url": "<lionagi:redacted-binary field=url media_type=image/png bytes=49152>",
  "detail": "auto"
}
```

The field is still present and still a string, so the log's shape is unchanged and anything walking it keeps working. It records the field name, the media type, and the decoded byte length — enough to correlate the entry with the call and to see at a glance how large the image was. The length is computed arithmetically from the base64; the blob is never decoded.

Measured on one 48 KiB PNG, same fixture before and after: **65,880 bytes written → 390**.

## It cannot change what is sent to the provider

This is the part worth checking closely, because `emit_and_log(api_call)` runs while `api_call.payload` is the live object the endpoint sends. Rewriting it would silently strip images from provider requests.

Redaction happens on `Log.content` — the snapshot `Log.create()` already produced — and returns a new `Log` via `from_dict`, never touching the logged object. The walker is additionally pure: it rebuilds only the containers on a path to a redacted string and returns every other subtree by identity, so it cannot write through to anything the caller holds. Two tests pin this, and reverting the copy to an in-place write reddens exactly the non-mutation test.

## On by default

The cost of being wrong in the "off" direction is unbounded and silent: gigabytes overnight, and nobody looking until something else fails. The cost of being wrong in the "on" direction is bounded and loud: a placeholder that names exactly what it replaced, one env var from the raw bytes (`LIONAGI_LOG_REDACT_BINARY=false`). Nobody should discover redaction by having their disk fill up.

## What counts as binary

The predicate is "base64-encoded binary", not "large": a `data:<media-type>;base64,` URI, or a bare base64 string under a key providers use for binary (`data`, `b64_json`, `image`, `images`, `audio`, `input_audio`) that is correctly padded and uses only the base64 alphabet. Threshold is 1024 decoded bytes, so a tracking pixel or a small inline fixture stays whole.

It deliberately does not catch merely-large text. A 200 KB context block is exactly what you want in a debugging log — readable, greppable, diffable. Binary differs in kind, not degree: it is unreadable at any size, so size is the wrong axis. Both boundaries are pinned by tests.

Covers four provider shapes: OpenAI data URIs, Anthropic content blocks (`source.data` with sibling `media_type`), Ollama `images[]`, and OpenAI image-generation `b64_json`.

## Tests

`tests/protocols/generic/test_log_redaction.py`, 19 tests. Each was proven able to fail by reverting exactly the change it guards — eight probes, each reddening the test that names its property and leaving the rest green.

Suites: `tests/protocols tests/session` 2456 passed; `tests/operations tests/test_config.py` 783 passed, 1 skipped.
