### PR TITLE
fix(mcp): say in a run's own log when its terminal notice was not delivered

### DIFF
--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -34,7 +34,7 @@ from typing import Any
 
 # The CLI runs this file's module by absolute interpreter path; lionagi is on
 # the path because that interpreter is the one lionagi is installed in.
-from . import jobs
+from . import config, jobs
 
 # A configured notifier's stdout/stderr is free text that can carry a
 # credential the command obtained anywhere, so it is never captured or logged:
@@ -138,6 +138,39 @@ def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
     }
 
 
+def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
+    """Append one line to the run's own log when a configured delivery failed.
+
+    The outcome is already on the job record, but that record is only seen by
+    someone who thinks to query it. A run whose notice never arrived is
+    indistinguishable, in its log, from one still working: the log simply ends.
+    Ending it with a stated failure is what lets the log serve as the fallback
+    for a notice that did not.
+
+    Nothing about *why* it failed is available here by design -- the command's
+    output goes to DEVNULL because it is free text that can carry a credential
+    -- so the line reports the exit code and no more.
+
+    Best-effort like everything else in this hook: the run has already
+    finished, and a log that cannot be appended to must not turn a delivered
+    outcome into a crash.
+    """
+    if not outcome.get("attempted") and not outcome.get("error"):
+        return  # nothing was configured; silence is the documented default
+    if outcome.get("ok"):
+        return
+    detail = outcome.get("error") or f"exit code {outcome.get('exit_code')}"
+    try:
+        path = config.job_dir(run_id) / "console.log"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"\n[notify] terminal notice NOT delivered for run {run_id}: {detail}. "
+                f"This run finished; its completion signal did not.\n"
+            )
+    except OSError:
+        pass
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(prog="lionagi.mcp._notify_hook")
     ap.add_argument("--run-id", required=True)
@@ -170,6 +203,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         outcome = {"attempted": False}  # nothing configured — not a failure
     jobs.record_notify_delivery(args.run_id, outcome)
+    _note_failure_in_console_log(args.run_id, outcome)
     return 0
 
 

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -335,3 +335,87 @@ def test_unknown_run_id_is_noop(monkeypatch, tmp_path):
     rc = _notify_hook.main(["--run-id", "nope", "--status", "completed"])
     assert rc == 0
     assert calls == []
+
+
+def _console_log(run_id: str) -> str:
+    path = config.job_dir(run_id) / "console.log"
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_failed_delivery_ends_the_leg_log_with_a_stated_failure(job, monkeypatch):
+    """The log is the fallback for the notice, so it must say the notice died.
+
+    Without this the log of a run whose notice never arrived is
+    indistinguishable from the log of a run still working: it simply ends.
+    """
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+
+    command = json.dumps(["notify", "{status}"])
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    log = _console_log(job)
+    assert "work happened" in log  # appended, never rewritten
+    assert "NOT delivered" in log
+    assert "exit code 7" in log
+
+
+def test_spawn_error_is_named_in_the_leg_log(job, monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("no such command")
+
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(_notify_hook.subprocess, "run", boom)
+
+    command = json.dumps(["nonexistent-notifier", "{status}"])
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert "OSError" in _console_log(job)
+
+
+def test_a_configured_but_unusable_notifier_also_reaches_the_log(job, monkeypatch):
+    """Recorded as a failure on the job, so it must read as one in the log too."""
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    _no_settings_notifier(monkeypatch)
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
+
+    assert "delivery_command_is_not_valid_json" in _console_log(job)
+
+
+def test_successful_delivery_writes_nothing_to_the_log(job, monkeypatch):
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+
+    command = json.dumps(["notify", "{status}"])
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert _console_log(job) == "work happened\n"
+
+
+def test_silence_by_choice_writes_nothing_to_the_log(job, monkeypatch):
+    """Nothing configured is the documented default, not a delivery failure."""
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
+    _no_settings_notifier(monkeypatch)
+
+    _notify_hook.main(["--run-id", job, "--status", "completed"])
+
+    assert _console_log(job) == "work happened\n"
+
+
+def test_an_unwritable_log_does_not_break_the_terminal_path(job, monkeypatch):
+    """The run already finished; a log that cannot be appended to is not fatal."""
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+    # A directory where the log file belongs: opening it for append raises an
+    # OSError from the real filesystem rather than from a patched stand-in.
+    (config.job_dir(job) / "console.log").mkdir(parents=True, exist_ok=True)
+
+    command = json.dumps(["notify", "{status}"])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    assert jobs._read_job(job)["notify_delivery"]["ok"] is False


### PR DESCRIPTION
## The problem

A background run's terminal notice can fail to deliver. When it does, the
outcome is recorded on the job record, so `job_status` reports it. But the
run's own log says nothing at all.

That matters because the log is what a person actually reads. A run whose
notice never arrived has a log that simply ends, which is indistinguishable
from the log of a run still working. The failure presents as progress, which
is the worst direction for it to fail in: nobody goes looking.

## The change

The terminal hook appends one line to the run's console log when a configured
delivery fails, or when a configured notifier turns out to be unusable:

```
[notify] terminal notice NOT delivered for run <id>: exit code 7.
This run finished; its completion signal did not.
```

Nothing else changes. Silence by choice stays silent: with no notifier
configured, which is the documented default, the log is untouched. So is a
successful delivery.

## Two constraints kept

**No output capture.** The line carries the exit code or the named reason and
nothing more. The delivery command's stdout and stderr go to `DEVNULL` because
they are free text that can carry a credential the command obtained anywhere.
That decision is deliberately unchanged, which does mean the log can say a
notice failed but not why beyond its status.

**Best-effort.** The run has already reached terminal by the time this runs, so
a log that cannot be appended to must not turn a recorded outcome into a crash.
The `OSError` path is covered by a test that produces a real filesystem error
rather than a patched one.

## Verification

- `tests/mcp`: 379 passed, 0 failed.
- Six new tests: the failure line appears and appends rather than rewrites; a
  spawn error is named; a configured-but-unusable notifier reaches the log too;
  a successful delivery writes nothing; silence by choice writes nothing; an
  unwritable log leaves the terminal path intact.
- Mutation check: removing the call from the hook fails exactly the three
  positive tests and passes with it.
