### PR TITLE
fix(state): ask the configured store whether a record exists, not the default path

### DIFF
--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -295,9 +295,12 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
     raised. The guard covers the open alone — the caller's own body runs outside
     it, and a bug in a reader still surfaces as the crash it is.
     """
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_known_absent
 
-    if not DEFAULT_DB_PATH.exists():
+    # Asked of the configured store, not of the default path: the open below
+    # honours LIONAGI_STATE_DB_URL, so a guard that consulted the file would
+    # report "nothing recorded" for a store that is full of rows.
+    if state_db_known_absent():
         yield None, state_db_absent()
         return
     async with AsyncExitStack() as stack:
@@ -310,17 +313,22 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
             # claims the store is open, which is what the claim has to mean.
             await db.fetch_all("SELECT 1")
         except Exception as exc:  # noqa: BLE001 — an unopenable store is an answer, not a crash
-            yield None, unavailable(REASON_UNREADABLE, f"{DEFAULT_DB_PATH}: {type(exc).__name__}")
+            yield None, unavailable(REASON_UNREADABLE, f"{StateDB().url}: {type(exc).__name__}")
             return
         yield db, None
 
 
 def state_db_absent() -> dict[str, Any]:
-    """The unavailability every store-backed reader reports when there is no store."""
-    from lionagi.state.db import DEFAULT_DB_PATH
+    """The unavailability every store-backed reader reports when there is no store.
+
+    Names the store that was actually consulted. Naming the default path while a
+    URL is configured sends the reader to a file that is not the one their
+    command would have read.
+    """
+    from lionagi.state.db import StateDB
 
     return unavailable(
-        REASON_NOT_FOUND, f"{DEFAULT_DB_PATH} does not exist; nothing has been recorded yet"
+        REASON_NOT_FOUND, f"{StateDB().url} does not exist; nothing has been recorded yet"
     )
 
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -830,9 +830,9 @@ async def _run_table(
     project: str | None,
 ) -> str:
     try:
-        from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+        from lionagi.state.db import StateDB, state_db_known_absent
 
-        if not DEFAULT_DB_PATH.exists():
+        if state_db_known_absent():
             return _dim("(no state.db — run `li agent` at least once)")
         async with StateDB() as db:
             rows = await _gather_table_rows(
@@ -845,9 +845,9 @@ async def _run_table(
 
 async def _run_detail(entity_id: str) -> str:
     try:
-        from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+        from lionagi.state.db import StateDB, state_db_known_absent
 
-        if not DEFAULT_DB_PATH.exists():
+        if state_db_known_absent():
             return _red(f"state.db not found — cannot look up {entity_id!r}")
         async with StateDB() as db:
             result = await _find_entity(db, entity_id)
@@ -1335,12 +1335,12 @@ def _dispatch_wait(
     """Block until every id in `ids` reaches a terminal schedule_run status;
     see docs/internals/cli.md for chain-following and max_wait semantics."""
     from lionagi.ln.concurrency import run_async
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_known_absent
 
     from ._logging import log_error
     from .status import EXIT_RUNNING, EXIT_UNKNOWN
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         log_error("state.db not found — no schedule runs recorded yet")
         return EXIT_UNKNOWN
 

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -53,9 +53,9 @@ async def _resolve_session(db: Any, entity_id: str) -> dict[str, Any] | None:
 async def _enqueue_control_inner(
     *, entity_id: str, verb: str, payload: dict[str, Any] | None
 ) -> tuple[str, int]:
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_known_absent
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return "state.db not found — no runs recorded yet", EXIT_UNKNOWN
 
     async with StateDB() as db:

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -435,13 +435,31 @@ _STATS_PRAGMAS = (
 
 
 def _db_sizes() -> dict[str, Any]:
-    from lionagi.state.db import DEFAULT_DB_PATH
+    """Bytes on disk for the configured store, when the configured store is a file.
 
-    wal_path = DEFAULT_DB_PATH.with_name(DEFAULT_DB_PATH.name + "-wal")
+    Size and WAL are questions about a file. A server or in-memory URL still has
+    rows to report; it just has no bytes on disk to report them next to, and
+    answering with the default path's size there would describe a file nothing
+    is reading. ``is_file`` says which case this is, so a null size means "not
+    answerable" and can never be read as "empty".
+    """
+    from lionagi.state.db import StateDB, state_db_file
+
+    db_path = state_db_file()
+    if db_path is None:
+        return {
+            "path": StateDB().url,
+            "is_file": False,
+            "exists": False,
+            "size_bytes": None,
+            "wal_size_bytes": None,
+        }
+    wal_path = db_path.with_name(db_path.name + "-wal")
     return {
-        "path": str(DEFAULT_DB_PATH),
-        "exists": DEFAULT_DB_PATH.exists(),
-        "size_bytes": DEFAULT_DB_PATH.stat().st_size if DEFAULT_DB_PATH.exists() else 0,
+        "path": str(db_path),
+        "is_file": True,
+        "exists": db_path.exists(),
+        "size_bytes": db_path.stat().st_size if db_path.exists() else 0,
         "wal_size_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
     }
 
@@ -495,16 +513,19 @@ async def _collect_stats(db: Any) -> dict[str, Any]:
 
 
 async def _print_stats() -> None:
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB
 
     sizes = _db_sizes()
 
-    print(f"state.db path:   {DEFAULT_DB_PATH}")
-    print(f"state.db size:   {_format_bytes(sizes['size_bytes'])}")
-    print(f"state.db-wal:    {_format_bytes(sizes['wal_size_bytes'])}")
+    print(f"state.db path:   {sizes['path']}")
+    if sizes["is_file"]:
+        print(f"state.db size:   {_format_bytes(sizes['size_bytes'])}")
+        print(f"state.db-wal:    {_format_bytes(sizes['wal_size_bytes'])}")
+    else:
+        print("state.db size:   (not a local file)")
     print()
 
-    if not sizes["exists"]:
+    if sizes["is_file"] and not sizes["exists"]:
         print("(no state.db yet — first run will create it)")
         return
 

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -400,9 +400,9 @@ def _render_human(view: dict[str, Any]) -> str:
 async def _run_status_inner(
     *, command: str, entity_id: str | None, as_json: bool
 ) -> tuple[str, int]:
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_known_absent
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return f"state.db not found — no {command} runs recorded yet", EXIT_UNKNOWN
 
     async with StateDB() as db:
@@ -498,9 +498,9 @@ async def _audit_degraded(db: Any) -> dict[str, Any]:
 
 def _dispatch_audit(*, as_json: bool) -> int:
     from lionagi.ln.concurrency import run_async
-    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+    from lionagi.state.db import StateDB, state_db_known_absent
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         log_error("state.db not found — no runs recorded yet")
         return EXIT_UNKNOWN
 

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -225,7 +225,7 @@ def run_wait(argv: list[str]) -> int:
     See docs/internals/cli.md for the SIGINT/SIGTERM handling contract.
     """
     from lionagi.ln.concurrency import SigtermInterrupt, run_async
