### PR TITLE
fix(studio): ask GitHub for its maximum page size so a merged-PR scan can outrun its backlog

### DIFF
--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -73,10 +73,20 @@ _cached_token: str | None = None
 # Bounds how many pages github_poll() will fetch hunting for an older,
 # still-undispatched merged PR (merged_at can trail the API's updated_at
 # sort key -- see GithubPollResult.scan_complete). Worst case
-# _MERGED_MODE_MAX_PAGES * per_page (100) PRs inspected per poll; anything
-# buried deeper is picked up on a later poll once the noise ages out.
-# Bounded latency, not bounded correctness.
+# _MERGED_MODE_MAX_PAGES * per_page PRs inspected per poll, so 500 at the
+# per_page=100 the request sends; anything buried deeper is picked up on a
+# later poll once the noise ages out. Bounded latency, not bounded
+# correctness -- as long as the reach stays ahead of the backlog above the
+# stored cursor. It does not recover on its own if it falls behind: nothing
+# dispatches, so the cursor never advances, so the next scan is no shorter.
 _MERGED_MODE_MAX_PAGES = 5
+
+# Page size requested from the API (GitHub's maximum). The page budget above
+# is stated in terms of this, so lowering it shortens the scan's reach by the
+# same factor -- which is how a busy repo ends up with a backlog the scan can
+# never cross. Read it from here rather than restating the literal, so a
+# change to the reach cannot silently disagree with anything measuring it.
+_PER_PAGE = 100
 
 _LINK_NEXT_RE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
 
@@ -259,7 +269,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         "state": "closed" if merged_mode else github_filter.get("state", "open"),
         "sort": "updated",
         "direction": "desc",
-        "per_page": "20",
+        "per_page": str(_PER_PAGE),
     }
     if "base" in github_filter:
         params["base"] = github_filter["base"]
@@ -382,6 +392,8 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     # the oldest fetched updated_at can't be proven safe to dispatch -- drop
     # it entirely (not just mark non-dispatchable) so it's re-fetched and
     # reconsidered on a later poll instead of risking a skipped merge.
+    # (Dispatching one advances the cursor to ITS merged_at, which would step
+    # over any unfetched PR merged earlier -- losing it permanently.)
     unsafe_floor: str | None = None
     if merged_mode and not scan_complete and prs:
         unsafe_floor = min(pr.get("updated_at", "") for pr in prs)
@@ -389,6 +401,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
     draft_filter = github_filter.get("draft")
     same_repo_filter = github_filter.get("same_repo_only")
     items: list[GithubPollItem] = []
+    held_back: list[Any] = []
     for pr in prs:
         updated = pr.get("updated_at", "")
         if merged_mode:
@@ -405,6 +418,7 @@ async def github_poll(schedule: dict) -> GithubPollResult:
             continue
 
         if unsafe_floor is not None and cursor_at >= unsafe_floor:
+            held_back.append(pr.get("number"))
             continue
 
         is_draft = bool(pr.get("draft", False))
@@ -457,6 +471,27 @@ async def github_poll(schedule: dict) -> GithubPollResult:
         if merged_mode:
             event["pr_merged_at"] = merged_at
         items.append(GithubPollItem(event=event, updated_at=cursor_at, dispatchable=dispatchable))
+
+    # Holding some events back while returning others is ordinary: the caller
+    # advances the cursor past what it got, so the next scan starts higher and
+    # the held-back band drains. Holding back EVERYTHING is the stuck shape --
+    # an empty result means the caller advances no cursor at all, so the next
+    # scan repeats this one exactly, and it is indistinguishable from a quiet
+    # repo at every other signal (the result is "ok", the schedule keeps a
+    # future fire time, no run is recorded). Only that case warns; a truncation
+    # notice that fires on every truncated poll is not a signal.
+    if held_back and not items:
+        _log.warning(
+            "%s: merged-PR scan found %d event(s) past the cursor and dispatched "
+            "none -- all sit at or above the unproven boundary %s of a truncated "
+            "scan (PR numbers: %s). No cursor advances, so the next poll repeats "
+            "this one. If this persists, the backlog above the stored cursor is "
+            "deeper than the scan can reach.",
+            repo,
+            len(held_back),
+            unsafe_floor,
+            ", ".join(str(n) for n in held_back[:10]) + ("..." if len(held_back) > 10 else ""),
+        )
 
     # API order (updated_at desc) isn't contractually identical to the
     # cursor field in merged mode; sort explicitly so cursor advance stays

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -14,6 +14,7 @@ GithubPollItem list instead of a StateDB write.
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import httpx
 import pytest
