### PR TITLE
test(mcp): drive the server over its real transport, and pin the catalog docs to the registry

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -95,8 +95,8 @@ relative timestamps, formatted durations, or tables.
       "required": []
     }
   ],
-  "verb_count": 47,
-  "available_count": 36,
+  "verb_count": 68,
+  "available_count": 40,
   "max_ops": 8,
   "help_usage": "help=true returns this catalog; help='<verb>' returns that verb's full parameter schema; ...",
   "synonyms_removed_after": "2026-09-30"
@@ -130,16 +130,24 @@ resolves that playbook's own declared arguments into the schema.
 
 ## The catalog
 
-36 verbs are reachable. This list is generated from the registry:
+40 verbs are reachable. Both tables in this section are checked against the
+registry by the test suite, so a verb added or withdrawn without updating them
+fails a test rather than going unnoticed. The registry is the authority; ask it
+directly with:
 
 ```bash
 python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) for n in sorted(v.VERBS)]"
 ```
 
+<!-- mcp-catalog:available:start -->
+
 | Verb | Summary |
 |------|---------|
 | `agent.submit` | Run one agent on one task as a detached background run. |
+| `dispatch.ack` | Acknowledge a delivered dispatch with its ack token, so the queue stops redelivering it. A wrong token is refused without echoing the real one. |
 | `dispatch.ls` | Rows in the durable dispatch outbox, newest first, without their payloads. |
+| `dispatch.purge` | Delete one dispatch row by id, whatever its status, recording an audit row. Deleting by --status/--before is refused here: a sweep deletes rows the caller never named and reports a count for rows that can no longer be inspected. |
+| `dispatch.retry` | Return a failed or dead-lettered dispatch to pending so delivery is attempted again. |
 | `dispatch.show` | One dispatch row in full, including its payload and ack token. |
 | `doctor` | Environment checks and which of them failed. |
 | `fanout.submit` | Run N agents on one task in parallel, optionally synthesized. |
@@ -151,6 +159,7 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `job.output` | Console tail and artifact list of a background run. |
 | `job.status` | Current state of a background run: liveness, job record, CLI manifest. |
 | `job.wait` | Observe runs until terminal or the window closes; partial results, never a bool. |
+| `lifecycle` | What the lifecycle store records about one run: whether every session it opened has ended, and with what outcome. |
 | `monitor` | Entities in flight right now: sessions, invocations, shows, plays. |
 | `play.submit` | Run a saved playbook: a flow whose plan and prompt are already written down. |
 | `plugin.info` | One plugin's version, trust state, and everything its manifest declares. |
@@ -175,6 +184,8 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `stats.runs` | Run counts and first/last timestamps, grouped by project/kind/agent/model/status. |
 | `team.list` | Teams on disk with their members and message counts. |
 
+<!-- mcp-catalog:available:end -->
+
 There is deliberately **no parameter table here**. A verb's parameters are
 projected from the CLI parser at call time, so a table written by hand would
 drift away from what the server actually accepts. Ask for the parameters
@@ -183,27 +194,56 @@ against rather than a copy of it.
 
 ## Operations the surface does not offer
 
-Eleven further names are catalogued as **unavailable**, each with its reason.
-They are not omissions: a caller that asks what exists gets the name and why it
-cannot be called, which is a different answer from the name never having been
-considered.
+Twenty-eight further names are catalogued as **unavailable**, each with its
+reason. They are not omissions: a caller that asks what exists gets the name and
+why it cannot be called, which is a different answer from the name never having
+been considered. The right-hand column below abbreviates the reason; `help=true`
+returns each one in full.
 
-| Verb | Summary |
-|------|---------|
-| `schedule.apply` | Reconcile a whole ScheduleSet file into the store, atomically. |
-| `schedule.run` | One schedule run. |
-| `team.create`, `team.show`, `team.send`, `team.receive` | Messaging between agents working as a team. |
-| `state.doctor` | Read-only inspection of the lifecycle store. |
-| `dispatch.ack`, `dispatch.retry`, `dispatch.purge` | The outbound dispatch queue. |
-| `plugin.list` | Installed plugin bundles and their trust state. |
+<!-- mcp-catalog:unavailable:start -->
 