-    from lionagi.state.db import DEFAULT_DB_PATH
+    from lionagi.state.db import state_db_known_absent
 
     parser = argparse.ArgumentParser(prog="li wait", add_help=True)
     parser.add_argument(
@@ -249,7 +249,7 @@ def run_wait(argv: list[str]) -> int:
     if not watched_ids:
         parser.error("no run ids given (only empty/comma-only tokens)")
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         log_error("state.db not found — no runs recorded yet")
         return EXIT_UNKNOWN
 

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -332,11 +332,11 @@ class SessionObserver(Observer):
                     )
                 else:
                     # Fallback: open a fresh connection (standalone / test use).
-                    from lionagi.state.db import DEFAULT_DB_PATH, StateDB  # noqa: PLC0415
+                    from lionagi.state.db import StateDB, state_db_known_absent  # noqa: PLC0415
 
-                    if not DEFAULT_DB_PATH.exists():
+                    if state_db_known_absent():
                         return
-                    async with StateDB(DEFAULT_DB_PATH) as _db:
+                    async with StateDB() as _db:
                         await _db.insert_session_signal(
                             session_id=session_id,
                             kind=kind,

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import OperationalError as _SAOperationalError
 from lionagi.cli._util import pid_alive as _pid_is_live
 from lionagi.ln import now_utc
 from lionagi.state.db import ADMIN_TRANSITION_TARGETS as _ADMIN_TRANSITION_TARGETS
-from lionagi.state.db import DEFAULT_DB_PATH
+from lionagi.state.db import DEFAULT_DB_PATH, state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, validate_reason_code
 
 from ..registry import studio_route
@@ -547,7 +547,7 @@ async def transition_sessions(
     evidence_refs = list(evidence_refs or [])
     if not session_ids:
         return {"transitioned": [], "skipped": [], "event_id": None}
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return {"transitioned": [], "skipped": session_ids, "event_id": None}
 
     from lionagi.state.db import StateDB
@@ -726,7 +726,7 @@ async def list_admin_events(
     target_id: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     from lionagi.state.db import StateDB
 

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -13,7 +13,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from lionagi._errors import LionError
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 _log = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ async def checkpoint_state_db(
 
     Returns the PRAGMA result dict: busy, log_pages, checkpointed.
     """
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return {"mode": mode, "busy": None, "log_pages": None, "checkpointed": None}
 
     async with StateDB() as db:
@@ -119,7 +119,7 @@ async def checkpoint_state_db(
 
 async def get_last_checkpoint_at() -> float | None:
     """Return the ``created_at`` timestamp of the most recent checkpoint event."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     try:
         async with StateDB() as db:
@@ -164,7 +164,7 @@ async def prune_old_data(
     if dispatch_dead_letter_keep_days is None:
         dispatch_dead_letter_keep_days = DISPATCH_RETENTION_DEAD_LETTER_DAYS
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return {"sessions_pruned": 0, "runs_pruned": 0, "dispatch_purged": 0}
 
     cutoff = time.time() - keep_days * 86400.0
@@ -443,7 +443,7 @@ async def vacuum_state_db(
     actor: str = "studio_db_maintenance",
 ) -> dict[str, str]:
     """Run ``VACUUM`` (exclusive lock) and write an audit event; call after ``prune_old_data()``."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return {"status": "skipped"}
 
     async with StateDB() as db:

--- a/lionagi/studio/services/engine_defs.py
+++ b/lionagi/studio/services/engine_defs.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
 
@@ -105,21 +105,21 @@ async def list_engine_defs(
     limit: int = 100,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         return await db.list_engine_defs(kind=kind, limit=limit, offset=offset)
 
 
 async def get_engine_def(def_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         return await db.get_engine_def(def_id)
 
 
 async def get_engine_def_by_name(name: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         return await db.get_engine_def_by_name(name)

--- a/lionagi/studio/services/engine_runs.py
+++ b/lionagi/studio/services/engine_runs.py
@@ -11,11 +11,9 @@ from typing import Any
 from fastapi import Query
 
 from lionagi._errors import NotFoundError
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
-
-_DB = str(DEFAULT_DB_PATH)
 
 
 def _parse_spec_json(raw: Any) -> Any:
@@ -36,10 +34,10 @@ async def list_engine_runs(
     offset: int = 0,
 ) -> list[dict[str, Any]]:
     """Return engine run rows, newest-first, with optional filters."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
 
-    async with StateDB(_DB) as db:
+    async with StateDB() as db:
         rows = await db.list_engine_runs(
             kind=kind,
             status=status,
@@ -55,10 +53,10 @@ async def list_engine_runs(
 
 async def get_engine_run(run_id: str) -> dict[str, Any] | None:
     """Return a single engine run row as a dict, or None if not found."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
 
-    async with StateDB(_DB) as db:
+    async with StateDB() as db:
         row = await db.get_engine_run(run_id)
 
     if row is None:

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -10,7 +10,7 @@ from typing import Any
 from fastapi import Query
 
 from lionagi._errors import NotFoundError
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
 from ._io import parse_json_col as _parse_json_col
@@ -23,7 +23,7 @@ async def list_invocations(
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         rows = await db.list_invocations(skill=skill, status=status, limit=limit, offset=offset)
@@ -65,7 +65,7 @@ async def list_invocations(
 
 
 async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         row = await db.get_invocation(invocation_id)
@@ -145,7 +145,7 @@ def _serialize_artifact(row: dict[str, Any]) -> dict[str, Any]:
 
 
 async def list_artifacts_for_session(session_id: str) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         rows = await db.list_artifacts_for_session(session_id)
@@ -153,7 +153,7 @@ async def list_artifacts_for_session(session_id: str) -> list[dict[str, Any]]:
 
 
 async def get_artifact(artifact_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         row = await db.get_artifact(artifact_id)

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -9,7 +9,7 @@ import os
 import time
 from pathlib import Path
 
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, ShowReasons
 
 from . import admin as admin_svc
@@ -73,7 +73,7 @@ async def reap_stale_invocations(
     if zero_session_grace_seconds is None:
         zero_session_grace_seconds = ZERO_SESSION_GRACE_SECONDS
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     now = time.time()
@@ -181,7 +181,7 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
         stale_hours = PHANTOM_STALE_HOURS
     stale_seconds = stale_hours * 3600
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     now = time.time()
@@ -260,7 +260,7 @@ async def reap_phantom_sessions(
     if stale_hours is None:
         stale_hours = PHANTOM_STALE_HOURS
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     phantoms = await admin_svc.list_phantom_sessions(stale_hours=stale_hours)
@@ -353,7 +353,7 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
         stale_hours = PLAY_STALE_HOURS
     stale_seconds = stale_hours * 3600
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     now = time.time()
@@ -500,7 +500,7 @@ async def reap_stale_schedule_runs(*, stale_hours: float | None = None) -> int:
         stale_hours = SCHEDULE_RUN_STALE_HOURS
     stale_seconds = stale_hours * 3600
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     now = time.time()
@@ -629,7 +629,7 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
         stale_hours = SHOW_STALE_HOURS
     stale_seconds = stale_hours * 3600
 
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return 0
 
     now = time.time()

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
 from . import run_view
@@ -442,7 +442,7 @@ async def list_schedules(
     trigger_type: str | None = None,
     project: str | None = None,
 ) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         rows = await db.list_schedules(enabled=enabled, trigger_type=trigger_type, project=project)
@@ -459,7 +459,7 @@ async def list_schedules(
 
 
 async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         row = await db.get_schedule(schedule_id)
@@ -477,7 +477,7 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
 
 
 async def get_schedule_by_name(name: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         return await db.get_schedule_by_name(name)
@@ -707,7 +707,7 @@ async def list_schedule_runs(
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         return await db.list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
@@ -721,7 +721,7 @@ async def list_schedule_run_views(
     offset: int = 0,
 ) -> list[dict[str, Any]]:
     """RunView list — each row additionally carries a reconciled ``outcome``."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         return await run_view.list_run_views(
@@ -730,7 +730,7 @@ async def list_schedule_run_views(
 
 
 async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         run = await db.get_schedule_run(run_id)
@@ -754,7 +754,7 @@ async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
 
 async def get_schedule_status(schedule_id: str) -> dict[str, Any] | None:
     """'Did it work?' view: schedule header + latest RunView + shared exit code."""
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         return await run_view.get_schedule_status_view(db, schedule_id)

--- a/lionagi/studio/services/stats.py
+++ b/lionagi/studio/services/stats.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from fastapi import HTTPException, Query
 
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import DEFAULT_DB_PATH, StateDB, state_db_known_absent
 
 from ..registry import studio_route
 from . import agents as agents_svc
@@ -48,10 +48,10 @@ async def get_activity_stats(window: str) -> dict[str, Any]:
     oldest_bucket_start = now_bucket_start - (bucket_count - 1) * bucket_seconds
 
     # A dashboard read must not create/migrate the DB on a fresh workspace.
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         rows: list[dict[str, Any]] = []
     else:
-        async with StateDB(DEFAULT_DB_PATH) as db:
+        async with StateDB() as db:
             rows = await db.activity_stats(
                 window_start=oldest_bucket_start, bucket_seconds=bucket_seconds
             )

--- a/lionagi/studio/services/workflow_defs.py
+++ b/lionagi/studio/services/workflow_defs.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
 
@@ -139,14 +139,14 @@ def _validate_name(name: str) -> None:
 
 
 async def list_workflow_defs(*, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return []
     async with StateDB() as db:
         return await db.list_workflow_defs(limit=limit, offset=offset)
 
 
 async def get_workflow_def(def_id: str) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if state_db_known_absent():
         return None
     async with StateDB() as db:
         return await db.get_workflow_def(def_id)

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -13,6 +13,8 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
+
 # ---------------------------------------------------------------------------
 # Shared fixture helpers
 # ---------------------------------------------------------------------------
@@ -20,7 +22,6 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 def _make_client(tmp_path, monkeypatch):
     """Return (client, db_path) with all relevant service modules pointed at db_path."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.db_maintenance as maint_mod
     import lionagi.studio.services.sessions as sessions_mod
@@ -31,7 +32,7 @@ def _make_client(tmp_path, monkeypatch):
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(maint_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -12,6 +12,7 @@ import pytest
 
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
 from ._helpers import run_async  # noqa: E402
@@ -20,14 +21,13 @@ from ._helpers import run_async  # noqa: E402
 
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _seed_session(
@@ -353,10 +353,9 @@ def test_1173_prune_does_not_touch_running_old_sessions(tmp_path, monkeypatch):
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
-    import lionagi.state.db as state_db_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     ancient = time.time() - 365 * 86400  # 1 year old
 
@@ -388,10 +387,9 @@ def test_1173_prune_status_transitions_cleanup(tmp_path, monkeypatch):
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
-    import lionagi.state.db as state_db_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     old_ts = time.time() - 40 * 86400
 
@@ -439,10 +437,9 @@ def test_1173_prune_preserves_recent_terminal_sessions(tmp_path, monkeypatch):
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
-    import lionagi.state.db as state_db_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     recent_ts = time.time() - 5 * 86400  # 5 days ago, within 30-day keep window
 

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -13,6 +13,8 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -760,13 +762,12 @@ def _real_svc_client(monkeypatch, tmp_path: Path) -> TestClient:
     """Return a TestClient backed by the real service layer + temp DB."""
     from fastapi.testclient import TestClient
 
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.schedules as sched_svc_mod
     from lionagi.studio.app import app
 
     db_file = tmp_path / "test_state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
-    monkeypatch.setattr(sched_svc_mod, "DEFAULT_DB_PATH", db_file)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
@@ -1189,12 +1190,11 @@ class TestGithubRepoRealServiceValidation:
 
         # 1. Build the temp DB and wire the app to it.
         db_file = tmp_path / "test_state.db"
-        import lionagi.state.db as state_db_mod
         import lionagi.studio.services.schedules as sched_svc_mod
         from lionagi.studio.app import app
 
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
-        monkeypatch.setattr(sched_svc_mod, "DEFAULT_DB_PATH", db_file)
+        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
 
         # 2. Use the real service to create the schema (create a throw-away schedule).
         from fastapi.testclient import TestClient

--- a/tests/apps_studio_server/test_cas_race_conditions.py
+++ b/tests/apps_studio_server/test_cas_race_conditions.py
@@ -24,6 +24,7 @@ from sqlalchemy import text
 
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB, TransitionRejectedError  # noqa: E402
 
 from ._helpers import run_async  # noqa: E402
@@ -32,11 +33,10 @@ from ._helpers import run_async  # noqa: E402
 
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _make_session(db_path: Path, *, status: str | None = "running") -> str:
@@ -310,10 +310,8 @@ def test_prune_cleans_orphaned_messages_and_progressions(tmp_path, monkeypatch):
 
     db_path = tmp_path / "state.db"
 
-    import lionagi.state.db as state_db_mod
-
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     old_ts = time.time() - 40 * 86400
     recent_ts = time.time() - 1 * 86400
@@ -477,7 +475,6 @@ async def _run_global_delete(db_path: Path) -> None:
 
 def test_newborn_orphan_global_delete_destroys_progression(tmp_path, monkeypatch):
     """FAIL-before: the old global-delete spuriously deletes a newborn progression with no session yet -- reproducing the race where _persist.py commits the progression before the session, so the old NOT-IN-sessions/branches query sees no session row and deletes it."""
-    import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
@@ -533,12 +530,11 @@ def test_newborn_orphan_global_delete_destroys_progression(tmp_path, monkeypatch
 
 def test_newborn_orphan_scoped_delete_preserves_progression(tmp_path, monkeypatch):
     """PASS-after: the scoped delete only targets progressions/messages captured from the pruned sessions' lineage before the DELETE, so a newborn progression with no referencing session (not in that candidate set) survives."""
-    import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     old_ts = time.time() - 40 * 86400
 
@@ -592,12 +588,11 @@ def test_null_in_collection_does_not_stall_message_cleanup(tmp_path, monkeypatch
     """A progression collection containing a JSON null entry must not stall message cleanup: the NOT-IN guard filters out NULL collection values so a null entry can't propagate into the NOT IN set and suppress all message deletions."""
     import json
 
-    import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     old_ts = time.time() - 40 * 86400
 
@@ -735,7 +730,6 @@ async def _seed_shared_message_scenario(db_path: Path) -> tuple[str, str, str, s
 
 def test_shared_message_collection_only_check_deletes_it(tmp_path, monkeypatch):
     """FAIL-before, foreign_keys=OFF: the old collection-only survivor check (NOT IN progressions.collection) spuriously deletes shared_msg once the pruned progression is gone, even though surviving_branch.system_msg_id still holds it -- the failure mode for any runtime that doesn't enforce FKs."""
-    import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
@@ -791,12 +785,11 @@ def test_shared_message_collection_only_check_deletes_it(tmp_path, monkeypatch):
 
 def test_shared_message_fk_survivor_check_preserves_it(tmp_path, monkeypatch):
     """PASS-after: the full survivor check (collection + FK columns) UNIONs first_msg_id/last_msg_id/system_msg_id into the NOT IN subquery, so shared_msg_id survives via surviving_branch.system_msg_id while the unshared message is still correctly deleted."""
-    import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     _, _, shared_msg_id, unshared_msg_id = run_async(_seed_shared_message_scenario(db_path))
 

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -42,6 +42,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
 from ._helpers import run_async  # noqa: E402
@@ -350,7 +351,6 @@ def test_api_prefix_appears_exactly_once_in_every_route_path():
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
     """Point every service module's DB reference at a fresh temp path; must run before any seeding call since StateDB() re-reads DEFAULT_DB_PATH fresh per instantiation, and admin.py/sessions.py additionally cache the path in their own module-level `_DB`."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.db_maintenance as db_maintenance_mod
     import lionagi.studio.services.schedules as schedules_mod
@@ -377,10 +377,10 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     # db_maintenance imports DEFAULT_DB_PATH by value, so the state_db_mod
     # patch above never reaches its own module-level binding.
-    monkeypatch.setattr(db_maintenance_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 def _make_client() -> TestClient:

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
 
 from ._helpers import run_async
@@ -61,11 +62,10 @@ async def _make_schedule_run(db: StateDB, *, status: str, fired_at: float) -> st
 
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.state.db as state_db_mod
     from lionagi.studio.services import db_maintenance as maint
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 # ── checkpoint tests ──────────────────────────────────────────────────────────
@@ -77,7 +77,6 @@ def test_checkpoint_writes_admin_event(tmp_path, monkeypatch):
 
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
-    import lionagi.state.db as state_db_mod
 
     fixed_now = 1_000_000.0
     monkeypatch.setattr(state_db_mod, "time", SimpleNamespace(time=lambda: fixed_now))
@@ -137,7 +136,6 @@ def test_stats_endpoint_exposes_checkpoint_and_size_fields(tmp_path, monkeypatch
     pytest.importorskip("fastapi", reason="studio extra not installed")
     from fastapi.testclient import TestClient
 
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.stats as stats_mod
     from lionagi.studio.services import db_maintenance as maint
@@ -148,7 +146,7 @@ def test_stats_endpoint_exposes_checkpoint_and_size_fields(tmp_path, monkeypatch
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
     monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(stats_mod, "_DB", str(db_path))
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     run_async(_make_session_in(db_path, status="running", started_at=time.time()))
     run_async(maint.checkpoint_state_db(actor="test"))
@@ -603,7 +601,6 @@ def test_prune_old_data_endpoint(tmp_path, monkeypatch):
     pytest.importorskip("fastapi", reason="studio extra not installed")
     from fastapi.testclient import TestClient
 
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.stats as stats_mod
     from lionagi.studio.services import db_maintenance as maint
@@ -614,7 +611,7 @@ def test_prune_old_data_endpoint(tmp_path, monkeypatch):
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
     monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(stats_mod, "_DB", str(db_path))
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     run_async(_make_session_in(db_path, status="completed", started_at=time.time() - 40 * 86400))
 

--- a/tests/apps_studio_server/test_engine_defs_api.py
+++ b/tests/apps_studio_server/test_engine_defs_api.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 
@@ -73,7 +75,7 @@ def patched_svc(tmp_path: Path, monkeypatch):
     from lionagi.state.db import DEFAULT_DB_PATH
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     # Also patch db module's DEFAULT_DB_PATH so StateDB() picks up the temp path.
     import lionagi.state.db as db_mod
 
@@ -214,7 +216,7 @@ def patched_app(tmp_path: Path, monkeypatch):
     import lionagi.studio.services.engine_defs as ed_svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(ed_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app

--- a/tests/apps_studio_server/test_engine_runs_api.py
+++ b/tests/apps_studio_server/test_engine_runs_api.py
@@ -12,6 +12,7 @@ import pytest
 
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -58,8 +59,7 @@ def patched_engine_runs_svc(tmp_path: Path, monkeypatch):
     import lionagi.studio.services.engine_runs as svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(svc, "_DB", str(db_path))
-    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     return svc, db_path
 
 
@@ -184,8 +184,7 @@ def patched_app(tmp_path: Path, monkeypatch):
     import lionagi.studio.services.engine_runs as er_svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(er_svc, "_DB", str(db_path))
-    monkeypatch.setattr(er_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 
@@ -317,8 +316,7 @@ def test_list_endpoint_bearer_auth(tmp_path: Path, monkeypatch):
     import lionagi.studio.services.engine_runs as er_svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(er_svc, "_DB", str(db_path))
-    monkeypatch.setattr(er_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "secret-engine-token")
 
     from lionagi.studio.app import app

--- a/tests/apps_studio_server/test_invocations_service.py
+++ b/tests/apps_studio_server/test_invocations_service.py
@@ -35,7 +35,7 @@ async def test_get_invocation_returns_reason_fields_when_set(tmp_path, monkeypat
     status with a reason."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_id = await _create_invocation(db)
@@ -61,7 +61,7 @@ async def test_get_invocation_returns_none_reason_fields_when_unset(tmp_path, mo
     invocation has never been transitioned (columns are NULL)."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_id = await _create_invocation(db)
@@ -115,7 +115,7 @@ async def test_get_invocation_surfaces_schedule_run_failure_fields(tmp_path, mon
     error_detail so the UI can show WHY a scheduled run failed."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_id = await _create_invocation(db, status="failed")
@@ -141,7 +141,7 @@ async def test_get_invocation_schedule_run_fields_none_for_interactive_invocatio
     run, not a scheduled one) reports None for both fields, not an error."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_id = await _create_invocation(db)
@@ -158,7 +158,7 @@ async def test_list_invocations_includes_schedule_run_failure_fields(tmp_path, m
     existing JOIN, for both a failed-scheduled and a plain invocation."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_a = await _create_invocation(db, status="failed")
@@ -179,7 +179,7 @@ async def test_list_invocations_includes_reason_fields(tmp_path, monkeypatch):
     status_reason_summary with exact values for both the set and null cases."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(invocations_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     async with StateDB(db_path) as db:
         inv_a = await _create_invocation(db)

--- a/tests/apps_studio_server/test_lifecycle_play_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_play_reaper.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
 
 from ._helpers import run_async
@@ -19,14 +20,13 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _seed_show(db_path: Path, *, show_id: str | None = None, status: str = "active") -> str:
@@ -318,8 +318,6 @@ def test_reap_stale_plays_cas_guard_skips_concurrently_transitioned_row(tmp_path
         _seed_play(db_path, show_id, status="running", session_id=None, updated_at=_STALE)
     )
 
-    import lionagi.state.db as state_db_mod
-
     original_update_status = state_db_mod.StateDB.update_status
     flipped = {"done": False}
 
@@ -353,8 +351,6 @@ def test_reap_stale_plays_skips_row_claimed_between_scan_and_write(tmp_path, mon
     play_id = run_async(
         _seed_play(db_path, show_id, status="prepared", session_id=None, updated_at=_STALE)
     )
-
-    import lionagi.state.db as state_db_mod
 
     original_fetch_one = state_db_mod.StateDB.fetch_one
     claimed = {"done": False}
@@ -396,8 +392,6 @@ def test_reap_stale_plays_version_guard_skips_claim_after_revalidation(tmp_path,
     play_id = run_async(
         _seed_play(db_path, show_id, status="running", session_id=None, updated_at=_STALE)
     )
-
-    import lionagi.state.db as state_db_mod
 
     original_update_status = state_db_mod.StateDB.update_status
     claimed = {"done": False}

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
 
 from ._helpers import run_async
@@ -21,14 +22,13 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _seed_session(
@@ -255,7 +255,6 @@ def test_reap_stale_invocations_per_kind_override(tmp_path, monkeypatch):
     # Patch list_invocations to inject action_kind into the returned rows
     # (the invocations table currently has no action_kind column; the per-kind
     # lookup is tested here at the reaper level via the list_invocations result).
-    import lionagi.state.db as state_db_mod
 
     _original_list = state_db_mod.StateDB.list_invocations
 
@@ -648,8 +647,6 @@ def test_admin_prune_all_phantom_transitions_not_deletes(tmp_path, monkeypatch):
         )
     )
 
-    import lionagi.state.db as state_db_mod
-
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
@@ -677,7 +674,6 @@ def test_stats_includes_phantom_count(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -17,20 +17,20 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
 
 from ._helpers import run_async
 
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _seed_schedule(db_path: Path, *, schedule_id: str | None = None) -> str:
@@ -317,8 +317,6 @@ def test_reap_stale_schedule_runs_version_guard_skips_row_touched_between_scan_a
 
     sid = run_async(_seed_schedule(db_path))
     run_id = run_async(_seed_schedule_run(db_path, sid, status="running", updated_at=_STALE))
-
-    import lionagi.state.db as state_db_mod
 
     original_update_status = state_db_mod.StateDB.update_status
     flipped = {"done": False}

--- a/tests/apps_studio_server/test_lifecycle_show_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_show_reaper.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from pathlib import Path
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
 
 from ._helpers import run_async
@@ -20,14 +21,13 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lifecycle_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(lifecycle_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 async def _seed_show(
@@ -359,8 +359,6 @@ def test_reap_stale_shows_version_guard_skips_claimed_row(tmp_path, monkeypatch)
     _monkey_db(monkeypatch, db_path)
 
     show_id = run_async(_seed_show(db_path, show_dir, updated_at=_STALE))
-
-    import lionagi.state.db as state_db_mod
 
     original_update_status = state_db_mod.StateDB.update_status
     claimed = {"done": False}

--- a/tests/apps_studio_server/test_schedule_limits_route.py
+++ b/tests/apps_studio_server/test_schedule_limits_route.py
@@ -16,13 +16,14 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
+
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.schedules as schedules_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 def _make_client() -> TestClient:

--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -20,6 +20,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 from lionagi.studio.services.schedules import create_schedule  # noqa: E402
 
@@ -65,11 +66,10 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     """Point both the StateDB default and the schedules service's own bound
     name at the temp path -- must run before any seeding, or seed writes
     land in the real default DB."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.schedules as schedules_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 def _make_client() -> TestClient:

--- a/tests/apps_studio_server/test_schedule_streaks.py
+++ b/tests/apps_studio_server/test_schedule_streaks.py
@@ -24,7 +24,7 @@ from lionagi.studio.services.schedules import (  # noqa: E402
 def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     db_path = tmp_path / "state.db"
     monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
     return db_path
 
 

--- a/tests/apps_studio_server/test_stats_db_health.py
+++ b/tests/apps_studio_server/test_stats_db_health.py
@@ -13,6 +13,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
 
@@ -41,7 +42,6 @@ async def _seed_two_sessions(db_path: Path) -> None:
 
 
 def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.stats as stats_mod
 
@@ -101,7 +101,6 @@ def test_stats_size_comes_from_stats_db_path(tmp_path, monkeypatch):
     small_db = tmp_path / "small_state.db"
     _run(_seed_two_sessions(small_db))
 
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.stats as stats_mod
@@ -146,7 +145,6 @@ async def _seed_invocation_with_bad_metadata(db_path: Path, inv_id: str) -> None
 
 def test_invocation_bad_metadata_becomes_none(tmp_path, monkeypatch):
     """Corrupted node_metadata must be None, not the raw invalid string."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.invocations as inv_mod
 
     db_path = tmp_path / "state.db"
@@ -154,7 +152,7 @@ def test_invocation_bad_metadata_becomes_none(tmp_path, monkeypatch):
     _run(_seed_invocation_with_bad_metadata(db_path, inv_id))
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(inv_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 
@@ -169,7 +167,6 @@ def test_invocation_bad_metadata_becomes_none(tmp_path, monkeypatch):
 
 def test_invocation_list_bad_metadata_becomes_none(tmp_path, monkeypatch):
     """Corrupted node_metadata in list endpoint must also be None."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.invocations as inv_mod
 
     db_path = tmp_path / "state.db"
@@ -177,7 +174,7 @@ def test_invocation_list_bad_metadata_becomes_none(tmp_path, monkeypatch):
     _run(_seed_invocation_with_bad_metadata(db_path, inv_id))
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(inv_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
@@ -41,7 +43,7 @@ def patched_svc(tmp_path: Path, monkeypatch):
     import lionagi.studio.services.workflow_defs as svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
     return svc, db_path
 

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -18,6 +18,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
@@ -111,8 +113,8 @@ def patched_env(tmp_path: Path, monkeypatch):
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(wf_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     # sessions.py freezes `_DB = str(DEFAULT_DB_PATH)` at import time (module
     # constant, not re-read per call) — both attrs need patching, matching the
     # convention already established in test_admin.py.

--- a/tests/apps_studio_server/test_workflow_run_transcript_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_transcript_persist.py
@@ -26,6 +26,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
@@ -126,8 +128,8 @@ def patched_env(tmp_path: Path, monkeypatch):
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(wf_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 # ---------------------------------------------------------------------------
 # subprocess.build_argv tests
 # ---------------------------------------------------------------------------
@@ -239,12 +241,11 @@ def _minimal_command_schedule(name: str) -> dict:
 def test_create_schedule_route_duplicate_name_returns_409(tmp_path, monkeypatch):
     """Creating a schedule with a name that already exists must return 409,
     not a generic server error."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.schedules as schedules_mod
 
     fake_db = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
     from fastapi.testclient import TestClient
 
     from lionagi.studio.app import app
@@ -260,12 +261,11 @@ def test_create_schedule_route_duplicate_name_returns_409(tmp_path, monkeypatch)
 def test_create_schedule_route_storage_failure_is_not_409(tmp_path, monkeypatch):
     """A non-conflict exception from the storage layer (e.g. RuntimeError)
     must not be reported to the client as a 409 name conflict."""
-    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.schedules as schedules_mod
 
     fake_db = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     async def _boom(self, schedule):
         raise RuntimeError("storage offline")

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -121,6 +121,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LIONAGI_ROOT = REPO_ROOT / "lionagi"
 
@@ -4257,8 +4259,8 @@ async def test_run_workflow_def_delegates_to_session_flow_with_progress_wrapper(
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(wf_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 
@@ -4312,7 +4314,7 @@ async def test_compile_workflow_def_never_calls_session_flow(tmp_path, monkeypat
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from tests.apps_studio_server.test_workflow_run import _spec
 

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -185,3 +185,71 @@ async def test_a_server_url_does_not_answer_from_the_filesystem(absent_default, 
 
     with pytest.raises(Exception):  # noqa: B017 — any failure beats a silent []
         await svc.list_engine_defs()
+
+
+# ── the shared readonly seam ──────────────────────────────────────────────────
+# Several reporting commands stopped guarding for themselves and now go through
+# one helper. That concentrates the same question in one place: if the helper
+# asks the filesystem while opening the configured store, every reader that
+# migrated to it inherits the defect at once.
+
+
+@pytest.mark.asyncio
+async def test_the_readonly_seam_opens_a_moved_store_instead_of_reporting_it_absent(
+    moved_sqlite_url,
+):
+    from lionagi.cli.machine import readonly_state_db
+
+    name = f"seam-{uuid.uuid4().hex[:8]}"
+    await _seed_engine_def(name)
+
+    async with readonly_state_db() as (db, why):
+        assert why is None, why
+        assert db is not None
+        rows = await db.fetch_all("SELECT name FROM engine_defs", [])
+
+    assert name in {row["name"] for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_the_readonly_seam_will_not_call_a_server_url_absent(absent_default, monkeypatch):
+    # Nothing here connects: the point is that "absent" must not be answerable
+    # from the filesystem for a store the filesystem knows nothing about. A
+    # failure to reach it is a different answer, and the reason says which.
+    from lionagi.cli.machine import REASON_NOT_FOUND, readonly_state_db
+
+    _set_url(monkeypatch, _SERVER_URL)
+
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            assert why["reason_code"] != REASON_NOT_FOUND, why
+
+
+def test_the_absent_reason_names_the_store_that_was_consulted(moved_sqlite_url, absent_default):
+    from lionagi.cli.machine import state_db_absent
+
+    detail = state_db_absent()["detail"]
+    assert str(absent_default) not in detail
+    assert "moved" in detail
+
+
+def test_reported_sizes_describe_the_configured_store(moved_sqlite_url, tmp_path):
+    from lionagi.cli.state import _db_sizes
+
+    sizes = _db_sizes()
+    assert sizes["is_file"] is True
+    assert sizes["path"] == str(tmp_path / "moved" / "state.db")
+
+
+def test_a_store_with_no_file_reports_no_size_rather_than_zero(absent_default, monkeypatch):
+    # Zero would be a claim about an empty file. There is no file, so the honest
+    # answer is that the question does not apply -- and `is_file` is what lets a
+    # reader tell those apart instead of guessing from a bare 0.
+    from lionagi.cli.state import _db_sizes
+
+    _set_url(monkeypatch, _SERVER_URL)
+
+    sizes = _db_sizes()
+    assert sizes["is_file"] is False
+    assert sizes["size_bytes"] is None
+    assert sizes["wal_size_bytes"] is None

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readers must decide "there is nothing recorded" against the configured
+store, not against the default path.
+
+``LIONAGI_STATE_DB_URL`` moves the state store — to another SQLite file, to a
+server, or into memory. A guard that asks whether ``DEFAULT_DB_PATH`` exists
+answers about a file that need not be involved, and every row in the store that
+*is* involved is reported missing.
+
+Both shapes are covered here: a SQLite store moved to a non-default path, and a
+URL that is not a local file at all.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import lionagi.state.db as db_mod
+from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
+
+
+def _set_url(monkeypatch, url: str | None) -> None:
+    """Settings are frozen, so redirect the whole object the module reads."""
+    monkeypatch.setattr(
+        db_mod, "settings", db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": url})
+    )
+
+
+@pytest.fixture
+def absent_default(tmp_path, monkeypatch):
+    """Point the default path at a file that does not exist.
+
+    Without this the machine's own ``~/.lionagi/state.db`` may exist and mask
+    the defect: the guard would pass for the wrong reason.
+    """
+    missing = tmp_path / "no-such-home" / "state.db"
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", missing)
+    return missing
+
+
+@pytest.fixture
+def moved_sqlite_url(tmp_path, absent_default, monkeypatch):
+    """A real SQLite store at a non-default path, selected by the env URL."""
+    moved = tmp_path / "moved" / "state.db"
+    moved.parent.mkdir(parents=True, exist_ok=True)
+    url = f"sqlite+aiosqlite:///{moved}"
+    _set_url(monkeypatch, url)
+    return url
+
+
+# A URL with no local file behind it. The host is unreachable by construction —
+# nothing here connects to it; what matters is that the guard cannot answer
+# "absent" from the filesystem for a store shaped like this.
+_SERVER_URL = "postgresql+asyncpg://user:pw@127.0.0.1:1/lionagi_state"
+
+
+async def _seed_engine_def(name: str) -> str:
+    def_id = str(uuid.uuid4())
+    async with StateDB() as db:
+        await db.create_engine_def(
+            {
+                "id": def_id,
+                "name": name,
+                "kind": "fanout",
+                "model": "openai/gpt-4.1-mini",
+                "max_depth": 1,
+                "max_agents": 1,
+                "options": {},
+                "description": "",
+            }
+        )
+    return def_id
+
+
+# ── the helpers themselves ────────────────────────────────────────────────
+
+
+def test_state_db_file_follows_the_url(moved_sqlite_url, absent_default, tmp_path):
+    assert state_db_file() == tmp_path / "moved" / "state.db"
+
+
+def test_state_db_file_is_none_when_the_store_is_not_a_file(absent_default, monkeypatch):
+    _set_url(monkeypatch, _SERVER_URL)
+    assert state_db_file() is None
+
+
+def test_known_absent_is_false_once_the_moved_store_exists(moved_sqlite_url, tmp_path):
+    assert state_db_known_absent() is True
+    (tmp_path / "moved" / "state.db").touch()
+    assert state_db_known_absent() is False
+
+
+def test_known_absent_is_false_for_a_server_url(absent_default, monkeypatch):
+    """No filesystem answer exists, so the open attempt must give the real one."""
+    _set_url(monkeypatch, _SERVER_URL)
+    assert state_db_known_absent() is False
+
+
+def test_known_absent_is_false_for_an_in_memory_url(absent_default, monkeypatch):
+    _set_url(monkeypatch, "sqlite+aiosqlite:///:memory:")
+    assert state_db_known_absent() is False
+
+
+# ── shape 1: a SQLite store moved off the default path ────────────────────
+
+
+async def test_engine_defs_are_found_in_a_moved_store(moved_sqlite_url):
+    from lionagi.studio.services import engine_defs as svc
+
+    await _seed_engine_def("moved-def")
+
+    rows = await svc.list_engine_defs()
+    assert [r["name"] for r in rows] == ["moved-def"]
+    assert await svc.get_engine_def_by_name("moved-def") is not None
+
+
+async def test_schedules_are_found_in_a_moved_store(moved_sqlite_url):
+    from lionagi.studio.services import schedules as svc
+
+    await svc.create_schedule(
+        {
+            "name": "moved-schedule",
+            "trigger_type": "interval",
+            "interval_sec": 3600,
+            "action_kind": "agent",
+            "action_model": "openai/gpt-4.1-mini",
+            "action_prompt": "noop",
+        }
+    )
+
+    assert [r["name"] for r in await svc.list_schedules()] == ["moved-schedule"]
+    assert await svc.get_schedule_by_name("moved-schedule") is not None
+
+
+async def test_li_status_consults_a_moved_store(moved_sqlite_url, monkeypatch):
+    """`li status` must report on the id, not on a file it never opens."""
+    from lionagi.cli import status as status_mod
+
+    await _seed_engine_def("anything")  # materializes the moved store
+    monkeypatch.setattr(status_mod, "detect_project", lambda _p: ("dburl-sweep", "test"))
+    out, _code = await status_mod._run_status_inner(
+        command="agent", entity_id="deadbeef", as_json=False
+    )
+    assert "state.db not found" not in out
+
+
+async def test_li_ctl_consults_a_moved_store(moved_sqlite_url):
+    from lionagi.cli.orchestrate import _control
+
+    await _seed_engine_def("anything")  # materializes the moved store
+    msg, _code = await _control._enqueue_control_inner(
+        entity_id="deadbeef", verb="pause", payload=None
+    )
+    assert "state.db not found" not in msg
+
+
+async def test_engine_def_absent_from_a_moved_store_still_reads_as_absent(
+    moved_sqlite_url,
+):
+    """The other half of the contract: a genuine miss keeps its answer."""
+    from lionagi.studio.services import engine_defs as svc
+
+    await _seed_engine_def("present")
+
+    assert await svc.get_engine_def_by_name("never-created") is None
+
+
+# ── shape 2: a URL that is not a local file ───────────────────────────────
+
+
+async def test_a_server_url_does_not_answer_from_the_filesystem(absent_default, monkeypatch):
+    """The default path is absent and the store is a server, so a filesystem
+    guard would return an empty list without ever trying to connect.
+
+    The reader must instead attempt the store and let the attempt speak — here
+    that surfaces as a raised error (the driver is absent, or the host refuses),
+    which is a true answer where ``[]`` was a fabricated one.
+    """
+    _set_url(monkeypatch, _SERVER_URL)
+    from lionagi.studio.services import engine_defs as svc
+
+    with pytest.raises(Exception):  # noqa: B017 — any failure beats a silent []
+        await svc.list_engine_defs()

--- a/tests/studio/test_auth.py
+++ b/tests/studio/test_auth.py
@@ -18,6 +18,8 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
+
 # Every data-returning GET prefix that must be gated when a token is configured.
 _DATA_GET_PREFIXES = [
     "/api/runs/",
@@ -53,6 +55,7 @@ def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
             monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
         if hasattr(mod, "_DB"):
             monkeypatch.setattr(mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     # A fresh app instance (via create_app()) instead of importlib.reload(app_mod):
     # reload mutates the shared module singleton every other importer holds a

--- a/tests/studio/test_hosted_hardening.py
+++ b/tests/studio/test_hosted_hardening.py
@@ -20,6 +20,8 @@ import anyio  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
+import lionagi.state.db as state_db_mod
+
 
 @contextmanager
 def _entered_client(app: FastAPI, **kwargs: object) -> Generator[TestClient]:
@@ -66,6 +68,7 @@ def make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
             monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
         if hasattr(mod, "_DB"):
             monkeypatch.setattr(mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     stack = ExitStack()
 
@@ -289,6 +292,7 @@ class TestJsonContentTypeEnforcement:
                 monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
             if hasattr(mod, "_DB"):
                 monkeypatch.setattr(mod, "_DB", str(fake_db))
+        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
         app = app_mod.create_app()
 
         async def _chunks():

--- a/tests/studio/test_schedule_effective_timezone.py
+++ b/tests/studio/test_schedule_effective_timezone.py
@@ -26,11 +26,16 @@ pytest.importorskip("croniter", reason="studio extra not installed")
 
 @pytest.fixture
 def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Per-test temp file DB. Both ``state.db`` and the schedules service
-    bind ``DEFAULT_DB_PATH`` by plain import, so both need patching."""
+    """Per-test temp file DB.
+
+    Only the one binding is patched, because only one is read. ``StateDB``
+    resolves the default at call time from its own module, and the schedules
+    service no longer decides anything from a path: it asks the configured
+    store. Patching a name the service does not read would pin nothing while
+    looking like it pinned something.
+    """
     db_path = tmp_path / "state.db"
     monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
     return db_path
 
 

--- a/tests/studio/test_schedule_run_view_service.py
+++ b/tests/studio/test_schedule_run_view_service.py
@@ -24,7 +24,7 @@ from lionagi.studio.services.schedules import (
 def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     db_path = tmp_path / "state.db"
     monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
     return db_path
 
 

--- a/tests/studio/test_schedule_runs_regression.py
+++ b/tests/studio/test_schedule_runs_regression.py
@@ -27,7 +27,7 @@ from lionagi.studio.services.schedules import get_schedule_run, list_schedule_ru
 def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     db_path = tmp_path / "state.db"
     monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
     return db_path
 
 

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -28,7 +28,7 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     name directly, so both bindings need patching)."""
     db_path = tmp_path / "state.db"
     monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
     return db_path
 
 


### PR DESCRIPTION
`LIONAGI_STATE_DB_URL` moves the state store — to another SQLite file, to a server, or into memory. `StateDB.__init__` honours it. Dozens of readers guarded themselves with `if not DEFAULT_DB_PATH.exists(): return []` and then opened `StateDB()` on the next line, so with a URL configured the guard answered about a file nothing was reading and every row in the store that *was* being read got reported missing.

The failure mode is the bad one: not an error, an **empty answer**. The scheduler UI reads as having no history, every reaper silently skips its sweep, `li wait` exits immediately, invocation lookups 404.

## Every site splits three ways, and only one group is wrong

**A — guard on the filesystem, reader honours the URL.** The defect. 38 guards converted, across `studio/services/{schedules,lifecycle,invocations,db_maintenance,engine_defs,workflow_defs,engine_runs,admin,stats}.py`, `cli/{monitor,status,wait,stats}.py`, `cli/orchestrate/_control.py` and `session/observer.py`. Three readers in that set were themselves pinned to the default path and were unpinned so the conversion actually lands — otherwise the guard consults the configured store and the reader still opens the default file.

**B — guard and reader both pinned to the default path.** 19 guards, deliberately left alone. These use a raw `aiosqlite.connect` against a module-level path frozen at import, so the guard is *correct about the file its reader opens*. Converting the guard alone would remove a true guard and let `connect` create an empty stray database at the default path, still returning nothing. Those readers are a separate and larger defect — SQLite-only, path-pinned, unable to talk to a server URL at all — and fixing them is a reader rewrite, not a guard swap.

**C — the question really is about a file.** Size on disk, WAL bytes. Handled below rather than converted.

`DEFAULT_DB_PATH` references in `lionagi/` go from 105 across 24 files (57 guard-shaped) to 46 (19 guard-shaped, all group B).

## The shared readonly seam had the same defect one level down

Several reporting commands have stopped guarding for themselves and now open the store through one helper. That is the better shape, but it concentrated the same question in one place and the helper still asked the filesystem — checking whether the default path exists, then opening whatever the URL names. Every reader that migrated to it inherited the defect at once. The unavailability it handed back named the default path too, sending readers to a file that is not the one their command would have read.

## Sizes: a null that cannot be read as zero

Size and WAL genuinely are questions about a file, so when the store is a server or in memory there are no bytes to report. Reporting the default path's size there would describe a file nothing is reading. `is_file` now says which case it is, and the size is `null` rather than `0` — `0` is a claim about an empty file, and this is the question not applying. (`size_bytes: int | None` is already the sanctioned shape in ADR-0078.)

## Tests

`tests/state/test_state_db_url_guards.py`, 16 tests, covering both shapes a moved store takes: a SQLite file at a non-default path, and a URL with no local file behind it. The fixtures point `DEFAULT_DB_PATH` at a file that does not exist, so a passing guard cannot pass for the wrong reason on a machine that happens to have a real `~/.lionagi/state.db`.

Each new test proved able to fail by reverting exactly the change it guards.

One fixture needed updating: it patched `DEFAULT_DB_PATH` on two modules, and the schedules service no longer reads a path at all — so the second patch would have pinned nothing while looking like it pinned something.

Suites: `tests/state tests/cli tests/mcp tests/studio tests/apps_studio_server`, postgres deselected — **5203 passed, 2 skipped, 4 failed**. All four are pre-existing: three in `tests/mcp/test_schedule_verbs.py` reproduce identically on a branch that touches none of this code, and `test_pack_routing_shown_in_dry_run` depends on the contents of the developer's home directory.
