### PR TITLE
feat(mcp): let a client read which code the server is actually running

### DIFF
--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -22,17 +22,19 @@ because an uncommitted edit moves the files and leaves the commit id alone. Two
 things follow. A commit id does not describe a dirty tree in the first place, so
 a snapshot taken over uncommitted changes can only ever be a partial identity and
 says so. And to notice an edit made afterwards, the snapshot carries a digest of
-the tree's uncommitted state — its shape and the size and modification time of
-every path git names, never its content — which is compared live exactly as the
-commit is. The two kinds of movement stay separate in the payload: moving the
+the tree's uncommitted state — its shape, and the size, modification time, mode
+and inode of every path git names, never its content — which is compared live
+exactly as the commit is. The two kinds of movement stay separate in the payload: moving the
 checkout and editing files under it are different operator actions with different
 remedies, and one boolean cannot carry both.
 
-What that digest can miss is stated where it is computed, and it comes to one
-thing: a rewrite that leaves both the size and the modification time untouched.
-Everything else an operator can do to a file under this process — including to an
-untracked file, to a file inside an untracked directory, and to a file git renders
-only as a modified binary — moves the digest.
+What that digest can miss is enumerated where it is computed, as a list rather
+than as a count: an edit is invisible to it only if it moves none of a path's
+size, modification time, mode or inode, or if it happens somewhere git never
+names, which is what ``.gitignore`` puts out of scope. Everything else an operator
+can do to a file under this process — including to an untracked file, to a file
+inside an untracked directory, to a file git renders only as a modified binary,
+and a permission change that rewrites no bytes at all — moves the digest.
 
 Failure is closed: a tree whose git state cannot be read is ``unknown``, never
 ``ok``. "Cannot tell" and "nothing wrong" are different answers, and a git call
