### PR TITLE
fix(studio): stop answering ok to a schedule write that was silently dropped

### DIFF
--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
@@ -800,6 +800,12 @@ async def get_schedule_status(schedule_id: str) -> dict[str, Any] | None:
 
 
 class CreateScheduleRequest(BaseModel):
+    # An unknown key is a caller mistake, and silently dropping it means the
+    # request reports success for a change that never happened. The schedule
+    # declaration models next door already forbid extras; these two were the
+    # holdouts.
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     description: str | None = None
     trigger_type: str
@@ -832,6 +838,12 @@ class CreateScheduleRequest(BaseModel):
 
 
 class UpdateScheduleRequest(BaseModel):
+    # An unknown key is a caller mistake, and silently dropping it means the
+    # request reports success for a change that never happened. The schedule
+    # declaration models next door already forbid extras; these two were the
+    # holdouts.
+    model_config = ConfigDict(extra="forbid")
+
     name: str | None = None
     description: str | None = None
     trigger_type: str | None = None
@@ -935,7 +947,10 @@ async def update_schedule_route(schedule_id: str, body: UpdateScheduleRequest) -
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not ok:
         raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
-    return {"ok": True}
+    # Naming what was applied: an empty body is a legitimate no-op on an
+    # existing schedule, but a bare "ok" reads the same as a change that
+    # landed. The caller can tell the two apart from the list.
+    return {"ok": True, "updated": sorted(fields)}
 
 
 @studio_route(

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -823,11 +823,33 @@ def test_schedules_patch_success_response_shape(tmp_path, monkeypatch):
 
     r = client.patch(f"/api/schedules/{schedule_id}", json={"description": "gate patch"})
     assert r.status_code == 200
-    assert r.json() == {"ok": True}
+    assert r.json() == {"ok": True, "updated": ["description"]}
 
     # The write actually landed, not just an accepted-and-dropped no-op.
     detail = client.get(f"/api/schedules/{schedule_id}")
     assert detail.json()["description"] == "gate patch"
+
+
+def test_schedules_patch_refuses_a_field_it_cannot_apply(tmp_path, monkeypatch):
+    """The same regression one level down: accepted, dropped, reported ok.
+
+    ``enabled`` is settable in the store and has its own routes, but is not on
+    the PATCH model. Before this was forbidden the request answered 200 ok and
+    changed nothing, so an operator disabling a schedule this way believed it
+    was off while it kept firing.
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    schedule_id = _create_gate_schedule(db_path)
+    client = _make_client()
+
+    r = client.patch(f"/api/schedules/{schedule_id}", json={"enabled": False})
+    assert r.status_code == 422
+    assert "enabled" in r.text
+
+    # And the schedule is untouched, rather than half-applied.
+    detail = client.get(f"/api/schedules/{schedule_id}")
+    assert detail.json()["enabled"] in (1, True)
 
 
 def test_schedules_delete_success_response_shape(tmp_path, monkeypatch):

--- a/tests/studio/test_schedule_patch_reports_what_it_applied.py
+++ b/tests/studio/test_schedule_patch_reports_what_it_applied.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A schedule PATCH must not answer success for a change it did not make.
+
+Both request models used to ignore unknown keys. A caller sending a field the
+model does not declare got ``{"ok": True}`` and no change, which is the worst
+direction for an API to fail in: the operator believes the write landed and
+only finds out when the behaviour they were configuring never happens.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lionagi.studio.services.schedules import (
+    CreateScheduleRequest,
+    UpdateScheduleRequest,
+    update_schedule_route,
+)
+
+
+def test_update_rejects_a_field_it_cannot_apply():
+    """``enabled`` is in the store's allowlist but not on this model.
+
+    It has dedicated enable/disable routes, so its absence here is a choice.
+    Answering ok to a PATCH that sets it is not.
+    """
+    with pytest.raises(ValidationError) as exc:
+        UpdateScheduleRequest(enabled=True)
+    assert "enabled" in str(exc.value)
+
+
+def test_update_rejects_a_plain_typo():
+    with pytest.raises(ValidationError) as exc:
+        UpdateScheduleRequest(github_cursors="2026-07-26T00:00:00Z")
+    assert "github_cursors" in str(exc.value)
+
+
+def test_create_rejects_an_unknown_field_too():
+    """A schedule created without the option you asked for is the same defect.
+
+    Both models are now consistent with the declaration models next door,
+    which have forbidden extras all along.
+    """
+    with pytest.raises(ValidationError) as exc:
+        CreateScheduleRequest(
+            name="t", trigger_type="cron", action_kind="agent", polling_interval_sec=60
+        )
+    assert "polling_interval_sec" in str(exc.value)
+
+
+def test_a_declared_field_still_passes():
+    """The guard must not reject the fields the route exists to accept."""
+    req = UpdateScheduleRequest(github_cursor="2026-07-26T00:00:00Z")
+    assert req.model_dump(exclude_unset=True) == {"github_cursor": "2026-07-26T00:00:00Z"}
+
+
+def test_an_explicit_null_still_passes_through():
+    """exclude_unset, not exclude_none: clearing a field is a real request."""
+    req = UpdateScheduleRequest(github_cursor=None)
+    assert req.model_dump(exclude_unset=True) == {"github_cursor": None}
+
+
+@pytest.mark.asyncio
+async def test_the_response_names_what_landed(monkeypatch):
+    seen: dict = {}
+
+    async def fake_update(schedule_id, fields):
+        seen["fields"] = fields
+        return True
+
+    monkeypatch.setattr("lionagi.studio.services.schedules.update_schedule", fake_update)
+    body = UpdateScheduleRequest(github_cursor="2026-07-26T00:00:00Z", name="renamed")
+    result = await update_schedule_route("sched-001", body)
+
+    assert result == {"ok": True, "updated": ["github_cursor", "name"]}
+    assert seen["fields"] == {"github_cursor": "2026-07-26T00:00:00Z", "name": "renamed"}
+
+
+@pytest.mark.asyncio
+async def test_an_empty_body_is_still_a_no_op_but_says_so(monkeypatch):
+    """An empty PATCH remains legitimate; it just stops looking like a change."""
+
+    async def fake_update(schedule_id, fields):
+        return True
+
+    monkeypatch.setattr("lionagi.studio.services.schedules.update_schedule", fake_update)
+    result = await update_schedule_route("sched-001", UpdateScheduleRequest())
+
+    assert result == {"ok": True, "updated": []}

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -493,7 +493,7 @@ async def test_patch_route_all_null_body_no_longer_404s(temp_db_path):
 
     body = UpdateScheduleRequest(description=None)
     result = await update_schedule_route(sid, body)
-    assert result == {"ok": True}
+    assert result == {"ok": True, "updated": ["description"]}
 
     from lionagi.studio.services.schedules import get_schedule
 


### PR DESCRIPTION
## How this was found

Re-enabling a schedule with `PATCH /api/schedules/{id}` and `{"enabled": true}`.
The response was `{"ok": true}`. The schedule stayed disabled.

`enabled` is in the store's update allowlist and is perfectly writable. It is
simply not declared on `UpdateScheduleRequest`, so pydantic dropped the key,
`model_dump(exclude_unset=True)` produced an empty dict, and the route reported
success on an empty update.

That is the worst direction for an API to fail in. The operator believes the
write landed, and the only feedback is the configured behaviour never happening
— possibly much later, possibly never noticed. A schedule someone believes they
disabled and which keeps firing is the concrete version.

## The change

**Both request models forbid extras.** An undeclared field now returns 422
naming it. This is not a new convention: the schedule *declaration* models in
`schedule_declaration.py` have carried `extra="forbid"` on all eleven of their
models from the start. These two were the holdouts, in the same feature area.

`CreateScheduleRequest` is included deliberately. A schedule *created* without
the option you asked for is the same defect, and leaving PATCH strict while POST
stays permissive teaches callers a rule that is wrong half the time.

**The success response names what it applied**: `{"ok": true, "updated": [...]}`.
An empty PATCH body is still a legitimate no-op on an existing schedule and still
returns 200, but a bare `ok` read identically to a change that landed. The list
distinguishes them without changing any status code.

## What this does *not* change

The set of patchable fields. Seventeen allowlisted columns are absent from the
request model and most should stay absent — `last_fired_at`, `next_fire_at`,
`poller_consecutive_401` and the `resolved_*` family are engine bookkeeping, not
operator surface. `enabled` has its own `/enable` and `/disable` routes. The
defect was never the field list; it was that a rejected write answered success.

## Verification

- `tests/studio tests/cli tests/mcp tests/apps_studio_server tests/state`:
  **5270 passed, 8 failed**. Seven are PostgreSQL-backed tests needing a driver
  absent from this environment; the eighth is an unrelated pre-existing failure
  where a developer-HOME profile shadows pack routing. All eight fail identically
  on the base commit.
- Seven new tests: the two dropped-field cases, the create case, a declared field
  still passing, an explicit null still passing through, the response naming what
  landed, and an empty body still being a no-op.
- One existing test extended at the HTTP layer: a PATCH setting `enabled` now
  gets 422 and the schedule is verified untouched rather than half-applied.
- Two existing assertions updated for the response shape. One of them
  (`test_daemon_api_gate.py`) exists specifically to catch success-shape drift
  and its comment anticipates this exact case; it did its job.
- Mutation check: removing `extra="forbid"` fails three of the new tests;
  removing the `updated` list fails two.
