### PR TITLE
fix(mcp): name every command the catalog was silent about, and register the one that already answers

### DIFF
--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -609,7 +609,14 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
         }
 
     async def _read() -> list[dict[str, Any]]:
-        async with StateDB() as db:
+        # Read-only at the connection, not by intention. The ordinary open
+        # reconciles the schema — `create_all`, index reconciliation, seed
+        # inserts — so a reporting command that used it would write to the store
+        # it is reporting on, and against a store opened read-only elsewhere it
+        # fails on an `INSERT INTO schema_meta` while claiming to be a read.
+        # This function's own docstring says it changes nothing; that is only
+        # true of this connection.
+        async with StateDB(readonly=True) as db:
             return await db.get_sessions_for_run(run_id)
 
     try:

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -112,11 +112,19 @@ class Verb:
 
 @dataclass(frozen=True)
 class AbsentVerb:
-    """A verb the catalog names and cannot run, with why."""
+    """A verb the catalog names and cannot run, with why.
+
+    ``cli_path`` is the command this entry speaks for. It is stated rather than
+    derived from ``name`` because a verb name is not a dotted spelling of its
+    path — ``orchestrate fanout`` is registered as ``fanout.submit`` — so a
+    coverage check that guessed one from the other would need a table of
+    exceptions, and the table is what goes stale.
+    """
 
     name: str
     summary: str
     reason: str
+    cli_path: str
 
 
 # ── parameters this server implements rather than passes through ─────────────