-Most share one reason: the CLI path emits no versioned machine result
-(`li <path> --machine`), so there is nothing to return that is not scraped
-console text. Scraping would make a command's console wording an API contract,
-so the fix belongs in the CLI, where the command gains a machine-result seam.
-The rest carry their own reason: `schedule.run` is already covered by
-`schedule.runs`, `schedule.apply` has no decided machine-result shape yet, and
-`plugin.list` prunes trust records as part of listing, which is a write.
+| Verb | Summary | Not offered because |
+|------|---------|---------------------|
+| `casts` | The built-in roles and modes an agent can be composed from. | no machine result |
+| `orchestrate.ctl.status` | What a running flow's control plane reports about it. | no machine result |
+| `state.doctor` | Read-only inspection of the lifecycle store. | no machine result |
+| `team.create` | Messaging between agents working as a team. | no machine result |
+| `team.receive` | Messaging between agents working as a team. | no machine result |
+| `team.send` | Messaging between agents working as a team. | no machine result |
+| `team.show` | Messaging between agents working as a team. | no machine result |
+| `state.checkpoint` | Writes against the lifecycle store. | invalidating write |
+| `state.import` | Writes against the lifecycle store. | invalidating write |
+| `state.import-teams` | Writes against the lifecycle store. | invalidating write |
+| `state.prune` | Writes against the lifecycle store. | invalidating write |
+| `state.vacuum` | Writes against the lifecycle store. | invalidating write |
+| `hooks.import` | Importing hook commands from another tool's config. | grants privilege |
+| `plugin.disable` | Plugin bundle enablement. | grants privilege |
+| `plugin.enable` | Plugin bundle enablement. | grants privilege |
+| `plugin.list` | Installed plugin bundles and their trust state. | grants privilege |
+| `orchestrate.ctl.msg` | The running-flow control plane. | effect lands elsewhere |
+| `orchestrate.ctl.pause` | The running-flow control plane. | effect lands elsewhere |
+| `orchestrate.ctl.resume` | The running-flow control plane. | effect lands elsewhere |
+| `invoke.end` | Opening and closing a skill-level orchestration record. | no caller identity |
+| `invoke.start` | Opening and closing a skill-level orchestration record. | no caller identity |
+| `mirror` | Mirror Claude Code sessions into Studio, live. | a process, not a call |
+| `studio.start` | The Studio server. | a process, not a call |
+| `engine.run` | Run a domain-specific multi-agent pipeline. | spawns without a job record |
+| `kill` | Terminate a run, session, play or show by id. | no identity to correlate |
+| `mcp` | Serve this surface over stdio. | it is this server |
+| `schedule.apply` | Reconcile a whole ScheduleSet file into the store, atomically. | shape undecided |
+| `schedule.run` | One schedule run. | already covered |
+
+<!-- mcp-catalog:unavailable:end -->
+
+The largest group is *no machine result*: the CLI path emits no versioned
+machine result (`li <path> --machine`), so there is nothing to return that is
+not scraped console text. Scraping would make a command's console wording an API
+contract, so the fix belongs in the CLI, where the command gains a machine-result
+seam. The others are refusals on their own terms rather than gaps waiting to be
+filled — a write whose effect no machine result can describe, a path that would
+grant the calling agent a right it did not have, a control-plane signal whose
+effect lands on a running flow rather than in a reply, or a long-lived process
+that never returns at all.
 
 Asking for one of these inside `ops` returns a catalogued answer rather than a
 bare unknown-verb error: the op comes back `ok=false` with an `unavailable`

--- a/lionagi/cli/_argtypes.py
+++ b/lionagi/cli/_argtypes.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""argparse ``type`` callables that state the shape they accept.
+
+A command line carries one string per flag, so a flag whose value is a list or
+an object can only arrive JSON-encoded. Doing that decode inside a command
+handler leaves the shape undeclared: the parser says ``string``, anything
+reading the parser says ``string``, and the caller finds out that a plain
+string is refused only by sending one. Declaring it as the argument's ``type``
+puts the shape on the argument itself, where the parser enforces it and a
+reader of the parser can describe it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+__all__ = ("JsonArgument",)
+
+
+class JsonArgument:
+    """Decode one JSON-encoded flag value and check it against *schema*.
+
+    ``schema`` is the JSON Schema of the **decoded** value — the shape a caller
+    thinks in — and is bounded to what argparse can be handed on a command
+    line: an ``array`` of scalars, or an ``object``.
+    """
+
+    def __init__(self, schema: dict[str, Any]) -> None:
+        self.json_schema = dict(schema)
+        # argparse prints `type.__name__` in its own error prose.
+        self.__name__ = f"json-{self.json_schema.get('type', 'value')}"
+
+    def __call__(self, raw: str) -> Any:
+        try:
+            value = json.loads(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"must be valid JSON: {exc}") from exc
+        want = self.json_schema.get("type")
+        if want == "array" and not isinstance(value, list):
+            raise argparse.ArgumentTypeError("must be a JSON array")
+        if want == "object" and not isinstance(value, dict):
+            raise argparse.ArgumentTypeError("must be a JSON object")
+        item = self.json_schema.get("items", {}).get("type") if want == "array" else None
+        if item == "string" and not all(isinstance(e, str) for e in value):
+            raise argparse.ArgumentTypeError("must be a JSON array of strings")
+        return value
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"JsonArgument({self.json_schema!r})"

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -200,17 +200,24 @@ def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied
         "help": {"verb": name} if verb.playbook_aware else name,
         "schema_fingerprint": current,
     }
