### PR TITLE
fix(scheduler): keep the error a run already recorded instead of overwriting it

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -370,6 +370,7 @@ TEAM_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["team"]
 EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": frozenset({"ended_at", "node_metadata"}),
     "invocation": frozenset({"ended_at"}),
+    "schedule_run": frozenset({"ended_at", "error_detail"}),
 }
 
 # ── ADR-0035 status vocabulary (valid, not just terminal) ──────────────

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1806,12 +1806,18 @@ class SchedulerEngine:
         source: str,
         actor: str,
         metadata: dict | None = None,
+        extra_fields: dict | None = None,
     ) -> bool:
         """Write a terminal ``schedule_run``/``invocation`` status without
         crashing (or losing follow-on side effects) when the row is already
         terminal — a concurrent writer (e.g. the deadline reaper) may have
         finalized it first. Guarded on the row still being ``running``, so a
         lost race is a checked no-op rather than a raised exception.
+
+        *extra_fields* carries same-row columns (``ended_at``, ``error_detail``)
+        that belong to this finalization, so they ride the same guard and the
+        same transaction as the status: when the race is lost, the winner's
+        values stay intact instead of being overwritten by ours.
         """
         written = await self._svc.update_status(
             entity_type,
@@ -1824,6 +1830,7 @@ class SchedulerEngine:
             actor=actor,
             metadata=metadata,
             expected_statuses={"running"},
+            extra_fields=extra_fields,
         )
         if not written:
             _log.debug(
@@ -2516,11 +2523,6 @@ class SchedulerEngine:
                 _fire_exc_reason = RunReasons.FAILED_EXCEPTION
                 _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
-            await self._svc.update_schedule_run(
-                run_id,
-                ended_at=_end_time,
-                error_detail="Internal scheduler error",
-            )
             written = await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
@@ -2531,6 +2533,10 @@ class SchedulerEngine:
                 source="executor",
                 actor=run_id,
                 metadata={"exception_class": type(exc).__name__},
+                extra_fields={
+                    "ended_at": _end_time,
+                    "error_detail": f"{type(exc).__name__}: {exc}",
+                },
             )
             if written:
                 await self._dispatch_signal(
@@ -2548,7 +2554,6 @@ class SchedulerEngine:
             inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
-            await self._svc.update_invocation(inv_id, ended_at=_end_time)
             inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
@@ -2559,6 +2564,7 @@ class SchedulerEngine:
                 source="executor",
                 actor=inv_id,
                 metadata=inv_meta,
+                extra_fields={"ended_at": _end_time},
             )
             if inv_written:
                 await flush_run_telemetry(

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -91,6 +91,7 @@ class SchedulerStateService(Protocol):
         actor: str,
         metadata: dict | None = None,
         expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+        extra_fields: dict[str, Any] | None = None,
     ) -> bool: ...
 
     async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
@@ -210,6 +211,7 @@ class _DBSchedulerStateService:
         actor: str,
         metadata: dict | None = None,
         expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+        extra_fields: dict[str, Any] | None = None,
     ) -> bool:
         async with StateDB() as db:
             return await db.update_status(
@@ -223,6 +225,7 @@ class _DBSchedulerStateService:
                 actor=actor,
                 metadata=metadata,
                 expected_statuses=expected_statuses,
+                extra_fields=extra_fields,
             )
 
     async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]:

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -1793,3 +1793,78 @@ async def test_readonly_rejects_write_attempt(tmp_path):
             await ro.execute("INSERT INTO schema_meta (key, value) VALUES ('x', 'y')")
     finally:
         await ro.close()
+
+
+# ── update_status extra_fields: schedule_run ────────────────────────────────
+
+
+async def _make_running_schedule_run(db) -> str:
+    schedule_id = uid()
+    await db.create_schedule(
+        {
+            "id": schedule_id,
+            "name": "extras",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    run_id = uid()
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": schedule_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": "running",
+            "fired_at": time.time(),
+        }
+    )
+    return run_id
+
+
+async def test_schedule_run_status_write_carries_ended_at_and_error_detail(db):
+    """A schedule_run's terminal write may set ended_at and error_detail in the
+    same guarded transaction as the status, so the two can never disagree."""
+    run_id = await _make_running_schedule_run(db)
+    ended = time.time()
+
+    assert await db.update_status(
+        "schedule_run",
+        run_id,
+        new_status="failed",
+        reason_code="run.failed.exception",
+        reason_summary="RuntimeError: boom",
+        source="executor",
+        actor="test",
+        expected_statuses={"running"},
+        extra_fields={"ended_at": ended, "error_detail": "RuntimeError: boom"},
+    )
+
+    row = await db.get_schedule_run(run_id)
+    assert row["status"] == "failed"
+    assert row["error_detail"] == "RuntimeError: boom"
+    assert row["ended_at"] == pytest.approx(ended)
+
+
+async def test_schedule_run_status_write_rejects_an_unlisted_extra_field(db):
+    """Only the columns declared for schedule_run ride a status write; anything
+    else is refused rather than written."""
+    run_id = await _make_running_schedule_run(db)
+
+    with pytest.raises(ValueError, match="extra_fields"):
+        await db.update_status(
+            "schedule_run",
+            run_id,
+            new_status="failed",
+            reason_code="run.failed.exception",
+            reason_summary="RuntimeError: boom",
+            source="executor",
+            actor="test",
+            expected_statuses={"running"},
+            extra_fields={"stderr_tail": "nope"},
+        )
+
+    row = await db.get_schedule_run(run_id)
+    assert row["status"] == "running"

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -2595,3 +2595,122 @@ async def test_fire_command_kind_nonzero_exit_records_failed_status():
         if c.args[0] == "schedule_run" and c.kwargs.get("new_status") == "failed"
     ]
     assert failed_calls, "Expected update_status('schedule_run', ..., new_status='failed')"
