### PR TITLE
feat(studio): report on the daemon's health which code it is running

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Literal
 
+import anyio
 from fastapi import HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import text
@@ -362,6 +363,38 @@ async def doctor(*, stale_hours: float = 1.0) -> dict[str, Any]:
     }
 
 
+async def _code_identity_report() -> dict[str, Any]:
+    """Which code this daemon is actually running, and whether it has fallen behind.
+
+    The daemon imports lionagi once, at start. With an editable install that
+    import resolves to a working tree, so which code is running is a property of
+    whatever commit that checkout sits on — a property nothing else in this
+    report can see. The version string cannot distinguish them: a stale tree and
+    a current one report the same one.
+
+    Read fresh on every call rather than cached at start, because the answer this
+    is asked for is "is the tree still current", and a value captured at start
+    can only ever say it was current then. The read shells out to git, so it runs
+    off the event loop and its own budget bounds it; a daemon must not stall on
+    its own health check.
+    """
+    try:
+        from lionagi.cli._code_identity import code_identity
+
+        return await anyio.to_thread.run_sync(code_identity)
+    except Exception as exc:  # noqa: BLE001 — an unanswerable check is unknown, never absent
+        # Reported rather than omitted: a missing key reads as "not checked",
+        # which is the same shape as "checked and current" to anything scanning
+        # this response.
+        return {
+            "drift": {
+                "status": "unknown",
+                "reasons": [],
+                "unknown": [f"could not establish code identity: {type(exc).__name__}: {exc}"],
+            }
+        }
+
+
 async def health_report() -> dict[str, Any]:
     """Composite session health snapshot for the admin console."""
     from collections import Counter
@@ -377,6 +410,7 @@ async def health_report() -> dict[str, Any]:
             "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
             "db": db_health(),
             "scheduler_timezone": scheduler_timezone_report(),
+            "code_identity": await _code_identity_report(),
             "diagnostic_run_at": now_utc().isoformat(),
         }
 
@@ -493,6 +527,10 @@ async def health_report() -> dict[str, Any]:
         # value is frozen per process: nothing in the source tree or the host's
         # configuration can be read back from a running scheduler otherwise.
         "scheduler_timezone": scheduler_timezone_report(),
