### PR TITLE
fix(cli): give a spawned agent its MCP servers and its notice's sender from the submission

### DIFF
--- a/lionagi/cli/_mcp_resolve.py
+++ b/lionagi/cli/_mcp_resolve.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve, at submit time, the MCP servers a spawned leg should be given.
+
+A CLI-backed agent discovers MCP servers by walking up from its own working
+directory. That makes its tool surface a property of *where it was told to
+work* rather than of the submission: the same command, same model and same
+prompt, pointed at a checkout instead of the directory holding the config,
+starts with no MCP servers at all. Nothing fails and nothing is reported — the
+agent simply has fewer tools than its instructions assume, and only its own
+confused output says so, much later.
+
+So the submitting side resolves the config from *its* directory and hands the
+result to the child explicitly. Two consequences are deliberate:
+
+* The servers are read and snapshotted here, not passed on as a path. A path
+  would be re-read by the child at an unknown later moment, and would also have
+  to live inside the child's working directory to survive the provider's
+  repo-containment check — which is exactly the directory that does not have it.
+* "Nothing was configured" and "something was configured and could not be used"
+  are returned as different states. Collapsing them is what makes the original
+  defect silent, so a resolution that fails carries the reason with it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = (
+    "MCP_CONFIG_FILENAME",
+    "McpConfigError",
+    "McpResolution",
+    "discover_mcp_config",
+    "resolve_spawn_mcp_servers",
+)
+
+MCP_CONFIG_FILENAME = ".mcp.json"
+
+
+class McpConfigError(ValueError):
+    """A named MCP config cannot be used. Its own type, so a caller can refuse
+    the spawn on it without also catching every other ValueError raised on the
+    way there."""
+
+
+@dataclass(frozen=True)
+class McpResolution:
+    """What the submitting side resolved, and why it is what it is.
+
+    ``servers`` is None whenever no server set could be produced; ``reason`` is
+    then a short machine-readable token saying why, and is None only when the
+    caller explicitly asked for no config at all.
+    """
+
+    servers: dict[str, Any] | None
+    reason: str | None
+    source: Path | None
+    searched_from: Path
+
+    @property
+    def ok(self) -> bool:
+        return self.servers is not None
+
+
+def discover_mcp_config(start: str | Path) -> Path | None:
+    """Nearest ``.mcp.json`` at or above *start*, or None.
+
+    Mirrors how a CLI agent finds its own config, so that resolving here from
+    the submitting directory produces what the child would have found had it
+    been started there.
+    """
+    current = Path(start).expanduser().resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / MCP_CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _read_servers(path: Path) -> dict[str, Any]:
+    """Parse ``{"mcpServers": {...}}`` from *path*; raises ValueError on any
+    shape this cannot hand to a provider."""
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        raise McpConfigError(f"could not read {path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise McpConfigError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise McpConfigError(f"{path} must contain a JSON object, got {type(data).__name__}")
+    servers = data.get("mcpServers")
+    if servers is None:
+        raise McpConfigError(f"{path} has no 'mcpServers' key")
+    if not isinstance(servers, dict):
+        raise McpConfigError(
+            f"{path}: 'mcpServers' must be an object, got {type(servers).__name__}"
+        )
+    return servers
+
+
+def resolve_spawn_mcp_servers(
+    explicit: str | Path | None = None,
+    *,
+    launch_dir: str | Path,
+    disabled: bool = False,
+) -> McpResolution:
+    """Resolve the server set to hand a child spawned from *launch_dir*.
+
+    *explicit* names a config file directly and is an error when it cannot be
+    used — a caller who named a file is not asking for a silent fallback.
+    Without one, the nearest config at or above *launch_dir* is used. *disabled*
+    is the caller saying "no MCP servers", which is a choice and not a failure.
+    """
+    searched_from = Path(launch_dir).expanduser().resolve()
+
+    if disabled:
+        return McpResolution(None, None, None, searched_from)
+
+    if explicit is not None:
+        path = Path(explicit).expanduser()
+        if not path.is_absolute():
+            path = (searched_from / path).resolve()
+        if not path.is_file():
+            raise McpConfigError(f"--mcp-config {str(explicit)!r} is not a readable file ({path})")
+        return McpResolution(_read_servers(path), None, path, searched_from)
+
+    found = discover_mcp_config(searched_from)
+    if found is None:
+        return McpResolution(None, "no_mcp_config_found", None, searched_from)
+    try:
+        servers = _read_servers(found)
+    except McpConfigError as exc:
+        return McpResolution(None, f"mcp_config_unusable:{exc}", found, searched_from)
+    if not servers:
+        return McpResolution(None, "mcp_config_declares_no_servers", found, searched_from)
+    return McpResolution(servers, None, found, searched_from)

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -128,10 +128,17 @@ def build_chat_model(
     effort: str | None = None,
     fast: bool = False,
     bypass: bool = False,
+    mcp_servers: dict | None = None,
 ) -> iModel | str:
     """Legacy: for agent.py compat. Returns bare spec string when no flags."""
     effort = normalize_effort(effort)
     extra: dict = {}
+    if mcp_servers is not None:
+        # Only the Claude CLI lane carries a server set on the request; the
+        # other CLI providers read a user-level config no caller directory
+        # affects, so handing them this here would drop it without a word.
+        if provider in _CLAUDE_PROVIDER_NAMES:
+            extra["mcp_servers"] = mcp_servers
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))
     elif yolo:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -32,6 +32,7 @@ from ._context_from import (
     resolve_and_build_context_block,
 )
 from ._logging import hint, log_error
+from ._mcp_resolve import McpConfigError, McpResolution, resolve_spawn_mcp_servers
 from ._providers import (
     _CLAUDE_PROVIDER_NAMES,
     BACKENDS,
@@ -294,6 +295,43 @@ class _ProgressReport:
         )
 
 
