### PR TITLE
fix(lndl): select inner-chat transport from the effective model, not the branch

### DIFF
--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -123,7 +123,11 @@ async def _run_round_chat(
     chat_param: ChatParam,
 ) -> str:
     """Run one inner-chat turn, dispatching to communicate() (API) or run_and_collect() (CLI) — mirrors operate()'s own selection."""
-    if isinstance(chat_param, RunParam) or getattr(branch.chat_model, "is_cli", False):
+    # A model carried on the chat param overrides the branch default for this
+    # call, so transport must follow the effective model's CLI flag rather than
+    # the branch's -- mirrors operate()'s own selection.
+    effective_imodel = chat_param.imodel or branch.chat_model
+    if isinstance(chat_param, RunParam) or getattr(effective_imodel, "is_cli", False):
         from ..run.run import run_and_collect
 
         return await run_and_collect(branch, instruction, chat_param, skip_validation=True)

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -233,6 +233,26 @@ class TestRunRoundChatDispatch:
         fake.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_chat_param_cli_model_overrides_api_branch(self):
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=False))
+        chat_param = ChatParam(imodel=SimpleNamespace(is_cli=True))
+        fake = AsyncMock(return_value="cli text")
+        with patch("lionagi.operations.run.run.run_and_collect", new=fake):
+            result = await _run_round_chat(branch, "hi", chat_param)
+        assert result == "cli text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_param_api_model_overrides_cli_branch(self):
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=True))
+        chat_param = ChatParam(imodel=SimpleNamespace(is_cli=False))
+        fake = AsyncMock(return_value="api text")
+        with patch("lionagi.operations.communicate.communicate.communicate", new=fake):
+            result = await _run_round_chat(branch, "hi", chat_param)
+        assert result == "api text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_real_scripted_branch_round_trips_via_run_and_collect(self):
         """End-to-end sanity check with a real TestBranch (necessarily
         CLI-routed, see class docstring) — confirms the dispatch wiring


### PR DESCRIPTION
Closes #2403

`_run_round_chat` read `is_cli` off `branch.chat_model`, so a per-call model supplied on `ChatParam.imodel` was ignored when picking the transport: a CLI model on an API branch took the `communicate()` path, and an API model on a CLI branch took `run_and_collect()`. `operate()` already selects on the effective model (`_cctx.imodel or branch.chat_model`); this brings the LNDL round dispatch in line with it.

Two dispatch tests added alongside the existing `TestRunRoundChatDispatch` cases cover both override directions; both fail on `main` and pass with the fix.
