### PR TITLE
test(state): skip the Postgres leg when its driver is missing, not only when the container will not start

### DIFF
--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -43,12 +43,33 @@ def pg_url():
 
     env_url = os.environ.get("LIONAGI_TEST_PG_URL")
     if env_url:
-        # Whatever driver the caller's URL names, not the one the container path
-        # happens to use. A bare `postgresql://` is psycopg2 by SQLAlchemy's own
-        # default, so that is what gets checked.
-        scheme = env_url.split("://", 1)[0]
-        _require_driver(scheme.split("+", 1)[1] if "+" in scheme else "psycopg2")
-        yield env_url
+        # Normalised with the project's own function, then guarded on whatever
+        # driver the normalised URL names. Deriving the driver from the raw string
+        # would guard the wrong one: `normalize_state_db_url` rewrites a bare
+        # `postgres://` or `postgresql://` to `postgresql+asyncpg://`, so a bare
+        # alias needs asyncpg here even though SQLAlchemy's own default for that
+        # scheme is psycopg2. Guarding on psycopg2 would admit the override on a
+        # machine that has it and asyncpg missing, and the tests would fail later
+        # on the driver that is actually used.
+        #
+        # Normalising the yielded URL rather than only inspecting it also settles a
+        # disagreement between this fixture's two kinds of consumer: StateBD-backed
+        # tests normalise the URL themselves, while others hand it straight to
+        # `create_async_engine`, where a bare `postgres://` is not a dialect at all
+        # and raises `NoSuchModuleError`. Both now receive the same fully qualified
+        # async URL.
+        from lionagi.state.engine import normalize_state_db_url
+
+        url = normalize_state_db_url(env_url)
+        scheme = url.split("://", 1)[0]
+        # The dialect is checked as well as the driver, so a URL for some other
+        # database is refused as one rather than sent to import whatever driver it
+        # names: `mysql+aiomysql://` would otherwise skip on a missing aiomysql and
+        # read as a Postgres availability problem.
+        if not scheme.startswith("postgresql+"):
+            _unavailable(f"not a Postgres URL this suite can drive: {env_url!r}")
+        _require_driver(scheme.split("+", 1)[1])
+        yield url
         return
 
     try:

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib
 import os
 
 import pytest
@@ -18,20 +19,47 @@ def pg_url():
     Skipped locally when neither is available; a hard failure under CI so the
     Postgres leg can never silently no-op on the runner.
     """
-    env_url = os.environ.get("LIONAGI_TEST_PG_URL")
-    if env_url:
-        yield env_url
-        return
 
     def _unavailable(msg: str) -> None:
         if os.environ.get("CI"):
             pytest.fail(f"Postgres backend unavailable in CI: {msg}")
         pytest.skip(msg)
 
+    def _require_driver(driver: str) -> None:
+        """A URL alone does not make Postgres reachable; the driver has to import.
+
+        This is the guard that was missing. The fixture checked that the container
+        could start and never that the driver existed, so the import fired inside
+        SQLAlchemy in the test body instead: these tests skipped when Docker was
+        busy and failed with a bare `ModuleNotFoundError` when it was free.
+        Whether the suite reported a skip or a failure came down to whether a port
+        happened to be available, which makes every "was this failure already
+        here?" judgment against this suite unsound.
+        """
+        try:
+            importlib.import_module(driver)
+        except ImportError as exc:
+            _unavailable(f"{driver} not installed: {exc}")
+
+    env_url = os.environ.get("LIONAGI_TEST_PG_URL")
+    if env_url:
+        # Whatever driver the caller's URL names, not the one the container path
+        # happens to use. A bare `postgresql://` is psycopg2 by SQLAlchemy's own
+        # default, so that is what gets checked.
+        scheme = env_url.split("://", 1)[0]
+        _require_driver(scheme.split("+", 1)[1] if "+" in scheme else "psycopg2")
+        yield env_url
+        return
+
     try:
         from testcontainers.postgres import PostgresContainer
     except ImportError as exc:
         _unavailable(f"testcontainers not installed: {exc}")
+
+    # Checked before the container starts rather than after: pulling an image and
+    # waiting for readiness only to skip on a missing import wastes the slowest
+    # part of the run.
+    _require_driver("asyncpg")
 
     pg = None
     try:


### PR DESCRIPTION
## The problem

`tests/state/conftest.py::pg_url` checked that `testcontainers` was importable and that the
container started. It never checked that the database driver existed. The driver import happens
inside SQLAlchemy when a test opens its engine, so a missing `asyncpg` surfaced as a bare
`ModuleNotFoundError` from the test body rather than as an unavailable backend from the fixture.

The outcome therefore depended on Docker. Measured on one machine, one commit, one missing
driver:

- port already taken → container fails to start → all seven Postgres tests **skip** cleanly
  (`could not start Postgres container: Port mapping ... port 8080 is not available`)
- port free → container starts → the same seven **fail** on
  `ModuleNotFoundError: No module named 'asyncpg'`

## Why it is worth a change rather than a note

Those seven are the failures anyone comparing a branch against `main` has to account for. A
baseline that alternates between skipped and failed undermines every "was this already
failing?" judgment made against this suite, and that judgment is what decides whether a real
regression gets investigated or waved through as pre-existing.

It also interacts badly with the repo's `--maxfail`: seven failures consume the budget and
truncate the run, so an unrelated selection reports a smaller failure count that looks like a
total.

## The change

The driver is required the same way `testcontainers` already was, through the same
`_unavailable` path — skip locally, fail hard under CI so the Postgres leg can never silently
no-op on the runner. CI behaviour is unchanged: a CI runner without the driver already failed
these tests, and now fails them earlier with a message that names the reason.

The check reads the driver from the URL rather than assuming one:

| fixture path | driver required |
|---|---|
| `LIONAGI_TEST_PG_URL=postgresql+psycopg://…` | `psycopg` |
| `LIONAGI_TEST_PG_URL=postgresql://…` | `psycopg2`, SQLAlchemy's own default for a bare scheme |
| testcontainers | `asyncpg`, which is what that path constructs |

On the container path the check runs before the container starts, since pulling an image and
waiting for readiness only to skip on a missing import wastes the slowest part of the run.

## Verification

Executed on this branch, `--maxfail=200` passed explicitly so the run cannot truncate, rc read
directly:

- `tests/state` → rc=0, 0 failed, 0 errors, complete run; all seven skip with
  `asyncpg not installed: No module named 'asyncpg'`
- run twice, identical reason both times — previously the reason depended on port availability
- each of the three driver spellings above skips naming the driver it actually needs

Before this change the same selection gave 7 failures.
