### PR TITLE
feat(mcp): make the verb catalog sufficient to write the call it describes

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -104,6 +104,11 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
 
     required = [name for name in schema.get("required", []) if name in properties]
     required += [name for name in verb.requires if name not in required]
+    unenforced = [
+        name
+        for name in schema.get("x-required-unenforced", [])
+        if name in properties and name not in required
+    ]
     order = [name for name in schema.get("x-positional-order", []) if name in properties]
 
     out: dict[str, Any] = {
@@ -116,6 +121,8 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
     }
     if required:
         out["required"] = required
+    if unenforced:
+        out["x-required-unenforced"] = unenforced
     if order:
         out["x-positional-order"] = order
     if verb.refuses:
@@ -130,12 +137,35 @@ def verb_schema(verb: Verb, *, playbook: str | None = None) -> dict[str, Any]:
 
 
 def catalog() -> dict[str, Any]:
-    """Every verb, with enough of a signature to write the common invocation."""
+    """Every verb, with enough of a signature to write the common invocation.
+
+    "Enough" is measured against the gate the call actually meets. A verb whose
+    ops must carry a ``schema_fingerprint`` gets that fingerprint here, because
+    an entry that lists a verb's parameters and withholds the one thing without
+    which the call is refused describes a call that cannot be made. The schema is
+    built anyway to read ``required`` off it, so the fingerprint is a hash of a
+    document already in hand and costs no extra work.
+
+    Where the schema depends on an argument, no fingerprint is quoted: the one
+    for the argument-free schema would be a value that never matches. The entry
+    names the parameter it varies with instead, so the caller knows to ask help
+    for that spelling rather than to retry with a stale string.
+    """
     entries: list[dict[str, Any]] = []
     for verb in VERBS.values():
         entry: dict[str, Any] = {"verb": verb.name, "available": True, "summary": verb.summary}
         try:
-            entry["required"] = list(verb_schema(verb).get("required", []))
+            schema = verb_schema(verb)
+            entry["required"] = list(schema.get("required", []))
+            unenforced = list(schema.get("x-required-unenforced", []))
+            if unenforced:
+                # Named apart from `required` because the parser will not refuse a
+                # call that omits these, and the schema may offer another way to
+                # supply the same thing. Reporting them inside `required` would
+                # make the schema and what is admitted two different contracts.
+                entry["required_unenforced"] = unenforced
+            if verb.executor == "spawn":
+                _describe_fingerprint(entry, verb, schema)
         except Exception as exc:  # noqa: BLE001 — one unreadable parser must not hide the rest
             entry["available"] = False
             entry["reason"] = f"schema generation failed: {type(exc).__name__}: {exc}"
@@ -158,9 +188,14 @@ def catalog() -> dict[str, Any]:
         "help_usage": (
             "help=true returns this catalog; help='<verb>' returns that verb's full "
             "parameter schema; help={'verb': '<verb>', 'playbook': '<name>'} resolves a "
-            "playbook's own declared arguments into the schema. A spawn verb's help also "
-            "returns a schema_fingerprint, which that verb's ops must carry: "
-            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from help>'}."
+            "playbook's own declared arguments into the schema. An entry carrying a "
+            "schema_fingerprint names a verb whose ops must repeat it: "
+            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from this entry>'}. "
+            "An entry carrying schema_fingerprint_varies_with names the parameters that "
+            "change the schema: pass one of them and the fingerprint to send is the one "
+            "help returns for that spelling, not the one quoted here. "
+            "required_unenforced names parameters the parser will not refuse a call for "
+            "omitting but the command cannot do its work without."
         ),
         "synonyms_removed_after": SYNONYM_REMOVAL_DATE,
     }