+    # Where the key goes is the part a caller gets wrong: put it inside `args`
+    # and it is simply not read, so this refusal repeats verbatim and the
+    # failure reads as idempotent rather than as a misplaced key. Spelling the
+    # whole op is the only form of the instruction that cannot be misread.
+    shape = f"{{'op': {name!r}, 'args': {{...}}, 'schema_fingerprint': {current!r}}}"
     if supplied is None:
         raise OpError(
             "stale_schema",
-            f"{name!r} needs the schema_fingerprint that help returns for it; "
-            f"ask for help={name!r} and send its schema_fingerprint with the op",
+            f"{name!r} needs the schema_fingerprint that help returns for it; ask for "
+            f"help={name!r} and send the fingerprint as a sibling of 'args', not a "
+            f"member of it: {shape}",
             remedy,
         )
     raise OpError(
         "stale_schema",
         f"{name!r} was called with schema_fingerprint {supplied!r}, which is not the "
-        f"current {current!r}; the parameters changed since that schema was read",
+        f"current {current!r}; the parameters changed since that schema was read. "
+        f"Re-read help={name!r} and send: {shape}",
         remedy,
     )
 
@@ -383,7 +390,11 @@ def render_argv(schema: dict[str, Any], args: dict[str, Any]) -> list[str]:
             positional[name] = value
             continue
         flag = spec["x-flag"]
-        if spec.get("type") == "boolean":
+        if spec.get("x-json-encoded"):
+            # The parser decodes this flag's single token from JSON, so the
+            # value the caller sent has to reach it encoded.
+            flags += _flag_tokens(name, flag, json.dumps(value))
+        elif spec.get("type") == "boolean":
             # A store_false action defaults to true and its flag turns it off, so
             # the flag belongs on the line exactly when the value differs from
             # what the parser would have chosen on its own.

