### PR TITLE
fix(cli): resolve a schedule's next-fire zone through the resolver that still exists

### DIFF
--- a/lionagi/cli/machine_schedule.py
+++ b/lionagi/cli/machine_schedule.py
@@ -195,8 +195,7 @@ def _resolved_next_fire(row: dict[str, Any]) -> dict[str, Any]:
     can see whether it got 09:00 local.
     """
     try:
-        from lionagi.studio.config import SCHEDULER_TZ
-        from lionagi.studio.scheduler.engine import _resolve_scheduler_tzinfo, scheduler
+        from lionagi.studio.scheduler.engine import resolve_schedule_timezone, scheduler
     except Exception as exc:  # noqa: BLE001 — an unimportable resolver is not a create failure
         return unavailable("unresolved", f"the scheduler's resolver is unavailable here: {exc}")
 
@@ -207,15 +206,18 @@ def _resolved_next_fire(row: dict[str, Any]) -> dict[str, Any]:
             f"the scheduler's resolver returned no next occurrence for trigger_type "
             f"{row.get('trigger_type')!r}",
         )
-    tz_name = row.get("resolved_timezone") or SCHEDULER_TZ
-    tz = _resolve_scheduler_tzinfo(tz_name)
+    # The row's own zone if it declares one, else the configured default, with
+    # an unloadable name falling back to UTC rather than raising. Asking the
+    # scheduler's resolver for that is what keeps the zone reported here the
+    # same one the fire is actually computed in.
+    zone = resolve_schedule_timezone(row)
     from datetime import datetime
 
     return available(
         {
             "epoch": epoch,
-            "rfc3339": datetime.fromtimestamp(epoch, tz=tz).isoformat(timespec="seconds"),
-            "timezone": str(tz),
+            "rfc3339": datetime.fromtimestamp(epoch, tz=zone.tzinfo).isoformat(timespec="seconds"),
+            "timezone": zone.name,
         }
     )
 


### PR DESCRIPTION
`main` is red on every Python version with a single failing test:

```
FAILED tests/mcp/test_schedule_verbs.py::test_create_reports_the_row_written_and_when_it_next_fires
1 failed, 15335 passed, 38 skipped
```

`_resolved_next_fire` in `lionagi/cli/machine_schedule.py` imports
`_resolve_scheduler_tzinfo` from `lionagi/studio/scheduler/engine.py`, which no longer
defines it. Timezone resolution moved to `resolve_schedule_timezone(schedule)`, which
takes the row and returns the zone name, its provenance, and a loaded `tzinfo`.

Two changes landed close together and are individually consistent: one removed the old
name-to-tzinfo helper, the other added a fresh call to it. Each was green against the
base it was tested on, so nothing caught the pair until both were on `main`.

Nothing crashed, which is why this surfaces as one assertion rather than a broad
failure. The import sits inside a `try` whose `except` deliberately treats an
unimportable resolver as a soft failure, so `li schedule create` kept succeeding and
reported its next fire as `unavailable` with the ImportError text as the detail. The
write path was never affected; what was lost is the caller's ability to see which local
time its cron expression resolved to — the whole point of reporting the next fire.

## The change

`_resolved_next_fire` now calls `resolve_schedule_timezone(row)`. That also removes the
hand-rolled `row.get("resolved_timezone") or SCHEDULER_TZ` fallback beside it, so the
zone reported to the caller is resolved exactly the way the zone the fire is computed in
is resolved — including the UTC fallback for a zone name this host cannot load, which
the hand-rolled version would have raised on.

`timezone` in the payload now reports `zone.name` rather than `str(tzinfo)`. These agree
for a loadable name, and where they would differ the name is the honest answer: an
unloadable zone falls back to a UTC `tzinfo`, and the resolver records that as UTC with a
source that distinguishes it from a UTC someone asked for.

## Verification

Reproduced on `main` before changing anything — `1 failed, 27 passed` in
`tests/mcp/test_schedule_verbs.py`, with the ImportError text in the assertion. After the
change, `28 passed`.