@@ -178,6 +213,23 @@ def schema_fingerprint(schema: dict[str, Any]) -> str:
     """
     body = json.dumps(schema, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(body.encode()).hexdigest()[:16]
+
+
+def _describe_fingerprint(entry: dict[str, Any], verb: Verb, schema: dict[str, Any]) -> None:
+    """Say what a fingerprint-gated verb's ops have to carry.
+
+    A playbook-aware verb is projected again once a playbook is named, so its
+    fingerprint is a function of that argument. When the playbook is optional the
+    argument-free schema is a real call and its fingerprint is quoted; when the
+    verb requires a playbook there is no such call, so quoting anything would
+    hand the caller a string that is guaranteed to be refused.
+    """
+    varies = ["playbook"] if verb.playbook_aware else []
+    if varies:
+        entry["schema_fingerprint_varies_with"] = varies
+    if any(name in verb.requires for name in varies):
+        return
+    entry["schema_fingerprint"] = schema_fingerprint(schema)
 
 
 def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied: Any) -> None:

--- a/lionagi/mcp/projection.py
+++ b/lionagi/mcp/projection.py
@@ -338,7 +338,13 @@ def _accepts_no_values(action: argparse.Action) -> bool:
     but argparse marks the action required all the same and then never enforces
     it. Carrying that flag into the schema would tell a caller a parameter is
     mandatory when the parser itself does not think so, and the caller has no
-    way to check. The rule is stated about the action rather than read off
+    way to check. Such an action is still reported, under
+    ``x-required-unenforced``: the command is declared as being about this value,
+    and a caller told only ``required: []`` reads that as "a call with no
+    arguments is valid", which is a different and wronger claim than the one
+    ``required`` was dropped to avoid.
+
+    The rule is stated about the action rather than read off
     ``required``, because ``required`` is what is wrong here: Python 3.14 stopped
     setting it for exactly these actions, so trusting it makes the schema — and
     every golden pinned to it — say different things on different interpreters
@@ -369,6 +375,7 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
 
     properties: dict[str, Any] = {}
     required: list[str] = []
+    unenforced: list[str] = []
     positionals: list[str] = []
 
     for action in parser._actions:
@@ -377,7 +384,9 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
         if action.dest == argparse.SUPPRESS:
             continue
         properties[action.dest] = _project_action(path, parser, action)
-        if action.required and not _accepts_no_values(action):
+        if _accepts_no_values(action):
+            unenforced.append(action.dest)
+        elif action.required:
             required.append(action.dest)
         if not action.option_strings:
             positionals.append(action.dest)
@@ -392,6 +401,8 @@ def project_parser(parser: argparse.ArgumentParser, *, path: str) -> dict[str, A
         schema["description"] = parser.description.strip()
     if required:
         schema["required"] = required
+    if unenforced:
+        schema["x-required-unenforced"] = unenforced
     if positionals:
         schema["x-positional-order"] = positionals
     exclusive = _mutually_exclusive(parser)

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -61,9 +61,11 @@ async def request(
 ) -> dict[str, Any]:
     """Dispatch lionagi operations, or ask what operations exist.
 
-    Start with ``help=true``: it returns every verb with its required parameters
-    and a one-line summary, which is enough to write the common call without a
-    second round-trip. ``help='<verb>'`` returns that verb's full schema.
+    Start with ``help=true``: it returns every verb with its required parameters,
+    a one-line summary, and — for the verbs whose ops must carry one — the
+    ``schema_fingerprint`` to send with the call, which is enough to write the
+    common call without a second round-trip. ``help='<verb>'`` returns that
+    verb's full schema.
 
     Results come back as ``{'status': 'success'|'partial', 'ops': [...]}``, one
     entry per op in the order given, each ``{'ok': true, 'op', 'result'}`` or

--- a/tests/mcp/golden_projections/agent.json
+++ b/tests/mcp/golden_projections/agent.json
@@ -164,6 +164,9 @@
     "type": "object",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "static"

--- a/tests/mcp/golden_projections/orchestrate__fanout.json
+++ b/tests/mcp/golden_projections/orchestrate__fanout.json
@@ -169,6 +169,9 @@
     "type": "object",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "static"

