### PR TITLE
docs(mcp): give a user with no source checkout a one-pass install path

### DIFF
--- a/docs/guides/mcp-setup.md
+++ b/docs/guides/mcp-setup.md
@@ -1,0 +1,171 @@
+# Connect an MCP Client to LionAGI
+
+Install the server, register it with your MCP client, and confirm the
+connection is live. No LionAGI source checkout is required at any point — the
+server ships inside the published wheel.
+
+For what the server exposes once connected, see the
+[MCP Server Reference](../reference/mcp-server.md).
+
+## 1. Install
+
+The server needs the optional `mcp` extra:
+
+```bash
+pip install 'lionagi[mcp]'
+```
+
+or, with uv:
+
+```bash
+uv pip install 'lionagi[mcp]'
+```
+
+That installs two things you will use below: the `li` console script, and the
+`lionagi.mcp` package the script serves from. Both land in the environment's
+`bin/` and `site-packages/`, so a virtualenv that contains nothing else is
+enough.
+
+Importing `lionagi.mcp` does not pull the extra — only serving does. If the
+extra is missing, `li mcp` refuses to start with a message naming the install
+command and exits with the environment-error code, so a misconfigured client
+sees a failed launch rather than a server that half-works.
+
+## 2. Register it with your client
+
+The server speaks **stdio**. There is no HTTP listener and no port: the client
+launches the process and talks to it on its standard streams.
+
+Point the client at the `li` executable **by absolute path**. A bare `li`
+depends on whatever `PATH` your client inherits, which is frequently not your
+shell's:
+
+```json
+{
+  "mcpServers": {
+    "lion": {
+      "command": "/absolute/path/to/venv/bin/li",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+`python -m lionagi.mcp` is equivalent if you would rather name the interpreter:
+
+```json
+{
+  "mcpServers": {
+    "lion": {
+      "command": "/absolute/path/to/venv/bin/python",
+      "args": ["-m", "lionagi.mcp"]
+    }
+  }
+}
+```
+
+The key in `mcpServers` is your client's local name for the entry and is what
+you address the server by. The name the server reports over the protocol is
+`lion`.
+
+**Your client will show one tool, `request`.** That is correct and current:
+every operation is a namespaced verb behind that tool, and `request(help=true)`
+lists them. A client showing one entry is a healthy connection, not a truncated
+one.
+
+## 3. Environment variables
+
+The server itself reads four variables. Every one of them is optional.
+
+| Variable | Effect | When unset |
+|----------|--------|------------|
+| `LIONAGI_HOME` | Root of all on-disk state. Runs go to `$LIONAGI_HOME/runs/`, the server's own job records to `$LIONAGI_HOME/mcp/jobs/`. | Defaults to `~/.lionagi`. The directory is created on first write; nothing fails if it does not exist yet. |
+| `LIONAGI_MCP_LI_BIN` | Explicit argv prefix for the `li` CLI the server spawns, split on whitespace. | The server uses the `li` script next to its own interpreter, by absolute path. Failing that, `<that interpreter> -m lionagi.cli`. `PATH` is never consulted, so leaving this unset is the normal case. |
+| `LIONAGI_MCP_NOTIFY_TARGET` | Value substituted for the `{target}` placeholder in the terminal-run notification command. | The placeholder resolves to an empty string. |
+| `LIONAGI_MCP_NOTIFY_COMMAND` | JSON argv list delivering a notice when a background run reaches a terminal state. Overrides the configured `notify.on_terminal` adapter. | Falls back to lionagi's own `notify.on_terminal` setting. If that is unconfigured too, no notification is sent — deliberate silence, distinct from a notifier that was configured and failed, which is reported rather than swallowed. |
+
+`LIONAGI_RUN_ID` is also part of this surface, but it is **written** by the
+server into each run it spawns so the run id can be returned before the child
+starts. Setting it in the client environment would force every spawned run to
+share one id. Leave it alone.
+
+Two further points about environment:
+
+- **Provider credentials are not read by the server.** The runs it spawns
+  inherit its environment, so any API key an agent needs (`OPENAI_API_KEY` and
+  the rest) must be present in the environment your MCP client launches the
+  server with — not merely in your shell profile. Clients commonly launch
+  servers without a login shell.
+- **Working directory matters.** Project-scoped configuration under `.lionagi/`
+  is resolved from the launch directory upward. Set the client entry's working
+  directory to the project root if you want project profiles and settings to
+  apply.
+
+## 4. Verify the connection
+
+Three checks, in increasing strength.
+
+**The client lists one tool.** Look for `request` in your client's tool list.
+One entry is the expected count.
+
+**The catalog answers.** Call `request` with:
+
+```json
+{"help": true}
+```
+
+You get every verb with its required parameters, plus `verb_count`,
+`available_count`, and `max_ops`. If this returns, dispatch is working.
+
+**A verb actually runs.** `server.info` is the cheapest one that proves the
+whole path, because it reports which build answered:
+
+```json
+{"ops": [{"op": "server.info", "args": {}}]}
+```
+
+```json
+{
+  "status": "success",
+  "ops": [{"ok": true, "op": "server.info", "result": {
+    "lionagi_version": "0.30.2",
+    "contract_version": 1,
+    "verb_count": 40,
+    "absent_verb_count": 28,
+    "tool_count": 1,
+    "uptime_seconds": 0.045,
+    "pid": 55661
+  }}]
+}
+```
+
+Read `lionagi_version` and `verb_count` rather than assuming them. A server
+process loads its code once, at start: upgrading the package on disk changes
+nothing about a client session that is already connected, and a restart command
+returning success is not evidence of which code answered. `server.info` is.
+`handshake` is the companion check — it returns the machine-result contract
+version and the filesystem path of the CLI module actually in use, which
+settles "is this the build I just installed" without inference.
+
+If a verb comes back `ok=false`, read its `error.kind`. A `not_found` means the
+name was never registered — ask `help=true` for the real spelling. An
+`unavailable` means the name is catalogued but not callable here, and the error
+carries the reason.
+
+## Troubleshooting
+
+**The client shows the server as failed to start.** Run the exact command from
+your config in a terminal. `li mcp` holds the connection open on stdin and
+prints a startup banner to stderr; that banner is not an error. An immediate
+exit with a message about a missing module means the `mcp` extra is not
+installed in that environment.
+
+**The client shows zero tools.** The process started but the handshake did not
+complete. Check that the `command` path exists and is executable, and that the
+client is not passing extra arguments — `li mcp` takes only the optional
+`serve` action.
+
+**Verbs run but find nothing.** Runs and job records are read from
+`$LIONAGI_HOME`. If the client launches the server with a different
+`LIONAGI_HOME` than your shell uses, the server is looking at a different store.
+`server.info` and `job.list` will both succeed and both be empty.

--- a/docs/guides/mcp-setup.md
+++ b/docs/guides/mcp-setup.md
@@ -80,14 +80,15 @@ The server itself reads four variables. Every one of them is optional.
 | Variable | Effect | When unset |
 |----------|--------|------------|
 | `LIONAGI_HOME` | Root of all on-disk state. Runs go to `$LIONAGI_HOME/runs/`, the server's own job records to `$LIONAGI_HOME/mcp/jobs/`. | Defaults to `~/.lionagi`. The directory is created on first write; nothing fails if it does not exist yet. |
-| `LIONAGI_MCP_LI_BIN` | Explicit argv prefix for the `li` CLI the server spawns, split on whitespace. | The server uses the `li` script next to its own interpreter, by absolute path. Failing that, `<that interpreter> -m lionagi.cli`. `PATH` is never consulted, so leaving this unset is the normal case. |
+| `LIONAGI_MCP_LI_BIN` | Explicit argv prefix for the `li` CLI the server spawns, split on whitespace. A value that is not an absolute path (a bare `li`) is executed as-is, so the OS resolves it through `PATH` — give an absolute path unless you specifically want that. | The server uses the `li` script in its own interpreter's directory, by absolute path. Failing that, `<that interpreter> -m lionagi.cli`. Neither default consults `PATH`, so leaving this unset is the normal case. |
 | `LIONAGI_MCP_NOTIFY_TARGET` | Value substituted for the `{target}` placeholder in the terminal-run notification command. | The placeholder resolves to an empty string. |
 | `LIONAGI_MCP_NOTIFY_COMMAND` | JSON argv list delivering a notice when a background run reaches a terminal state. Overrides the configured `notify.on_terminal` adapter. | Falls back to lionagi's own `notify.on_terminal` setting. If that is unconfigured too, no notification is sent — deliberate silence, distinct from a notifier that was configured and failed, which is reported rather than swallowed. |
 
 `LIONAGI_RUN_ID` is also part of this surface, but it is **written** by the
 server into each run it spawns so the run id can be returned before the child
-starts. Setting it in the client environment would force every spawned run to
-share one id. Leave it alone.
+starts. The server sets it per run, overwriting whatever the client environment
+held, so a value you export here is not inherited by spawned runs — it is
+replaced. Leave it alone.
 
 Two further points about environment:
 

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -32,6 +32,10 @@ Importing `lionagi.mcp` does not pull that dependency. Only serving does, so a
 missing extra surfaces when you run `li mcp`, with a message naming the install
 command.
 
+No source checkout is needed: the server ships inside the wheel. For the full
+setup path — client registration, environment variables, and how to confirm the
+connection — see [Connect an MCP client](../guides/mcp-setup.md).
+
 Register it with any MCP client, for example in an `.mcp.json`:
 
 ```json
@@ -95,8 +99,8 @@ relative timestamps, formatted durations, or tables.
       "required": []
     }
   ],
-  "verb_count": 47,
-  "available_count": 36,
+  "verb_count": 68,
+  "available_count": 40,
   "max_ops": 8,
   "help_usage": "help=true returns this catalog; help='<verb>' returns that verb's full parameter schema; ...",
   "synonyms_removed_after": "2026-09-30"
@@ -130,7 +134,7 @@ resolves that playbook's own declared arguments into the schema.
 
 ## The catalog
 