+def _report_mcp_resolution(resolution: McpResolution, *, provider: str, cwd: str | None) -> None:
+    """Say at spawn time what tool surface the leg is actually getting.
+
+    The whole point of resolving here is that a leg starting without the
+    servers its instructions assume should be visible when it is launched
+    rather than inferred from its output an hour later. Silence is reserved
+    for the one case where it is accurate: servers resolved and handed over.
+    """
+    from lionagi.cli._logging import warn
+
+    if provider not in _CLAUDE_PROVIDER_NAMES:
+        if resolution.servers is not None:
+            warn(
+                f"MCP servers resolved from {resolution.source} are not carried to "
+                f"provider {provider!r}: only the Claude CLI lane accepts a server "
+                "set per request. This leg gets whatever that CLI discovers for itself."
+            )
+        return
+
+    if resolution.servers is not None:
+        names = ", ".join(sorted(resolution.servers))
+        hint(f"[mcp] {len(resolution.servers)} server(s) from {resolution.source}: {names}")
+        return
+
+    if resolution.reason is None:
+        return  # --no-mcp-config: chosen, not degraded
+
+    target = cwd or os.getcwd()
+    warn(
+        f"no MCP servers are being handed to this leg ({resolution.reason}; searched "
+        f"from {resolution.searched_from}). It will start with only whatever the "
+        f"Claude CLI discovers from {target} itself, which is where a leg pointed at "
+        "a checkout silently loses them. Pass --mcp-config PATH, or --no-mcp-config "
+        "to state that this is intended."
+    )
+
+
 async def _run_agent(
     model_str: str | None,
     prompt: str,
@@ -316,6 +354,8 @@ async def _run_agent(
     context_budget: int | None = None,
     notify: str | None = None,
     images: list[str] | None = None,
+    mcp_config: str | None = None,
+    no_mcp_config: bool = False,
     _auto_resumed: bool = False,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
@@ -327,6 +367,14 @@ async def _run_agent(
     # into a provider-created dir. Forward the tilde-expanded path — providers
     # never expand `~`.
     cwd = validate_cwd_exists(cwd)
+    # Read from *this* process's directory, before --cwd is applied to anything.
+    # The child's tool surface is meant to be a property of the submission, and
+    # this is the only point at which the submitting directory is still known.
+    mcp_resolution = resolve_spawn_mcp_servers(
+        mcp_config,
+        launch_dir=os.getcwd(),
+        disabled=no_mcp_config,
+    )
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
     if preset and (resume or continue_last):
@@ -453,8 +501,19 @@ async def _run_agent(
                 "sandboxed default, or use an agent profile (-a). --bypass also "
                 "works but disables the sandbox."
             )
-        chat_model = build_chat_model(provider, model, yolo, verbose, theme, effort, fast, bypass)
+        chat_model = build_chat_model(
+            provider,
+            model,
+            yolo,
+            verbose,
+            theme,
+            effort,
+            fast,
+            bypass,
+            mcp_servers=mcp_resolution.servers,
+        )
         effort = resolve_persisted_effort(provider, chat_model, effort)
+        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
 
         # Opt-in profile `role:` key switches a plain `-a <profile>` leg onto
         # the same create_agent path as --preset coding, parameterized by role.
@@ -552,6 +611,12 @@ async def _run_agent(
             cfg.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
         if fast:
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
+        # A resumed leg re-spawns a CLI child, so it needs the server set handed
+        # to it just as a new one does; the persisted branch carries the model,
+        # not the caller's directory.
+        if mcp_resolution.servers is not None and provider in _CLAUDE_PROVIDER_NAMES:
+            cfg["mcp_servers"] = mcp_resolution.servers
+        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
 
     # Add the profile system prompt for every leg EXCEPT one whose branch carries
     # (or, on a brand-new leg, would carry) a create_agent-composed system message
@@ -803,6 +868,8 @@ async def _run_agent(
             bypass=bypass,
             resume_on_timeout=resume_on_timeout,
             notify=notify,
+            mcp_config=mcp_config,
+            no_mcp_config=no_mcp_config,
             _auto_resumed=True,
         )
 
@@ -959,6 +1026,27 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
 
+    agent.add_argument(
+        "--mcp-config",
+        dest="mcp_config",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Read this MCP config and hand its servers to the leg explicitly. "
+            "By default the nearest .mcp.json at or above the directory this "
+            "command was run in is used, so the leg's tools come from the "
+            "submission rather than from --cwd. The file is read once at spawn."
+        ),
+    )
+    agent.add_argument(
+        "--no-mcp-config",
+        dest="no_mcp_config",
+        action="store_true",
+        help=(
+            "Hand the leg no MCP servers, and say so deliberately instead of "
+            "arriving there by an empty search."
+        ),
+    )
     add_common_cli_args(agent)
     return agent
 
@@ -1083,8 +1171,15 @@ def run_agent(args: argparse.Namespace) -> int:
                 context_budget=getattr(args, "context_budget", None),
                 notify=getattr(args, "notify", None),
                 images=image_uris,
+                mcp_config=getattr(args, "mcp_config", None),
+                no_mcp_config=getattr(args, "no_mcp_config", False),
             )
         )
+    except McpConfigError as exc:
+        # An explicitly named --mcp-config that cannot be used: refuse at spawn,
+        # rather than starting a leg whose tool surface is not what was asked for.
+        log_error(str(exc))
+        return 2
     except ContextFromError as exc:
         log_error(str(exc))
         return 2

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -218,6 +218,15 @@ def main(argv: list[str] | None = None) -> int:
         args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
         cwd=(job or {}).get("cwd"),
     )
