### PR TITLE
fix(parse): vary the reformat retry, and say which half of parsing failed

### DIFF
--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -16,10 +16,12 @@ from ..fields import Instruct
 from ..types import (
     ActionParam,
     ChatParam,
+    ExtractionError,
     HandleValidation,
     Middle,
     ParseParam,
     RunParam,
+    SchemaRejectedError,
 )
 
 if TYPE_CHECKING:
@@ -263,7 +265,18 @@ async def operate(
             case "raise":
                 expected_name = getattr(model_class, "__name__", repr(model_class))
                 received_snippet = repr(result)[:200]
-                raise ValueError(
+                if getattr(result, "failure_kind", None) == "validation":
+                    # JSON came back intact and the schema refused it. The
+                    # generic hint below blames the provider's structured-output
+                    # support, which sends the caller to the wrong place — the
+                    # pydantic error already names the offending field.
+                    raise SchemaRejectedError(
+                        f"Model response parsed as JSON but did not satisfy "
+                        f"'{expected_name}': {result.validation_error}. "
+                        f"Received (truncated): {received_snippet}.",
+                        validation_error=result.validation_error,
+                    )
+                raise ExtractionError(
                     f"Failed to parse LLM response into '{expected_name}'. "
                     f"Received (truncated): {received_snippet}. "
                     f"Hint: verify the model supports structured JSON output "

--- a/lionagi/operations/parse/__init__.py
+++ b/lionagi/operations/parse/__init__.py
@@ -1,2 +1,18 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
+
+from ..types import (
+    ExtractionError,
+    ParseError,
+    ParseFailureKind,
+    SchemaRejectedError,
+    UnparsedResponse,
+)
+
+__all__ = (
+    "ExtractionError",
+    "ParseError",
+    "ParseFailureKind",
+    "SchemaRejectedError",
+    "UnparsedResponse",
+)

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
+import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from lionagi.ln import (
     AlcallParams,
@@ -18,11 +19,82 @@ from lionagi.operations.schema.structure import Structure
 from lionagi.protocols.types import AssistantResponse
 
 from .._defaults import get_default_parse_call as get_default_call
-from ..types import HandleValidation, ParseParam
+from ..types import (
+    ExtractionError,
+    HandleValidation,
+    ParseError,
+    ParseParam,
+    SchemaRejectedError,
+    UnparsedResponse,
+)
 
 if TYPE_CHECKING:
     from lionagi.ln.types import Operable
     from lionagi.session.branch import Branch
+
+
+logger = logging.getLogger(__name__)
+
+_BASE_REFORMAT_GUIDANCE = "follow the required response format, using the model schema as a guide"
+
+# Validation errors list every offending field; keep the tail out of the prompt.
+_MAX_REPORTED_ERROR_CHARS = 800
+
+
+class _ReformatAttempts:
+    """Per-attempt framing for the reformat turn.
+
+    Every reformat turn is a repair of the *same* text, so without this the
+    retry loop reissues a byte-identical request; on a deterministic engine
+    (temperature 0) that cannot produce a different answer, and the caller pays
+    for each repetition. Each turn instead reports the failure that preceded
+    it, so the request differs and the model is told what to fix.
+    """
+
+    __slots__ = ("count", "last_error", "last_exc")
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.last_error: str | None = None
+        self.last_exc: Exception | None = None
+
+    def record_failure(self, exc: Exception) -> None:
+        message = str(exc).strip() or type(exc).__name__
+        if len(message) > _MAX_REPORTED_ERROR_CHARS:
+            message = message[:_MAX_REPORTED_ERROR_CHARS] + " …(truncated)"
+        self.last_error = message
+        self.last_exc = exc
+
+    def failure_kind(self) -> str:
+        """Classify the last failure; unclassified causes count as extraction."""
+        return self.last_exc.kind if isinstance(self.last_exc, ParseError) else "extraction"
+
+    def as_unparsed(self, text: str) -> UnparsedResponse:
+        """Wrap the raw text with why it could not be parsed."""
+        exc = self.last_exc
+        return UnparsedResponse(
+            text,
+            failure_kind=self.failure_kind(),
+            validation_error=(
+                exc.validation_error if isinstance(exc, SchemaRejectedError) else None
+            ),
+        )
+
+    def guidance(self) -> str:
+        self.count += 1
+        parts = [_BASE_REFORMAT_GUIDANCE]
+        if self.last_error:
+            parts.append(
+                f"The previous attempt did not validate: {self.last_error}. "
+                "Correct exactly what that error names — every field it reports "
+                "must carry a value of the required type."
+            )
+        if self.count > 1:
+            parts.append(
+                f"This is attempt {self.count}; earlier attempts failed. Return only "
+                "the JSON object, with no text before or after it."
+            )
+        return " ".join(parts)
 
 
 def _try_propagate_structure(content: Any, parse_param: "ParseParam") -> "ParseParam":
@@ -90,20 +162,25 @@ async def parse(
     return_res_message: bool = False,
 ) -> Any | tuple[Any, AssistantResponse | None]:
     structure = parse_param.structure if isinstance(parse_param.structure, Structure) else None
+    attempts = _ReformatAttempts()
 
     if structure is not None:
-        with contextlib.suppress(Exception):
+        try:
             result = structure.parse(
                 text,
                 fuzzy_match_params=parse_param.fuzzy_match_params,
             )
             return result if not return_res_message else (result, None)
+        except Exception as e:
+            attempts.record_failure(e)
     else:
-        with contextlib.suppress(Exception):
+        try:
             result = _validate_dict_or_model(
                 text, parse_param.response_format, parse_param.fuzzy_match_params
             )
             return result if not return_res_message else (result, None)
+        except Exception as e:
+            attempts.record_failure(e)
 
     async def _inner_parse(i):
         # This retries a failed parse by calling the public Branch.chat()
@@ -114,7 +191,7 @@ async def parse(
 
         _, res = await branch.chat(
             instruction="reformat text into specified model or structure",
-            guidance="follow the required response format, using the model schema as a guide",
+            guidance=attempts.guidance(),
             context=[{"text_to_format": text}],
             request_fields=(
                 parse_param.response_format
@@ -140,22 +217,22 @@ async def parse(
         res.metadata["is_parsed"] = True
         res.metadata["original_text"] = text
 
-        if structure is not None:
-            return (
-                structure.parse(
+        try:
+            if structure is not None:
+                parsed = structure.parse(
                     res.response,
                     fuzzy_match_params=parse_param.fuzzy_match_params,
-                ),
-                res,
-            )
-        return (
-            _validate_dict_or_model(
-                res.response,
-                parse_param.response_format,
-                parse_param.fuzzy_match_params,
-            ),
-            res,
-        )
+                )
+            else:
+                parsed = _validate_dict_or_model(
+                    res.response,
+                    parse_param.response_format,
+                    parse_param.fuzzy_match_params,
+                )
+        except Exception as e:
+            attempts.record_failure(e)
+            raise
+        return parsed, res
 
     _call = parse_param.alcall_params or get_default_call()
     if isinstance(parse_param.alcall_params, dict):
@@ -168,11 +245,36 @@ async def parse(
     except Exception as e:
         match parse_param.handle_validation:
             case "raise":
-                raise ValueError(f"Failed to parse response: {e}") from e
+                # Keep the message and the ValueError base, so existing handlers
+                # are unaffected, but carry the kind and the pydantic error.
+                failure_cls = (
+                    SchemaRejectedError
+                    if attempts.failure_kind() == "validation"
+                    else ExtractionError
+                )
+                last = attempts.last_exc
+                raise failure_cls(
+                    f"Failed to parse response: {e}",
+                    validation_error=(
+                        last.validation_error if isinstance(last, SchemaRejectedError) else None
+                    ),
+                ) from e
             case "return_none":
                 return (None, None) if return_res_message else None
             case "return_value":
-                return (text, None) if return_res_message else text
+                # Degrade to the raw text as before, but attached to why it
+                # failed — a schema rejection must not look like a parse error.
+                value = attempts.as_unparsed(text)
+                if value.failure_kind == "validation":
+                    logger.warning(
+                        "parse: response was valid JSON but did not satisfy %s; "
+                        "returning raw text. Validation error: %s",
+                        getattr(
+                            parse_param.response_format, "__name__", parse_param.response_format
+                        ),
+                        attempts.last_error,
+                    )
+                return (value, None) if return_res_message else value
     return (*result[0],) if return_res_message else result[0][0]
 
 
@@ -233,8 +335,15 @@ def _validate_dict_or_model(
                 strict=False,
             )
         if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-            return response_format.model_validate(dict_)
+            # Isolated from the extraction steps above: by here the JSON was
+            # recovered, so anything raised is the schema rejecting the data.
+            try:
+                return response_format.model_validate(dict_)
+            except PydanticValidationError as e:
+                raise SchemaRejectedError(f"Failed to parse text: {e}", validation_error=e) from e
         return dict_
 
+    except ParseError:
+        raise
     except Exception as e:
-        raise ValueError(f"Failed to parse text: {e}") from e
+        raise ExtractionError(f"Failed to parse text: {e}") from e

--- a/lionagi/operations/types.py
+++ b/lionagi/operations/types.py
@@ -24,6 +24,68 @@ if TYPE_CHECKING:
 
 HandleValidation = Literal["raise", "return_value", "return_none"]
 
+# Why a response could not be turned into the requested model. These two need
+# opposite fixes from the caller — "extraction" means the text never yielded
+# JSON, so the prompt or the model is at fault; "validation" means the JSON was
+# recovered intact and the schema refused it, so the schema or the data is.
+# Collapsing them into one string return makes a schema mismatch look like a
+# parsing bug, which costs a diagnostic round trip.
+ParseFailureKind = Literal["extraction", "validation"]
+
+
+class ParseError(ValueError):
+    """A response could not be turned into the requested model.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` handlers keep
+    working; ``kind`` is what lets a caller tell the two causes apart.
+    """
+
+    kind: ClassVar[ParseFailureKind]
+
+    def __init__(self, message: str, *, validation_error: Exception | None = None):
+        super().__init__(message)
+        self.validation_error = validation_error
+
+
+class ExtractionError(ParseError):
+    """No JSON could be recovered from the text at all."""
+
+    kind: ClassVar[ParseFailureKind] = "extraction"
+
+
+class SchemaRejectedError(ParseError):
+    """JSON was recovered intact, but it does not satisfy the response model.
+
+    ``validation_error`` carries the underlying pydantic error, which names the
+    offending field and value.
+    """
+
+    kind: ClassVar[ParseFailureKind] = "validation"
+
+
+class UnparsedResponse(str):
+    """The raw model text, returned when parsing gave up.
+
+    Subclasses ``str`` so callers that only ever wanted the text are unaffected
+    — equality, formatting and ``isinstance(x, str)`` all behave as before —
+    while ``failure_kind`` and ``validation_error`` make the reason reachable
+    without a second round trip.
+    """
+
+    __slots__ = ("failure_kind", "validation_error")
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        failure_kind: ParseFailureKind,
+        validation_error: Exception | None = None,
+    ) -> "UnparsedResponse":
+        obj = super().__new__(cls, text)
+        obj.failure_kind = failure_kind
+        obj.validation_error = validation_error
+        return obj
+
 
 @dataclass(slots=True, frozen=True, init=False)
 class MorphParam(Params):

--- a/lionagi/operations/types.py
+++ b/lionagi/operations/types.py
@@ -86,6 +86,18 @@ class UnparsedResponse(str):
         obj.validation_error = validation_error
         return obj
 
+    def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, Any]]:
+        # copy, deepcopy and pickle all rebuild a str subclass by calling
+        # __new__ with the arguments this returns. Without it they call
+        # __new__(text) alone and raise on the keyword-only argument -- so a
+        # plain str survives being copied while this one would not, which is
+        # exactly the kind of difference "it is still a str" is meant to rule
+        # out.
+        return (str(self),), {
+            "failure_kind": self.failure_kind,
+            "validation_error": self.validation_error,
+        }
+
 
 @dataclass(slots=True, frozen=True, init=False)
 class MorphParam(Params):

--- a/tests/operations/test_parse_failure_diagnostics.py
+++ b/tests/operations/test_parse_failure_diagnostics.py
@@ -9,6 +9,9 @@ extraction path works, that the two causes stay distinguishable, and that the
 reformat retries do not reissue an identical request.
 """
 
+import copy
+import json
+import pickle
 from unittest.mock import patch
 
 import pytest
@@ -216,3 +219,61 @@ class TestOperateSurfacesTheDistinction:
 
         assert isinstance(exc_info.value, ExtractionError)
         assert exc_info.value.validation_error is None
+
+
+class TestUnparsedResponseIsStillAnOrdinaryString:
+    """The give-up path used to return a plain str, and callers rely on that.
+
+    Carrying the failure reason is only free if nothing a caller already did to
+    the returned text stops working. Copying is the case that is easy to miss:
+    a str subclass is rebuilt by calling ``__new__`` with the arguments
+    ``__getnewargs_ex__`` reports, so a keyword-only ``__new__`` without it
+    raises on ``copy``, ``deepcopy`` and ``pickle`` alike -- while the plain str
+    it replaced survives all three.
+    """
+
+    def _response(self, error: Exception | None = None) -> UnparsedResponse:
+        return UnparsedResponse(
+            "some model text", failure_kind="validation", validation_error=error
+        )
+
+    @pytest.mark.parametrize(
+        "roundtrip",
+        [copy.copy, copy.deepcopy, lambda value: pickle.loads(pickle.dumps(value))],
+        ids=["copy", "deepcopy", "pickle"],
+    )
+    def test_a_roundtrip_keeps_the_text_and_the_reason(self, roundtrip):
+        original = self._response(ValueError("boom"))
+        restored = roundtrip(original)
+
+        assert restored == original
+        assert type(restored) is UnparsedResponse
+        assert restored.failure_kind == "validation"
+        assert isinstance(restored.validation_error, ValueError)
+
+    @pytest.mark.parametrize(
+        "roundtrip",
+        [copy.copy, copy.deepcopy, lambda value: pickle.loads(pickle.dumps(value))],
+        ids=["copy", "deepcopy", "pickle"],
+    )
+    def test_a_roundtrip_survives_a_real_pydantic_error(self, roundtrip):
+        # The error actually attached in production is a pydantic
+        # ValidationError, not a ValueError anyone constructed in a test.
+        try:
+            Course.model_validate({"name": None, "credits": 3})
+        except Exception as validation_error:
+            original = self._response(validation_error)
+
+        restored = roundtrip(original)
+        assert restored == original
+        assert "name" in str(restored.validation_error)
+
+    def test_it_behaves_as_the_plain_string_it_replaced(self):
+        raw = "some model text"
+        response = self._response()
+
+        assert isinstance(response, str)
+        assert (response, hash(response), len(response)) == (raw, hash(raw), len(raw))
+        assert f"{response}" == raw
+        assert json.dumps(response) == json.dumps(raw)
+        assert {raw: "value"}[response] == "value"

--- a/tests/operations/test_parse_failure_diagnostics.py
+++ b/tests/operations/test_parse_failure_diagnostics.py
@@ -15,11 +15,16 @@ import pytest
 from pydantic import BaseModel
 
 from lionagi.operations._defaults import make_parse_param
-from lionagi.operations.parse import SchemaRejectedError, UnparsedResponse
+from lionagi.operations.parse import (
+    ExtractionError,
+    SchemaRejectedError,
+    UnparsedResponse,
+)
 from lionagi.operations.parse.parse import _validate_dict_or_model
 from lionagi.operations.parse.parse import parse as _parse
 from lionagi.protocols.types import AssistantResponse
 from lionagi.session.branch import Branch
+from lionagi.testing import LionAGIMockFactory
 
 
 class Course(BaseModel):
@@ -161,5 +166,53 @@ class TestReformatRequestsVary:
 
         assert len(seen) == 4, "expected 1 attempt plus 3 retries"
         assert len(set(seen)) == len(seen), "retries reissued an identical request"
-        # The failure that preceded each retry is what makes it differ.
-        assert all("courses.2.name" in g for g in seen[0:])
+        # The failure that preceded each turn is what makes it differ.
+        assert all("courses.2.name" in g for g in seen)
+
+
+class TestOperateSurfacesTheDistinction:
+    """operate() is the entry point this was reported through.
+
+    It pins parse to ``return_value`` internally, so whatever parse degrades to
+    is what a caller of operate() actually receives.
+    """
+
+    @staticmethod
+    def _branch(body: str):
+        return LionAGIMockFactory.create_mocked_branch(response=body, model="gpt-4.1-mini")
+
+    async def _operate(self, body: str, **kw):
+        return await self._branch(body).operate(
+            instruction="extract the transcript",
+            response_format=Transcript,
+            invoke_actions=False,
+            **kw,
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_return_carries_the_reason_through_operate(self):
+        result = await self._operate(FENCED_SCHEMA_VIOLATION)
+
+        assert isinstance(result, str), "the raw-text degradation must survive"
+        assert result.failure_kind == "validation"
+        assert result.validation_error.errors()[0]["type"] == "string_type"
+
+    @pytest.mark.asyncio
+    async def test_raise_names_the_schema_not_the_provider(self):
+        """A schema rejection must not be blamed on structured-output support."""
+        with pytest.raises(ValueError) as exc_info:
+            await self._operate(FENCED_SCHEMA_VIOLATION, handle_validation="raise")
+
+        exc = exc_info.value
+        assert isinstance(exc, SchemaRejectedError)
+        assert exc.validation_error is not None
+        assert "courses.2.name" in str(exc)
+        assert "supports structured JSON output" not in str(exc)
+
+    @pytest.mark.asyncio
+    async def test_unparseable_text_still_blames_extraction(self):
+        with pytest.raises(ValueError) as exc_info:
+            await self._operate(NOTHING_PARSEABLE, handle_validation="raise")
+
+        assert isinstance(exc_info.value, ExtractionError)
+        assert exc_info.value.validation_error is None

--- a/tests/operations/test_parse_failure_diagnostics.py
+++ b/tests/operations/test_parse_failure_diagnostics.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A failed parse has two very different causes, and they need different fixes.
+
+Either no JSON could be recovered from the text, or JSON was recovered intact
+and the response model refused it. These tests pin that the fenced-block
+extraction path works, that the two causes stay distinguishable, and that the
+reformat retries do not reissue an identical request.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.operations._defaults import make_parse_param
+from lionagi.operations.parse import SchemaRejectedError, UnparsedResponse
+from lionagi.operations.parse.parse import _validate_dict_or_model
+from lionagi.operations.parse.parse import parse as _parse
+from lionagi.protocols.types import AssistantResponse
+from lionagi.session.branch import Branch
+
+
+class Course(BaseModel):
+    name: str
+    credits: int
+
+
+class Transcript(BaseModel):
+    student: str
+    courses: list[Course]
+
+
+# A short preamble line, then a complete fenced JSON block. Row 2 carries a
+# null where the schema requires a string.
+FENCED_SCHEMA_VIOLATION = """Here is the extracted transcript from the image:
+
+```json
+{
+  "student": "A. Rivera",
+  "courses": [
+    {"name": "Linear Algebra", "credits": 4},
+    {"name": "Organic Chemistry", "credits": 5},
+    {"name": null, "credits": 3}
+  ]
+}
+```"""
+
+FENCED_CONFORMANT = FENCED_SCHEMA_VIOLATION.replace('"name": null', '"name": "Thermodynamics"')
+
+NOTHING_PARSEABLE = "I'm sorry, I can't read that image clearly enough to extract a transcript."
+
+
+def _fmp():
+    return make_parse_param(Transcript, None).fuzzy_match_params
+
+
+async def _parse_returning(body: str, **kw):
+    """Run the real parse loop with the reformat turn stubbed out."""
+    branch = Branch()
+
+    async def fake_chat(*_a, **_kw):
+        return None, AssistantResponse(
+            role="assistant",
+            content={"assistant_response": body},
+            sender=branch.id,
+            recipient=branch.user,
+        )
+
+    param = make_parse_param(Transcript, None, **kw)
+    with patch.object(Branch, "chat", fake_chat):
+        return await _parse(branch, body, param)
+
+
+class TestFencedExtraction:
+    """The fenced block itself extracts fine; only the schema rejects it."""
+
+    def test_preamble_plus_fenced_block_validates_when_conformant(self):
+        result = _validate_dict_or_model(FENCED_CONFORMANT, Transcript, _fmp())
+
+        assert isinstance(result, Transcript)
+        assert [c.name for c in result.courses] == [
+            "Linear Algebra",
+            "Organic Chemistry",
+            "Thermodynamics",
+        ]
+
+    def test_schema_violation_reaches_validation_not_extraction(self):
+        """The JSON is recovered whole; pydantic is what refuses it."""
+        with pytest.raises(SchemaRejectedError) as exc_info:
+            _validate_dict_or_model(FENCED_SCHEMA_VIOLATION, Transcript, _fmp())
+
+        underlying = exc_info.value.validation_error
+        assert underlying is not None
+        first = underlying.errors()[0]
+        assert tuple(first["loc"]) == ("courses", 2, "name")
+        assert first["type"] == "string_type"
+        assert first["input"] is None
+
+
+class TestFailureKindSurvives:
+    """A caller must be able to tell the two causes apart after the retries."""
+
+    @pytest.mark.asyncio
+    async def test_schema_rejection_is_reported_as_validation(self):
+        result = await _parse_returning(FENCED_SCHEMA_VIOLATION)
+
+        assert isinstance(result, UnparsedResponse)
+        assert result.failure_kind == "validation"
+        assert result.validation_error is not None
+        first = result.validation_error.errors()[0]
+        assert tuple(first["loc"]) == ("courses", 2, "name")
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_text_is_reported_as_extraction(self):
+        result = await _parse_returning(NOTHING_PARSEABLE)
+
+        assert isinstance(result, UnparsedResponse)
+        assert result.failure_kind == "extraction"
+        assert result.validation_error is None
+
+    @pytest.mark.asyncio
+    async def test_raw_text_return_stays_a_plain_string(self):
+        """The degradation is deliberate; attaching a reason must not break it."""
+        result = await _parse_returning(FENCED_SCHEMA_VIOLATION)
+
+        assert isinstance(result, str)
+        assert result == FENCED_SCHEMA_VIOLATION
+        assert f"{result}" == FENCED_SCHEMA_VIOLATION
+
+    @pytest.mark.asyncio
+    async def test_raise_mode_carries_the_validation_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            await _parse_returning(FENCED_SCHEMA_VIOLATION, handle_validation="raise")
+
+        assert isinstance(exc_info.value, SchemaRejectedError)
+        assert exc_info.value.validation_error is not None
+
+
+class TestReformatRequestsVary:
+    """An identical request on a deterministic engine cannot change the outcome."""
+
+    @pytest.mark.asyncio
+    async def test_each_reformat_turn_sends_different_guidance(self):
+        branch = Branch()
+        seen: list[str] = []
+
+        async def fake_chat(*_a, **kw):
+            seen.append(kw.get("guidance"))
+            return None, AssistantResponse(
+                role="assistant",
+                content={"assistant_response": FENCED_SCHEMA_VIOLATION},
+                sender=branch.id,
+                recipient=branch.user,
+            )
+
+        param = make_parse_param(Transcript, None, num_retries=3)
+        with patch.object(Branch, "chat", fake_chat):
+            await _parse(branch, FENCED_SCHEMA_VIOLATION, param)
+
+        assert len(seen) == 4, "expected 1 attempt plus 3 retries"
+        assert len(set(seen)) == len(seen), "retries reissued an identical request"
+        # The failure that preceded each retry is what makes it differ.
+        assert all("courses.2.name" in g for g in seen[0:])


### PR DESCRIPTION
A vision call through `operate(response_format=...)` returned a complete fenced JSON block, parsing failed, the reformat turn ran four times, and the caller got back a bare string that looked like a parsing problem. Three separate questions were tangled in that, and only two of them were defects.

## The extractor is not one of them

`extract_json` recovers a preamble line followed by a complete fenced block correctly, nulls and all. The identical body with the null replaced by a string validates end to end. The failure was pydantic rejecting a null in a required field — the model answered honestly and the schema refused it. **No extractor change was made and none is warranted for that shape.**

## The retry loop reissued the same request

`parse` makes one direct attempt, then `alcall` retries `_inner_parse` three times: 1 + 3 = 4 calls, which is the four that were observed. The reformat prompt was a fixed `guidance` string and nothing else varied per attempt either, so on a deterministic engine every retry reproduced the previous failure exactly — four times the cost for zero information. Measured before: `4 turns, 1 distinct prompt`. After: `4 turns, 4 distinct prompts`, each naming the prior failure.

Varying the framing rather than capping the retries was a deliberate choice, and it rests on something verified rather than assumed: **temperature is not readable at this layer.** `make_parse_param` sets `imodel_kw={}` and `_inner_parse` never forwards it, so a caller's `temperature=0` never reaches the repair turn. Gating retry count on a value this layer cannot see would be guessing, and guessing wrong silently deletes retries that were doing useful work on a non-deterministic engine. The retry count is untouched.

## A schema rejection was indistinguishable from unparseable text

Those need different actions from the caller — fix your schema versus fix your prompt — and they looked identical. `_validate_dict_or_model` now classifies the two at the only place that knows which happened.

- `handle_validation="raise"` raises `SchemaRejectedError` or `ExtractionError`, both subclasses of `ValueError` so existing handlers keep working, carrying the pydantic error.
- The give-up path returns `UnparsedResponse`, a `str` subclass carrying `failure_kind` and `validation_error`.

Returning a `str` subclass rather than raising was deliberate: the raw-string return is a degradation for callers who want *something*, and turning it into a raise is a breaking change. Nothing in this repo consumes the raw string; the one inspection site is a negative `isinstance` that a `str` subclass satisfies.

### Being a `str` subclass has to mean it, including when copied

The claim that this is non-breaking rests on the value behaving like the plain string it replaced, so it was checked rather than asserted — and one case failed. A `str` subclass is rebuilt by calling `__new__` with whatever `__getnewargs_ex__` reports, and with no such method the rebuild calls `__new__(text)` alone, which raises because `failure_kind` is keyword-only and required. `copy`, `deepcopy` and `pickle` all failed on it while a plain `str` survives all three.

That is a real behaviour change on a public return, on the least-exercised path: anything caching a result, sending it to another process, or deep-copying a structure containing it would raise `TypeError` where it used to work. `__getnewargs_ex__` carries the text and both fields through, verified including when the attached error is a real pydantic `ValidationError`.

## Tests

Required suites, `--maxfail` removed so nothing truncates: **3209 passed, 3 skipped**, collected 3212. `tests/operations tests/protocols` after the copy fix: 2750 passed, 1 skipped, 1 failed — `test_adump_snapshot_excludes_sync_thread_mutation`, a `threading` + `sleep` timing test on `Pile` that this branch does not touch; run three times in isolation it passes twice and fails once.

Revert probes: each new test proved red by reverting exactly the change it guards. The extraction test guards behaviour that was not changed, so rather than pass it off as a revert probe it was proved non-vacuous by breaking the fence regex.

## Not covered

Bare JSON after a preamble, and untagged fences, both genuinely fail extraction. Verified, out of scope here.