--- a/tests/mcp/golden_projections/orchestrate__flow.json
+++ b/tests/mcp/golden_projections/orchestrate__flow.json
@@ -232,6 +232,9 @@
     "x-playbook-arguments": "This command accepts arguments declared by the playbook named in 'playbook'. Ask for this schema again with that playbook named to see them.",
     "x-positional-order": [
       "query"
+    ],
+    "x-required-unenforced": [
+      "query"
     ]
   },
   "stage": "base"

--- a/tests/mcp/stdio_client.py
+++ b/tests/mcp/stdio_client.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Drive a real ``python -m lionagi.mcp`` over stdio, the way a client does.
+
+Every other module under ``tests/mcp/`` exercises the Python objects beneath
+the transport, so a defect that lives in the wire shape — a key read from the
+op rather than from ``args``, a schema that only the projector sees — is
+invisible to all of them. This starts the server as a subprocess and speaks
+JSON-RPC to it: ``initialize``, ``notifications/initialized``, then
+``tools/call``, in that order, because the server refuses work before the
+handshake completes.
+
+Every wait is bounded. A server that stops answering has to fail the test that
+is waiting on it rather than hang the suite, and the child is terminated on
+every exit path including an exception mid-conversation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+from typing import Any
+
+__all__ = ("StdioMCPClient", "TransportError", "tool_payload")
+
+# Generous enough for interpreter start plus the import of the CLI registry the
+# catalog is projected from, short enough that a wedged server fails the run.
+START_TIMEOUT = 90.0
+CALL_TIMEOUT = 60.0
+STOP_TIMEOUT = 10.0
+
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class TransportError(RuntimeError):
+    """The transport itself failed: no start, no answer, or a closed pipe."""
+
+
+class StdioMCPClient:
+    """A minimal JSON-RPC client over one server subprocess.
+
+    Reads run on a background thread so that a silent server costs a timeout
+    rather than a blocked interpreter.
+    """
+
+    def __init__(self, *, cwd: str | None = None, env: dict[str, str] | None = None) -> None:
+        self._id = 0
+        self._inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr: list[str] = []
+        self._proc = subprocess.Popen(
+            [sys.executable, "-m", "lionagi.mcp"],
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._readers = [
+            threading.Thread(target=self._read_stdout, daemon=True),
+            threading.Thread(target=self._read_stderr, daemon=True),
+        ]
+        for thread in self._readers:
+            thread.start()
+
+    # ── plumbing ─────────────────────────────────────────────────────────────
+
+    def _read_stdout(self) -> None:
+        assert self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                self._inbox.put(json.loads(line))
+            except ValueError:
+                # Not a JSON-RPC frame; keep it as diagnostics for a failure.
+                self._stderr.append(f"[non-json stdout] {line}")
+
+    def _read_stderr(self) -> None:
+        assert self._proc.stderr is not None
+        for line in self._proc.stderr:
+            self._stderr.append(line.rstrip())
+
+    @property
+    def stderr(self) -> list[str]:
+        return list(self._stderr)
+
+    def _diagnostics(self) -> str:
+        tail = self._stderr[-20:]
+        return f"exit={self._proc.poll()} stderr_tail={tail}"
+
+    def _send(self, message: dict[str, Any]) -> None:
+        if self._proc.poll() is not None:
+            raise TransportError(f"server already exited; {self._diagnostics()}")
+        assert self._proc.stdin is not None
+        try:
+            self._proc.stdin.write(json.dumps(message) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as exc:
+            raise TransportError(f"server closed stdin: {exc}; {self._diagnostics()}") from exc
+
+    def _await_id(self, want: int, timeout: float) -> dict[str, Any]:
+        import time
+
+        deadline = time.monotonic() + timeout
+        pending: list[dict[str, Any]] = []
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TransportError(
+                        f"no reply to request id {want} within {timeout}s; {self._diagnostics()}"
+                    )
+                try:
+                    message = self._inbox.get(timeout=min(remaining, 1.0))
+                except queue.Empty:
+                    if self._proc.poll() is not None:
+                        raise TransportError(
+                            f"server exited while awaiting id {want}; {self._diagnostics()}"
+                        ) from None
+                    continue
+                if message.get("id") == want:
+                    return message
+                # A notification or an out-of-order reply: keep it for the
+                # caller that is waiting on it.
+                pending.append(message)
+        finally:
+            for message in pending:
+                self._inbox.put(message)
+
+    # ── protocol ─────────────────────────────────────────────────────────────
+
+    def call(
+        self, method: str, params: dict[str, Any] | None = None, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}})
+        return self._await_id(rid, CALL_TIMEOUT if timeout is None else timeout)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def initialize(self) -> dict[str, Any]:
+        reply = self.call(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "lionagi-tests", "version": "0"},
+            },
+            timeout=START_TIMEOUT,
+        )
+        if "error" in reply:
+            raise TransportError(f"initialize failed: {reply['error']}; {self._diagnostics()}")
+        self.notify("notifications/initialized")
+        return reply["result"]
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        reply = self.call("tools/list")
+        if "error" in reply:
+            raise TransportError(f"tools/list failed: {reply['error']}")
+        return reply["result"]["tools"]
+
+    def request(
+        self,
+        *,
+        ops: list[dict[str, Any]] | None = None,
+        help: Any = None,  # noqa: A002 - the surface's own parameter name
+        timeout: float | None = None,
+    ) -> Any:
+        """One ``request`` tool call, unwrapped to the verb surface's own JSON."""
+        arguments: dict[str, Any] = {}
+        if ops is not None:
+            arguments["ops"] = ops
+        if help is not None:
+            arguments["help"] = help
+        reply = self.call(
+            "tools/call", {"name": "request", "arguments": arguments}, timeout=timeout
+        )
+        if "error" in reply:
+            raise TransportError(f"tools/call transport error: {reply['error']}")
+        return tool_payload(reply["result"])
+
+    def op(self, name: str, args: dict[str, Any] | None = None, **op_fields: Any) -> dict[str, Any]:
+        """One op, returned as the single result entry the surface answers with."""
+        payload = self.request(ops=[{"op": name, "args": args or {}, **op_fields}])
+        entries = payload.get("ops") if isinstance(payload, dict) else None
+        if not isinstance(entries, list) or len(entries) != 1:
+            raise TransportError(f"unexpected response envelope: {payload!r}")
+        return entries[0]
+
+    def close(self) -> None:
+        """Terminate the child, whatever state it is in."""
+        proc = self._proc
+        if proc.poll() is None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.close()
+            except (OSError, ValueError):
+                pass
+            try:
+                proc.wait(timeout=STOP_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=STOP_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=STOP_TIMEOUT)
+        for stream in (proc.stdout, proc.stderr, proc.stdin):
+            if stream is not None:
+                try:
+                    stream.close()
+                except (OSError, ValueError):
+                    pass
+
+    def __enter__(self) -> StdioMCPClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def tool_payload(result: dict[str, Any]) -> Any:
+    """The verb surface's JSON out of an MCP ``tools/call`` result."""
+    if "structuredContent" in result:
+        return result["structuredContent"]
+    for block in result.get("content") or []:
+        if block.get("type") == "text":
+            try:
+                return json.loads(block["text"])
+            except ValueError:
+                return {"text": block["text"]}
+    return result