+    if template and not sender and any("{sender}" in tok for tok in template):
+        # The command asks who the notice is from and there is no answer. An
+        # empty string is not one: it puts a blank where an identity belongs,
+        # and a delivery tool that accepts it — or falls back to resolving a
+        # sender from its own working directory — signs the notice with a seat
+        # that did not send it, silently. Unusable in the same sense as a
+        # template that cannot be parsed, and recorded the same way.
+        template, unusable = None, "delivery_command_needs_a_sender_and_none_was_given"
+
     if template:
         fields = {
             "run_id": args.run_id,

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -99,7 +99,7 @@ def _resolve_command(
 
 
 def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
-    """Replace ``{run_id}``/``{status}``/``{label}``/``{target}`` per token."""
+    """Replace ``{run_id}``/``{status}``/``{label}``/``{target}``/``{sender}`` per token."""
     out: list[str] = []
     for tok in argv:
         for key, value in fields.items():
@@ -108,7 +108,31 @@ def _substitute(argv: list[str], fields: dict[str, str]) -> list[str]:
     return out
 
 
-def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
+def _delivery_env(sender: str) -> dict[str, str] | None:
+    """Environment for the delivery command, carrying an explicit sender.
+
+    A notifier that resolves who it is from its working directory reports the
+    identity of whoever owns that directory, not the identity of whoever
+    submitted the run. That misattribution is silent — the notice arrives, it
+    just arrives signed by the wrong seat, and downstream routing rules act on
+    the signature. Naming the sender here is the caller's answer to that.
+
+    This publishes the value; it does not force any particular notifier to
+    prefer it over its own directory-based resolution. A notifier whose
+    identity precedence puts a working-directory config first has to be given
+    the sender in its command line, which is what the ``{sender}`` placeholder
+    is for.
+    """
+    if not sender:
+        return None
+    env = dict(os.environ)
+    env["LIONAGI_NOTIFY_SENDER"] = sender
+    return env
+
+
+def _deliver(
+    argv: list[str], payload: dict[str, str], env: dict[str, str] | None = None
+) -> dict[str, Any]:
     """Run the delivery command best-effort; return its outcome for the record.
 
     The outcome is recorded on the job so a dead completion notice surfaces in
@@ -126,6 +150,7 @@ def _deliver(argv: list[str], payload: dict[str, str]) -> dict[str, Any]:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+            env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         # never fail the run's terminal path; record the failure instead
@@ -177,11 +202,17 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--status", default="completed")
     ap.add_argument("--target", default=None, help="value for the {target} placeholder")
     ap.add_argument("--command", default=None, help="delivery argv override (JSON list)")
+    ap.add_argument(
+        "--sender",
+        default=None,
+        help="value for the {sender} placeholder: who the notice is from",
+    )
     args = ap.parse_args(argv)
 
     job = jobs.mark_terminal(args.run_id, args.status)
 
     target = args.target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
+    sender = args.sender or os.environ.get("LIONAGI_MCP_NOTIFY_SENDER") or ""
     label = (job or {}).get("label") or (job or {}).get("kind") or "run"
     template, unusable = _resolve_command(
         args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
@@ -193,8 +224,9 @@ def main(argv: list[str] | None = None) -> int:
             "status": args.status,
             "label": label,
             "target": target,
+            "sender": sender,
         }
-        outcome = _deliver(_substitute(template, fields), fields)
+        outcome = _deliver(_substitute(template, fields), fields, _delivery_env(sender))
     elif unusable:
         # Configured but unusable. Recorded as a failure so job_status shows a
         # notifier that cannot deliver, rather than the silence of one that was

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -455,6 +455,7 @@ def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict
         label=args.get("label") or args.get("playbook"),
         notify_command=args.get("notify_command"),
         notify_target=args.get("notify_seat"),
+        notify_sender=args.get("notify_sender"),
     )
     fingerprint = schema.get("x-playbook-fingerprint")
     if fingerprint is not None:

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -456,6 +456,8 @@ def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict
         notify_command=args.get("notify_command"),
         notify_target=args.get("notify_seat"),
         notify_sender=args.get("notify_sender"),
+        mcp_config=args.get("mcp_config"),
+        no_mcp_config=bool(args.get("no_mcp_config")),
     )
     fingerprint = schema.get("x-playbook-fingerprint")
     if fingerprint is not None:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -587,20 +587,46 @@ def submit(
     # An agent leg discovers MCP servers from the directory it is told to work
     # in, which for a detached run is a checkout and not the directory holding
     # this server's config. Resolve it here, where the submitting directory is
-    # still the one in effect, and name the file on the child's command line.
+    # still the one in effect, and hand the resolved set to the child.
     # Both outcomes are reported on the handle: a leg that starts without the
     # tools its brief assumes should be visible at submit, not deduced later
     # from its own confused output.
+    #
+    # The servers are read here and written into this run's own directory, and
+    # that copy is what the child is pointed at. Naming the discovered file
+    # instead would leave the run's tool surface tied to a file anyone may edit
+    # between submission and execution — and a run that resumes hours later
+    # would re-read it again, so the same submission could start with a
+    # different set of tools every time. A file only this run writes cannot
+    # change under it, and staying a path keeps the child's existing flag
+    # working. A config that exists but cannot be used fails the submission,
+    # because a child that discovers the problem reports it minutes later and
+    # only in its own log, while the submitter was told the run started.
     mcp_config_path: str | None = None
+    mcp_config_source: str | None = None
     mcp_config_reason: str | None = None
+    mcp_servers: dict[str, Any] | None = None
     if kind == "agent" and not any(tok == "--mcp-config" for tok in options):
-        from lionagi.cli._mcp_resolve import discover_mcp_config
+        from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
 
-        found = discover_mcp_config(os.getcwd())
-        if found is None:
-            mcp_config_reason = f"no_mcp_config_found_at_or_above:{os.getcwd()}"
+        launch_dir = os.getcwd()
+        resolution = resolve_spawn_mcp_servers(launch_dir=launch_dir)
+        if resolution.servers is None:
+            if resolution.reason and resolution.reason.startswith("mcp_config_unusable:"):
+                raise McpConfigError(
+                    f"cannot submit this agent run: the MCP config found at "
+                    f"{resolution.source} cannot be used "
+                    f"({resolution.reason.split(':', 1)[1].strip()})"
+                )
+            mcp_config_reason = (
+                f"{resolution.reason}_at_or_above:{launch_dir}"
+                if resolution.reason == "no_mcp_config_found"
+                else resolution.reason
+            )
         else:
-            mcp_config_path = str(found)
+            mcp_servers = resolution.servers
+            mcp_config_source = str(resolution.source) if resolution.source else None
+            mcp_config_path = str(d / "mcp-servers.json")
             options = ["--mcp-config", mcp_config_path, *options]
 
     # Wire the CLI's terminal hook back to the MCP server so we record a reliable
@@ -627,6 +653,8 @@ def submit(
     d.mkdir(parents=True, exist_ok=True)
     if prompt_path is not None:
         prompt_path.write_text(prompt)
+    if mcp_servers is not None and mcp_config_path is not None:
+        Path(mcp_config_path).write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
     # always finds a record to mark. mark_terminal no-ops on a missing record, so
@@ -650,6 +678,7 @@ def submit(
         "notify_target": notify_target,
         "notify_sender": notify_sender,
         "mcp_config": mcp_config_path,
+        "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
         "submitted_at": _now_iso(),
         "finished_at": None,
@@ -710,6 +739,7 @@ def submit(
         "spawn_state": latest["spawn_state"],
         "log": str(log_path),
         "mcp_config": mcp_config_path,
+        "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
         "notify_sender": notify_sender,
     }

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -542,6 +542,8 @@ def submit(
     notify_command: str | None = None,
     notify_target: str | None = None,
     notify_sender: str | None = None,
+    mcp_config: str | None = None,
+    no_mcp_config: bool = False,
 ) -> dict[str, Any]:
     """Spawn a ``li`` run in the background and return its handle immediately.
 
@@ -554,6 +556,13 @@ def submit(
     per-submit delivery-argv override (JSON list); *notify_target* fills the
     ``{target}`` placeholder in the configured command. With neither and no
     configured default, the run simply records its status and delivers nothing.
+
+    *mcp_config* and *no_mcp_config* are the caller's own answer to where the
+    child's MCP servers come from, handed over as values rather than left to be
+    read back out of *flags*. Both are already rendered into *flags* by the
+    surface; they are repeated here because this function has to decide whether
+    to resolve a set of its own, and that is a decision about intent, not about
+    tokens.
     """
     if kind not in _KIND_ARGV:
         raise ValueError(f"unknown job kind {kind!r}; expected one of {sorted(_KIND_ARGV)}")
@@ -602,11 +611,31 @@ def submit(
     # working. A config that exists but cannot be used fails the submission,
     # because a child that discovers the problem reports it minutes later and
     # only in its own log, while the submitter was told the run started.
+    #
+    # A snapshot is taken only when the caller left the choice open. Whether
+    # they did is answered from the values they passed, never by looking through
+    # the tokens for a flag: those tokens are built by the same surface, in a
+    # form (`--flag=value`) chosen so that nothing downstream can take them
+    # apart, so a scan of them reports on spelling rather than on intent.
     mcp_config_path: str | None = None
     mcp_config_source: str | None = None
     mcp_config_reason: str | None = None
     mcp_servers: dict[str, Any] | None = None
-    if kind == "agent" and not any(tok == "--mcp-config" for tok in options):
+    if kind == "agent" and no_mcp_config:
+        # The caller asked for no servers. That is an answer, not an absence, so
+        # nothing is resolved and the handle says whose decision it was.
+        mcp_config_reason = "mcp_disabled_by_caller"
+    elif kind == "agent" and mcp_config is not None:
+        # The caller named the file, and their flag is already on the line. No
+        # snapshot is taken and none is prepended: a second --mcp-config would
+        # let the parser pick between them, and the handle would go on naming
+        # the one the child did not read. What the child reads is what the
+        # handle reports, and its source is the caller's own path, which this
+        # run does not own and cannot promise will hold still.
+        mcp_config_path = mcp_config
+        mcp_config_source = mcp_config
+        mcp_config_reason = "mcp_config_named_by_caller"
+    elif kind == "agent":
         from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
 
         launch_dir = os.getcwd()

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -267,7 +267,12 @@ def _split_at_sentinel(flags: Sequence[str]) -> tuple[list[str], list[str]]:
     return tokens[:cut], tokens[cut:]
 
 
-def _notify_template(run_id: str, notify_target: str | None, notify_command: str | None) -> str:
+def _notify_template(
+    run_id: str,
+    notify_target: str | None,
+    notify_command: str | None,
+    notify_sender: str | None = None,
+) -> str:
     """Command the CLI runs on terminal status (records finished_at + delivery).
 
     Invokes the terminal hook module by absolute interpreter path with a
@@ -289,6 +294,8 @@ def _notify_template(run_id: str, notify_target: str | None, notify_command: str
         parts += ["--target", shlex.quote(notify_target)]
     if notify_command:
         parts += ["--command", shlex.quote(notify_command)]
+    if notify_sender:
+        parts += ["--sender", shlex.quote(notify_sender)]
     return " ".join(parts)
 
 
@@ -534,6 +541,7 @@ def submit(
     label: str | None = None,
     notify_command: str | None = None,
     notify_target: str | None = None,
+    notify_sender: str | None = None,
 ) -> dict[str, Any]:
     """Spawn a ``li`` run in the background and return its handle immediately.
 
@@ -576,9 +584,32 @@ def submit(
                 positionals = ["--"]
             positionals.append(prompt)
 
+    # An agent leg discovers MCP servers from the directory it is told to work
+    # in, which for a detached run is a checkout and not the directory holding
+    # this server's config. Resolve it here, where the submitting directory is
+    # still the one in effect, and name the file on the child's command line.
+    # Both outcomes are reported on the handle: a leg that starts without the
+    # tools its brief assumes should be visible at submit, not deduced later
+    # from its own confused output.
+    mcp_config_path: str | None = None
+    mcp_config_reason: str | None = None
+    if kind == "agent" and not any(tok == "--mcp-config" for tok in options):
+        from lionagi.cli._mcp_resolve import discover_mcp_config
+
+        found = discover_mcp_config(os.getcwd())
+        if found is None:
+            mcp_config_reason = f"no_mcp_config_found_at_or_above:{os.getcwd()}"
+        else:
+            mcp_config_path = str(found)
+            options = ["--mcp-config", mcp_config_path, *options]
+
     # Wire the CLI's terminal hook back to the MCP server so we record a reliable
     # finished_at/status (and fire the configured delivery) even across a restart.
-    options = ["--notify", _notify_template(run_id, notify_target, notify_command), *options]
+    options = [
+        "--notify",
+        _notify_template(run_id, notify_target, notify_command, notify_sender),
+        *options,
+    ]
 
     argv = [*config.li_command(), *_KIND_ARGV[kind], *options, *positionals]
 
@@ -617,6 +648,9 @@ def submit(
         "label": label,
         "notify_command": notify_command,
         "notify_target": notify_target,
+        "notify_sender": notify_sender,
+        "mcp_config": mcp_config_path,
+        "mcp_config_reason": mcp_config_reason,
         "submitted_at": _now_iso(),
         "finished_at": None,
         "status": "running",
@@ -675,6 +709,9 @@ def submit(
         "reason_code": derived["reason_code"],
         "spawn_state": latest["spawn_state"],
         "log": str(log_path),
+        "mcp_config": mcp_config_path,
+        "mcp_config_reason": mcp_config_reason,
+        "notify_sender": notify_sender,
     }
 
 

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -174,6 +174,18 @@ _NOTIFY_SEAT = {
     "x-server-owned": True,
 }
 
+_NOTIFY_SENDER = {
+    "type": "string",
+    "description": (
+        "Who the terminal notice is from. Fills the {sender} placeholder in the "
+        "delivery command and is published to it as LIONAGI_NOTIFY_SENDER. "
+        "Without it the notifier reports whatever identity it resolves from the "
+        "run's working directory, which is the directory's owner and not the "
+        "submitter."
+    ),
+    "x-server-owned": True,
+}
+
 _PLAYBOOK_FINGERPRINT = {
     "type": "string",
     "description": (
@@ -192,6 +204,7 @@ _SPAWN_SERVER_PARAMS: Mapping[str, dict[str, Any]] = {
     "label": _LABEL,
     "notify_command": _NOTIFY_COMMAND,
     "notify_seat": _NOTIFY_SEAT,
+    "notify_sender": _NOTIFY_SENDER,
 }
 
 _FLOW_SERVER_PARAMS: Mapping[str, dict[str, Any]] = {

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -103,6 +103,8 @@ AGENT_HELP_FLAGS = [
     "--image",
     "--invocation",
     "--list-profiles",
+    "--mcp-config",
+    "--no-mcp-config",
     "--notify",
     "--preset",
     "--project",

--- a/tests/cli/test_mcp_resolve.py
+++ b/tests/cli/test_mcp_resolve.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Submit-time MCP resolution: the leg's tool surface comes from the submission."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.cli._mcp_resolve import (
+    McpConfigError,
+    discover_mcp_config,
+    resolve_spawn_mcp_servers,
+)
+
+SERVERS = {"khive": {"command": "kkernel", "args": ["mcp"]}}
+
+
+def _write_config(directory, servers=SERVERS):
+    path = directory / ".mcp.json"
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return path
+
+
+def test_discovery_walks_up_from_the_launch_directory(tmp_path):
+    _write_config(tmp_path)
+    deep = tmp_path / "a" / "b"
+    deep.mkdir(parents=True)
+    assert discover_mcp_config(deep) == tmp_path / ".mcp.json"
+
+
+def test_servers_are_read_from_the_launch_dir_not_the_target_cwd(tmp_path):
+    """The defect this exists for: a leg pointed at a checkout keeps the
+    submitting directory's servers instead of finding none of its own."""
+    caller = tmp_path / "caller"
+    checkout = tmp_path / "checkout"
+    caller.mkdir()
+    checkout.mkdir()
+    _write_config(caller)
+
+    assert discover_mcp_config(checkout) is None
+    resolution = resolve_spawn_mcp_servers(launch_dir=caller)
+    assert resolution.servers == SERVERS
+    assert resolution.source == caller / ".mcp.json"
+
+
+def test_no_config_reports_a_reason_rather_than_an_empty_result(tmp_path):
+    """Nothing-configured must stay distinguishable from configured-and-unusable;
+    collapsing them is what made the original loss silent."""
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.servers is None
+    assert resolution.reason == "no_mcp_config_found"
+    assert not resolution.ok
+
+
+def test_disabled_is_a_choice_and_carries_no_reason(tmp_path):
+    _write_config(tmp_path)
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path, disabled=True)
+    assert resolution.servers is None
+    assert resolution.reason is None
+
+
+def test_unusable_discovered_config_reports_why(tmp_path):
+    (tmp_path / ".mcp.json").write_text("{not json")
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.servers is None
+    assert resolution.reason.startswith("mcp_config_unusable:")
+
+
+def test_explicit_config_that_cannot_be_used_is_an_error(tmp_path):
+    """A caller who named a file is not asking for a silent fallback."""
+    with pytest.raises(McpConfigError, match="--mcp-config"):
+        resolve_spawn_mcp_servers(str(tmp_path / "absent.json"), launch_dir=tmp_path)
+
+
+def test_explicit_config_wins_over_discovery(tmp_path):
+    _write_config(tmp_path, {"discovered": {"command": "x"}})
+    named = tmp_path / "named.json"
+    named.write_text(json.dumps({"mcpServers": SERVERS}))
+    resolution = resolve_spawn_mcp_servers(str(named), launch_dir=tmp_path)
+    assert resolution.servers == SERVERS
+
+
+def test_config_without_servers_key_is_unusable_not_empty(tmp_path):
+    (tmp_path / ".mcp.json").write_text(json.dumps({"other": {}}))
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.reason.startswith("mcp_config_unusable:")
+
+
+def test_only_the_claude_lane_receives_the_server_set():
+    """The other CLI providers read a user-level config; handing them a server
+    set here would drop it silently, so the builder does not."""
+    from lionagi.cli._providers import build_chat_model
+
+    claude = build_chat_model("claude_code", "opus", False, False, None, mcp_servers=SERVERS)
+    assert claude.endpoint.config.kwargs["mcp_servers"] == SERVERS
+
+    codex = build_chat_model("codex", "gpt-5.6", False, False, None, mcp_servers=SERVERS)
+    kwargs = getattr(getattr(codex, "endpoint", None), "config", None)
+    assert kwargs is None or "mcp_servers" not in kwargs.kwargs

--- a/tests/mcp/golden_projections/agent.json
+++ b/tests/mcp/golden_projections/agent.json
@@ -80,6 +80,17 @@
         "type": "boolean",
         "x-flag": "--list-profiles"
       },
+      "mcp_config": {
+        "description": "Read this MCP config and hand its servers to the leg explicitly. By default the nearest .mcp.json at or above the directory this command was run in is used, so the leg's tools come from the submission rather than from --cwd. The file is read once at spawn.",
+        "type": "string",
+        "x-flag": "--mcp-config"
+      },
+      "no_mcp_config": {
+        "default": false,
+        "description": "Hand the leg no MCP servers, and say so deliberately instead of arriving there by an empty search.",
+        "type": "boolean",
+        "x-flag": "--no-mcp-config"
+      },
       "notify": {
         "description": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}.",
         "type": "string",

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -88,7 +88,15 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
     assert captured["argv"] == ["notify", job, "failed", "t1", "downstream"]
     # the same fields are offered as a JSON payload on stdin
     payload = json.loads(captured["input"])
-    assert payload == {"run_id": job, "status": "failed", "label": "t1", "target": "downstream"}
+    assert payload == {
+        "run_id": job,
+        "status": "failed",
+        "label": "t1",
+        "target": "downstream",
+        # Empty, not absent: no sender was given, and the notifier is told that
+        # rather than left to fill the gap from its working directory.
+        "sender": "",
+    }
     assert rec["notify_delivery"] == {
         "attempted": True,
         "ok": True,

--- a/tests/mcp/test_notify_sender.py
+++ b/tests/mcp/test_notify_sender.py
@@ -40,3 +40,113 @@ def test_hook_command_omits_the_sender_when_none_is_given():
     --sender token, which the hook would read as an explicit empty identity."""
     template = jobs._notify_template("run-1", "seat-b", None, None)
     assert "--sender" not in template
+
+
+def _job(monkeypatch, tmp_path):
+    from lionagi.mcp import config
+
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_SENDER", raising=False)
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 1,
+            "kind": "agent",
+            "label": "t",
+            "cwd": None,
+            "status": "running",
+            "log": None,
+        }
+    )
+    return rid
+
+
+def test_no_delivery_runs_when_the_template_needs_a_sender_and_none_was_given(
+    monkeypatch, tmp_path
+):
+    """A command that asks who the notice is from cannot be run without an answer.
+
+    Substituting an empty string hands the delivery tool a blank where an
+    identity belongs, and a tool that accepts it — or resolves a sender of its
+    own — signs the notice with the wrong seat. Nothing is spawned; the reason
+    is recorded, so job_status shows a notifier that could not deliver rather
+    than the silence of one never asked.
+    """
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+    monkeypatch.setattr(
+        _notify_hook.subprocess, "run", lambda *a, **k: spawned.append(a) or _Completed()
+    )
+
+    rc = _notify_hook.main(
+        [
+            "--run-id",
+            rid,
+            "--status",
+            "completed",
+            "--command",
+            '["notify", "--from", "{sender}", "--to", "seat-b"]',
+        ]
+    )
+
+    assert rc == 0
+    assert spawned == []  # the point: no process was started
+    rec = jobs._read_job(rid)
+    assert rec["notify_delivery"]["attempted"] is False
+    assert rec["notify_delivery"]["error"] == "delivery_command_needs_a_sender_and_none_was_given"
+
+
+def test_a_template_that_needs_a_sender_delivers_when_one_is_given(monkeypatch, tmp_path):
+    """The guard is on the missing sender alone, not on the placeholder."""
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return _Completed()
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+
+    rc = _notify_hook.main(
+        [
+            "--run-id",
+            rid,
+            "--status",
+            "completed",
+            "--sender",
+            "seat-a",
+            "--command",
+            '["notify", "--from", "{sender}"]',
+        ]
+    )
+
+    assert rc == 0
+    assert spawned == [["notify", "--from", "seat-a"]]
+
+
+def test_a_template_without_the_placeholder_is_unaffected_by_a_missing_sender(
+    monkeypatch, tmp_path
+):
+    """A non-regression guard: a command that never asks who it is from still
+    delivers with no sender supplied."""
+    rid = _job(monkeypatch, tmp_path)
+    spawned: list = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return _Completed()
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+
+    rc = _notify_hook.main(
+        ["--run-id", rid, "--status", "completed", "--command", '["notify", "{run_id}"]']
+    )
+
+    assert rc == 0
+    assert spawned == [["notify", rid]]
+
+
+class _Completed:
+    returncode = 0

--- a/tests/mcp/test_notify_sender.py
+++ b/tests/mcp/test_notify_sender.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The terminal notice says who it is from, instead of leaving the notifier to
+resolve an identity from whatever directory the run happened to work in."""
+
+from __future__ import annotations
+
+from lionagi.mcp import _notify_hook, jobs
+
+
+def test_sender_substitutes_into_the_delivery_command():
+    argv = _notify_hook._substitute(
+        ["notify", "--from", "{sender}", "--to", "{target}"],
+        {"sender": "seat-a", "target": "seat-b", "status": "completed", "run_id": "r"},
+    )
+    assert argv == ["notify", "--from", "seat-a", "--to", "seat-b"]
+
+
+def test_sender_is_published_to_the_delivery_environment():
+    env = _notify_hook._delivery_env("seat-a")
+    assert env is not None
+    assert env["LIONAGI_NOTIFY_SENDER"] == "seat-a"
+    # Inherits the rest: a notifier still needs its own PATH and credentials.
+    assert "PATH" in env
+
+
+def test_no_sender_leaves_the_environment_untouched():
+    """Without a sender there is nothing to publish, and an env dict built here
+    would claim an identity was set when none was."""
+    assert _notify_hook._delivery_env("") is None
+
+
+def test_hook_command_carries_the_sender_when_one_is_given():
+    template = jobs._notify_template("run-1", "seat-b", None, "seat-a")
+    assert "--sender seat-a" in template
+
+
+def test_hook_command_omits_the_sender_when_none_is_given():
+    """A guard on the ordinary case: an absent sender must not become an empty
+    --sender token, which the hook would read as an explicit empty identity."""
+    template = jobs._notify_template("run-1", "seat-b", None, None)
+    assert "--sender" not in template

--- a/tests/mcp/test_spawn_mcp_snapshot.py
+++ b/tests/mcp/test_spawn_mcp_snapshot.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A detached leg's MCP server set is fixed by the submission, not re-read later.
+
+Popen is doubled so no real `li` process is spawned; the tests read the argv the
+engine built and resolve it the way the child would.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
+from lionagi.mcp import config, jobs
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+    return tmp_path
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+@pytest.fixture
+def submit_dir(monkeypatch, tmp_path):
+    """A submitting directory holding its own .mcp.json, with no config above it.
+
+    The search walks to the filesystem root, so an ancestor's real .mcp.json
+    would otherwise decide these tests. A HOME-shaped tmp dir is used as the
+    launch dir and the walk stops at the file planted here.
+    """
+    d = tmp_path / "submit"
+    d.mkdir()
+    monkeypatch.chdir(d)
+    return d
+
+
+def _config_arg(argv: list[str]) -> str:
+    return argv[argv.index("--mcp-config") + 1]
+
+
+def test_spawned_leg_keeps_the_server_set_the_submission_resolved(sandbox, submit_dir, monkeypatch):
+    """The source config is replaced after submit; the leg still gets S1.
+
+    This is the whole guarantee: the tool surface a leg starts with is a
+    property of the submission, and an edit to the file afterwards belongs to
+    the next submission, not to a run already under way.
+    """
+    source = submit_dir / ".mcp.json"
+    source.write_text(json.dumps({"mcpServers": {"s1": {"command": "one"}}}))
+
+    captured: dict = {}
+
+    def fake_popen(argv, **kw):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    # The submission is assembled and the child is spawned. Now the file moves.
+    source.write_text(json.dumps({"mcpServers": {"s2": {"command": "two"}}}))
+
+    seen = resolve_spawn_mcp_servers(_config_arg(captured["argv"]), launch_dir=submit_dir)
+    assert set(seen.servers) == {"s1"}
+    assert handle["mcp_config_reason"] is None
+
+
+def test_spawned_leg_survives_the_source_config_being_removed(sandbox, submit_dir, monkeypatch):
+    """Deletion is the same failure with a louder symptom: the leg would start
+    with no servers at all, or fail resolving a path that no longer exists."""
+    source = submit_dir / ".mcp.json"
+    source.write_text(json.dumps({"mcpServers": {"s1": {"command": "one"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+    jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    source.unlink()
+
+    seen = resolve_spawn_mcp_servers(_config_arg(captured["argv"]), launch_dir=submit_dir)
+    assert set(seen.servers) == {"s1"}
+
+
+def test_submission_fails_when_the_discovered_config_cannot_be_used(
+    sandbox, submit_dir, monkeypatch
+):
+    """An unusable config is refused at submit rather than handed to the child.
+
+    A child that discovers the problem reports it in its own log, minutes later
+    and only to whoever reads that log; the submitter is told the run started.
+    """
+    (submit_dir / ".mcp.json").write_text("{not json")
+
+    spawned: list = []
+    monkeypatch.setattr(
+        jobs.subprocess, "Popen", lambda argv, **kw: (spawned.append(argv), _FakeProc())[1]
+    )
+
+    with pytest.raises(McpConfigError) as exc:
+        jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert "mcp" in str(exc.value).lower()
+    assert spawned == []
+    # Rejected before anything was written: no half-made job record is left to
+    # read back as a run that never finishes.
+    assert not (config.JOBS_DIR).exists() or list(config.JOBS_DIR.iterdir()) == []
+
+
+def test_no_config_anywhere_is_reported_not_raised(sandbox, submit_dir, monkeypatch):
+    """Nothing configured is a choice, not a failure — the run still starts and
+    the handle says why it has no servers."""
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr("lionagi.cli._mcp_resolve.discover_mcp_config", lambda start: None)
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+    assert handle["mcp_config"] is None
+    assert handle["mcp_config_reason"]

--- a/tests/mcp/test_spawn_mcp_snapshot.py
+++ b/tests/mcp/test_spawn_mcp_snapshot.py
@@ -8,12 +8,13 @@ engine built and resolve it the way the child would.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
 
 from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
-from lionagi.mcp import config, jobs
+from lionagi.mcp import config, dispatch, jobs
 
 
 @pytest.fixture
@@ -46,6 +47,35 @@ def submit_dir(monkeypatch, tmp_path):
 
 def _config_arg(argv: list[str]) -> str:
     return argv[argv.index("--mcp-config") + 1]
+
+
+def _child_config(argv: list[str]) -> str | None:
+    """The config the child's parser would settle on, in either spelling.
+
+    argparse keeps the last occurrence, so a line carrying two of these does not
+    fail — it quietly picks one. Reading it the same way is what lets a test say
+    which file the child actually opens rather than which one appears first.
+    """
+    seen: list[str] = []
+    for i, tok in enumerate(argv):
+        if tok == "--mcp-config" and i + 1 < len(argv):
+            seen.append(argv[i + 1])
+        elif tok.startswith("--mcp-config="):
+            seen.append(tok.split("=", 1)[1])
+    return seen[-1] if seen else None
+
+
+def _spawn_agent(args: dict) -> dict:
+    """Drive the real spawn verb, fingerprint fetched the way a caller must."""
+    fingerprint = asyncio.run(dispatch.request(help="agent.submit"))["schema_fingerprint"]
+    answer = asyncio.run(
+        dispatch.request(
+            ops=[{"op": "agent.submit", "args": args, "schema_fingerprint": fingerprint}]
+        )
+    )
+    op = answer["ops"][0]
+    assert op["ok"], op
+    return op["result"]
 
 
 def test_spawned_leg_keeps_the_server_set_the_submission_resolved(sandbox, submit_dir, monkeypatch):
@@ -129,3 +159,82 @@ def test_no_config_anywhere_is_reported_not_raised(sandbox, submit_dir, monkeypa
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
     assert handle["mcp_config"] is None
     assert handle["mcp_config_reason"]
+
+
+def test_a_caller_who_names_a_config_gets_that_config_and_a_handle_that_says_so(
+    sandbox, submit_dir, monkeypatch
+):
+    """The named file is what the child opens, and what the handle reports.
+
+    Both halves matter. A snapshot generated beside the caller's own choice puts
+    two configs on the line, and the one the parser drops is the one the handle
+    was naming — so the surface would be describing a file the run never reads.
+    """
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+    chosen = submit_dir / "chosen.json"
+    chosen.write_text(json.dumps({"mcpServers": {"mine": {"command": "m"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "mcp_config": str(chosen), "cwd": str(submit_dir)})
+
+    child_sees = _child_config(captured["argv"])
+    assert child_sees == str(chosen)
+    seen = resolve_spawn_mcp_servers(child_sees, launch_dir=submit_dir)
+    assert set(seen.servers) == {"mine"}
+    # The handle names the file the child opens, and does not claim a snapshot
+    # it never took.
+    assert handle["mcp_config"] == str(chosen)
+    assert handle["mcp_config_source"] == str(chosen)
+    assert not (config.job_dir(handle["run_id"]) / "mcp-servers.json").exists()
+
+
+def test_the_generated_snapshot_still_wins_when_the_caller_says_nothing(
+    sandbox, submit_dir, monkeypatch
+):
+    """Saying nothing is still the ambient config, snapshotted into the run."""
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "cwd": str(submit_dir)})
+
+    snapshot = config.job_dir(handle["run_id"]) / "mcp-servers.json"
+    assert _child_config(captured["argv"]) == str(snapshot)
+    assert handle["mcp_config"] == str(snapshot)
+    assert handle["mcp_config_source"] == str(submit_dir / ".mcp.json")
+    seen = resolve_spawn_mcp_servers(str(snapshot), launch_dir=submit_dir)
+    assert set(seen.servers) == {"ambient"}
+
+
+def test_a_caller_who_asks_for_no_servers_is_not_handed_a_snapshot(
+    sandbox, submit_dir, monkeypatch
+):
+    """Asking for none is an answer. Resolving one anyway would put a config on
+    the line beside the switch that turns configs off, and name it on a handle
+    for a run whose child was told to ignore it."""
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"ambient": {"command": "a"}}}))
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        jobs.subprocess,
+        "Popen",
+        lambda argv, **kw: (captured.update(argv=argv), _FakeProc())[1],
+    )
+
+    handle = _spawn_agent({"prompt": "hi", "no_mcp_config": True, "cwd": str(submit_dir)})
+
+    assert _child_config(captured["argv"]) is None
+    assert handle["mcp_config"] is None
+    assert handle["mcp_config_source"] is None
+    assert not (config.job_dir(handle["run_id"]) / "mcp-servers.json").exists()


### PR DESCRIPTION
Two defects with the same root: a spawned agent's capabilities and its outbound identity were
accidents of which directory it was pointed at, rather than properties of the submission.

**MCP servers were inherited from the agent's working directory.** The Claude CLI resolves MCP
servers by walking up from its cwd, so an agent sent to work in a checkout outside the tree holding
the configuration silently started with none of them. Measured with the engine, prompt and profile
held fixed and only `--cwd` varying: from the directory holding the config the agent executed a real
tool call and returned rows; from a worktree elsewhere no such tool existed at all. Nothing errored
and nothing reported it.

`li agent` now resolves the configuration from the **submitting** process's directory, before
`--cwd` applies to anything, and hands the resulting server set to the child. New `--mcp-config
PATH` names one explicitly and `--no-mcp-config` declines. The detached submit path does the same.
Servers are passed as a snapshotted set rather than a path, both because a later edit to the file
should not change a running agent, and because the provider's path containment check is scoped to
the agent's own `--cwd` and so rejects a path form in exactly the case this addresses.

**The terminal notice had no sender of its own.** It was delivered by a subprocess that resolved
its identity from whatever configuration its working directory happened to sit under, so an agent
launched from a directory belonging to another identity announced itself as that identity. The
notice now carries an explicit `--sender`, exposes it as a `{sender}` substitution field, and
publishes it to the delivery subprocess in the environment.

**Degradation is now visible at submit time rather than an hour later.** Resolving nothing prints a
warning naming the reason and the directory searched; naming a configuration that cannot be used is
an error with a non-zero exit and no spawn; a provider that cannot carry servers says so. The
distinction between "the caller declined" and "this degraded, and here is why" is kept explicit,
because collapsing the two is what made the original loss silent.

Tests cover the resolution helper, the sender plumbing, and the projected spawn surface.