@@ -222,10 +224,31 @@ def _worktree_fingerprint(
     A clean tree needs no diff — an empty status listing is already the whole
     answer, and skipping the call keeps the common case off the allowance.
 
-    One edit remains invisible: a rewrite that leaves both the size and the
-    modification time as they were. That is a deliberate residual of measuring
-    metadata instead of content, and it is the price of a cost that does not grow
-    with the size of the tree.
+    The per-path measurement sits inside the same allowance as the git calls,
+    because a tree with a large unignored untracked directory is exactly the case
+    the allowance exists for. Running out of it yields no digest and a reason, not
+    the digest built so far: a partial digest compares unequal to a full one taken
+    at another moment, which would report an edit to a tree nobody touched. A
+    timeout is a thing that could not be measured, and the honest report of it is
+    "cannot tell", not a manufactured difference.
+
+    What this cannot see is a list, and it is worth keeping as a list because
+    "only one case" is the shape of claim that goes stale without anyone noticing:
+
+    - a rewrite that leaves the size, the modification time, the mode and the
+      inode all as they were — the deliberate residual of measuring metadata
+      instead of content, and the price of a cost that does not grow with the
+      size of the tree;
+    - any change beneath ``.gitignore``, which git never names here, so nothing
+      stats it;
+    - ownership and extended attributes, which are not in the mark.
+
+    The inode is in the mark so that replacing a file by renaming another over it
+    stays visible even when the replacement matches on every other field. The cost
+    is that a filesystem which does not hold inode numbers stable across stats
+    would read as an edit that did not happen; the digest is only ever compared
+    within one process against one tree, which is the narrow condition that makes
+    that safe to rely on.
     """
     digest = hashlib.sha256(porcelain.encode(errors="replace"))
     if porcelain:
@@ -234,7 +257,14 @@ def _worktree_fingerprint(
             return None, f"could not read the uncommitted changes: {err or 'no output'}"
         digest.update(b"\x00")
         digest.update(diff.encode(errors="replace"))
-        for relative in _status_paths(porcelain):
+        paths = _status_paths(porcelain)
+        for measured, relative in enumerate(paths):
+            if budget.remaining() <= 0:
+                return None, (
+                    f"the {budget.total}s allowance for reading git state was spent "
+                    f"after measuring {measured} of the {len(paths)} paths the status "
+                    "listing names, so no digest of the uncommitted state was taken"
+                )
             try:
                 stat = (root / relative).lstat()
             except FileNotFoundError:
@@ -245,7 +275,7 @@ def _worktree_fingerprint(
                     f"{type(exc).__name__}: {exc}"
                 )
             else:
-                mark = f"{stat.st_size}:{stat.st_mtime_ns}"
+                mark = f"{stat.st_size}:{stat.st_mtime_ns}:{stat.st_mode}:{stat.st_ino}"
             digest.update(f"\x00{relative}\x00{mark}".encode(errors="replace"))
     return digest.hexdigest()[:_FINGERPRINT_CHARS], None
 

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -17,6 +17,16 @@ current position is read too, and reported beside it: when the two disagree the
 checkout moved after this process loaded, and that divergence is itself the fact
 an operator needs, so it is named in the payload rather than left to be inferred.
 
+A tree can also part from the running code without its commit changing at all,
+because an uncommitted edit moves the files and leaves the commit id alone. Two
+things follow. A commit id does not describe a dirty tree in the first place, so
+a snapshot taken over uncommitted changes can only ever be a partial identity and
+says so. And to notice an edit made afterwards, the snapshot carries a digest of
+the tree's uncommitted state — its shape, never its content — which is compared
+live exactly as the commit is. The two kinds of movement stay separate in the
+payload: moving the checkout and editing files under it are different operator
+actions with different remedies, and one boolean cannot carry both.
+
 Failure is closed: a tree whose git state cannot be read is ``unknown``, never
 ``ok``. "Cannot tell" and "nothing wrong" are different answers, and a git call
 that could not run at all is a third thing again — it is not evidence that the
@@ -25,6 +35,7 @@ tree lacks an upstream, so it never falls through to the fallback comparison.
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -52,6 +63,11 @@ GIT_TIMEOUT_SECONDS = 5.0
 IDENTITY_BUDGET_SECONDS = 6.0
 
 _SHORT_SHA = 12
+
+# The digest is only ever compared against another digest of the same tree, so it
+# needs to be long enough that an accidental collision is not a concern and short
+# enough to read in a payload.
+_FINGERPRINT_CHARS = 16
 
 # Return codes for calls that never produced one: git could not be run at all,
 # or the allowance was already spent before this call's turn came.
@@ -150,6 +166,32 @@ def _comparison_ref(tree: Path, budget: _Budget) -> tuple[str | None, str, str |
     return None, "none", err or "no upstream configured and origin/HEAD does not resolve", True
 
 
+def _worktree_fingerprint(
+    tree: Path, porcelain: str, budget: _Budget
+) -> tuple[str | None, str | None]:
+    """A digest of what is uncommitted in *tree*, or why one could not be taken.
+
+    Enough to tell whether the uncommitted state changed between two readings,
+    and deliberately not enough to reconstruct it: the digest is over the status
+    listing and the diff against HEAD, and only the digest is kept.
+
+    A clean tree needs no diff — an empty status listing is already the whole
+    answer, and skipping the call keeps the common case off the allowance.
+
+    Two edits are invisible to this: a change inside a directory git reports as
+    untracked as a whole, and a change to a file already listed as a modified
+    binary, since the diff names those rather than rendering them.
+    """
+    digest = hashlib.sha256(porcelain.encode(errors="replace"))
+    if porcelain:
+        rc, diff, err = _git(tree, "diff", "HEAD", budget=budget)
+        if rc != 0:
+            return None, f"could not read the uncommitted changes: {err or 'no output'}"
+        digest.update(b"\x00")
+        digest.update(diff.encode(errors="replace"))
+    return digest.hexdigest()[:_FINGERPRINT_CHARS], None
+
+
 def git_identity(tree: Path, budget: _Budget | None = None) -> dict[str, Any]:
     """Where *tree* sits in git history now, or why that could not be established.
 
@@ -188,6 +230,11 @@ def _read_git_identity(tree: Path, budget: _Budget) -> dict[str, Any]:
     if rc != 0:
         return {"status": "unknown", "detail": f"could not read working tree: {err}"}
     identity["dirty"] = bool(porcelain)
+
+    fingerprint, fingerprint_detail = _worktree_fingerprint(tree, porcelain, budget)
+    identity["worktree_fingerprint"] = fingerprint
+    if fingerprint_detail is not None:
+        identity["worktree_fingerprint_detail"] = fingerprint_detail
 
     ref, source, why, asked = _comparison_ref(tree, budget)
     if not asked:
@@ -302,6 +349,49 @@ def _checkout_movement(
     return False, None
 
 
+def _worktree_movement(
+    snapshot: dict[str, Any], live: dict[str, Any], commit_moved: bool | None
+) -> tuple[bool | None, str | None]:
+    """Whether the files under this process were edited since it loaded its code.
+
+    This is the movement that leaves the commit alone, so nothing about the commit
+    can answer it — only the two digests can. When either is missing the answer is
+    ``None``, because a digest that was never taken cannot show a tree standing
+    still.
+
+    A digest is taken against HEAD, so once the checkout has moved the two are
+    measured from different commits and are not comparable. That case is already
+    reported as a moved checkout; claiming anything about the files on top of it
+    would be claiming more than was measured.
+    """
+    if live is snapshot:
+        return False, None
+    if commit_moved is not False:
+        return None, (
+            "the uncommitted state cannot be compared across a checkout that moved or "
+            "whose position is unknown — the two readings are measured from different "
+            "commits"
+        )
+
+    before = snapshot.get("worktree_fingerprint")
+    after = live.get("worktree_fingerprint")
+    if before is None or after is None:
+        missing = snapshot if before is None else live
+        which = "when this process loaded" if before is None else "now"
+        return None, (
+            f"the uncommitted state of the tree could not be read {which}: "
+            f"{missing.get('worktree_fingerprint_detail', 'no detail')}"
+        )
+    if before != after:
+        return True, (
+            f"the working tree at {snapshot.get('toplevel')} was edited after this "
+            f"process loaded its code — commit {snapshot.get('commit_short')} is "
+            "unchanged, so the edit is invisible to the commit id, and the modules "
+            "answering here are the ones read before it"
+        )
+    return False, None
+
+
 def _distribution_version() -> tuple[str | None, str | None]:
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as dist_version
@@ -330,6 +420,8 @@ def _drift(
     live: dict[str, Any] | None = None,
     moved: bool | None = False,
     movement_detail: str | None = None,
+    worktree_edited: bool | None = False,
+    worktree_detail: str | None = None,
 ) -> dict[str, Any]:
     """The verdict on *git*, the position of the code this process actually loaded.
 
@@ -337,6 +429,14 @@ def _drift(
     against a fresher view of the remote, so it is the better source for how far
     behind the loaded code is. When it has moved, the live reading is about some
     other commit and only the snapshot speaks for what is running.
+
+    Uncommitted changes present when the snapshot was taken make the verdict
+    ``unknown`` rather than ``ok``. Not because something is known to be wrong —
+    the edits may be exactly what the operator intended to run — but because the
+    commit id, which is the whole of what this surface can report, is then not a
+    description of the loaded code. Saying ``ok`` there would be answering a
+    question ("does the reported identity match what is running?") that the
+    reading cannot reach.
     """
     reasons: list[str] = []
     unknowns: list[str] = []
@@ -352,6 +452,18 @@ def _drift(
         reasons.append(movement_detail)
     elif moved is None and movement_detail:
         unknowns.append(movement_detail)
+
+    if worktree_edited is True and worktree_detail:
+        reasons.append(worktree_detail)
+    elif worktree_edited is None and worktree_detail:
+        unknowns.append(worktree_detail)
+
+    if git.get("dirty") is True:
+        unknowns.append(
+            f"the tree this process loaded from had uncommitted changes at "
+            f"{git.get('commit_short', 'the captured commit')}, so that commit does not "
+            "describe the code being run — some of it was only ever on disk"
+        )
 
     position = git
     if moved is False and live is not None and live.get("status") == "ok":
@@ -389,6 +501,11 @@ def code_identity() -> dict[str, Any]:
     position captured when this process first looked, which is what it loaded;
     ``git_live`` is the tree as it stands now. On the call that takes the
     snapshot the two are one reading and are reported as such.
+
+    ``checkout_moved`` and ``worktree_edited`` are separate answers to separate
+    questions — the checkout was moved to another commit, and the files were
+    edited where they stand — because the operator who caused one did not do the
+    other, and undoing them is not the same act.
     """
     from lionagi.version import __version__
 
@@ -403,6 +520,7 @@ def code_identity() -> dict[str, Any]:
         live = snapshot
 
     moved, movement_detail = _checkout_movement(snapshot, live)
+    worktree_edited, worktree_detail = _worktree_movement(snapshot, live, moved)
     distribution_version, distribution_detail = _distribution_version()
     verb_count, verb_detail = _verb_count()
 
@@ -415,6 +533,7 @@ def code_identity() -> dict[str, Any]:
         "git_snapshot_taken_at": snapshot.get("observed_at"),
         "git_live": live,
         "checkout_moved": moved,
+        "worktree_edited": worktree_edited,
         "drift": _drift(
             snapshot,
             __version__,
@@ -422,10 +541,14 @@ def code_identity() -> dict[str, Any]:
             live=live,
             moved=moved,
             movement_detail=movement_detail,
+            worktree_edited=worktree_edited,
+            worktree_detail=worktree_detail,
         ),
     }
     if movement_detail is not None:
         identity["checkout_moved_detail"] = movement_detail
+    if worktree_detail is not None:
+        identity["worktree_edited_detail"] = worktree_detail
     if distribution_detail is not None:
         identity["distribution_detail"] = distribution_detail
     if verb_detail is not None:

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -22,10 +22,17 @@ because an uncommitted edit moves the files and leaves the commit id alone. Two
 things follow. A commit id does not describe a dirty tree in the first place, so
 a snapshot taken over uncommitted changes can only ever be a partial identity and
 says so. And to notice an edit made afterwards, the snapshot carries a digest of
-the tree's uncommitted state — its shape, never its content — which is compared
-live exactly as the commit is. The two kinds of movement stay separate in the
-payload: moving the checkout and editing files under it are different operator
-actions with different remedies, and one boolean cannot carry both.
+the tree's uncommitted state — its shape and the size and modification time of
+every path git names, never its content — which is compared live exactly as the
+commit is. The two kinds of movement stay separate in the payload: moving the
+checkout and editing files under it are different operator actions with different
+remedies, and one boolean cannot carry both.
+
+What that digest can miss is stated where it is computed, and it comes to one
+thing: a rewrite that leaves both the size and the modification time untouched.
+Everything else an operator can do to a file under this process — including to an
+untracked file, to a file inside an untracked directory, and to a file git renders
+only as a modified binary — moves the digest.
 
 Failure is closed: a tree whose git state cannot be read is ``unknown``, never
 ``ok``. "Cannot tell" and "nothing wrong" are different answers, and a git call
@@ -166,21 +173,59 @@ def _comparison_ref(tree: Path, budget: _Budget) -> tuple[str | None, str, str |
     return None, "none", err or "no upstream configured and origin/HEAD does not resolve", True
 
 
+def _status_paths(porcelain: str) -> list[str]:
+    """The worktree paths a NUL-delimited status listing names, relative to the root.
+
+    Records are ``XY<space><path>``. A rename or copy carries the name it came
+    from as an extra field, which is dropped: that name is gone from the disk by
+    definition, so asking the filesystem about it would measure nothing.
+    """
+    fields = [field for field in porcelain.split("\x00") if field]
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        entry = fields[index]
+        index += 1
+        if len(entry) < 4:
+            continue
+        paths.append(entry[3:])
+        if "R" in entry[:2] or "C" in entry[:2]:
+            index += 1
+    return paths
+
+
 def _worktree_fingerprint(
-    tree: Path, porcelain: str, budget: _Budget
+    tree: Path, root: Path, porcelain: str, budget: _Budget
 ) -> tuple[str | None, str | None]:
     """A digest of what is uncommitted in *tree*, or why one could not be taken.
 
     Enough to tell whether the uncommitted state changed between two readings,
     and deliberately not enough to reconstruct it: the digest is over the status
-    listing and the diff against HEAD, and only the digest is kept.
+    listing, the diff against HEAD, and the size and modification time of every
+    path the listing names. No file is read, so a large file costs the same as a
+    small one and the digest never carries content.
+
+    The size and mtime are what make an ordinary edit visible when the other two
+    inputs cannot see it. Neither the listing nor the diff carries the contents of
+    an untracked file or of a file git renders as a modified binary, so for those
+    a rewrite in place leaves both byte-identical; the file's own metadata is the
+    only thing that moves. Untracked entries are enumerated as files rather than
+    collapsed directories for the same reason — otherwise a whole tree of code
+    hides behind one unchanging line. ``.gitignore`` still applies, so build
+    output and virtualenvs stay out and the listing stays bounded.
+
+    A path that is absent has been measured, not missed: git lists deletions, and
+    a deletion is exactly a path that is not there. Absence is recorded as such.
+    A path that exists and still cannot be read is a different matter and yields
+    no digest at all, so the caller reports "cannot tell" rather than "unchanged".
 
     A clean tree needs no diff — an empty status listing is already the whole
     answer, and skipping the call keeps the common case off the allowance.
 
-    Two edits are invisible to this: a change inside a directory git reports as
-    untracked as a whole, and a change to a file already listed as a modified
-    binary, since the diff names those rather than rendering them.
+    One edit remains invisible: a rewrite that leaves both the size and the
+    modification time as they were. That is a deliberate residual of measuring
+    metadata instead of content, and it is the price of a cost that does not grow
+    with the size of the tree.
     """
     digest = hashlib.sha256(porcelain.encode(errors="replace"))
     if porcelain:
@@ -189,6 +234,19 @@ def _worktree_fingerprint(
             return None, f"could not read the uncommitted changes: {err or 'no output'}"
         digest.update(b"\x00")
         digest.update(diff.encode(errors="replace"))
+        for relative in _status_paths(porcelain):
+            try:
+                stat = (root / relative).lstat()
+            except FileNotFoundError:
+                mark = "absent"
+            except OSError as exc:
+                return None, (
+                    f"could not read the state of {relative} under {root}: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+            else:
+                mark = f"{stat.st_size}:{stat.st_mtime_ns}"
+            digest.update(f"\x00{relative}\x00{mark}".encode(errors="replace"))
     return digest.hexdigest()[:_FINGERPRINT_CHARS], None
 
 
@@ -226,12 +284,17 @@ def _read_git_identity(tree: Path, budget: _Budget) -> dict[str, Any]:
     identity["detached"] = detached
     identity["branch"] = None if detached else branch
 
-    rc, porcelain, err = _git(tree, "status", "--porcelain", budget=budget)
+    # `-z` so a path with a newline or a quote in it stays one field, and
+    # `--untracked-files=all` so an untracked directory is listed as the files
+    # inside it rather than as a single line that an edit within cannot move.
+    rc, porcelain, err = _git(
+        tree, "status", "--porcelain", "-z", "--untracked-files=all", budget=budget
+    )
     if rc != 0:
         return {"status": "unknown", "detail": f"could not read working tree: {err}"}
     identity["dirty"] = bool(porcelain)
 
-    fingerprint, fingerprint_detail = _worktree_fingerprint(tree, porcelain, budget)
+    fingerprint, fingerprint_detail = _worktree_fingerprint(tree, Path(top), porcelain, budget)
     identity["worktree_fingerprint"] = fingerprint
     if fingerprint_detail is not None:
         identity["worktree_fingerprint_detail"] = fingerprint_detail

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -9,20 +9,34 @@ version, the resolved path it imported itself from, that tree's git position,
 and how many verbs it registered — and every answer is derived here, in one
 place, so the handshake and the server's own info cannot disagree.
 
+The git position is the part that can go stale under a running process, because
+someone can move the checkout the process imported from and the loaded module
+objects will not notice. So it is captured once, as early as the process can
+manage, and that capture is what the identity calls the running code. The tree's
+current position is read too, and reported beside it: when the two disagree the
+checkout moved after this process loaded, and that divergence is itself the fact
+an operator needs, so it is named in the payload rather than left to be inferred.
+
 Failure is closed: a tree whose git state cannot be read is ``unknown``, never
-``ok``. "Cannot tell" and "nothing wrong" are different answers.
+``ok``. "Cannot tell" and "nothing wrong" are different answers, and a git call
+that could not run at all is a third thing again — it is not evidence that the
+tree lacks an upstream, so it never falls through to the fallback comparison.
 """
 
 from __future__ import annotations
 
 import subprocess
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 __all__ = (
     "code_identity",
     "git_identity",
+    "snapshot_git_position",
     "GIT_TIMEOUT_SECONDS",
+    "IDENTITY_BUDGET_SECONDS",
 )
 
 # Bounded because this runs inside a handshake a client is waiting on, and a git
@@ -30,51 +44,127 @@ __all__ = (
 # otherwise hang the answer instead of failing it.
 GIT_TIMEOUT_SECONDS = 5.0
 
+# One allowance for the whole computation, not one per call: half a dozen git
+# calls each free to take the per-call timeout is a worst case measured in tens
+# of seconds, which is longer than the handshake it sits inside is worth waiting.
+# When the allowance runs out the answer is `unknown` with the reason, which is
+# the honest reading — a check that could not finish has not passed.
+IDENTITY_BUDGET_SECONDS = 6.0
+
 _SHORT_SHA = 12
 
+# Return codes for calls that never produced one: git could not be run at all,
+# or the allowance was already spent before this call's turn came.
+_COULD_NOT_RUN = -1
+_BUDGET_SPENT = -2
 
-def _git(tree: Path, *argv: str) -> tuple[int, str, str]:
+_REF_CAVEATS = {
+    "upstream": (
+        "this is a remote-tracking ref, updated only by a fetch in this tree, so the "
+        "comparison is as current as the last fetch and no more"
+    ),
+    "remote_head": (
+        "origin/HEAD is a local symbolic ref, written when this clone was made and "
+        "refreshed only on request; if the remote's default branch has changed since, "
+        "this measures against the wrong branch and understates how far behind the "
+        "checkout is. It is also a remote-tracking ref, so it is only as current as "
+        "the last fetch in this tree"
+    ),
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _Budget:
+    """One wall-clock allowance shared by every git call in a single computation."""
+
+    def __init__(self, seconds: float) -> None:
+        self.total = seconds
+        self._deadline = time.monotonic() + seconds
+
+    def remaining(self) -> float:
+        return self._deadline - time.monotonic()
+
+
+def _ran(rc: int) -> bool:
+    """Whether git actually ran and produced this return code."""
+    return rc >= 0
+
+
+def _git(tree: Path, *argv: str, budget: _Budget) -> tuple[int, str, str]:
     """Run one git command against *tree*; returns (rc, stdout, stderr), stripped.
 
-    An rc of -1 means git itself could not be run, which is a different fact
+    A negative rc means no git process produced it — either git could not be run,
+    or the shared allowance was gone before this call. Both are a different fact
     from git running and refusing.
     """
+    left = budget.remaining()
+    if left <= 0:
+        return (
+            _BUDGET_SPENT,
+            "",
+            f"the {budget.total}s allowance for reading git state was spent before "
+            f"`git {' '.join(argv)}` could run",
+        )
     try:
         completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
             ["git", "-C", str(tree), *argv],  # noqa: S607 — resolved from PATH by design
             capture_output=True,
             text=True,
-            timeout=GIT_TIMEOUT_SECONDS,
+            timeout=min(GIT_TIMEOUT_SECONDS, left),
             check=False,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        return -1, "", f"{type(exc).__name__}: {exc}"
+        return _COULD_NOT_RUN, "", f"{type(exc).__name__}: {exc}"
     return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
 
 
-def _comparison_ref(tree: Path) -> tuple[str | None, str, str | None]:
-    """The ref this checkout should be measured against, and where it came from.
+def _comparison_ref(tree: Path, budget: _Budget) -> tuple[str | None, str, str | None, bool]:
+    """The ref this checkout should be measured against, where it came from, and
+    whether the question could be asked at all.
 
     The configured upstream is preferred. A detached checkout has none — which is
     exactly the state a pinned deployment sits in — so the remote's default
     branch is the fallback, because "behind the branch this remote publishes" is
     the question a detached tree still has an answer to.
+
+    The fallback is only reached when git ran and told us there is no upstream. A
+    call that never ran — a timeout, a missing binary, a spent allowance — says
+    nothing about upstreams, so it stops here instead of being read as one.
     """
-    rc, out, _ = _git(tree, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+    rc, out, err = _git(
+        tree, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}", budget=budget
+    )
     if rc == 0 and out:
-        return out, "upstream", None
+        return out, "upstream", None, True
+    if not _ran(rc):
+        return None, "unreadable", err or "the upstream lookup did not run", False
 
-    rc, out, err = _git(tree, "rev-parse", "--abbrev-ref", "origin/HEAD")
+    rc, out, err = _git(tree, "rev-parse", "--abbrev-ref", "origin/HEAD", budget=budget)
     if rc == 0 and out:
-        return out, "remote_head", None
-    return None, "none", err or "no upstream configured and origin/HEAD does not resolve"
+        return out, "remote_head", None, True
+    if not _ran(rc):
+        return None, "unreadable", err or "the origin/HEAD lookup did not run", False
+    return None, "none", err or "no upstream configured and origin/HEAD does not resolve", True
 
 
-def git_identity(tree: Path) -> dict[str, Any]:
-    """Where *tree* sits in git history, or why that could not be established."""
-    rc, top, err = _git(tree, "rev-parse", "--show-toplevel")
+def git_identity(tree: Path, budget: _Budget | None = None) -> dict[str, Any]:
+    """Where *tree* sits in git history now, or why that could not be established.
+
+    The reading is stamped with when it was taken, because a git position is only
+    true of the instant it was read.
+    """
+    identity = _read_git_identity(tree, budget or _Budget(IDENTITY_BUDGET_SECONDS))
+    identity["observed_at"] = _now()
+    return identity
+
+
+def _read_git_identity(tree: Path, budget: _Budget) -> dict[str, Any]:
+    rc, top, err = _git(tree, "rev-parse", "--show-toplevel", budget=budget)
     if rc != 0:
-        if "not a git repository" in err.lower():
+        if _ran(rc) and "not a git repository" in err.lower():
             return {
                 "status": "not_a_git_checkout",
                 "detail": f"{tree} is not inside a git checkout",
@@ -83,32 +173,42 @@ def git_identity(tree: Path) -> dict[str, Any]:
 
     identity: dict[str, Any] = {"status": "ok", "toplevel": top}
 
-    rc, commit, err = _git(tree, "rev-parse", "HEAD")
+    rc, commit, err = _git(tree, "rev-parse", "HEAD", budget=budget)
     if rc != 0 or not commit:
         return {"status": "unknown", "detail": f"could not read HEAD: {err or 'no output'}"}
     identity["commit"] = commit
     identity["commit_short"] = commit[:_SHORT_SHA]
 
-    rc, branch, _ = _git(tree, "rev-parse", "--abbrev-ref", "HEAD")
+    rc, branch, _ = _git(tree, "rev-parse", "--abbrev-ref", "HEAD", budget=budget)
     detached = rc != 0 or branch == "HEAD"
     identity["detached"] = detached
     identity["branch"] = None if detached else branch
 
-    rc, porcelain, err = _git(tree, "status", "--porcelain")
+    rc, porcelain, err = _git(tree, "status", "--porcelain", budget=budget)
     if rc != 0:
         return {"status": "unknown", "detail": f"could not read working tree: {err}"}
     identity["dirty"] = bool(porcelain)
 
-    ref, source, why = _comparison_ref(tree)
+    ref, source, why, asked = _comparison_ref(tree, budget)
+    if not asked:
+        return {
+            "status": "unknown",
+            "detail": f"could not establish a comparison ref: {why}",
+            "commit": commit,
+        }
     identity["comparison_ref"] = ref
     identity["comparison_ref_source"] = source
+    if source in _REF_CAVEATS:
+        identity["comparison_ref_caveat"] = _REF_CAVEATS[source]
     if ref is None:
         identity["ahead"] = None
         identity["behind"] = None
         identity["comparison_detail"] = why
         return identity
 
-    rc, counts, err = _git(tree, "rev-list", "--left-right", "--count", f"HEAD...{ref}")
+    rc, counts, err = _git(
+        tree, "rev-list", "--left-right", "--count", f"HEAD...{ref}", budget=budget
+    )
     if rc != 0:
         return {
             "status": "unknown",
@@ -126,6 +226,80 @@ def git_identity(tree: Path) -> dict[str, Any]:
             "commit": commit,
         }
     return identity
+
+
+def loaded_package_path() -> str | None:
+    """The directory this process actually imported ``lionagi`` from."""
+    import lionagi
+
+    module_file = getattr(lionagi, "__file__", None)
+    return str(Path(module_file).resolve().parent) if module_file else None
+
+
+# The position of the tree this process loaded from, read once and kept. `None`
+# until something asks for it; a process that wants an honest answer later takes
+# it at startup, before anything can move the tree underneath it.
+_SNAPSHOT: dict[str, Any] | None = None
+
+
+def snapshot_git_position(budget: _Budget | None = None) -> dict[str, Any]:
+    """Read the loaded tree's git position once and keep it for every later call.
+
+    Call this as early in the process as possible. The module objects this
+    process holds were fixed at import; the tree they came from is a directory
+    anyone can move afterwards. Capturing the position at startup is what makes a
+    later divergence visible as a divergence rather than silently replacing the
+    answer with a commit that was never loaded.
+    """
+    global _SNAPSHOT
+    if _SNAPSHOT is None:
+        _SNAPSHOT = _read_loaded_tree(budget or _Budget(IDENTITY_BUDGET_SECONDS))
+    return _SNAPSHOT
+
+
+def _read_loaded_tree(budget: _Budget) -> dict[str, Any]:
+    try:
+        package_path = loaded_package_path()
+        if package_path is None:
+            return {
+                "status": "unknown",
+                "detail": "the loaded lionagi package has no __file__",
+                "observed_at": _now(),
+            }
+        return git_identity(Path(package_path), budget)
+    except Exception as exc:  # noqa: BLE001 — startup must not fail on an unreadable tree
+        return {
+            "status": "unknown",
+            "detail": f"could not read the loaded tree: {type(exc).__name__}: {exc}",
+            "observed_at": _now(),
+        }
+
+
+def _checkout_movement(
+    snapshot: dict[str, Any], live: dict[str, Any]
+) -> tuple[bool | None, str | None]:
+    """Whether the tree this process loaded from has moved since it loaded.
+
+    ``True`` and ``False`` are answers; ``None`` means the comparison could not be
+    made, which is not the same as the checkout having stayed put.
+    """
+    if live is snapshot:
+        return False, None
+    if snapshot.get("status") != "ok":
+        return None, (
+            "the position this process started from was never established: "
+            f"{snapshot.get('detail', 'no detail')}"
+        )
+    if live.get("status") != "ok":
+        return None, (f"the tree's position cannot be read now: {live.get('detail', 'no detail')}")
+    if snapshot.get("commit") != live.get("commit"):
+        return True, (
+            f"the checkout at {snapshot.get('toplevel')} moved from "
+            f"{snapshot.get('commit_short')} to {live.get('commit_short')} after this "
+            "process loaded its code — the code answering here is the earlier commit, "
+            "and reading that tree now describes something this process never imported"
+        )
+    return False, None
 
 
 def _distribution_version() -> tuple[str | None, str | None]:
@@ -152,7 +326,18 @@ def _drift(
     git: dict[str, Any],
     version: str,
     distribution_version: str | None,
+    *,
+    live: dict[str, Any] | None = None,
+    moved: bool | None = False,
+    movement_detail: str | None = None,
 ) -> dict[str, Any]:
+    """The verdict on *git*, the position of the code this process actually loaded.
+
+    When the checkout has not moved, the live reading measures that same commit
+    against a fresher view of the remote, so it is the better source for how far
+    behind the loaded code is. When it has moved, the live reading is about some
+    other commit and only the snapshot speaks for what is running.
+    """
     reasons: list[str] = []
     unknowns: list[str] = []
 
@@ -163,20 +348,30 @@ def _drift(
             "serving the installed build"
         )
 
-    status = git.get("status")
+    if moved is True and movement_detail:
+        reasons.append(movement_detail)
+    elif moved is None and movement_detail:
+        unknowns.append(movement_detail)
+
+    position = git
+    if moved is False and live is not None and live.get("status") == "ok":
+        position = live
+
+    status = position.get("status")
     if status == "unknown":
-        unknowns.append(f"git state unreadable: {git.get('detail', 'no detail')}")
+        unknowns.append(f"git state unreadable: {position.get('detail', 'no detail')}")
     elif status == "ok":
-        behind = git.get("behind")
+        behind = position.get("behind")
         if behind is None:
             unknowns.append(
                 "nothing to compare this checkout against: "
-                f"{git.get('comparison_detail', 'no comparison ref')}"
+                f"{position.get('comparison_detail', 'no comparison ref')}"
             )
+
         elif behind > 0:
             reasons.append(
                 f"the loaded checkout is {behind} commit(s) behind "
-                f"{git['comparison_ref']} — it is serving code older than that ref"
+                f"{position['comparison_ref']} — it is serving code older than that ref"
             )
 
     if reasons:
@@ -190,19 +385,24 @@ def code_identity() -> dict[str, Any]:
     """The running process's own code identity, drift verdict included.
 
     Everything here describes the module objects this process actually imported,
-    never the environment that was supposed to supply them.
+    never the environment that was supposed to supply them. ``git`` is the
+    position captured when this process first looked, which is what it loaded;
+    ``git_live`` is the tree as it stands now. On the call that takes the
+    snapshot the two are one reading and are reported as such.
     """
-    import lionagi
     from lionagi.version import __version__
 
-    module_file = getattr(lionagi, "__file__", None)
-    package_path = str(Path(module_file).resolve().parent) if module_file else None
+    budget = _Budget(IDENTITY_BUDGET_SECONDS)
+    package_path = loaded_package_path()
 
-    git = (
-        git_identity(Path(package_path))
-        if package_path
-        else {"status": "unknown", "detail": "the loaded lionagi package has no __file__"}
-    )
+    already_snapshotted = _SNAPSHOT is not None
+    snapshot = snapshot_git_position(budget)
+    if already_snapshotted and package_path is not None:
+        live = git_identity(Path(package_path), budget)
+    else:
+        live = snapshot
+
+    moved, movement_detail = _checkout_movement(snapshot, live)
     distribution_version, distribution_detail = _distribution_version()
     verb_count, verb_detail = _verb_count()
 
@@ -211,9 +411,21 @@ def code_identity() -> dict[str, Any]:
         "package_path": package_path,
         "distribution_version": distribution_version,
         "verb_count": verb_count,
-        "git": git,
-        "drift": _drift(git, __version__, distribution_version),
+        "git": snapshot,
+        "git_snapshot_taken_at": snapshot.get("observed_at"),
+        "git_live": live,
+        "checkout_moved": moved,
+        "drift": _drift(
+            snapshot,
+            __version__,
+            distribution_version,
+            live=live,
+            moved=moved,
+            movement_detail=movement_detail,
+        ),
     }
+    if movement_detail is not None:
+        identity["checkout_moved_detail"] = movement_detail
     if distribution_detail is not None:
         identity["distribution_detail"] = distribution_detail
     if verb_detail is not None:

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -245,10 +245,20 @@ def _worktree_fingerprint(
 
     The inode is in the mark so that replacing a file by renaming another over it
     stays visible even when the replacement matches on every other field. The cost
-    is that a filesystem which does not hold inode numbers stable across stats
-    would read as an edit that did not happen; the digest is only ever compared
-    within one process against one tree, which is the narrow condition that makes
-    that safe to rely on.
+    is real and is not bounded by anything this module controls: on a filesystem
+    that hands back a fresh synthetic inode for an unchanged path, which some
+    network and userspace filesystems do, two readings of a tree nobody touched
+    disagree, and the answer is an edit that did not happen. Staying inside one
+    process and one tree does not constrain that, because it says nothing about
+    what the filesystem returns from two separate stats.
+
+    That direction of error is the deliberate one. This surface exists so an
+    operator asking "is the code I am running the code I think I am running"
+    cannot be told a reassuring falsehood, and between an edit reported that did
+    not happen and an edit missed that did, only the second defeats the purpose.
+    An operator who looks and finds nothing has lost a minute; one who was told
+    nothing moved is left with the exact wrong belief this module was written to
+    prevent.
     """
     digest = hashlib.sha256(porcelain.encode(errors="replace"))
     if porcelain:

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""What code is actually running, as a value a caller with no shell can read.
+
+A long-lived process loads its code once, at startup. A commit landing on disk
+does not change it, and a restart command that exits 0 says nothing about which
+tree the new process imported. So the running process reports its own identity —
+version, the resolved path it imported itself from, that tree's git position,
+and how many verbs it registered — and every answer is derived here, in one
+place, so the handshake and the server's own info cannot disagree.
+
+Failure is closed: a tree whose git state cannot be read is ``unknown``, never
+``ok``. "Cannot tell" and "nothing wrong" are different answers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+__all__ = (
+    "code_identity",
+    "git_identity",
+    "GIT_TIMEOUT_SECONDS",
+)
+
+# Bounded because this runs inside a handshake a client is waiting on, and a git
+# call against an unhealthy tree (a stale index lock, a dead network remote) can
+# otherwise hang the answer instead of failing it.
+GIT_TIMEOUT_SECONDS = 5.0
+
+_SHORT_SHA = 12
+
+
+def _git(tree: Path, *argv: str) -> tuple[int, str, str]:
+    """Run one git command against *tree*; returns (rc, stdout, stderr), stripped.
+
+    An rc of -1 means git itself could not be run, which is a different fact
+    from git running and refusing.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["git", "-C", str(tree), *argv],  # noqa: S607 — resolved from PATH by design
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return -1, "", f"{type(exc).__name__}: {exc}"
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def _comparison_ref(tree: Path) -> tuple[str | None, str, str | None]:
+    """The ref this checkout should be measured against, and where it came from.
+
+    The configured upstream is preferred. A detached checkout has none — which is
+    exactly the state a pinned deployment sits in — so the remote's default
+    branch is the fallback, because "behind the branch this remote publishes" is
+    the question a detached tree still has an answer to.
+    """
+    rc, out, _ = _git(tree, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+    if rc == 0 and out:
+        return out, "upstream", None
+
+    rc, out, err = _git(tree, "rev-parse", "--abbrev-ref", "origin/HEAD")
+    if rc == 0 and out:
+        return out, "remote_head", None
+    return None, "none", err or "no upstream configured and origin/HEAD does not resolve"
+
+
+def git_identity(tree: Path) -> dict[str, Any]:
+    """Where *tree* sits in git history, or why that could not be established."""
+    rc, top, err = _git(tree, "rev-parse", "--show-toplevel")
+    if rc != 0:
+        if "not a git repository" in err.lower():
+            return {
+                "status": "not_a_git_checkout",
+                "detail": f"{tree} is not inside a git checkout",
+            }
+        return {"status": "unknown", "detail": f"git rev-parse failed: {err or 'no output'}"}
+
+    identity: dict[str, Any] = {"status": "ok", "toplevel": top}
+
+    rc, commit, err = _git(tree, "rev-parse", "HEAD")
+    if rc != 0 or not commit:
+        return {"status": "unknown", "detail": f"could not read HEAD: {err or 'no output'}"}
+    identity["commit"] = commit
+    identity["commit_short"] = commit[:_SHORT_SHA]
+
+    rc, branch, _ = _git(tree, "rev-parse", "--abbrev-ref", "HEAD")
+    detached = rc != 0 or branch == "HEAD"
+    identity["detached"] = detached
+    identity["branch"] = None if detached else branch
+
+    rc, porcelain, err = _git(tree, "status", "--porcelain")
+    if rc != 0:
+        return {"status": "unknown", "detail": f"could not read working tree: {err}"}
+    identity["dirty"] = bool(porcelain)
+
+    ref, source, why = _comparison_ref(tree)
+    identity["comparison_ref"] = ref
+    identity["comparison_ref_source"] = source
+    if ref is None:
+        identity["ahead"] = None
+        identity["behind"] = None
+        identity["comparison_detail"] = why
+        return identity
+
+    rc, counts, err = _git(tree, "rev-list", "--left-right", "--count", f"HEAD...{ref}")
+    if rc != 0:
+        return {
+            "status": "unknown",
+            "detail": f"could not compare HEAD against {ref}: {err or 'no output'}",
+            "commit": commit,
+        }
+    try:
+        ahead_text, behind_text = counts.split()
+        identity["ahead"] = int(ahead_text)
+        identity["behind"] = int(behind_text)
+    except ValueError:
+        return {
+            "status": "unknown",
+            "detail": f"unreadable rev-list output comparing HEAD against {ref}: {counts!r}",
+            "commit": commit,
+        }
+    return identity
+
+
+def _distribution_version() -> tuple[str | None, str | None]:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as dist_version
+
+    try:
+        return dist_version("lionagi"), None
+    except PackageNotFoundError:
+        return None, "no installed lionagi distribution metadata (running from source?)"
+    except Exception as exc:  # noqa: BLE001 — metadata readers raise broadly
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _verb_count() -> tuple[int | None, str | None]:
+    try:
+        from lionagi.mcp.verbs import VERBS
+    except Exception as exc:  # noqa: BLE001 — a broken verb table must not break the handshake
+        return None, f"could not import the verb table: {type(exc).__name__}: {exc}"
+    return len(VERBS), None
+
+
+def _drift(
+    git: dict[str, Any],
+    version: str,
+    distribution_version: str | None,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    unknowns: list[str] = []
+
+    if distribution_version is not None and distribution_version != version:
+        reasons.append(
+            f"the loaded package reports version {version} but the installed "
+            f"distribution declares {distribution_version} — the import path is not "
+            "serving the installed build"
+        )
+
+    status = git.get("status")
+    if status == "unknown":
+        unknowns.append(f"git state unreadable: {git.get('detail', 'no detail')}")
+    elif status == "ok":
+        behind = git.get("behind")
+        if behind is None:
+            unknowns.append(
+                "nothing to compare this checkout against: "
+                f"{git.get('comparison_detail', 'no comparison ref')}"
+            )
+        elif behind > 0:
+            reasons.append(
+                f"the loaded checkout is {behind} commit(s) behind "
+                f"{git['comparison_ref']} — it is serving code older than that ref"
+            )
+
+    if reasons:
+        return {"status": "drift", "reasons": reasons, "unknown": unknowns}
+    if unknowns:
+        return {"status": "unknown", "reasons": [], "unknown": unknowns}
+    return {"status": "ok", "reasons": [], "unknown": []}
+
+
+def code_identity() -> dict[str, Any]:
+    """The running process's own code identity, drift verdict included.
+
+    Everything here describes the module objects this process actually imported,
+    never the environment that was supposed to supply them.
+    """
+    import lionagi
+    from lionagi.version import __version__
+
+    module_file = getattr(lionagi, "__file__", None)
+    package_path = str(Path(module_file).resolve().parent) if module_file else None
+
+    git = (
+        git_identity(Path(package_path))
+        if package_path
+        else {"status": "unknown", "detail": "the loaded lionagi package has no __file__"}
+    )
+    distribution_version, distribution_detail = _distribution_version()
+    verb_count, verb_detail = _verb_count()
+
+    identity: dict[str, Any] = {
+        "version": __version__,
+        "package_path": package_path,
+        "distribution_version": distribution_version,
+        "verb_count": verb_count,
+        "git": git,
+        "drift": _drift(git, __version__, distribution_version),
+    }
+    if distribution_detail is not None:
+        identity["distribution_detail"] = distribution_detail
+    if verb_detail is not None:
+        identity["verb_count_detail"] = verb_detail
+    return identity

--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -177,6 +177,11 @@ def _check_code_identity() -> dict[str, str]:
         else:
             position += " (detached)"
         where += f", git {position}"
+        # The position is the one read when this process started, not the tree's
+        # position now, so it is quoted with the time it was true of.
+        taken_at = identity.get("git_snapshot_taken_at")
+        if taken_at:
+            where += f" as read at {taken_at}"
     elif git["status"] == "not_a_git_checkout":
         where += ", not a git checkout"
 

--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -176,6 +176,9 @@ def _check_code_identity() -> dict[str, str]:
             position += f" on {git['branch']}"
         else:
             position += " (detached)"
+        if git.get("dirty"):
+            # A commit id next to a dirty tree reads as the whole story; it isn't.
+            position += " with uncommitted changes"
         where += f", git {position}"
         # The position is the one read when this process started, not the tree's
         # position now, so it is quoted with the time it was true of.

--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -40,7 +40,12 @@ _CORE_DEPS: dict[str, str] = {
 
 _STUDIO_HEALTH_URL_DEFAULT = "http://127.0.0.1:8765/api/admin/health"
 
-_SYMBOLS = {"ok": "✓", "warn": "!", "fail": "✗"}
+_SYMBOLS = {"ok": "✓", "warn": "!", "fail": "✗", "unknown": "?"}
+
+# Statuses that must not be read as a passing check. `unknown` is here because a
+# check that could not be run has established nothing, and reporting it as a pass
+# is the failure mode this file exists to prevent.
+_NOT_PASSING = ("fail", "unknown")
 
 
 def _result(status: str, detail: str) -> dict[str, str]:
@@ -144,10 +149,50 @@ def _check_lionagi_home(home: Path | None = None) -> dict[str, str]:
     return _result("ok", f"{home} writable (runs/ dir ok)")
 
 
+def _check_code_identity() -> dict[str, str]:
+    """Fail when the code that answered is not the code the environment implies.
+
+    An install can be healthy in every other respect and still be serving a tree
+    that stopped tracking its upstream commits ago — the process loaded that tree
+    once, at startup, and nothing since has told anyone. This is the check that
+    tells them.
+    """
+    from ._code_identity import code_identity
+
+    try:
+        identity = code_identity()
+    except Exception as exc:  # noqa: BLE001 — an unanswerable check is unknown, not ok
+        return _result("unknown", f"could not establish code identity: {type(exc).__name__}: {exc}")
+
+    version = identity["version"]
+    path = identity["package_path"]
+    verbs = identity["verb_count"]
+    where = f"lionagi {version} at {path}, {verbs} verbs registered"
+
+    git = identity["git"]
+    if git["status"] == "ok":
+        position = git["commit_short"]
+        if git["branch"]:
+            position += f" on {git['branch']}"
+        else:
+            position += " (detached)"
+        where += f", git {position}"
+    elif git["status"] == "not_a_git_checkout":
+        where += ", not a git checkout"
+
+    drift = identity["drift"]
+    if drift["status"] == "drift":
+        return _result("fail", f"{where} — " + "; ".join(drift["reasons"]))
+    if drift["status"] == "unknown":
+        return _result("unknown", f"{where} — " + "; ".join(drift["unknown"]))
+    return _result("ok", where)
+
+
 def collect_checks() -> dict[str, dict[str, str]]:
     """Run every check and return a flat name -> {status, detail} mapping."""
     checks: dict[str, dict[str, str]] = {}
     checks["lionagi_version"] = _check_version()
+    checks["code_identity"] = _check_code_identity()
     checks["python"] = _check_python()
     for mod, result in _check_imports().items():
         checks[f"import:{mod}"] = result
@@ -184,6 +229,6 @@ def run_doctor(args: argparse.Namespace) -> int:
         for name, result in checks.items():
             symbol = _SYMBOLS.get(result["status"], "?")
             print(f"{symbol} {name}: {result['detail']}")
-    if any(result["status"] == "fail" for result in checks.values()):
+    if any(result["status"] in _NOT_PASSING for result in checks.values()):
         return 1
     return 0

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -433,12 +433,17 @@ def reserve_stdout() -> Iterator[MachineChannel]:
 def handshake_data() -> dict[str, Any]:
     from lionagi.version import __version__
 
+    from ._code_identity import code_identity
+
     return {
         "contract_version": CONTRACT_VERSION,
         "min_supported_version": MIN_SUPPORTED_CONTRACT_VERSION,
         "implementation": "lionagi",
         "implementation_version": __version__,
         "module": str(Path(__file__).resolve().parent),
+        # Which build answered, not which build was installed: a caller with no
+        # shell on this host has no other way to tell the two apart.
+        "code_identity": code_identity(),
     }
 
 
@@ -449,6 +454,10 @@ def doctor_data() -> dict[str, Any]:
     return {
         "checks": checks,
         "failed": sorted(name for name, result in checks.items() if result["status"] == "fail"),
+        # Reported apart from `failed` because a check that could not be run is
+        # not a check that passed, and a caller that only reads `failed` would
+        # otherwise treat the two the same.
+        "unknown": sorted(name for name, result in checks.items() if result["status"] == "unknown"),
     }
 
 

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -468,12 +468,17 @@ def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict
 
 
 def _server_info() -> dict[str, Any]:
+    from lionagi.cli._code_identity import code_identity
     from lionagi.cli.machine import CONTRACT_VERSION
     from lionagi.version import __version__
 
     return {
         "lionagi_version": __version__,
         "contract_version": CONTRACT_VERSION,
+        # The verb count below is this process's registration; `code_identity`
+        # says which tree that registration was read from and whether that tree
+        # is behind what it should be serving.
+        "code_identity": code_identity(),
         "started_at": _STARTED_AT,
         "uptime_seconds": round(time.time() - _STARTED_MONOTONIC, 3),
         "tool_count": 1,

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -80,6 +80,13 @@ async def request(
 
 def main() -> None:
     """Console entrypoint: run the server over stdio."""
+    from lionagi.cli._code_identity import snapshot_git_position
+
+    # Read where this server's code came from before serving anything. The
+    # process keeps the modules it imported for its whole life, so a checkout
+    # that moves later is divergence to report, not a new answer to give — and
+    # only a reading taken now can tell the two apart.
+    snapshot_git_position()
     mcp.run()
 
 

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -125,6 +125,51 @@ def test_missing_git_binary_is_unknown_not_a_missing_checkout(
     assert "FileNotFoundError" in git["detail"]
 
 
+def test_a_git_call_that_never_ran_does_not_read_as_a_missing_upstream(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lookup that could not run is not evidence the tree has no upstream.
+
+    origin/HEAD resolves here, so falling through to it would produce a confident
+    `ok` built on a question that was never actually asked.
+    """
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    real_run = subprocess.run
+
+    def _upstream_probe_times_out(argv: list[str], **kwargs: object):
+        if "@{upstream}" in argv:
+            raise subprocess.TimeoutExpired(argv, 5.0)
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _upstream_probe_times_out)
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "unknown"
+    assert "TimeoutExpired" in git["detail"]
+    assert git.get("comparison_ref_source") != "remote_head"
+
+
+def test_a_spent_allowance_is_unknown_not_ok(checkout_behind: Path) -> None:
+    """The whole identity gets one allowance; running out of it is not a pass."""
+    git = git_identity(checkout_behind, _code_identity._Budget(0.0))
+    assert git["status"] == "unknown"
+    assert "allowance" in git["detail"]
+
+
+def test_the_remote_head_fallback_carries_its_own_staleness(checkout_behind: Path) -> None:
+    """origin/HEAD is local and can name a branch the remote no longer defaults to."""
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    _git(checkout_behind, "checkout", "--detach", "HEAD")
+
+    git = git_identity(checkout_behind)
+    assert git["comparison_ref_source"] == "remote_head"
+    assert "local symbolic ref" in git["comparison_ref_caveat"]
+
+
+def test_a_reading_says_when_it_was_taken(checkout_behind: Path) -> None:
+    assert git_identity(checkout_behind)["observed_at"]
+
+
 def test_no_comparison_ref_is_unknown_not_ok(tmp_path: Path) -> None:
     """A checkout with no remote cannot be measured, so it is not declared current."""
     _git(tmp_path, "init", "-b", "main", ".")
@@ -162,6 +207,99 @@ def test_behind_outranks_unknown_in_the_verdict() -> None:
     assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
 
 
+# ── the snapshot, and the tree moving underneath it ──────────────────────────
+
+
+@pytest.fixture
+def loaded_from(checkout_behind: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pretend this process imported itself from *checkout_behind*, snapshot unset."""
+    monkeypatch.setattr(_code_identity, "_SNAPSHOT", None)
+    monkeypatch.setattr(_code_identity, "loaded_package_path", lambda: str(checkout_behind))
+    return checkout_behind
+
+
+def test_the_first_call_takes_the_snapshot_and_it_is_the_current_reading(
+    loaded_from: Path,
+) -> None:
+    identity = code_identity()
+    assert identity["git_snapshot_taken_at"]
+    assert identity["checkout_moved"] is False
+    assert identity["git"]["commit"] == identity["git_live"]["commit"]
+
+
+def test_a_checkout_that_moves_under_the_process_is_reported_as_moved(
+    loaded_from: Path,
+) -> None:
+    """The loaded code is the snapshot; the tree's new position is a separate fact."""
+    loaded_commit = code_identity()["git"]["commit"]
+
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+
+    after = code_identity()
+    assert after["git"]["commit"] == loaded_commit
+    assert after["git_live"]["commit"] != loaded_commit
+    assert after["checkout_moved"] is True
+    assert "moved from" in after["checkout_moved_detail"]
+    assert after["drift"]["status"] == "drift"
+    assert any("moved from" in reason for reason in after["drift"]["reasons"])
+
+
+def test_the_snapshot_is_read_once_not_once_per_call(loaded_from: Path) -> None:
+    first = code_identity()["git_snapshot_taken_at"]
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+    assert code_identity()["git_snapshot_taken_at"] == first
+
+
+def test_the_server_snapshots_its_position_before_it_starts_serving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.mcp import server
+
+    monkeypatch.setattr(_code_identity, "_SNAPSHOT", None)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(server.mcp, "run", lambda: seen.update(snapshot=_code_identity._SNAPSHOT))
+
+    server.main()
+    assert seen["snapshot"] is not None
+
+
+def test_an_unreadable_live_position_is_unknown_movement_not_no_movement() -> None:
+    moved, detail = _code_identity._checkout_movement(
+        {"status": "ok", "commit": "a" * 40},
+        {"status": "unknown", "detail": "git went away"},
+    )
+    assert moved is None
+    assert "cannot be read" in detail
+
+
+def test_the_live_count_answers_when_the_checkout_has_not_moved() -> None:
+    """Same commit, fresher view of the remote: the newer measurement is the true one."""
+    drift = _code_identity._drift(
+        {"status": "ok", "behind": 0, "comparison_ref": "origin/main"},
+        "0.1.0",
+        None,
+        live={"status": "ok", "behind": 3, "comparison_ref": "origin/main"},
+        moved=False,
+    )
+    assert drift["status"] == "drift"
+    assert any("3 commit(s) behind" in reason for reason in drift["reasons"])
+
+
+def test_the_snapshot_answers_when_the_checkout_has_moved() -> None:
+    """Once the tree moves, the live count is about a commit that is not running."""
+    drift = _code_identity._drift(
+        {"status": "ok", "behind": 24, "comparison_ref": "origin/main"},
+        "0.1.0",
+        None,
+        live={"status": "ok", "behind": 0, "comparison_ref": "origin/main"},
+        moved=True,
+        movement_detail="it moved",
+    )
+    assert drift["status"] == "drift"
+    assert "it moved" in drift["reasons"]
+    assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
+
+
 def test_code_identity_reports_this_process() -> None:
     identity = code_identity()
     assert identity["version"]
@@ -170,6 +308,9 @@ def test_code_identity_reports_this_process() -> None:
     assert identity["verb_count"] > 0
     assert identity["git"]["status"] in ("ok", "not_a_git_checkout", "unknown")
     assert identity["drift"]["status"] in ("ok", "drift", "unknown")
+    assert identity["git_snapshot_taken_at"]
+    assert identity["checkout_moved"] in (True, False, None)
+    assert identity["git_live"]["status"] in ("ok", "not_a_git_checkout", "unknown")
 
 
 # ── the doctor check ─────────────────────────────────────────────────────────
@@ -217,6 +358,17 @@ def test_doctor_ok_when_identity_is_clean(monkeypatch: pytest.MonkeyPatch) -> No
     result = doctor._check_code_identity()
     assert result["status"] == "ok"
     assert "abc123def456 (detached)" in result["detail"]
+
+
+def test_doctor_quotes_when_the_position_was_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A commit with no time attached reads as current; this one says what it is."""
+    monkeypatch.setattr(
+        _code_identity,
+        "code_identity",
+        lambda: _identity("ok", git_snapshot_taken_at="2026-07-26T00:00:00+00:00"),
+    )
+    detail = doctor._check_code_identity()["detail"]
+    assert "as read at 2026-07-26T00:00:00+00:00" in detail
 
 
 def test_doctor_check_that_cannot_run_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -514,6 +514,108 @@ def test_a_renamed_path_does_not_stat_the_name_it_came_from(checkout_behind: Pat
     assert "worktree_fingerprint_detail" not in git
 
 
+def test_a_permission_change_on_an_untracked_file_is_an_edit(loaded_from: Path) -> None:
+    """chmod rewrites no bytes, so nothing but the mode moves — and it still counts.
+
+    Making a file executable changes what an operator can run out of the tree
+    while leaving the size, the modification time and the status listing exactly
+    as they were.
+    """
+    scratch = loaded_from / "scratch.txt"
+    scratch.write_text("plain")
+    scratch.chmod(0o644)
+    was = scratch.lstat()
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    scratch.chmod(0o755)
+
+    now = scratch.lstat()
+    assert (now.st_size, now.st_mtime_ns) == (was.st_size, was.st_mtime_ns), (
+        "the premise of this test is that size and mtime cannot see a chmod"
+    )
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+
+
+class _SpentAfter:
+    """A budget generous for a fixed number of readings, then exhausted.
+
+    Deterministic where a wall-clock deadline is not: exhaustion lands on a chosen
+    iteration of the per-path loop rather than wherever the machine happens to be
+    slow that day.
+    """
+
+    total = 6.0
+
+    def __init__(self, readings: int) -> None:
+        self._left = readings
+
+    def remaining(self) -> float:
+        if self._left > 0:
+            self._left -= 1
+            return self.total
+        return -1.0
+
+
+def test_an_allowance_spent_inside_the_per_path_loop_yields_no_digest(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The loop is inside the allowance, and running out of it is not a partial answer.
+
+    A digest over some of the paths compares unequal to one over all of them, so a
+    loop that stopped at the deadline and returned what it had would report an
+    edit to a tree nobody touched. This pins the difference that truncation would
+    manufacture, then shows the code declines to manufacture it.
+    """
+    for name in ("one.txt", "two.txt", "three.txt"):
+        (checkout_behind / name).write_text(name)
+
+    top = Path(_git(checkout_behind, "rev-parse", "--show-toplevel"))
+    porcelain = _git(checkout_behind, "status", "--porcelain", "-z", "--untracked-files=all")
+    paths = _code_identity._status_paths(porcelain)
+    assert len(paths) == 3
+
+    full, detail = _code_identity._worktree_fingerprint(
+        checkout_behind, top, porcelain, _code_identity._Budget(60.0)
+    )
+    assert detail is None
+    assert full
+
+    with monkeypatch.context() as stop_after_one:
+        stop_after_one.setattr(_code_identity, "_status_paths", lambda _: paths[:1])
+        truncated, _ = _code_identity._worktree_fingerprint(
+            checkout_behind, top, porcelain, _code_identity._Budget(60.0)
+        )
+    assert truncated != full, "truncation invents a difference in a tree that did not change"
+
+    spent, reason = _code_identity._worktree_fingerprint(
+        checkout_behind, top, porcelain, _SpentAfter(2)
+    )
+    assert spent is None, "a spent allowance must not return the digest built so far"
+    assert spent != truncated
+    assert "allowance" in reason
+    assert f"measuring 1 of the {len(paths)} paths" in reason
+
+    edited, movement = _code_identity._worktree_movement(
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": full},
+        {
+            "status": "ok",
+            "commit": "a" * 40,
+            "worktree_fingerprint": spent,
+            "worktree_fingerprint_detail": reason,
+        },
+        False,
+    )
+    assert edited is None, "a timeout is 'cannot tell', never 'the tree was edited'"
+    assert "allowance" in movement
+
+
 def test_a_dirty_snapshot_is_unknown_not_ok() -> None:
     """A commit id cannot describe a tree with changes that are not in it."""
     git = {

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -300,6 +300,146 @@ def test_the_snapshot_answers_when_the_checkout_has_moved() -> None:
     assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
 
 
+# ── the tree moving without the commit moving ────────────────────────────────
+
+
+def test_a_dirty_tree_is_fingerprinted_and_a_clean_one_is_too(checkout_behind: Path) -> None:
+    """The digest is a value on every readable tree, so it can always be compared."""
+    clean = git_identity(checkout_behind)["worktree_fingerprint"]
+    assert clean
+
+    (checkout_behind / "first").write_text("edited")
+    dirty = git_identity(checkout_behind)["worktree_fingerprint"]
+    assert dirty
+    assert dirty != clean
+
+
+def test_editing_an_already_modified_file_changes_the_fingerprint(
+    checkout_behind: Path,
+) -> None:
+    """The status listing alone would not move here — the path and its code are the same."""
+    (checkout_behind / "first").write_text("one")
+    before = git_identity(checkout_behind)
+    (checkout_behind / "first").write_text("two")
+    after = git_identity(checkout_behind)
+
+    assert before["dirty"] is True
+    assert after["dirty"] is True
+    assert before["worktree_fingerprint"] != after["worktree_fingerprint"]
+
+
+def test_a_fingerprint_that_could_not_be_taken_is_none_with_a_reason(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (checkout_behind / "first").write_text("edited")
+    real_run = subprocess.run
+
+    def _diff_fails(argv: list[str], **kwargs: object):
+        if argv[3:5] == ["diff", "HEAD"]:
+            raise subprocess.TimeoutExpired(argv, 5.0)
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _diff_fails)
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is None
+    assert "TimeoutExpired" in git["worktree_fingerprint_detail"]
+
+
+def test_an_edit_under_the_process_is_reported_though_the_commit_never_moved(
+    loaded_from: Path,
+) -> None:
+    """The case that used to read as a clean `ok`: same commit, different files."""
+    before = code_identity()
+    assert before["worktree_edited"] is False
+
+    (loaded_from / "first").write_text("edited under the running process")
+
+    after = code_identity()
+    assert after["git"]["commit"] == after["git_live"]["commit"]
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+    assert after["drift"]["status"] == "drift"
+    assert any("was edited after this process loaded" in r for r in after["drift"]["reasons"])
+
+
+def test_the_two_kinds_of_movement_are_reported_separately(loaded_from: Path) -> None:
+    """Moving the checkout is one operator action; editing files is another."""
+    code_identity()
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+
+    after = code_identity()
+    assert after["checkout_moved"] is True
+    assert after["worktree_edited"] is None, "not comparable across a commit change"
+    assert "different commits" in after["worktree_edited_detail"]
+    assert any("different commits" in u for u in after["drift"]["unknown"])
+
+
+def test_a_missing_fingerprint_is_unknown_movement_not_a_still_tree() -> None:
+    edited, detail = _code_identity._worktree_movement(
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": None},
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": "beef"},
+        False,
+    )
+    assert edited is None
+    assert "when this process loaded" in detail
+
+
+def test_a_dirty_snapshot_is_unknown_not_ok() -> None:
+    """A commit id cannot describe a tree with changes that are not in it."""
+    git = {
+        "status": "ok",
+        "behind": 0,
+        "comparison_ref": "origin/main",
+        "commit_short": "abc123def456",
+        "dirty": True,
+    }
+    drift = _code_identity._drift(git, "0.1.0", "0.1.0")
+    assert drift["status"] == "unknown"
+    assert any("uncommitted changes" in u for u in drift["unknown"])
+
+
+def test_a_clean_snapshot_at_its_ref_is_still_ok() -> None:
+    """The dirty rule must not swallow the one state that is genuinely fine."""
+    git = {"status": "ok", "behind": 0, "comparison_ref": "origin/main", "dirty": False}
+    assert _code_identity._drift(git, "0.1.0", "0.1.0")["status"] == "ok"
+
+
+def test_a_dirty_tree_read_end_to_end_does_not_claim_ok(loaded_from: Path) -> None:
+    """Before anything moves at all: dirty at snapshot time is already not `ok`."""
+    (loaded_from / "first").write_text("uncommitted when the process started")
+
+    identity = code_identity()
+    assert identity["git"]["dirty"] is True
+    assert identity["checkout_moved"] is False
+    assert identity["drift"]["status"] != "ok"
+    assert any("uncommitted changes" in u for u in identity["drift"]["unknown"])
+
+
+def test_doctor_says_the_tree_was_dirty_beside_the_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _code_identity,
+        "code_identity",
+        lambda: _identity(
+            "unknown",
+            git={
+                "status": "ok",
+                "commit_short": "abc123def456",
+                "branch": None,
+                "detached": True,
+                "dirty": True,
+            },
+        ),
+    )
+    assert (
+        "abc123def456 (detached) with uncommitted changes"
+        in (doctor._check_code_identity()["detail"])
+    )
+
+
 def test_code_identity_reports_this_process() -> None:
     identity = code_identity()
     assert identity["version"]

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -386,6 +386,134 @@ def test_a_missing_fingerprint_is_unknown_movement_not_a_still_tree() -> None:
     assert "when this process loaded" in detail
 
 
+def test_rewriting_an_untracked_file_that_already_existed_is_an_edit(
+    loaded_from: Path,
+) -> None:
+    """Neither the status listing nor the diff carries an untracked file's contents."""
+    scratch = loaded_from / "scratch.txt"
+    scratch.write_text("present before the process started")
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    scratch.write_text("rewritten while the process was running")
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+
+
+def test_an_edit_inside_an_untracked_directory_is_an_edit(loaded_from: Path) -> None:
+    """git collapses an untracked directory to one line; the listing alone cannot move."""
+    package = loaded_from / "plugins"
+    package.mkdir()
+    (package / "handler.py").write_text("def run(): return 1\n")
+
+    before = code_identity()
+    assert before["worktree_edited"] is False
+
+    (package / "handler.py").write_text("def run(): return 2\n")
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+
+
+def test_a_new_file_inside_an_untracked_directory_is_an_edit(loaded_from: Path) -> None:
+    package = loaded_from / "plugins"
+    package.mkdir()
+    (package / "handler.py").write_text("def run(): return 1\n")
+
+    assert code_identity()["worktree_edited"] is False
+
+    (package / "extra.py").write_text("def also(): return 3\n")
+
+    assert code_identity()["worktree_edited"] is True
+
+
+def test_an_ignored_path_is_not_enumerated(checkout_behind: Path) -> None:
+    """The listing stays bounded: build output and virtualenvs are still excluded."""
+    (checkout_behind / ".gitignore").write_text("build/\n")
+    _git(checkout_behind, "add", ".gitignore")
+    _git(checkout_behind, "commit", "-m", "ignore build")
+    build = checkout_behind / "build"
+    build.mkdir()
+    (build / "artifact.bin").write_bytes(b"\x00" * 32)
+
+    before = git_identity(checkout_behind)
+    assert before["dirty"] is False
+
+    (build / "artifact.bin").write_bytes(b"\x01" * 64)
+
+    assert git_identity(checkout_behind)["worktree_fingerprint"] == before["worktree_fingerprint"]
+
+
+def test_a_path_that_cannot_be_stat_d_is_none_with_a_reason(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable path is not evidence that the tree stood still."""
+    (checkout_behind / "scratch.txt").write_text("untracked")
+    real_lstat = Path.lstat
+
+    def _refuse(self: Path):
+        if self.name == "scratch.txt":
+            raise PermissionError(13, "Permission denied")
+        return real_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", _refuse)
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is None
+    assert "scratch.txt" in git["worktree_fingerprint_detail"]
+    assert "PermissionError" in git["worktree_fingerprint_detail"]
+
+
+def test_a_stat_failure_makes_the_edit_answer_unknown_not_false(
+    loaded_from: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (loaded_from / "scratch.txt").write_text("untracked")
+    code_identity()
+
+    real_lstat = Path.lstat
+
+    def _refuse(self: Path):
+        if self.name == "scratch.txt":
+            raise PermissionError(13, "Permission denied")
+        return real_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", _refuse)
+
+    after = code_identity()
+    assert after["worktree_edited"] is None
+    assert "scratch.txt" in after["worktree_edited_detail"]
+    assert any("scratch.txt" in u for u in after["drift"]["unknown"])
+
+
+def test_a_deleted_path_is_measured_rather_than_read_as_unreadable(
+    loaded_from: Path,
+) -> None:
+    """A path git lists as deleted is absent by definition — absence is the reading."""
+    (loaded_from / "first").unlink()
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    after = code_identity()
+    assert after["worktree_edited"] is False, "an absent path must not read as unknown"
+
+
+def test_a_renamed_path_does_not_stat_the_name_it_came_from(checkout_behind: Path) -> None:
+    """The origin path of a rename no longer exists; only the destination is on disk."""
+    _git(checkout_behind, "mv", "first", "renamed")
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is not None
+    assert "worktree_fingerprint_detail" not in git
+
+
 def test_a_dirty_snapshot_is_unknown_not_ok() -> None:
     """A commit id cannot describe a tree with changes that are not in it."""
     git = {

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The running code's self-report, and the checks that call it out when it drifts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli import _code_identity, doctor
+from lionagi.cli._code_identity import code_identity, git_identity
+
+
+class _Args:
+    """Stand-in for the argparse namespace `run_doctor` reads."""
+
+    json = False
+
+
+def _git(tree: Path, *argv: str) -> str:
+    completed = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "-C",
+            str(tree),
+            *argv,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _commit(tree: Path, name: str) -> None:
+    (tree / name).write_text(name)
+    _git(tree, "add", name)
+    _git(tree, "commit", "-m", name)
+
+
+@pytest.fixture
+def checkout_behind(tmp_path: Path) -> Path:
+    """A working checkout whose HEAD is one commit behind its own upstream."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "-b", "main", ".")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-b", "main", ".")
+    _commit(work, "first")
+    _commit(work, "second")
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-u", "origin", "main")
+    _git(work, "reset", "--hard", "HEAD~1")
+    return work
+
+
+def test_checkout_behind_upstream_reads_as_drift(checkout_behind: Path) -> None:
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["comparison_ref"] == "origin/main"
+    assert git["comparison_ref_source"] == "upstream"
+    assert git["behind"] == 1
+    assert git["ahead"] == 0
+
+
+def test_detached_checkout_falls_back_to_the_remote_default_branch(
+    checkout_behind: Path,
+) -> None:
+    """A pinned deployment has no upstream — the remote's HEAD still answers for it."""
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    _git(checkout_behind, "checkout", "--detach", "HEAD")
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["detached"] is True
+    assert git["branch"] is None
+    assert git["comparison_ref_source"] == "remote_head"
+    assert git["behind"] == 1
+
+
+def test_up_to_date_checkout_is_not_behind(checkout_behind: Path) -> None:
+    """The guard fires on drift, not on every checkout that has a remote."""
+    _git(checkout_behind, "merge", "--ff-only", "origin/main")
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["behind"] == 0
+
+
+def test_directory_outside_any_checkout_says_so_plainly(tmp_path: Path) -> None:
+    git = git_identity(tmp_path)
+    assert git["status"] == "not_a_git_checkout"
+    assert str(tmp_path) in git["detail"]
+
+
+def test_unreadable_head_is_unknown_not_ok(tmp_path: Path) -> None:
+    """An initialized tree with no commits: git answers, HEAD does not resolve."""
+    _git(tmp_path, "init", "-b", "main", ".")
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "unknown"
+    assert "HEAD" in git["detail"]
+
+
+def test_missing_git_binary_is_unknown_not_a_missing_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _no_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _no_git)
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "unknown"
+    assert "FileNotFoundError" in git["detail"]
+
+
+def test_no_comparison_ref_is_unknown_not_ok(tmp_path: Path) -> None:
+    """A checkout with no remote cannot be measured, so it is not declared current."""
+    _git(tmp_path, "init", "-b", "main", ".")
+    _commit(tmp_path, "only")
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "ok"
+    assert git["comparison_ref"] is None
+    assert git["behind"] is None
+
+    drift = _code_identity._drift(git, "1.0.0", "1.0.0")
+    assert drift["status"] == "unknown"
+    assert drift["unknown"]
+
+
+# ── the drift verdict ────────────────────────────────────────────────────────
+
+
+def test_version_mismatch_against_installed_distribution_is_drift() -> None:
+    git = {"status": "not_a_git_checkout", "detail": "wheel install"}
+    drift = _code_identity._drift(git, "0.1.0", "9.9.9")
+    assert drift["status"] == "drift"
+    assert any("9.9.9" in reason for reason in drift["reasons"])
+
+
+def test_wheel_install_with_matching_version_is_ok() -> None:
+    git = {"status": "not_a_git_checkout", "detail": "wheel install"}
+    assert _code_identity._drift(git, "0.1.0", "0.1.0")["status"] == "ok"
+
+
+def test_behind_outranks_unknown_in_the_verdict() -> None:
+    git = {"status": "ok", "behind": 24, "comparison_ref": "origin/main"}
+    drift = _code_identity._drift(git, "0.1.0", None)
+    assert drift["status"] == "drift"
+    assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
+
+
+def test_code_identity_reports_this_process() -> None:
+    identity = code_identity()
+    assert identity["version"]
+    assert identity["package_path"].endswith("/lionagi")
+    assert Path(identity["package_path"]).is_dir()
+    assert identity["verb_count"] > 0
+    assert identity["git"]["status"] in ("ok", "not_a_git_checkout", "unknown")
+    assert identity["drift"]["status"] in ("ok", "drift", "unknown")
+
+
+# ── the doctor check ─────────────────────────────────────────────────────────
+
+
+def _identity(drift_status: str, **overrides: object) -> dict[str, object]:
+    identity: dict[str, object] = {
+        "version": "0.1.0",
+        "package_path": "/somewhere/lionagi",
+        "distribution_version": "0.1.0",
+        "verb_count": 40,
+        "git": {
+            "status": "ok",
+            "commit_short": "abc123def456",
+            "branch": None,
+            "detached": True,
+        },
+        "drift": {
+            "status": drift_status,
+            "reasons": ["24 commit(s) behind origin/main"] if drift_status == "drift" else [],
+            "unknown": ["git state unreadable"] if drift_status == "unknown" else [],
+        },
+    }
+    identity.update(overrides)
+    return identity
+
+
+def test_doctor_fails_on_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("drift"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "fail"
+    assert "24 commit(s) behind origin/main" in result["detail"]
+    assert "40 verbs" in result["detail"]
+
+
+def test_doctor_reports_unknown_rather_than_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("unknown"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "unknown"
+    assert "git state unreadable" in result["detail"]
+
+
+def test_doctor_ok_when_identity_is_clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("ok"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "ok"
+    assert "abc123def456 (detached)" in result["detail"]
+
+
+def test_doctor_check_that_cannot_run_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> dict[str, object]:
+        raise RuntimeError("no")
+
+    monkeypatch.setattr(_code_identity, "code_identity", _boom)
+    assert doctor._check_code_identity()["status"] == "unknown"
+
+
+def test_run_doctor_exits_nonzero_on_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "collect_checks",
+        lambda: {"code_identity": {"status": "unknown", "detail": "cannot tell"}},
+    )
+    assert doctor.run_doctor(_Args()) == 1
+
+
+# ── the surfaces a client reads ──────────────────────────────────────────────
+
+
+def test_handshake_carries_code_identity() -> None:
+    from lionagi.cli.machine import handshake_data
+
+    identity = handshake_data()["code_identity"]
+    assert identity["package_path"]
+    assert identity["verb_count"] > 0
+    assert "status" in identity["drift"]
+
+
+def test_server_info_carries_code_identity() -> None:
+    from lionagi.mcp.dispatch import _server_info
+
+    info = _server_info()
+    assert info["code_identity"]["version"] == info["lionagi_version"]
+    assert info["code_identity"]["verb_count"] == info["verb_count"]
+
+
+def test_doctor_machine_payload_separates_unknown_from_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.cli import machine
+
+    monkeypatch.setattr(
+        doctor,
+        "collect_checks",
+        lambda: {
+            "a": {"status": "unknown", "detail": "cannot tell"},
+            "b": {"status": "fail", "detail": "broken"},
+            "c": {"status": "ok", "detail": "fine"},
+        },
+    )
+    data = machine.doctor_data()
+    assert data["failed"] == ["b"]
+    assert data["unknown"] == ["a"]

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -207,9 +207,12 @@ def test_collect_checks_shape() -> None:
     assert "lionagi_home" in checks
     assert any(k.startswith("import:") for k in checks)
     assert any(k.startswith("dep:") for k in checks)
+    assert "code_identity" in checks
     for result in checks.values():
         assert set(result) == {"status", "detail"}
-        assert result["status"] in ("ok", "warn", "fail")
+        # `unknown` is a status in its own right: a check that could not be run
+        # has not passed, and collapsing it into `warn` would say it had.
+        assert result["status"] in ("ok", "warn", "fail", "unknown")
 
 
 def test_run_doctor_json_output(capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
A long-lived process loads its code once, at startup. A commit landing on disk
does not change what it is executing, and a restart command that exits 0 says
nothing about which tree the new process imported. Until now a client had no way
to ask.

`handshake` and `server.info` now carry a `code_identity` block: the loaded
version, the resolved import path the process actually imported itself from,
that tree's git position, the registered verb count, and a `drift` verdict of
`ok`, `drift`, or `unknown`. Everything is derived in one module,
`lionagi/cli/_code_identity.py`, so the two surfaces cannot disagree with each
other. `li doctor` gains a matching check.

Two decisions worth calling out.

**The comparison ref falls back to `origin/HEAD`.** A detached checkout has no
configured upstream, and a detached checkout is exactly the state a pinned
deployment sits in. An upstream-only check would answer "cannot compare" on
precisely the tree most likely to be behind, which is a fail-open result
wearing the costume of a careful one.

**`unknown` exits non-zero.** A tree whose git state cannot be read reports
`unknown`, never `ok`, and the doctor check treats it as failure: a check that
could not run has not passed. The git call is bounded at five seconds because it
runs inside a handshake a client is waiting on, and a stale index lock or a dead
remote should fail the answer rather than hang it.

Verified against a real drifted checkout: a tree pinned 24 commits back now
reports `detached: true, behind: 24` with the comparison ref sourced from the
remote head, a tree at its branch tip reports `behind: 0`, and a path outside any
checkout reports `not_a_git_checkout` rather than an error. Tests pass, return
code 0 captured from the command itself.