### PR TITLE
fix(mcp): tell a caller what a schedule verb actually requires

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1712,7 +1712,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule get sched-abc123",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    get_p.add_argument("id", help="Schedule ID.")
+    get_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
 
     # limits
     sched_sub.add_parser(
@@ -1741,7 +1743,13 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    create_p.add_argument("name", help="Schedule name.")
+    create_p.add_argument(
+        "name",
+        help=(
+            "Unique name identifying this schedule. Reused as the display label in "
+            "listings; a name already in use is rejected rather than overwritten."
+        ),
+    )
     create_p.add_argument(
         "--trigger-type",
         dest="trigger_type",
@@ -1749,8 +1757,23 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         choices=("cron", "interval", "github", "github_poll"),
         help="Trigger type (default: cron). 'github' is an alias for 'github_poll'.",
     )
-    create_p.add_argument("--cron", metavar="EXPR", help='Cron expression, e.g. "0 * * * *".')
-    create_p.add_argument("--interval", type=int, metavar="SECONDS", help="Interval in seconds.")
+    create_p.add_argument(
+        "--cron",
+        metavar="EXPR",
+        help=(
+            'Cron expression, e.g. "0 * * * *". Required when --trigger-type is cron, '
+            "which is the default; ignored for other trigger types."
+        ),
+    )
+    create_p.add_argument(
+        "--interval",
+        type=int,
+        metavar="SECONDS",
+        help=(
+            "Seconds between fires. Required when --trigger-type is interval; "
+            "ignored for other trigger types."
+        ),
+    )
     create_p.add_argument(
         "--github-repo",
         dest="github_repo",
@@ -1796,9 +1819,22 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         choices=tuple(sorted(_VALID_ACTION_KINDS | set(_ALIAS_ACTION_KINDS))),
         help="Stored action kind or accepted alias (default: agent).",
     )
-    create_p.add_argument("--prompt", help="Prompt for agent action.")
+    create_p.add_argument(
+        "--prompt",
+        help=(
+            "Instruction the scheduled agent runs at each fire. Required when "
+            "--action-kind is agent, which is the default, unless --agent names a "
+            "profile that carries its own prompt."
+        ),
+    )
     create_p.add_argument("--model", help="Model spec for agent action.")
-    create_p.add_argument("--agent", help="Agent profile name.")
+    create_p.add_argument(
+        "--agent",
+        help=(
+            "Agent profile to run, resolved the same way `li agent --agent` resolves "
+            "it. Supplies the system prompt, model and effort the fire runs with."
+        ),
+    )
     create_p.add_argument("--playbook", help="Playbook name (for action-kind=play/playbook).")
     create_p.add_argument(
         "--flow-yaml",
@@ -1827,7 +1863,13 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
             '\'["review-pr", "--pr", "{{pr_number}}"]\'.'
         ),
     )
