### PR TITLE
fix(mcp): stop a job kill from signalling a pid a finished run no longer owns

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -885,7 +885,19 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     # relabel a run that completed or was cancelled as "killed".
     if _record_is_terminal(job):
         recorded = job.get("status", "unknown")
-        return {"run_id": run_id, "killed": False, "reason": f"already ended as {recorded}"}
+        # The pid rides along on the refusal. A record can be marked terminal
+        # while its group leader is still alive: the terminal status is persisted
+        # from the lifecycle transition, and the run's own teardown finishes
+        # after that. Refusing is still right, because this pid may equally have
+        # been reused by then and nothing here can tell the two apart. But an
+        # operator reaping a group that really did outlive its recorded end needs
+        # the number, and this is the last place it is reported.
+        return {
+            "run_id": run_id,
+            "killed": False,
+            "reason": f"already ended as {recorded}; pid not signalled because it may since have been reused",
+            "pid": job.get("pid"),
+        }
     pid = job.get("pid")
     if not pid or pid <= 1:  # never signal pgid 0/1 (self/init)
         return {"run_id": run_id, "killed": False, "reason": "no pid on record"}

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -706,6 +706,19 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
     return SpawnError(run_id, record, f"could not spawn run {run_id}: {exc}")
 
 
+def _record_is_terminal(job: dict[str, Any]) -> bool:
+    """Whether the record itself already says the run ended.
+
+    The same notion `_derive` classifies on, and deliberately not a membership
+    test against a set of terminal status strings: the status is whatever the CLI
+    reported, recorded verbatim, so any such set would silently read the statuses
+    it did not happen to list as still running. What marks an end is the presence
+    of ``finished_at``, or a spawn that failed — a run that never started is over
+    however its status reads.
+    """
+    return job.get("finished_at") is not None or job.get("spawn_state") == "failed"
+
+
 def _needs_lifecycle_read(job: dict[str, Any] | None, alive: bool) -> bool:
     """Whether this observation has to go and ask the lifecycle store.
 
@@ -718,7 +731,7 @@ def _needs_lifecycle_read(job: dict[str, Any] | None, alive: bool) -> bool:
     """
     if job is None or alive:
         return False
-    return job.get("finished_at") is None and job.get("spawn_state") != "failed"
+    return not _record_is_terminal(job)
 
 
 def _cache_lifecycle_end(
@@ -865,6 +878,14 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     job = _read_job(run_id)
     if job is None:
         return {"run_id": run_id, "killed": False, "reason": "no such job"}
+    # Before the pid is read, let alone signalled. A record that already ended
+    # keeps its pid, and the operating system reuses pid numbers: probing that
+    # number can find an unrelated live process, and signalling it would kill a
+    # stranger's process group and report success. The write below would also
+    # relabel a run that completed or was cancelled as "killed".
+    if _record_is_terminal(job):
+        recorded = job.get("status", "unknown")
+        return {"run_id": run_id, "killed": False, "reason": f"already ended as {recorded}"}
     pid = job.get("pid")
     if not pid or pid <= 1:  # never signal pgid 0/1 (self/init)
         return {"run_id": run_id, "killed": False, "reason": "no pid on record"}

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import builtins
 import os
+import signal
 from pathlib import Path
 
 import pytest
@@ -186,6 +187,60 @@ def test_kill_guards_low_pid(sandbox):
 def test_kill_unknown_job(sandbox):
     out = jobs.kill("nope")
     assert out["killed"] is False and out["reason"] == "no such job"
+
+
+@pytest.mark.parametrize(
+    "recorded",
+    [
+        {"status": "completed", "finished_at": "2026-01-01T00:00:00+00:00"},
+        {"status": "cancelled", "finished_at": "2026-01-01T00:00:00+00:00"},
+        {"status": "timed_out", "finished_at": "2026-01-01T00:00:00+00:00"},
+        {"status": "failed", "spawn_state": "failed", "finished_at": "2026-01-01T00:00:00+00:00"},
+    ],
+)
+def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded):
+    """A run that ended is never probed and never signalled, however it ended.
+
+    The pid stays on the record after the run ends and pid numbers get reused, so
+    a liveness probe of that number can find an unrelated process — signalling it
+    would kill a stranger's process group. The recorded end must also survive: a
+    kill that should be a no-op must not relabel a completed or cancelled run.
+    """
+    killpg_calls: list[tuple] = []
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(jobs.os, "killpg", lambda *a: killpg_calls.append(a))
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "log": None, **recorded})
+
+    out = jobs.kill(rid)
+
+    assert killpg_calls == [], "a job that already ended must not be signalled"
+    assert out["killed"] is False
+    assert recorded["status"] in out["reason"]
+    after = jobs._read_job(rid)
+    assert after["status"] == recorded["status"]
+    assert after["finished_at"] == recorded["finished_at"]
+
+
+def test_kill_signals_the_process_group_of_a_live_run(sandbox, monkeypatch):
+    """The whole point of kill: a live, non-terminal run gets SIGTERM by group."""
+    killpg_calls: list[tuple] = []
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 9000 + pid)
+    monkeypatch.setattr(jobs.os, "killpg", lambda *a: killpg_calls.append(a))
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
+
+    out = jobs.kill(rid)
+
+    assert killpg_calls == [(9000 + 4242, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason"] is None and out["pid"] == 4242
+    after = jobs._read_job(rid)
+    assert after["status"] == "killed" and after["finished_at"] is not None
+    assert jobs.status(rid)["terminal"] is True
 
 
 @pytest.mark.parametrize("cli_status", ["timed_out", "cancelled", "aborted", "completed_empty"])

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -196,6 +196,11 @@ def test_kill_unknown_job(sandbox):
         {"status": "cancelled", "finished_at": "2026-01-01T00:00:00+00:00"},
         {"status": "timed_out", "finished_at": "2026-01-01T00:00:00+00:00"},
         {"status": "failed", "spawn_state": "failed", "finished_at": "2026-01-01T00:00:00+00:00"},
+        # No finished_at: a spawn failure is terminal on the spawn state alone,
+        # which is what `status` derives from it. Without this case the guard
+        # could drop its spawn-state arm and every other case here would still
+        # pass, putting kill and status back into disagreement.
+        {"status": "failed", "spawn_state": "failed"},
     ],
 )
 def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded):