@@ -459,6 +467,14 @@ _REGISTERED: tuple[Verb, ...] = (
         admits=("limit",),
     ),
     Verb(
+        name="lifecycle",
+        summary="What the lifecycle store records about one run: whether every session it "
+        "opened has ended, and with what outcome.",
+        executor="machine",
+        cli_path="lifecycle",
+        admits=("run_id",),
+    ),
+    Verb(
         name="schedule.list",
         summary="Every schedule this Studio holds, with its trigger and enabled state.",
         executor="machine",
@@ -669,10 +685,52 @@ _REGISTERED: tuple[Verb, ...] = (
 )
 
 
-def _absent(prefix: str, names: tuple[str, ...], summary: str) -> tuple[AbsentVerb, ...]:
+def _absent(
+    prefix: str, names: tuple[str, ...], summary: str, reason: str = _NO_MACHINE_SEAM
+) -> tuple[AbsentVerb, ...]:
+    """Absent entries sharing a prefix, a summary and a reason.
+
+    The CLI path is the prefix and name spelled with spaces, which is how every
+    grouped entry happens to read. An entry whose path does not follow from its
+    name is written out in full below instead of forced through here.
+    """
     return tuple(
-        AbsentVerb(name=f"{prefix}.{n}", summary=summary, reason=_NO_MACHINE_SEAM) for n in names
+        AbsentVerb(
+            name=f"{prefix}.{n}",
+            summary=summary,
+            reason=reason,
+            cli_path=f"{prefix.replace('.', ' ')} {n}",
+        )
+        for n in names
     )
+
+
+# Granting a right to the caller. Every caller here is an agent, so a verb that
+# trusts a bundle, enables a plugin, or imports a hook command lets the thing
+# being granted a right be the thing that grants it. This reason does not expire
+# when the CLI grows a machine seam, which is why it is written separately from
+# _NO_MACHINE_SEAM: a seam would make these callable, not safe to call.
+_PRIVILEGE = (
+    "it widens what this caller can reach — trusting a bundle, enabling a plugin "
+    "or importing a hook command grants a right to the agent asking for it, so no "
+    "machine seam would make it available here"
+)
+
+# Rewriting or deleting from the store every other verb reports on. A caller
+# cannot see from a machine result which of its own earlier reads a checkpoint,
+# prune or vacuum has since invalidated.
+_STORE_MUTATION = (
+    "it rewrites or removes rows in the lifecycle store that every read verb "
+    "reports on, and nothing in a machine result tells a caller which of its own "
+    "earlier answers the write invalidated"
+)
+
+# Occupying the process for as long as it runs. A verb returns one result; these
+# are the process, not a call within it.
+_LONG_RUNNING = (
+    "it runs for as long as the process lives rather than returning a result, so "
+    "it is a process to start, not a call to make"
+)
 
 
 ABSENT: tuple[AbsentVerb, ...] = (
@@ -683,6 +741,7 @@ ABSENT: tuple[AbsentVerb, ...] = (
             "it writes a whole ScheduleSet atomically and reports a per-row plan; the "
             "plan's shape has not been decided as a machine result yet"
         ),
+        cli_path="schedule apply",
     ),
     AbsentVerb(
         name="schedule.run",
@@ -690,6 +749,7 @@ ABSENT: tuple[AbsentVerb, ...] = (
         reason=(
             "it reports one schedule run, which schedule.runs already returns in a machine result"
         ),
+        cli_path="schedule run",
     ),
     *_absent(
         "team",
@@ -706,6 +766,101 @@ ABSENT: tuple[AbsentVerb, ...] = (
         ("ack", "retry", "purge"),
         "The outbound dispatch queue.",
     ),
+    # `plugin trust` and `hooks trust` are deliberately not here. A fenced path is
+    # accounted for by FENCED_PATHS, and naming it in the catalog would advertise
+    # the capability to the caller it is fenced from; that is a different silence
+    # from the one the absent entries exist to end.
+    *_absent(
+        "plugin",
+        ("enable", "disable"),
+        "Plugin bundle enablement.",
+        _PRIVILEGE,
+    ),
+    *_absent(
+        "hooks",
+        ("import",),
+        "Importing hook commands from another tool's config.",
+        _PRIVILEGE,
+    ),
+    *_absent(
+        "state",
+        ("checkpoint", "prune", "vacuum", "import", "import-teams"),
+        "Writes against the lifecycle store.",
+        _STORE_MUTATION,
+    ),
+    *_absent(
+        "studio",
+        ("start",),
+        "The Studio server.",
+        _LONG_RUNNING,
+    ),
+    AbsentVerb(
+        name="mirror",
+        summary="Mirror Claude Code sessions into Studio, live.",
+        reason=_LONG_RUNNING,
+        cli_path="mirror",
+    ),
+    AbsentVerb(
+        name="mcp",
+        summary="Serve this surface over stdio.",
+        reason=(
+            "it is this server: a call to it from here would serve a second copy of "
+            "the surface the call arrived on"
+        ),
+        cli_path="mcp",
+    ),
+    AbsentVerb(
+        name="engine.run",
+        summary="Run a domain-specific multi-agent pipeline.",
+        reason=(
+            "the spawn verbs return a job id because they go through this server's "
+            "job records; this path spawns without one, so a caller would get a "
+            "result it could not later ask about"
+        ),
+        cli_path="engine run",
+    ),
+    *_absent(
+        "invoke",
+        ("start", "end"),
+        "Opening and closing a skill-level orchestration record.",
+        (
+            "the pair brackets a caller's own work, and this surface has no way to "
+            "tell that the caller who opened a record is the one closing it; "
+            "invoke.list reads what they wrote"
+        ),
+    ),
+    AbsentVerb(
+        name="kill",
+        summary="Terminate a run, session, play or show by id.",
+        reason=(
+            "job.kill covers the jobs this server spawned, where the record carries "
+            "the pid to correlate against; this path reaches entities this server "
+            "never spawned and holds no identity for"
+        ),
+        cli_path="kill",
+    ),
+    *_absent(
+        "orchestrate.ctl",
+        ("pause", "resume", "msg"),
+        "The running-flow control plane.",
+        (
+            "it steers a flow that is already running, and the effect lands on the "
+            "flow rather than in a result; whether the flow honoured it is read from "
+            "the flow's own state, not returned here"
+        ),
+    ),
+    AbsentVerb(
+        name="orchestrate.ctl.status",
+        summary="What a running flow's control plane reports about it.",
+        reason=_NO_MACHINE_SEAM,
+        cli_path="orchestrate ctl status",
+    ),
+    AbsentVerb(
+        name="casts",
+        summary="The built-in roles and modes an agent can be composed from.",
+        reason=_NO_MACHINE_SEAM,
+        cli_path="casts",
+    ),
     AbsentVerb(
         name="plugin.list",
         summary="Installed plugin bundles and their trust state.",
@@ -719,6 +874,7 @@ ABSENT: tuple[AbsentVerb, ...] = (
             "gone, so it writes to user settings on the trust surface; a listing "
             "that skipped the prune would not be this command"
         ),
+        cli_path="plugin list",
     ),
 )
 

--- a/tests/mcp/golden_projections/lifecycle.json
+++ b/tests/mcp/golden_projections/lifecycle.json
@@ -1,0 +1,29 @@
+{
+  "path": "lifecycle",
+  "schema": {
+    "additionalProperties": false,
+    "description": "Read-only: what the lifecycle store records about one run id \u2014 whether a session was ever recorded for it, whether every one of them has ended, and with what outcome. A run stopped by `li kill` reads as cancelled here. Add --machine for the contract envelope on stdout.",
+    "properties": {
+      "machine": {
+        "default": false,
+        "description": "Emit the machine-result envelope.",
+        "type": "boolean",
+        "x-flag": "--machine"
+      },
+      "run_id": {
+        "description": "The run id to report on.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "run_id"
+    ],
+    "title": "lifecycle",
+    "type": "object",
+    "x-positional-order": [
+      "run_id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/test_catalog_coverage.py
+++ b/tests/mcp/test_catalog_coverage.py
@@ -24,74 +24,163 @@ from lionagi.cli.main import _COMMAND_REGISTRY
 from lionagi.mcp.verbs import ABSENT, FENCED_PATHS, VERBS
 
 
-def _leaves(parser: argparse.ArgumentParser, prefix: str) -> list[str]:
-    """Every leaf command path under *parser*, spelled as it is typed."""
+def _leaves(parser: argparse.ArgumentParser, prefix: str) -> dict[str, str]:
+    """Every typed leaf spelling under *parser*, mapped to its canonical one.
+
+    Aliases are measured, not skipped. Dropping them would leave a command
+    reachable only under an alias invisible to this test, which is the shape of
+    silence it exists to catch. argparse keeps no canonical flag, so the first
+    name registered for a given parser object is taken as canonical — that is the
+    `name` argument of `add_parser`, with `aliases=` following it.
+    """
     subactions = [
         action
         for action in parser._actions  # noqa: SLF001 — the parser tree has no public reader
         if isinstance(action, argparse._SubParsersAction)  # noqa: SLF001
     ]
     if not subactions:
-        return [prefix]
-    found: list[str] = []
+        return {prefix: prefix}
+    found: dict[str, str] = {}
     for action in subactions:
-        seen: set[int] = set()
+        canonical_of: dict[int, str] = {}
         for name, sub in action.choices.items():
-            # Aliases point at the same parser object; count the command once.
-            if id(sub) in seen:
-                continue
-            seen.add(id(sub))
-            found.extend(_leaves(sub, f"{prefix} {name}"))
+            canonical_name = canonical_of.setdefault(id(sub), name)
+            for spelling, canonical in _leaves(sub, f"{prefix} {name}").items():
+                # Rewrite this level's segment back to the canonical spelling,
+                # leaving deeper levels' own canonicalisation intact.
+                found[spelling] = canonical.replace(
+                    f"{prefix} {name}", f"{prefix} {canonical_name}", 1
+                )
     return found
 
 
-def _cli_leaves() -> tuple[frozenset[str], dict[str, str]]:
-    """The CLI's leaf command paths, and the commands that would not build.
+def _cli_leaves() -> tuple[dict[str, str], dict[str, str]]:
+    """Every typed leaf spelling in the CLI, mapped to its canonical path.
 
-    A top-level command whose parser needs an uninstalled extra is reported
-    rather than skipped silently: its subcommands are invisible to this test, so
-    a gap under it would not be caught, and the caller deserves to know which
-    part of the surface went unmeasured.
+    Top-level aliases are included for the same reason as nested ones, and are
+    canonicalised to the registry's own `spec.name`.
     """
-    leaves: set[str] = set()
+    leaves: dict[str, str] = {}
     unbuildable: dict[str, str] = {}
     for spec in _COMMAND_REGISTRY:
         root = argparse.ArgumentParser(prog="li")
         subparsers = root.add_subparsers(dest="command")
         try:
             getattr(spec.loader(), spec.parser_factory)(subparsers)
-        except Exception as exc:  # noqa: BLE001 — a missing extra, not a catalog gap
+        except Exception as exc:  # noqa: BLE001 — recorded, and failed on by the caller
             unbuildable[spec.name] = f"{type(exc).__name__}: {exc}"
             continue
         for name, sub in subparsers.choices.items():
-            if name == spec.name:
-                leaves.update(_leaves(sub, spec.name))
-    return frozenset(leaves), unbuildable
+            if name not in (spec.name, *spec.aliases):
+                continue
+            for spelling, canonical in _leaves(sub, name).items():
+                leaves[spelling] = canonical.replace(name, spec.name, 1)
+    return leaves, unbuildable
+
+
+def _measured_surface() -> dict[str, str]:
+    """The leaf map, or a failure naming what went unmeasured.
+
+    A coverage gate that cannot see part of the surface must fail rather than
+    report on the part it can see. The earlier version printed the unbuildable
+    commands and passed, so a whole command tree could go unmeasured while this
+    file claimed the catalog covered everything. If an optional extra is missing,
+    that is the environment to fix — not a silence to inherit.
+    """
+    leaves, unbuildable = _cli_leaves()
+    assert unbuildable == {}, (
+        "these top-level commands' parsers would not build, so their subcommands "
+        f"went unmeasured and this gate cannot speak for them: {unbuildable}"
+    )
+    assert leaves, "no CLI commands were measured; the parser walk is broken"
+    return leaves
+
+
+# A fence for a capability that has no command yet. Kept deliberately: removing a
+# fence because its path is absent today is how the path comes back unfenced, and
+# store migration is exactly the capability that must not arrive reachable. Listed
+# here so that a *typo* or a retired path in FENCED_PATHS still fails the
+# existence check below instead of hiding inside a blanket exemption.
+PREEMPTIVE_FENCES = frozenset({"state migrate"})
 
 
 def test_every_cli_command_is_registered_or_named_absent():
-    leaves, unbuildable = _cli_leaves()
-    assert leaves, "no CLI commands were measured; the parser walk is broken"
+    leaves = _measured_surface()
 
     registered = {verb.cli_path for verb in VERBS.values() if verb.cli_path is not None}
     named_absent = {absent.cli_path for absent in ABSENT}
     # A fenced path is accounted for, and accounted for somewhere that deliberately
     # keeps it out of the catalog: naming it there would tell the caller it is
     # fenced from that the capability exists. That is not the silence this test is
-    # about, so it is subtracted rather than demanded as an absent entry.
+    # about, so it is subtracted rather than demanded as an absent entry. The
+    # subtraction is only safe because every fenced path is itself checked below.
     fenced = set(FENCED_PATHS)
 
-    silent = sorted(leaves - registered - named_absent - fenced)
+    # Coverage is asked of canonical paths: an alias and its canonical name are one
+    # parser, so one catalog entry answers for both. Asking of every spelling would
+    # demand an entry per alias, which is a second name for one operation.
+    silent = sorted(set(leaves.values()) - registered - named_absent - fenced)
     assert silent == [], (
         "these CLI commands are neither registered nor named absent, so the catalog "
         f"is silent about them: {silent}. Add a Verb if the path answers "
         "`--machine`, or an AbsentVerb with the reason it cannot."
     )
-    # Reported, not asserted: an extra that is absent here is an environment
-    # fact, and failing on it would make this test's verdict depend on which
-    # extras the runner installed.
-    if unbuildable:
-        print(f"unmeasured top-level commands: {unbuildable}")
+
+
+def test_an_alias_reaches_a_command_the_catalog_accounts_for():
+    """Aliases are in scope, and their treatment is stated rather than assumed.
+
+    `team ls`, `team recv`, `li o` and `li mon` are callable spellings. The policy
+    is that a spelling is covered by its canonical path's catalog entry, which
+    holds because they are the same parser. What this asserts is that every
+    spelling resolves to a canonical path the catalog accounts for — so a command
+    added only under an alias cannot slip through.
+    """
+    leaves = _measured_surface()
+    accounted = (
+        {verb.cli_path for verb in VERBS.values() if verb.cli_path is not None}
+        | {absent.cli_path for absent in ABSENT}
+        | set(FENCED_PATHS)
+    )
+    aliases = {
+        spelling: canonical for spelling, canonical in leaves.items() if spelling != canonical
+    }
+    assert aliases, "no aliases were measured; the canonicalisation is not being exercised"
+    unaccounted = sorted(
+        f"{spelling} -> {canonical}"
+        for spelling, canonical in aliases.items()
+        if canonical not in accounted
+    )
+    assert unaccounted == [], (
+        f"alias spellings resolving to nothing the catalog names: {unaccounted}"
+    )
+
+
+def test_every_fenced_path_is_a_real_command_or_a_declared_preemptive_fence():
+    """The fenced set is subtracted from coverage, so it must not be a place to hide.
+
+    Without this, adding a string to FENCED_PATHS silently waives coverage for it,
+    and a typo or a retired path is invisible because nothing ever checks that a
+    fenced string names anything.
+    """
+    leaves = _measured_surface()
+    canonical = set(leaves.values())
+    unreal = sorted(
+        path for path in FENCED_PATHS if path not in canonical and path not in PREEMPTIVE_FENCES
+    )
+    assert unreal == [], (
+        f"fenced paths that name no CLI command: {unreal}. Either the path is gone "
+        "and the fence should say so, or it is pre-emptive and belongs in "
+        "PREEMPTIVE_FENCES with the reason."
+    )
+    # The other direction: a pre-emptive fence whose command has since landed is
+    # no longer pre-emptive, and leaving it here would exempt a real command from
+    # the existence check for good.
+    landed = sorted(path for path in PREEMPTIVE_FENCES if path in canonical)
+    assert landed == [], (
+        f"these are declared pre-emptive but now exist as commands: {landed}; "
+        "drop them from PREEMPTIVE_FENCES so the fence is checked against the CLI"
+    )
 
 
 def test_no_absent_entry_names_a_command_that_is_gone():
@@ -101,19 +190,9 @@ def test_no_absent_entry_names_a_command_that_is_gone():
     question about a command that no longer exists, and the answer explains why
     it cannot be called rather than that there is nothing to call.
     """
-    leaves, unbuildable = _cli_leaves()
-    stale = []
-    for absent in ABSENT:
-        if absent.cli_path in leaves:
-            continue
-        # Its whole top-level command went unmeasured, so its absence here says
-        # nothing about whether the command exists.
-        if absent.cli_path.split()[0] in unbuildable:
-            continue
-        stale.append(absent.cli_path)
-    assert sorted(stale) == [], (
-        f"absent entries naming commands the CLI no longer has: {sorted(stale)}"
-    )
+    canonical = set(_measured_surface().values())
+    stale = sorted(absent.cli_path for absent in ABSENT if absent.cli_path not in canonical)
+    assert stale == [], f"absent entries naming commands the CLI no longer has: {stale}"
 
 
 def test_absent_names_do_not_collide_with_registered_ones():

--- a/tests/mcp/test_catalog_coverage.py
+++ b/tests/mcp/test_catalog_coverage.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Every command the CLI offers is either registered or named absent.
+
+The privilege fence already guards the other direction: a verb cannot become
+reachable without someone writing its path into a reviewed list. Nothing guarded
+this one. A command could be added to the CLI and the catalog would simply not
+mention it, and silence reads the same as considered-and-declined -- which is the
+one thing the absent entries exist to distinguish. Twenty-three commands had
+accumulated that way before this test existed.
+
+The CLI surface is measured here rather than listed, because a list of command
+paths in a test is a second copy of the parser tree and would go stale in the
+same way the catalog did.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from lionagi.cli.main import _COMMAND_REGISTRY
+from lionagi.mcp.verbs import ABSENT, FENCED_PATHS, VERBS
+
+
+def _leaves(parser: argparse.ArgumentParser, prefix: str) -> list[str]:
+    """Every leaf command path under *parser*, spelled as it is typed."""
+    subactions = [
+        action
+        for action in parser._actions  # noqa: SLF001 — the parser tree has no public reader
+        if isinstance(action, argparse._SubParsersAction)  # noqa: SLF001
+    ]
+    if not subactions:
+        return [prefix]
+    found: list[str] = []
+    for action in subactions:
+        seen: set[int] = set()
+        for name, sub in action.choices.items():
+            # Aliases point at the same parser object; count the command once.
+            if id(sub) in seen:
+                continue
+            seen.add(id(sub))
+            found.extend(_leaves(sub, f"{prefix} {name}"))
+    return found
+
+
+def _cli_leaves() -> tuple[frozenset[str], dict[str, str]]:
+    """The CLI's leaf command paths, and the commands that would not build.
+
+    A top-level command whose parser needs an uninstalled extra is reported
+    rather than skipped silently: its subcommands are invisible to this test, so
+    a gap under it would not be caught, and the caller deserves to know which
+    part of the surface went unmeasured.
+    """
+    leaves: set[str] = set()
+    unbuildable: dict[str, str] = {}
+    for spec in _COMMAND_REGISTRY:
+        root = argparse.ArgumentParser(prog="li")
+        subparsers = root.add_subparsers(dest="command")
+        try:
+            getattr(spec.loader(), spec.parser_factory)(subparsers)
+        except Exception as exc:  # noqa: BLE001 — a missing extra, not a catalog gap
+            unbuildable[spec.name] = f"{type(exc).__name__}: {exc}"
+            continue
+        for name, sub in subparsers.choices.items():
+            if name == spec.name:
+                leaves.update(_leaves(sub, spec.name))
+    return frozenset(leaves), unbuildable
+
+
+def test_every_cli_command_is_registered_or_named_absent():
+    leaves, unbuildable = _cli_leaves()
+    assert leaves, "no CLI commands were measured; the parser walk is broken"
+
+    registered = {verb.cli_path for verb in VERBS.values() if verb.cli_path is not None}
+    named_absent = {absent.cli_path for absent in ABSENT}
+    # A fenced path is accounted for, and accounted for somewhere that deliberately
+    # keeps it out of the catalog: naming it there would tell the caller it is
+    # fenced from that the capability exists. That is not the silence this test is
+    # about, so it is subtracted rather than demanded as an absent entry.
+    fenced = set(FENCED_PATHS)
+
+    silent = sorted(leaves - registered - named_absent - fenced)
+    assert silent == [], (
+        "these CLI commands are neither registered nor named absent, so the catalog "
+        f"is silent about them: {silent}. Add a Verb if the path answers "
+        "`--machine`, or an AbsentVerb with the reason it cannot."
+    )
+    # Reported, not asserted: an extra that is absent here is an environment
+    # fact, and failing on it would make this test's verdict depend on which
+    # extras the runner installed.
+    if unbuildable:
+        print(f"unmeasured top-level commands: {unbuildable}")
+
+
+def test_no_absent_entry_names_a_command_that_is_gone():
+    """The reverse drift: an absence outliving the command it speaks for.
+
+    A stale absent entry is worse than a missing one. It answers a caller's
+    question about a command that no longer exists, and the answer explains why
+    it cannot be called rather than that there is nothing to call.
+    """
+    leaves, unbuildable = _cli_leaves()
+    stale = []
+    for absent in ABSENT:
+        if absent.cli_path in leaves:
+            continue
+        # Its whole top-level command went unmeasured, so its absence here says
+        # nothing about whether the command exists.
+        if absent.cli_path.split()[0] in unbuildable:
+            continue
+        stale.append(absent.cli_path)
+    assert sorted(stale) == [], (
+        f"absent entries naming commands the CLI no longer has: {sorted(stale)}"
+    )
+
+
+def test_absent_names_do_not_collide_with_registered_ones():
+    overlap = sorted({absent.name for absent in ABSENT} & set(VERBS))
+    assert overlap == [], f"named both available and absent: {overlap}"
+
+
+@pytest.mark.parametrize("absent", ABSENT, ids=lambda a: a.name)
+def test_every_absence_states_a_reason_and_a_path(absent):
+    assert absent.cli_path, f"{absent.name} names no CLI path"
+    assert absent.reason.strip(), f"{absent.name} gives no reason"
+    # A reason is what a caller reads instead of a result, so a placeholder is a
+    # silence with extra steps.
+    assert len(absent.reason) > 40, (
+        f"{absent.name} reason is too short to be one: {absent.reason!r}"
+    )

--- a/tests/mcp/test_lifecycle_verb_is_readonly.py
+++ b/tests/mcp/test_lifecycle_verb_is_readonly.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`lifecycle` is reachable from the MCP surface, so its read must be a read.
+
+The ordinary store open reconciles the schema: `create_all`, index reconciliation
+and seed inserts. A reporting path that used it would write to the store it
+reports on, and against a store it may not write to it fails on an
+`INSERT INTO schema_meta` while presenting itself as a read. Only
+``readonly=True`` avoids that, and nothing in the function's own docstring makes
+it so.
+
+These are behavioural probes rather than an assertion about which keyword was
+passed. A keyword check passes as soon as someone writes the keyword; what has to
+hold is that the path does not need write access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.cli.machine import lifecycle_data
+
+
+def _redirect(monkeypatch, db_path: Path) -> None:
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+
+
+def _make_store(db_path: Path) -> None:
+    """A real, fully reconciled store, so a later open has nothing to migrate."""
+    from lionagi.state.db import StateDB
+
+    async def _open():
+        async with StateDB(db_path) as db:
+            await db.fetch_all("SELECT 1")
+
+    asyncio.run(_open())
+
+
+def test_reading_a_run_does_not_bring_a_store_into_existence(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    _redirect(monkeypatch, db_path)
+
+    answer = lifecycle_data("some-run")
+
+    assert answer["lifecycle"]["available"] is False
+    assert answer["lifecycle"]["reason_code"] == "not_found"
+    assert not db_path.exists(), "a read created the store it was reporting on"
+
+
+def test_reading_a_run_runs_none_of_the_schema_writes(monkeypatch, tmp_path):
+    """The probe that fails if the connection is not read-only.
+
+    A read-only open skips three things by construction: the writable engine, the
+    reserved `BEGIN IMMEDIATE` lock, and schema reconciliation. Each of those
+    mutates the file -- PRAGMAs persisted into the header, a write lock, the
+    schema and seed writes that produced the observed `INSERT INTO schema_meta`.
+    Asserting none of them ran tests the property that matters, whereas denying
+    writes on the file would fail for an unrelated reason: SQLite in WAL mode
+    needs to write a sidecar even for a genuine read-only read.
+    """
+    from lionagi.state import db as db_module
+
+    db_path = tmp_path / "state.db"
+    _make_store(db_path)
+    _redirect(monkeypatch, db_path)
+
+    ran: list[str] = []
+
+    async def _refuse_schema(self):
+        ran.append("_apply_schema")
+
+    monkeypatch.setattr(db_module.StateDB, "_apply_schema", _refuse_schema)
+    monkeypatch.setattr(
+        db_module, "make_engine", lambda *a, **k: ran.append("make_engine") or pytest.fail()
+    )
+    monkeypatch.setattr(
+        db_module,
+        "_install_begin_immediate",
+        lambda *a, **k: ran.append("_install_begin_immediate"),
+    )
+
+    answer = lifecycle_data("some-run")
+
+    assert ran == [], f"the read performed writable-open work: {ran}"
+    lifecycle = answer["lifecycle"]
+    assert lifecycle["available"] is True, (
+        f"the read did not reach the store ({lifecycle.get('reason_code')}: "
+        f"{lifecycle.get('detail')})"
+    )
+    # An established answer about a run with no sessions, which is a different
+    # thing from not having been able to look.
+    assert lifecycle["value"]["found"] is False
+
+
+def test_the_store_is_unchanged_by_reading_it(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    _make_store(db_path)
+    _redirect(monkeypatch, db_path)
+    before = db_path.read_bytes()
+
+    lifecycle_data("some-run")
+
+    assert db_path.read_bytes() == before, "reading a run modified the store's bytes"

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -49,6 +49,9 @@ REVIEWED_PATHS = frozenset(
         "dispatch ls",
         "dispatch show",
         "invoke list",
+        # Read-only: reports what the lifecycle store already recorded about one
+        # run id. It writes nothing and names no path of its own.
+        "lifecycle",
         "monitor",
         "plugin info",
         "schedule create",

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -55,6 +55,7 @@ GOLDEN_VERBS = (
     # quietly reshape a schema a caller validated against.
     "dispatch show",
     "invoke list",
+    "lifecycle",
     "plugin info",
     "state stats",
     "team list",


### PR DESCRIPTION
## What

The catalog's absent entries exist so a caller can tell a command that was
considered and cannot be reached from one nobody thought about. Twenty-three
commands were in neither state — not registered, not named absent, simply
unmentioned — so asking what exists returned silence for them.

`li lifecycle` was the only one of the twenty-three that already emits a versioned
machine result. It sits in the same machine dispatch table as handshake, doctor and
runs, all three of which are registered verbs. By the admission rule it belongs on
the surface, so it is registered rather than named absent: read-only, one positional
run id, and an unknown run answers `found: false` rather than erroring.

The other twenty-two are named with the reason each cannot be called, grouped by
what the reason actually is — granting a right to the caller, rewriting rows every
read verb reports on, being a process rather than a call, or having no machine
result at all. Three needed their own reason: `engine run` spawns without the job
record that makes a spawn id answerable later, `invoke start`/`end` bracket work
this surface cannot attribute to one caller, and `kill` reaches entities it never
spawned and holds no pid identity for.

`plugin trust` and `hooks trust` stay unmentioned on purpose. A fenced path is
accounted for by the fence, and naming it would advertise the capability to the
caller it is fenced from; an existing test asserts exactly that, and the new
coverage test subtracts the fenced set rather than demanding entries for it.

## Why it could go silent again

`AbsentVerb` now carries the CLI path it speaks for, because a verb name is not a
dotted spelling of its path (`orchestrate fanout` is `fanout.submit`), so coverage
checked by guessing one from the other would need a table of exceptions.

The new test measures the parser tree rather than listing paths, and guards both
directions: a command with no catalog entry fails it, and an entry outliving its
command fails it too. The second is the worse drift — it explains why a command
cannot be called when there is nothing to call.

## Measured

- 23 silent commands before, 0 after. Catalog: 37 available + 31 absent = 68 entries.
- `lifecycle` exercised through dispatch, not just registered: schema projects one
  required positional, and a call with an unknown run id returns the machine
  envelope with `found: false`.
- Mutation-tested the guard. Dropping one absent entry fails it naming that path
  (`['casts']`) and also trips the stale-entry direction; replacing a reason with
  `"tbd"` fails the reason check naming the verb. Restored, green.
- `tests/mcp` green, read from an unpiped exit status with FAILED and ERROR lines
  counted separately.
- One unrelated failure in the wider run, `test_pack_routing_shown_in_dry_run`,
  reproduces identically on a clean tree at an older base. It resolves an agent
  profile from the developer's home directory and is tracked separately.

## Note, not fixed here

`FENCED_PATHS` includes `state migrate`, which is not a CLI command and, by
history, never was. Fencing a name that does not exist is harmless but buys nothing:
if store migration ever lands under any other spelling it arrives unfenced. Left
alone rather than removed, since removing a fence because its path is absent today
is how the path comes back unfenced.
