### PR TITLE
feat(studio): let an operator move a github_poll schedule's cursor

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2954,13 +2954,23 @@ class StateDB:
         }
     )
 
-    async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
-        stmt, params = self._build_update_schedule_stmt(schedule_id, fields)
+    async def update_schedule(
+        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
+    ) -> None:
+        stmt, params = self._build_update_schedule_stmt(
+            schedule_id, fields, guard_cursor_forward=guard_cursor_forward
+        )
         async with self._tx() as conn:
             await conn.execute(stmt, params)
 
     @classmethod
-    def _build_update_schedule_stmt(cls, schedule_id: str, fields: dict[str, Any]):
+    def _build_update_schedule_stmt(
+        cls,
+        schedule_id: str,
+        fields: dict[str, Any],
+        *,
+        guard_cursor_forward: bool = False,
+    ):
         """Validate + build the ``UPDATE schedules`` statement + bound
         params for *fields* without opening a transaction.
 
@@ -2969,6 +2979,18 @@ class StateDB:
         transaction as the occurrence insert) -- the single choke point for
         both the field allowlist and the SQL shape, so the two write paths
         can never drift apart.
+
+        ``guard_cursor_forward`` makes the ``github_cursor`` assignment
+        monotonic: the column moves only if the new value sorts above the
+        stored one. The scheduler passes it, because a poll reads the cursor
+        at tick start and writes it back much later, so its value is a
+        snapshot that an operator's deliberate cursor move can outrun. Without
+        the guard the stale write silently undoes that move, and a backlog the
+        operator had declined becomes eligible again.
+
+        It is a per-COLUMN condition rather than a row predicate on purpose:
+        the same statement carries ``last_fired_at``/``next_fire_at``, and
+        those must land whether or not the cursor is allowed to advance.
         """
         bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
         if bad:
@@ -2987,9 +3009,24 @@ class StateDB:
         }
         fields = dict(fields)
         fields["updated_at"] = time.time()
+        guarded_cursor = (
+            guard_cursor_forward
+            and "github_cursor" in fields
+            and fields["github_cursor"] is not None
+        )
         sets_parts = []
         bind_params = []
         for k in fields:
+            if k == "github_cursor" and guarded_cursor:
+                # Cursors are compared as strings everywhere (the poller
+                # compares them against GitHub's own timestamps), so plain
+                # lexical order IS the ordering.
+                sets_parts.append(
+                    '"github_cursor" = CASE WHEN github_cursor IS NULL '
+                    "OR github_cursor < :github_cursor "
+                    "THEN :github_cursor ELSE github_cursor END"
+                )
+                continue
             sets_parts.append(f'"{k}" = :{k}')
             if k in json_fields:
                 bind_params.append(bindparam(k, type_=JSON))