@@ -657,23 +658,15 @@ def test_github_poll_merged_mode_pages_past_closed_unmerged_noise(monkeypatch):
     updated_at is older than every unmerged PR on page 1, but its merged_at is
     still after the cursor, so it must be found and dispatched.
 
-    Page 1 is exactly per_page (20) items long -- the poller's own signal
+    Page 1 is exactly per_page items long -- the poller's own signal
     that there may be more -- and its oldest item's updated_at is still newer
     than the cursor, so github_poll must follow the Link: rel="next" header
     onto page 2 rather than stopping at page 1.
     """
     cursor = "2026-06-01T00:00:00Z"
-    page1 = [
-        _pr(
-            100 + n,
-            f"2026-07-06T{10 - n // 10:02d}:{59 - (n % 10) * 5:02d}:00Z",
-            state="closed",
-            merged_at=None,
-        )
-        for n in range(20)
-    ]
+    page1 = _closed_page(10, 100)
     # Sanity: page1 is a full page, strictly newer than the cursor throughout.
-    assert len(page1) == 20
+    assert len(page1) == gh_mod._PER_PAGE
     assert all(pr["updated_at"] > cursor for pr in page1)
 
     merged_pr = _pr(
@@ -713,7 +706,7 @@ def test_github_poll_merged_mode_stops_paging_once_cursor_reached(monkeypatch):
             state="closed",
             merged_at=None,
         )
-        for n in range(20)
+        for n in range(gh_mod._PER_PAGE)
     ]
     # Oldest item on page1 must already be at/under the cursor.
     assert page1[-1]["updated_at"] <= cursor
@@ -737,13 +730,23 @@ def test_github_poll_merged_mode_stops_paging_once_cursor_reached(monkeypatch):
 
 
 def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None = None):
-    """20 closed PRs at a fixed hour, minutes descending. ``merges`` maps a
-    within-page index to a merged_at value for that PR (unmerged otherwise)."""
+    """One FULL page of closed PRs at a fixed hour, updated_at descending.
+
+    The size is read from ``gh_mod._PER_PAGE`` rather than hard-coded: the
+    poller decides a page is terminal via ``len(page) < per_page``, so a
+    fixture that states its own size silently turns every page short — and
+    every pagination test into a single-page test — the moment the reach
+    changes. ``merges`` maps a within-page index to a merged_at value for that
+    PR (unmerged otherwise).
+    """
     merges = merges or {}
+    n = gh_mod._PER_PAGE
+    # Spread across the hour so timestamps stay strictly descending at any n.
+    step = max(1, (3600 - 60) // n)
     items = []
-    for i in range(20):
-        minute = 59 - i * 3
-        updated_at = f"2026-07-06T{hour:02d}:{minute:02d}:00Z"
+    for i in range(n):
+        secs = 3540 - i * step
+        updated_at = f"2026-07-06T{hour:02d}:{secs // 60:02d}:{secs % 60:02d}Z"
         items.append(_pr(base_number + i, updated_at, state="closed", merged_at=merges.get(i)))
     return items
 
@@ -1052,10 +1055,7 @@ def test_github_poll_pagination_401_clears_cached_token(monkeypatch):
     still clears the cache -- GitHub has rejected the credential, so the next
     poll must re-resolve instead of reusing a proven-dead token."""
     cursor = "2026-06-01T00:00:00Z"
-    page1 = [
-        _pr(200 + n, f"2026-07-06T{10 - n // 10:02d}:00:00Z", state="closed", merged_at=None)
-        for n in range(20)
-    ]
+    page1 = _closed_page(10, 200)
 
     async def _fake_token(prefer_cli: bool = False):
         return "faketoken"