-    create_p.add_argument("--project", help="Project name.")
+    create_p.add_argument(
+        "--project",
+        help=(
+            "Project this schedule's runs are recorded under. Defaults to the project "
+            "detected from the execution root."
+        ),
+    )
     create_p.add_argument(
         "--cwd",
         metavar="PATH",
@@ -1997,7 +2039,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
             epilog=f"Example: {example}",
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        p.add_argument("id", help="Schedule ID.")
+        p.add_argument(
+            "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+        )
 
     # trigger
     trigger_p = sched_sub.add_parser(
@@ -2006,7 +2050,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule trigger sched-abc123 --wait",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    trigger_p.add_argument("id", help="Schedule ID.")
+    trigger_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     trigger_p.add_argument(
         "--wait",
         action="store_true",
@@ -2025,7 +2071,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule runs sched-abc123 --status failed --limit 5",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    runs_p.add_argument("id", help="Schedule ID.")
+    runs_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     runs_p.add_argument(
         "--limit",
         type=int,
@@ -2058,7 +2106,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule status sched-abc123 --wait",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    status_p.add_argument("id", help="Schedule ID.")
+    status_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     status_p.add_argument(
         "--wait", action="store_true", help="Wait for the latest in-flight run to finish first."
     )

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1823,8 +1823,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         "--prompt",
         help=(
             "Instruction the scheduled agent runs at each fire. Required when "
-            "--action-kind is agent, which is the default, unless --agent names a "
-            "profile that carries its own prompt."
+            "--action-kind is agent, which is the default. A profile named by "
+            "--agent supplies the model and settings, never this instruction, so "
+            "a schedule created without it fires and fails."
         ),
     )
     create_p.add_argument("--model", help="Model spec for agent action.")

--- a/tests/mcp/golden_projections/invoke__end.json
+++ b/tests/mcp/golden_projections/invoke__end.json
@@ -1,0 +1,40 @@
+{
+  "path": "invoke end",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "invocation_id": {
+        "description": "The id printed by `li invoke start`. An invocation never closed stays 'running' forever.",
+        "type": "string",
+        "x-positional": true
+      },
+      "metadata": {
+        "description": "JSON merged key-by-key into the invocation's existing metadata, so anything written during the run survives unless this overwrites that key.",
+        "type": "string",
+        "x-flag": "--metadata"
+      },
+      "status": {
+        "default": "completed",
+        "description": "How the work ended, which also fixes the reason stored with it: 'completed' for success, 'failed' for an exception, 'timed_out' for a deadline, 'aborted' for a user interrupt, 'cancelled' for a system cancellation. Later listings and dashboards filter on this, so leaving the default on work that did not succeed records it as a success.",
+        "enum": [
+          "completed",
+          "failed",
+          "timed_out",
+          "aborted",
+          "cancelled"
+        ],
+        "type": "string",
+        "x-flag": "--status"
+      }
+    },
+    "required": [
+      "invocation_id"
+    ],
+    "title": "invoke end",
+    "type": "object",
+    "x-positional-order": [
+      "invocation_id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__create.json
+++ b/tests/mcp/golden_projections/schedule__create.json
@@ -30,12 +30,12 @@
         "x-flag": "--action-kind"
       },
       "agent": {
-        "description": "Agent profile name.",
+        "description": "Agent profile to run, resolved the same way `li agent --agent` resolves it. Supplies the system prompt, model and effort the fire runs with.",
         "type": "string",
         "x-flag": "--agent"
       },
       "cron": {
-        "description": "Cron expression, e.g. \"0 * * * *\".",
+        "description": "Cron expression, e.g. \"0 * * * *\". Required when --trigger-type is cron, which is the default; ignored for other trigger types.",
         "type": "string",
         "x-flag": "--cron"
       },
@@ -65,7 +65,7 @@
         "x-flag": "--github-repo"
       },
       "interval": {
-        "description": "Interval in seconds.",
+        "description": "Seconds between fires. Required when --trigger-type is interval; ignored for other trigger types.",
         "type": "integer",
         "x-flag": "--interval"
       },
@@ -90,7 +90,7 @@
         "x-flag": "--model"
       },
       "name": {
-        "description": "Schedule name.",
+        "description": "Unique name identifying this schedule. Reused as the display label in listings; a name already in use is rejected rather than overwritten.",
         "type": "string",
         "x-positional": true
       },
@@ -121,12 +121,12 @@
         "x-flag": "--poll-interval"
       },
       "project": {
-        "description": "Project name.",
+        "description": "Project this schedule's runs are recorded under. Defaults to the project detected from the execution root.",
         "type": "string",
         "x-flag": "--project"
       },
       "prompt": {
-        "description": "Prompt for agent action.",
+        "description": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default, unless --agent names a profile that carries its own prompt.",
         "type": "string",
         "x-flag": "--prompt"
       },

--- a/tests/mcp/golden_projections/schedule__create.json
+++ b/tests/mcp/golden_projections/schedule__create.json
@@ -126,7 +126,7 @@
         "x-flag": "--project"
       },
       "prompt": {
-        "description": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default, unless --agent names a profile that carries its own prompt.",
+        "description": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default. A profile named by --agent supplies the model and settings, never this instruction, so a schedule created without it fires and fails.",
         "type": "string",
         "x-flag": "--prompt"
       },