+        # The commit this daemon's code came from, and whether that checkout has
+        # since fallen behind the ref it tracks. Every scheduled run this daemon
+        # spawns executes the tree named here.
+        "code_identity": await _code_identity_report(),
         "diagnostic_run_at": now_utc().isoformat(),
     }
 

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -441,6 +441,7 @@ def test_admin_health_response_shape(tmp_path, monkeypatch):
     r = client.get("/api/admin/health")
     assert r.status_code == 200
     assert sorted(r.json().keys()) == [
+        "code_identity",
         "db",
         "diagnostic_run_at",
         "scheduler_timezone",

--- a/tests/studio/test_admin_health_code_identity.py
+++ b/tests/studio/test_admin_health_code_identity.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Which code the daemon is running, reported on /api/admin/health.
+
+A daemon imports lionagi once, at start. Under an editable install that import
+resolves to a working tree, so the code being served is whatever commit that
+checkout happens to sit on — and it keeps serving it after the tree moves,
+after a branch switch, after the rest of the fleet has advanced. Nothing else
+in the health response can see that: the version string is identical between a
+current tree and one many commits behind, so every other field looks the same
+either way.
+
+These pin the commit and the behind-verdict onto the endpoint an operator or a
+monitor already reads, and pin that an *unanswerable* reading is reported as
+unknown rather than dropped — an absent key reads as "not checked", which is
+indistinguishable from "checked and current" to anything scanning the response.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    import lionagi.studio.app as app_mod
+    import lionagi.studio.services.admin as admin_mod
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(admin_mod, "_DB", str(fake_db))
+
+    app = app_mod.create_app()
+    return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
+
+
+def _health_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict:
+    client = _make_client(monkeypatch, tmp_path)
+    response = client.get("/api/admin/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert "code_identity" in body, "the health response must always carry the key"
+    return body["code_identity"]
+
+
+def _install_identity(monkeypatch: pytest.MonkeyPatch, identity: dict) -> None:
+    """Stand in for the real reading, which shells out to git."""
+    import lionagi.cli._code_identity as ci
+
+    monkeypatch.setattr(ci, "code_identity", lambda: identity)
+
+
+def test_a_checkout_behind_its_ref_is_reported_as_drift(monkeypatch, tmp_path):
+    # The whole point: the daemon says so itself, on the endpoint already being
+    # polled, instead of the operator having to go and rev-parse the tree.
+    _install_identity(
+        monkeypatch,
+        {
+            "version": "0.30.2",
+            "package_path": "/srv/lionagi/lionagi",
+            "git": {"status": "ok", "commit_short": "5ec3bd79cbb5", "behind": 15},
+            "drift": {
+                "status": "drift",
+                "reasons": ["the loaded checkout is 15 commit(s) behind origin/main"],
+                "unknown": [],
+            },
+        },
+    )
+
+    payload = _health_identity(monkeypatch, tmp_path)
+
+    assert payload["drift"]["status"] == "drift"
+    assert payload["git"]["behind"] == 15
+    # The commit is what makes the verdict actionable — "behind" alone does not
+    # tell anyone what is running.
+    assert payload["git"]["commit_short"] == "5ec3bd79cbb5"
+
+
+def test_a_current_checkout_is_reported_ok(monkeypatch, tmp_path):
+    _install_identity(
+        monkeypatch,
+        {
+            "version": "0.30.2",
+            "package_path": "/srv/lionagi/lionagi",
+            "git": {"status": "ok", "commit_short": "12411ddb3ab1", "behind": 0},
+            "drift": {"status": "ok", "reasons": [], "unknown": []},
+        },
+    )
+
+    payload = _health_identity(monkeypatch, tmp_path)
+
+    assert payload["drift"]["status"] == "ok"
+    assert payload["git"]["behind"] == 0
+
+
+def test_an_unreadable_identity_is_unknown_and_still_present(monkeypatch, tmp_path):
+    # The failure that matters: the reading raised. Dropping the key would leave
+    # the response looking exactly like a healthy one.
+    import lionagi.cli._code_identity as ci
+
+    def _boom() -> dict:
+        raise RuntimeError("git is not on PATH")
+
+    monkeypatch.setattr(ci, "code_identity", _boom)
+
+    payload = _health_identity(monkeypatch, tmp_path)
+
+    assert payload["drift"]["status"] == "unknown"
+    assert any("git is not on PATH" in u for u in payload["drift"]["unknown"])
+
+
+def test_the_reading_does_not_block_the_event_loop(monkeypatch, tmp_path):
+    """A health check must not stall the daemon it is reporting on.
+
+    The reading shells out to git, which can take seconds against an unhealthy
+    tree, so it has to run off the loop. Asserting it is a *different* thread
+    than the one serving the request is what distinguishes an offloaded call
+    from an inline one; timing would not, since a fast mock returns instantly
+    either way.
+    """
+    import threading
+
+    import lionagi.cli._code_identity as ci
+
+    serving_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def _record() -> dict:
+        seen["thread"] = threading.get_ident()
+        return {"drift": {"status": "ok", "reasons": [], "unknown": []}}
+
+    monkeypatch.setattr(ci, "code_identity", _record)
+
+    _health_identity(monkeypatch, tmp_path)
+
+    assert "thread" in seen, "the reading never ran"
+    assert seen["thread"] != serving_thread


### PR DESCRIPTION
The studio daemon imports lionagi once, at start. Under an editable install that
import resolves to a working tree, so which code is running is a property of
whatever commit the checkout sits on, and it keeps serving that code after the
tree moves or the rest of the fleet advances.

Nothing in the health response could see this. The version string is identical
between a current tree and one many commits behind, so every other field looked
the same either way.

`/api/admin/health` now carries `code_identity`: the commit the process loaded,
the ref it is measured against, how far behind that ref it has fallen, and the
drift verdict. A detached checkout, which is the state a pinned deployment sits
in, has no upstream and falls back to the remote's default branch.

Three properties worth naming:

- The reading is taken **fresh per request**. The question being asked is whether
  the tree is still current, and a value captured at start can only report that
  it was current then.
- It runs **off the event loop**. Establishing identity shells out to git, which
  can take seconds against an unhealthy tree, and a daemon must not stall on its
  own health check.
- A reading that cannot be established is reported as **unknown, not omitted**. An
  absent key reads as "not checked", which is the same shape as "checked and
  current" to anything scanning the response.

Verified against a real checkout rather than only mocks: a clean tree at the
branch head reports `behind: 0`, `drift: ok`; the same tree detached at an older
commit reports `detached: true`, ref `origin/main` via the remote-head fallback,
`behind: 1`, and `drift: drift` with the reason stated in plain language.

The API contract gate pinning the health response's key set is updated in the
same commit, since adding a key is a deliberate contract change.
