### PR TITLE
feat(cli): give dispatch ack, retry and purge machine seams that a caller can act on

### DIFF
--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 import time
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 
 __all__ = (
@@ -67,6 +69,66 @@ async def _cmd_show(dispatch_id: str) -> int:
     return 0
 
 
+async def _ack_outcome(db: Any, dispatch_id: str, ack_token: str) -> dict[str, Any]:
+    """What acknowledging this row did, as data rather than as a printed line.
+
+    The write itself stays the library's: this classifies its refusal instead of
+    pre-checking the same conditions, so there is no second copy of the
+    preconditions here to drift from the ones that are enforced.
+
+    Classification is a re-read, not a parse of the exception message. The
+    message is prose for a person, and a reword would silently move a caller
+    from one outcome to another.
+    """
+    from lionagi.dispatch import ack_dispatch, get_dispatch
+
+    try:
+        applied = await ack_dispatch(db, dispatch_id, ack_token)
+    except LookupError:
+        return {"outcome": "not_found"}
+    except ValueError:
+        row = await get_dispatch(db, dispatch_id)
+        if row is None:
+            # Deleted between the library's read and this one.
+            return {"outcome": "not_found"}
+        if not row["ack_required"]:
+            return {"outcome": "not_ack_required", "status": row["status"]}
+        return {"outcome": "token_mismatch", "status": row["status"]}
+
+    if applied:
+        return {"outcome": "acked"}
+    # The transition was refused because the row left the status it was read in.
+    # Its current status is the useful thing to report, so it is re-read rather
+    # than described.
+    row = await get_dispatch(db, dispatch_id)
+    return {"outcome": "status_changed", "status": None if row is None else row["status"]}
+
+
+async def _retry_outcome(db: Any, dispatch_id: str) -> dict[str, Any]:
+    """What forcing a retry of this row did. Same discipline as _ack_outcome."""
+    from lionagi.dispatch import get_dispatch, retry_dispatch
+
+    try:
+        applied = await retry_dispatch(db, dispatch_id)
+    except LookupError:
+        return {"outcome": "not_found"}
+    except ValueError:
+        row = await get_dispatch(db, dispatch_id)
+        if row is None:
+            return {"outcome": "not_found"}
+        return {"outcome": "not_retryable", "status": row["status"]}
+
+    if applied:
+        return {"outcome": "retrying"}
+    row = await get_dispatch(db, dispatch_id)
+    return {"outcome": "status_changed", "status": None if row is None else row["status"]}
+
+
+# The human paths below deliberately keep raising on a precondition the library
+# refuses: a mismatched ack_token reaches a person as a traceback naming the
+# reason, which is a poor report but is the behaviour this command has and is
+# asserted as such. Making it a printed line is a change to this surface, not
+# part of giving the machine channel a seam, so it is left alone here.
 async def _cmd_ack(dispatch_id: str, ack_token: str) -> int:
     from lionagi.dispatch import ack_dispatch
     from lionagi.state.db import StateDB
@@ -349,6 +411,218 @@ def _machine_show(argv: list[str]) -> dict[str, Any]:
     return run_async(_machine_show_data(args.id))
 
 
+# ── the writes ────────────────────────────────────────────────────────────────
+
+
+@asynccontextmanager
+async def _writable_state_db() -> AsyncIterator[Any]:
+    """The store, open for writing, or a refusal naming why it could not be.
+
+    A write has no availability wrapper to report unavailability inside: it
+    either happened or it did not, so an unreachable store is a refusal rather
+    than a reported field. The absent case is `not_found` and says so
+    definitively — with no store there is no such row to act on — while a store
+    that exists and will not open says nothing about what it holds and must not
+    be reported as an absent row.
+
+    The guard covers the open alone. A failure inside the caller's body is that
+    body's bug and surfaces as the crash it is.
+    """
+    from lionagi.state.db import StateDB, state_db_known_absent
+
+    from .machine import MachineError
+
+    # Asked of the configured store, not the default path: the open honours
+    # LIONAGI_STATE_DB_URL, so consulting the file would answer about a store
+    # this command would not have written to.
+    if state_db_known_absent():
+        raise MachineError(
+            "not_found", f"{StateDB().url} does not exist; there are no dispatches to act on"
+        )
+    async with AsyncExitStack() as stack:
+        try:
+            db = await stack.enter_async_context(StateDB())
+            # The engine connects on the first statement, so without this a
+            # refusal would surface mid-write, where it is indistinguishable
+            # from the write itself being wrong.
+            await db.fetch_all("SELECT 1")
+        except MachineError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — an unopenable store is a refusal, not a crash
+            raise MachineError("unavailable", f"{StateDB().url}: {type(exc).__name__}") from exc
+        yield db
+
+
+# What each refusing outcome is, as a contract error. A lost race is a `conflict`
+# rather than a success carrying `acked: false`, because a caller that branches on
+# `ok` alone must not read "the row moved under me" as "done" — the one direction
+# of this that is unsafe.
+_ACK_REFUSALS: dict[str, tuple[str, str]] = {
+    "not_found": ("not_found", "no dispatch with id {id!r}"),
+    "not_ack_required": (
+        "conflict",
+        "dispatch {id!r} does not require ack (ack_required is not set)",
+    ),
+    # The caller's own argument was wrong, which is input, not state. The expected
+    # token is not echoed: `dispatch.show` is where a caller reads it, and an error
+    # that hands it over turns a failed attempt into a successful one.
+    "token_mismatch": ("invalid_input", "the ack_token given for {id!r} does not match"),
+    "status_changed": (
+        "conflict",
+        "dispatch {id!r} left the status it was read in before the acknowledgement "
+        "was applied; it is now {status!r}",
+    ),
+}
+
+_RETRY_REFUSALS: dict[str, tuple[str, str]] = {
+    "not_found": ("not_found", "no dispatch with id {id!r}"),
+    "not_retryable": (
+        "conflict",
+        "dispatch {id!r} is {status!r}; retry applies to dead_letter or expired rows",
+    ),
+    "status_changed": (
+        "conflict",
+        "dispatch {id!r} left the status it was read in before the retry was applied; "
+        "it is now {status!r}",
+    ),
+}
+
+
+def _refuse(refusals: dict[str, tuple[str, str]], outcome: dict[str, Any], dispatch_id: str):
+    from .machine import MachineError
+
+    kind, template = refusals[outcome["outcome"]]
+    status = outcome.get("status")
+    return MachineError(
+        kind,
+        template.format(id=dispatch_id, status=status),
+        {"dispatch_id": dispatch_id, "status": status, "outcome": outcome["outcome"]},
+    )
+
+
+async def _machine_ack_data(dispatch_id: str, ack_token: str) -> dict[str, Any]:
+    async with _writable_state_db() as db:
+        outcome = await _ack_outcome(db, dispatch_id, ack_token)
+    if outcome["outcome"] != "acked":
+        raise _refuse(_ACK_REFUSALS, outcome, dispatch_id)
+    # The transition carries a fixed idempotency key, so presenting the same
+    # token again is absorbed rather than doubling anything. Said here because a
+    # caller that times out mid-call needs to know retrying is safe.
+    return {"dispatch_id": dispatch_id, "acked": True, "status": "acked", "idempotent": True}
+
+
+async def _machine_retry_data(dispatch_id: str) -> dict[str, Any]:
+    async with _writable_state_db() as db:
+        outcome = await _retry_outcome(db, dispatch_id)
+    if outcome["outcome"] != "retrying":
+        raise _refuse(_RETRY_REFUSALS, outcome, dispatch_id)
+    # `pending` is what the row is now, not a claim that delivery happened or
+    # that a daemon is running to attempt it.
+    return {
+        "dispatch_id": dispatch_id,
+        "requeued": True,
+        "status": "pending",
+        "attempt": 0,
+    }
+
+
+async def _machine_purge_data(dispatch_id: str, *, dry_run: bool) -> dict[str, Any]:
+    from lionagi.dispatch import get_dispatch, purge_dispatch
+
+    from .machine import MachineError
+
+    async with _writable_state_db() as db:
+        if dry_run:
+            row = await get_dispatch(db, dispatch_id)
+            if row is None:
+                raise MachineError("not_found", f"no dispatch with id {dispatch_id!r}")
+            # The audit row is written for the preview too, matching what the
+            # human path records: the question having been asked is itself the
+            # thing an operator later wants to find.
+            await db.insert_admin_event(
+                action="dispatch_purge",
+                target_id=dispatch_id,
+                details={
+                    "dispatch_id": dispatch_id,
+                    "dry_run": True,
+                    "status": row["status"],
+                    "total": 1,
+                },
+                actor="li_dispatch_purge",
+            )
+            return {
+                "dispatch_id": dispatch_id,
+                "purged": False,
+                "dry_run": True,
+                "would_purge": True,
+                "status": row["status"],
+            }
+        # Read before deleting so the reported status is the one the row had.
+        # After the delete there is nothing left to ask.
+        row = await get_dispatch(db, dispatch_id)
+        deleted = await purge_dispatch(db, dispatch_id, actor="li_dispatch_purge")
+    if not deleted:
+        raise MachineError("not_found", f"no dispatch with id {dispatch_id!r}")
+    return {
+        "dispatch_id": dispatch_id,
+        "purged": True,
+        "dry_run": False,
+        "status": None if row is None else row["status"],
+    }
+
+
+def _machine_ack(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch ack")
+    parser.add_argument("id", help=argparse.SUPPRESS)
+    parser.add_argument("token", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return run_async(_machine_ack_data(args.id, args.token))
+
+
+def _machine_retry(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch retry")
+    parser.add_argument("id", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+    return run_async(_machine_retry_data(args.id))
+
+
+def _machine_purge(argv: list[str]) -> dict[str, Any]:
+    from lionagi.ln.concurrency import run_async
+
+    from .machine import CONTRACT_VERSION, MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li dispatch purge")
+    parser.add_argument("id", nargs="?", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--status", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--before", type=float, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
+    args = parse_machine_argv(parser, argv)
+
+    # Bulk purge is reachable from a terminal and not from here. One id is a
+    # deliberate act against a row the caller has read; a criteria sweep deletes
+    # rows it never named, and the result would report a count for rows nobody
+    # can now inspect. Refused by name rather than ignored, so a caller that
+    # passes criteria is told they did not apply instead of watching one row go.
+    if args.status is not None or args.before is not None:
+        raise MachineError(
+            "unavailable",
+            f"bulk purge has no machine result in contract version {CONTRACT_VERSION}: "
+            "--status/--before delete rows the caller never named. Purge one id at a "
+            "time, or run the sweep from a terminal.",
+        )
+    if args.id is None:
+        raise MachineError("invalid_input", "purge needs the id of the dispatch to delete")
+    return run_async(_machine_purge_data(args.id, dry_run=args.dry_run))
+
+
 def machine_result(argv: list[str]) -> dict[str, Any]:
     """`li dispatch <sub> --machine`."""
     from .machine import machine_subcommand
@@ -356,10 +630,12 @@ def machine_result(argv: list[str]) -> dict[str, Any]:
     return machine_subcommand(
         "dispatch",
         argv,
-        {"ls": _machine_ls, "show": _machine_show},
-        without_seam={
-            "ack": "it acknowledges a delivery, which is a write to the outbox",
-            "retry": "it re-queues a row for delivery, which is a write to the outbox",
-            "purge": "it deletes rows from the outbox",
+        {
+            "ls": _machine_ls,
+            "show": _machine_show,
+            "ack": _machine_ack,
+            "retry": _machine_retry,
+            "purge": _machine_purge,
         },
+        without_seam={},
     )

--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -99,9 +99,15 @@ async def _ack_outcome(db: Any, dispatch_id: str, ack_token: str) -> dict[str, A
         return {"outcome": "acked"}
     # The transition was refused because the row left the status it was read in.
     # Its current status is the useful thing to report, so it is re-read rather
-    # than described.
+    # than described. A row that is gone by the time of the re-read is not a
+    # conflict with a missing status; it is an absence, and reporting it as
+    # `status_changed` with a null status would give one value two meanings and
+    # leave the caller unable to tell a surviving conflicting row from a deleted
+    # one. Same answer the exception path above gives for the same state.
     row = await get_dispatch(db, dispatch_id)
-    return {"outcome": "status_changed", "status": None if row is None else row["status"]}
+    if row is None:
+        return {"outcome": "not_found"}
+    return {"outcome": "status_changed", "status": row["status"]}
 
 
 async def _retry_outcome(db: Any, dispatch_id: str) -> dict[str, Any]:
@@ -121,7 +127,9 @@ async def _retry_outcome(db: Any, dispatch_id: str) -> dict[str, Any]:
     if applied:
         return {"outcome": "retrying"}
     row = await get_dispatch(db, dispatch_id)
-    return {"outcome": "status_changed", "status": None if row is None else row["status"]}
+    if row is None:
+        return {"outcome": "not_found"}
+    return {"outcome": "status_changed", "status": row["status"]}
 
 
 # The human paths below deliberately keep raising on a precondition the library
@@ -492,11 +500,16 @@ def _refuse(refusals: dict[str, tuple[str, str]], outcome: dict[str, Any], dispa
     from .machine import MachineError
 
     kind, template = refusals[outcome["outcome"]]
-    status = outcome.get("status")
+    detail: dict[str, Any] = {"dispatch_id": dispatch_id, "outcome": outcome["outcome"]}
+    # A row that is gone has no status, and carrying a null one would say it has a
+    # status that could not be determined. The two are different answers, and the
+    # caller reading this detail is the one that cannot tell them apart.
+    if "status" in outcome:
+        detail["status"] = outcome["status"]
     return MachineError(
         kind,
-        template.format(id=dispatch_id, status=status),
-        {"dispatch_id": dispatch_id, "status": status, "outcome": outcome["outcome"]},
+        template.format(id=dispatch_id, status=outcome.get("status")),
+        detail,
     )
 
 

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -295,7 +295,13 @@ def _validate(schema: dict[str, Any], args: dict[str, Any], verb: Verb) -> None:
             continue
         reason = verb.refuses.get(name)
         if reason is not None:
-            problems.append(f"{name!r} is not accepted on a background run: {reason}")
+            # Every refusal used to be on a spawn verb, so the message could say
+            # why in general terms: nobody is attached to the terminal. A refusal
+            # on a synchronous verb has nothing to do with detachment, and saying
+            # so would send the caller looking for a background run that is not
+            # what they invoked.
+            where = "on a background run" if verb.executor in ("job", "spawn") else "here"
+            problems.append(f"{name!r} is not accepted {where}: {reason}")
         else:
             problems.append(f"unknown parameter {name!r} for {verb.name!r}")
 

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -209,6 +209,13 @@ _SPAWN_REFUSALS: Mapping[str, str] = {
     "notify": "the server wires the terminal hook; use notify_command and notify_seat",
 }
 
+_PURGE_SWEEP_REFUSALS: Mapping[str, str] = {
+    "status": "sweeps every row in that status, including rows the caller never read; "
+    "purge one id, or run the sweep from a terminal",
+    "before": "sweeps by age, so it deletes rows the caller never named and reports a "
+    "count for rows that can no longer be inspected; purge one id instead",
+}
+
 _AGENT_REFUSALS: Mapping[str, str] = {
     **_SPAWN_REFUSALS,
     "list_profiles": "prints the agent-profile catalog and exits without running anything",
@@ -655,6 +662,41 @@ _REGISTERED: tuple[Verb, ...] = (
         admits=("id",),
     ),
     Verb(
+        name="dispatch.ack",
+        summary="Acknowledge a delivered dispatch with its ack token, so the queue "
+        "stops redelivering it. A wrong token is refused without echoing the real one.",
+        executor="machine",
+        cli_path="dispatch ack",
+        admits=("id", "token"),
+    ),
+    Verb(
+        name="dispatch.retry",
+        summary="Return a failed or dead-lettered dispatch to pending so delivery is "
+        "attempted again.",
+        executor="machine",
+        cli_path="dispatch retry",
+        admits=("id",),
+    ),
+    Verb(
+        name="dispatch.purge",
+        summary="Delete one dispatch row by id, whatever its status, recording an audit "
+        "row. Deleting by --status/--before is refused here: a sweep deletes rows the "
+        "caller never named and reports a count for rows that can no longer be inspected.",
+        executor="machine",
+        cli_path="dispatch purge",
+        admits=("id", "dry_run"),
+        # The parser leaves `id` optional because omitting it is how a terminal
+        # asks for a sweep. Here a sweep is refused, so an absent id is never a
+        # valid call, and stating that in the schema beats letting the caller make
+        # a request that cannot succeed.
+        requires=("id",),
+        # Named as refused rather than left out of `admits`. Both keep the sweep
+        # unreachable, but an unadmitted parameter is reported as unknown, and
+        # these are not unknown: they exist, they are spelled correctly, and they
+        # are declined. A caller told "unknown parameter" looks for a typo.
+        refuses=_PURGE_SWEEP_REFUSALS,
+    ),
+    Verb(
         name="state.ls",
         summary="Sessions in the lifecycle store with their branch and message counts.",
         executor="machine",
@@ -761,11 +803,9 @@ ABSENT: tuple[AbsentVerb, ...] = (
         ("doctor",),
         "Read-only inspection of the lifecycle store.",
     ),
-    *_absent(
-        "dispatch",
-        ("ack", "retry", "purge"),
-        "The outbound dispatch queue.",
-    ),
+    # `dispatch ack`, `retry` and `purge` are registered above rather than named
+    # absent here. They are the queue's writes, and the caller that reads the queue
+    # from this surface is the one that has to resolve what it finds.
     # `plugin trust` and `hooks trust` are deliberately not here. A fenced path is
     # accounted for by FENCED_PATHS, and naming it in the catalog would advertise
     # the capability to the caller it is fenced from; that is a different silence

--- a/tests/cli/test_dispatch_machine_writes.py
+++ b/tests/cli/test_dispatch_machine_writes.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li dispatch ack/retry/purge --machine` — the write seams.
+
+Exercised against a real store rather than a mocked one. What these seams are
+for is telling a caller which of several refusals happened, and every one of
+those distinctions lives in the store's state; a mock would be asserting that
+the code returns what the test told it to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.cli.main import main
+
+
+def _redirect_state_db(monkeypatch, tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _seed(db_path: Path, **kwargs) -> str:
+    from lionagi.dispatch import enqueue_dispatch
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path) as db:
+        return await enqueue_dispatch(db, **kwargs)
+
+
+async def _row(db_path: Path, dispatch_id: str):
+    from lionagi.dispatch import get_dispatch
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path) as db:
+        return await get_dispatch(db, dispatch_id)
+
+
+async def _force_status(db_path: Path, dispatch_id: str, status: str) -> None:
+    """Put a row in a status the ordinary flow would take time to reach."""
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path) as db, db._tx() as conn:
+        await conn.execute(
+            text("UPDATE dispatch_outbox SET status = :s WHERE id = :id"),
+            {"s": status, "id": dispatch_id},
+        )
+
+
+def _envelope(capfd) -> dict:
+    """The one JSON object the machine channel emitted.
+
+    Captured at the file descriptor, not through `capsys`: the channel hands the
+    envelope to a duplicate of the real fd 1 precisely so that Python-level
+    rebinding cannot put anything else on it, and a Python-level capture
+    therefore never sees it.
+    """
+    out = capfd.readouterr().out
+    return json.loads(out)
+
+
+def _run(argv: list[str], capfd) -> tuple[int, dict]:
+    rc = main([*argv, "--machine"])
+    return rc, _envelope(capfd)
+
+
+# ── ack ──────────────────────────────────────────────────────────────────────
+
+
+def test_ack_applies_and_reports_the_row_acked(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(
+        _seed(db_path, kind="terminal_notify", deliver_to="seat-1", ack_required=True)
+    )
+    token = asyncio.run(_row(db_path, dispatch_id))["ack_token"]
+
+    rc, envelope = _run(["dispatch", "ack", dispatch_id, token], capfd)
+
+    assert rc == 0
+    assert envelope["ok"] is True
+    assert envelope["data"] == {
+        "dispatch_id": dispatch_id,
+        "acked": True,
+        "status": "acked",
+        "idempotent": True,
+    }
+    assert asyncio.run(_row(db_path, dispatch_id))["status"] == "acked"
+
+
+def test_ack_with_a_wrong_token_is_invalid_input_and_does_not_leak_the_real_one(
+    monkeypatch, tmp_path, capfd
+):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(
+        _seed(db_path, kind="terminal_notify", deliver_to="seat-1", ack_required=True)
+    )
+    real_token = asyncio.run(_row(db_path, dispatch_id))["ack_token"]
+
+    rc, envelope = _run(["dispatch", "ack", dispatch_id, "not-the-token"], capfd)
+
+    assert rc == 0, "the envelope is the answer; the exit status is transport only"
+    assert envelope["ok"] is False
+    # The caller's argument was wrong, which is input rather than row state.
+    assert envelope["error"]["kind"] == "invalid_input"
+    # An error that hands over the token would turn a failed attempt into a
+    # successful one, so the whole envelope is searched, not just the message.
+    assert real_token not in json.dumps(envelope)
+    assert asyncio.run(_row(db_path, dispatch_id))["status"] != "acked"
+
+
+def test_ack_on_a_row_that_does_not_require_one_is_a_conflict(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(
+        _seed(db_path, kind="terminal_notify", deliver_to="seat-1", ack_required=False)
+    )
+
+    rc, envelope = _run(["dispatch", "ack", dispatch_id, "anything"], capfd)
+
+    assert envelope["ok"] is False
+    # State, not input: the argument is fine and the row is the wrong shape for it.
+    assert envelope["error"]["kind"] == "conflict"
+    assert envelope["error"]["detail"]["outcome"] == "not_ack_required"
+
+
+def test_ack_of_an_unknown_id_is_not_found(monkeypatch, tmp_path, capfd):
+    _redirect_state_db(monkeypatch, tmp_path)
+    asyncio.run(_seed(tmp_path / "state.db", kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "ack", "no-such-dispatch", "token"], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "not_found"
+
+
+def test_ack_reports_conflict_not_success_when_the_row_moved_under_it(monkeypatch, tmp_path, capfd):
+    """The unsafe direction, asserted.
+
+    A lost race must not arrive as ok=true carrying acked=false: a caller that
+    branches on `ok` alone would read "the row moved under me" as "done". The
+    transition is refused because the row is no longer in the status it was read
+    in, which is simulated here by moving it between the read and the write.
+    """
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(
+        _seed(db_path, kind="terminal_notify", deliver_to="seat-1", ack_required=True)
+    )
+    token = asyncio.run(_row(db_path, dispatch_id))["ack_token"]
+
+    from lionagi.dispatch import outbox
+
+    real_transition = outbox.transition
+
+    async def moving_transition(db, request, **kwargs):
+        # Between the library's read and its guarded write, the row leaves the
+        # status the request was built against.
+        await _force_status(db_path, dispatch_id, "expired")
+        return await real_transition(db, request, **kwargs)
+
+    monkeypatch.setattr(outbox, "transition", moving_transition)
+    rc, envelope = _run(["dispatch", "ack", dispatch_id, token], capfd)
+
+    assert envelope["ok"] is False, "a lost race reported as ok would be read as success"
+    assert envelope["error"]["kind"] == "conflict"
+    assert envelope["error"]["detail"]["outcome"] == "status_changed"
+    assert envelope["error"]["detail"]["status"] == "expired"
+
+
+# ── retry ────────────────────────────────────────────────────────────────────
+
+
+def test_retry_requeues_a_dead_letter_row(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(_seed(db_path, kind="terminal_notify", deliver_to="seat-1"))
+    asyncio.run(_force_status(db_path, dispatch_id, "dead_letter"))
+
+    rc, envelope = _run(["dispatch", "retry", dispatch_id], capfd)
+
+    assert envelope["ok"] is True
+    assert envelope["data"]["requeued"] is True
+    assert envelope["data"]["status"] == "pending"
+    assert envelope["data"]["attempt"] == 0
+    assert asyncio.run(_row(db_path, dispatch_id))["status"] == "pending"
+
+
+def test_retry_of_a_pending_row_is_a_conflict_naming_the_status(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(_seed(db_path, kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "retry", dispatch_id], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "conflict"
+    assert envelope["error"]["detail"]["outcome"] == "not_retryable"
+    assert envelope["error"]["detail"]["status"] == "pending"
+
+
+def test_retry_of_an_unknown_id_is_not_found(monkeypatch, tmp_path, capfd):
+    _redirect_state_db(monkeypatch, tmp_path)
+    asyncio.run(_seed(tmp_path / "state.db", kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "retry", "no-such-dispatch"], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "not_found"
+
+
+# ── purge ────────────────────────────────────────────────────────────────────
+
+
+def test_purge_deletes_the_row_and_reports_the_status_it_had(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(_seed(db_path, kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "purge", dispatch_id], capfd)
+
+    assert envelope["ok"] is True
+    assert envelope["data"]["purged"] is True
+    # Read before the delete: afterwards there is nothing left to ask.
+    assert envelope["data"]["status"] == "pending"
+    assert asyncio.run(_row(db_path, dispatch_id)) is None
+
+
+def test_purge_dry_run_previews_without_deleting(monkeypatch, tmp_path, capfd):
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(_seed(db_path, kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "purge", dispatch_id, "--dry-run"], capfd)
+
+    assert envelope["ok"] is True
+    assert envelope["data"]["purged"] is False
+    assert envelope["data"]["would_purge"] is True
+    assert asyncio.run(_row(db_path, dispatch_id)) is not None
+
+    async def _events():
+        from lionagi.state.db import StateDB
+
+        async with StateDB(db_path) as db:
+            return await db.list_admin_events(action="dispatch_purge", target_id=dispatch_id)
+
+    events = asyncio.run(_events())
+    assert len(events) == 1, "the preview is audited, same as the human path"
+    assert json.loads(events[0]["details"])["dry_run"] is True
+
+
+def test_purge_of_an_unknown_id_is_not_found(monkeypatch, tmp_path, capfd):
+    _redirect_state_db(monkeypatch, tmp_path)
+    asyncio.run(_seed(tmp_path / "state.db", kind="terminal_notify", deliver_to="seat-1"))
+
+    rc, envelope = _run(["dispatch", "purge", "no-such-dispatch"], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "not_found"
+
+
+@pytest.mark.parametrize(
+    "criteria",
+    [["--status", "delivered"], ["--before", "1"], ["--status", "delivered", "--before", "1"]],
+    ids=["status", "before", "both"],
+)
+def test_bulk_purge_is_refused_by_name_rather_than_silently_narrowed(
+    monkeypatch, tmp_path, capfd, criteria
+):
+    """Passing criteria must not quietly do something else.
+
+    The dangerous shape is accepting the call and purging nothing, or purging one
+    row, while the caller believes a sweep ran. The refusal names the parameters
+    so a caller learns their request did not apply.
+    """
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(_seed(db_path, kind="terminal_notify", deliver_to="seat-1"))
+    asyncio.run(_force_status(db_path, dispatch_id, "delivered"))
+
+    rc, envelope = _run(["dispatch", "purge", *criteria], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "unavailable"
+    assert "--status" in envelope["error"]["message"]
+    assert asyncio.run(_row(db_path, dispatch_id)) is not None, "nothing was deleted"
+
+
+def test_purge_with_no_id_and_no_criteria_is_invalid_input(monkeypatch, tmp_path, capfd):
+    _redirect_state_db(monkeypatch, tmp_path)
+    rc, envelope = _run(["dispatch", "purge"], capfd)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "invalid_input"
+
+
+# ── the store itself ─────────────────────────────────────────────────────────
+
+
+def test_a_write_against_a_store_that_does_not_exist_is_not_found(monkeypatch, tmp_path, capfd):
+    """Definitive, and distinguishable from a store that would not open.
+
+    With no store there is no such row, which `not_found` says exactly. The other
+    case — a store that exists and refuses — says nothing about what it holds and
+    must not arrive as the same answer.
+    """
+    _redirect_state_db(monkeypatch, tmp_path)  # nothing seeded, so nothing created
+    rc, envelope = _run(["dispatch", "ack", "any-id", "any-token"], capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "not_found"
+    assert "does not exist" in envelope["error"]["message"]
+
+
+def test_every_dispatch_subcommand_now_answers_on_the_machine_channel():
+    """No subcommand is left declared seamless.
+
+    The catalog reads this: a subcommand in `without_seam` is reported to a
+    caller as considered-and-unavailable, and one that has since gained a seam
+    would keep being reported that way.
+    """
+    from lionagi.cli import dispatch as dispatch_cli
+    from lionagi.cli.machine import MachineError
+
+    for sub in ("ls", "show", "ack", "retry", "purge"):
+        try:
+            dispatch_cli.machine_result([sub, "--help-nonexistent-arg"])
+        except MachineError as exc:
+            assert "no machine result" not in str(exc), f"{sub} is still declared seamless"
+        except SystemExit:
+            pass  # argparse rejecting a bad flag means the handler was reached

--- a/tests/cli/test_dispatch_machine_writes.py
+++ b/tests/cli/test_dispatch_machine_writes.py
@@ -174,6 +174,54 @@ def test_ack_reports_conflict_not_success_when_the_row_moved_under_it(monkeypatc
     assert envelope["error"]["detail"]["status"] == "expired"
 
 
+@pytest.mark.parametrize("verb", ["ack", "retry"])
+def test_a_lost_race_on_a_row_that_is_then_deleted_is_not_found_not_a_null_conflict(
+    monkeypatch, tmp_path, capfd, verb
+):
+    """Two things happened to the row, and the answer has to name the later one.
+
+    The transition is refused because the row moved, and by the time the outcome
+    is re-read the row is gone. Reporting `status_changed` with a null status
+    gives one value two meanings: a caller cannot tell a surviving conflicting
+    row from a deleted one, and null is also what a genuinely absent status would
+    look like. The exception path already answers `not_found` for this state; this
+    is the same state reached through the guarded write.
+    """
+    db_path = _redirect_state_db(monkeypatch, tmp_path)
+    dispatch_id = asyncio.run(
+        _seed(db_path, kind="terminal_notify", deliver_to="seat-1", ack_required=True)
+    )
+    token = asyncio.run(_row(db_path, dispatch_id))["ack_token"]
+    if verb == "retry":
+        asyncio.run(_force_status(db_path, dispatch_id, "dead_letter"))
+
+    from lionagi.dispatch import outbox, purge_dispatch
+    from lionagi.state.db import StateDB
+
+    real_transition = outbox.transition
+
+    async def vanishing_transition(db, request, **kwargs):
+        # The row is deleted after the library read it and before its guarded
+        # write lands, so the write matches nothing and the re-read finds nothing.
+        # A real purge rather than a stubbed absence, so `get_dispatch` is
+        # answering about a store that genuinely no longer holds the row.
+        async with StateDB(db_path) as other:
+            await purge_dispatch(other, dispatch_id)
+        return await real_transition(db, request, **kwargs)
+
+    monkeypatch.setattr(outbox, "transition", vanishing_transition)
+    argv = ["dispatch", verb, dispatch_id] + ([token] if verb == "ack" else [])
+    rc, envelope = _run(argv, capfd)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "not_found", (
+        f"a deleted row was reported as {envelope['error']['kind']}: {envelope['error']}"
+    )
+    assert envelope["error"]["detail"] is None or "status" not in (
+        envelope["error"]["detail"] or {}
+    ), "an absent row was given a status field"
+
+
 # ── retry ────────────────────────────────────────────────────────────────────
 
 

--- a/tests/mcp/golden_projections/dispatch__ack.json
+++ b/tests/mcp/golden_projections/dispatch__ack.json
@@ -1,0 +1,29 @@
+{
+  "path": "dispatch ack",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the dispatch to acknowledge, as listed by `li dispatch ls`.",
+        "type": "string",
+        "x-positional": true
+      },
+      "token": {
+        "description": "The ack_token this dispatch was delivered with, reported by `li dispatch show`. A mismatched token is refused, so an acknowledgement cannot be guessed.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id",
+      "token"
+    ],
+    "title": "dispatch ack",
+    "type": "object",
+    "x-positional-order": [
+      "id",
+      "token"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/dispatch__purge.json
+++ b/tests/mcp/golden_projections/dispatch__purge.json
@@ -1,0 +1,36 @@
+{
+  "path": "dispatch purge",
+  "schema": {
+    "additionalProperties": false,
+    "description": "With ID: delete that one row (any status), auditable via admin_events action=dispatch_purge. Without ID: bulk-delete by --status/--before (at least one required, so a bare `purge` cannot mass-delete); --dry-run reports counts without deleting. An explicit --status is honored exactly as given, including pending/delivering (naming an in-flight status is deliberate operator intent). A bare --before with no --status is scoped to terminal statuses only (delivered/acked/dead_letter/expired) and never touches pending/delivering rows.",
+    "properties": {
+      "before": {
+        "description": "Bulk purge: match rows with updated_at <= this epoch-seconds value. Without --status, this is scoped to terminal statuses only (delivered/acked/dead_letter/expired) and never sweeps pending/delivering rows.",
+        "type": "number",
+        "x-flag": "--before"
+      },
+      "dry_run": {
+        "default": false,
+        "description": "Report what would be deleted without deleting (single-row and bulk).",
+        "type": "boolean",
+        "x-flag": "--dry-run"
+      },
+      "id": {
+        "description": "Id of a single dispatch to delete, whatever its status. Omit it to bulk-delete by --status/--before instead; one of the two is then required.",
+        "type": "string",
+        "x-positional": true
+      },
+      "status": {
+        "description": "Bulk purge: match this status exactly, including pending/delivering (explicit status is deliberate operator intent).",
+        "type": "string",
+        "x-flag": "--status"
+      }
+    },
+    "title": "dispatch purge",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/dispatch__retry.json
+++ b/tests/mcp/golden_projections/dispatch__retry.json
@@ -1,0 +1,22 @@
+{
+  "path": "dispatch retry",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the dispatch to re-queue for delivery.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "dispatch retry",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -176,6 +176,45 @@ def test_a_missing_required_parameter_names_itself(submitted):
     assert "missing required parameter 'playbook'" in answer["ops"][0]["error"]["message"]
 
 
+def test_a_refusal_on_a_synchronous_verb_does_not_blame_a_background_run():
+    """The reason a parameter is declined has to match the verb it was passed to.
+
+    Every refusal used to be on a spawn verb, where "nobody is attached to the
+    terminal" explains all of them, so the message said so in general terms.
+    `dispatch purge` is synchronous: a caller told its parameter was refused
+    because the run is detached would go looking for a background run they never
+    started.
+    """
+    answer = call(ops=[{"op": "dispatch.purge", "args": {"id": "d1", "status": "dead_letter"}}])
+    message = answer["ops"][0]["error"]["message"]
+    assert "'status' is not accepted here" in message
+    assert "background run" not in message
+    # And the reason travels with it, so the caller learns what to do instead.
+    assert "purge one id" in message
+
+
+def test_a_refusal_on_a_detached_verb_still_says_the_run_is_detached(submitted):
+    answer = call(ops=[spawn_op("agent.submit", {"verbose": True})])
+    assert "not accepted on a background run" in answer["ops"][0]["error"]["message"]
+
+
+def test_the_queue_sweep_is_refused_by_name_rather_than_left_undeclared():
+    """An unadmitted parameter and a refused one read very differently to a caller.
+
+    Dropping `--status`/`--before` from `admits` alone would report them as
+    unknown, and they are not unknown: they exist on the command, they are spelled
+    correctly, and they are declined. A caller told "unknown parameter" looks for
+    a typo instead of reading why.
+    """
+    schema = dispatch.verb_schema(verbs.VERBS["dispatch.purge"])
+    assert sorted(schema["properties"]) == ["dry_run", "id"]
+    assert sorted(schema["x-refused"]) == ["before", "status"]
+    # The parser leaves `id` optional because omitting it is how a terminal asks
+    # for a sweep. Here an absent id can never succeed, so the schema says so
+    # rather than letting the caller make the call and find out.
+    assert schema["required"] == ["id"]
+
+
 # ── previous-surface names ───────────────────────────────────────────────────
 
 

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -228,13 +228,44 @@ def test_the_listing_that_prunes_trust_never_runs_from_this_surface(home):
 
 @pytest.mark.parametrize(
     ("command", "sub"),
-    [("state", "prune"), ("dispatch", "purge"), ("team", "send"), ("invoke", "start")],
+    [("state", "prune"), ("team", "send"), ("invoke", "start")],
 )
 def test_a_subcommand_that_writes_says_so_instead_of_running(home, command, sub):
     done = li(command, sub, "--machine")
     envelope = json.loads(done.stdout)
     assert envelope["ok"] is False
     assert envelope["error"]["kind"] == "unavailable"
+
+
+# `dispatch purge` used to sit in the roster above, refused wholesale because it
+# writes. It is now open for one named id and still closed for a criteria sweep,
+# so the rule it obeys is narrower than "writes, therefore refused" and is stated
+# here rather than left as a gap in that list.
+
+
+def test_purging_by_criteria_is_refused_even_though_purging_one_id_is_not(home):
+    """The line is named rows, not writes.
+
+    Deleting a row the caller read and named is a deliberate act. A sweep by
+    `--status`/`--before` deletes rows nobody named and reports a count for rows
+    that can no longer be inspected, which is not an answer a caller can check.
+    Refused by name rather than quietly ignoring the criteria, because ignoring
+    them would purge the one row the caller also happened to pass.
+    """
+    for criteria in (["--status", "dead_letter"], ["--before", "1"]):
+        envelope = json.loads(li("dispatch", "purge", *criteria, "--machine").stdout)
+        assert envelope["ok"] is False, f"a criteria sweep ran: {criteria}"
+        assert envelope["error"]["kind"] == "unavailable"
+        assert "never named" in envelope["error"]["message"]
+
+
+def test_purge_with_no_id_is_bad_input_rather_than_an_absent_seam(home):
+    # The seam exists, so "you gave me nothing to purge" is the honest answer.
+    # Reporting `unavailable` here would tell a caller the capability is missing
+    # and send them to a terminal for something they can do from here.
+    envelope = json.loads(li("dispatch", "purge", "--machine").stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "invalid_input"
 
 
 def test_a_subcommand_nobody_has_is_bad_input_not_an_absent_seam(home):

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -48,6 +48,14 @@ REVIEWED_PATHS = frozenset(
         "runs",
         "dispatch ls",
         "dispatch show",
+        # The queue's writes. Reviewed together because the caller that reads the
+        # queue from this surface is the one that has to resolve what it finds, and
+        # each acts on a single row the caller named: `ack` needs the row's own ack
+        # token, `retry` moves one row back to pending, `purge` deletes one row by id
+        # and refuses a criteria sweep.
+        "dispatch ack",
+        "dispatch retry",
+        "dispatch purge",
         "invoke list",
         # Read-only: reports what the lifecycle store already recorded about one
         # run id. It writes nothing and names no path of its own.

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -59,6 +59,12 @@ GOLDEN_VERBS = (
     "plugin info",
     "state stats",
     "team list",
+    # The queue's writes. A golden matters more here than on a read: a caller acts
+    # on the schema, so an argparse change that silently made `token` optional or
+    # renamed `--dry-run` would turn a refused call into a destructive one.
+    "dispatch ack",
+    "dispatch retry",
+    "dispatch purge",
 )
 
 # Everything the MCP surface is a candidate to dispatch. `mirror` is


### PR DESCRIPTION
An agent could read the dispatch queue from the machine surface and not touch it. `ls` and
`show` answered `--machine`; the three verbs that resolve a stuck dispatch did not, so the
one caller that needs them had to shell out to a terminal and parse prose written for a
person to find out what happened. These are the queue's writes, and the caller that reads
the queue is the one that has to resolve what it finds.

The part that was not just wiring: the library reports every refusal the same way. A wrong
ack token, an already-acked dispatch, and a dispatch purged between the read and the write
all arrive as one `ValueError` whose text is written for a human reader. Parsing that text
would bind the seam to the wording. Each refusal is instead classified by re-reading the row
and asking what is true of it now — `not_found` when the dispatch is gone, `invalid_input`
when the token is wrong, `conflict` when the row moved on. `conflict` was a declared kind
with no user; a lost ack race is its case, since two callers acking the same dispatch means
one acted on a state that no longer holds, which is a different thing from asking for
something impossible.

The ack token appears in no machine result on any path, including the error detail for a
mismatch, because echoing it back would hand a caller that guessed wrong the value it failed
to guess. A test asserts the real token appears nowhere in the envelope rather than checking
the fields that happen to exist today.

Store access is one helper so the three cannot disagree about what a missing store means: an
absent store is `not_found` (there is no queue to act on, rather than a fault), one that will
not open is `unavailable`. The helper runs `SELECT 1` at the open so an unopenable store
fails there instead of surfacing later inside the write.

Bulk purge stays out. `--status`/`--before` delete rows the caller never named and report a
count for rows that can no longer be inspected, which is not an answer anyone can check. It
is refused by name rather than ignored, since silently dropping the criteria would purge the
one row the caller also passed. Purge by id is a deliberate act against a row the caller has
read, and `--dry-run` writes the same audit row the human path does, because the question
having been asked is itself what an operator later looks for.

The catalog registers the three in the same change rather than continuing to name them
absent, so it never describes an existing seam as a missing one. The total stays 68.

Two consequences worth calling out for review:

- `dispatch purge` leaves the roster of subcommands refused from the machine surface
  *because they write*. That roster is a policy statement, so the entry was not deleted
  quietly: the narrower rule it now obeys is written where the roster is. The line moved from
  writes-therefore-refused to names-the-row-or-refused.
- Refusal messages used to explain themselves in general terms — the parameter is not
  accepted on a background run — which held while every refusal was on a spawn verb and is
  meaningless for a synchronous queue write. The message now matches the verb it reports
  about, and both branches are asserted.

The human `ack` and `retry` paths keep their existing behaviour, including raising on a bad
token, so a person's error message is unchanged.

Verified on this head: `tests/mcp tests/cli` is clean apart from one pre-existing failure
that resolves an agent profile from the developer's home directory and fails the same way on
main.