--- a/tests/mcp/golden_projections/schedule__delete.json
+++ b/tests/mcp/golden_projections/schedule__delete.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule delete",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule delete",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__disable.json
+++ b/tests/mcp/golden_projections/schedule__disable.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule disable",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule disable",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__enable.json
+++ b/tests/mcp/golden_projections/schedule__enable.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule enable",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule enable",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__export.json
+++ b/tests/mcp/golden_projections/schedule__export.json
@@ -1,0 +1,27 @@
+{
+  "path": "schedule export",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "legacy": {
+        "default": false,
+        "description": "Convert chain-free legacy rows (managed_by is null, i.e. rows predating the declaration layer) instead of declaration/cli-managed rows. A row with on_success/on_fail is reported BLOCKED and omitted.",
+        "type": "boolean",
+        "x-flag": "--legacy"
+      },
+      "output": {
+        "description": "Write the ScheduleSet YAML here (default: stdout).",
+        "type": "string",
+        "x-flag": "--output"
+      },
+      "report": {
+        "description": "Write the human-readable conversion report here (default: stderr).",
+        "type": "string",
+        "x-flag": "--report"
+      }
+    },
+    "title": "schedule export",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__get.json
+++ b/tests/mcp/golden_projections/schedule__get.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule get",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule get",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__limits.json
+++ b/tests/mcp/golden_projections/schedule__limits.json
@@ -1,0 +1,10 @@
+{
+  "path": "schedule limits",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "schedule limits",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__list.json
+++ b/tests/mcp/golden_projections/schedule__list.json
@@ -1,0 +1,10 @@
+{
+  "path": "schedule list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "schedule list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__runs.json
+++ b/tests/mcp/golden_projections/schedule__runs.json
@@ -1,0 +1,42 @@
+{
+  "path": "schedule runs",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "limit": {
+        "default": 20,
+        "description": "Max runs to return, 1-200 (default: 20).",
+        "type": "integer",
+        "x-flag": "--limit"
+      },
+      "status": {
+        "description": "Filter by run status; repeatable (e.g. --status failed --status timed_out).",
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "x-flag": "--status"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule runs",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__status.json
+++ b/tests/mcp/golden_projections/schedule__status.json
@@ -1,0 +1,34 @@
+{
+  "path": "schedule status",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "wait": {
+        "default": false,
+        "description": "Wait for the latest in-flight run to finish first.",
+        "type": "boolean",
+        "x-flag": "--wait"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule status",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__trigger.json
+++ b/tests/mcp/golden_projections/schedule__trigger.json
@@ -1,0 +1,28 @@
+{
+  "path": "schedule trigger",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "wait": {
+        "default": false,
+        "description": "Block until the fired occurrence reaches a terminal status (retries a short grace period first, since the occurrence row isn't durably written until just after this returns a run id), then print its outcome and exit non-zero on failure.",
+        "type": "boolean",
+        "x-flag": "--wait"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule trigger",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__validate.json
+++ b/tests/mcp/golden_projections/schedule__validate.json
@@ -1,0 +1,28 @@
+{
+  "path": "schedule validate",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "file": {
+        "description": "Path to a ScheduleSet YAML file.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "file"
+    ],
+    "title": "schedule validate",
+    "type": "object",
+    "x-positional-order": [
+      "file"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__create.json
+++ b/tests/mcp/golden_projections/team__create.json
@@ -1,0 +1,31 @@
+{
+  "path": "team create",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "members": {
+        "description": "Comma-separated member names. Only these names can send or receive as themselves; a message from or to anyone else still goes through, with a warning.",
+        "type": "string",
+        "x-aliases": [
+          "-m"
+        ],
+        "x-flag": "--members"
+      },
+      "name": {
+        "description": "Name for the new team. Every other team command accepts it in place of the team id.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "name",
+      "members"
+    ],
+    "title": "team create",
+    "type": "object",
+    "x-positional-order": [
+      "name"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__receive.json
+++ b/tests/mcp/golden_projections/team__receive.json
@@ -1,0 +1,27 @@
+{
+  "path": "team receive",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "member": {
+        "description": "Read as this member: returns only their unread mail and marks it read. Omit it to dump every message and mark nothing read.",
+        "type": "string",
+        "x-flag": "--as"
+      },
+      "team": {
+        "description": "Team to read from \u2014 its id, its name, or an unambiguous id prefix.",
+        "type": "string",
+        "x-aliases": [
+          "-t"
+        ],
+        "x-flag": "--team"
+      }
+    },
+    "required": [
+      "team"
+    ],
+    "title": "team receive",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__show.json
+++ b/tests/mcp/golden_projections/team__show.json
@@ -1,0 +1,22 @@
+{
+  "path": "team show",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "team": {
+        "description": "Team to show \u2014 its id, its name, or an unambiguous id prefix.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "team"
+    ],
+    "title": "team show",
+    "type": "object",
+    "x-positional-order": [
+      "team"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -32,41 +32,6 @@ from lionagi.mcp.projection import (
 
 GOLDEN_DIR = Path(__file__).parent / "golden_projections"
 
-# One per shape worth pinning: positionals with nargs, repeated flags, enums,
-# int/float scalars, a mutually exclusive group, and the playbook-bearing pair.
-GOLDEN_VERBS = (
-    "agent",
-    "casts",
-    "dispatch ls",
-    "doctor",
-    "invoke start",
-    "kill",
-    "monitor",
-    "orchestrate fanout",
-    "orchestrate flow",
-    "plugin list",
-    "schedule create",
-    "state ls",
-    "stats runs",
-    "studio start",
-    "team send",
-    # The observability reads: every one of these is a path the surface now
-    # dispatches, so an argparse change under it must fail here rather than
-    # quietly reshape a schema a caller validated against.
-    "dispatch show",
-    "invoke list",
-    "lifecycle",
-    "plugin info",
-    "state stats",
-    "team list",
-    # The queue's writes. A golden matters more here than on a read: a caller acts
-    # on the schema, so an argparse change that silently made `token` optional or
-    # renamed `--dry-run` would turn a refused call into a destructive one.
-    "dispatch ack",
-    "dispatch retry",
-    "dispatch purge",
-)
-
 # Everything the MCP surface is a candidate to dispatch. `mirror` is
 # deliberately absent — see test_mirror_since_is_unrepresentable.
 CANDIDATE_VERBS = (
@@ -107,6 +72,13 @@ CANDIDATE_VERBS = (
     "team send",
     "team show",
 )
+
+# Every dispatchable path is pinned, not a sample of them. A caller acts on the
+# schema it is handed, so an argparse change under any of these must fail here
+# with a diff rather than quietly reshape a schema someone already validated
+# against. `lifecycle` and `studio start` are pinned too: neither is a dispatch
+# candidate, but both project and both are read by the surface.
+GOLDEN_VERBS = CANDIDATE_VERBS + ("lifecycle", "studio start")
 
 
 def _golden_path(verb: str) -> Path:


### PR DESCRIPTION
The MCP tool schemas are projected from the CLI's own parsers, so a parameter's
help text is the only place a machine caller learns what that parameter means.
Several of them said nothing useful, and one combination is actively misleading.

**`schedule.create` requiredness is conditional and the schema cannot say so.**
It advertises `name` as its single required parameter, but what is actually
required depends on `--trigger-type` and `--action-kind`, which a JSON Schema
`required` list has no way to express. The default path was the worst
documented of all: only the `github_repo` branch described its own
conditionality, so the most likely call — default `cron` trigger, default
`agent` action — carried the least guidance. The conditions are now stated in
the help text of each conditionally-required parameter, where the projection
picks them up automatically and they stay in one place.

**`"Schedule ID."` told a caller nothing.** Five parameters used that string,
which names the type and withholds the only thing a caller needs: where an id
comes from. They now name the command that returns one.

**Golden projections now cover every dispatchable path**, up from a sampled
subset. A parser edit can no longer change an advertised schema without a test
noticing. Fifteen of these are characterization tests: they pin
previously-unpinned behaviour rather than discriminating against a bug, which
is why they pass before and after. The updated `schedule__create.json` is the
one that discriminates.

Verification: `tests/mcp/` passes, return code 0 captured from the command
itself. Note that `-q` combined with this project's xdist settings suppresses
pytest's summary line entirely, so the count comes from progress dots — 443.
The full suite has three failures on this branch; all three reproduce
identically on an unmodified `main` and are unrelated to this change.