--- a/lionagi/mcp/projection.py
+++ b/lionagi/mcp/projection.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from lionagi.cli._argtypes import JsonArgument
+
 __all__ = (
     "SchemaProjectionError",
     "PlaybookResolutionError",
@@ -288,6 +290,12 @@ def _project_action(
             raise SchemaProjectionError(
                 path, f"append with nargs={nargs!r} nests arrays", action=label
             )
+        if isinstance(action.type, JsonArgument):
+            if nargs is not None or kind is _APPEND:
+                raise SchemaProjectionError(
+                    path, f"JSON-encoded value with nargs={nargs!r}", action=label
+                )
+            return _project_json_action(parser, action, action.type)
         item: dict[str, Any] = {"type": _scalar_type(path, action, label)}
         enum = _choices_enum(path, action, label)
         if enum is not None:
@@ -315,6 +323,13 @@ def _project_action(
     else:
         raise SchemaProjectionError(path, f"unknown action class {kind.__name__}", action=label)
 
+    return _annotate(schema, parser, action)
+
+
+def _annotate(
+    schema: dict[str, Any], parser: argparse.ArgumentParser, action: argparse.Action
+) -> dict[str, Any]:
+    """Add the parts every parameter carries: prose, default, and how it spells."""
     description = _description(parser, action)
     if description:
         schema["description"] = description
@@ -329,6 +344,21 @@ def _project_action(
         if aliases:
             schema["x-aliases"] = list(aliases)
     return schema
+
+
+def _project_json_action(
+    parser: argparse.ArgumentParser, action: argparse.Action, kind: JsonArgument
+) -> dict[str, Any]:
+    """A flag whose value the parser decodes from JSON, described as it decodes.
+
+    The advertised type is the *decoded* shape, because that is the shape the
+    argument accepts; ``x-json-encoded`` tells a renderer that the one argv
+    token this becomes has to be the encoding of it. Advertising ``string``
+    instead would name a type that no plain string satisfies.
+    """
+    schema = dict(kind.json_schema)
+    schema["x-json-encoded"] = True
+    return _annotate(schema, parser, action)
 
 
 def _accepts_no_values(action: argparse.Action) -> bool:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi._paths import ensure_lionagi_dir
+from lionagi.cli._argtypes import JsonArgument
 from lionagi.cli._logging import log_error, warn
 from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES
 
@@ -803,13 +804,8 @@ def build_create_body(args: argparse.Namespace) -> tuple[dict[str, Any] | None, 
     if getattr(args, "action_command", None):
         body["action_command"] = args.action_command
     if getattr(args, "action_command_args", None):
-        try:
-            parsed_command_args = json.loads(args.action_command_args)
-        except (ValueError, TypeError) as exc:
-            return None, f"--action-command-args must be valid JSON: {exc}"
-        if not isinstance(parsed_command_args, list):
-            return None, "--action-command-args must be a JSON array."
-        body["action_command_args"] = parsed_command_args
+        # Already a list: the argument's own type decoded and checked it.
+        body["action_command_args"] = args.action_command_args
     # ADR-0070 delta 1: persist a stable execution root instead of depending
     # on the daemon's cwd when it fires. An explicit --cwd always wins.
     if getattr(args, "cwd", None):
@@ -1821,6 +1817,7 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         "--action-command-args",
         dest="action_command_args",
         metavar="JSON",
+        type=JsonArgument({"type": "array", "items": {"type": "string"}}),
         help=(
             "action-kind=command argv, as a JSON array of {{var}} templates "
             "rendered from trigger_context at fire time, e.g. "

--- a/tests/cli/test_command_action_kind.py
+++ b/tests/cli/test_command_action_kind.py
@@ -441,7 +441,9 @@ class TestCliActionKindChoices:
         )
         assert args.action_kind == "command"
         assert args.action_command == "kdev"
-        assert args.action_command_args == '["review-pr"]'
+        # The flag declares its shape as its argparse type, so the parser hands
+        # back the decoded list rather than the JSON text it arrived as.
+        assert args.action_command_args == ["review-pr"]
 
 
 # ---------------------------------------------------------------------------
@@ -540,30 +542,35 @@ class TestCmdCreateActionCommandArgsJSON:
         ]
 
     def test_invalid_json_rejected_before_api_call(self, capsys):
-        """Malformed JSON in --action-command-args must return 1 and never
-        reach the HTTP layer."""
-        from lionagi.studio.cli import _cmd_create
+        """Malformed JSON in --action-command-args is refused while parsing, so
+        no handler runs and nothing can reach the HTTP layer.
 
-        args = self._parse(self._argv("{not valid json"))
+        The shape is declared as the argument's type, which means the parser
+        rejects a bad value itself and exits 2 the way it does for every other
+        malformed argument, rather than a handler decoding the string later and
+        returning 1."""
         with patch("lionagi.studio.cli._api") as mock_api:
-            rc = _cmd_create(args)
+            with pytest.raises(SystemExit) as excinfo:
+                self._parse(self._argv("{not valid json"))
 
-        assert rc == 1
+        assert excinfo.value.code == 2
         mock_api.assert_not_called()
-        assert "--action-command-args must be valid JSON" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "--action-command-args" in err
+        assert "must be valid JSON" in err
 
     def test_valid_json_non_array_rejected_before_api_call(self, capsys):
-        """Valid JSON that parses to a non-array (e.g. an object) must return
-        1 and never reach the HTTP layer."""
-        from lionagi.studio.cli import _cmd_create
-
-        args = self._parse(self._argv('{"not": "an array"}'))
+        """Valid JSON that parses to a non-array (e.g. an object) is refused
+        while parsing, so no handler runs and nothing reaches the HTTP layer."""
         with patch("lionagi.studio.cli._api") as mock_api:
-            rc = _cmd_create(args)
+            with pytest.raises(SystemExit) as excinfo:
+                self._parse(self._argv('{"not": "an array"}'))
 
-        assert rc == 1
+        assert excinfo.value.code == 2
         mock_api.assert_not_called()
-        assert "--action-command-args must be a JSON array" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "--action-command-args" in err
+        assert "must be a JSON array" in err
 
     def test_valid_json_array_parsed_and_forwarded(self):
         """A well-formed JSON array must be parsed and forwarded as the

--- a/tests/mcp/golden_projections/schedule__create.json
+++ b/tests/mcp/golden_projections/schedule__create.json
@@ -10,8 +10,12 @@
       },
       "action_command_args": {
         "description": "action-kind=command argv, as a JSON array of {{var}} templates rendered from trigger_context at fire time, e.g. '[\"review-pr\", \"--pr\", \"{{pr_number}}\"]'.",
-        "type": "string",
-        "x-flag": "--action-command-args"
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "x-flag": "--action-command-args",
+        "x-json-encoded": true
       },
       "action_kind": {
         "default": "agent",

--- a/tests/mcp/stdio_client.py
+++ b/tests/mcp/stdio_client.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Drive a real ``python -m lionagi.mcp`` over stdio, the way a client does.
+
+Every other module under ``tests/mcp/`` exercises the Python objects beneath
+the transport, so a defect that lives in the wire shape — a key read from the
+op rather than from ``args``, a schema that only the projector sees — is
+invisible to all of them. This starts the server as a subprocess and speaks
+JSON-RPC to it: ``initialize``, ``notifications/initialized``, then
+``tools/call``, in that order, because the server refuses work before the
+handshake completes.
+
+Every wait is bounded. A server that stops answering has to fail the test that
+is waiting on it rather than hang the suite, and the child is terminated on
+every exit path including an exception mid-conversation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+from typing import Any
+
+__all__ = ("StdioMCPClient", "TransportError", "tool_payload")
+
+# Generous enough for interpreter start plus the import of the CLI registry the
+# catalog is projected from, short enough that a wedged server fails the run.
+START_TIMEOUT = 90.0
+CALL_TIMEOUT = 60.0
+STOP_TIMEOUT = 10.0
+
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class TransportError(RuntimeError):
+    """The transport itself failed: no start, no answer, or a closed pipe."""
+
+
+class StdioMCPClient:
+    """A minimal JSON-RPC client over one server subprocess.
+
+    Reads run on a background thread so that a silent server costs a timeout
+    rather than a blocked interpreter.
+    """
+
+    def __init__(self, *, cwd: str | None = None, env: dict[str, str] | None = None) -> None:
+        self._id = 0
+        self._inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr: list[str] = []
+        self._proc = subprocess.Popen(
+            [sys.executable, "-m", "lionagi.mcp"],
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._readers = [
+            threading.Thread(target=self._read_stdout, daemon=True),
+            threading.Thread(target=self._read_stderr, daemon=True),
+        ]
+        for thread in self._readers:
+            thread.start()
+
+    # ── plumbing ─────────────────────────────────────────────────────────────
+
+    def _read_stdout(self) -> None:
+        assert self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                self._inbox.put(json.loads(line))
+            except ValueError:
+                # Not a JSON-RPC frame; keep it as diagnostics for a failure.
+                self._stderr.append(f"[non-json stdout] {line}")
+
+    def _read_stderr(self) -> None:
+        assert self._proc.stderr is not None
+        for line in self._proc.stderr:
+            self._stderr.append(line.rstrip())
+
+    @property
+    def stderr(self) -> list[str]:
+        return list(self._stderr)
+
+    def _diagnostics(self) -> str:
+        tail = self._stderr[-20:]
+        return f"exit={self._proc.poll()} stderr_tail={tail}"
+
+    def _send(self, message: dict[str, Any]) -> None:
+        if self._proc.poll() is not None:
+            raise TransportError(f"server already exited; {self._diagnostics()}")
+        assert self._proc.stdin is not None
+        try:
+            self._proc.stdin.write(json.dumps(message) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as exc:
+            raise TransportError(f"server closed stdin: {exc}; {self._diagnostics()}") from exc
+
+    def _await_id(self, want: int, timeout: float) -> dict[str, Any]:
+        import time
+
+        deadline = time.monotonic() + timeout
+        pending: list[dict[str, Any]] = []
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TransportError(
+                        f"no reply to request id {want} within {timeout}s; {self._diagnostics()}"
+                    )
+                try:
+                    message = self._inbox.get(timeout=min(remaining, 1.0))
+                except queue.Empty:
+                    if self._proc.poll() is not None:
+                        raise TransportError(
+                            f"server exited while awaiting id {want}; {self._diagnostics()}"
+                        ) from None
+                    continue
+                if message.get("id") == want:
+                    return message
+                # A notification or an out-of-order reply: keep it for the
+                # caller that is waiting on it.
+                pending.append(message)
+        finally:
+            for message in pending:
+                self._inbox.put(message)
+
+    # ── protocol ─────────────────────────────────────────────────────────────
+
+    def call(
+        self, method: str, params: dict[str, Any] | None = None, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}})
+        return self._await_id(rid, CALL_TIMEOUT if timeout is None else timeout)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def initialize(self) -> dict[str, Any]:
+        reply = self.call(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "lionagi-tests", "version": "0"},
+            },
+            timeout=START_TIMEOUT,
+        )
+        if "error" in reply:
+            raise TransportError(f"initialize failed: {reply['error']}; {self._diagnostics()}")
+        self.notify("notifications/initialized")
+        return reply["result"]
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        reply = self.call("tools/list")
+        if "error" in reply:
+            raise TransportError(f"tools/list failed: {reply['error']}")
+        return reply["result"]["tools"]
+
+    def request(
+        self,
+        *,
+        ops: list[dict[str, Any]] | None = None,
+        help: Any = None,  # noqa: A002 - the surface's own parameter name
+        timeout: float | None = None,
+    ) -> Any:
+        """One ``request`` tool call, unwrapped to the verb surface's own JSON."""
+        arguments: dict[str, Any] = {}
+        if ops is not None:
+            arguments["ops"] = ops
+        if help is not None:
+            arguments["help"] = help
+        reply = self.call(
+            "tools/call", {"name": "request", "arguments": arguments}, timeout=timeout
+        )
+        if "error" in reply:
+            raise TransportError(f"tools/call transport error: {reply['error']}")
+        return tool_payload(reply["result"])
+
+    def op(self, name: str, args: dict[str, Any] | None = None, **op_fields: Any) -> dict[str, Any]:
+        """One op, returned as the single result entry the surface answers with."""
+        payload = self.request(ops=[{"op": name, "args": args or {}, **op_fields}])
+        entries = payload.get("ops") if isinstance(payload, dict) else None
+        if not isinstance(entries, list) or len(entries) != 1:
+            raise TransportError(f"unexpected response envelope: {payload!r}")
+        return entries[0]
+
+    def close(self) -> None:
+        """Terminate the child, whatever state it is in."""
+        proc = self._proc
+        if proc.poll() is None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.close()
+            except (OSError, ValueError):
+                pass
+            try:
+                proc.wait(timeout=STOP_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=STOP_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=STOP_TIMEOUT)
+        for stream in (proc.stdout, proc.stderr, proc.stdin):
+            if stream is not None:
+                try:
+                    stream.close()
+                except (OSError, ValueError):
+                    pass
+
+    def __enter__(self) -> StdioMCPClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def tool_payload(result: dict[str, Any]) -> Any:
+    """The verb surface's JSON out of an MCP ``tools/call`` result."""
+    if "structuredContent" in result:
+        return result["structuredContent"]
+    for block in result.get("content") or []:
+        if block.get("type") == "text":
+            try:
+                return json.loads(block["text"])
+            except ValueError:
+                return {"text": block["text"]}
+    return result

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -165,6 +165,25 @@ def test_a_flag_that_is_legal_bare_takes_both_forms_it_declares(submitted, value
     assert expected in submitted["flags"]
 
 
+def test_a_json_encoded_flag_reaches_the_parser_encoded():
+    # The parser decodes this flag's single token from JSON, so the schema
+    # advertises the decoded shape while the rendered token has to be the
+    # encoding of it. Those are two halves of one contract held in two files:
+    # a test of the projection alone, or of the parser alone, passes while the
+    # round-trip is broken and every caller gets an unusable command line.
+    schema = call(help="schedule.create")["schema"]
+    assert schema["properties"]["action_command_args"]["x-json-encoded"] is True
+
+    argv = dispatch.render_argv(
+        schema, {"name": "n", "action_command_args": ["review-pr", "--repo", "{{r}}"]}
+    )
+
+    flag = next(t for t in argv if t.startswith("--action-command-args"))
+    # One token, so the values cannot be read as further options.
+    assert flag == f"--action-command-args={json.dumps(['review-pr', '--repo', '{{r}}'])}"
+    assert json.loads(flag.split("=", 1)[1]) == ["review-pr", "--repo", "{{r}}"]
+
+
 def test_a_flag_a_detached_run_cannot_honour_is_refused_with_its_reason(submitted):
     # Accepting it and dropping it would leave the caller believing it applied.
     answer = call(ops=[spawn_op("agent.submit", {"verbose": True})])

--- a/tests/mcp/test_doc_matches_registry.py
+++ b/tests/mcp/test_doc_matches_registry.py
@@ -1,0 +1,146 @@
+"""The reference document's catalog tables must match the registry.
+
+The tables in `docs/reference/mcp-server.md` are written by hand, so they drift
+the moment a verb is registered or withdrawn without someone remembering to
+edit them. A reader who trusts a stale table is told a working verb cannot be
+called, or is never told a verb exists. These tests fail on that drift and name
+the verbs that differ, so the fix does not start with a hand diff.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lionagi.mcp.verbs import ABSENT, VERBS
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "reference" / "mcp-server.md"
+
+# Verb names as the document writes them: backticked, in a table's first cell.
+_ROW_NAME = re.compile(r"^\|\s*`([a-z][a-z0-9.\-]*)`\s*\|")
+
+_NUMBER_WORDS = {
+    "One": 1,
+    "Two": 2,
+    "Three": 3,
+    "Four": 4,
+    "Five": 5,
+    "Six": 6,
+    "Seven": 7,
+    "Eight": 8,
+    "Nine": 9,
+    "Ten": 10,
+    "Eleven": 11,
+    "Twelve": 12,
+    "Thirteen": 13,
+    "Fourteen": 14,
+    "Fifteen": 15,
+    "Sixteen": 16,
+    "Seventeen": 17,
+    "Eighteen": 18,
+    "Nineteen": 19,
+    "Twenty": 20,
+    "Twenty-one": 21,
+    "Twenty-two": 22,
+    "Twenty-three": 23,
+    "Twenty-four": 24,
+    "Twenty-five": 25,
+    "Twenty-six": 26,
+    "Twenty-seven": 27,
+    "Twenty-eight": 28,
+    "Twenty-nine": 29,
+    "Thirty": 30,
+}
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def _marked_region(text: str, key: str) -> str:
+    start = f"<!-- mcp-catalog:{key}:start -->"
+    end = f"<!-- mcp-catalog:{key}:end -->"
+    assert start in text and end in text, (
+        f"{DOC.name} no longer carries the {key!r} table markers ({start} / {end}). "
+        "The catalog tables are checked against the registry by name, so removing "
+        "the markers removes the check — restore them, or delete this test "
+        "deliberately along with the tables it guards."
+    )
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+
+def _documented(text: str, key: str) -> set[str]:
+    return {
+        m.group(1)
+        for line in _marked_region(text, key).splitlines()
+        if (m := _ROW_NAME.match(line.strip()))
+    }
+
+
+def _explain(kind: str, documented: set[str], registry: set[str]) -> str:
+    missing = sorted(registry - documented)
+    extra = sorted(documented - registry)
+    parts = [f"{DOC.name} disagrees with the registry about which verbs are {kind}."]
+    if missing:
+        parts.append(
+            f"  {kind.capitalize()} in the registry but absent from the {kind} table "
+            f"({len(missing)}): {', '.join(missing)}"
+        )
+    if extra:
+        parts.append(
+            f"  Listed in the {kind} table but not {kind} in the registry "
+            f"({len(extra)}): {', '.join(extra)}"
+        )
+    parts.append(
+        "  Regenerate the table from the registry rather than editing single rows: "
+        "`help=true` (or lionagi.mcp.verbs.VERBS / ABSENT) is the authority."
+    )
+    return "\n".join(parts)
+
+
+def test_available_table_matches_registry(doc_text):
+    registry = set(VERBS)
+    documented = _documented(doc_text, "available")
+    assert documented == registry, _explain("available", documented, registry)
+
+
+def test_unavailable_table_matches_registry(doc_text):
+    registry = {absent.name for absent in ABSENT}
+    documented = _documented(doc_text, "unavailable")
+    assert documented == registry, _explain("unavailable", documented, registry)
+
+
+def test_stated_available_count_matches_registry(doc_text):
+    match = re.search(r"^(\d+) verbs are reachable\.", doc_text, re.MULTILINE)
+    assert match, (
+        "The catalog section no longer opens with 'N verbs are reachable.'; "
+        f"the registry currently registers {len(VERBS)}."
+    )
+    stated = int(match.group(1))
+    assert stated == len(VERBS), (
+        f"{DOC.name} says {stated} verbs are reachable; the registry registers "
+        f"{len(VERBS)}. A reader sizing the surface from the prose is told the "
+        "wrong number even when the table below it is right."
+    )
+
+
+def test_stated_unavailable_count_matches_registry(doc_text):
+    match = re.search(
+        r"^([A-Z][a-z]+(?:-[a-z]+)?) further names are catalogued", doc_text, re.MULTILINE
+    )
+    assert match, (
+        "The unavailable section no longer opens with 'N further names are "
+        f"catalogued'; the registry currently catalogues {len(ABSENT)} of them."
+    )
+    word = match.group(1)
+    assert word in _NUMBER_WORDS, (
+        f"{DOC.name} states the unavailable count as {word!r}, which is not a "
+        f"number word this test knows. The registry catalogues {len(ABSENT)}."
+    )
+    assert _NUMBER_WORDS[word] == len(ABSENT), (
+        f"{DOC.name} says {word} ({_NUMBER_WORDS[word]}) names are catalogued as "
+        f"unavailable; the registry catalogues {len(ABSENT)}."
+    )

--- a/tests/mcp/test_stdio_transport.py
+++ b/tests/mcp/test_stdio_transport.py
@@ -115,8 +115,9 @@ def test_missing_fingerprint_error_states_the_op_level_shape(mcp: StdioMCPClient
 def test_fingerprint_inside_args_is_refused_as_a_wrong_place(mcp: StdioMCPClient) -> None:
     """Putting it in ``args`` used to repeat the same refusal verbatim.
 
-    Same text for "you did not send it" and "you sent it in the wrong place"
-    reads as an idempotent failure, which is what cost the diagnosis.
+    Identical text for "you did not send it" and "you sent it in the wrong
+    place" reads as an idempotent failure, so a caller retries the shape it
+    already sent instead of moving the field.
     """
     fingerprint = mcp.request(help="agent.submit")["schema_fingerprint"]
     result = mcp.op("agent.submit", {"prompt": "unused", "schema_fingerprint": fingerprint})

--- a/tests/mcp/test_stdio_transport.py
+++ b/tests/mcp/test_stdio_transport.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The verb surface as a client reaches it: over stdio, after a handshake.
+
+These are deliberately not skipped when the transport will not start. A server
+that cannot be spoken to is the failure this module exists to catch, and a skip
+would report that absence as a pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .stdio_client import StdioMCPClient
+
+pytestmark = pytest.mark.timeout(180)
+
+
+@pytest.fixture(scope="module")
+def mcp() -> StdioMCPClient:
+    """One handshaken server for the module; terminated however the tests end."""
+    client = StdioMCPClient()
+    try:
+        client.initialize()
+    except BaseException:
+        client.close()
+        raise
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_handshake_advertises_the_request_tool(mcp: StdioMCPClient) -> None:
+    names = [tool["name"] for tool in mcp.list_tools()]
+    assert "request" in names, names
+
+
+def test_a_read_verb_answers_over_the_wire(mcp: StdioMCPClient) -> None:
+    result = mcp.op("server.info")
+    assert result["ok"] is True, result
+
+
+def test_help_returns_the_catalog(mcp: StdioMCPClient) -> None:
+    catalog = mcp.request(help=True)
+    assert catalog["available_count"] > 0
+    assert any(entry["verb"] == "schedule.create" for entry in catalog["verbs"])
+
+
+# ── the JSON-encoded flag a caller could not satisfy ─────────────────────────
+
+
+def test_schedule_create_advertises_the_shape_it_accepts(mcp: StdioMCPClient) -> None:
+    """The advertised type is the one the parser decodes, not ``string``.
+
+    A plain string was refused as invalid JSON and a list as the wrong type,
+    so the advertised ``string`` named a type no value satisfied.
+    """
+    schema = mcp.request(help="schedule.create")["schema"]
+    spec = schema["properties"]["action_command_args"]
+    assert spec["type"] == "array"
+    assert spec["items"] == {"type": "string"}
+    assert spec["x-json-encoded"] is True
+
+
+def test_schedule_create_accepts_the_list_it_advertises(mcp: StdioMCPClient) -> None:
+    """A value valid per the advertised schema gets past argument validation.
+
+    The call is expected to fail further in — the command allowlist, or no
+    scheduler to write to — but it has to get past argument validation, and it
+    must not fail naming this parameter.
+    """
+    result = mcp.op(
+        "schedule.create",
+        {
+            "name": "transport-harness-probe",
+            "interval": 3600,
+            "trigger_type": "interval",
+            "action_kind": "command",
+            "action_command": "echo",
+            "action_command_args": ["hello", "{{run_id}}"],
+        },
+    )
+    if not result["ok"]:
+        message = result["error"]["message"]
+        assert "action_command_args" not in message, message
+        # The two ways the old contract refused a schema-obeying caller.
+        assert "expects string" not in message, message
+        assert "must be valid JSON" not in message, message
+
+
+def test_schedule_create_refuses_a_bare_string(mcp: StdioMCPClient) -> None:
+    """The type it advertises is also the type it enforces."""
+    result = mcp.op(
+        "schedule.create",
+        {"name": "transport-harness-probe", "action_command_args": "hello"},
+    )
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "invalid_input"
+    assert "action_command_args" in result["error"]["message"]
+
+
+# ── the fingerprint gate says where the fingerprint goes ─────────────────────
+
+
+def test_missing_fingerprint_error_states_the_op_level_shape(mcp: StdioMCPClient) -> None:
+    result = mcp.op("agent.submit", {"prompt": "unused"})
+    assert result["ok"] is False
+    message = result["error"]["message"]
+    assert "'args'" in message and "schema_fingerprint" in message
+    # The literal op shape, so a caller cannot read "with the op" as "in args".
+    assert "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint':" in message
+
+
+def test_fingerprint_inside_args_is_refused_as_a_wrong_place(mcp: StdioMCPClient) -> None:
+    """Putting it in ``args`` used to repeat the same refusal verbatim.
+
+    Same text for "you did not send it" and "you sent it in the wrong place"
+    reads as an idempotent failure, which is what cost the diagnosis.
+    """
+    fingerprint = mcp.request(help="agent.submit")["schema_fingerprint"]
+    result = mcp.op("agent.submit", {"prompt": "unused", "schema_fingerprint": fingerprint})
+    assert result["ok"] is False
+    message = result["error"]["message"]
+    assert "sibling of 'args'" in message or "unknown parameter" in message


### PR DESCRIPTION
Two changes to the MCP surface, both about the contract a client actually sees.

**A test that speaks the wire protocol.** The MCP tests all exercised the Python objects beneath
the transport, so nothing in the suite could see a defect that only appears over JSON-RPC. This
adds a client fixture that starts the server as a subprocess and does `initialize` →
`notifications/initialized` → `tools/call` the way a real client does. Every wait is bounded and
the child is terminated on every path, so a server that never comes up fails the test instead of
hanging it.

Driving it that way found two contract defects, both fixed here at the layer the schema is
projected from rather than patched at the edge:

- A parameter advertised as a string rejected a plain string as invalid JSON and rejected a list
  as the wrong type, so a caller obeying the advertised schema could not make the call at all. The
  argparse type now carries the JSON Schema of the decoded value, and one declaration feeds the
  parser, the projected schema and the argv renderer.
- Two refusals named the wrong place for a required field, so putting it where the error said
  reproduced the same error. Both now spell the accepted shape and say where the field belongs.

**Catalog documentation pinned to the registry.** The reference tables had drifted: three
registered verbs were listed as unavailable, one was missing entirely, and the stated counts were
from an earlier state of the surface. Both tables are regenerated from the registry, all
unavailable verbs are listed with their reasons rather than elided, and new tests compare each
table and each stated count against the registry so the document cannot drift again silently.

The guard binds this repository. A reader on a published package can still be looking at a
different version, so `help=true` remains the authoritative catalog for a running server.