--- a/tests/mcp/test_catalog_sufficiency.py
+++ b/tests/mcp/test_catalog_sufficiency.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The catalog has to be enough to write the call it describes.
+
+The tool tells a caller to start with ``help=true`` and says the answer is
+enough to make the common call. That promise is only kept if the entry carries
+everything the call is gated on, so these tests construct ops from the catalog
+reply and nothing else, and check that what refuses them is never the gate the
+catalog was supposed to have satisfied.
+
+The spawn verbs are the gated ones, and running one starts a background agent.
+So the ops here are steered into a refusal that lies *past* every gate — an
+unreadable prompt file — and the assertion is on which refusal comes back. A
+call rejected for its prompt is a call whose fingerprint was accepted, which is
+the fact under test; nothing is spawned to establish it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp import dispatch
+
+from .stdio_client import StdioMCPClient
+
+# A path that cannot exist, so the op is refused while reading it rather than
+# spawned. Absolute because the server refuses a relative prompt_file by rule.
+UNREADABLE_PROMPT_FILE = "/nonexistent/lionagi-catalog-sufficiency/prompt.txt"
+
+
+def _entry(catalog: dict, verb: str) -> dict:
+    return next(e for e in catalog["verbs"] if e["verb"] == verb)
+
+
+def _gated_verbs() -> list[str]:
+    return [name for name, verb in dispatch.VERBS.items() if verb.executor == "spawn"]
+
+
+@pytest.fixture(scope="module")
+def catalog() -> dict:
+    return dispatch.catalog()
+
+
+def test_every_fingerprint_gated_verb_says_so_in_the_catalog(catalog: dict) -> None:
+    """A caller reading one entry can tell whether that verb needs a fingerprint.
+
+    Without this the gate is discoverable only by tripping it, which costs the
+    round-trip the catalog exists to save.
+    """
+    for name in _gated_verbs():
+        entry = _entry(catalog, name)
+        assert "schema_fingerprint" in entry or "schema_fingerprint_varies_with" in entry, (
+            f"{name} is fingerprint-gated and its catalog entry says nothing about it"
+        )
+
+
+def test_a_quoted_fingerprint_is_the_one_the_gate_wants(catalog: dict) -> None:
+    """The value in the entry is the value the dispatcher compares against.
+
+    Checked against the dispatcher's own computation rather than a pinned
+    string, so the test tracks the schema instead of dating with it.
+    """
+    quoted = {
+        name: _entry(catalog, name)["schema_fingerprint"]
+        for name in _gated_verbs()
+        if "schema_fingerprint" in _entry(catalog, name)
+    }
+    assert quoted, "no verb quotes a fingerprint, so the promise cannot hold for any of them"
+    for name, fingerprint in quoted.items():
+        wanted = dispatch.schema_fingerprint(dispatch.verb_schema(dispatch.VERBS[name]))
+        assert fingerprint == wanted
+
+
+def test_a_verb_whose_schema_depends_on_an_argument_quotes_no_fingerprint(catalog: dict) -> None:
+    """Silence beats a string that is guaranteed to be refused.
+
+    ``play.submit`` requires a playbook and is projected again once one is named,
+    so the argument-free schema it would otherwise be fingerprinted from
+    describes a call that cannot be made.
+    """
+    for name in _gated_verbs():
+        verb = dispatch.VERBS[name]
+        entry = _entry(catalog, name)
+        varies = entry.get("schema_fingerprint_varies_with", [])
+        if any(parameter in verb.requires for parameter in varies):
+            assert "schema_fingerprint" not in entry
+            assert varies
+
+
+def test_a_positional_the_parser_will_not_enforce_is_still_reported(catalog: dict) -> None:
+    """``required: []`` alone reads as "a call with no arguments is valid".
+
+    Every spawn verb's prompt arrives through a positional argparse declares with
+    ``nargs="*"``, which the parser accepts empty and the command cannot run
+    without.
+    """
+    for name in _gated_verbs():
+        entry = _entry(catalog, name)
+        assert entry.get("required_unenforced"), (
+            f"{name} reports no unenforced requirement, though its prompt positional is one"
+        )
+        assert not set(entry["required_unenforced"]) & set(entry.get("required", []))
+
+
+def test_the_unenforced_parameters_are_real_parameters(catalog: dict) -> None:
+    """A name reported here has to be one the caller may actually pass."""
+    for entry in catalog["verbs"]:
+        if not entry.get("available"):
+            continue
+        named = entry.get("required_unenforced")
+        if not named:
+            continue
+        schema = dispatch.verb_schema(dispatch.VERBS[entry["verb"]])
+        for parameter in named:
+            assert parameter in schema["properties"]
+
+
+@pytest.mark.parametrize("verb", ["agent.submit", "flow.submit", "fanout.submit"])
+def test_a_call_built_only_from_the_catalog_clears_the_gate(verb: str, tmp_path) -> None:
+    """The whole point, driven over the wire the way a client drives it.
+
+    Ask for the catalog, read one entry, send the op it describes. Before the
+    entry carried a fingerprint the first attempt came back ``stale_schema``,
+    which is the gate refusing a caller who did exactly what the tool told them
+    to do. Now the refusal is about the prompt file this test deliberately made
+    unreadable, which is a refusal from past the gate.
+    """
+    with StdioMCPClient(cwd=str(tmp_path)) as client:
+        client.initialize()
+        catalog = client.request(help=True)
+        entry = _entry(catalog, verb)
+
+        op_fields = {}
+        if "schema_fingerprint" in entry:
+            op_fields["schema_fingerprint"] = entry["schema_fingerprint"]
+        result = client.op(verb, {"prompt_file": UNREADABLE_PROMPT_FILE}, **op_fields)
+
+    assert result["ok"] is False, "the unreadable prompt file should have refused this op"
+    kind = result["error"]["kind"]
+    assert kind != "stale_schema", (
+        f"{verb} was refused at the fingerprint gate by a call built from the catalog: "
+        f"{json.dumps(result['error'])}"
+    )
+    assert kind == "invalid_input"
+    assert "prompt_file" in result["error"]["message"]
+
+
+def test_a_catalog_built_call_to_an_ordinary_read_verb_succeeds(tmp_path) -> None:
+    """The same construction on a verb with no gate and no side effects.
+
+    Separates "the fingerprint path now works" from "the transport works at all",
+    so a green above cannot be read as either one on its own.
+    """
+    with StdioMCPClient(cwd=str(tmp_path)) as client:
+        client.initialize()
+        catalog = client.request(help=True)
+        entry = _entry(catalog, "job.list")
+        assert entry["required"] == []
+        assert "schema_fingerprint" not in entry
+        result = client.op("job.list", {})
+
+    assert result["ok"] is True, json.dumps(result)