-36 verbs are reachable. This list is generated from the registry:
+40 verbs are reachable. This list is generated from the registry:
 
 ```bash
 python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) for n in sorted(v.VERBS)]"
@@ -139,7 +143,10 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | Verb | Summary |
 |------|---------|
 | `agent.submit` | Run one agent on one task as a detached background run. |
+| `dispatch.ack` | Acknowledge a delivered dispatch with its ack token, so the queue stops redelivering it. A wrong token is refused without echoing the real one. |
 | `dispatch.ls` | Rows in the durable dispatch outbox, newest first, without their payloads. |
+| `dispatch.purge` | Delete one dispatch row by id, whatever its status, recording an audit row. Deleting by --status/--before is refused here: a sweep deletes rows the caller never named and reports a count for rows that can no longer be inspected. |
+| `dispatch.retry` | Return a failed or dead-lettered dispatch to pending so delivery is attempted again. |
 | `dispatch.show` | One dispatch row in full, including its payload and ack token. |
 | `doctor` | Environment checks and which of them failed. |
 | `fanout.submit` | Run N agents on one task in parallel, optionally synthesized. |
@@ -151,6 +158,7 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `job.output` | Console tail and artifact list of a background run. |
 | `job.status` | Current state of a background run: liveness, job record, CLI manifest. |
 | `job.wait` | Observe runs until terminal or the window closes; partial results, never a bool. |
+| `lifecycle` | What the lifecycle store records about one run: whether every session it opened has ended, and with what outcome. |
 | `monitor` | Entities in flight right now: sessions, invocations, shows, plays. |
 | `play.submit` | Run a saved playbook: a flow whose plan and prompt are already written down. |
 | `plugin.info` | One plugin's version, trust state, and everything its manifest declares. |
@@ -183,7 +191,7 @@ against rather than a copy of it.
 
 ## Operations the surface does not offer
 
-Eleven further names are catalogued as **unavailable**, each with its reason.
+Twenty-eight further names are catalogued as **unavailable**, each with its reason.
 They are not omissions: a caller that asks what exists gets the name and why it
 cannot be called, which is a different answer from the name never having been
 considered.

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -95,8 +95,8 @@ relative timestamps, formatted durations, or tables.
       "required": []
     }
   ],
-  "verb_count": 47,
-  "available_count": 36,
+  "verb_count": 68,
+  "available_count": 40,
   "max_ops": 8,
   "help_usage": "help=true returns this catalog; help='<verb>' returns that verb's full parameter schema; ...",
   "synonyms_removed_after": "2026-09-30"
@@ -130,16 +130,24 @@ resolves that playbook's own declared arguments into the schema.
 
 ## The catalog
 
-36 verbs are reachable. This list is generated from the registry:
+40 verbs are reachable. Both tables in this section are checked against the
+registry by the test suite, so a verb added or withdrawn without updating them
+fails a test rather than going unnoticed. The registry is the authority; ask it
+directly with:
 
 ```bash
 python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) for n in sorted(v.VERBS)]"
 ```
 
+<!-- mcp-catalog:available:start -->
+
 | Verb | Summary |
 |------|---------|
 | `agent.submit` | Run one agent on one task as a detached background run. |
+| `dispatch.ack` | Acknowledge a delivered dispatch with its ack token, so the queue stops redelivering it. A wrong token is refused without echoing the real one. |
 | `dispatch.ls` | Rows in the durable dispatch outbox, newest first, without their payloads. |
+| `dispatch.purge` | Delete one dispatch row by id, whatever its status, recording an audit row. Deleting by --status/--before is refused here: a sweep deletes rows the caller never named and reports a count for rows that can no longer be inspected. |
+| `dispatch.retry` | Return a failed or dead-lettered dispatch to pending so delivery is attempted again. |
 | `dispatch.show` | One dispatch row in full, including its payload and ack token. |
 | `doctor` | Environment checks and which of them failed. |
 | `fanout.submit` | Run N agents on one task in parallel, optionally synthesized. |
@@ -151,6 +159,7 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `job.output` | Console tail and artifact list of a background run. |
 | `job.status` | Current state of a background run: liveness, job record, CLI manifest. |
 | `job.wait` | Observe runs until terminal or the window closes; partial results, never a bool. |
+| `lifecycle` | What the lifecycle store records about one run: whether every session it opened has ended, and with what outcome. |
 | `monitor` | Entities in flight right now: sessions, invocations, shows, plays. |
 | `play.submit` | Run a saved playbook: a flow whose plan and prompt are already written down. |
 | `plugin.info` | One plugin's version, trust state, and everything its manifest declares. |
@@ -175,6 +184,8 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `stats.runs` | Run counts and first/last timestamps, grouped by project/kind/agent/model/status. |
 | `team.list` | Teams on disk with their members and message counts. |
 
+<!-- mcp-catalog:available:end -->
+
 There is deliberately **no parameter table here**. A verb's parameters are
 projected from the CLI parser at call time, so a table written by hand would
 drift away from what the server actually accepts. Ask for the parameters
@@ -183,27 +194,56 @@ against rather than a copy of it.
 
 ## Operations the surface does not offer
 
-Eleven further names are catalogued as **unavailable**, each with its reason.
-They are not omissions: a caller that asks what exists gets the name and why it
-cannot be called, which is a different answer from the name never having been
-considered.
+Twenty-eight further names are catalogued as **unavailable**, each with its
+reason. They are not omissions: a caller that asks what exists gets the name and
+why it cannot be called, which is a different answer from the name never having
+been considered. The right-hand column below abbreviates the reason; `help=true`
+returns each one in full.
 
-| Verb | Summary |
-|------|---------|
-| `schedule.apply` | Reconcile a whole ScheduleSet file into the store, atomically. |
-| `schedule.run` | One schedule run. |
-| `team.create`, `team.show`, `team.send`, `team.receive` | Messaging between agents working as a team. |
-| `state.doctor` | Read-only inspection of the lifecycle store. |
-| `dispatch.ack`, `dispatch.retry`, `dispatch.purge` | The outbound dispatch queue. |
-| `plugin.list` | Installed plugin bundles and their trust state. |
+<!-- mcp-catalog:unavailable:start -->
 
-Most share one reason: the CLI path emits no versioned machine result
-(`li <path> --machine`), so there is nothing to return that is not scraped
-console text. Scraping would make a command's console wording an API contract,
-so the fix belongs in the CLI, where the command gains a machine-result seam.
-The rest carry their own reason: `schedule.run` is already covered by
-`schedule.runs`, `schedule.apply` has no decided machine-result shape yet, and
-`plugin.list` prunes trust records as part of listing, which is a write.
+| Verb | Summary | Not offered because |
+|------|---------|---------------------|
+| `casts` | The built-in roles and modes an agent can be composed from. | no machine result |
+| `orchestrate.ctl.status` | What a running flow's control plane reports about it. | no machine result |
+| `state.doctor` | Read-only inspection of the lifecycle store. | no machine result |
+| `team.create` | Messaging between agents working as a team. | no machine result |
+| `team.receive` | Messaging between agents working as a team. | no machine result |
+| `team.send` | Messaging between agents working as a team. | no machine result |
+| `team.show` | Messaging between agents working as a team. | no machine result |
+| `state.checkpoint` | Writes against the lifecycle store. | invalidating write |
+| `state.import` | Writes against the lifecycle store. | invalidating write |
+| `state.import-teams` | Writes against the lifecycle store. | invalidating write |
+| `state.prune` | Writes against the lifecycle store. | invalidating write |
+| `state.vacuum` | Writes against the lifecycle store. | invalidating write |
+| `hooks.import` | Importing hook commands from another tool's config. | grants privilege |
+| `plugin.disable` | Plugin bundle enablement. | grants privilege |
+| `plugin.enable` | Plugin bundle enablement. | grants privilege |
+| `plugin.list` | Installed plugin bundles and their trust state. | grants privilege |
+| `orchestrate.ctl.msg` | The running-flow control plane. | effect lands elsewhere |
+| `orchestrate.ctl.pause` | The running-flow control plane. | effect lands elsewhere |
+| `orchestrate.ctl.resume` | The running-flow control plane. | effect lands elsewhere |
+| `invoke.end` | Opening and closing a skill-level orchestration record. | no caller identity |
+| `invoke.start` | Opening and closing a skill-level orchestration record. | no caller identity |
+| `mirror` | Mirror Claude Code sessions into Studio, live. | a process, not a call |
+| `studio.start` | The Studio server. | a process, not a call |
+| `engine.run` | Run a domain-specific multi-agent pipeline. | spawns without a job record |
+| `kill` | Terminate a run, session, play or show by id. | no identity to correlate |
+| `mcp` | Serve this surface over stdio. | it is this server |
+| `schedule.apply` | Reconcile a whole ScheduleSet file into the store, atomically. | shape undecided |
+| `schedule.run` | One schedule run. | already covered |
+
+<!-- mcp-catalog:unavailable:end -->
+
+The largest group is *no machine result*: the CLI path emits no versioned
+machine result (`li <path> --machine`), so there is nothing to return that is
+not scraped console text. Scraping would make a command's console wording an API
+contract, so the fix belongs in the CLI, where the command gains a machine-result
+seam. The others are refusals on their own terms rather than gaps waiting to be
+filled — a write whose effect no machine result can describe, a path that would
+grant the calling agent a right it did not have, a control-plane signal whose
+effect lands on a running flow rather than in a reply, or a long-lived process
+that never returns at all.
 
 Asking for one of these inside `ops` returns a catalogued answer rather than a
 bare unknown-verb error: the op comes back `ok=false` with an `unavailable`

--- a/lionagi/cli/_argtypes.py
+++ b/lionagi/cli/_argtypes.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""argparse ``type`` callables that state the shape they accept.
+
+A command line carries one string per flag, so a flag whose value is a list or
+an object can only arrive JSON-encoded. Doing that decode inside a command
+handler leaves the shape undeclared: the parser says ``string``, anything
+reading the parser says ``string``, and the caller finds out that a plain
+string is refused only by sending one. Declaring it as the argument's ``type``
+puts the shape on the argument itself, where the parser enforces it and a
+reader of the parser can describe it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+__all__ = ("JsonArgument",)
+
+
+class JsonArgument:
+    """Decode one JSON-encoded flag value and check it against *schema*.
+
+    ``schema`` is the JSON Schema of the **decoded** value — the shape a caller
+    thinks in — and is bounded to what argparse can be handed on a command
+    line: an ``array`` of scalars, or an ``object``.
+    """
+
+    def __init__(self, schema: dict[str, Any]) -> None:
+        self.json_schema = dict(schema)
+        # argparse prints `type.__name__` in its own error prose.
+        self.__name__ = f"json-{self.json_schema.get('type', 'value')}"
+
+    def __call__(self, raw: str) -> Any:
+        try:
+            value = json.loads(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"must be valid JSON: {exc}") from exc
+        want = self.json_schema.get("type")
+        if want == "array" and not isinstance(value, list):
+            raise argparse.ArgumentTypeError("must be a JSON array")
+        if want == "object" and not isinstance(value, dict):
+            raise argparse.ArgumentTypeError("must be a JSON object")
+        item = self.json_schema.get("items", {}).get("type") if want == "array" else None
+        if item == "string" and not all(isinstance(e, str) for e in value):
+            raise argparse.ArgumentTypeError("must be a JSON array of strings")
+        return value
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"JsonArgument({self.json_schema!r})"

--- a/lionagi/cli/_code_identity.py
+++ b/lionagi/cli/_code_identity.py
@@ -1,0 +1,659 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""What code is actually running, as a value a caller with no shell can read.
+
+A long-lived process loads its code once, at startup. A commit landing on disk
+does not change it, and a restart command that exits 0 says nothing about which
+tree the new process imported. So the running process reports its own identity —
+version, the resolved path it imported itself from, that tree's git position,
+and how many verbs it registered — and every answer is derived here, in one
+place, so the handshake and the server's own info cannot disagree.
+
+The git position is the part that can go stale under a running process, because
+someone can move the checkout the process imported from and the loaded module
+objects will not notice. So it is captured once, as early as the process can
+manage, and that capture is what the identity calls the running code. The tree's
+current position is read too, and reported beside it: when the two disagree the
+checkout moved after this process loaded, and that divergence is itself the fact
+an operator needs, so it is named in the payload rather than left to be inferred.
+
+A tree can also part from the running code without its commit changing at all,
+because an uncommitted edit moves the files and leaves the commit id alone. Two
+things follow. A commit id does not describe a dirty tree in the first place, so
+a snapshot taken over uncommitted changes can only ever be a partial identity and
+says so. And to notice an edit made afterwards, the snapshot carries a digest of
+the tree's uncommitted state — its shape, and the size, modification time, mode
+and inode of every path git names, never its content — which is compared live
+exactly as the commit is. The two kinds of movement stay separate in the payload: moving the
+checkout and editing files under it are different operator actions with different
+remedies, and one boolean cannot carry both.
+
+What that digest can miss is enumerated where it is computed, as a list rather
+than as a count: an edit is invisible to it only if it moves none of a path's
+size, modification time, mode or inode, or if it happens somewhere git never
+names, which is what ``.gitignore`` puts out of scope. Everything else an operator
+can do to a file under this process — including to an untracked file, to a file
+inside an untracked directory, to a file git renders only as a modified binary,
+and a permission change that rewrites no bytes at all — moves the digest.
+
+Failure is closed: a tree whose git state cannot be read is ``unknown``, never
+``ok``. "Cannot tell" and "nothing wrong" are different answers, and a git call
+that could not run at all is a third thing again — it is not evidence that the
+tree lacks an upstream, so it never falls through to the fallback comparison.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = (
+    "code_identity",
+    "git_identity",
+    "snapshot_git_position",
+    "GIT_TIMEOUT_SECONDS",
+    "IDENTITY_BUDGET_SECONDS",
+)
+
+# Bounded because this runs inside a handshake a client is waiting on, and a git
+# call against an unhealthy tree (a stale index lock, a dead network remote) can
+# otherwise hang the answer instead of failing it.
+GIT_TIMEOUT_SECONDS = 5.0
+
+# One allowance for the whole computation, not one per call: half a dozen git
+# calls each free to take the per-call timeout is a worst case measured in tens
+# of seconds, which is longer than the handshake it sits inside is worth waiting.
+# When the allowance runs out the answer is `unknown` with the reason, which is
+# the honest reading — a check that could not finish has not passed.
+IDENTITY_BUDGET_SECONDS = 6.0
+
+_SHORT_SHA = 12
+
+# The digest is only ever compared against another digest of the same tree, so it
+# needs to be long enough that an accidental collision is not a concern and short
+# enough to read in a payload.
+_FINGERPRINT_CHARS = 16
+
+# Return codes for calls that never produced one: git could not be run at all,
+# or the allowance was already spent before this call's turn came.
+_COULD_NOT_RUN = -1
+_BUDGET_SPENT = -2
+
+_REF_CAVEATS = {
+    "upstream": (
+        "this is a remote-tracking ref, updated only by a fetch in this tree, so the "
+        "comparison is as current as the last fetch and no more"
+    ),
+    "remote_head": (
+        "origin/HEAD is a local symbolic ref, written when this clone was made and "
+        "refreshed only on request; if the remote's default branch has changed since, "
+        "this measures against the wrong branch and understates how far behind the "
+        "checkout is. It is also a remote-tracking ref, so it is only as current as "
+        "the last fetch in this tree"
+    ),
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _Budget:
+    """One wall-clock allowance shared by every git call in a single computation."""
+
+    def __init__(self, seconds: float) -> None:
+        self.total = seconds
+        self._deadline = time.monotonic() + seconds
+
+    def remaining(self) -> float:
+        return self._deadline - time.monotonic()
+
+
+def _ran(rc: int) -> bool:
+    """Whether git actually ran and produced this return code."""
+    return rc >= 0
+
+
+def _git(tree: Path, *argv: str, budget: _Budget) -> tuple[int, str, str]:
+    """Run one git command against *tree*; returns (rc, stdout, stderr), stripped.
+
+    A negative rc means no git process produced it — either git could not be run,
+    or the shared allowance was gone before this call. Both are a different fact
+    from git running and refusing.
+    """
+    left = budget.remaining()
+    if left <= 0:
+        return (
+            _BUDGET_SPENT,
+            "",
+            f"the {budget.total}s allowance for reading git state was spent before "
+            f"`git {' '.join(argv)}` could run",
+        )
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["git", "-C", str(tree), *argv],  # noqa: S607 — resolved from PATH by design
+            capture_output=True,
+            text=True,
+            timeout=min(GIT_TIMEOUT_SECONDS, left),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _COULD_NOT_RUN, "", f"{type(exc).__name__}: {exc}"
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def _comparison_ref(tree: Path, budget: _Budget) -> tuple[str | None, str, str | None, bool]:
+    """The ref this checkout should be measured against, where it came from, and
+    whether the question could be asked at all.
+
+    The configured upstream is preferred. A detached checkout has none — which is
+    exactly the state a pinned deployment sits in — so the remote's default
+    branch is the fallback, because "behind the branch this remote publishes" is
+    the question a detached tree still has an answer to.
+
+    The fallback is only reached when git ran and told us there is no upstream. A
+    call that never ran — a timeout, a missing binary, a spent allowance — says
+    nothing about upstreams, so it stops here instead of being read as one.
+    """
+    rc, out, err = _git(
+        tree, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}", budget=budget
+    )
+    if rc == 0 and out:
+        return out, "upstream", None, True
+    if not _ran(rc):
+        return None, "unreadable", err or "the upstream lookup did not run", False
+
+    rc, out, err = _git(tree, "rev-parse", "--abbrev-ref", "origin/HEAD", budget=budget)
+    if rc == 0 and out:
+        return out, "remote_head", None, True
+    if not _ran(rc):
+        return None, "unreadable", err or "the origin/HEAD lookup did not run", False
+    return None, "none", err or "no upstream configured and origin/HEAD does not resolve", True
+
+
+def _status_paths(porcelain: str) -> list[str]:
+    """The worktree paths a NUL-delimited status listing names, relative to the root.
+
+    Records are ``XY<space><path>``. A rename or copy carries the name it came
+    from as an extra field, which is dropped: that name is gone from the disk by
+    definition, so asking the filesystem about it would measure nothing.
+    """
+    fields = [field for field in porcelain.split("\x00") if field]
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        entry = fields[index]
+        index += 1
+        if len(entry) < 4:
+            continue
+        paths.append(entry[3:])
+        if "R" in entry[:2] or "C" in entry[:2]:
+            index += 1
+    return paths
+
+
+def _worktree_fingerprint(
+    tree: Path, root: Path, porcelain: str, budget: _Budget
+) -> tuple[str | None, str | None]:
+    """A digest of what is uncommitted in *tree*, or why one could not be taken.
+
+    Enough to tell whether the uncommitted state changed between two readings,
+    and deliberately not enough to reconstruct it: the digest is over the status
+    listing, the diff against HEAD, and the size and modification time of every
+    path the listing names. No file is read, so a large file costs the same as a
+    small one and the digest never carries content.
+
+    The size and mtime are what make an ordinary edit visible when the other two
+    inputs cannot see it. Neither the listing nor the diff carries the contents of
+    an untracked file or of a file git renders as a modified binary, so for those
+    a rewrite in place leaves both byte-identical; the file's own metadata is the
+    only thing that moves. Untracked entries are enumerated as files rather than
+    collapsed directories for the same reason — otherwise a whole tree of code
+    hides behind one unchanging line. ``.gitignore`` still applies, so build
+    output and virtualenvs stay out and the listing stays bounded.
+
+    A path that is absent has been measured, not missed: git lists deletions, and
+    a deletion is exactly a path that is not there. Absence is recorded as such.
+    A path that exists and still cannot be read is a different matter and yields
+    no digest at all, so the caller reports "cannot tell" rather than "unchanged".
+
+    A clean tree needs no diff — an empty status listing is already the whole
+    answer, and skipping the call keeps the common case off the allowance.
+
+    The per-path measurement sits inside the same allowance as the git calls,
+    because a tree with a large unignored untracked directory is exactly the case
+    the allowance exists for. Running out of it yields no digest and a reason, not
+    the digest built so far: a partial digest compares unequal to a full one taken
+    at another moment, which would report an edit to a tree nobody touched. A
+    timeout is a thing that could not be measured, and the honest report of it is
+    "cannot tell", not a manufactured difference.
+
+    What this cannot see is a list, and it is worth keeping as a list because
+    "only one case" is the shape of claim that goes stale without anyone noticing:
+
+    - a rewrite that leaves the size, the modification time, the mode and the
+      inode all as they were — the deliberate residual of measuring metadata
+      instead of content, and the price of a cost that does not grow with the
+      size of the tree;
+    - any change beneath ``.gitignore``, which git never names here, so nothing
+      stats it;
+    - ownership and extended attributes, which are not in the mark.
+
+    The inode is in the mark so that replacing a file by renaming another over it
+    stays visible even when the replacement matches on every other field. The cost
+    is real and is not bounded by anything this module controls: on a filesystem
+    that hands back a fresh synthetic inode for an unchanged path, which some
+    network and userspace filesystems do, two readings of a tree nobody touched
+    disagree, and the answer is an edit that did not happen. Staying inside one
+    process and one tree does not constrain that, because it says nothing about
+    what the filesystem returns from two separate stats.
+
+    That direction of error is the deliberate one. This surface exists so an
+    operator asking "is the code I am running the code I think I am running"
+    cannot be told a reassuring falsehood, and between an edit reported that did
+    not happen and an edit missed that did, only the second defeats the purpose.
+    An operator who looks and finds nothing has lost a minute; one who was told
+    nothing moved is left with the exact wrong belief this module was written to
+    prevent.
+    """
+    digest = hashlib.sha256(porcelain.encode(errors="replace"))
+    if porcelain:
+        rc, diff, err = _git(tree, "diff", "HEAD", budget=budget)
+        if rc != 0:
+            return None, f"could not read the uncommitted changes: {err or 'no output'}"
+        digest.update(b"\x00")
+        digest.update(diff.encode(errors="replace"))
+        paths = _status_paths(porcelain)
+        for measured, relative in enumerate(paths):
+            if budget.remaining() <= 0:
+                return None, (
+                    f"the {budget.total}s allowance for reading git state was spent "
+                    f"after measuring {measured} of the {len(paths)} paths the status "
+                    "listing names, so no digest of the uncommitted state was taken"
+                )
+            try:
+                stat = (root / relative).lstat()
+            except FileNotFoundError:
+                mark = "absent"
+            except OSError as exc:
+                return None, (
+                    f"could not read the state of {relative} under {root}: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+            else:
+                mark = f"{stat.st_size}:{stat.st_mtime_ns}:{stat.st_mode}:{stat.st_ino}"
+            digest.update(f"\x00{relative}\x00{mark}".encode(errors="replace"))
+    return digest.hexdigest()[:_FINGERPRINT_CHARS], None
+
+
+def git_identity(tree: Path, budget: _Budget | None = None) -> dict[str, Any]:
+    """Where *tree* sits in git history now, or why that could not be established.
+
+    The reading is stamped with when it was taken, because a git position is only
+    true of the instant it was read.
+    """
+    identity = _read_git_identity(tree, budget or _Budget(IDENTITY_BUDGET_SECONDS))
+    identity["observed_at"] = _now()
+    return identity
+
+
+def _read_git_identity(tree: Path, budget: _Budget) -> dict[str, Any]:
+    rc, top, err = _git(tree, "rev-parse", "--show-toplevel", budget=budget)
+    if rc != 0:
+        if _ran(rc) and "not a git repository" in err.lower():
+            return {
+                "status": "not_a_git_checkout",
+                "detail": f"{tree} is not inside a git checkout",
+            }
+        return {"status": "unknown", "detail": f"git rev-parse failed: {err or 'no output'}"}
+
+    identity: dict[str, Any] = {"status": "ok", "toplevel": top}
+
+    rc, commit, err = _git(tree, "rev-parse", "HEAD", budget=budget)
+    if rc != 0 or not commit:
+        return {"status": "unknown", "detail": f"could not read HEAD: {err or 'no output'}"}
+    identity["commit"] = commit
+    identity["commit_short"] = commit[:_SHORT_SHA]
+
+    rc, branch, _ = _git(tree, "rev-parse", "--abbrev-ref", "HEAD", budget=budget)
+    detached = rc != 0 or branch == "HEAD"
+    identity["detached"] = detached
+    identity["branch"] = None if detached else branch
+
+    # `-z` so a path with a newline or a quote in it stays one field, and
+    # `--untracked-files=all` so an untracked directory is listed as the files
+    # inside it rather than as a single line that an edit within cannot move.
+    rc, porcelain, err = _git(
+        tree, "status", "--porcelain", "-z", "--untracked-files=all", budget=budget
+    )
+    if rc != 0:
+        return {"status": "unknown", "detail": f"could not read working tree: {err}"}
+    identity["dirty"] = bool(porcelain)
+
+    fingerprint, fingerprint_detail = _worktree_fingerprint(tree, Path(top), porcelain, budget)
+    identity["worktree_fingerprint"] = fingerprint
+    if fingerprint_detail is not None:
+        identity["worktree_fingerprint_detail"] = fingerprint_detail
+
+    ref, source, why, asked = _comparison_ref(tree, budget)
+    if not asked:
+        return {
+            "status": "unknown",
+            "detail": f"could not establish a comparison ref: {why}",
+            "commit": commit,
+        }
+    identity["comparison_ref"] = ref
+    identity["comparison_ref_source"] = source
+    if source in _REF_CAVEATS:
+        identity["comparison_ref_caveat"] = _REF_CAVEATS[source]
+    if ref is None:
+        identity["ahead"] = None
+        identity["behind"] = None
+        identity["comparison_detail"] = why
+        return identity
+
+    rc, counts, err = _git(
+        tree, "rev-list", "--left-right", "--count", f"HEAD...{ref}", budget=budget
+    )
+    if rc != 0:
+        return {
+            "status": "unknown",
+            "detail": f"could not compare HEAD against {ref}: {err or 'no output'}",
+            "commit": commit,
+        }
+    try:
+        ahead_text, behind_text = counts.split()
+        identity["ahead"] = int(ahead_text)
+        identity["behind"] = int(behind_text)
+    except ValueError:
+        return {
+            "status": "unknown",
+            "detail": f"unreadable rev-list output comparing HEAD against {ref}: {counts!r}",
+            "commit": commit,
+        }
+    return identity
+
+
+def loaded_package_path() -> str | None:
+    """The directory this process actually imported ``lionagi`` from."""
+    import lionagi
+
+    module_file = getattr(lionagi, "__file__", None)
+    return str(Path(module_file).resolve().parent) if module_file else None
+
+
+# The position of the tree this process loaded from, read once and kept. `None`
+# until something asks for it; a process that wants an honest answer later takes
+# it at startup, before anything can move the tree underneath it.
+_SNAPSHOT: dict[str, Any] | None = None
+
+
+def snapshot_git_position(budget: _Budget | None = None) -> dict[str, Any]:
+    """Read the loaded tree's git position once and keep it for every later call.
+
+    Call this as early in the process as possible. The module objects this
+    process holds were fixed at import; the tree they came from is a directory
+    anyone can move afterwards. Capturing the position at startup is what makes a
+    later divergence visible as a divergence rather than silently replacing the
+    answer with a commit that was never loaded.
+    """
+    global _SNAPSHOT
+    if _SNAPSHOT is None:
+        _SNAPSHOT = _read_loaded_tree(budget or _Budget(IDENTITY_BUDGET_SECONDS))
+    return _SNAPSHOT
+
+
+def _read_loaded_tree(budget: _Budget) -> dict[str, Any]:
+    try:
+        package_path = loaded_package_path()
+        if package_path is None:
+            return {
+                "status": "unknown",
+                "detail": "the loaded lionagi package has no __file__",
+                "observed_at": _now(),
+            }
+        return git_identity(Path(package_path), budget)
+    except Exception as exc:  # noqa: BLE001 — startup must not fail on an unreadable tree
+        return {
+            "status": "unknown",
+            "detail": f"could not read the loaded tree: {type(exc).__name__}: {exc}",
+            "observed_at": _now(),
+        }
+
+
+def _checkout_movement(
+    snapshot: dict[str, Any], live: dict[str, Any]
+) -> tuple[bool | None, str | None]:
+    """Whether the tree this process loaded from has moved since it loaded.
+
+    ``True`` and ``False`` are answers; ``None`` means the comparison could not be
+    made, which is not the same as the checkout having stayed put.
+    """
+    if live is snapshot:
+        return False, None
+    if snapshot.get("status") != "ok":
+        return None, (
+            "the position this process started from was never established: "
+            f"{snapshot.get('detail', 'no detail')}"
+        )
+    if live.get("status") != "ok":
+        return None, (f"the tree's position cannot be read now: {live.get('detail', 'no detail')}")
+    if snapshot.get("commit") != live.get("commit"):
+        return True, (
+            f"the checkout at {snapshot.get('toplevel')} moved from "
+            f"{snapshot.get('commit_short')} to {live.get('commit_short')} after this "
+            "process loaded its code — the code answering here is the earlier commit, "
+            "and reading that tree now describes something this process never imported"
+        )
+    return False, None
+
+
+def _worktree_movement(
+    snapshot: dict[str, Any], live: dict[str, Any], commit_moved: bool | None
+) -> tuple[bool | None, str | None]:
+    """Whether the files under this process were edited since it loaded its code.
+
+    This is the movement that leaves the commit alone, so nothing about the commit
+    can answer it — only the two digests can. When either is missing the answer is
+    ``None``, because a digest that was never taken cannot show a tree standing
+    still.
+
+    A digest is taken against HEAD, so once the checkout has moved the two are
+    measured from different commits and are not comparable. That case is already
+    reported as a moved checkout; claiming anything about the files on top of it
+    would be claiming more than was measured.
+    """
+    if live is snapshot:
+        return False, None
+    if commit_moved is not False:
+        return None, (
+            "the uncommitted state cannot be compared across a checkout that moved or "
+            "whose position is unknown — the two readings are measured from different "
+            "commits"
+        )
+
+    before = snapshot.get("worktree_fingerprint")
+    after = live.get("worktree_fingerprint")
+    if before is None or after is None:
+        missing = snapshot if before is None else live
+        which = "when this process loaded" if before is None else "now"
+        return None, (
+            f"the uncommitted state of the tree could not be read {which}: "
+            f"{missing.get('worktree_fingerprint_detail', 'no detail')}"
+        )
+    if before != after:
+        return True, (
+            f"the working tree at {snapshot.get('toplevel')} was edited after this "
+            f"process loaded its code — commit {snapshot.get('commit_short')} is "
+            "unchanged, so the edit is invisible to the commit id, and the modules "
+            "answering here are the ones read before it"
+        )
+    return False, None
+
+
+def _distribution_version() -> tuple[str | None, str | None]:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as dist_version
+
+    try:
+        return dist_version("lionagi"), None
+    except PackageNotFoundError:
+        return None, "no installed lionagi distribution metadata (running from source?)"
+    except Exception as exc:  # noqa: BLE001 — metadata readers raise broadly
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _verb_count() -> tuple[int | None, str | None]:
+    try:
+        from lionagi.mcp.verbs import VERBS
+    except Exception as exc:  # noqa: BLE001 — a broken verb table must not break the handshake
+        return None, f"could not import the verb table: {type(exc).__name__}: {exc}"
+    return len(VERBS), None
+
+
+def _drift(
+    git: dict[str, Any],
+    version: str,
+    distribution_version: str | None,
+    *,
+    live: dict[str, Any] | None = None,
+    moved: bool | None = False,
+    movement_detail: str | None = None,
+    worktree_edited: bool | None = False,
+    worktree_detail: str | None = None,
+) -> dict[str, Any]:
+    """The verdict on *git*, the position of the code this process actually loaded.
+
+    When the checkout has not moved, the live reading measures that same commit
+    against a fresher view of the remote, so it is the better source for how far
+    behind the loaded code is. When it has moved, the live reading is about some
+    other commit and only the snapshot speaks for what is running.
+
+    Uncommitted changes present when the snapshot was taken make the verdict
+    ``unknown`` rather than ``ok``. Not because something is known to be wrong —
+    the edits may be exactly what the operator intended to run — but because the
+    commit id, which is the whole of what this surface can report, is then not a
+    description of the loaded code. Saying ``ok`` there would be answering a
+    question ("does the reported identity match what is running?") that the
+    reading cannot reach.
+    """
+    reasons: list[str] = []
+    unknowns: list[str] = []
+
+    if distribution_version is not None and distribution_version != version:
+        reasons.append(
+            f"the loaded package reports version {version} but the installed "
+            f"distribution declares {distribution_version} — the import path is not "
+            "serving the installed build"
+        )
+
+    if moved is True and movement_detail:
+        reasons.append(movement_detail)
+    elif moved is None and movement_detail:
+        unknowns.append(movement_detail)
+
+    if worktree_edited is True and worktree_detail:
+        reasons.append(worktree_detail)
+    elif worktree_edited is None and worktree_detail:
+        unknowns.append(worktree_detail)
+
+    if git.get("dirty") is True:
+        unknowns.append(
+            f"the tree this process loaded from had uncommitted changes at "
+            f"{git.get('commit_short', 'the captured commit')}, so that commit does not "
+            "describe the code being run — some of it was only ever on disk"
+        )
+
+    position = git
+    if moved is False and live is not None and live.get("status") == "ok":
+        position = live
+
+    status = position.get("status")
+    if status == "unknown":
+        unknowns.append(f"git state unreadable: {position.get('detail', 'no detail')}")
+    elif status == "ok":
+        behind = position.get("behind")
+        if behind is None:
+            unknowns.append(
+                "nothing to compare this checkout against: "
+                f"{position.get('comparison_detail', 'no comparison ref')}"
+            )
+
+        elif behind > 0:
+            reasons.append(
+                f"the loaded checkout is {behind} commit(s) behind "
+                f"{position['comparison_ref']} — it is serving code older than that ref"
+            )
+
+    if reasons:
+        return {"status": "drift", "reasons": reasons, "unknown": unknowns}
+    if unknowns:
+        return {"status": "unknown", "reasons": [], "unknown": unknowns}
+    return {"status": "ok", "reasons": [], "unknown": []}
+
+
+def code_identity() -> dict[str, Any]:
+    """The running process's own code identity, drift verdict included.
+
+    Everything here describes the module objects this process actually imported,
+    never the environment that was supposed to supply them. ``git`` is the
+    position captured when this process first looked, which is what it loaded;
+    ``git_live`` is the tree as it stands now. On the call that takes the
+    snapshot the two are one reading and are reported as such.
+
+    ``checkout_moved`` and ``worktree_edited`` are separate answers to separate
+    questions — the checkout was moved to another commit, and the files were
+    edited where they stand — because the operator who caused one did not do the
+    other, and undoing them is not the same act.
+    """
+    from lionagi.version import __version__
+
+    budget = _Budget(IDENTITY_BUDGET_SECONDS)
+    package_path = loaded_package_path()
+
+    already_snapshotted = _SNAPSHOT is not None
+    snapshot = snapshot_git_position(budget)
+    if already_snapshotted and package_path is not None:
+        live = git_identity(Path(package_path), budget)
+    else:
+        live = snapshot
+
+    moved, movement_detail = _checkout_movement(snapshot, live)
+    worktree_edited, worktree_detail = _worktree_movement(snapshot, live, moved)
+    distribution_version, distribution_detail = _distribution_version()
+    verb_count, verb_detail = _verb_count()
+
+    identity: dict[str, Any] = {
+        "version": __version__,
+        "package_path": package_path,
+        "distribution_version": distribution_version,
+        "verb_count": verb_count,
+        "git": snapshot,
+        "git_snapshot_taken_at": snapshot.get("observed_at"),
+        "git_live": live,
+        "checkout_moved": moved,
+        "worktree_edited": worktree_edited,
+        "drift": _drift(
+            snapshot,
+            __version__,
+            distribution_version,
+            live=live,
+            moved=moved,
+            movement_detail=movement_detail,
+            worktree_edited=worktree_edited,
+            worktree_detail=worktree_detail,
+        ),
+    }
+    if movement_detail is not None:
+        identity["checkout_moved_detail"] = movement_detail
+    if worktree_detail is not None:
+        identity["worktree_edited_detail"] = worktree_detail
+    if distribution_detail is not None:
+        identity["distribution_detail"] = distribution_detail
+    if verb_detail is not None:
+        identity["verb_count_detail"] = verb_detail
+    return identity

--- a/lionagi/cli/_mcp_resolve.py
+++ b/lionagi/cli/_mcp_resolve.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve, at submit time, the MCP servers a spawned leg should be given.
+
+A CLI-backed agent discovers MCP servers by walking up from its own working
+directory. That makes its tool surface a property of *where it was told to
+work* rather than of the submission: the same command, same model and same
+prompt, pointed at a checkout instead of the directory holding the config,
+starts with no MCP servers at all. Nothing fails and nothing is reported — the
+agent simply has fewer tools than its instructions assume, and only its own
+confused output says so, much later.
+
+So the submitting side resolves the config from *its* directory and hands the
+result to the child explicitly. Two consequences are deliberate:
+
+* The servers are read and snapshotted here, not passed on as a path. A path
+  would be re-read by the child at an unknown later moment, and would also have
+  to live inside the child's working directory to survive the provider's
+  repo-containment check — which is exactly the directory that does not have it.
+* "Nothing was configured" and "something was configured and could not be used"
+  are returned as different states. Collapsing them is what makes the original
+  defect silent, so a resolution that fails carries the reason with it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = (
+    "MCP_CONFIG_FILENAME",
+    "McpConfigError",
+    "McpResolution",
+    "discover_mcp_config",
+    "resolve_spawn_mcp_servers",
+)
+
+MCP_CONFIG_FILENAME = ".mcp.json"
+
+
+class McpConfigError(ValueError):
+    """A named MCP config cannot be used. Its own type, so a caller can refuse
+    the spawn on it without also catching every other ValueError raised on the
+    way there."""
+
+
+@dataclass(frozen=True)
+class McpResolution:
+    """What the submitting side resolved, and why it is what it is.
+
+    ``servers`` is None whenever no server set could be produced; ``reason`` is
+    then a short machine-readable token saying why, and is None only when the
+    caller explicitly asked for no config at all.
+    """
+
+    servers: dict[str, Any] | None
+    reason: str | None
+    source: Path | None
+    searched_from: Path
+
+    @property
+    def ok(self) -> bool:
+        return self.servers is not None
+
+
+def discover_mcp_config(start: str | Path) -> Path | None:
+    """Nearest ``.mcp.json`` at or above *start*, or None.
+
+    Mirrors how a CLI agent finds its own config, so that resolving here from
+    the submitting directory produces what the child would have found had it
+    been started there.
+    """
+    current = Path(start).expanduser().resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / MCP_CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _read_servers(path: Path) -> dict[str, Any]:
+    """Parse ``{"mcpServers": {...}}`` from *path*; raises ValueError on any
+    shape this cannot hand to a provider."""
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        raise McpConfigError(f"could not read {path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise McpConfigError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise McpConfigError(f"{path} must contain a JSON object, got {type(data).__name__}")
+    servers = data.get("mcpServers")
+    if servers is None:
+        raise McpConfigError(f"{path} has no 'mcpServers' key")
+    if not isinstance(servers, dict):
+        raise McpConfigError(
+            f"{path}: 'mcpServers' must be an object, got {type(servers).__name__}"
+        )
+    return servers
+
+
+def resolve_spawn_mcp_servers(
+    explicit: str | Path | None = None,
+    *,
+    launch_dir: str | Path,
+    disabled: bool = False,
+) -> McpResolution:
+    """Resolve the server set to hand a child spawned from *launch_dir*.
+
+    *explicit* names a config file directly and is an error when it cannot be
+    used — a caller who named a file is not asking for a silent fallback.
+    Without one, the nearest config at or above *launch_dir* is used. *disabled*
+    is the caller saying "no MCP servers", which is a choice and not a failure.
+    """
+    searched_from = Path(launch_dir).expanduser().resolve()
+
+    if disabled:
+        return McpResolution(None, None, None, searched_from)
+
+    if explicit is not None:
+        path = Path(explicit).expanduser()
+        if not path.is_absolute():
+            path = (searched_from / path).resolve()
+        if not path.is_file():
+            raise McpConfigError(f"--mcp-config {str(explicit)!r} is not a readable file ({path})")
+        return McpResolution(_read_servers(path), None, path, searched_from)
+
+    found = discover_mcp_config(searched_from)
+    if found is None:
+        return McpResolution(None, "no_mcp_config_found", None, searched_from)
+    try:
+        servers = _read_servers(found)
+    except McpConfigError as exc:
+        return McpResolution(None, f"mcp_config_unusable:{exc}", found, searched_from)
+    if not servers:
+        return McpResolution(None, "mcp_config_declares_no_servers", found, searched_from)
+    return McpResolution(servers, None, found, searched_from)

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -128,10 +128,17 @@ def build_chat_model(
     effort: str | None = None,
     fast: bool = False,
     bypass: bool = False,
+    mcp_servers: dict | None = None,
 ) -> iModel | str:
     """Legacy: for agent.py compat. Returns bare spec string when no flags."""
     effort = normalize_effort(effort)
     extra: dict = {}
+    if mcp_servers is not None:
+        # Only the Claude CLI lane carries a server set on the request; the
+        # other CLI providers read a user-level config no caller directory
+        # affects, so handing them this here would drop it without a word.
+        if provider in _CLAUDE_PROVIDER_NAMES:
+            extra["mcp_servers"] = mcp_servers
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))
     elif yolo:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -32,6 +32,7 @@ from ._context_from import (
     resolve_and_build_context_block,
 )
 from ._logging import hint, log_error
+from ._mcp_resolve import McpConfigError, McpResolution, resolve_spawn_mcp_servers
 from ._providers import (
     _CLAUDE_PROVIDER_NAMES,
     BACKENDS,
@@ -294,6 +295,43 @@ class _ProgressReport:
         )
 
 
+def _report_mcp_resolution(resolution: McpResolution, *, provider: str, cwd: str | None) -> None:
+    """Say at spawn time what tool surface the leg is actually getting.
+
+    The whole point of resolving here is that a leg starting without the
+    servers its instructions assume should be visible when it is launched
+    rather than inferred from its output an hour later. Silence is reserved
+    for the one case where it is accurate: servers resolved and handed over.
+    """
+    from lionagi.cli._logging import warn
+
+    if provider not in _CLAUDE_PROVIDER_NAMES:
+        if resolution.servers is not None:
+            warn(
+                f"MCP servers resolved from {resolution.source} are not carried to "
+                f"provider {provider!r}: only the Claude CLI lane accepts a server "
+                "set per request. This leg gets whatever that CLI discovers for itself."
+            )
+        return
+
+    if resolution.servers is not None:
+        names = ", ".join(sorted(resolution.servers))
+        hint(f"[mcp] {len(resolution.servers)} server(s) from {resolution.source}: {names}")
+        return
+
+    if resolution.reason is None:
+        return  # --no-mcp-config: chosen, not degraded
+
+    target = cwd or os.getcwd()
+    warn(
+        f"no MCP servers are being handed to this leg ({resolution.reason}; searched "
+        f"from {resolution.searched_from}). It will start with only whatever the "
+        f"Claude CLI discovers from {target} itself, which is where a leg pointed at "
+        "a checkout silently loses them. Pass --mcp-config PATH, or --no-mcp-config "
+        "to state that this is intended."
+    )
+
+
 async def _run_agent(
     model_str: str | None,
     prompt: str,
@@ -316,6 +354,8 @@ async def _run_agent(
     context_budget: int | None = None,
     notify: str | None = None,
     images: list[str] | None = None,
+    mcp_config: str | None = None,
+    no_mcp_config: bool = False,
     _auto_resumed: bool = False,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
@@ -327,6 +367,14 @@ async def _run_agent(
     # into a provider-created dir. Forward the tilde-expanded path — providers
     # never expand `~`.
     cwd = validate_cwd_exists(cwd)
+    # Read from *this* process's directory, before --cwd is applied to anything.
+    # The child's tool surface is meant to be a property of the submission, and
+    # this is the only point at which the submitting directory is still known.
+    mcp_resolution = resolve_spawn_mcp_servers(
+        mcp_config,
+        launch_dir=os.getcwd(),
+        disabled=no_mcp_config,
+    )
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
     if preset and (resume or continue_last):
@@ -453,8 +501,19 @@ async def _run_agent(
                 "sandboxed default, or use an agent profile (-a). --bypass also "
                 "works but disables the sandbox."
             )
-        chat_model = build_chat_model(provider, model, yolo, verbose, theme, effort, fast, bypass)
+        chat_model = build_chat_model(
+            provider,
+            model,
+            yolo,
+            verbose,
+            theme,
+            effort,
+            fast,
+            bypass,
+            mcp_servers=mcp_resolution.servers,
+        )
         effort = resolve_persisted_effort(provider, chat_model, effort)
+        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
 
         # Opt-in profile `role:` key switches a plain `-a <profile>` leg onto
         # the same create_agent path as --preset coding, parameterized by role.
@@ -552,6 +611,12 @@ async def _run_agent(
             cfg.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
         if fast:
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
+        # A resumed leg re-spawns a CLI child, so it needs the server set handed
+        # to it just as a new one does; the persisted branch carries the model,
+        # not the caller's directory.
+        if mcp_resolution.servers is not None and provider in _CLAUDE_PROVIDER_NAMES:
+            cfg["mcp_servers"] = mcp_resolution.servers
+        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
 
     # Add the profile system prompt for every leg EXCEPT one whose branch carries
     # (or, on a brand-new leg, would carry) a create_agent-composed system message
@@ -803,6 +868,8 @@ async def _run_agent(
             bypass=bypass,
             resume_on_timeout=resume_on_timeout,
             notify=notify,
+            mcp_config=mcp_config,
+            no_mcp_config=no_mcp_config,
             _auto_resumed=True,
         )
 
@@ -959,6 +1026,27 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
 
+    agent.add_argument(
+        "--mcp-config",
+        dest="mcp_config",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Read this MCP config and hand its servers to the leg explicitly. "
+            "By default the nearest .mcp.json at or above the directory this "
+            "command was run in is used, so the leg's tools come from the "
+            "submission rather than from --cwd. The file is read once at spawn."
+        ),
+    )
+    agent.add_argument(
+        "--no-mcp-config",
+        dest="no_mcp_config",
+        action="store_true",
+        help=(
+            "Hand the leg no MCP servers, and say so deliberately instead of "
+            "arriving there by an empty search."
+        ),
+    )
     add_common_cli_args(agent)
     return agent
 
@@ -1083,8 +1171,15 @@ def run_agent(args: argparse.Namespace) -> int:
                 context_budget=getattr(args, "context_budget", None),
                 notify=getattr(args, "notify", None),
                 images=image_uris,
+                mcp_config=getattr(args, "mcp_config", None),
+                no_mcp_config=getattr(args, "no_mcp_config", False),
             )
         )
+    except McpConfigError as exc:
+        # An explicitly named --mcp-config that cannot be used: refuse at spawn,
+        # rather than starting a leg whose tool surface is not what was asked for.
+        log_error(str(exc))
+        return 2
     except ContextFromError as exc:
         log_error(str(exc))
         return 2

--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -40,7 +40,12 @@ _CORE_DEPS: dict[str, str] = {
 
 _STUDIO_HEALTH_URL_DEFAULT = "http://127.0.0.1:8765/api/admin/health"
 
-_SYMBOLS = {"ok": "✓", "warn": "!", "fail": "✗"}
+_SYMBOLS = {"ok": "✓", "warn": "!", "fail": "✗", "unknown": "?"}
+
+# Statuses that must not be read as a passing check. `unknown` is here because a
+# check that could not be run has established nothing, and reporting it as a pass
+# is the failure mode this file exists to prevent.
+_NOT_PASSING = ("fail", "unknown")
 
 
 def _result(status: str, detail: str) -> dict[str, str]:
@@ -144,10 +149,58 @@ def _check_lionagi_home(home: Path | None = None) -> dict[str, str]:
     return _result("ok", f"{home} writable (runs/ dir ok)")
 
 
+def _check_code_identity() -> dict[str, str]:
+    """Fail when the code that answered is not the code the environment implies.
+
+    An install can be healthy in every other respect and still be serving a tree
+    that stopped tracking its upstream commits ago — the process loaded that tree
+    once, at startup, and nothing since has told anyone. This is the check that
+    tells them.
+    """
+    from ._code_identity import code_identity
+
+    try:
+        identity = code_identity()
+    except Exception as exc:  # noqa: BLE001 — an unanswerable check is unknown, not ok
+        return _result("unknown", f"could not establish code identity: {type(exc).__name__}: {exc}")
+
+    version = identity["version"]
+    path = identity["package_path"]
+    verbs = identity["verb_count"]
+    where = f"lionagi {version} at {path}, {verbs} verbs registered"
+
+    git = identity["git"]
+    if git["status"] == "ok":
+        position = git["commit_short"]
+        if git["branch"]:
+            position += f" on {git['branch']}"
+        else:
+            position += " (detached)"
+        if git.get("dirty"):
+            # A commit id next to a dirty tree reads as the whole story; it isn't.
+            position += " with uncommitted changes"
+        where += f", git {position}"
+        # The position is the one read when this process started, not the tree's
+        # position now, so it is quoted with the time it was true of.
+        taken_at = identity.get("git_snapshot_taken_at")
+        if taken_at:
+            where += f" as read at {taken_at}"
+    elif git["status"] == "not_a_git_checkout":
+        where += ", not a git checkout"
+
+    drift = identity["drift"]
+    if drift["status"] == "drift":
+        return _result("fail", f"{where} — " + "; ".join(drift["reasons"]))
+    if drift["status"] == "unknown":
+        return _result("unknown", f"{where} — " + "; ".join(drift["unknown"]))
+    return _result("ok", where)
+
+
 def collect_checks() -> dict[str, dict[str, str]]:
     """Run every check and return a flat name -> {status, detail} mapping."""
     checks: dict[str, dict[str, str]] = {}
     checks["lionagi_version"] = _check_version()
+    checks["code_identity"] = _check_code_identity()
     checks["python"] = _check_python()
     for mod, result in _check_imports().items():
         checks[f"import:{mod}"] = result
@@ -184,6 +237,6 @@ def run_doctor(args: argparse.Namespace) -> int:
         for name, result in checks.items():
             symbol = _SYMBOLS.get(result["status"], "?")
             print(f"{symbol} {name}: {result['detail']}")
-    if any(result["status"] == "fail" for result in checks.values()):
+    if any(result["status"] in _NOT_PASSING for result in checks.values()):
         return 1
     return 0

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -433,12 +433,17 @@ def reserve_stdout() -> Iterator[MachineChannel]:
 def handshake_data() -> dict[str, Any]:
     from lionagi.version import __version__
 
+    from ._code_identity import code_identity
+
     return {
         "contract_version": CONTRACT_VERSION,
         "min_supported_version": MIN_SUPPORTED_CONTRACT_VERSION,
         "implementation": "lionagi",
         "implementation_version": __version__,
         "module": str(Path(__file__).resolve().parent),
+        # Which build answered, not which build was installed: a caller with no
+        # shell on this host has no other way to tell the two apart.
+        "code_identity": code_identity(),
     }
 
 
@@ -449,6 +454,10 @@ def doctor_data() -> dict[str, Any]:
     return {
         "checks": checks,
         "failed": sorted(name for name, result in checks.items() if result["status"] == "fail"),
+        # Reported apart from `failed` because a check that could not be run is
+        # not a check that passed, and a caller that only reads `failed` would
+        # otherwise treat the two the same.
+        "unknown": sorted(name for name, result in checks.items() if result["status"] == "unknown"),
     }
 
 

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -99,7 +99,7 @@ def _resolve_command(
 
 
 def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
-    """Replace ``{run_id}``/``{status}``/``{label}``/``{target}`` per token."""
+    """Replace ``{run_id}``/``{status}``/``{label}``/``{target}``/``{sender}`` per token."""
     out: list[str] = []
     for tok in argv:
         for key, value in fields.items():
@@ -108,7 +108,31 @@ def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
     return out
 
 
-def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
+def _delivery_env(sender: str) -> dict[str, str] | None:
+    """Environment for the delivery command, carrying an explicit sender.
+
+    A notifier that resolves who it is from its working directory reports the
+    identity of whoever owns that directory, not the identity of whoever
+    submitted the run. That misattribution is silent — the notice arrives, it
+    just arrives signed by the wrong seat, and downstream routing rules act on
+    the signature. Naming the sender here is the caller's answer to that.
+
+    This publishes the value; it does not force any particular notifier to
+    prefer it over its own directory-based resolution. A notifier whose
+    identity precedence puts a working-directory config first has to be given
+    the sender in its command line, which is what the ``{sender}`` placeholder
+    is for.
+    """
+    if not sender:
+        return None
+    env = dict(os.environ)
+    env["LIONAGI_NOTIFY_SENDER"] = sender
+    return env
+
+
+def _deliver(
+    argv: list[str], payload: dict[str, str], env: dict[str, str] | None = None
+) -> dict[str, Any]:
     """Run the delivery command best-effort; return its outcome for the record.
 
     The outcome is recorded on the job so a dead completion notice surfaces in
@@ -126,6 +150,7 @@ def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+            env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         # never fail the run's terminal path; record the failure instead
@@ -177,24 +202,40 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--status", default="completed")
     ap.add_argument("--target", default=None, help="value for the {target} placeholder")
     ap.add_argument("--command", default=None, help="delivery argv override (JSON list)")
+    ap.add_argument(
+        "--sender",
+        default=None,
+        help="value for the {sender} placeholder: who the notice is from",
+    )
     args = ap.parse_args(argv)
 
     job = jobs.mark_terminal(args.run_id, args.status)
 
     target = args.target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
+    sender = args.sender or os.environ.get("LIONAGI_MCP_NOTIFY_SENDER") or ""
     label = (job or {}).get("label") or (job or {}).get("kind") or "run"
     template, unusable = _resolve_command(
         args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
         cwd=(job or {}).get("cwd"),
     )
+    if template and not sender and any("{sender}" in tok for tok in template):
+        # The command asks who the notice is from and there is no answer. An
+        # empty string is not one: it puts a blank where an identity belongs,
+        # and a delivery tool that accepts it — or falls back to resolving a
+        # sender from its own working directory — signs the notice with a seat
+        # that did not send it, silently. Unusable in the same sense as a
+        # template that cannot be parsed, and recorded the same way.
+        template, unusable = None, "delivery_command_needs_a_sender_and_none_was_given"
+
     if template:
         fields = {
             "run_id": args.run_id,
             "status": args.status,
             "label": label,
             "target": target,
+            "sender": sender,
         }
-        outcome = _deliver(_substitute(template, fields), fields)
+        outcome = _deliver(_substitute(template, fields), fields, _delivery_env(sender))
     elif unusable:
         # Configured but unusable. Recorded as a failure so job_status shows a
         # notifier that cannot deliver, rather than the silence of one that was

--- a/lionagi/mcp/config.py
+++ b/lionagi/mcp/config.py
@@ -49,9 +49,15 @@ def li_command() -> list[str]:
     if override:
         return override.split()
 
-    bin_li = Path(sys.executable).resolve().parent / "li"
-    if bin_li.exists():
-        return [str(bin_li)]
+    # A venv's bin/python is a symlink to the base interpreter, so resolving it
+    # before looking for the sibling script searches the base installation's
+    # bin and misses the `li` the venv itself installed. Try the interpreter's
+    # own directory first, and the resolved one only as a fallback.
+    interpreter = Path(sys.executable)
+    for bindir in (interpreter.parent, interpreter.resolve().parent):
+        bin_li = bindir / "li"
+        if bin_li.exists():
+            return [str(bin_li)]
 
     return [sys.executable, "-m", "lionagi.cli"]
 

--- a/lionagi/mcp/config.py
+++ b/lionagi/mcp/config.py
@@ -40,7 +40,9 @@ def li_command() -> list[str]:
     the one installed alongside the running interpreter — no working-tree
     hunting, no dependency resync on spawn. Resolution order:
 
-      1. ``LIONAGI_MCP_LI_BIN`` (explicit override, split on whitespace).
+      1. ``LIONAGI_MCP_LI_BIN`` (explicit override, split on whitespace). Used
+         verbatim, so a value that is not an absolute path is resolved by the
+         OS through ``PATH`` like any other bare command.
       2. The ``li`` console script next to ``sys.executable`` (same venv/bin),
          invoked by absolute path so it never depends on ``PATH``.
       3. ``<this-interpreter> -m lionagi.cli`` as a last resort.

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -200,17 +200,24 @@ def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied
         "help": {"verb": name} if verb.playbook_aware else name,
         "schema_fingerprint": current,
     }
+    # Where the key goes is the part a caller gets wrong: put it inside `args`
+    # and it is simply not read, so this refusal repeats verbatim and the
+    # failure reads as idempotent rather than as a misplaced key. Spelling the
+    # whole op is the only form of the instruction that cannot be misread.
+    shape = f"{{'op': {name!r}, 'args': {{...}}, 'schema_fingerprint': {current!r}}}"
     if supplied is None:
         raise OpError(
             "stale_schema",
-            f"{name!r} needs the schema_fingerprint that help returns for it; "
-            f"ask for help={name!r} and send its schema_fingerprint with the op",
+            f"{name!r} needs the schema_fingerprint that help returns for it; ask for "
+            f"help={name!r} and send the fingerprint as a sibling of 'args', not a "
+            f"member of it: {shape}",
             remedy,
         )
     raise OpError(
         "stale_schema",
         f"{name!r} was called with schema_fingerprint {supplied!r}, which is not the "
-        f"current {current!r}; the parameters changed since that schema was read",
+        f"current {current!r}; the parameters changed since that schema was read. "
+        f"Re-read help={name!r} and send: {shape}",
         remedy,
     )
 
@@ -383,7 +390,11 @@ def render_argv(schema: dict[str, Any], args: dict[str, Any]) -> list[str]:
             positional[name] = value
             continue
         flag = spec["x-flag"]
-        if spec.get("type") == "boolean":
+        if spec.get("x-json-encoded"):
+            # The parser decodes this flag's single token from JSON, so the
+            # value the caller sent has to reach it encoded.
+            flags += _flag_tokens(name, flag, json.dumps(value))
+        elif spec.get("type") == "boolean":
             # A store_false action defaults to true and its flag turns it off, so
             # the flag belongs on the line exactly when the value differs from
             # what the parser would have chosen on its own.

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -104,6 +104,11 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
 
     required = [name for name in schema.get("required", []) if name in properties]
     required += [name for name in verb.requires if name not in required]
+    unenforced = [
+        name
+        for name in schema.get("x-required-unenforced", [])
+        if name in properties and name not in required
+    ]
     order = [name for name in schema.get("x-positional-order", []) if name in properties]
 
     out: dict[str, Any] = {
@@ -116,6 +121,8 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
     }
     if required:
         out["required"] = required
+    if unenforced:
+        out["x-required-unenforced"] = unenforced
     if order:
         out["x-positional-order"] = order
     if verb.refuses:
@@ -130,12 +137,35 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
 
 
 def catalog() -> dict[str, Any]:
-    """Every verb, with enough of a signature to write the common invocation."""
+    """Every verb, with enough of a signature to write the common invocation.
+
+    "Enough" is measured against the gate the call actually meets. A verb whose
+    ops must carry a ``schema_fingerprint`` gets that fingerprint here, because
+    an entry that lists a verb's parameters and withholds the one thing without
+    which the call is refused describes a call that cannot be made. The schema is
+    built anyway to read ``required`` off it, so the fingerprint is a hash of a
+    document already in hand and costs no extra work.
+
+    Where the schema depends on an argument, no fingerprint is quoted: the one
+    for the argument-free schema would be a value that never matches. The entry
+    names the parameter it varies with instead, so the caller knows to ask help
+    for that spelling rather than to retry with a stale string.
+    """
     entries: list[dict[str, Any]] = []
     for verb in VERBS.values():
         entry: dict[str, Any] = {"verb": verb.name, "available": True, "summary": verb.summary}
         try:
-            entry["required"] = list(verb_schema(verb).get("required", []))
+            schema = verb_schema(verb)
+            entry["required"] = list(schema.get("required", []))
+            unenforced = list(schema.get("x-required-unenforced", []))
+            if unenforced:
+                # Named apart from `required` because the parser will not refuse a
+                # call that omits these, and the schema may offer another way to
+                # supply the same thing. Reporting them inside `required` would
+                # make the schema and what is admitted two different contracts.
+                entry["required_unenforced"] = unenforced
+            if verb.executor == "spawn":
+                _describe_fingerprint(entry, verb, schema)
         except Exception as exc:  # noqa: BLE001 — one unreadable parser must not hide the rest
             entry["available"] = False
             entry["reason"] = f"schema generation failed: {type(exc).__name__}: {exc}"
@@ -158,9 +188,14 @@ def catalog() -> dict[str, Any]:
         "help_usage": (
             "help=true returns this catalog; help='<verb>' returns that verb's full "
             "parameter schema; help={'verb': '<verb>', 'playbook': '<name>'} resolves a "
-            "playbook's own declared arguments into the schema. A spawn verb's help also "
-            "returns a schema_fingerprint, which that verb's ops must carry: "
-            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from help>'}."
+            "playbook's own declared arguments into the schema. An entry carrying a "
+            "schema_fingerprint names a verb whose ops must repeat it: "
+            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from this entry>'}. "
+            "An entry carrying schema_fingerprint_varies_with names the parameters that "
+            "change the schema: pass one of them and the fingerprint to send is the one "
+            "help returns for that spelling, not the one quoted here. "
+            "required_unenforced names parameters the parser will not refuse a call for "
+            "omitting but the command cannot do its work without."
         ),
         "synonyms_removed_after": SYNONYM_REMOVAL_DATE,
     }
@@ -178,6 +213,23 @@ def schema_fingerprint(schema: dict[str, Any]) -> str:
     """
     body = json.dumps(schema, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(body.encode()).hexdigest()[:16]
+
+
+def _describe_fingerprint(entry: dict[str, Any], verb: Verb, schema: dict[str, Any]) -> None:
+    """Say what a fingerprint-gated verb's ops have to carry.
+
+    A playbook-aware verb is projected again once a playbook is named, so its
+    fingerprint is a function of that argument. When the playbook is optional the
+    argument-free schema is a real call and its fingerprint is quoted; when the
+    verb requires a playbook there is no such call, so quoting anything would
+    hand the caller a string that is guaranteed to be refused.
+    """
+    varies = ["playbook"] if verb.playbook_aware else []
+    if varies:
+        entry["schema_fingerprint_varies_with"] = varies
+    if any(name in verb.requires for name in varies):
+        return
+    entry["schema_fingerprint"] = schema_fingerprint(schema)
 
 
 def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied: Any) -> None:

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -518,6 +518,9 @@ def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict
         label=args.get("label") or args.get("playbook"),
         notify_command=args.get("notify_command"),
         notify_target=args.get("notify_seat"),
+        notify_sender=args.get("notify_sender"),
+        mcp_config=args.get("mcp_config"),
+        no_mcp_config=bool(args.get("no_mcp_config")),
     )
     fingerprint = schema.get("x-playbook-fingerprint")
     if fingerprint is not None:

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -534,12 +534,17 @@ def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict
 
 
 def _server_info() -> dict[str, Any]:
+    from lionagi.cli._code_identity import code_identity
     from lionagi.cli.machine import CONTRACT_VERSION
     from lionagi.version import __version__
 
     return {
         "lionagi_version": __version__,
         "contract_version": CONTRACT_VERSION,
+        # The verb count below is this process's registration; `code_identity`
+        # says which tree that registration was read from and whether that tree
+        # is behind what it should be serving.
+        "code_identity": code_identity(),
         "started_at": _STARTED_AT,
         "uptime_seconds": round(time.time() - _STARTED_MONOTONIC, 3),
         "tool_count": 1,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -267,7 +267,12 @@ def _split_at_sentinel(flags: Sequence[str]) -> tuple[list[str], list[str]]:
     return tokens[:cut], tokens[cut:]
 
 
-def _notify_template(run_id: str, notify_target: str | None, notify_command: str | None) -> str:
+def _notify_template(
+    run_id: str,
+    notify_target: str | None,
+    notify_command: str | None,
+    notify_sender: str | None = None,
+) -> str:
     """Command the CLI runs on terminal status (records finished_at + delivery).
 
     Invokes the terminal hook module by absolute interpreter path with a
@@ -289,6 +294,8 @@ def _notify_template(run_id: str, notify_target: str | None, notify_command: str
         parts += ["--target", shlex.quote(notify_target)]
     if notify_command:
         parts += ["--command", shlex.quote(notify_command)]
+    if notify_sender:
+        parts += ["--sender", shlex.quote(notify_sender)]
     return " ".join(parts)
 
 
@@ -534,6 +541,9 @@ def submit(
     label: str | None = None,
     notify_command: str | None = None,
     notify_target: str | None = None,
+    notify_sender: str | None = None,
+    mcp_config: str | None = None,
+    no_mcp_config: bool = False,
 ) -> dict[str, Any]:
     """Spawn a ``li`` run in the background and return its handle immediately.
 
@@ -546,6 +556,13 @@ def submit(
     per-submit delivery-argv override (JSON list); *notify_target* fills the
     ``{target}`` placeholder in the configured command. With neither and no
     configured default, the run simply records its status and delivers nothing.
+
+    *mcp_config* and *no_mcp_config* are the caller's own answer to where the
+    child's MCP servers come from, handed over as values rather than left to be
+    read back out of *flags*. Both are already rendered into *flags* by the
+    surface; they are repeated here because this function has to decide whether
+    to resolve a set of its own, and that is a decision about intent, not about
+    tokens.
     """
     if kind not in _KIND_ARGV:
         raise ValueError(f"unknown job kind {kind!r}; expected one of {sorted(_KIND_ARGV)}")
@@ -576,9 +593,78 @@ def submit(
                 positionals = ["--"]
             positionals.append(prompt)
 
+    # An agent leg discovers MCP servers from the directory it is told to work
+    # in, which for a detached run is a checkout and not the directory holding
+    # this server's config. Resolve it here, where the submitting directory is
+    # still the one in effect, and hand the resolved set to the child.
+    # Both outcomes are reported on the handle: a leg that starts without the
+    # tools its brief assumes should be visible at submit, not deduced later
+    # from its own confused output.
+    #
+    # The servers are read here and written into this run's own directory, and
+    # that copy is what the child is pointed at. Naming the discovered file
+    # instead would leave the run's tool surface tied to a file anyone may edit
+    # between submission and execution — and a run that resumes hours later
+    # would re-read it again, so the same submission could start with a
+    # different set of tools every time. A file only this run writes cannot
+    # change under it, and staying a path keeps the child's existing flag
+    # working. A config that exists but cannot be used fails the submission,
+    # because a child that discovers the problem reports it minutes later and
+    # only in its own log, while the submitter was told the run started.
+    #
+    # A snapshot is taken only when the caller left the choice open. Whether
+    # they did is answered from the values they passed, never by looking through
+    # the tokens for a flag: those tokens are built by the same surface, in a
+    # form (`--flag=value`) chosen so that nothing downstream can take them
+    # apart, so a scan of them reports on spelling rather than on intent.
+    mcp_config_path: str | None = None
+    mcp_config_source: str | None = None
+    mcp_config_reason: str | None = None
+    mcp_servers: dict[str, Any] | None = None
+    if kind == "agent" and no_mcp_config:
+        # The caller asked for no servers. That is an answer, not an absence, so
+        # nothing is resolved and the handle says whose decision it was.
+        mcp_config_reason = "mcp_disabled_by_caller"
+    elif kind == "agent" and mcp_config is not None:
+        # The caller named the file, and their flag is already on the line. No
+        # snapshot is taken and none is prepended: a second --mcp-config would
+        # let the parser pick between them, and the handle would go on naming
+        # the one the child did not read. What the child reads is what the
+        # handle reports, and its source is the caller's own path, which this
+        # run does not own and cannot promise will hold still.
+        mcp_config_path = mcp_config
+        mcp_config_source = mcp_config
+        mcp_config_reason = "mcp_config_named_by_caller"
+    elif kind == "agent":
+        from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
+
+        launch_dir = os.getcwd()
+        resolution = resolve_spawn_mcp_servers(launch_dir=launch_dir)
+        if resolution.servers is None:
+            if resolution.reason and resolution.reason.startswith("mcp_config_unusable:"):
+                raise McpConfigError(
+                    f"cannot submit this agent run: the MCP config found at "
+                    f"{resolution.source} cannot be used "
+                    f"({resolution.reason.split(':', 1)[1].strip()})"
+                )
+            mcp_config_reason = (
+                f"{resolution.reason}_at_or_above:{launch_dir}"
+                if resolution.reason == "no_mcp_config_found"
+                else resolution.reason
+            )
+        else:
+            mcp_servers = resolution.servers
+            mcp_config_source = str(resolution.source) if resolution.source else None
+            mcp_config_path = str(d / "mcp-servers.json")
+            options = ["--mcp-config", mcp_config_path, *options]
+
     # Wire the CLI's terminal hook back to the MCP server so we record a reliable
     # finished_at/status (and fire the configured delivery) even across a restart.
-    options = ["--notify", _notify_template(run_id, notify_target, notify_command), *options]
+    options = [
+        "--notify",
+        _notify_template(run_id, notify_target, notify_command, notify_sender),
+        *options,
+    ]
 
     argv = [*config.li_command(), *_KIND_ARGV[kind], *options, *positionals]
 
@@ -596,6 +682,8 @@ def submit(
     d.mkdir(parents=True, exist_ok=True)
     if prompt_path is not None:
         prompt_path.write_text(prompt)
+    if mcp_servers is not None and mcp_config_path is not None:
+        Path(mcp_config_path).write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
     # always finds a record to mark. mark_terminal no-ops on a missing record, so
@@ -617,6 +705,10 @@ def submit(
         "label": label,
         "notify_command": notify_command,
         "notify_target": notify_target,
+        "notify_sender": notify_sender,
+        "mcp_config": mcp_config_path,
+        "mcp_config_source": mcp_config_source,
+        "mcp_config_reason": mcp_config_reason,
         "submitted_at": _now_iso(),
         "finished_at": None,
         "status": "running",
@@ -675,6 +767,10 @@ def submit(
         "reason_code": derived["reason_code"],
         "spawn_state": latest["spawn_state"],
         "log": str(log_path),
+        "mcp_config": mcp_config_path,
+        "mcp_config_source": mcp_config_source,
+        "mcp_config_reason": mcp_config_reason,
+        "notify_sender": notify_sender,
     }
 
 

--- a/lionagi/mcp/projection.py
+++ b/lionagi/mcp/projection.py
@@ -368,7 +368,13 @@ def _accepts_no_values(action: argparse.Action) -> bool:
     but argparse marks the action required all the same and then never enforces
     it. Carrying that flag into the schema would tell a caller a parameter is
     mandatory when the parser itself does not think so, and the caller has no
-    way to check. The rule is stated about the action rather than read off
+    way to check. Such an action is still reported, under
+    ``x-required-unenforced``: the command is declared as being about this value,
+    and a caller told only ``required: []`` reads that as "a call with no
+    arguments is valid", which is a different and wronger claim than the one
+    ``required`` was dropped to avoid.
+
+    The rule is stated about the action rather than read off
     ``required``, because ``required`` is what is wrong here: Python 3.14 stopped
     setting it for exactly these actions, so trusting it makes the schema — and
     every golden pinned to it — say different things on different interpreters
@@ -399,6 +405,7 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
 
     properties: dict[str, Any] = {}
     required: list[str] = []
+    unenforced: list[str] = []
     positionals: list[str] = []
 
     for action in parser._actions:
@@ -407,7 +414,9 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
         if action.dest == argparse.SUPPRESS:
             continue
         properties[action.dest] = _project_action(path, parser, action)
-        if action.required and not _accepts_no_values(action):
+        if _accepts_no_values(action):
+            unenforced.append(action.dest)
+        elif action.required:
             required.append(action.dest)
         if not action.option_strings:
             positionals.append(action.dest)
@@ -422,6 +431,8 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
         schema["description"] = parser.description.strip()
     if required:
         schema["required"] = required
+    if unenforced:
+        schema["x-required-unenforced"] = unenforced
     if positionals:
         schema["x-positional-order"] = positionals
     exclusive = _mutually_exclusive(parser)

--- a/lionagi/mcp/projection.py
+++ b/lionagi/mcp/projection.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from lionagi.cli._argtypes import JsonArgument
+
 __all__ = (
     "SchemaProjectionError",
     "PlaybookResolutionError",
@@ -288,6 +290,12 @@ def _project_action(
             raise SchemaProjectionError(
                 path, f"append with nargs={nargs!r} nests arrays", action=label
             )
+        if isinstance(action.type, JsonArgument):
+            if nargs is not None or kind is _APPEND:
+                raise SchemaProjectionError(
+                    path, f"JSON-encoded value with nargs={nargs!r}", action=label
+                )
+            return _project_json_action(parser, action, action.type)
         item: dict[str, Any] = {"type": _scalar_type(path, action, label)}
         enum = _choices_enum(path, action, label)
         if enum is not None:
@@ -315,6 +323,13 @@ def _project_action(
     else:
         raise SchemaProjectionError(path, f"unknown action class {kind.__name__}", action=label)
 
+    return _annotate(schema, parser, action)
+
+
+def _annotate(
+    schema: dict[str, Any], parser: argparse.ArgumentParser, action: argparse.Action
+) -> dict[str, Any]:
+    """Add the parts every parameter carries: prose, default, and how it spells."""
     description = _description(parser, action)
     if description:
         schema["description"] = description
@@ -329,6 +344,21 @@ def _project_action(
         if aliases:
             schema["x-aliases"] = list(aliases)
     return schema
+
+
+def _project_json_action(
+    parser: argparse.ArgumentParser, action: argparse.Action, kind: JsonArgument
+) -> dict[str, Any]:
+    """A flag whose value the parser decodes from JSON, described as it decodes.
+
+    The advertised type is the *decoded* shape, because that is the shape the
+    argument accepts; ``x-json-encoded`` tells a renderer that the one argv
+    token this becomes has to be the encoding of it. Advertising ``string``
+    instead would name a type that no plain string satisfies.
+    """
+    schema = dict(kind.json_schema)
+    schema["x-json-encoded"] = True
+    return _annotate(schema, parser, action)
 
 
 def _accepts_no_values(action: argparse.Action) -> bool:

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -82,6 +82,13 @@ async def request(
 
 def main() -> None:
     """Console entrypoint: run the server over stdio."""
+    from lionagi.cli._code_identity import snapshot_git_position
+
+    # Read where this server's code came from before serving anything. The
+    # process keeps the modules it imported for its whole life, so a checkout
+    # that moves later is divergence to report, not a new answer to give — and
+    # only a reading taken now can tell the two apart.
+    snapshot_git_position()
     mcp.run()
 
 

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -61,9 +61,11 @@ async def request(
 ) -> dict[str, Any]:
     """Dispatch lionagi operations, or ask what operations exist.
 
-    Start with ``help=true``: it returns every verb with its required parameters
-    and a one-line summary, which is enough to write the common call without a
-    second round-trip. ``help='<verb>'`` returns that verb's full schema.
+    Start with ``help=true``: it returns every verb with its required parameters,
+    a one-line summary, and — for the verbs whose ops must carry one — the
+    ``schema_fingerprint`` to send with the call, which is enough to write the
+    common call without a second round-trip. ``help='<verb>'`` returns that
+    verb's full schema.
 
     Results come back as ``{'status': 'success'|'partial', 'ops': [...]}``, one
     entry per op in the order given, each ``{'ok': true, 'op', 'result'}`` or

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -174,6 +174,18 @@ _NOTIFY_SEAT = {
     "x-server-owned": True,
 }
 
+_NOTIFY_SENDER = {
+    "type": "string",
+    "description": (
+        "Who the terminal notice is from. Fills the {sender} placeholder in the "
+        "delivery command and is published to it as LIONAGI_NOTIFY_SENDER. "
+        "Without it the notifier reports whatever identity it resolves from the "
+        "run's working directory, which is the directory's owner and not the "
+        "submitter."
+    ),
+    "x-server-owned": True,
+}
+
 _PLAYBOOK_FINGERPRINT = {
     "type": "string",
     "description": (
@@ -192,6 +204,7 @@ _SPAWN_SERVER_PARAMS: Mapping[str, dict[str, Any]] = {
     "label": _LABEL,
     "notify_command": _NOTIFY_COMMAND,
     "notify_seat": _NOTIFY_SEAT,
+    "notify_sender": _NOTIFY_SENDER,
 }
 
 _FLOW_SERVER_PARAMS: Mapping[str, dict[str, Any]] = {

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi._paths import ensure_lionagi_dir
+from lionagi.cli._argtypes import JsonArgument
 from lionagi.cli._logging import log_error, warn
 from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES
 
@@ -803,13 +804,8 @@ def build_create_body(args: argparse.Namespace) -> tuple[dict[str, Any] | None, 
     if getattr(args, "action_command", None):
         body["action_command"] = args.action_command
     if getattr(args, "action_command_args", None):
-        try:
-            parsed_command_args = json.loads(args.action_command_args)
-        except (ValueError, TypeError) as exc:
-            return None, f"--action-command-args must be valid JSON: {exc}"
-        if not isinstance(parsed_command_args, list):
-            return None, "--action-command-args must be a JSON array."
-        body["action_command_args"] = parsed_command_args
+        # Already a list: the argument's own type decoded and checked it.
+        body["action_command_args"] = args.action_command_args
     # ADR-0070 delta 1: persist a stable execution root instead of depending
     # on the daemon's cwd when it fires. An explicit --cwd always wins.
     if getattr(args, "cwd", None):
@@ -1858,6 +1854,7 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         "--action-command-args",
         dest="action_command_args",
         metavar="JSON",
+        type=JsonArgument({"type": "array", "items": {"type": "string"}}),
         help=(
             "action-kind=command argv, as a JSON array of {{var}} templates "
             "rendered from trigger_context at fire time, e.g. "

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -1712,7 +1712,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule get sched-abc123",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    get_p.add_argument("id", help="Schedule ID.")
+    get_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
 
     # limits
     sched_sub.add_parser(
@@ -1741,7 +1743,13 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    create_p.add_argument("name", help="Schedule name.")
+    create_p.add_argument(
+        "name",
+        help=(
+            "Unique name identifying this schedule. Reused as the display label in "
+            "listings; a name already in use is rejected rather than overwritten."
+        ),
+    )
     create_p.add_argument(
         "--trigger-type",
         dest="trigger_type",
@@ -1749,8 +1757,23 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         choices=("cron", "interval", "github", "github_poll"),
         help="Trigger type (default: cron). 'github' is an alias for 'github_poll'.",
     )
-    create_p.add_argument("--cron", metavar="EXPR", help='Cron expression, e.g. "0 * * * *".')
-    create_p.add_argument("--interval", type=int, metavar="SECONDS", help="Interval in seconds.")
+    create_p.add_argument(
+        "--cron",
+        metavar="EXPR",
+        help=(
+            'Cron expression, e.g. "0 * * * *". Required when --trigger-type is cron, '
+            "which is the default; ignored for other trigger types."
+        ),
+    )
+    create_p.add_argument(
+        "--interval",
+        type=int,
+        metavar="SECONDS",
+        help=(
+            "Seconds between fires. Required when --trigger-type is interval; "
+            "ignored for other trigger types."
+        ),
+    )
     create_p.add_argument(
         "--github-repo",
         dest="github_repo",
@@ -1796,9 +1819,23 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         choices=tuple(sorted(_VALID_ACTION_KINDS | set(_ALIAS_ACTION_KINDS))),
         help="Stored action kind or accepted alias (default: agent).",
     )
-    create_p.add_argument("--prompt", help="Prompt for agent action.")
+    create_p.add_argument(
+        "--prompt",
+        help=(
+            "Instruction the scheduled agent runs at each fire. Required when "
+            "--action-kind is agent, which is the default. A profile named by "
+            "--agent supplies the model and settings, never this instruction, so "
+            "a schedule created without it fires and fails."
+        ),
+    )
     create_p.add_argument("--model", help="Model spec for agent action.")
-    create_p.add_argument("--agent", help="Agent profile name.")
+    create_p.add_argument(
+        "--agent",
+        help=(
+            "Agent profile to run, resolved the same way `li agent --agent` resolves "
+            "it. Supplies the system prompt, model and effort the fire runs with."
+        ),
+    )
     create_p.add_argument("--playbook", help="Playbook name (for action-kind=play/playbook).")
     create_p.add_argument(
         "--flow-yaml",
@@ -1827,7 +1864,13 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
             '\'["review-pr", "--pr", "{{pr_number}}"]\'.'
         ),
     )
-    create_p.add_argument("--project", help="Project name.")
+    create_p.add_argument(
+        "--project",
+        help=(
+            "Project this schedule's runs are recorded under. Defaults to the project "
+            "detected from the execution root."
+        ),
+    )
     create_p.add_argument(
         "--cwd",
         metavar="PATH",
@@ -1997,7 +2040,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
             epilog=f"Example: {example}",
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        p.add_argument("id", help="Schedule ID.")
+        p.add_argument(
+            "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+        )
 
     # trigger
     trigger_p = sched_sub.add_parser(
@@ -2006,7 +2051,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule trigger sched-abc123 --wait",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    trigger_p.add_argument("id", help="Schedule ID.")
+    trigger_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     trigger_p.add_argument(
         "--wait",
         action="store_true",
@@ -2025,7 +2072,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule runs sched-abc123 --status failed --limit 5",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    runs_p.add_argument("id", help="Schedule ID.")
+    runs_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     runs_p.add_argument(
         "--limit",
         type=int,
@@ -2058,7 +2107,9 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         epilog="Example: li schedule status sched-abc123 --wait",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    status_p.add_argument("id", help="Schedule ID.")
+    status_p.add_argument(
+        "id", help="Id of the schedule, as returned by `li schedule list` in its `id` field."
+    )
     status_p.add_argument(
         "--wait", action="store_true", help="Wait for the latest in-flight run to finish first."
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
       - Durable operations: guides/durable-operations.md
       - Studio & schedules: guides/studio.md
       - Scheduling workflows: guides/scheduling-workflows.md
+      - Connect an MCP client: guides/mcp-setup.md
       - MCP server: reference/mcp-server.md
       - Providers: reference/providers.md
       - State & testing: reference/testing-state-session.md

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -103,6 +103,8 @@ AGENT_HELP_FLAGS = [
     "--image",
     "--invocation",
     "--list-profiles",
+    "--mcp-config",
+    "--no-mcp-config",
     "--notify",
     "--preset",
     "--project",

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -1,0 +1,797 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The running code's self-report, and the checks that call it out when it drifts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli import _code_identity, doctor
+from lionagi.cli._code_identity import code_identity, git_identity
+
+
+class _Args:
+    """Stand-in for the argparse namespace `run_doctor` reads."""
+
+    json = False
+
+
+def _git(tree: Path, *argv: str) -> str:
+    completed = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "-C",
+            str(tree),
+            *argv,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _commit(tree: Path, name: str) -> None:
+    (tree / name).write_text(name)
+    _git(tree, "add", name)
+    _git(tree, "commit", "-m", name)
+
+
+@pytest.fixture
+def checkout_behind(tmp_path: Path) -> Path:
+    """A working checkout whose HEAD is one commit behind its own upstream."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "-b", "main", ".")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-b", "main", ".")
+    _commit(work, "first")
+    _commit(work, "second")
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-u", "origin", "main")
+    _git(work, "reset", "--hard", "HEAD~1")
+    return work
+
+
+def test_checkout_behind_upstream_reads_as_drift(checkout_behind: Path) -> None:
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["comparison_ref"] == "origin/main"
+    assert git["comparison_ref_source"] == "upstream"
+    assert git["behind"] == 1
+    assert git["ahead"] == 0
+
+
+def test_detached_checkout_falls_back_to_the_remote_default_branch(
+    checkout_behind: Path,
+) -> None:
+    """A pinned deployment has no upstream — the remote's HEAD still answers for it."""
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    _git(checkout_behind, "checkout", "--detach", "HEAD")
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["detached"] is True
+    assert git["branch"] is None
+    assert git["comparison_ref_source"] == "remote_head"
+    assert git["behind"] == 1
+
+
+def test_up_to_date_checkout_is_not_behind(checkout_behind: Path) -> None:
+    """The guard fires on drift, not on every checkout that has a remote."""
+    _git(checkout_behind, "merge", "--ff-only", "origin/main")
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "ok"
+    assert git["behind"] == 0
+
+
+def test_directory_outside_any_checkout_says_so_plainly(tmp_path: Path) -> None:
+    git = git_identity(tmp_path)
+    assert git["status"] == "not_a_git_checkout"
+    assert str(tmp_path) in git["detail"]
+
+
+def test_unreadable_head_is_unknown_not_ok(tmp_path: Path) -> None:
+    """An initialized tree with no commits: git answers, HEAD does not resolve."""
+    _git(tmp_path, "init", "-b", "main", ".")
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "unknown"
+    assert "HEAD" in git["detail"]
+
+
+def test_missing_git_binary_is_unknown_not_a_missing_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _no_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _no_git)
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "unknown"
+    assert "FileNotFoundError" in git["detail"]
+
+
+def test_a_git_call_that_never_ran_does_not_read_as_a_missing_upstream(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lookup that could not run is not evidence the tree has no upstream.
+
+    origin/HEAD resolves here, so falling through to it would produce a confident
+    `ok` built on a question that was never actually asked.
+    """
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    real_run = subprocess.run
+
+    def _upstream_probe_times_out(argv: list[str], **kwargs: object):
+        if "@{upstream}" in argv:
+            raise subprocess.TimeoutExpired(argv, 5.0)
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _upstream_probe_times_out)
+
+    git = git_identity(checkout_behind)
+    assert git["status"] == "unknown"
+    assert "TimeoutExpired" in git["detail"]
+    assert git.get("comparison_ref_source") != "remote_head"
+
+
+def test_a_spent_allowance_is_unknown_not_ok(checkout_behind: Path) -> None:
+    """The whole identity gets one allowance; running out of it is not a pass."""
+    git = git_identity(checkout_behind, _code_identity._Budget(0.0))
+    assert git["status"] == "unknown"
+    assert "allowance" in git["detail"]
+
+
+def test_the_remote_head_fallback_carries_its_own_staleness(checkout_behind: Path) -> None:
+    """origin/HEAD is local and can name a branch the remote no longer defaults to."""
+    _git(checkout_behind, "remote", "set-head", "origin", "-a")
+    _git(checkout_behind, "checkout", "--detach", "HEAD")
+
+    git = git_identity(checkout_behind)
+    assert git["comparison_ref_source"] == "remote_head"
+    assert "local symbolic ref" in git["comparison_ref_caveat"]
+
+
+def test_a_reading_says_when_it_was_taken(checkout_behind: Path) -> None:
+    assert git_identity(checkout_behind)["observed_at"]
+
+
+def test_no_comparison_ref_is_unknown_not_ok(tmp_path: Path) -> None:
+    """A checkout with no remote cannot be measured, so it is not declared current."""
+    _git(tmp_path, "init", "-b", "main", ".")
+    _commit(tmp_path, "only")
+
+    git = git_identity(tmp_path)
+    assert git["status"] == "ok"
+    assert git["comparison_ref"] is None
+    assert git["behind"] is None
+
+    drift = _code_identity._drift(git, "1.0.0", "1.0.0")
+    assert drift["status"] == "unknown"
+    assert drift["unknown"]
+
+
+# ── the drift verdict ────────────────────────────────────────────────────────
+
+
+def test_version_mismatch_against_installed_distribution_is_drift() -> None:
+    git = {"status": "not_a_git_checkout", "detail": "wheel install"}
+    drift = _code_identity._drift(git, "0.1.0", "9.9.9")
+    assert drift["status"] == "drift"
+    assert any("9.9.9" in reason for reason in drift["reasons"])
+
+
+def test_wheel_install_with_matching_version_is_ok() -> None:
+    git = {"status": "not_a_git_checkout", "detail": "wheel install"}
+    assert _code_identity._drift(git, "0.1.0", "0.1.0")["status"] == "ok"
+
+
+def test_behind_outranks_unknown_in_the_verdict() -> None:
+    git = {"status": "ok", "behind": 24, "comparison_ref": "origin/main"}
+    drift = _code_identity._drift(git, "0.1.0", None)
+    assert drift["status"] == "drift"
+    assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
+
+
+# ── the snapshot, and the tree moving underneath it ──────────────────────────
+
+
+@pytest.fixture
+def loaded_from(checkout_behind: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pretend this process imported itself from *checkout_behind*, snapshot unset."""
+    monkeypatch.setattr(_code_identity, "_SNAPSHOT", None)
+    monkeypatch.setattr(_code_identity, "loaded_package_path", lambda: str(checkout_behind))
+    return checkout_behind
+
+
+def test_the_first_call_takes_the_snapshot_and_it_is_the_current_reading(
+    loaded_from: Path,
+) -> None:
+    identity = code_identity()
+    assert identity["git_snapshot_taken_at"]
+    assert identity["checkout_moved"] is False
+    assert identity["git"]["commit"] == identity["git_live"]["commit"]
+
+
+def test_a_checkout_that_moves_under_the_process_is_reported_as_moved(
+    loaded_from: Path,
+) -> None:
+    """The loaded code is the snapshot; the tree's new position is a separate fact."""
+    loaded_commit = code_identity()["git"]["commit"]
+
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+
+    after = code_identity()
+    assert after["git"]["commit"] == loaded_commit
+    assert after["git_live"]["commit"] != loaded_commit
+    assert after["checkout_moved"] is True
+    assert "moved from" in after["checkout_moved_detail"]
+    assert after["drift"]["status"] == "drift"
+    assert any("moved from" in reason for reason in after["drift"]["reasons"])
+
+
+def test_the_snapshot_is_read_once_not_once_per_call(loaded_from: Path) -> None:
+    first = code_identity()["git_snapshot_taken_at"]
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+    assert code_identity()["git_snapshot_taken_at"] == first
+
+
+def test_the_server_snapshots_its_position_before_it_starts_serving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.mcp import server
+
+    monkeypatch.setattr(_code_identity, "_SNAPSHOT", None)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(server.mcp, "run", lambda: seen.update(snapshot=_code_identity._SNAPSHOT))
+
+    server.main()
+    assert seen["snapshot"] is not None
+
+
+def test_an_unreadable_live_position_is_unknown_movement_not_no_movement() -> None:
+    moved, detail = _code_identity._checkout_movement(
+        {"status": "ok", "commit": "a" * 40},
+        {"status": "unknown", "detail": "git went away"},
+    )
+    assert moved is None
+    assert "cannot be read" in detail
+
+
+def test_the_live_count_answers_when_the_checkout_has_not_moved() -> None:
+    """Same commit, fresher view of the remote: the newer measurement is the true one."""
+    drift = _code_identity._drift(
+        {"status": "ok", "behind": 0, "comparison_ref": "origin/main"},
+        "0.1.0",
+        None,
+        live={"status": "ok", "behind": 3, "comparison_ref": "origin/main"},
+        moved=False,
+    )
+    assert drift["status"] == "drift"
+    assert any("3 commit(s) behind" in reason for reason in drift["reasons"])
+
+
+def test_the_snapshot_answers_when_the_checkout_has_moved() -> None:
+    """Once the tree moves, the live count is about a commit that is not running."""
+    drift = _code_identity._drift(
+        {"status": "ok", "behind": 24, "comparison_ref": "origin/main"},
+        "0.1.0",
+        None,
+        live={"status": "ok", "behind": 0, "comparison_ref": "origin/main"},
+        moved=True,
+        movement_detail="it moved",
+    )
+    assert drift["status"] == "drift"
+    assert "it moved" in drift["reasons"]
+    assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
+
+
+# ── the tree moving without the commit moving ────────────────────────────────
+
+
+def test_a_dirty_tree_is_fingerprinted_and_a_clean_one_is_too(checkout_behind: Path) -> None:
+    """The digest is a value on every readable tree, so it can always be compared."""
+    clean = git_identity(checkout_behind)["worktree_fingerprint"]
+    assert clean
+
+    (checkout_behind / "first").write_text("edited")
+    dirty = git_identity(checkout_behind)["worktree_fingerprint"]
+    assert dirty
+    assert dirty != clean
+
+
+def test_editing_an_already_modified_file_changes_the_fingerprint(
+    checkout_behind: Path,
+) -> None:
+    """The status listing alone would not move here — the path and its code are the same."""
+    (checkout_behind / "first").write_text("one")
+    before = git_identity(checkout_behind)
+    (checkout_behind / "first").write_text("two")
+    after = git_identity(checkout_behind)
+
+    assert before["dirty"] is True
+    assert after["dirty"] is True
+    assert before["worktree_fingerprint"] != after["worktree_fingerprint"]
+
+
+def test_a_fingerprint_that_could_not_be_taken_is_none_with_a_reason(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (checkout_behind / "first").write_text("edited")
+    real_run = subprocess.run
+
+    def _diff_fails(argv: list[str], **kwargs: object):
+        if argv[3:5] == ["diff", "HEAD"]:
+            raise subprocess.TimeoutExpired(argv, 5.0)
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(_code_identity.subprocess, "run", _diff_fails)
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is None
+    assert "TimeoutExpired" in git["worktree_fingerprint_detail"]
+
+
+def test_an_edit_under_the_process_is_reported_though_the_commit_never_moved(
+    loaded_from: Path,
+) -> None:
+    """The case that used to read as a clean `ok`: same commit, different files."""
+    before = code_identity()
+    assert before["worktree_edited"] is False
+
+    (loaded_from / "first").write_text("edited under the running process")
+
+    after = code_identity()
+    assert after["git"]["commit"] == after["git_live"]["commit"]
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+    assert after["drift"]["status"] == "drift"
+    assert any("was edited after this process loaded" in r for r in after["drift"]["reasons"])
+
+
+def test_the_two_kinds_of_movement_are_reported_separately(loaded_from: Path) -> None:
+    """Moving the checkout is one operator action; editing files is another."""
+    code_identity()
+    _git(loaded_from, "merge", "--ff-only", "origin/main")
+
+    after = code_identity()
+    assert after["checkout_moved"] is True
+    assert after["worktree_edited"] is None, "not comparable across a commit change"
+    assert "different commits" in after["worktree_edited_detail"]
+    assert any("different commits" in u for u in after["drift"]["unknown"])
+
+
+def test_a_missing_fingerprint_is_unknown_movement_not_a_still_tree() -> None:
+    edited, detail = _code_identity._worktree_movement(
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": None},
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": "beef"},
+        False,
+    )
+    assert edited is None
+    assert "when this process loaded" in detail
+
+
+def test_rewriting_an_untracked_file_that_already_existed_is_an_edit(
+    loaded_from: Path,
+) -> None:
+    """Neither the status listing nor the diff carries an untracked file's contents."""
+    scratch = loaded_from / "scratch.txt"
+    scratch.write_text("present before the process started")
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    scratch.write_text("rewritten while the process was running")
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+
+
+def test_an_edit_inside_an_untracked_directory_is_an_edit(loaded_from: Path) -> None:
+    """git collapses an untracked directory to one line; the listing alone cannot move."""
+    package = loaded_from / "plugins"
+    package.mkdir()
+    (package / "handler.py").write_text("def run(): return 1\n")
+
+    before = code_identity()
+    assert before["worktree_edited"] is False
+
+    (package / "handler.py").write_text("def run(): return 2\n")
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+
+
+def test_a_new_file_inside_an_untracked_directory_is_an_edit(loaded_from: Path) -> None:
+    package = loaded_from / "plugins"
+    package.mkdir()
+    (package / "handler.py").write_text("def run(): return 1\n")
+
+    assert code_identity()["worktree_edited"] is False
+
+    (package / "extra.py").write_text("def also(): return 3\n")
+
+    assert code_identity()["worktree_edited"] is True
+
+
+def test_an_ignored_path_is_not_enumerated(checkout_behind: Path) -> None:
+    """The listing stays bounded: build output and virtualenvs are still excluded."""
+    (checkout_behind / ".gitignore").write_text("build/\n")
+    _git(checkout_behind, "add", ".gitignore")
+    _git(checkout_behind, "commit", "-m", "ignore build")
+    build = checkout_behind / "build"
+    build.mkdir()
+    (build / "artifact.bin").write_bytes(b"\x00" * 32)
+
+    before = git_identity(checkout_behind)
+    assert before["dirty"] is False
+
+    (build / "artifact.bin").write_bytes(b"\x01" * 64)
+
+    assert git_identity(checkout_behind)["worktree_fingerprint"] == before["worktree_fingerprint"]
+
+
+def test_a_path_that_cannot_be_stat_d_is_none_with_a_reason(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable path is not evidence that the tree stood still."""
+    (checkout_behind / "scratch.txt").write_text("untracked")
+    real_lstat = Path.lstat
+
+    def _refuse(self: Path):
+        if self.name == "scratch.txt":
+            raise PermissionError(13, "Permission denied")
+        return real_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", _refuse)
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is None
+    assert "scratch.txt" in git["worktree_fingerprint_detail"]
+    assert "PermissionError" in git["worktree_fingerprint_detail"]
+
+
+def test_a_stat_failure_makes_the_edit_answer_unknown_not_false(
+    loaded_from: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (loaded_from / "scratch.txt").write_text("untracked")
+    code_identity()
+
+    real_lstat = Path.lstat
+
+    def _refuse(self: Path):
+        if self.name == "scratch.txt":
+            raise PermissionError(13, "Permission denied")
+        return real_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", _refuse)
+
+    after = code_identity()
+    assert after["worktree_edited"] is None
+    assert "scratch.txt" in after["worktree_edited_detail"]
+    assert any("scratch.txt" in u for u in after["drift"]["unknown"])
+
+
+def test_a_deleted_path_is_measured_rather_than_read_as_unreadable(
+    loaded_from: Path,
+) -> None:
+    """A path git lists as deleted is absent by definition — absence is the reading."""
+    (loaded_from / "first").unlink()
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    after = code_identity()
+    assert after["worktree_edited"] is False, "an absent path must not read as unknown"
+
+
+def test_a_renamed_path_does_not_stat_the_name_it_came_from(checkout_behind: Path) -> None:
+    """The origin path of a rename no longer exists; only the destination is on disk."""
+    _git(checkout_behind, "mv", "first", "renamed")
+
+    git = git_identity(checkout_behind)
+    assert git["worktree_fingerprint"] is not None
+    assert "worktree_fingerprint_detail" not in git
+
+
+def test_a_permission_change_on_an_untracked_file_is_an_edit(loaded_from: Path) -> None:
+    """chmod rewrites no bytes, so nothing but the mode moves — and it still counts.
+
+    Making a file executable changes what an operator can run out of the tree
+    while leaving the size, the modification time and the status listing exactly
+    as they were.
+    """
+    scratch = loaded_from / "scratch.txt"
+    scratch.write_text("plain")
+    scratch.chmod(0o644)
+    was = scratch.lstat()
+
+    before = code_identity()
+    assert before["git"]["dirty"] is True
+    assert before["worktree_edited"] is False
+
+    scratch.chmod(0o755)
+
+    now = scratch.lstat()
+    assert (now.st_size, now.st_mtime_ns) == (was.st_size, was.st_mtime_ns), (
+        "the premise of this test is that size and mtime cannot see a chmod"
+    )
+
+    after = code_identity()
+    assert after["checkout_moved"] is False
+    assert after["worktree_edited"] is True
+    assert "was edited after this process loaded" in after["worktree_edited_detail"]
+
+
+class _SpentAfter:
+    """A budget generous for a fixed number of readings, then exhausted.
+
+    Deterministic where a wall-clock deadline is not: exhaustion lands on a chosen
+    iteration of the per-path loop rather than wherever the machine happens to be
+    slow that day.
+    """
+
+    total = 6.0
+
+    def __init__(self, readings: int) -> None:
+        self._left = readings
+
+    def remaining(self) -> float:
+        if self._left > 0:
+            self._left -= 1
+            return self.total
+        return -1.0
+
+
+def test_an_allowance_spent_inside_the_per_path_loop_yields_no_digest(
+    checkout_behind: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The loop is inside the allowance, and running out of it is not a partial answer.
+
+    A digest over some of the paths compares unequal to one over all of them, so a
+    loop that stopped at the deadline and returned what it had would report an
+    edit to a tree nobody touched. This pins the difference that truncation would
+    manufacture, then shows the code declines to manufacture it.
+    """
+    for name in ("one.txt", "two.txt", "three.txt"):
+        (checkout_behind / name).write_text(name)
+
+    top = Path(_git(checkout_behind, "rev-parse", "--show-toplevel"))
+    porcelain = _git(checkout_behind, "status", "--porcelain", "-z", "--untracked-files=all")
+    paths = _code_identity._status_paths(porcelain)
+    assert len(paths) == 3
+
+    full, detail = _code_identity._worktree_fingerprint(
+        checkout_behind, top, porcelain, _code_identity._Budget(60.0)
+    )
+    assert detail is None
+    assert full
+
+    with monkeypatch.context() as stop_after_one:
+        stop_after_one.setattr(_code_identity, "_status_paths", lambda _: paths[:1])
+        truncated, _ = _code_identity._worktree_fingerprint(
+            checkout_behind, top, porcelain, _code_identity._Budget(60.0)
+        )
+    assert truncated != full, "truncation invents a difference in a tree that did not change"
+
+    spent, reason = _code_identity._worktree_fingerprint(
+        checkout_behind, top, porcelain, _SpentAfter(2)
+    )
+    assert spent is None, "a spent allowance must not return the digest built so far"
+    assert spent != truncated
+    assert "allowance" in reason
+    assert f"measuring 1 of the {len(paths)} paths" in reason
+
+    edited, movement = _code_identity._worktree_movement(
+        {"status": "ok", "commit": "a" * 40, "worktree_fingerprint": full},
+        {
+            "status": "ok",
+            "commit": "a" * 40,
+            "worktree_fingerprint": spent,
+            "worktree_fingerprint_detail": reason,
+        },
+        False,
+    )
+    assert edited is None, "a timeout is 'cannot tell', never 'the tree was edited'"
+    assert "allowance" in movement
+
+
+def test_a_dirty_snapshot_is_unknown_not_ok() -> None:
+    """A commit id cannot describe a tree with changes that are not in it."""
+    git = {
+        "status": "ok",
+        "behind": 0,
+        "comparison_ref": "origin/main",
+        "commit_short": "abc123def456",
+        "dirty": True,
+    }
+    drift = _code_identity._drift(git, "0.1.0", "0.1.0")
+    assert drift["status"] == "unknown"
+    assert any("uncommitted changes" in u for u in drift["unknown"])
+
+
+def test_a_clean_snapshot_at_its_ref_is_still_ok() -> None:
+    """The dirty rule must not swallow the one state that is genuinely fine."""
+    git = {"status": "ok", "behind": 0, "comparison_ref": "origin/main", "dirty": False}
+    assert _code_identity._drift(git, "0.1.0", "0.1.0")["status"] == "ok"
+
+
+def test_a_dirty_tree_read_end_to_end_does_not_claim_ok(loaded_from: Path) -> None:
+    """Before anything moves at all: dirty at snapshot time is already not `ok`."""
+    (loaded_from / "first").write_text("uncommitted when the process started")
+
+    identity = code_identity()
+    assert identity["git"]["dirty"] is True
+    assert identity["checkout_moved"] is False
+    assert identity["drift"]["status"] != "ok"
+    assert any("uncommitted changes" in u for u in identity["drift"]["unknown"])
+
+
+def test_doctor_says_the_tree_was_dirty_beside_the_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _code_identity,
+        "code_identity",
+        lambda: _identity(
+            "unknown",
+            git={
+                "status": "ok",
+                "commit_short": "abc123def456",
+                "branch": None,
+                "detached": True,
+                "dirty": True,
+            },
+        ),
+    )
+    assert (
+        "abc123def456 (detached) with uncommitted changes"
+        in (doctor._check_code_identity()["detail"])
+    )
+
+
+def test_code_identity_reports_this_process() -> None:
+    identity = code_identity()
+    assert identity["version"]
+    assert identity["package_path"].endswith("/lionagi")
+    assert Path(identity["package_path"]).is_dir()
+    assert identity["verb_count"] > 0
+    assert identity["git"]["status"] in ("ok", "not_a_git_checkout", "unknown")
+    assert identity["drift"]["status"] in ("ok", "drift", "unknown")
+    assert identity["git_snapshot_taken_at"]
+    assert identity["checkout_moved"] in (True, False, None)
+    assert identity["git_live"]["status"] in ("ok", "not_a_git_checkout", "unknown")
+
+
+# ── the doctor check ─────────────────────────────────────────────────────────
+
+
+def _identity(drift_status: str, **overrides: object) -> dict[str, object]:
+    identity: dict[str, object] = {
+        "version": "0.1.0",
+        "package_path": "/somewhere/lionagi",
+        "distribution_version": "0.1.0",
+        "verb_count": 40,
+        "git": {
+            "status": "ok",
+            "commit_short": "abc123def456",
+            "branch": None,
+            "detached": True,
+        },
+        "drift": {
+            "status": drift_status,
+            "reasons": ["24 commit(s) behind origin/main"] if drift_status == "drift" else [],
+            "unknown": ["git state unreadable"] if drift_status == "unknown" else [],
+        },
+    }
+    identity.update(overrides)
+    return identity
+
+
+def test_doctor_fails_on_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("drift"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "fail"
+    assert "24 commit(s) behind origin/main" in result["detail"]
+    assert "40 verbs" in result["detail"]
+
+
+def test_doctor_reports_unknown_rather_than_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("unknown"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "unknown"
+    assert "git state unreadable" in result["detail"]
+
+
+def test_doctor_ok_when_identity_is_clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_code_identity, "code_identity", lambda: _identity("ok"))
+    result = doctor._check_code_identity()
+    assert result["status"] == "ok"
+    assert "abc123def456 (detached)" in result["detail"]
+
+
+def test_doctor_quotes_when_the_position_was_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A commit with no time attached reads as current; this one says what it is."""
+    monkeypatch.setattr(
+        _code_identity,
+        "code_identity",
+        lambda: _identity("ok", git_snapshot_taken_at="2026-07-26T00:00:00+00:00"),
+    )
+    detail = doctor._check_code_identity()["detail"]
+    assert "as read at 2026-07-26T00:00:00+00:00" in detail
+
+
+def test_doctor_check_that_cannot_run_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> dict[str, object]:
+        raise RuntimeError("no")
+
+    monkeypatch.setattr(_code_identity, "code_identity", _boom)
+    assert doctor._check_code_identity()["status"] == "unknown"
+
+
+def test_run_doctor_exits_nonzero_on_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "collect_checks",
+        lambda: {"code_identity": {"status": "unknown", "detail": "cannot tell"}},
+    )
+    assert doctor.run_doctor(_Args()) == 1
+
+
+# ── the surfaces a client reads ──────────────────────────────────────────────
+
+
+def test_handshake_carries_code_identity() -> None:
+    from lionagi.cli.machine import handshake_data
+
+    identity = handshake_data()["code_identity"]
+    assert identity["package_path"]
+    assert identity["verb_count"] > 0
+    assert "status" in identity["drift"]
+
+
+def test_server_info_carries_code_identity() -> None:
+    from lionagi.mcp.dispatch import _server_info
+
+    info = _server_info()
+    assert info["code_identity"]["version"] == info["lionagi_version"]
+    assert info["code_identity"]["verb_count"] == info["verb_count"]
+
+
+def test_doctor_machine_payload_separates_unknown_from_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.cli import machine
+
+    monkeypatch.setattr(
+        doctor,
+        "collect_checks",
+        lambda: {
+            "a": {"status": "unknown", "detail": "cannot tell"},
+            "b": {"status": "fail", "detail": "broken"},
+            "c": {"status": "ok", "detail": "fine"},
+        },
+    )
+    data = machine.doctor_data()
+    assert data["failed"] == ["b"]
+    assert data["unknown"] == ["a"]

--- a/tests/cli/test_command_action_kind.py
+++ b/tests/cli/test_command_action_kind.py
@@ -441,7 +441,9 @@ class TestCliActionKindChoices:
         )
         assert args.action_kind == "command"
         assert args.action_command == "kdev"
-        assert args.action_command_args == '["review-pr"]'
+        # The flag declares its shape as its argparse type, so the parser hands
+        # back the decoded list rather than the JSON text it arrived as.
+        assert args.action_command_args == ["review-pr"]
 
 
 # ---------------------------------------------------------------------------
@@ -540,30 +542,35 @@ class TestCmdCreateActionCommandArgsJSON:
         ]
 
     def test_invalid_json_rejected_before_api_call(self, capsys):
-        """Malformed JSON in --action-command-args must return 1 and never
-        reach the HTTP layer."""
-        from lionagi.studio.cli import _cmd_create
+        """Malformed JSON in --action-command-args is refused while parsing, so
+        no handler runs and nothing can reach the HTTP layer.
 
-        args = self._parse(self._argv("{not valid json"))
+        The shape is declared as the argument's type, which means the parser
+        rejects a bad value itself and exits 2 the way it does for every other
+        malformed argument, rather than a handler decoding the string later and
+        returning 1."""
         with patch("lionagi.studio.cli._api") as mock_api:
-            rc = _cmd_create(args)
+            with pytest.raises(SystemExit) as excinfo:
+                self._parse(self._argv("{not valid json"))
 
-        assert rc == 1
+        assert excinfo.value.code == 2
         mock_api.assert_not_called()
-        assert "--action-command-args must be valid JSON" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "--action-command-args" in err
+        assert "must be valid JSON" in err
 
     def test_valid_json_non_array_rejected_before_api_call(self, capsys):
-        """Valid JSON that parses to a non-array (e.g. an object) must return
-        1 and never reach the HTTP layer."""
-        from lionagi.studio.cli import _cmd_create
-
-        args = self._parse(self._argv('{"not": "an array"}'))
+        """Valid JSON that parses to a non-array (e.g. an object) is refused
+        while parsing, so no handler runs and nothing reaches the HTTP layer."""
         with patch("lionagi.studio.cli._api") as mock_api:
-            rc = _cmd_create(args)
+            with pytest.raises(SystemExit) as excinfo:
+                self._parse(self._argv('{"not": "an array"}'))
 
-        assert rc == 1
+        assert excinfo.value.code == 2
         mock_api.assert_not_called()
-        assert "--action-command-args must be a JSON array" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "--action-command-args" in err
+        assert "must be a JSON array" in err
 
     def test_valid_json_array_parsed_and_forwarded(self):
         """A well-formed JSON array must be parsed and forwarded as the

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -207,9 +207,12 @@ def test_collect_checks_shape() -> None:
     assert "lionagi_home" in checks
     assert any(k.startswith("import:") for k in checks)
     assert any(k.startswith("dep:") for k in checks)
+    assert "code_identity" in checks
     for result in checks.values():
         assert set(result) == {"status", "detail"}
-        assert result["status"] in ("ok", "warn", "fail")
+        # `unknown` is a status in its own right: a check that could not be run
+        # has not passed, and collapsing it into `warn` would say it had.
+        assert result["status"] in ("ok", "warn", "fail", "unknown")
 
 
 def test_run_doctor_json_output(capsys: pytest.CaptureFixture) -> None:

--- a/tests/cli/test_mcp_resolve.py
+++ b/tests/cli/test_mcp_resolve.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Submit-time MCP resolution: the leg's tool surface comes from the submission."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.cli._mcp_resolve import (
+    McpConfigError,
+    discover_mcp_config,
+    resolve_spawn_mcp_servers,
+)
+
+SERVERS = {"khive": {"command": "kkernel", "args": ["mcp"]}}
+
+
+def _write_config(directory, servers=SERVERS):
+    path = directory / ".mcp.json"
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return path
+
+
+def test_discovery_walks_up_from_the_launch_directory(tmp_path):
+    _write_config(tmp_path)
+    deep = tmp_path / "a" / "b"
+    deep.mkdir(parents=True)
+    assert discover_mcp_config(deep) == tmp_path / ".mcp.json"
+
+
+def test_servers_are_read_from_the_launch_dir_not_the_target_cwd(tmp_path):
+    """The defect this exists for: a leg pointed at a checkout keeps the
+    submitting directory's servers instead of finding none of its own."""
+    caller = tmp_path / "caller"
+    checkout = tmp_path / "checkout"
+    caller.mkdir()
+    checkout.mkdir()
+    _write_config(caller)
+
+    assert discover_mcp_config(checkout) is None
+    resolution = resolve_spawn_mcp_servers(launch_dir=caller)
+    assert resolution.servers == SERVERS
+    assert resolution.source == caller / ".mcp.json"
+
+
+def test_no_config_reports_a_reason_rather_than_an_empty_result(tmp_path):
+    """Nothing-configured must stay distinguishable from configured-and-unusable;
+    collapsing them is what made the original loss silent."""
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.servers is None
+    assert resolution.reason == "no_mcp_config_found"
+    assert not resolution.ok
+
+
+def test_disabled_is_a_choice_and_carries_no_reason(tmp_path):
+    _write_config(tmp_path)
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path, disabled=True)
+    assert resolution.servers is None
+    assert resolution.reason is None
+
+
+def test_unusable_discovered_config_reports_why(tmp_path):
+    (tmp_path / ".mcp.json").write_text("{not json")
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.servers is None
+    assert resolution.reason.startswith("mcp_config_unusable:")
+
+
+def test_explicit_config_that_cannot_be_used_is_an_error(tmp_path):
+    """A caller who named a file is not asking for a silent fallback."""
+    with pytest.raises(McpConfigError, match="--mcp-config"):
+        resolve_spawn_mcp_servers(str(tmp_path / "absent.json"), launch_dir=tmp_path)
+
+
+def test_explicit_config_wins_over_discovery(tmp_path):
+    _write_config(tmp_path, {"discovered": {"command": "x"}})
+    named = tmp_path / "named.json"
+    named.write_text(json.dumps({"mcpServers": SERVERS}))
+    resolution = resolve_spawn_mcp_servers(str(named), launch_dir=tmp_path)
+    assert resolution.servers == SERVERS
+
+
+def test_config_without_servers_key_is_unusable_not_empty(tmp_path):
+    (tmp_path / ".mcp.json").write_text(json.dumps({"other": {}}))
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.reason.startswith("mcp_config_unusable:")
+
+
+def test_only_the_claude_lane_receives_the_server_set():
+    """The other CLI providers read a user-level config; handing them a server
+    set here would drop it silently, so the builder does not."""
+    from lionagi.cli._providers import build_chat_model
+
+    claude = build_chat_model("claude_code", "opus", False, False, None, mcp_servers=SERVERS)
+    assert claude.endpoint.config.kwargs["mcp_servers"] == SERVERS
+
+    codex = build_chat_model("codex", "gpt-5.6", False, False, None, mcp_servers=SERVERS)
+    kwargs = getattr(getattr(codex, "endpoint", None), "config", None)
+    assert kwargs is None or "mcp_servers" not in kwargs.kwargs

--- a/tests/mcp/golden_projections/agent.json
+++ b/tests/mcp/golden_projections/agent.json
@@ -164,6 +164,9 @@
     "type": "object",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "static"

--- a/tests/mcp/golden_projections/agent.json
+++ b/tests/mcp/golden_projections/agent.json
@@ -80,6 +80,17 @@
         "type": "boolean",
         "x-flag": "--list-profiles"
       },
+      "mcp_config": {
+        "description": "Read this MCP config and hand its servers to the leg explicitly. By default the nearest .mcp.json at or above the directory this command was run in is used, so the leg's tools come from the submission rather than from --cwd. The file is read once at spawn.",
+        "type": "string",
+        "x-flag": "--mcp-config"
+      },
+      "no_mcp_config": {
+        "default": false,
+        "description": "Hand the leg no MCP servers, and say so deliberately instead of arriving there by an empty search.",
+        "type": "boolean",
+        "x-flag": "--no-mcp-config"
+      },
       "notify": {
         "description": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}.",
         "type": "string",

--- a/tests/mcp/golden_projections/invoke__end.json
+++ b/tests/mcp/golden_projections/invoke__end.json
@@ -1,0 +1,40 @@
+{
+  "path": "invoke end",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "invocation_id": {
+        "description": "The id printed by `li invoke start`. An invocation never closed stays 'running' forever.",
+        "type": "string",
+        "x-positional": true
+      },
+      "metadata": {
+        "description": "JSON merged key-by-key into the invocation's existing metadata, so anything written during the run survives unless this overwrites that key.",
+        "type": "string",
+        "x-flag": "--metadata"
+      },
+      "status": {
+        "default": "completed",
+        "description": "How the work ended, which also fixes the reason stored with it: 'completed' for success, 'failed' for an exception, 'timed_out' for a deadline, 'aborted' for a user interrupt, 'cancelled' for a system cancellation. Later listings and dashboards filter on this, so leaving the default on work that did not succeed records it as a success.",
+        "enum": [
+          "completed",
+          "failed",
+          "timed_out",
+          "aborted",
+          "cancelled"
+        ],
+        "type": "string",
+        "x-flag": "--status"
+      }
+    },
+    "required": [
+      "invocation_id"
+    ],
+    "title": "invoke end",
+    "type": "object",
+    "x-positional-order": [
+      "invocation_id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/orchestrate__fanout.json
+++ b/tests/mcp/golden_projections/orchestrate__fanout.json
@@ -169,6 +169,9 @@
     "type": "object",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "static"

--- a/tests/mcp/golden_projections/orchestrate__flow.json
+++ b/tests/mcp/golden_projections/orchestrate__flow.json
@@ -232,6 +232,9 @@
     "x-playbook-arguments": "This command accepts arguments declared by the playbook named in 'playbook'. Ask for this schema again with that playbook named to see them.",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "base"

--- a/tests/mcp/golden_projections/schedule__create.json
+++ b/tests/mcp/golden_projections/schedule__create.json
@@ -30,12 +30,12 @@
         "x-flag": "--action-kind"
       },
       "agent": {
-        "description": "Agent profile name.",
+        "description": "Agent profile to run, resolved the same way `li agent --agent` resolves it. Supplies the system prompt, model and effort the fire runs with.",
         "type": "string",
         "x-flag": "--agent"
       },
       "cron": {
-        "description": "Cron expression, e.g. \"0 * * * *\".",
+        "description": "Cron expression, e.g. \"0 * * * *\". Required when --trigger-type is cron, which is the default; ignored for other trigger types.",
         "type": "string",
         "x-flag": "--cron"
       },
@@ -65,7 +65,7 @@
         "x-flag": "--github-repo"
       },
       "interval": {
-        "description": "Interval in seconds.",
+        "description": "Seconds between fires. Required when --trigger-type is interval; ignored for other trigger types.",
         "type": "integer",
         "x-flag": "--interval"
       },
@@ -90,7 +90,7 @@
         "x-flag": "--model"
       },
       "name": {
-        "description": "Schedule name.",
+        "description": "Unique name identifying this schedule. Reused as the display label in listings; a name already in use is rejected rather than overwritten.",
         "type": "string",
         "x-positional": true
       },
@@ -121,12 +121,12 @@
         "x-flag": "--poll-interval"
       },
       "project": {
-        "description": "Project name.",
+        "description": "Project this schedule's runs are recorded under. Defaults to the project detected from the execution root.",
         "type": "string",
         "x-flag": "--project"
       },
       "prompt": {
-        "description": "Prompt for agent action.",
+        "description": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default. A profile named by --agent supplies the model and settings, never this instruction, so a schedule created without it fires and fails.",
         "type": "string",
         "x-flag": "--prompt"
       },

--- a/tests/mcp/golden_projections/schedule__create.json
+++ b/tests/mcp/golden_projections/schedule__create.json
@@ -10,8 +10,12 @@
       },
       "action_command_args": {
         "description": "action-kind=command argv, as a JSON array of {{var}} templates rendered from trigger_context at fire time, e.g. '[\"review-pr\", \"--pr\", \"{{pr_number}}\"]'.",
-        "type": "string",
-        "x-flag": "--action-command-args"
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "x-flag": "--action-command-args",
+        "x-json-encoded": true
       },
       "action_kind": {
         "default": "agent",

--- a/tests/mcp/golden_projections/schedule__delete.json
+++ b/tests/mcp/golden_projections/schedule__delete.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule delete",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule delete",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__disable.json
+++ b/tests/mcp/golden_projections/schedule__disable.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule disable",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule disable",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__enable.json
+++ b/tests/mcp/golden_projections/schedule__enable.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule enable",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule enable",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__export.json
+++ b/tests/mcp/golden_projections/schedule__export.json
@@ -1,0 +1,27 @@
+{
+  "path": "schedule export",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "legacy": {
+        "default": false,
+        "description": "Convert chain-free legacy rows (managed_by is null, i.e. rows predating the declaration layer) instead of declaration/cli-managed rows. A row with on_success/on_fail is reported BLOCKED and omitted.",
+        "type": "boolean",
+        "x-flag": "--legacy"
+      },
+      "output": {
+        "description": "Write the ScheduleSet YAML here (default: stdout).",
+        "type": "string",
+        "x-flag": "--output"
+      },
+      "report": {
+        "description": "Write the human-readable conversion report here (default: stderr).",
+        "type": "string",
+        "x-flag": "--report"
+      }
+    },
+    "title": "schedule export",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__get.json
+++ b/tests/mcp/golden_projections/schedule__get.json
@@ -1,0 +1,22 @@
+{
+  "path": "schedule get",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule get",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__limits.json
+++ b/tests/mcp/golden_projections/schedule__limits.json
@@ -1,0 +1,10 @@
+{
+  "path": "schedule limits",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "schedule limits",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__list.json
+++ b/tests/mcp/golden_projections/schedule__list.json
@@ -1,0 +1,10 @@
+{
+  "path": "schedule list",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {},
+    "title": "schedule list",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__runs.json
+++ b/tests/mcp/golden_projections/schedule__runs.json
@@ -1,0 +1,42 @@
+{
+  "path": "schedule runs",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "limit": {
+        "default": 20,
+        "description": "Max runs to return, 1-200 (default: 20).",
+        "type": "integer",
+        "x-flag": "--limit"
+      },
+      "status": {
+        "description": "Filter by run status; repeatable (e.g. --status failed --status timed_out).",
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "x-flag": "--status"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule runs",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__status.json
+++ b/tests/mcp/golden_projections/schedule__status.json
@@ -1,0 +1,34 @@
+{
+  "path": "schedule status",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "wait": {
+        "default": false,
+        "description": "Wait for the latest in-flight run to finish first.",
+        "type": "boolean",
+        "x-flag": "--wait"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule status",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__trigger.json
+++ b/tests/mcp/golden_projections/schedule__trigger.json
@@ -1,0 +1,28 @@
+{
+  "path": "schedule trigger",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+        "type": "string",
+        "x-positional": true
+      },
+      "wait": {
+        "default": false,
+        "description": "Block until the fired occurrence reaches a terminal status (retries a short grace period first, since the occurrence row isn't durably written until just after this returns a run id), then print its outcome and exit non-zero on failure.",
+        "type": "boolean",
+        "x-flag": "--wait"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "title": "schedule trigger",
+    "type": "object",
+    "x-positional-order": [
+      "id"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/schedule__validate.json
+++ b/tests/mcp/golden_projections/schedule__validate.json
@@ -1,0 +1,28 @@
+{
+  "path": "schedule validate",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "as_json": {
+        "default": false,
+        "description": "Emit JSON.",
+        "type": "boolean",
+        "x-flag": "--json"
+      },
+      "file": {
+        "description": "Path to a ScheduleSet YAML file.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "file"
+    ],
+    "title": "schedule validate",
+    "type": "object",
+    "x-positional-order": [
+      "file"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__create.json
+++ b/tests/mcp/golden_projections/team__create.json
@@ -1,0 +1,31 @@
+{
+  "path": "team create",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "members": {
+        "description": "Comma-separated member names. Only these names can send or receive as themselves; a message from or to anyone else still goes through, with a warning.",
+        "type": "string",
+        "x-aliases": [
+          "-m"
+        ],
+        "x-flag": "--members"
+      },
+      "name": {
+        "description": "Name for the new team. Every other team command accepts it in place of the team id.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "name",
+      "members"
+    ],
+    "title": "team create",
+    "type": "object",
+    "x-positional-order": [
+      "name"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__receive.json
+++ b/tests/mcp/golden_projections/team__receive.json
@@ -1,0 +1,27 @@
+{
+  "path": "team receive",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "member": {
+        "description": "Read as this member: returns only their unread mail and marks it read. Omit it to dump every message and mark nothing read.",
+        "type": "string",
+        "x-flag": "--as"
+      },
+      "team": {
+        "description": "Team to read from \u2014 its id, its name, or an unambiguous id prefix.",
+        "type": "string",
+        "x-aliases": [
+          "-t"
+        ],
+        "x-flag": "--team"
+      }
+    },
+    "required": [
+      "team"
+    ],
+    "title": "team receive",
+    "type": "object"
+  },
+  "stage": "static"
+}

--- a/tests/mcp/golden_projections/team__show.json
+++ b/tests/mcp/golden_projections/team__show.json
@@ -1,0 +1,22 @@
+{
+  "path": "team show",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "team": {
+        "description": "Team to show \u2014 its id, its name, or an unambiguous id prefix.",
+        "type": "string",
+        "x-positional": true
+      }
+    },
+    "required": [
+      "team"
+    ],
+    "title": "team show",
+    "type": "object",
+    "x-positional-order": [
+      "team"
+    ]
+  },
+  "stage": "static"
+}

--- a/tests/mcp/stdio_client.py
+++ b/tests/mcp/stdio_client.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Drive a real ``python -m lionagi.mcp`` over stdio, the way a client does.
+
+Every other module under ``tests/mcp/`` exercises the Python objects beneath
+the transport, so a defect that lives in the wire shape — a key read from the
+op rather than from ``args``, a schema that only the projector sees — is
+invisible to all of them. This starts the server as a subprocess and speaks
+JSON-RPC to it: ``initialize``, ``notifications/initialized``, then
+``tools/call``, in that order, because the server refuses work before the
+handshake completes.
+
+Every wait is bounded. A server that stops answering has to fail the test that
+is waiting on it rather than hang the suite, and the child is terminated on
+every exit path including an exception mid-conversation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+from typing import Any
+
+__all__ = ("StdioMCPClient", "TransportError", "tool_payload")
+
+# Generous enough for interpreter start plus the import of the CLI registry the
+# catalog is projected from, short enough that a wedged server fails the run.
+START_TIMEOUT = 90.0
+CALL_TIMEOUT = 60.0
+STOP_TIMEOUT = 10.0
+
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class TransportError(RuntimeError):
+    """The transport itself failed: no start, no answer, or a closed pipe."""
+
+
+class StdioMCPClient:
+    """A minimal JSON-RPC client over one server subprocess.
+
+    Reads run on a background thread so that a silent server costs a timeout
+    rather than a blocked interpreter.
+    """
+
+    def __init__(self, *, cwd: str | None = None, env: dict[str, str] | None = None) -> None:
+        self._id = 0
+        self._inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr: list[str] = []
+        self._proc = subprocess.Popen(
+            [sys.executable, "-m", "lionagi.mcp"],
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._readers = [
+            threading.Thread(target=self._read_stdout, daemon=True),
+            threading.Thread(target=self._read_stderr, daemon=True),
+        ]
+        for thread in self._readers:
+            thread.start()
+
+    # ── plumbing ─────────────────────────────────────────────────────────────
+
+    def _read_stdout(self) -> None:
+        assert self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                self._inbox.put(json.loads(line))
+            except ValueError:
+                # Not a JSON-RPC frame; keep it as diagnostics for a failure.
+                self._stderr.append(f"[non-json stdout] {line}")
+
+    def _read_stderr(self) -> None:
+        assert self._proc.stderr is not None
+        for line in self._proc.stderr:
+            self._stderr.append(line.rstrip())
+
+    @property
+    def stderr(self) -> list[str]:
+        return list(self._stderr)
+
+    def _diagnostics(self) -> str:
+        tail = self._stderr[-20:]
+        return f"exit={self._proc.poll()} stderr_tail={tail}"
+
+    def _send(self, message: dict[str, Any]) -> None:
+        if self._proc.poll() is not None:
+            raise TransportError(f"server already exited; {self._diagnostics()}")
+        assert self._proc.stdin is not None
+        try:
+            self._proc.stdin.write(json.dumps(message) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as exc:
+            raise TransportError(f"server closed stdin: {exc}; {self._diagnostics()}") from exc
+
+    def _await_id(self, want: int, timeout: float) -> dict[str, Any]:
+        import time
+
+        deadline = time.monotonic() + timeout
+        pending: list[dict[str, Any]] = []
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TransportError(
+                        f"no reply to request id {want} within {timeout}s; {self._diagnostics()}"
+                    )
+                try:
+                    message = self._inbox.get(timeout=min(remaining, 1.0))
+                except queue.Empty:
+                    if self._proc.poll() is not None:
+                        raise TransportError(
+                            f"server exited while awaiting id {want}; {self._diagnostics()}"
+                        ) from None
+                    continue
+                if message.get("id") == want:
+                    return message
+                # A notification or an out-of-order reply: keep it for the
+                # caller that is waiting on it.
+                pending.append(message)
+        finally:
+            for message in pending:
+                self._inbox.put(message)
+
+    # ── protocol ─────────────────────────────────────────────────────────────
+
+    def call(
+        self, method: str, params: dict[str, Any] | None = None, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}})
+        return self._await_id(rid, CALL_TIMEOUT if timeout is None else timeout)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def initialize(self) -> dict[str, Any]:
+        reply = self.call(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "lionagi-tests", "version": "0"},
+            },
+            timeout=START_TIMEOUT,
+        )
+        if "error" in reply:
+            raise TransportError(f"initialize failed: {reply['error']}; {self._diagnostics()}")
+        self.notify("notifications/initialized")
+        return reply["result"]
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        reply = self.call("tools/list")
+        if "error" in reply:
+            raise TransportError(f"tools/list failed: {reply['error']}")
+        return reply["result"]["tools"]
+
+    def request(
+        self,
+        *,
+        ops: list[dict[str, Any]] | None = None,
+        help: Any = None,  # noqa: A002 - the surface's own parameter name
+        timeout: float | None = None,
+    ) -> Any:
+        """One ``request`` tool call, unwrapped to the verb surface's own JSON."""
+        arguments: dict[str, Any] = {}
+        if ops is not None:
+            arguments["ops"] = ops
+        if help is not None:
+            arguments["help"] = help
+        reply = self.call(
+            "tools/call", {"name": "request", "arguments": arguments}, timeout=timeout
+        )
+        if "error" in reply:
+            raise TransportError(f"tools/call transport error: {reply['error']}")
+        return tool_payload(reply["result"])
+
+    def op(self, name: str, args: dict[str, Any] | None = None, **op_fields: Any) -> dict[str, Any]:
+        """One op, returned as the single result entry the surface answers with."""
+        payload = self.request(ops=[{"op": name, "args": args or {}, **op_fields}])
+        entries = payload.get("ops") if isinstance(payload, dict) else None
+        if not isinstance(entries, list) or len(entries) != 1:
+            raise TransportError(f"unexpected response envelope: {payload!r}")
+        return entries[0]
+
+    def close(self) -> None:
+        """Terminate the child, whatever state it is in."""
+        proc = self._proc
+        if proc.poll() is None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.close()
+            except (OSError, ValueError):
+                pass
+            try:
+                proc.wait(timeout=STOP_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=STOP_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=STOP_TIMEOUT)
+        for stream in (proc.stdout, proc.stderr, proc.stdin):
+            if stream is not None:
+                try:
+                    stream.close()
+                except (OSError, ValueError):
+                    pass
+
+    def __enter__(self) -> StdioMCPClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def tool_payload(result: dict[str, Any]) -> Any:
+    """The verb surface's JSON out of an MCP ``tools/call`` result."""
+    if "structuredContent" in result:
+        return result["structuredContent"]
+    for block in result.get("content") or []:
+        if block.get("type") == "text":
+            try:
+                return json.loads(block["text"])
+            except ValueError:
+                return {"text": block["text"]}
+    return result

--- a/tests/mcp/test_catalog_sufficiency.py
+++ b/tests/mcp/test_catalog_sufficiency.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The catalog has to be enough to write the call it describes.
+
+The tool tells a caller to start with ``help=true`` and says the answer is
+enough to make the common call. That promise is only kept if the entry carries
+everything the call is gated on, so these tests construct ops from the catalog
+reply and nothing else, and check that what refuses them is never the gate the
+catalog was supposed to have satisfied.
+
+The spawn verbs are the gated ones, and running one starts a background agent.
+So the ops here are steered into a refusal that lies *past* every gate — an
+unreadable prompt file — and the assertion is on which refusal comes back. A
+call rejected for its prompt is a call whose fingerprint was accepted, which is
+the fact under test; nothing is spawned to establish it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp import dispatch
+
+from .stdio_client import StdioMCPClient
+
+# A path that cannot exist, so the op is refused while reading it rather than
+# spawned. Absolute because the server refuses a relative prompt_file by rule.
+UNREADABLE_PROMPT_FILE = "/nonexistent/lionagi-catalog-sufficiency/prompt.txt"
+
+
+def _entry(catalog: dict, verb: str) -> dict:
+    return next(e for e in catalog["verbs"] if e["verb"] == verb)
+
+
+def _gated_verbs() -> list[str]:
+    return [name for name, verb in dispatch.VERBS.items() if verb.executor == "spawn"]
+
+
+@pytest.fixture(scope="module")
+def catalog() -> dict:
+    return dispatch.catalog()
+
+
+def test_every_fingerprint_gated_verb_says_so_in_the_catalog(catalog: dict) -> None:
+    """A caller reading one entry can tell whether that verb needs a fingerprint.
+
+    Without this the gate is discoverable only by tripping it, which costs the
+    round-trip the catalog exists to save.
+    """
+    for name in _gated_verbs():
+        entry = _entry(catalog, name)
+        assert "schema_fingerprint" in entry or "schema_fingerprint_varies_with" in entry, (
+            f"{name} is fingerprint-gated and its catalog entry says nothing about it"
+        )
+
+
+def test_a_quoted_fingerprint_is_the_one_the_gate_wants(catalog: dict) -> None:
+    """The value in the entry is the value the dispatcher compares against.
+
+    Checked against the dispatcher's own computation rather than a pinned
+    string, so the test tracks the schema instead of dating with it.
+    """
+    quoted = {
+        name: _entry(catalog, name)["schema_fingerprint"]
+        for name in _gated_verbs()
+        if "schema_fingerprint" in _entry(catalog, name)
+    }
+    assert quoted, "no verb quotes a fingerprint, so the promise cannot hold for any of them"
+    for name, fingerprint in quoted.items():
+        wanted = dispatch.schema_fingerprint(dispatch.verb_schema(dispatch.VERBS[name]))
+        assert fingerprint == wanted
+
+
+def test_a_verb_whose_schema_depends_on_an_argument_quotes_no_fingerprint(catalog: dict) -> None:
+    """Silence beats a string that is guaranteed to be refused.
+
+    ``play.submit`` requires a playbook and is projected again once one is named,
+    so the argument-free schema it would otherwise be fingerprinted from
+    describes a call that cannot be made.
+    """
+    for name in _gated_verbs():
+        verb = dispatch.VERBS[name]
+        entry = _entry(catalog, name)
+        varies = entry.get("schema_fingerprint_varies_with", [])
+        if any(parameter in verb.requires for parameter in varies):
+            assert "schema_fingerprint" not in entry
+            assert varies
+
+
+def test_a_positional_the_parser_will_not_enforce_is_still_reported(catalog: dict) -> None:
+    """``required: []`` alone reads as "a call with no arguments is valid".
+
+    Every spawn verb's prompt arrives through a positional argparse declares with
+    ``nargs="*"``, which the parser accepts empty and the command cannot run
+    without.
+    """
+    for name in _gated_verbs():
+        entry = _entry(catalog, name)
+        assert entry.get("required_unenforced"), (
+            f"{name} reports no unenforced requirement, though its prompt positional is one"
+        )
+        assert not set(entry["required_unenforced"]) & set(entry.get("required", []))
+
+
+def test_the_unenforced_parameters_are_real_parameters(catalog: dict) -> None:
+    """A name reported here has to be one the caller may actually pass."""
+    for entry in catalog["verbs"]:
+        if not entry.get("available"):
+            continue
+        named = entry.get("required_unenforced")
+        if not named:
+            continue
+        schema = dispatch.verb_schema(dispatch.VERBS[entry["verb"]])
+        for parameter in named:
+            assert parameter in schema["properties"]
+
+
+@pytest.mark.parametrize("verb", ["agent.submit", "flow.submit", "fanout.submit"])
+def test_a_call_built_only_from_the_catalog_clears_the_gate(verb: str, tmp_path) -> None:
+    """The whole point, driven over the wire the way a client drives it.
+
+    Ask for the catalog, read one entry, send the op it describes. Before the
+    entry carried a fingerprint the first attempt came back ``stale_schema``,
+    which is the gate refusing a caller who did exactly what the tool told them
+    to do. Now the refusal is about the prompt file this test deliberately made
+    unreadable, which is a refusal from past the gate.
+    """
+    with StdioMCPClient(cwd=str(tmp_path)) as client:
+        client.initialize()
+        catalog = client.request(help=True)
+        entry = _entry(catalog, verb)
+
+        op_fields = {}
+        if "schema_fingerprint" in entry:
+            op_fields["schema_fingerprint"] = entry["schema_fingerprint"]
+        result = client.op(verb, {"prompt_file": UNREADABLE_PROMPT_FILE}, **op_fields)
+
+    assert result["ok"] is False, "the unreadable prompt file should have refused this op"
+    kind = result["error"]["kind"]
+    assert kind != "stale_schema", (
+        f"{verb} was refused at the fingerprint gate by a call built from the catalog: "
+        f"{json.dumps(result['error'])}"
+    )
+    assert kind == "invalid_input"
+    assert "prompt_file" in result["error"]["message"]
+
+
+def test_a_catalog_built_call_to_an_ordinary_read_verb_succeeds(tmp_path) -> None:
+    """The same construction on a verb with no gate and no side effects.
+
+    Separates "the fingerprint path now works" from "the transport works at all",
+    so a green above cannot be read as either one on its own.
+    """
+    with StdioMCPClient(cwd=str(tmp_path)) as client:
+        client.initialize()
+        catalog = client.request(help=True)
+        entry = _entry(catalog, "job.list")
+        assert entry["required"] == []
+        assert "schema_fingerprint" not in entry
+        result = client.op("job.list", {})
+
+    assert result["ok"] is True, json.dumps(result)

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -38,3 +38,41 @@ def test_module_fallback_when_no_sibling_li(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "executable", str(bindir / "python"))
     cmd = config.li_command()
     assert cmd == [str(bindir / "python"), "-m", "lionagi.cli"]
+
+
+def test_finds_li_in_a_venv_whose_python_is_a_symlink(monkeypatch, tmp_path):
+    # Every venv builds bin/python as a symlink to the base interpreter, and
+    # installs its console scripts beside the symlink rather than beside the
+    # target. Following the link first therefore searches the base
+    # installation, where no `li` exists, and silently misses the venv's own.
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    (base_bin / "python3").write_text("#!/bin/sh\n")
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python").symlink_to(base_bin / "python3")
+    venv_li = venv_bin / "li"
+    venv_li.write_text("#!/bin/sh\n")
+
+    monkeypatch.delenv("LIONAGI_MCP_LI_BIN", raising=False)
+    monkeypatch.setattr(sys, "executable", str(venv_bin / "python"))
+    assert config.li_command() == [str(venv_li)]
+
+
+def test_path_is_never_consulted(monkeypatch, tmp_path):
+    # The setup guide states this as an absolute: a `li` reachable on PATH must
+    # not be selected. Without a decoy on PATH the module-fallback test only
+    # rules this out when the ambient environment happens to lack `li`.
+    decoy_bin = tmp_path / "decoy"
+    decoy_bin.mkdir()
+    (decoy_bin / "li").write_text("#!/bin/sh\n")
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "python").write_text("#!/bin/sh\n")  # no sibling `li`
+
+    monkeypatch.delenv("LIONAGI_MCP_LI_BIN", raising=False)
+    monkeypatch.setenv("PATH", str(decoy_bin))
+    monkeypatch.setattr(sys, "executable", str(bindir / "python"))
+    assert config.li_command() == [str(bindir / "python"), "-m", "lionagi.cli"]

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -165,6 +165,25 @@ def test_a_flag_that_is_legal_bare_takes_both_forms_it_declares(submitted, value
     assert expected in submitted["flags"]
 
 
+def test_a_json_encoded_flag_reaches_the_parser_encoded():
+    # The parser decodes this flag's single token from JSON, so the schema
+    # advertises the decoded shape while the rendered token has to be the
+    # encoding of it. Those are two halves of one contract held in two files:
+    # a test of the projection alone, or of the parser alone, passes while the
+    # round-trip is broken and every caller gets an unusable command line.
+    schema = call(help="schedule.create")["schema"]
+    assert schema["properties"]["action_command_args"]["x-json-encoded"] is True
+
+    argv = dispatch.render_argv(
+        schema, {"name": "n", "action_command_args": ["review-pr", "--repo", "{{r}}"]}
+    )
+
+    flag = next(t for t in argv if t.startswith("--action-command-args"))
+    # One token, so the values cannot be read as further options.
+    assert flag == f"--action-command-args={json.dumps(['review-pr', '--repo', '{{r}}'])}"
+    assert json.loads(flag.split("=", 1)[1]) == ["review-pr", "--repo", "{{r}}"]
+
+
 def test_a_flag_a_detached_run_cannot_honour_is_refused_with_its_reason(submitted):
     # Accepting it and dropping it would leave the caller believing it applied.
     answer = call(ops=[spawn_op("agent.submit", {"verbose": True})])

--- a/tests/mcp/test_doc_matches_registry.py
+++ b/tests/mcp/test_doc_matches_registry.py
@@ -1,0 +1,146 @@
+"""The reference document's catalog tables must match the registry.
+
+The tables in `docs/reference/mcp-server.md` are written by hand, so they drift
+the moment a verb is registered or withdrawn without someone remembering to
+edit them. A reader who trusts a stale table is told a working verb cannot be
+called, or is never told a verb exists. These tests fail on that drift and name
+the verbs that differ, so the fix does not start with a hand diff.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lionagi.mcp.verbs import ABSENT, VERBS
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "reference" / "mcp-server.md"
+
+# Verb names as the document writes them: backticked, in a table's first cell.
+_ROW_NAME = re.compile(r"^\|\s*`([a-z][a-z0-9.\-]*)`\s*\|")
+
+_NUMBER_WORDS = {
+    "One": 1,
+    "Two": 2,
+    "Three": 3,
+    "Four": 4,
+    "Five": 5,
+    "Six": 6,
+    "Seven": 7,
+    "Eight": 8,
+    "Nine": 9,
+    "Ten": 10,
+    "Eleven": 11,
+    "Twelve": 12,
+    "Thirteen": 13,
+    "Fourteen": 14,
+    "Fifteen": 15,
+    "Sixteen": 16,
+    "Seventeen": 17,
+    "Eighteen": 18,
+    "Nineteen": 19,
+    "Twenty": 20,
+    "Twenty-one": 21,
+    "Twenty-two": 22,
+    "Twenty-three": 23,
+    "Twenty-four": 24,
+    "Twenty-five": 25,
+    "Twenty-six": 26,
+    "Twenty-seven": 27,
+    "Twenty-eight": 28,
+    "Twenty-nine": 29,
+    "Thirty": 30,
+}
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def _marked_region(text: str, key: str) -> str:
+    start = f"<!-- mcp-catalog:{key}:start -->"
+    end = f"<!-- mcp-catalog:{key}:end -->"
+    assert start in text and end in text, (
+        f"{DOC.name} no longer carries the {key!r} table markers ({start} / {end}). "
+        "The catalog tables are checked against the registry by name, so removing "
+        "the markers removes the check — restore them, or delete this test "
+        "deliberately along with the tables it guards."
+    )
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+
+def _documented(text: str, key: str) -> set[str]:
+    return {
+        m.group(1)
+        for line in _marked_region(text, key).splitlines()
+        if (m := _ROW_NAME.match(line.strip()))
+    }
+
+
+def _explain(kind: str, documented: set[str], registry: set[str]) -> str:
+    missing = sorted(registry - documented)
+    extra = sorted(documented - registry)
+    parts = [f"{DOC.name} disagrees with the registry about which verbs are {kind}."]
+    if missing:
+        parts.append(
+            f"  {kind.capitalize()} in the registry but absent from the {kind} table "
+            f"({len(missing)}): {', '.join(missing)}"
+        )
+    if extra:
+        parts.append(
+            f"  Listed in the {kind} table but not {kind} in the registry "
+            f"({len(extra)}): {', '.join(extra)}"
+        )
+    parts.append(
+        "  Regenerate the table from the registry rather than editing single rows: "
+        "`help=true` (or lionagi.mcp.verbs.VERBS / ABSENT) is the authority."
+    )
+    return "\n".join(parts)
+
+
+def test_available_table_matches_registry(doc_text):
+    registry = set(VERBS)
+    documented = _documented(doc_text, "available")
+    assert documented == registry, _explain("available", documented, registry)
+
+
+def test_unavailable_table_matches_registry(doc_text):
+    registry = {absent.name for absent in ABSENT}
+    documented = _documented(doc_text, "unavailable")
+    assert documented == registry, _explain("unavailable", documented, registry)
+
+
+def test_stated_available_count_matches_registry(doc_text):
+    match = re.search(r"^(\d+) verbs are reachable\.", doc_text, re.MULTILINE)
+    assert match, (
+        "The catalog section no longer opens with 'N verbs are reachable.'; "
+        f"the registry currently registers {len(VERBS)}."
+    )
+    stated = int(match.group(1))
+    assert stated == len(VERBS), (
+        f"{DOC.name} says {stated} verbs are reachable; the registry registers "
+        f"{len(VERBS)}. A reader sizing the surface from the prose is told the "
+        "wrong number even when the table below it is right."
+    )
+
+
+def test_stated_unavailable_count_matches_registry(doc_text):
+    match = re.search(
+        r"^([A-Z][a-z]+(?:-[a-z]+)?) further names are catalogued", doc_text, re.MULTILINE
+    )
+    assert match, (
+        "The unavailable section no longer opens with 'N further names are "
+        f"catalogued'; the registry currently catalogues {len(ABSENT)} of them."
+    )
+    word = match.group(1)
+    assert word in _NUMBER_WORDS, (
+        f"{DOC.name} states the unavailable count as {word!r}, which is not a "
+        f"number word this test knows. The registry catalogues {len(ABSENT)}."
+    )
+    assert _NUMBER_WORDS[word] == len(ABSENT), (
+        f"{DOC.name} says {word} ({_NUMBER_WORDS[word]}) names are catalogued as "
+        f"unavailable; the registry catalogues {len(ABSENT)}."
+    )

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -88,7 +88,15 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
     assert captured["argv"] == ["notify", job, "failed", "t1", "downstream"]
     # the same fields are offered as a JSON payload on stdin
     payload = json.loads(captured["input"])
-    assert payload == {"run_id": job, "status": "failed", "label": "t1", "target": "downstream"}
+    assert payload == {
+        "run_id": job,
+        "status": "failed",
+        "label": "t1",
+        "target": "downstream",
+        # Empty, not absent: no sender was given, and the notifier is told that
+        # rather than left to fill the gap from its working directory.
+        "sender": "",
+    }
     assert rec["notify_delivery"] == {
         "attempted": True,
         "ok": True,

--- a/tests/mcp/test_notify_sender.py
+++ b/tests/mcp/test_notify_sender.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The terminal notice says who it is from, instead of leaving the notifier to
+resolve an identity from whatever directory the run happened to work in."""
+
+from __future__ import annotations
+
+from lionagi.mcp import _notify_hook, jobs
+
+
+def test_sender_substitutes_into_the_delivery_command():
+    argv = _notify_hook._substitute(
+        ["notify", "--from", "{sender}", "--to", "{target}"],
+        {"sender": "seat-a", "target": "seat-b", "status": "completed", "run_id": "r"},
+    )
+    assert argv == ["notify", "--from", "seat-a", "--to", "seat-b"]
+
+
+def test_sender_is_published_to_the_delivery_environment():
+    env = _notify_hook._delivery_env("seat-a")
+    assert env is not None
+    assert env["LIONAGI_NOTIFY_SENDER"] == "seat-a"
+    # Inherits the rest: a notifier still needs its own PATH and credentials.
+    assert "PATH" in env
+
+
+def test_no_sender_leaves_the_environment_untouched():
+    """Without a sender there is nothing to publish, and an env dict built here
+    would claim an identity was set when none was."""
+    assert _notify_hook._delivery_env("") is None
+
+
+def test_hook_command_carries_the_sender_when_one_is_given():
+    template = jobs._notify_template("run-1", "seat-b", None, "seat-a")
+    assert "--sender seat-a" in template
+
+
+def test_hook_command_omits_the_sender_when_none_is_given():
+    """A guard on the ordinary case: an absent sender must not become an empty
+    --sender token, which the hook would read as an explicit empty identity."""
+    template = jobs._notify_template("run-1", "seat-b", None, None)
+    assert "--sender" not in template
+
+
+def _job(monkeypatch, tmp_path):
+    from lionagi.mcp import config
+
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_SENDER", raising=False)
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 1,
+            "kind": "agent",
+            "label": "t",
+            "cwd": None,
+            "status": "running",
+            "log": None,
+        }
+    )
+    return rid
+
+
+def test_no_delivery_runs_when_the_template_needs_a_sender_and_none_was_given(
+    monkeypatch, tmp_path
+):
+    """A command that asks who the notice is from cannot be run without an answer.
+
+    Substituting an empty string hands the delivery tool a blank where an
+    identity belongs, and a tool that accepts it — or resolves a sender of its
+    own — signs the notice with the wrong seat. Nothing is spawned; the reason
+    is recorded, so job_status shows a notifier that could not deliver rather
+    than the silence of one never asked.
+    """
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+    monkeypatch.setattr(
+        _notify_hook.subprocess, "run", lambda *a, **k: spawned.append(a) or _Completed()
+    )
+
+    rc = _notify_hook.main(
+        [
+            "--run-id",
+            rid,
+            "--status",
+            "completed",
+            "--command",
+            '["notify", "--from", "{sender}", "--to", "seat-b"]',
+        ]
+    )
+
+    assert rc == 0
+    assert spawned == []  # the point: no process was started
+    rec = jobs._read_job(rid)
+    assert rec["notify_delivery"]["attempted"] is False
+    assert rec["notify_delivery"]["error"] == "delivery_command_needs_a_sender_and_none_was_given"
+
+
+def test_a_template_that_needs_a_sender_delivers_when_one_is_given(monkeypatch, tmp_path):
+    """The guard is on the missing sender alone, not on the placeholder."""
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return _Completed()
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+
+    rc = _notify_hook.main(
+        [
+            "--run-id",
+            rid,
+            "--status",
+            "completed",
+            "--sender",
+            "seat-a",
+            "--command",
+            '["notify", "--from", "{sender}"]',
+        ]
+    )
+
+    assert rc == 0
+    assert spawned == [["notify", "--from", "seat-a"]]
+
+
+def test_a_template_without_the_placeholder_is_unaffected_by_a_missing_sender(
+    monkeypatch, tmp_path
+):
+    """A non-regression guard: a command that never asks who it is from still
+    delivers with no sender supplied."""
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return _Completed()
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+
+    rc = _notify_hook.main(
+        ["--run-id", rid, "--status", "completed", "--command", '["notify", "{run_id}"]']
+    )
+
+    assert rc == 0
+    assert spawned == [["notify", rid]]
+
+
+class _Completed:
+    returncode = 0

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -32,41 +32,6 @@ from lionagi.mcp.projection import (
 
 GOLDEN_DIR = Path(__file__).parent / "golden_projections"
 
-# One per shape worth pinning: positionals with nargs, repeated flags, enums,
-# int/float scalars, a mutually exclusive group, and the playbook-bearing pair.
-GOLDEN_VERBS = (
-    "agent",
-    "casts",
-    "dispatch ls",
-    "doctor",
-    "invoke start",
-    "kill",
-    "monitor",
-    "orchestrate fanout",
-    "orchestrate flow",
-    "plugin list",
-    "schedule create",
-    "state ls",
-    "stats runs",
-    "studio start",
-    "team send",
-    # The observability reads: every one of these is a path the surface now
-    # dispatches, so an argparse change under it must fail here rather than
-    # quietly reshape a schema a caller validated against.
-    "dispatch show",
-    "invoke list",
-    "lifecycle",
-    "plugin info",
-    "state stats",
-    "team list",
-    # The queue's writes. A golden matters more here than on a read: a caller acts
-    # on the schema, so an argparse change that silently made `token` optional or
-    # renamed `--dry-run` would turn a refused call into a destructive one.
-    "dispatch ack",
-    "dispatch retry",
-    "dispatch purge",
-)
-
 # Everything the MCP surface is a candidate to dispatch. `mirror` is
 # deliberately absent — see test_mirror_since_is_unrepresentable.
 CANDIDATE_VERBS = (
@@ -107,6 +72,13 @@ CANDIDATE_VERBS = (
     "team send",
     "team show",
 )
+
+# Every dispatchable path is pinned, not a sample of them. A caller acts on the
+# schema it is handed, so an argparse change under any of these must fail here
+# with a diff rather than quietly reshape a schema someone already validated
+# against. `lifecycle` and `studio start` are pinned too: neither is a dispatch
+# candidate, but both project and both are read by the surface.
+GOLDEN_VERBS = CANDIDATE_VERBS + ("lifecycle", "studio start")
 
 
 def _golden_path(verb: str) -> Path:

--- a/tests/mcp/test_spawn_mcp_snapshot.py
+++ b/tests/mcp/test_spawn_mcp_snapshot.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A detached leg's MCP server set is fixed by the submission, not re-read later.
+
+Popen is doubled so no real `li` process is spawned; the tests read the argv the
+engine built and resolve it the way the child would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
+from lionagi.mcp import config, dispatch, jobs
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+    return tmp_path
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+@pytest.fixture
+def submit_dir(monkeypatch, tmp_path):
+    """A submitting directory holding its own .mcp.json, with no config above it.
+
+    The search walks to the filesystem root, so an ancestor's real .mcp.json
+    would otherwise decide these tests. A HOME-shaped tmp dir is used as the
+    launch dir and the walk stops at the file planted here.
+    """
+    d = tmp_path / "submit"
+    d.mkdir()
+    monkeypatch.chdir(d)
+    return d
+
+
+def _config_arg(argv: list[str]) -> str:
+    return argv[argv.index("--mcp-config") + 1]
+
+
+def _child_config(argv: list[str]) -> str | None:
+    """The config the child's parser would settle on, in either spelling.
+
+    argparse keeps the last occurrence, so a line carrying two of these does not
+    fail — it quietly picks one. Reading it the same way is what lets a test say
+    which file the child actually opens rather than which one appears first.
+    """
+    seen: list[str] = []
+    for i, tok in enumerate(argv):
+        if tok == "--mcp-config" and i + 1 < len(argv):
+            seen.append(argv[i + 1])
+        elif tok.startswith("--mcp-config="):
+            seen.append(tok.split("=", 1)[1])
+    return seen[-1] if seen else None
+
+
+def _spawn_agent(args: dict) -> dict:
+    """Drive the real spawn verb, fingerprint fetched the way a caller must."""
+    fingerprint = asyncio.run(dispatch.request(help="agent.submit"))["schema_fingerprint"]
+    answer = asyncio.run(
+        dispatch.request(
+            ops=[{"op": "agent.submit", "args": args, "schema_fingerprint": fingerprint}]
+        )
+    )
+    op = answer["ops"][0]
+    assert op["ok"], op
+    return op["result"]
+
+
+def test_spawned_leg_keeps_the_server_set_the_submission_resolved(sandbox, submit_dir, monkeypatch):
+    """The source config is replaced after submit; the leg still gets S1.
+
+    This is the whole guarantee: the tool surface a leg starts with is a
+    property of the submission, and an edit to the file afterwards belongs to
+    the next submission, not to a run already under way.
+    """
+    source = submit_dir / ".mcp.json"
+    source.write_text(json.dumps({"mcpServers": {"s1": {"command": "one"}}}))
+
+    captured: dict = {}
+
+    def fake_popen(argv, **kw):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    # The submission is assembled and the child is spawned. Now the file moves.
+    source.write_text(json.dumps({"mcpServers": {"s2": {"command": "two"}}}))
+
+    seen = resolve_spawn_mcp_servers(_config_arg(captured["argv"]), launch_dir=submit_dir)
+    assert set(seen.servers) == {"s1"}
+    assert handle["mcp_config_reason"] is None
+
+
+def test_spawned_leg_survives_the_source_config_being_removed(sandbox, submit_dir, monkeypatch):
+    """Deletion is the same failure with a louder symptom: the leg would start
+    with no servers at all, or fail resolving a path that no longer exists."""
+    source = submit_dir / ".mcp.json"
+    source.write_text(json.dumps({"mcpServers": {"s1": {"command": "one"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+    jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    source.unlink()
+
+    seen = resolve_spawn_mcp_servers(_config_arg(captured["argv"]), launch_dir=submit_dir)
+    assert set(seen.servers) == {"s1"}
+
+
+def test_submission_fails_when_the_discovered_config_cannot_be_used(
+    sandbox, submit_dir, monkeypatch
+):
+    """An unusable config is refused at submit rather than handed to the child.
+
+    A child that discovers the problem reports it in its own log, minutes later
+    and only to whoever reads that log; the submitter is told the run started.
+    """
+    (submit_dir / ".mcp.json").write_text("{not json")
+
+    spawned: list = []
+    monkeypatch.setattr(
+        jobs.subprocess, "Popen", lambda argv, **kw: (spawned.append(argv), _FakeProc())[1]
+    )
+
+    with pytest.raises(McpConfigError) as exc:
+        jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert "mcp" in str(exc.value).lower()
+    assert spawned == []
+    # Rejected before anything was written: no half-made job record is left to
+    # read back as a run that never finishes.
+    assert not (config.JOBS_DIR).exists() or list(config.JOBS_DIR.iterdir()) == []
+
+
+def test_no_config_anywhere_is_reported_not_raised(sandbox, submit_dir, monkeypatch):
+    """Nothing configured is a choice, not a failure — the run still starts and
+    the handle says why it has no servers."""
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr("lionagi.cli._mcp_resolve.discover_mcp_config", lambda start: None)
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+    assert handle["mcp_config"] is None
+    assert handle["mcp_config_reason"]
+
+
+def test_a_caller_who_names_a_config_gets_that_config_and_a_handle_that_says_so(
+    sandbox, submit_dir, monkeypatch
+):
+    """The named file is what the child opens, and what the handle reports.
+
+    Both halves matter. A snapshot generated beside the caller's own choice puts
+    two configs on the line, and the one the parser drops is the one the handle
+    was naming — so the surface would be describing a file the run never reads.
+    """
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+    chosen = submit_dir / "chosen.json"
+    chosen.write_text(json.dumps({"mcpServers": {"mine": {"command": "m"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "mcp_config": str(chosen), "cwd": str(submit_dir)})
+
+    child_sees = _child_config(captured["argv"])
+    assert child_sees == str(chosen)
+    seen = resolve_spawn_mcp_servers(child_sees, launch_dir=submit_dir)
+    assert set(seen.servers) == {"mine"}
+    # The handle names the file the child opens, and does not claim a snapshot
+    # it never took.
+    assert handle["mcp_config"] == str(chosen)
+    assert handle["mcp_config_source"] == str(chosen)
+    assert not (config.job_dir(handle["run_id"]) / "mcp-servers.json").exists()
+
+
+def test_the_generated_snapshot_still_wins_when_the_caller_says_nothing(
+    sandbox, submit_dir, monkeypatch
+):
+    """Saying nothing is still the ambient config, snapshotted into the run."""
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "cwd": str(submit_dir)})
+
+    snapshot = config.job_dir(handle["run_id"]) / "mcp-servers.json"
+    assert _child_config(captured["argv"]) == str(snapshot)
+    assert handle["mcp_config"] == str(snapshot)
+    assert handle["mcp_config_source"] == str(submit_dir / ".mcp.json")
+    seen = resolve_spawn_mcp_servers(str(snapshot), launch_dir=submit_dir)
+    assert set(seen.servers) == {"ambient"}
+
+
+def test_a_caller_who_asks_for_no_servers_is_not_handed_a_snapshot(
+    sandbox, submit_dir, monkeypatch
+):
+    """Asking for none is an answer. Resolving one anyway would put a config on
+    the line beside the switch that turns configs off, and name it on a handle
+    for a run whose child was told to ignore it."""
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "no_mcp_config": True, "cwd": str(submit_dir)})
+
+    assert _child_config(captured["argv"]) is None
+    assert handle["mcp_config"] is None
+    assert handle["mcp_config_source"] is None
+    assert not (config.job_dir(handle["run_id"]) / "mcp-servers.json").exists()

--- a/tests/mcp/test_stdio_transport.py
+++ b/tests/mcp/test_stdio_transport.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The verb surface as a client reaches it: over stdio, after a handshake.
+
+These are deliberately not skipped when the transport will not start. A server
+that cannot be spoken to is the failure this module exists to catch, and a skip
+would report that absence as a pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .stdio_client import StdioMCPClient
+
+pytestmark = pytest.mark.timeout(180)
+
+
+@pytest.fixture(scope="module")
+def mcp() -> StdioMCPClient:
+    """One handshaken server for the module; terminated however the tests end."""
+    client = StdioMCPClient()
+    try:
+        client.initialize()
+    except BaseException:
+        client.close()
+        raise
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_handshake_advertises_the_request_tool(mcp: StdioMCPClient) -> None:
+    names = [tool["name"] for tool in mcp.list_tools()]
+    assert "request" in names, names
+
+
+def test_a_read_verb_answers_over_the_wire(mcp: StdioMCPClient) -> None:
+    result = mcp.op("server.info")
+    assert result["ok"] is True, result
+
+
+def test_help_returns_the_catalog(mcp: StdioMCPClient) -> None:
+    catalog = mcp.request(help=True)
+    assert catalog["available_count"] > 0
+    assert any(entry["verb"] == "schedule.create" for entry in catalog["verbs"])
+
+
+# ── the JSON-encoded flag a caller could not satisfy ─────────────────────────
+
+
+def test_schedule_create_advertises_the_shape_it_accepts(mcp: StdioMCPClient) -> None:
+    """The advertised type is the one the parser decodes, not ``string``.
+
+    A plain string was refused as invalid JSON and a list as the wrong type,
+    so the advertised ``string`` named a type no value satisfied.
+    """
+    schema = mcp.request(help="schedule.create")["schema"]
+    spec = schema["properties"]["action_command_args"]
+    assert spec["type"] == "array"
+    assert spec["items"] == {"type": "string"}
+    assert spec["x-json-encoded"] is True
+
+
+def test_schedule_create_accepts_the_list_it_advertises(mcp: StdioMCPClient) -> None:
+    """A value valid per the advertised schema gets past argument validation.
+
+    The call is expected to fail further in — the command allowlist, or no
+    scheduler to write to — but it has to get past argument validation, and it
+    must not fail naming this parameter.
+    """
+    result = mcp.op(
+        "schedule.create",
+        {
+            "name": "transport-harness-probe",
+            "interval": 3600,
+            "trigger_type": "interval",
+            "action_kind": "command",
+            "action_command": "echo",
+            "action_command_args": ["hello", "{{run_id}}"],
+        },
+    )
+    if not result["ok"]:
+        message = result["error"]["message"]
+        assert "action_command_args" not in message, message
+        # The two ways the old contract refused a schema-obeying caller.
+        assert "expects string" not in message, message
+        assert "must be valid JSON" not in message, message
+
+
+def test_schedule_create_refuses_a_bare_string(mcp: StdioMCPClient) -> None:
+    """The type it advertises is also the type it enforces."""
+    result = mcp.op(
+        "schedule.create",
+        {"name": "transport-harness-probe", "action_command_args": "hello"},
+    )
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "invalid_input"
+    assert "action_command_args" in result["error"]["message"]
+
+
+# ── the fingerprint gate says where the fingerprint goes ─────────────────────
+
+
+def test_missing_fingerprint_error_states_the_op_level_shape(mcp: StdioMCPClient) -> None:
+    result = mcp.op("agent.submit", {"prompt": "unused"})
+    assert result["ok"] is False
+    message = result["error"]["message"]
+    assert "'args'" in message and "schema_fingerprint" in message
+    # The literal op shape, so a caller cannot read "with the op" as "in args".
+    assert "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint':" in message
+
+
+def test_fingerprint_inside_args_is_refused_as_a_wrong_place(mcp: StdioMCPClient) -> None:
+    """Putting it in ``args`` used to repeat the same refusal verbatim.
+
+    Identical text for "you did not send it" and "you sent it in the wrong
+    place" reads as an idempotent failure, so a caller retries the shape it
+    already sent instead of moving the field.
+    """
+    fingerprint = mcp.request(help="agent.submit")["schema_fingerprint"]
+    result = mcp.op("agent.submit", {"prompt": "unused", "schema_fingerprint": fingerprint})
+    assert result["ok"] is False
+    message = result["error"]["message"]
+    assert "sibling of 'args'" in message or "unknown parameter" in message


### PR DESCRIPTION
Using the MCP server previously meant having a source checkout wired up by hand.
Nothing about the package required that, but nothing documented the alternative
either.

Adds `docs/guides/mcp-setup.md`: what to install, both client configuration
forms with guidance on absolute paths, every environment variable the server
reads together with what happens when each is unset, a three-tier verification
sequence, and troubleshooting. Adds the nav entry.

Corrects stale verb counts in the reference page. They are now read from the
registry rather than maintained by hand.

The install path was verified rather than described. A wheel built from this
tree contains all ten `lionagi/mcp` modules; installed into a throwaway
virtualenv with isolation confirmed first — no checkout on `sys.path`,
`PYTHONPATH` stripped, neutral working directory — the server starts and answers
real calls, and its reported module path points inside that virtualenv.