@@ -3075,7 +3112,12 @@ class StateDB:
         allowlist as ``update_schedule``.
         """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
-        sched_stmt, sched_params = self._build_update_schedule_stmt(schedule_id, schedule_fields)
+        # Engine-only path, so the monotonic cursor guard always applies: the
+        # value being written came from a poll snapshot taken before this
+        # transaction and must never walk an operator's cursor move backwards.
+        sched_stmt, sched_params = self._build_update_schedule_stmt(
+            schedule_id, schedule_fields, guard_cursor_forward=True
+        )
         async with self._tx() as conn:
             await conn.execute(run_stmt, run_params)
             await self._initialize_managed_entity_in_tx(

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1349,7 +1349,12 @@ class SchedulerEngine:
             # atomic with. For a dispatched item it re-writes the same
             # value already committed, a harmless no-op.
             if cursor != schedule.get("github_cursor"):
-                await self._svc.update_schedule(sid, github_cursor=cursor)
+                # guard_cursor_forward: this value derives from the snapshot
+                # read at tick start, so it must not undo a cursor an operator
+                # moved forward while the poll was in flight.
+                await self._svc.update_schedule(
+                    sid, github_cursor=cursor, guard_cursor_forward=True
+                )
         finally:
             if pre_rate_claim is not None:
                 pre_rate_claim.release()

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -27,7 +27,9 @@ class SchedulerStateService(Protocol):
 
     async def list_schedules(self, *, enabled: bool | None = None) -> list[dict[str, Any]]: ...
 
-    async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
+    async def update_schedule(
+        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
+    ) -> None: ...
 
     async def count_schedule_runs(
         self,
@@ -105,9 +107,13 @@ class _DBSchedulerStateService:
         async with StateDB() as db:
             return await db.list_schedules(enabled=enabled)
 
-    async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
+    async def update_schedule(
+        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
+    ) -> None:
         async with StateDB() as db:
-            await db.update_schedule(schedule_id, **fields)
+            await db.update_schedule(
+                schedule_id, guard_cursor_forward=guard_cursor_forward, **fields
+            )
 
     async def count_schedule_runs(
         self,

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 import sqlite3
 import time
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -56,6 +58,36 @@ def _svc_validate_identifier(value: str | None, field_name: str) -> None:
     from lionagi.studio.scheduler.subprocess import _validate_identifier
 
     _validate_identifier(value, field_name)
+
+
+_GITHUB_CURSOR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def _svc_validate_github_cursor(cursor: str | None) -> None:
+    """Service-boundary check: a github_cursor must be a UTC ISO-8601 instant
+    spelled exactly as GitHub spells it, ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    The poller compares cursors as STRINGS against the API's own timestamps, so
+    the format is a correctness contract rather than a presentation choice: a
+    space separator, a fractional part, or a ``+00:00`` offset all denote the
+    right instant and all order wrongly against ``2026-07-20T15:21:57Z``, which
+    silently makes the poller skip or replay events.
+
+    ``None`` is allowed and clears the cursor, meaning "no bookmark". That is a
+    legitimate operator action and a consequential one -- an unbookmarked
+    merged-mode poll dispatches everything its scan reaches.
+    """
+    if cursor is None:
+        return
+    if not isinstance(cursor, str) or not _GITHUB_CURSOR_RE.match(cursor):
+        raise ValueError(
+            "github_cursor must be a UTC ISO-8601 timestamp of the form "
+            f"YYYY-MM-DDTHH:MM:SSZ (got {cursor!r})"
+        )
+    try:
+        datetime.strptime(cursor, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise ValueError(f"github_cursor is not a real timestamp: {cursor!r}") from exc
 
 
 def _svc_validate_action_cwd(cwd: str | None) -> None:
@@ -606,6 +638,8 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
             _svc_validate_github_repo(fields["github_repo"])
         if "github_filter" in fields:
             _svc_validate_github_filter(fields["github_filter"])
+        if "github_cursor" in fields:
+            _svc_validate_github_cursor(fields["github_cursor"])
         if "max_runs" in fields:
             _svc_validate_max_runs(fields["max_runs"])
         if "budget_usd" in fields:
@@ -805,6 +839,10 @@ class UpdateScheduleRequest(BaseModel):
     interval_sec: int | None = None
     github_repo: str | None = None
     github_filter: dict | None = None
+    # The poller's own bookmark, patchable so an operator can move it
+    # deliberately -- forward to skip a backlog the schedule would
+    # otherwise dispatch all at once, or back to replay one.
+    github_cursor: str | None = None
     poll_interval_sec: int | None = None
     action_kind: str | None = None
     action_model: str | None = None

--- a/tests/studio/test_schedule_github_cursor_patch.py
+++ b/tests/studio/test_schedule_github_cursor_patch.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for patching a schedule's github_cursor.
+
+The cursor is the merged-PR poller's bookmark. Until it was patchable there was
+no supported way to move it at all -- not the CLI, not the API, not the
+declarative apply path -- so an operator facing a schedule whose backlog would
+dispatch all at once had no mechanism short of writing to the store by hand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from unittest.mock import AsyncMock, patch
+
+from lionagi.studio.services.schedules import (
+    UpdateScheduleRequest,
+    _svc_validate_github_cursor,
+    update_schedule,
+)
+
+_EXISTING = {
+    "id": "sid-cursor-1",
+    "name": "cursor-patch-test",
+    "trigger_type": "github_poll",
+    "github_repo": "owner/name",
+    "action_kind": "agent",
+    "github_cursor": "2026-07-20T15:21:57Z",
+}
+
+
+def _patched_db():
+    mock_db = AsyncMock()
+    mock_db.get_schedule = AsyncMock(return_value=dict(_EXISTING))
+    mock_db.update_schedule = AsyncMock()
+    ctx = patch("lionagi.studio.services.schedules.StateDB")
+    return ctx, mock_db
+
+
+def _run_update(fields):
+    """Drive update_schedule against a mocked StateDB; return (result, mock_db)."""
+
+    async def _run():
+        ctx, mock_db = _patched_db()
+        with ctx as MockDB:
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await update_schedule("sid-cursor-1", fields)
+            return result, mock_db
+
+    return asyncio.run(_run())
+
+
+def _expect_rejected(fields, match):
+    async def _run():
+        ctx, mock_db = _patched_db()
+        with ctx as MockDB:
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ValueError, match=match):
+                await update_schedule("sid-cursor-1", fields)
+            mock_db.update_schedule.assert_not_called()
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# _svc_validate_github_cursor — pure logic
+# ---------------------------------------------------------------------------
+
+
+def test_validate_cursor_accepts_the_api_spelling():
+    _svc_validate_github_cursor("2026-07-20T15:21:57Z")
+    _svc_validate_github_cursor("2020-01-01T00:00:00Z")
+
+
+def test_validate_cursor_none_clears_and_is_allowed():
+    """None means "no bookmark". Consequential, but the operator's call."""
+    _svc_validate_github_cursor(None)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "2026-07-20 15:21:57Z",  # space separator
+        "2026-07-20T15:21:57+00:00",  # offset instead of Z
+        "2026-07-20T15:21:57.123Z",  # fractional seconds
+        "2026-07-20T15:21:57",  # no zone at all
+        "2026-07-20",  # date only
+        "  2026-07-20T15:21:57Z",  # leading whitespace
+        "2026-07-20T15:21:57Z ",  # trailing whitespace
+        "",
+    ],
+)
+def test_validate_cursor_rejects_other_spellings_of_the_same_instant(bad):
+    with pytest.raises(ValueError, match="github_cursor"):
+        _svc_validate_github_cursor(bad)
+
+
+def test_validate_cursor_rejects_non_string():
+    with pytest.raises(ValueError, match="github_cursor"):
+        _svc_validate_github_cursor(1753025000)
+
+
+def test_validate_cursor_rejects_well_formed_but_impossible_timestamp():
+    """The shape regex alone would pass month 13; the parse is what catches it."""
+    with pytest.raises(ValueError, match="not a real timestamp"):
+        _svc_validate_github_cursor("2026-13-45T99:00:00Z")
+
+
+def test_why_the_format_is_strict_rather_than_pedantic():
+    """The poller compares cursors as strings, so spelling decides ordering.
+
+    Each rejected spelling below is compared against a real API timestamp and
+    sorts the wrong way round, which is what makes a lenient validator a
+    correctness bug rather than a style preference. The three cases fail
+    differently, so they are spelled out rather than generalized.
+    """
+    api = "2026-07-20T15:21:57Z"
+
+    # A space separator sorts below 'T' (0x20 < 0x54), so a LATER instant reads
+    # as older and the poller re-dispatches everything between the two.
+    assert "2026-07-20 16:00:00Z" < api
+
+    # '+00:00' is the SAME instant as 'Z', and '+' sorts below 'Z' (0x2B <
+    # 0x5A), so the event sitting exactly on the cursor stops being excluded
+    # and fires again.
+    assert "2026-07-20T15:21:57+00:00" < api
+
+    # A fractional part sorts below 'Z' too ('.' is 0x2E), so a timestamp half
+    # a second LATER also reads as older.
+    assert "2026-07-20T15:21:57.500Z" < api
+
+    for wrong in (
+        "2026-07-20 16:00:00Z",
+        "2026-07-20T15:21:57+00:00",
+        "2026-07-20T15:21:57.500Z",
+    ):
+        with pytest.raises(ValueError):
+            _svc_validate_github_cursor(wrong)
+
+
+# ---------------------------------------------------------------------------
+# The API request model — the gate that was actually missing
+# ---------------------------------------------------------------------------
+
+
+def test_patch_model_carries_github_cursor():
+    """The validator is useless if the field never survives the request model.
+
+    update_schedule is driven entirely by UpdateScheduleRequest.model_dump
+    (exclude_unset), so a field absent from the model is silently dropped with
+    a 200 and no write -- which is exactly how the cursor came to be
+    unsettable while every layer beneath it already supported the column.
+    """
+    body = UpdateScheduleRequest(github_cursor="2026-07-26T07:00:00Z")
+    assert body.model_dump(exclude_unset=True) == {"github_cursor": "2026-07-26T07:00:00Z"}
+
+
+def test_patch_model_distinguishes_unset_from_explicit_null():
+    """Clearing the cursor and not mentioning it must not collapse together."""
+    assert "github_cursor" not in UpdateScheduleRequest(name="x").model_dump(exclude_unset=True)
+    assert UpdateScheduleRequest(github_cursor=None).model_dump(exclude_unset=True) == {
+        "github_cursor": None
+    }
+
+
+# ---------------------------------------------------------------------------
+# update_schedule — end to end against a mocked store
+# ---------------------------------------------------------------------------
+
+
+def test_update_persists_the_cursor_verbatim():
+    result, mock_db = _run_update({"github_cursor": "2026-07-26T07:00:00Z"})
+    assert result is True
+    mock_db.update_schedule.assert_awaited_once_with(
+        "sid-cursor-1", github_cursor="2026-07-26T07:00:00Z"
+    )
+
+
+def test_update_can_move_the_cursor_backwards_to_replay():
+    """Not just forward. Replaying a band is a legitimate operator action."""
+    result, mock_db = _run_update({"github_cursor": "2026-07-01T00:00:00Z"})
+    assert result is True
+    mock_db.update_schedule.assert_awaited_once_with(
+        "sid-cursor-1", github_cursor="2026-07-01T00:00:00Z"
+    )
+
+
+def test_update_can_clear_the_cursor():
+    result, mock_db = _run_update({"github_cursor": None})
+    assert result is True
+    mock_db.update_schedule.assert_awaited_once_with("sid-cursor-1", github_cursor=None)
+
+
+def test_update_rejects_a_malformed_cursor_before_any_write():
+    _expect_rejected({"github_cursor": "2026-07-26 07:00:00"}, "github_cursor")
+
+
+def test_update_rejects_an_impossible_cursor_before_any_write():
+    _expect_rejected({"github_cursor": "2026-02-30T00:00:00Z"}, "not a real timestamp")

