### PR TITLE
fix(scheduler): let the writer that wins a terminal transition own the whole record

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -370,7 +370,7 @@ TEAM_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["team"]
 EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": frozenset({"ended_at", "node_metadata"}),
     "invocation": frozenset({"ended_at"}),
-    "schedule_run": frozenset({"ended_at", "error_detail"}),
+    "schedule_run": frozenset({"ended_at", "error_detail", "exit_code"}),
 }
 
 # ── ADR-0035 status vocabulary (valid, not just terminal) ──────────────

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -2032,7 +2032,6 @@ class SchedulerEngine:
             inv_id,
             orphan_id,
         )
-        await self._svc.update_invocation(inv_id, ended_at=time.time())
         await self._guarded_terminal_status(
             "invocation",
             inv_id,
@@ -2046,6 +2045,7 @@ class SchedulerEngine:
             evidence_refs=[{"kind": "schedule_run", "id": orphan_id}],
             source="system",
             actor="scheduler_startup_recovery",
+            extra_fields={"ended_at": time.time()},
         )
 
     async def _fire_inner(
@@ -2222,7 +2222,6 @@ class SchedulerEngine:
                 inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                     self._svc, inv_id, fallback_status="failed", exception=exc
                 )
-                await self._svc.update_invocation(inv_id, ended_at=_end_time)
                 inv_written = await self._guarded_terminal_status(
                     "invocation",
                     inv_id,
@@ -2233,6 +2232,7 @@ class SchedulerEngine:
                     source="executor",
                     actor=inv_id,
                     metadata=inv_meta,
+                    extra_fields={"ended_at": _end_time},
                 )
                 if inv_written:
                     await flush_run_telemetry(
@@ -2355,12 +2355,6 @@ class SchedulerEngine:
                 reason_code = RunReasons.FAILED_EXIT_NONZERO
                 reason_summary = f"Scheduled process exited non-zero: {exit_code}."
 
-            await self._svc.update_schedule_run(
-                run_id,
-                exit_code=exit_code,
-                ended_at=end_time,
-                error_detail=stderr_tail if exit_code != 0 else None,
-            )
             written = await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
@@ -2371,6 +2365,11 @@ class SchedulerEngine:
                 source="executor",
                 actor=run_id,
                 metadata={"exit_code": exit_code},
+                extra_fields={
+                    "exit_code": exit_code,
+                    "ended_at": end_time,
+                    "error_detail": stderr_tail if exit_code != 0 else None,
+                },
             )
             if written:
                 await self._dispatch_signal(
@@ -2388,7 +2387,6 @@ class SchedulerEngine:
             inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status=status, exit_code=exit_code
             )
-            await self._svc.update_invocation(inv_id, ended_at=end_time)
             inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
@@ -2398,6 +2396,7 @@ class SchedulerEngine:
                 evidence_refs=inv_ev,
                 source="executor",
                 actor=inv_id,
+                extra_fields={"ended_at": end_time},
                 metadata=inv_meta,
             )
             if inv_written:
