### PR TITLE
fix(studio): read the daemon's code position at startup, not on first request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   never a hardcoded one, and the delivery outcome is recorded on the job and surfaced by the
   `job.status` operation. See `docs/reference/mcp-server.md` for the verb catalog and `.mcp.json`
   registration.
+- `/api/admin/health` reports `code_identity`: which commit the Studio daemon's code was loaded
+  from, whether that checkout has since moved or been edited, how far behind its comparison ref it
+  is, and a `drift` verdict over all of it. Under an editable install the code being served is
+  whatever commit the working tree sits on, and it keeps being served after the tree moves — a
+  state the version string cannot show, since it is identical between a current checkout and one
+  many commits behind. A reading that cannot be taken is reported as `unknown` with the reason
+  rather than omitted, because an absent key is indistinguishable from a healthy one to anything
+  scanning the response. The reading runs off the event loop, so a daemon never stalls on its own
+  health check.
 
 ### Fixed
 
+- The Studio daemon no longer reports a commit it never loaded. `code_identity` reads its git
+  position once and keeps it, initialising lazily, and the daemon left that initialisation to the
+  first `/api/admin/health` request. A checkout moved after startup but before that request — an
+  ordinary deploy or branch switch — was then read as the position the process had loaded from, so
+  the response named the new commit with `checkout_moved` false and a clean `drift` verdict, which
+  is the exact condition the field exists to detect. The daemon now takes the snapshot in its
+  lifespan, before the scheduler starts and before it serves anything, as the MCP server already
+  did.
 - The built-in provider collision filter no longer misses a plugin entry whose endpoint class
   comes from a helper module. `_reject_builtin_collisions` identified an activation's entries by
   requiring the class to be defined in the activated provider module, but a provider module may

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -146,8 +146,20 @@ async def _finalize_warmup(task: asyncio.Task | None) -> None:
 
 @asynccontextmanager
 async def lifespan(app_instance):
+    from lionagi.cli._code_identity import snapshot_git_position
+
     from .scheduler.engine import scheduler
     from .services.lifecycle import run_startup_reconciliation
+
+    # First, before anything else can run and long before the first request:
+    # read where this process's code came from. The modules in memory were fixed
+    # at import, but the checkout they came from is a directory anyone can move
+    # afterwards. Only a reading taken now distinguishes "the tree moved under a
+    # running daemon" from "this is the code we loaded" — deferred to the first
+    # health request, the snapshot would describe whatever the tree had become by
+    # then and report a commit this process never loaded, with a clean drift
+    # verdict on top.
+    snapshot_git_position()
 
     _emit_startup_warnings()
     # The second of the two settings-driven notify bootstrap points (CLI is the first).

--- a/tests/studio/test_admin_health_code_identity.py
+++ b/tests/studio/test_admin_health_code_identity.py
@@ -115,6 +115,55 @@ def test_an_unreadable_identity_is_unknown_and_still_present(monkeypatch, tmp_pa
     assert any("git is not on PATH" in u for u in payload["drift"]["unknown"])
 
 
+def test_the_daemon_snapshots_its_position_before_it_starts_serving(monkeypatch):
+    """The snapshot has to be taken at startup, not on the first health request.
+
+    ``code_identity`` reads its git position once and keeps it, initialising
+    lazily. Left to initialise on the first request, the reading describes
+    whatever the tree had become by then — so a checkout moved after the daemon
+    started would be reported as the code being *run*, with ``checkout_moved``
+    false and a clean drift verdict, which is precisely the condition the field
+    exists to detect.
+
+    Asserting the snapshot exists by the time the scheduler starts is what
+    distinguishes taking it at startup from taking it later: everything after
+    that point can already cause, or observe, a request.
+    """
+    import lionagi.cli._code_identity as ci
+    import lionagi.studio.app as app_mod
+    from lionagi.studio.scheduler.engine import scheduler
+
+    monkeypatch.setattr(ci, "_SNAPSHOT", None)
+    seen: dict[str, object] = {}
+
+    async def _record_start() -> None:
+        seen["snapshot_at_scheduler_start"] = ci._SNAPSHOT
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(scheduler, "start", _record_start)
+    monkeypatch.setattr(scheduler, "stop", _noop)
+    monkeypatch.setattr(app_mod, "run_startup_reconciliation", _noop, raising=False)
+    monkeypatch.setattr(app_mod, "_start_claude_mirror", lambda: (None, None))
+    monkeypatch.setattr(app_mod, "_stop_claude_mirror", lambda *a: _noop())
+    monkeypatch.setattr(app_mod, "_startup_warmup", _noop)
+    monkeypatch.setattr(app_mod, "_finalize_warmup", lambda *a: _noop())
+
+    async def _drive() -> None:
+        async with app_mod.lifespan(None):
+            seen["snapshot_while_serving"] = ci._SNAPSHOT
+
+    import anyio
+
+    anyio.run(_drive)
+
+    assert seen.get("snapshot_at_scheduler_start") is not None, (
+        "the position was not read before the scheduler started"
+    )
+    assert seen.get("snapshot_while_serving") is not None
+
+
 def test_the_reading_does_not_block_the_event_loop(monkeypatch, tmp_path):
     """A health check must not stall the daemon it is reporting on.
 


### PR DESCRIPTION
Closes #2539.

`code_identity` reads its git position once and keeps it, initialising lazily. The Studio daemon
never called `snapshot_git_position()`, so the first `/api/admin/health` request was what took the
snapshot.

That makes the answer depend on operator ordering rather than on the code. A checkout moved after
startup but before that first request — an ordinary deploy, branch switch, or pull — is read as the
position the process loaded from, and the response then names the new commit with
`checkout_moved: false`, `behind: 0` and `drift: ok`, while every module in memory came from the
old one. The surface asserts, with a clean verdict, a commit that was never loaded. That is exactly
the condition the field exists to detect, so the failure is silent and reads as health.

`snapshot_git_position` documents this as its precondition:

> Call this as early in the process as possible. [...] Capturing the position at startup is what
> makes a later divergence visible as a divergence rather than silently replacing the answer with a
> commit that was never loaded.

`lionagi/mcp/server.py` already honours it, calling the snapshot before `mcp.run()`. This does the
same for the daemon, in `lifespan`, before the scheduler starts and before anything is served.

## Test

`test_the_daemon_snapshots_its_position_before_it_starts_serving` asserts the snapshot exists by the
time the scheduler starts — everything after that point can already cause or observe a request, so
that boundary is what distinguishes taking it at startup from taking it later. Confirmed to fail
without the change (`snapshot_at_scheduler_start` is `None`) and pass with it.

Same shape as the existing `test_the_server_snapshots_its_position_before_it_starts_serving` for the
MCP server.

## Scope

`lionagi/studio/app.py` (+1 call, +1 import), one test, and CHANGELOG entries for both this fix and
the health-surface feature it corrects, which was not yet recorded.