--- a/tests/studio/test_schedule_github_cursor_patch.py
+++ b/tests/studio/test_schedule_github_cursor_patch.py
@@ -204,3 +204,184 @@ def test_update_rejects_a_malformed_cursor_before_any_write():
 
 def test_update_rejects_an_impossible_cursor_before_any_write():
     _expect_rejected({"github_cursor": "2026-02-30T00:00:00Z"}, "not a real timestamp")
+
+
+# ---------------------------------------------------------------------------
+# The interleaving: an operator PATCH vs an in-flight poll, against a real store
+# ---------------------------------------------------------------------------
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+
+def _gh_schedule(sid: str, cursor: str | None) -> dict:
+    return {
+        "id": sid,
+        "name": f"gh-{sid}",
+        "trigger_type": "github_poll",
+        "github_repo": "owner/name",
+        "github_filter": {"event": "pr_merged"},
+        "github_cursor": cursor,
+        "action_kind": "agent",
+        "action_prompt": "review",
+        "enabled": 1,
+        "missed_fire_policy": "skip",
+    }
+
+
+def _run_row(run_id: str, sid: str) -> dict:
+    return {
+        "id": run_id,
+        "schedule_id": sid,
+        "trigger_context": {"source": "github_poll"},
+        "action_kind": "agent",
+        "action_args": {"prompt": "review"},
+        "status": "running",
+        "fired_at": 1000.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_operator_patch_survives_an_in_flight_polls_cursor_write(tmp_path):
+    """The race the patchable cursor creates, and the reason for the guard.
+
+    A tick reads the schedule at its start and writes the cursor back much
+    later, so its value is a snapshot. If an operator moves the cursor forward
+    in between -- the whole point of the field -- an unguarded write from that
+    tick puts it back, and the backlog the operator declined becomes eligible
+    again on the next scan. Silent: the PATCH returned 200 and the run row is
+    perfectly valid.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-race"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_gh_schedule(sid, "2026-07-20T00:00:00Z"))
+
+    # Operator declines the backlog while a poll is in flight.
+    async with StateDB(db_path) as db:
+        await db.update_schedule(sid, github_cursor="2026-08-01T00:00:00Z")
+
+    # The in-flight tick now lands, carrying the value it computed from the
+    # cursor it read before the PATCH.
+    async with StateDB(db_path) as db:
+        await db.create_schedule_run_and_advance(
+            _run_row("run-race", sid),
+            schedule_id=sid,
+            schedule_fields={"github_cursor": "2026-07-21T00:00:00Z", "last_fired_at": 1000.0},
+        )
+
+    async with StateDB(db_path) as db:
+        schedule = await db.get_schedule(sid)
+        runs = await db.list_schedule_runs(sid)
+
+    assert schedule["github_cursor"] == "2026-08-01T00:00:00Z", (
+        "a stale poll walked the operator's cursor backwards"
+    )
+    # The occurrence still had to be recorded: the event DID fire, and a
+    # refused cursor advance must not discard the record of it.
+    assert len(runs) == 1
+    # Sibling fields in the same statement land regardless of the guard.
+    assert schedule["last_fired_at"] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_normal_forward_advance_is_unaffected_by_the_guard(tmp_path):
+    """The guard must not break the ordinary case it wraps."""
+    db_path = tmp_path / "state.db"
+    sid = "sched-fwd"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_gh_schedule(sid, "2026-07-20T00:00:00Z"))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-fwd", sid),
+            schedule_id=sid,
+            schedule_fields={"github_cursor": "2026-07-22T00:00:00Z"},
+        )
+        schedule = await db.get_schedule(sid)
+    assert schedule["github_cursor"] == "2026-07-22T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_guard_advances_from_a_null_cursor(tmp_path):
+    """A NULL cursor is below everything; ``NULL < x`` is NULL, not true, so
+    the explicit IS NULL branch is what makes a first advance work at all."""
+    db_path = tmp_path / "state.db"
+    sid = "sched-null"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_gh_schedule(sid, None))
+        await db.create_schedule_run_and_advance(
+            _run_row("run-null", sid),
+            schedule_id=sid,
+            schedule_fields={"github_cursor": "2026-07-22T00:00:00Z"},
+        )
+        schedule = await db.get_schedule(sid)
+    assert schedule["github_cursor"] == "2026-07-22T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_operator_path_is_not_guarded_so_a_replay_is_still_possible(tmp_path):
+    """The guard is the ENGINE's invariant, not the operator's.
+
+    Moving the cursor backwards to replay a band is a legitimate action and
+    must not be silently ignored -- which is exactly what a guard applied to
+    both writers would do.
+    """
+    db_path = tmp_path / "state.db"
+    sid = "sched-replay"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_gh_schedule(sid, "2026-07-25T00:00:00Z"))
+        await db.update_schedule(sid, github_cursor="2026-07-01T00:00:00Z")
+        schedule = await db.get_schedule(sid)
+    assert schedule["github_cursor"] == "2026-07-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_guard_is_inert_for_schedules_with_no_cursor_field(tmp_path):
+    """Non-github schedules go through the same statement builder."""
+    db_path = tmp_path / "state.db"
+    sid = "sched-cron"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            {
+                "id": sid,
+                "name": "cron-x",
+                "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+                "enabled": 1,
+                "missed_fire_policy": "skip",
+                "next_fire_at": 1000.0,
+            }
+        )
+        await db.create_schedule_run_and_advance(
+            _run_row("run-cron", sid),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        schedule = await db.get_schedule(sid)
+    assert schedule["next_fire_at"] == 2000.0
+    assert schedule["last_fired_at"] == 1000.0
+
+
+def test_guarded_statement_compiles_on_both_dialects():
+    """The guard repeats one bound parameter three times in a single statement.
+
+    SQLite renders positional placeholders and PostgreSQL renders named ones,
+    so the repetition is the part worth pinning: it is where a hand-written
+    predicate would break on one backend and not the other. The PostgreSQL
+    integration tests need a driver that is not installed in every
+    environment, so this compiles the statement instead of executing it --
+    which checks the parameter shape, not the runtime semantics.
+    """
+    from sqlalchemy.dialects import postgresql, sqlite
+
+    from lionagi.state.db import StateDB as _StateDB
+
+    stmt, _params = _StateDB._build_update_schedule_stmt(
+        "sid",
+        {"github_cursor": "2026-07-22T00:00:00Z", "last_fired_at": 1.0},
+        guard_cursor_forward=True,
+    )
+    for dialect in (sqlite.dialect(), postgresql.dialect()):
+        sql = str(stmt.compile(dialect=dialect))
+        assert "CASE WHEN github_cursor IS NULL" in sql
+        assert '"last_fired_at"' in sql  # sibling fields still assigned plainly

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -148,7 +148,9 @@ async def test_multi_event_poll_fires_once_per_dispatchable_event():
     # Trailing safety-net batched write still lands on the newest event too
     # (harmless re-write of what the last event's own atomic call already
     # persisted).
-    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T12:00:00Z")
+    svc.update_schedule.assert_any_call(
+        "sched-001", github_cursor="2026-07-07T12:00:00Z", guard_cursor_forward=True
+    )
     assert engine._global_inflight == 0
 
 
@@ -179,7 +181,9 @@ async def test_single_event_poll_behavior_unchanged():
     assert [e["pr_number"] for e in run_payload["trigger_context"]["github_events"]] == [7]
     assert run_payload["trigger_context"]["repo"] == "acme/widgets"
     assert kwargs["schedule_fields"]["github_cursor"] == "2026-07-07T10:00:00Z"
-    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T10:00:00Z")
+    svc.update_schedule.assert_any_call(
+        "sched-001", github_cursor="2026-07-07T10:00:00Z", guard_cursor_forward=True
+    )
     assert engine._global_inflight == 0
 
 
@@ -226,7 +230,9 @@ async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(ca
     assert svc.create_invocation.await_count == 2
 
     # Cursor stops at PR 2's updated_at, not PR 3's -- PR 3 was never dispatched.
-    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T11:00:00Z")
+    svc.update_schedule.assert_any_call(
+        "sched-001", github_cursor="2026-07-07T11:00:00Z", guard_cursor_forward=True
+    )
     cursor_calls = [c for c in svc.update_schedule.await_args_list if "github_cursor" in c.kwargs]
     assert all(c.kwargs["github_cursor"] != "2026-07-07T12:00:00Z" for c in cursor_calls)
 
@@ -274,7 +280,9 @@ async def test_global_slot_exhaustion_mid_batch_stops_cursor_before_undispatched
         await engine._tick_github(schedule, now=10_000.0)
 
     assert svc.create_invocation.await_count == 1
-    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T10:00:00Z")
+    svc.update_schedule.assert_any_call(
+        "sched-001", github_cursor="2026-07-07T10:00:00Z", guard_cursor_forward=True
+    )
     assert any(
         "sched-001" in r.message and "2" in r.message and "concurrent-fire" in r.message
         for r in caplog.records
@@ -311,7 +319,9 @@ async def test_filtered_event_between_dispatched_events_still_advances_cursor():
         await engine._tick_github(schedule, now=10_000.0)
 
     assert svc.create_invocation.await_count == 2
-    svc.update_schedule.assert_any_call("sched-001", github_cursor="2026-07-07T12:00:00Z")
+    svc.update_schedule.assert_any_call(
+        "sched-001", github_cursor="2026-07-07T12:00:00Z", guard_cursor_forward=True
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The gap

`github_cursor` is the merged-PR poller's bookmark. The engine advances it on every dispatched
event. Nothing else could touch it:

| path | why not |
|---|---|
| `PATCH /api/schedules/{id}` | the field is absent from `UpdateScheduleRequest`, and `update_schedule` is driven entirely by that model's `exclude_unset` dump — so a PATCH carrying it returns **200 and writes nothing** |
| `li schedule` | there is no `update` subcommand; `limits` is display-only |
| `li schedule apply` | declarative, and it cannot adopt a row whose `managed_by` is null |

The store layer was never the obstacle — `github_cursor` is already in
`StateDB._SCHEDULE_UPDATE_ALLOWED_FIELDS` and the column has always existed. The only missing
piece was the API request model, which is also the least visible place for it to be missing: the
silent-200 makes it look like the write succeeded.

## Why it needs to be movable

A merged-mode schedule dispatches one run per merged PR past its cursor. If the cursor falls
behind, the next successful scan dispatches the entire recovered band at once. Advancing the
cursor is how an operator declines that band; moving it backwards is how they ask for a replay of
one. Neither is exotic, and with no supported mechanism the remaining options were writing to a
live store by hand or deleting and recreating the schedule — which discards its cursor and its run
history, i.e. destroys the thing you were trying to adjust.

## Validation is about spelling, not just instants

The poller compares cursors as **strings** against GitHub's own timestamps
(`if cursor and cursor_at <= cursor: continue`). So the format is a correctness contract. Each of
these denotes a perfectly good time and each orders wrongly against a real API value of
`2026-07-20T15:21:57Z`:

| written | sorts | consequence |
|---|---|---|
| `2026-07-20 16:00:00Z` | before, because `' '` (0x20) < `'T'` | a **later** instant reads as older — the poller replays everything between |
| `2026-07-20T15:21:57+00:00` | before, because `'+'` (0x2B) < `'Z'` | the **same** instant stops being excluded — the boundary event fires twice |
| `2026-07-20T15:21:57.500Z` | before, because `'.'` (0x2E) < `'Z'` | a later instant reads as older, same as the first |

Accepted form is exactly `YYYY-MM-DDTHH:MM:SSZ`, pattern-matched **and** parsed — the pattern
alone would accept month 13. Those three cases are asserted directly in
`test_why_the_format_is_strict_rather_than_pedantic`, so the reason lives next to the rule.

An explicit `null` is accepted and clears the bookmark. That is consequential — an unbookmarked
merged-mode poll dispatches everything its scan reaches — but it is a real operation and the
operator's call. The request model already distinguishes "not sent" from "sent as null", and that
distinction is pinned by a test.

## Scope

Deliberately only the PATCH model. `CreateScheduleRequest` is untouched: a new schedule has no
history to skip. Also not included is a `li schedule update` subcommand — the CLI gap is real but
it is a convenience layer over an API that now works, whereas this was a capability that did not
exist at all.

## Tests

`tests/studio/test_schedule_github_cursor_patch.py`, 20 cases, both gates mutation-checked:

- removing the field from `UpdateScheduleRequest` fails `test_patch_model_carries_github_cursor`
  and the unset-vs-null test
- removing the validator dispatch fails both rejection tests

`tests/studio` + `tests/apps_studio_server`: 1898 passed, 0 failed, exit 0.


---

## Follow-up: the cursor advance is now monotonic on the engine's write paths

Exposing the cursor for operator writes surfaces a race that was previously
unreachable, because until now only the poller ever wrote the column.

A poll tick reads the schedule at its start, dispatches an event, and writes
that event's timestamp back as the new cursor. An operator moving the cursor
forward in between has their value overwritten by a write derived from a
pre-move snapshot, and the band they declined becomes eligible again on the
next scan.

The store's schedule-update builder now takes an opt-in `guard_cursor_forward`
flag that renders the assignment as a conditional:

```sql
"github_cursor" = CASE WHEN github_cursor IS NULL
                       OR github_cursor < :github_cursor
                  THEN :github_cursor ELSE github_cursor END
```

**Why a per-column `CASE` and not a `WHERE` predicate on the row.** The same
`UPDATE` carries `last_fired_at` and `next_fire_at`. Those describe what the
tick actually did and are correct regardless of whether its cursor value is
still current. A row predicate would discard them along with the cursor,
leaving a schedule that fired without recording that it fired. The per-column
form lets the sibling assignments land while freezing only the one field whose
value is stale.

**Why not "disable the schedule before patching it".** Disabling does not kill
a tick already in flight, so it narrows the window rather than closing it.

**Why the operator path stays unconditional.** Moving a cursor *backwards* to
replay a band is a legitimate operation. The guard is set only on the two
engine-owned writes: the per-event advance inside
`create_schedule_run_and_advance`, and the end-of-tick safety-net write.

### Verification

- A real-store interleaving test: an operator write to `2026-08-01T00:00:00Z`,
  then a stale engine advance carrying `2026-07-21T00:00:00Z`, asserts the
  cursor is unchanged **and** that the run row and `last_fired_at` from the
  same statement still landed. Removing the guard flag fails it on the first
  assertion.
- Four further interleaving cases: forward advance from a fresh cursor, first
  advance from `NULL`, equal-value no-op, and a plain unguarded update still
  able to move the cursor backwards.
- Five existing per-event poller tests assert the exact call the engine makes
  for the end-of-tick cursor write, so they failed on the added keyword. They
  now carry it, which also makes them the regression net for the guard on that
  path: removing the flag from the engine fails all five.
- `tests/studio`, `tests/state`, `tests/apps_studio_server`, same interpreter,
  `--maxfail` raised so the run completes rather than stopping at the
  configured limit:

  | tree | passed | failed |
  |---|---|---|
  | this branch | 2690 | 7 |
  | base commit, control | 2664 | 7 |

  The seven are the same seven in both runs, all PostgreSQL-backed tests that
  need a driver absent from this environment. The delta of 26 passing tests is
  exactly the new test file. The control was run in a separate checkout of the
  base commit with the same command, not inferred from the failure names.
- The `CASE` binds the same parameter three times in one statement.
  PostgreSQL cannot be executed here — its driver is not installed — so that
  rendering is pinned by a dialect compilation check rather than by a live run.
  That check covers the parameter shape, not the runtime semantics; the
  monotonicity itself is only executed against SQLite.