### PR DESCRIPTION
The MCP tool's own documentation tells a caller to start with `help=true` and says the
answer is enough to write the common call without a second round trip. It was not.

Two gaps, both in what the catalog reports about a verb rather than in the verb itself:

**The catalog omitted the fingerprint the call cannot proceed without.** The four spawn
verbs refuse any op that does not carry `schema_fingerprint`, and only `help='<verb>'`
returned one. A caller who followed the documented path was refused on their first
attempt with `stale_schema` and had to discover the second round trip from the error.
`catalog()` already builds each verb's full schema in order to read `required` off it,
so the fingerprint is a hash of a document it is already holding — it is now included
in the entry. `play.submit` is the exception: it requires a playbook and is re-projected
once one is named, so an argument-free fingerprint could never match. That entry quotes
none and carries `schema_fingerprint_varies_with: ["playbook"]` instead.

**`required` understated what a verb needs.** A positional declared `nargs="*"` projects
as not-required, so verbs that cannot run without an instruction advertised `required: []`.
This is fixed at the projection rather than per verb, keyed on the action's shape rather
than on argparse's `required` flag, which recent Python no longer sets for these actions.
Such parameters now land in `x-required-unenforced`. Four verbs are affected.

Verified over stdio against a real server subprocess, constructing the call from only what
`help=true` returned: before, the first attempt was refused as a stale schema; after, it
reaches argument validation and fails there on a deliberately unreadable prompt file, with
nothing spawned. The new tests give 6 failed / 3 passed against the previous behaviour and
9 passed against this one.

Cost: the fingerprints add 172 bytes to a 13.7 KB catalog, which is sent once and only on
request. The advertised tool schema, which is the budget paid on every request, goes from
2,202 to 2,308 bytes against a 4,096 ceiling.

Known limitation: `x-required-unenforced` still does not express "supply one of query /
prompt / prompt_file". Stating that needs a per-verb declaration of the alternatives.