@@ -219,9 +224,15 @@ def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded
     assert killpg_calls == [], "a job that already ended must not be signalled"
     assert out["killed"] is False
     assert recorded["status"] in out["reason"]
+    # The refusal reports the pid: a group that really did outlive its recorded
+    # end can only be found by an operator if this number survives the refusal.
+    assert out["pid"] == 4242
+    # kill and status must call the same record terminal. Whichever arm of the
+    # predicate this case exercises, disagreement here is the bug being guarded.
+    assert jobs.status(rid)["terminal"] is True
     after = jobs._read_job(rid)
     assert after["status"] == recorded["status"]
-    assert after["finished_at"] == recorded["finished_at"]
+    assert after.get("finished_at") == recorded.get("finished_at")
 
 
 def test_kill_signals_the_process_group_of_a_live_run(sandbox, monkeypatch):


### PR DESCRIPTION
## What

`kill()` for a background MCP job guarded a missing record, a missing or low pid,
and a dead pid. It never checked whether the job had already ended.

A finished record keeps its `pid` field, and the operating system reuses pid
numbers. So for a run that completed some time ago, the liveness probe can find an
unrelated live process wearing that number, and the signal goes to **that**
process's group while the caller is told `killed: true`.

The same path then wrote `"killed"` and a fresh `finished_at` over whatever the run
actually ended as, relabelling a completed or cancelled run as killed.

## The change

Refuse a record that already ended, before the pid is read, so such a record is
neither probed nor signalled, and report the state the record carries.

The check is deliberately **not** a membership test against terminal status names.
The status stored on a job is whatever the CLI reported, recorded verbatim, and that
is intentional: an earlier version of the terminal recorder matched against a local
set and fell through, which turned every status the set did not list into a false
success. A status-name set in this guard would repeat that in a new place, reading
any status it omitted as still running and letting the signal through.

Instead it tests the notion the module already used: a recorded `finished_at`, or a
spawn that failed. That pair is what the status derivation already classifies on,
and it is now extracted as one predicate so the two callers that expressed it
separately cannot drift apart.

## Tests

The positive case had no coverage at all: nothing asserted that a live job's kill
actually reaches its process group. That is added, asserting the exact process group
and signal.

The refusal is covered for each way a run can end, including a spawn that failed.
Both tests patch `killpg` and `getpgid` and stub the liveness probe to report alive,
so the pid looks killable and must still not be signalled. No test pid reaches a
real signal.

## Scope

Not included, and not silently left unexamined: the terminal recorder overwriting a
status this path wrote is correct and unchanged, because a kill's `"killed"` is only
an inference from having sent a signal while the CLI actually observed how the run
ended. The record writer does not serialise concurrent writers, so a read-modify-write
here can still lose an end recorded inside its own window; closing that needs a
compare-and-swap on the record and is a separate change.
