### PR TITLE
docs(mcp): document the single-dispatch-tool surface and drop the retired tool table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - `li mcp` serves an MCP server (over stdio) that submits `li` runs — agent, flow, and fanout —
-  as detached background jobs and exposes tools to query, tail, and stop them. Each `submit_*`
-  tool mirrors a `li` command but returns a `run_id` immediately while the run continues in its
-  own process group, so it survives an MCP-server restart. `fastmcp` stays behind the optional
+  as detached background jobs and answers questions about them. The server advertises a single
+  tool, `request`, and every operation is a namespaced verb passed to it. A submit returns a
+  `run_id` immediately while the run continues in its own process group, so it survives an
+  MCP-server restart. `fastmcp` stays behind the optional
   `[mcp]` extra; importing `lionagi` never pulls it, and the job engine plus terminal notify hook
   are standard-library only. Terminal notices are delivered through a configured command
   (lionagi's own `notify.on_terminal` setting, a per-submit override, or an environment default),
-  never a hardcoded one, and the delivery outcome is recorded on the job and surfaced in
-  `job_status`. See `docs/cli-reference.md` for the tool list and `.mcp.json` registration.
+  never a hardcoded one, and the delivery outcome is recorded on the job and surfaced by the
+  `job.status` operation. See `docs/reference/mcp-server.md` for the verb catalog and `.mcp.json`
+  registration.
 
 ### Fixed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -634,41 +634,40 @@ li hooks trust --yes                     # record trust without the prompt
 
 ## `li mcp`
 
-Serve an [MCP](https://modelcontextprotocol.io) server over stdio that submits
-`li` runs as **detached background jobs** and exposes tools to query, tail, and
-stop them. Each `submit_*` tool mirrors a `li` command but returns a `run_id`
-immediately instead of blocking; the run keeps going in its own process group,
-so it survives an MCP-server restart. Requires the `mcp` extra
+Serve an [MCP](https://modelcontextprotocol.io) server over stdio. The server is
+a control plane over this CLI: it submits `li` runs as **detached background
+jobs** and answers questions about them, so a submit returns a `run_id`
+immediately instead of blocking and the run keeps going in its own process
+group, surviving an MCP-server restart. Requires the `mcp` extra
 (`pip install 'lionagi[mcp]'`). Source: `lionagi/mcp/`.
 
 ```bash
 li mcp            # serve over stdio (same as: python -m lionagi.mcp)
 ```
 
-Register it with any MCP client (e.g. an `.mcp.json`):
+The server advertises a **single** tool, `request`, and every operation is a
+namespaced verb passed to it. Seeing one entry in a client's `tools/list` is
+correct. Call `request` with `help=true` for the catalog of verbs.
+
+Register it with any MCP client (e.g. an `.mcp.json`). The key here is the local
+name your client uses to launch the server; the name the server reports over the
+protocol is `lion`:
 
 ```json
 {
   "mcpServers": {
-    "lionagi": { "command": "li", "args": ["mcp"] }
+    "lion": { "command": "li", "args": ["mcp"] }
   }
 }
 ```
 
-| Tool | Purpose |
-|------|---------|
-| `submit_agent` | Background `li agent` — returns `{run_id, pid, status}` |
-| `submit_flow` | Background `li o flow` (DAG orchestration) |
-| `submit_fanout` | Background `li o fanout` (flat parallel workers) |
-| `job_status RUN_ID` | Liveness + authoritative terminal status + CLI manifest |
-| `job_output RUN_ID` | Console (an agent's final response) + artifacts |
-| `job_kill RUN_ID` | Signal the run's whole process group |
-| `jobs_list` | Recent jobs, newest first; optional `status` filter |
-
 Job records live under `~/.lionagi/mcp/jobs/<run_id>/`; the authoritative run
-state is the CLI's own `~/.lionagi/runs/<run_id>/`. In `job_status`, the
-top-level `status` is authoritative — the embedded `run` manifest is advisory
-and its own `status` may lag.
+state is the CLI's own `~/.lionagi/runs/<run_id>/`. In `job.status`, the
+top-level `status` is authoritative: the embedded `run` manifest is advisory and
+its own `status` may lag.
+
+The verb catalog, the `request` result contract, and a worked submit-and-poll
+example are in the [MCP server reference](reference/mcp-server.md).
 
 ### Terminal notices
 
@@ -694,7 +693,7 @@ Or per submit: `notify` overrides the delivery command for one run (a JSON argv
 list), and `notify_seat` fills the `{target}` placeholder. The environment
 variables `LIONAGI_MCP_NOTIFY_COMMAND` and `LIONAGI_MCP_NOTIFY_TARGET` set a
 process-wide default. Delivery outcome is recorded on the job and surfaced in
-`job_status` (`notify_delivery`), so a notice that failed to send is visible
+`job.status` (`notify_delivery`), so a notice that failed to send is visible
 rather than silently lost.
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -737,7 +737,8 @@ li runs --machine [--limit N]
 Each entry carries the run id, its state root, its artifact root, and the
 artifacts found there. It reports which runs EXIST and what they left behind,
 not whether any of them finished or succeeded — for that, ask `li job status` or
-the MCP `job_status` tool, which carry the terminal and outcome derivations.
+the MCP `request` operation `job.status`, which carry the terminal and outcome
+derivations.
 
 The artifact list is wrapped in the availability shape, so a directory that could
 not be read is reported as unavailable with a reason rather than as a run that

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -1,0 +1,302 @@
+# MCP Server Reference
+
+The operations LionAGI exposes to an [MCP](https://modelcontextprotocol.io)
+client, and the one tool they are reached through.
+
+## Purpose and transport
+
+`li mcp` (equivalently `python -m lionagi.mcp`) starts an MCP server that speaks
+over **stdio**. There is no HTTP listener and no port to configure: the client
+launches the process and talks to it on its standard streams.
+
+The server is a control plane over the `li` CLI, not a second implementation of
+it. Spawn and job verbs run `li` as a detached subprocess and keep a job record
+beside it; the remaining verbs run `li <path> --machine` and return the versioned
+envelope that command emits. A verb exists here only because it was registered,
+so adding a command to the CLI does not widen this surface.
+
+It advertises **one tool**, `request`. Every operation is a namespaced verb
+passed to that tool rather than a tool of its own, because an advertised tool
+schema is sent to the model on every request in every session for as long as the
+server is registered. A verb's parameters are fetched by asking for them.
+
+## Install and client registration
+
+The server needs the optional `mcp` extra:
+
+```bash
+pip install 'lionagi[mcp]'
+```
+
+Importing `lionagi.mcp` does not pull that dependency. Only serving does, so a
+missing extra surfaces when you run `li mcp`, with a message naming the install
+command.
+
+Register it with any MCP client, for example in an `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "lion": { "command": "li", "args": ["mcp"] }
+  }
+}
+```
+
+The key in `mcpServers` is your client's local name for the entry, and it is
+what your client addresses the server by. The name the server reports over the
+protocol is `lion`. Earlier builds reported `lionagi`, which is the name older
+registrations and logs show.
+
+## The `request` tool
+
+`request` takes two optional inputs:
+
+| Input | Type | Meaning |
+|-------|------|---------|
+| `ops` | list of objects | Operations to run, each `{"op": "<verb>", "args": {...}}`. A spawn verb's op also carries `"schema_fingerprint"`. At most 8 ops per call. |
+| `help` | `true`, a verb name, or `{"verb": ..., "playbook": ...}` | Ask what exists instead of running anything. |
+
+Passing neither is an error that says so. Exceeding the op limit is an error
+naming the count, never a truncation that would run part of a batch.
+
+**Result contract.** Ops run **in order**, and a failing op does not stop the
+ops beside it. The reply is:
+
+```json
+{
+  "status": "success",
+  "ops": [
+    {"ok": true, "op": "job.status", "result": {"...": "..."}}
+  ]
+}
+```
+
+`status` is `"success"` when every op succeeded and `"partial"` when any op did
+not. A per-op failure never fails the call, so **the caller must check each
+`ok`**. A failed entry carries `error` instead of `result`, with a `kind` and a
+`message`, and a rejected op also carries the schema it was judged against, so a
+wrong parameter tells you the right shape in the same reply.
+
+Argument validation is closed: an unknown or misspelled parameter is refused by
+name rather than ignored. Every value comes back as raw machine JSON, with no
+relative timestamps, formatted durations, or tables.
+
+### Asking what exists
+
+`help=true` returns the catalog. Trimmed to its envelope, the reply looks like:
+
+```json
+{
+  "verbs": [
+    {
+      "verb": "agent.submit",
+      "available": true,
+      "summary": "Run one agent on one task as a detached background run.",
+      "required": []
+    }
+  ],
+  "verb_count": 47,
+  "available_count": 36,
+  "max_ops": 8,
+  "help_usage": "help=true returns this catalog; help='<verb>' returns that verb's full parameter schema; ...",
+  "synonyms_removed_after": "2026-09-30"
+}
+```
+
+`help='<verb>'` returns that one verb's full parameter schema:
+
+```json
+{
+  "verb": "job.status",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "run_id": {
+        "type": "string",
+        "description": "Id of a background run as returned by a submit verb (format YYYYMMDDTHHMMSS-<6hex>). An id with no job record answers with known=false rather than failing."
+      }
+    },
+    "additionalProperties": false,
+    "required": ["run_id"],
+    "title": "job.status",
+    "description": "Current state of a background run: liveness, job record, CLI manifest."
+  }
+}
+```
+
+A spawn verb's help also returns a `schema_fingerprint`, which that verb's ops
+must carry. `help={"verb": "<verb>", "playbook": "<name>"}` additionally
+resolves that playbook's own declared arguments into the schema.
+
+## The catalog
+
+36 verbs are reachable. This list is generated from the registry:
+
+```bash
+python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) for n in sorted(v.VERBS)]"
+```
+
+| Verb | Summary |
+|------|---------|
+| `agent.submit` | Run one agent on one task as a detached background run. |
+| `dispatch.ls` | Rows in the durable dispatch outbox, newest first, without their payloads. |
+| `dispatch.show` | One dispatch row in full, including its payload and ack token. |
+| `doctor` | Environment checks and which of them failed. |
+| `fanout.submit` | Run N agents on one task in parallel, optionally synthesized. |
+| `flow.submit` | Plan and run a DAG of agents with dependencies, in the background. |
+| `handshake` | The machine-result contract version this build speaks. |
+| `invoke.list` | Recent skill-level invocations, newest first. |
+| `job.kill` | Stop a background job by signalling the process group this server created. |
+| `job.list` | Recent background jobs, newest first, optionally filtered by status. |
+| `job.output` | Console tail and artifact list of a background run. |
+| `job.status` | Current state of a background run: liveness, job record, CLI manifest. |
+| `job.wait` | Observe runs until terminal or the window closes; partial results, never a bool. |
+| `monitor` | Entities in flight right now: sessions, invocations, shows, plays. |
+| `play.submit` | Run a saved playbook: a flow whose plan and prompt are already written down. |
+| `plugin.info` | One plugin's version, trust state, and everything its manifest declares. |
+| `profile.list` | Agent profiles agent.submit would accept here, each with the file it comes from and the configuration it resolves to. |
+| `profile.show` | What one agent profile name resolves to: its winning file, the files it shadows, and its effective configuration. |
+| `runs` | Recorded runs on disk and what each one wrote. |
+| `schedule.create` | Write a schedule row, and report when its trigger next resolves in the scheduler's own timezone. |
+| `schedule.delete` | Remove a schedule row. Reports the deletion the store confirmed. |
+| `schedule.disable` | Stop a schedule firing. Reports the state that was committed. |
+| `schedule.enable` | Let a schedule fire again. Reports the state that was committed. |
+| `schedule.export` | Convert schedule rows into ScheduleSet documents, returned inline. |
+| `schedule.get` | One schedule in full, including its ten most recent runs. |
+| `schedule.limits` | The global concurrent-fire cap and how many fires are in flight now. |
+| `schedule.list` | Every schedule this Studio holds, with its trigger and enabled state. |
+| `schedule.runs` | Runs of one schedule, newest first, optionally filtered by status. |
+| `schedule.status` | Did it work: the schedule header, its latest run, and that run's verdict. |
+| `schedule.trigger` | Fire a schedule now: reports the run id allocated, never that the run ran. |
+| `schedule.validate` | Whether a ScheduleSet file resolves, and what each schedule resolves to. |
+| `server.info` | Which build is serving: version, contract version, uptime, verb counts. |
+| `state.ls` | Sessions in the lifecycle store with their branch and message counts. |
+| `state.stats` | Store and write-ahead-log size, per-table row counts, session status spread. |
+| `stats.runs` | Run counts and first/last timestamps, grouped by project/kind/agent/model/status. |
+| `team.list` | Teams on disk with their members and message counts. |
+
+There is deliberately **no parameter table here**. A verb's parameters are
+projected from the CLI parser at call time, so a table written by hand would
+drift away from what the server actually accepts. Ask for the parameters
+instead, with `help='<verb>'`, and you get the schema the call will be validated
+against rather than a copy of it.
+
+## Operations the surface does not offer
+
+Eleven further names are catalogued as **unavailable**, each with its reason.
+They are not omissions: a caller that asks what exists gets the name and why it
+cannot be called, which is a different answer from the name never having been
+considered.
+
+| Verb | Summary |
+|------|---------|
+| `schedule.apply` | Reconcile a whole ScheduleSet file into the store, atomically. |
+| `schedule.run` | One schedule run. |
+| `team.create`, `team.show`, `team.send`, `team.receive` | Messaging between agents working as a team. |
+| `state.doctor` | Read-only inspection of the lifecycle store. |
+| `dispatch.ack`, `dispatch.retry`, `dispatch.purge` | The outbound dispatch queue. |
+| `plugin.list` | Installed plugin bundles and their trust state. |
+
+Most share one reason: the CLI path emits no versioned machine result
+(`li <path> --machine`), so there is nothing to return that is not scraped
+console text. Scraping would make a command's console wording an API contract,
+so the fix belongs in the CLI, where the command gains a machine-result seam.
+The rest carry their own reason: `schedule.run` is already covered by
+`schedule.runs`, `schedule.apply` has no decided machine-result shape yet, and
+`plugin.list` prunes trust records as part of listing, which is a write.
+
+Asking for one of these inside `ops` returns a catalogued answer rather than a
+bare unknown-verb error: the op comes back `ok=false` with an `unavailable`
+error carrying that verb's reason and summary. A name that was never registered
+at all is a `not_found` error instead, pointing you at `help=true`.
+
+Separately, a small set of CLI paths that grant privilege to the caller has no
+verb at all, and no verb accepts opaque argv, so there is no route to them
+through this surface.
+
+## Worked example
+
+Submit an agent, then observe it. First ask for the schema, because a spawn
+verb's op must carry the fingerprint that help returns. The fingerprint below is
+illustrative: it tracks the verb's current schema, so always send the one your
+own help call returned rather than a value copied from here.
+
+```json
+{"help": "agent.submit"}
+```
+
+```json
+{
+  "verb": "agent.submit",
+  "schema": {"type": "object", "properties": {"prompt": {"...": "..."}}, "...": "..."},
+  "schema_fingerprint": "947259f8208faddc"
+}
+```
+
+Then submit:
+
+```json
+{
+  "ops": [
+    {
+      "op": "agent.submit",
+      "args": {"prompt": "Summarise the changes on this branch.", "agent": "reviewer"},
+      "schema_fingerprint": "947259f8208faddc"
+    }
+  ]
+}
+```
+
+The reply carries the allocated `run_id`. Poll it, or read what it wrote:
+
+```json
+{"ops": [{"op": "job.status", "args": {"run_id": "<run_id>"}}]}
+```
+
+```json
+{"ops": [{"op": "job.output", "args": {"run_id": "<run_id>"}}]}
+```
+
+To block instead of polling, use `job.wait`, which observes runs until they are
+terminal or the window closes and returns partial results rather than a bare
+boolean. Because ops run in order in one call, a status read and an output read
+can travel together:
+
+```json
+{
+  "ops": [
+    {"op": "job.status", "args": {"run_id": "<run_id>"}},
+    {"op": "job.output", "args": {"run_id": "<run_id>"}}
+  ]
+}
+```
+
+Check each entry's `ok`: the second can fail while the first succeeds, and
+`status` would then be `"partial"`.
+
+## Compatibility
+
+An earlier version of this server advertised one tool per operation. Those flat
+names are still accepted as **synonyms** inside `ops` and resolve silently to
+their namespaced verb:
+
+| Old name | Verb |
+|----------|------|
+| `submit_agent` | `agent.submit` |
+| `submit_flow` | `flow.submit` |
+| `submit_fanout` | `fanout.submit` |
+| `submit_play` | `play.submit` |
+| `job_status` | `job.status` |
+| `job_output` | `job.output` |
+| `job_kill` | `job.kill` |
+| `job_wait` | `job.wait` |
+| `jobs_list` | `job.list` |
+| `server_info` | `server.info` |
+
+They exist for callers already scripted against them, not as something new
+callers should learn, which is why they do not appear in the catalog. They will
+be **removed after the date the catalog reports as `synonyms_removed_after`**,
+currently `2026-09-30`. Write new calls against the namespaced verbs.
+
+If your client shows a single entry in `tools/list`, that is correct and
+current. The operations are behind `request`, and `help=true` lists them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
       - Durable operations: guides/durable-operations.md
       - Studio & schedules: guides/studio.md
       - Scheduling workflows: guides/scheduling-workflows.md
+      - MCP server: reference/mcp-server.md
       - Providers: reference/providers.md
       - State & testing: reference/testing-state-session.md
       - Troubleshooting: reference/troubleshooting.md


### PR DESCRIPTION
## What

The CLI reference's `li mcp` section documented a surface the server no longer has.
It presented a table of seven separately advertised tools — `submit_agent`,
`submit_flow`, `submit_fanout`, `job_status`, `job_output`, `job_kill`, `jobs_list`
— and told the reader those were what the server exposes.

The server advertises **one** tool, `request`, with every operation a namespaced
verb behind it. Those seven names survive only as synonyms accepted inside an `ops`
item, are deliberately kept out of the catalog, and have a removal date recorded in
source. The comment beside them says they exist for callers already scripted against
them, not as something new callers should learn.

So a reader following the documentation looked for seven tools in `tools/list`, found
one, and had nowhere to go. There was no other user-facing page describing the
current surface.

## The change

The `li mcp` section is now short and correct: what the server is, that it advertises
a single tool, that seeing one entry in `tools/list` is expected, that `help=true`
returns the catalog, and a link onward. The seven-tool table is gone. Stale `job_status`
spellings in the surviving prose are now `job.status`.

A new reference page, `docs/reference/mcp-server.md`, covers the surface: transport
and the control-plane relationship to the CLI, install and client registration, the
`request` tool with its inputs and its result contract including per-op `ok`, the
full verb catalog, the operations the surface deliberately does not offer and why, a
worked submit-and-observe example, and the synonym compatibility window with its
removal date read from the constant that holds it.

Added to the documentation navigation under Operate.

## How the facts were produced

The verb list and the per-verb summaries were generated by importing the module and
enumerating the registry, not written by hand. The help transcripts were captured by
executing a request against this tree. The removal date is quoted from the constant.

This matters because a hand-maintained table is exactly how the section being replaced
went wrong. For the same reason the page publishes no static per-verb parameter table:
parameters are projected from the CLI parsers at call time, so the page points readers
at per-verb `help` and says why.

The claim that asking for a catalogued-but-unavailable operation returns that entry's
recorded reason, rather than a bare unknown-verb error, was checked against the
dispatch path before being written; both branches are described.

`mkdocs build --strict` passes and the new page's nav entry resolves.

## Left alone

The list of files under `docs/adr/`, `docs/design/`, `docs/governance/` and
`docs/internals/` that the strict build reports as absent from the navigation is
pre-existing and untouched. The terminal-notices subsection's settings keys and
placeholders were not re-verified against source, so only the retired `job_status`
spelling in it was corrected.