+
+
+# ---------------------------------------------------------------------------
+# error_detail on the broad-except handler (real StateDB)
+# ---------------------------------------------------------------------------
+
+
+class _DbSvc:
+    """SchedulerStateService over one open StateDB (in-memory, one connection)."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    async def compute_files_overlap(self, invocation_id: str, *, top_n: int = 5) -> dict:
+        return {"count": 0, "top": []}
+
+
+async def _seed_schedule(db, schedule: dict) -> None:
+    await db.create_schedule(
+        {
+            "id": schedule["id"],
+            "name": schedule["name"],
+            "trigger_type": "interval",
+            "interval_sec": 3600,
+            "action_kind": schedule["action_kind"],
+        }
+    )
+
+
+@pytest.fixture
+async def state_db():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_fire_exception_keeps_the_error_detail_a_prior_finalizer_wrote(state_db):
+    """A concurrent finalizer that already moved the run to a terminal status
+    owns its error_detail. The broad-except handler's write is guarded on the
+    row still being 'running', so a lost race must leave the winner's text in
+    place instead of replacing it with the handler's own."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _DbSvc(state_db)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    await _seed_schedule(state_db, schedule)
+    run_id = "run-race-detail"
+
+    async def _reaper_then_raise(*args, **kwargs):
+        # Stand in for the deadline reaper winning this row mid-fire: it
+        # finalizes with the real cause, then the fire path blows up.
+        await state_db.update_status(
+            "schedule_run",
+            run_id,
+            new_status="timed_out",
+            reason_code=RunReasons.TIMED_OUT_DEADLINE,
+            reason_summary="Run exceeded its deadline.",
+            evidence_refs=[],
+            source="system",
+            actor="reaper",
+            expected_statuses={"running"},
+            extra_fields={"error_detail": "TimeoutError: run exceeded its deadline"},
+        )
+        raise RuntimeError("spawn exploded")
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=_reaper_then_raise),
+        ),
+    ):
+        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+
+    row = await state_db.get_schedule_run(run_id)
+    assert row["error_detail"] == "TimeoutError: run exceeded its deadline"
+
+
+@pytest.mark.asyncio
+async def test_fire_exception_records_the_real_exception_text_as_error_detail(state_db):
+    """On the ordinary path (nothing else finalized the row) the handler owns
+    the record, and the error_detail it stores is the same text the signal
+    carries — real exception type and message, not a generic placeholder."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _DbSvc(state_db)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    await _seed_schedule(state_db, schedule)
+    run_id = "run-real-detail"
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=ModuleNotFoundError("No module named 'nope'")),
+        ),
+    ):
+        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+
+    row = await state_db.get_schedule_run(run_id)
+    assert row["status"] == "failed"
+    assert row["error_detail"] == "ModuleNotFoundError: No module named 'nope'"
+    assert row["ended_at"] is not None


### PR DESCRIPTION
## What

When a schedule fire raised, the exception handler recorded the failure with two
writes. One was guarded on the run still being `running`, and carried the real
exception text. The other was unguarded, and carried the string
`"Internal scheduler error"`.

If another finalizer had already resolved the run, only the guarded write was
refused. The generic string landed anyway and replaced the cause the winner had
recorded, so a record that had a real explanation ended up with a placeholder,
and the operation reported success.

## Why it mattered beyond the lost text

Two other consumers already had the real thing, which made the row the odd one out.

The signal published for the same event carries `error_detail` set to
`"ExceptionType: message"`. Same field name, same event, a different value from the
row.

The run list's error classifier reads raw exception text: it matches
`ModuleNotFoundError`, `failed to spawn`, `timed out`, `permission denied` and
similar, and falls back to the last meaningful line of a traceback.
`"Internal scheduler error"` matches no pattern and its last line is itself, so
every classification branch was unreachable for scheduler-fire failures and the
interface could only show the placeholder.

## The change

The status write and the columns that describe it now travel together.

`schedule_run` joins `session` and `invocation` in the set of entity types whose
status write may carry same-row fields, and `_guarded_terminal_status` forwards
them. The validation that rejects unexpected extra keys was already in place and
needed no change; the service wrapper the engine talks to through did need the
parameter threaded.

`ended_at` and `error_detail` now ride the same guard and the same transaction as
the status. A lost race is a clean no-op that leaves the winner's record intact.
On the ordinary path the row stores `"ExceptionType: message"`, which agrees with
the signal and is the shape the classifier is written to read.

The invocation `ended_at` write in the same handler had the same unguarded shape
and now rides its guarded call too.

## Tests

Four added. Two drive the engine with a real in-memory state store: one asserts a
prior finalizer's `error_detail` survives the handler, and fails on the base commit
with `assert 'Internal scheduler error' == "ModuleNotFound... named 'nope'"`; the
other asserts the ordinary path records the real exception text. Two cover the
`update_status` extra-fields contract directly, including that an unexpected key
for `schedule_run` is still rejected.

The pre-existing PostgreSQL-backed failures, which need a driver that is not
installed, are unchanged.

## Not included

The cancellation branch in the same method has the same shape, an unguarded
`error_detail` of `"Scheduler shutdown"` ahead of a guarded `cancelled` write, plus
the same unguarded invocation `ended_at`. A third unguarded `ended_at` write sits in
another method. All are left for a separate change rather than widened into this one.