@@ -2454,11 +2453,6 @@ class SchedulerEngine:
             _log.info("Schedule fire cancelled %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             try:
-                await self._svc.update_schedule_run(
-                    run_id,
-                    ended_at=_end_time,
-                    error_detail="Scheduler shutdown",
-                )
                 written = await self._guarded_terminal_status(
                     "schedule_run",
                     run_id,
@@ -2468,6 +2462,10 @@ class SchedulerEngine:
                     evidence_refs=[{"kind": "schedule", "id": sid}],
                     source="executor",
                     actor=run_id,
+                    extra_fields={
+                        "ended_at": _end_time,
+                        "error_detail": "Scheduler shutdown",
+                    },
                 )
                 if written:
                     await self._dispatch_signal(
@@ -2484,7 +2482,6 @@ class SchedulerEngine:
                 inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                     self._svc, inv_id, fallback_status="cancelled"
                 )
-                await self._svc.update_invocation(inv_id, ended_at=_end_time)
                 inv_written = await self._guarded_terminal_status(
                     "invocation",
                     inv_id,
@@ -2495,6 +2492,7 @@ class SchedulerEngine:
                     source="executor",
                     actor=inv_id,
                     metadata=inv_meta,
+                    extra_fields={"ended_at": _end_time},
                 )
                 if inv_written:
                     await flush_run_telemetry(

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -209,13 +209,31 @@ async def test_fire_happy_path_records_invocation_and_run():
     assert run_payload["status"] == "running"
     assert kwargs["schedule_id"] == "sched-001"
     assert "last_fired_at" in kwargs["schedule_fields"]
-    svc.update_schedule_run.assert_awaited_once()
+    # The run's outcome columns are NOT written on their own. exit_code,
+    # ended_at and error_detail belong to the terminal transition, so they ride
+    # the guarded write and are subject to the same race check: a fire that
+    # loses to a concurrent finalizer must leave the winner's values alone
+    # rather than land its own beside a status it was refused.
+    svc.update_schedule_run.assert_not_awaited()
     # update_status called for schedule_run AND invocation
     assert svc.update_status.await_count == 3  # running + completed + invocation
-    # update_invocation is called twice: once to stamp ended_at, once more by
-    # flush_run_telemetry's read-modify-write of node_metadata["coordination"]
-    # after the invocation's terminal write lands (see scheduler_state.py).
-    assert svc.update_invocation.await_count == 2
+    # Only flush_run_telemetry's read-modify-write of
+    # node_metadata["coordination"] remains; the ended_at stamp that used to
+    # precede the terminal write now rides it.
+    assert svc.update_invocation.await_count == 1
+
+    terminal_run = [
+        call
+        for call in svc.update_status.await_args_list
+        if call.args[:2] == ("schedule_run", "run-001") and call.kwargs["new_status"] == "completed"
+    ]
+    assert len(terminal_run) == 1
+    extra = terminal_run[0].kwargs["extra_fields"]
+    assert set(extra) == {"exit_code", "ended_at", "error_detail"}
+    assert extra["exit_code"] == 0
+    assert extra["error_detail"] is None
+    assert isinstance(extra["ended_at"], float) and extra["ended_at"] > 0
+    assert terminal_run[0].kwargs["expected_statuses"] == {"running"}
     # update_schedule() itself isn't called for a plain fire -- its old job
     # (last_fired_at/next_fire_at) now rides create_schedule_run_and_advance's
     # schedule_fields above; update_schedule stays for other paths (backfill,
@@ -390,11 +408,23 @@ async def test_fire_cancellation_records_cancelled_run():
         with pytest.raises(asyncio.CancelledError):
             await engine._fire(schedule, "run-004", trigger_context={"scheduled": True})
 
-    svc.update_schedule_run.assert_awaited()
+    # "Scheduler shutdown" is a placeholder, not a measured cause, and it used
+    # to be written unguarded ahead of the guarded transition. A run already
+    # finalized by another writer (the deadline reaper recording a timeout, say)
+    # would keep its real status while that placeholder replaced the cause it
+    # recorded. The text now rides the guarded write, so losing the race writes
+    # nothing at all.
+    svc.update_schedule_run.assert_not_awaited()
     cancelled_calls = [
         c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "cancelled"
     ]
     assert cancelled_calls
+    run_cancel = [c for c in cancelled_calls if c.args[:2] == ("schedule_run", "run-004")]
+    assert len(run_cancel) == 1
+    extra = run_cancel[0].kwargs["extra_fields"]
+    assert extra["error_detail"] == "Scheduler shutdown"
+    assert isinstance(extra["ended_at"], float) and extra["ended_at"] > 0
+    assert run_cancel[0].kwargs["expected_statuses"] == {"running"}
 
 
 @pytest.mark.asyncio
@@ -920,12 +950,20 @@ async def test_fire_telemetry_flush_failure_does_not_alter_run_outcome():
     ):
         await engine._fire(schedule, "run-flush-fails", trigger_context={"scheduled": True})
 
-    # Exactly the one update_schedule_run call from the normal completion
-    # path -- no second rewrite from a broad-except handler catching a
-    # telemetry failure that leaked out of flush_run_telemetry().
-    svc.update_schedule_run.assert_awaited_once()
-    _, kwargs = svc.update_schedule_run.await_args
-    assert kwargs["error_detail"] is None
+    # Exactly the one terminal write from the normal completion path -- no
+    # second rewrite from a broad-except handler catching a telemetry failure
+    # that leaked out of flush_run_telemetry(). The run's outcome columns ride
+    # that write, so there is no standalone update_schedule_run to count.
+    svc.update_schedule_run.assert_not_awaited()
+    run_terminal_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[:2] == ("schedule_run", "run-flush-fails")
+        and c.kwargs.get("new_status") != "running"
+    ]
+    assert len(run_terminal_calls) == 1
+    assert run_terminal_calls[0].kwargs["new_status"] == "completed"
+    assert run_terminal_calls[0].kwargs["extra_fields"]["error_detail"] is None
     # The invocation's own terminal write is untouched by the telemetry
     # failure too.
     invocation_terminal_calls = [
@@ -2683,6 +2721,109 @@ async def test_fire_exception_keeps_the_error_detail_a_prior_finalizer_wrote(sta
 
     row = await state_db.get_schedule_run(run_id)
     assert row["error_detail"] == "TimeoutError: run exceeded its deadline"
+
+
+@pytest.mark.asyncio
+async def test_fire_cancellation_keeps_the_error_detail_a_prior_finalizer_wrote(state_db):
+    """Same guarantee on the cancellation branch. "Scheduler shutdown" is a
+    placeholder rather than a measured cause, so a shutdown arriving after some
+    other writer already finalized the row must not replace the cause that
+    writer recorded."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _DbSvc(state_db)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    await _seed_schedule(state_db, schedule)
+    run_id = "run-race-cancel"
+
+    async def _reaper_then_cancel(*args, **kwargs):
+        await state_db.update_status(
+            "schedule_run",
+            run_id,
+            new_status="timed_out",
+            reason_code=RunReasons.TIMED_OUT_DEADLINE,
+            reason_summary="Run exceeded its deadline.",
+            evidence_refs=[],
+            source="system",
+            actor="reaper",
+            expected_statuses={"running"},
+            extra_fields={"error_detail": "TimeoutError: run exceeded its deadline"},
+        )
+        raise asyncio.CancelledError()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=_reaper_then_cancel),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+
+    row = await state_db.get_schedule_run(run_id)
+    assert row["status"] == "timed_out"
+    assert row["error_detail"] == "TimeoutError: run exceeded its deadline"
+
+
+@pytest.mark.asyncio
+async def test_fire_completion_keeps_the_outcome_a_prior_finalizer_wrote(state_db):
+    """And on the ordinary completion path, whose columns are measured rather
+    than placeholders. A nonzero exit still does not entitle this path to
+    overwrite the exit_code, end time and cause of a row someone else already
+    finalized -- the terminal record belongs to whoever won the transition."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _DbSvc(state_db)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    await _seed_schedule(state_db, schedule)
+    run_id = "run-race-complete"
+
+    async def _reaper_then_exit_nonzero(*args, **kwargs):
+        # Deliberately writes only error_detail through extra_fields. Adding
+        # exit_code here would make this fixture itself unrunnable against a
+        # tree whose allowlist lacks that key, and the test would then fail for
+        # its own incompatibility rather than for the overwrite it exists to
+        # catch. exit_code is instead asserted to stay unset below.
+        await state_db.update_status(
+            "schedule_run",
+            run_id,
+            new_status="timed_out",
+            reason_code=RunReasons.TIMED_OUT_DEADLINE,
+            reason_summary="Run exceeded its deadline.",
+            evidence_refs=[],
+            source="system",
+            actor="reaper",
+            expected_statuses={"running"},
+            extra_fields={"error_detail": "TimeoutError: run exceeded its deadline"},
+        )
+        return (2, "some stderr the loser measured")
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=_reaper_then_exit_nonzero),
+        ),
+    ):
+        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+
+    row = await state_db.get_schedule_run(run_id)
+    assert row["status"] == "timed_out"
+    assert row["error_detail"] == "TimeoutError: run exceeded its deadline"
+    # The losing path measured exit code 2 and its own stderr. Neither belongs
+    # on a row it did not finalize.
+    assert row["exit_code"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -212,7 +212,10 @@ async def test_abandonment_failure_still_unregisters():
 
     svc = _make_engine_svc()
     svc.tombstone_and_replace_schedule_run = AsyncMock(return_value=False)
-    svc.update_invocation = AsyncMock(side_effect=RuntimeError("db down"))
+    # The abandonment's end timestamp rides its guarded terminal write rather
+    # than a separate update_invocation, so that write is where a database
+    # failure now surfaces.
+    svc.update_status = AsyncMock(side_effect=RuntimeError("db down"))
     engine = SchedulerEngine(svc=svc)
 
     with (


### PR DESCRIPTION
## What

A terminal record belongs to whichever writer won the terminal transition. Six
sites in the scheduler broke that: each wrote the run's outcome columns on their
own, immediately before the guarded transition, so a path that lost the race
landed its values over the winner's while its status change was correctly
refused.

The clearest case is the cancellation branch. `"Scheduler shutdown"` is a
placeholder rather than a measured cause, so a shutdown arriving after the
deadline reaper had already finalized a run replaced the reaper's real cause
with text that names nothing — and the guarded transition then declined, so the
status stayed correct while the explanation beside it did not.

The completion path had the same shape, and there it is easier to miss because
the overwriting values are genuinely measured: a nonzero exit does not entitle
that path to stamp its exit code, end time and stderr onto a row another writer
finalized.

## Change

All six sites now pass those columns through the guarded write, so losing the
race writes nothing at all rather than writing partially. `exit_code` joins the
`schedule_run` extra-field allowlist for the completion path.

The one remaining standalone `update_schedule_run` is a dispatch marker on a
still-running row. That is not a terminal write and is left alone.

## Tests

Two race tests against a real state database cover the cancellation and
completion paths: a run finalized first as `timed_out` keeps its status, its
cause, and an unset exit code. Both fail without the change, on the overwrite
itself — the cancellation one on `"Scheduler shutdown"` replacing the recorded
`TimeoutError`, the completion one on the loser's stderr replacing it.

One of those tests was initially written with a fixture that could not run
against the unpatched tree at all, so it failed there for its own
incompatibility rather than for the defect. That is noted in the test and the
fixture was narrowed until the base failure is the overwrite and nothing else.

Three existing tests asserted the standalone write had happened, which was the
defect itself; they now assert the fields ride the guarded call together with
its running precondition. The notify test that injected a database failure on
the abandonment path now injects it where that write lives.

`tests/studio tests/state tests/apps_studio_server` reports the same seven
failures as the base commit, all of them an absent PostgreSQL driver, with no
new ones.