@@ -1168,3 +1168,116 @@ def test_github_poll_result_default_poll_status_is_ok():
     construction that predates the observer-self-health signal."""
     result = gh_mod.GithubPollResult(items=[], scan_complete=True)
     assert result.poll_status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Scan reach: how far back a single merged-mode poll can actually see
+# ---------------------------------------------------------------------------
+
+
+def _all_merged(page):
+    """Mark every PR on a page as merged at its own updated_at.
+
+    The realistic shape for a merge that was never touched again, and the one
+    that puts every event at or above the unproven boundary of a truncated
+    scan.
+    """
+    for pr in page:
+        pr["merged_at"] = pr["updated_at"]
+    return page
+
+
+def test_github_poll_requests_the_page_size_the_reach_is_stated_in(monkeypatch):
+    """The page size sent to the API is the one the page budget is written
+    against, and it is the largest the API allows.
+
+    A merged-mode scan can only see ``_MERGED_MODE_MAX_PAGES * per_page`` PRs
+    back from the newest. If the request quietly asks for fewer per page than
+    the budget comment assumes, the reach shrinks by that factor with nothing
+    to say so -- and a repo whose backlog above the stored cursor grows past
+    the reach deadlocks, because held-back events never advance the cursor and
+    so never shorten the next scan. Tying the sent value to the constant keeps
+    the reach a single number instead of two that can disagree.
+    """
+    client = _install(monkeypatch, [_pr(1, "2026-07-07T10:00:00Z")])
+    _poll({"id": "s1", "github_repo": "owner/name"})
+    assert client.requests[0]["params"]["per_page"] == str(gh_mod._PER_PAGE)
+    assert gh_mod._PER_PAGE == 100  # GitHub's documented maximum
+
+
+def test_github_poll_truncated_scan_holding_everything_back_warns(monkeypatch, caplog):
+    """A truncated scan that holds back every event says so at WARNING.
+
+    This is the deadlock's own shape and it is invisible from every other
+    signal: the poll returns ``items == []`` with ``poll_status == "ok"``, so
+    the observer reports a healthy poller, no cursor advances, and the next
+    scan starts exactly where this one did. Nothing distinguishes it from a
+    quiet repo except a line saying events were found and discarded.
+    """
+    caplog.set_level(logging.WARNING, logger=gh_mod.__name__)
+    gh_log = logging.getLogger(gh_mod.__name__)
+    monkeypatch.setattr(gh_log, "propagate", True)
+
+    # One page more than the poller will fetch, so the scan hits its cap and
+    # reports itself incomplete rather than reaching a natural end.
+    pages = [
+        _all_merged(_closed_page(10 - i, 1000 + i * 1000))
+        for i in range(gh_mod._MERGED_MODE_MAX_PAGES + 1)
+    ]
+    _install_paginated(monkeypatch, pages)
+
+    result = _poll_result(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": "2026-01-01T00:00:00Z",
+        }
+    )
+
+    # The healthy-looking shape the warning exists to contradict.
+    assert result.items == []
+    assert result.scan_complete is False
+    assert result.poll_status == "ok"
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "a scan that found events and dispatched none logged nothing"
+    msg = warnings[-1].getMessage()
+    held = gh_mod._PER_PAGE * gh_mod._MERGED_MODE_MAX_PAGES
+    assert f"found {held} event(s) past the cursor and dispatched none" in msg
+    assert "owner/name" in msg
+
+
+def test_github_poll_truncated_scan_that_still_dispatches_does_not_warn(monkeypatch, caplog):
+    """Holding some events back while returning others is not the stuck shape.
+
+    The caller advances the cursor past what it got, so the next scan starts
+    higher and the held-back band drains on its own. Warning here too would
+    fire on every truncated poll of a busy repo, and a line that fires
+    constantly stops carrying the one case that matters.
+    """
+    caplog.set_level(logging.WARNING, logger=gh_mod.__name__)
+    gh_log = logging.getLogger(gh_mod.__name__)
+    monkeypatch.setattr(gh_log, "propagate", True)
+
+    pages = [
+        _all_merged(_closed_page(10 - i, 1000 + i * 1000))
+        for i in range(gh_mod._MERGED_MODE_MAX_PAGES + 1)
+    ]
+    # One PR on the first page merged long before the boundary, so it is
+    # provably safe to dispatch while its page-mates are held back.
+    pages[0][0]["merged_at"] = "2026-02-01T00:00:00Z"
+    _install_paginated(monkeypatch, pages)
+
+    result = _poll_result(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"event": "pr_merged"},
+            "github_cursor": "2026-01-01T00:00:00Z",
+        }
+    )
+
+    assert [i.event["pr_number"] for i in result.items] == [1000]
+    assert result.scan_complete is False
+    assert [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -431,14 +431,19 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
 
 
 def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None = None):
-    """20 closed PRs at a fixed hour, minutes descending -- one fake
-    "page" of a merged-mode poll response. ``merges`` maps a within-page
-    index to a merged_at value for that PR (closed-but-unmerged otherwise)."""
+    """One FULL page of closed PRs at a fixed hour, updated_at descending.
+
+    Size comes from ``gh_mod._PER_PAGE``: the poller treats a page shorter than
+    the requested size as terminal, so a fixture stating its own size turns
+    every pagination test into a single-page test as soon as the reach changes.
+    """
     merges = merges or {}
+    n = gh_mod._PER_PAGE
+    step = max(1, (3600 - 60) // n)
     items = []
-    for i in range(20):
-        minute = 59 - i * 3
-        updated_at = f"2026-07-06T{hour:02d}:{minute:02d}:00Z"
+    for i in range(n):
+        secs = 3540 - i * step
+        updated_at = f"2026-07-06T{hour:02d}:{secs // 60:02d}:{secs % 60:02d}Z"
         items.append(_pr(base_number + i, updated_at, state="closed", merged_at=merges.get(i)))
     return items
 


### PR DESCRIPTION
## The defect

`github_poll` in merged mode paginates up to `_MERGED_MODE_MAX_PAGES` (5) pages looking for
merges whose `merged_at` trails the API's `updated_at` sort key. The comment above that constant
states the resulting reach in terms of `per_page=100`. The request asked for `20`.

So the documented reach was 500 PRs and the real reach was 100.

## Why that is a deadlock and not just latency

When the scan is truncated, every candidate at or above the oldest `updated_at` it fetched is
dropped rather than dispatched. That is correct and must stay: dispatching one advances the
cursor to *that PR's* `merged_at`, which would step over PRs merged earlier that the scan never
reached, losing them permanently.

The failure is what happens when the backlog above the stored cursor grows deeper than the reach.
Then *every* candidate falls inside the held-back band:

- nothing is returned, so the caller advances no cursor
- the cursor does not move, so the next scan covers exactly the same range
- the same range is still deeper than the reach, so the next scan holds everything back too

It never drains. And it is silent at every signal a reader has:

| signal | what it shows while stuck |
|---|---|
| `poll_status` | `"ok"` — the poller reached GitHub and parsed a response |
| `last_healthy_poll_at` | advancing every poll |
| returned items | `[]` — identical to a quiet repo |
| `schedule_runs` | no rows; nothing fired, so nothing is recorded |
| `next_fire_at` | a normal future time |

The one existing log line covering truncation is INFO and fires on *every* truncated poll,
whether or not anything was actually held back, so it does not distinguish "held some, dispatched
the rest" from "held everything, dispatched nothing".

## What this changes

**The reach.** `per_page` now comes from a `_PER_PAGE = 100` constant that the page-budget comment
is written against. The reach is one number instead of two that can silently disagree. 100 is the
maximum the API accepts, so nothing is left on the table.

**A warning for the stuck shape, and only that shape.** When a truncated scan holds back every
event and dispatches none, it logs at WARNING with the count, the boundary, and the PR numbers.
Deliberately not logged when some events dispatch: that case advances the cursor, drains on its
own, and is normal on any busy repo. A truncation notice that fires on every truncated poll stops
carrying the one case that matters.

**Comments.** The floor comparison now records *why* it drops candidates outright rather than
marking them non-dispatchable, and the budget comment records that the stuck state does not
self-clear.

**Fixtures.** Test pages are built from `_PER_PAGE` rather than restating `20`. The poller treats
a page shorter than the requested size as terminal, so a fixture that hard-codes its own size
turns every pagination test into a single-page test the moment the reach changes — which is
exactly what happened here: six pagination tests went green against a page size the poller no
longer used.

## Tests

Two new pins, both mutation-checked (reverting the fix makes each fail, and for the stated reason):

- `test_github_poll_requests_the_page_size_the_reach_is_stated_in` — the value sent to the API is
  the constant the budget is written against, and it is the API maximum. Restoring the `"20"`
  literal fails it.
- `test_github_poll_truncated_scan_holding_everything_back_warns` — asserts the healthy-looking
  shape (`items == []`, `poll_status == "ok"`, `scan_complete is False`) *and* that the WARNING
  contradicts it. Removing the log line fails it.
- `test_github_poll_truncated_scan_that_still_dispatches_does_not_warn` — pins the scoping.
  Removing `and not items` fails it, and the unscoped message is also factually wrong there
  (it would claim nothing dispatched while one did).

`tests/studio`: 806 passed, 0 failed, exit 0.

Two failures observed in the wider run reproduce identically on the base commit with the same
invocation and are untouched by this change: `tests/state/test_dual_backend.py` and
`tests/state/test_engine_schema.py` Postgres cases (`ModuleNotFoundError: asyncpg`), and
`tests/cli/orchestrate/test_flow_planning.py::test_pack_routing_shown_in_dry_run`, which resolves
a `writer` profile from the developer's home directory instead of the pack under test.

## Known limitation this does not remove

A wider reach is still a bounded reach. If a repo's closed-PR churn above the stored cursor is
continuously refreshed, a particular held merge can stay beyond the page boundary indefinitely
while unrelated safe items keep advancing a much older cursor. That is perpetual partial
starvation rather than the deadlock above: the cursor does move, so the WARNING correctly stays
quiet, and the existing INFO truncation notice is the signal for it. Pre-existing and unchanged
here; noted so the new warning is not read as covering it.

## The first poll after this lands

Widening the reach means the first successful scan on a schedule whose cursor has fallen behind
sees the whole recovered band at once and dispatches **one run per merged PR in it**. Every one of
those runs performs whatever action the schedule is configured for. On a schedule that has been
stuck for days that is a stampede, and it is a foreseeable consequence of this change rather than
an operator's mistake. Decide what happens to that band **before** the change is live, not after.

**Count it first.** The number of merged PRs with `merged_at` after the stored `github_cursor` is
exactly the number of runs the first poll will start. One API query, and it is what makes the
choice below an informed one rather than a guess.

**Then pick one:**

- **Skip the band** (the simple default) — set `github_cursor` to the current time before
  enabling. Nothing in the backlog is dispatched, and anything in it that still deserves a run can
  be triggered individually. Best when the backlog is stale enough that a bulk replay has little
  value.
- **Drain the band, paced** — set the schedule's `rate_limit` (`{"max_fires": N, "window_sec": W}`)
  and let it work through. This is safe rather than lossy because of behaviour the engine already
  has: each dispatched event advances `github_cursor` atomically with its own occurrence insert,
  reaching the cap breaks the dispatch loop and logs the deferred PR numbers, and the cap is a
  *temporary refusal* that leaves the schedule enabled with the cursor at the last dispatched
  event. The next poll resumes exactly there, so the backlog drains across polls with nothing lost
  and nothing re-fired. `max_runs` is not a substitute — exhausting it disables the schedule.

Doing nothing is the one option that is not available: an unbounded schedule with a deep backlog
bursts on the first successful scan.

## Landing is not live

A merge does not change what a running scheduler executes. Two independent reasons, both of which
have to be satisfied before this fix is doing anything:

1. **The process holds the code it imported at startup.** A restart is required. `KeepAlive`
   restarts the daemon on kill, but the restart itself is not evidence.
2. **An editable install resolves to whatever a working tree is currently checked out at.** A
   daemon installed that way runs the branch that tree is on, not the branch that was merged. A
   restart alone will faithfully reload the same wrong code.

The check is a positive artifact only the new code can produce, never the restart's exit status
and never the process start time. For this change, after the daemon is bounced:

- confirm the poller is asking for 100 per page — `_PER_PAGE` read off the module the *running*
  process imported, not off the repo
- on a schedule known to be behind, confirm the next poll either dispatches or logs the new
  WARNING. Continued silence with `poll_status "ok"` means the fix is not live, not that the
  repo is quiet — those two are indistinguishable, which is the whole point of the defect.
