### PR TITLE
fix(scheduler): keep a github_poll trigger available when a fire refuses before dispatch

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2941,6 +2941,8 @@ class StateDB:
             "last_alert_at",
             "last_healthy_poll_at",
             "poller_consecutive_401",
+            "predispatch_refusal_event",
+            "predispatch_refusal_count",
             "spec_version",
             "managed_by",
             "owner_key",

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -501,6 +501,17 @@ CREATE TABLE IF NOT EXISTS schedules (
   -- github_poll_consecutive_401 threshold metrics.
   last_healthy_poll_at    REAL,
   poller_consecutive_401  INTEGER NOT NULL DEFAULT 0,
+  -- Bounded retry for a github_poll fire that refuses before it dispatches
+  -- anything. Such a refusal holds github_cursor back so the event is
+  -- re-offered, but the refusal can be a property of that one event's
+  -- rendered values rather than of the schedule, so an unbounded hold would
+  -- block every later event forever. predispatch_refusal_event names the
+  -- event (its updated_at, the cursor value being held back) the streak
+  -- applies to and predispatch_refusal_count counts the consecutive
+  -- refusals of that same event; both reset when a different event refuses
+  -- or when a fire dispatches.
+  predispatch_refusal_event  TEXT,
+  predispatch_refusal_count  INTEGER NOT NULL DEFAULT 0,
   -- Declarative ScheduleSet layer: versioned document identity, resolved
   -- target/trigger snapshot + digest, and set ownership. NULL on every row
   -- created before this layer (legacy) or by an unmanaged quick-create.

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -546,6 +546,9 @@ schedules = Table(
     # Observer self-health (github_poll poller); see schema.sql.
     Column("last_healthy_poll_at", Float),
     Column("poller_consecutive_401", Integer, nullable=False, server_default="0"),
+    # Bounded retry for a pre-dispatch refusal; see schema.sql.
+    Column("predispatch_refusal_event", Text),
+    Column("predispatch_refusal_count", Integer, nullable=False, server_default="0"),
     # Declarative ScheduleSet layer: versioned document identity, resolved
     # target/trigger snapshot + digest, and set ownership. NULL on every row
     # created before this layer (legacy) or by an unmanaged quick-create.

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -116,6 +116,10 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         # and the consecutive-401 counter (resets only on a healthy read).
         ("last_healthy_poll_at", "REAL"),
         ("poller_consecutive_401", "INTEGER NOT NULL DEFAULT 0"),
+        # Bounded retry for a fire that refuses before dispatching: which
+        # event the streak applies to, and how many times it has refused.
+        ("predispatch_refusal_event", "TEXT"),
+        ("predispatch_refusal_count", "INTEGER NOT NULL DEFAULT 0"),
         # ADR-0070 delta 1: persisted per-schedule execution root, captured
         # once at creation. NULL on rows created before this migration.
         ("action_cwd", "TEXT"),

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1291,7 +1291,7 @@ class SchedulerEngine:
                     }
                     run_id = uuid.uuid4().hex[:12]
                     admission_handed_off = True
-                    await self._fire(
+                    fired = await self._fire(
                         schedule,
                         run_id,
                         trigger_context=ctx,
@@ -1313,6 +1313,23 @@ class SchedulerEngine:
                         # and re-fire every already-executed event.
                         extra_schedule_fields={"github_cursor": item.updated_at},
                     )
+                    if not fired:
+                        # The fire refused before it started a process, so
+                        # its cursor advance was never committed. Leave the
+                        # cursor pointing at this event -- nothing ran, so
+                        # re-offering it next poll is not a re-execution.
+                        # Stop here rather than trying the rest: a
+                        # pre-dispatch refusal is a property of the schedule
+                        # (an unresolvable execution root, an action that
+                        # cannot be turned into a command line), so the
+                        # remaining events would refuse identically and
+                        # each would burn a rate-limit and max_runs unit
+                        # doing it.
+                        drop_reason = "an earlier event refused before dispatch"
+                        dropped_prs = [
+                            e.event.get("pr_number") for e in polled[idx:] if e.dispatchable
+                        ]
+                        break
                     # Track locally too, for the batched trailing-write
                     # safety net below (covers only non-dispatched/filtered
                     # items after the last fire, or an all-filtered poll
@@ -1910,7 +1927,7 @@ class SchedulerEngine:
         threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
-    ) -> None:
+    ) -> bool:
         """Thin wrapper that releases every admission claim on all exit paths.
 
         Only top-level callers (_maybe_fire, fire_now, _tick_github) that
@@ -1923,9 +1940,13 @@ class SchedulerEngine:
         *extra_schedule_fields* and *supersedes_run_id* pass straight
         through to _fire_inner() (github cursor fold-in and recovery
         re-fire, respectively -- see its docstring).
+
+        Returns _fire_inner()'s dispatched flag: True once an external
+        process was confirmed to exist, False for a refusal that happened
+        before anything was dispatched.
         """
         try:
-            await self._fire_inner(
+            return await self._fire_inner(
                 schedule,
                 run_id,
                 trigger_context=trigger_context,
@@ -2060,8 +2081,20 @@ class SchedulerEngine:
         max_runs_claim: _MaxRunsClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
-    ) -> None:
-        """Fire one occurrence of *schedule*.
+    ) -> bool:
+        """Fire one occurrence of *schedule*. Returns True once an external
+        process was confirmed to exist, False if the fire refused before
+        dispatching one.
+
+        PRE-DISPATCH REFUSALS DO NOT CONSUME THE TRIGGER. Everything that
+        can refuse without starting a process -- resolving the `li`
+        executable, building argv, resolving the execution root -- runs
+        BEFORE the occurrence transaction, so its failure is recorded
+        without the cursor advance in *extra_schedule_fields*. Nothing ran,
+        so re-offering the trigger is not a re-execution, and the caller
+        learns that from the False return. Only a failure of something that
+        did start (non-zero exit, timeout, kill) keeps the at-most-once
+        advance below.
 
         DELIVERY CONTRACT -- at-least-once up to confirmed process launch,
         at-most-once past it. Three windows: (1) before the occurrence
@@ -2082,6 +2115,11 @@ class SchedulerEngine:
         """
         sid = schedule["id"]
         now = time.time()
+        # Flipped by on_launched below, the instant the OS process is
+        # confirmed to exist. Every exit path reads it to tell "nothing was
+        # started" apart from "something was started and then failed".
+        dispatched = False
+        _tmp_path: str | None = None
 
         inv_id = uuid.uuid4().hex[:12]
         # Registered before the invocation can possibly reach a terminal
@@ -2136,8 +2174,28 @@ class SchedulerEngine:
             argv, _tmp_path = _subprocess.build_argv(
                 schedule, trigger_context, executable_prefix=li_prefix
             )
+            # Resolved here, ahead of the occurrence transaction, precisely
+            # because it can refuse: a schedule whose configured execution
+            # root no longer exists raises rather than run the action under
+            # a substituted working directory. Resolving it after the
+            # transaction would durably advance the trigger past an event
+            # that never got a process. This is a read -- directory
+            # existence checks plus a project lookup -- so it is safe to run
+            # before anything is committed.
+            action_cwd = await _resolve_action_cwd(schedule)
         except Exception as exc:
-            _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
+            if isinstance(exc, SchedulerCwdInheritRefusedError):
+                # A deliberate fail-closed refusal, not an internal error: the
+                # message already names the configured root and the daemon
+                # directory that would have been substituted, so log it plainly
+                # without a stack trace.
+                _setup_reason = RunReasons.FAILED_CWD_INHERIT_REFUSED
+                _log.warning("Schedule fire %s (run %s): %s", schedule.get("name"), run_id, exc)
+            else:
+                _setup_reason = RunReasons.FAILED_EXCEPTION
+                _log.exception(
+                    "Invalid schedule action for %s (run %s)", schedule.get("name"), run_id
+                )
             # The notify unregister lives in this handler's own finally:
             # every exit (including a failing terminal write below) drops
             # the registration, and any terminal write that does land
@@ -2151,15 +2209,17 @@ class SchedulerEngine:
                     self._threshold_alert_update_fields(schedule, chain_depth, now)
                 )
                 failed_schedule_fields.update(self._effective_timezone_fields(schedule))
-                if extra_schedule_fields:
-                    failed_schedule_fields.update(extra_schedule_fields)
-                # Occurrence-insert + cursor-advance atomic even on this
-                # invalid-action failure path -- otherwise a permanently
-                # misconfigured github_poll schedule would never advance its
-                # cursor past the offending event and re-fail it forever.
-                # (A recovery re-fire skips the cursor advance and is instead
-                # atomic with tombstoning the orphan it supersedes -- see
-                # _write_occurrence()'s docstring.)
+                # *extra_schedule_fields* -- the github_poll cursor advance --
+                # is deliberately NOT folded in here. This handler only runs
+                # for refusals raised before anything was dispatched, so no
+                # process ever saw the event; advancing past it would spend
+                # the trigger on a run that did nothing. last_fired_at /
+                # next_fire_at still move, so a cron schedule does not spin:
+                # only the event-consuming cursor is held back, and the next
+                # poll re-offers the same event once the schedule is fixed.
+                # (A recovery re-fire skips the cursor advance too, and is
+                # instead atomic with tombstoning the orphan it supersedes --
+                # see _write_occurrence()'s docstring.)
                 written_occurrence = await self._write_occurrence(
                     {
                         "id": run_id,
@@ -2186,7 +2246,7 @@ class SchedulerEngine:
                     await self._abandon_superseded_recovery_fire(
                         inv_id, orphan_id=supersedes_run_id
                     )
-                    return
+                    return False
                 if rate_limit_claim is not None:
                     # The durable row now accounts for this fire across process
                     # restarts; keeping the in-memory reservation would count it twice.
@@ -2199,7 +2259,7 @@ class SchedulerEngine:
                     "schedule_run",
                     run_id,
                     new_status="failed",
-                    reason_code=RunReasons.FAILED_EXCEPTION,
+                    reason_code=_setup_reason,
                     reason_summary=f"{type(exc).__name__}: {exc}",
                     evidence_refs=[{"kind": "schedule", "id": sid}],
                     source="executor",
@@ -2211,7 +2271,7 @@ class SchedulerEngine:
                         build_schedule_run_signal(
                             entity_id=run_id,
                             new_status="failed",
-                            reason_code=RunReasons.FAILED_EXCEPTION,
+                            reason_code=_setup_reason,
                             schedule_id=sid,
                             action_kind=schedule.get("action_kind", ""),
                             chain_depth=chain_depth,
@@ -2246,24 +2306,26 @@ class SchedulerEngine:
                     # per-run_id map forever (it never gets a second flush call
                     # for this run_id to consume them).
                     self._signal_bus.pop_run_counters(run_id)
-                # last_fired_at/next_fire_at (and any extra_schedule_fields)
-                # already landed atomically with the occurrence insert above.
+                # last_fired_at/next_fire_at already landed atomically with
+                # the occurrence insert above.
                 await self._check_max_runs(schedule, chain_depth)
-                return
+                return False
             finally:
                 _unregister_schedule_notify(notify_scope)
+                self._discard_tmp_argv_file(_tmp_path)
         except BaseException:
             # Cancellation (or any other non-Exception) during action setup
-            # is not an invalid action: propagate it untouched. This window
-            # sits before the main try/finally below, so the registration
-            # must be dropped here; no invocation terminal write has
-            # happened yet on this path.
+            # is not an invalid action: propagate it untouched. Nothing is
+            # durable yet on this path, so the trigger is untouched too.
+            # This window sits before the main try/finally below, so the
+            # registration must be dropped here; no invocation terminal
+            # write has happened yet on this path.
             _unregister_schedule_notify(notify_scope)
+            self._discard_tmp_argv_file(_tmp_path)
             raise
 
         # Ensure the flow_yaml tmp file is removed on any exception or
         # cancellation in the DB ops below, before spawn_and_wait() runs.
-        # suppress(OSError) makes double-unlink (spawn_and_wait already cleaned up) safe.
         try:
             next_at = self._compute_next_fire(schedule, now)
             update_fields: dict[str, Any] = {"last_fired_at": now}
@@ -2306,7 +2368,7 @@ class SchedulerEngine:
             )
             if not written_occurrence:
                 await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
-                return
+                return False
             if rate_limit_claim is not None:
                 # The durable running row now owns the rolling-window slot.
                 rate_limit_claim.release()
@@ -2332,20 +2394,30 @@ class SchedulerEngine:
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
             )
 
-            action_cwd = await _resolve_action_cwd(schedule)
+            async def _on_launched() -> None:
+                # Stamps dispatched_at the instant the OS process is
+                # confirmed to exist -- the signal _recover_undispatched_
+                # fires() uses to tell "committed but never launched" (safe
+                # to re-fire) apart from "launched, outcome merely lost"
+                # (never re-fired; see this method's docstring). The local
+                # flag is the same distinction in memory, for the exit paths
+                # that run before a restart could consult the column.
+                nonlocal dispatched
+                dispatched = True
+                await self._mark_dispatched(run_id)
+
             exit_code, stderr_tail = await _subprocess.spawn_and_wait(
                 argv,
                 inv_id,
                 tmp_path=_tmp_path,
                 cwd=action_cwd,
                 action_kind=schedule.get("action_kind"),
-                # Stamps dispatched_at the instant the OS process is
-                # confirmed to exist -- the signal _recover_undispatched_
-                # fires() uses to tell "committed but never launched" (safe
-                # to re-fire) apart from "launched, outcome merely lost"
-                # (never re-fired; see this method's docstring).
-                on_launched=lambda: self._mark_dispatched(run_id),
+                on_launched=_on_launched,
             )
+            # spawn_and_wait only returns once it has an exit code, which
+            # requires a process to have existed; on_launched flips the flag
+            # earlier so a cancellation mid-run is classified the same way.
+            dispatched = True
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"
             if exit_code == 0:
@@ -2448,9 +2520,28 @@ class SchedulerEngine:
                         chain_parent_id=run_id,
                         chain_depth=chain_depth + 1,
                     )
+            return dispatched
 
         except asyncio.CancelledError:
             _log.info("Schedule fire cancelled %s (run %s)", schedule.get("name"), run_id)
+            if not dispatched:
+                # Cancelled after the occurrence committed but before any
+                # process existed -- byte-for-byte the state a crash in that
+                # same window leaves behind: status "running" with
+                # dispatched_at still NULL. Writing a terminal "cancelled"
+                # here would take the row out of that recovery lane while
+                # the schedule's cursor has already advanced past the
+                # trigger, so the trigger would be spent on a run that never
+                # started anything. Leaving the row untouched lets
+                # _recover_undispatched_fires() re-fire it from its own
+                # trigger_context on the next startup -- which a shutdown
+                # cancellation is always followed by.
+                _log.info(
+                    "Leaving run %s undispatched for startup recovery: cancelled "
+                    "before its process was launched",
+                    run_id,
+                )
+                raise
             _end_time = time.time()
             try:
                 written = await self._guarded_terminal_status(
@@ -2576,13 +2667,25 @@ class SchedulerEngine:
                 # per-run_id map forever.
                 self._signal_bus.pop_run_counters(run_id)
             await self._check_max_runs(schedule, chain_depth)
+            return dispatched
         finally:
             _unregister_schedule_notify(notify_scope)
             if chain_depth == 0:
                 self._running.pop(sid, None)
-            if _tmp_path is not None:
-                with contextlib.suppress(OSError):
-                    os.unlink(_tmp_path)
+            self._discard_tmp_argv_file(_tmp_path)
+
+    @staticmethod
+    def _discard_tmp_argv_file(tmp_path: str | None) -> None:
+        """Remove the flow_yaml tmp file build_argv may have written.
+
+        suppress(OSError) makes double-unlink (spawn_and_wait already
+        cleaned up) safe, and every path that can leave the file behind --
+        a pre-dispatch refusal, a cancellation, the ordinary fire -- goes
+        through here.
+        """
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
 
     def _next_fire_field(self, schedule: dict, next_at: float | None) -> dict[str, float | None]:
         """Field(s) to merge into an ``update_schedule()`` call for *next_at*.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -47,6 +47,15 @@ _TICK_INTERVAL = 30  # seconds
 # this many deferrals (the first deferral always emits), so sustained
 # saturation doesn't spam schedule_runs.
 _DEFERRED_RECORD_EVERY = 10
+# How many consecutive times one github_poll event may refuse before dispatch
+# while still holding github_cursor back for it. A pre-dispatch refusal is not
+# necessarily a property of the schedule: the action's prompt and command
+# arguments are rendered per event, so one PR's title or author can fail argv
+# construction where the next PR's would not. Retrying loudly a few times keeps
+# a genuinely fixable misconfiguration re-offered; at this count the refusal is
+# recorded as terminal for that event and the cursor moves past it, so one
+# poison event cannot block the queue behind it forever.
+_MAX_PREDISPATCH_REFUSALS = 3
 
 
 def _register_schedule_notify(
@@ -1315,21 +1324,52 @@ class SchedulerEngine:
                     )
                     if not fired:
                         # The fire refused before it started a process, so
-                        # its cursor advance was never committed. Leave the
-                        # cursor pointing at this event -- nothing ran, so
-                        # re-offering it next poll is not a re-execution.
-                        # Stop here rather than trying the rest: a
-                        # pre-dispatch refusal is a property of the schedule
-                        # (an unresolvable execution root, an action that
-                        # cannot be turned into a command line), so the
-                        # remaining events would refuse identically and
-                        # each would burn a rate-limit and max_runs unit
-                        # doing it.
-                        drop_reason = "an earlier event refused before dispatch"
-                        dropped_prs = [
-                            e.event.get("pr_number") for e in polled[idx:] if e.dispatchable
-                        ]
-                        break
+                        # its cursor advance was never committed. Nothing
+                        # ran, so re-offering this event next poll is not a
+                        # re-execution -- but only up to a bound. A refusal
+                        # can be a property of the schedule (an unresolvable
+                        # execution root) OR of this one event's rendered
+                        # values (a PR title that cannot be turned into a
+                        # command argument), and holding the cursor forever
+                        # for the second kind blocks every later event
+                        # behind it. So: retry the same event loudly up to
+                        # _MAX_PREDISPATCH_REFUSALS, then take the refusal
+                        # as terminal for that event and step past it.
+                        refusals = await self._record_predispatch_refusal(schedule, item.updated_at)
+                        if refusals < _MAX_PREDISPATCH_REFUSALS:
+                            # Stop rather than trying the rest: if the cause
+                            # is the schedule, the remaining events refuse
+                            # identically and each burns a rate-limit and
+                            # max_runs unit doing it.
+                            drop_reason = (
+                                f"an earlier event refused before dispatch "
+                                f"({refusals}/{_MAX_PREDISPATCH_REFUSALS} attempts)"
+                            )
+                            dropped_prs = [
+                                e.event.get("pr_number") for e in polled[idx:] if e.dispatchable
+                            ]
+                            break
+                        _log.warning(
+                            "Schedule %s (%s): event (PR %s, updated_at %s) refused "
+                            "before dispatch %d times; recording the refusal as "
+                            "terminal for it and advancing the cursor past it so "
+                            "later events are not blocked behind it",
+                            schedule.get("name"),
+                            sid,
+                            item.event.get("pr_number"),
+                            item.updated_at,
+                            refusals,
+                        )
+                        cursor = item.updated_at
+                        await self._clear_predispatch_refusals(schedule)
+                        # The refusing fire already wrote its failed run row
+                        # without the cursor advance, so the advance rides
+                        # the trailing batched write below rather than that
+                        # transaction. A crash in between simply re-offers
+                        # the event, which is what every earlier attempt
+                        # already did.
+                        continue
+                    await self._clear_predispatch_refusals(schedule)
                     # Track locally too, for the batched trailing-write
                     # safety net below (covers only non-dispatched/filtered
                     # items after the last fire, or an all-filtered poll
@@ -1377,6 +1417,49 @@ class SchedulerEngine:
                 pre_rate_claim.release()
             if pre_slot_claim is not None:
                 pre_slot_claim.release()
+
+    async def _record_predispatch_refusal(self, schedule: dict, event_cursor: str) -> int:
+        """Count one pre-dispatch refusal of the event at *event_cursor* and
+        return the new consecutive total.
+
+        The streak is keyed to the event it is holding the cursor back for,
+        so a refusal of a different event starts over at 1 -- the bound is
+        per event, not a running tally of everything the schedule ever
+        refused. Persisted on the schedule row (like the poller's
+        consecutive-401 counter) because the retries are spread across
+        polls and process restarts, not held in one loop.
+        """
+        prior = schedule.get("predispatch_refusal_count") or 0
+        if schedule.get("predispatch_refusal_event") != event_cursor:
+            prior = 0
+        count = prior + 1
+        await self._svc.update_schedule(
+            schedule["id"],
+            predispatch_refusal_event=event_cursor,
+            predispatch_refusal_count=count,
+        )
+        # Keep this tick's snapshot in step, so a second refusal within the
+        # same poll counts from the value just written.
+        schedule["predispatch_refusal_event"] = event_cursor
+        schedule["predispatch_refusal_count"] = count
+        return count
+
+    async def _clear_predispatch_refusals(self, schedule: dict) -> None:
+        """Drop the pre-dispatch refusal streak -- called once the cursor
+        moves past the event it was counting, whether because a fire
+        dispatched or because the bound was reached and the refusal was
+        taken as terminal."""
+        if not schedule.get("predispatch_refusal_count") and not schedule.get(
+            "predispatch_refusal_event"
+        ):
+            return
+        await self._svc.update_schedule(
+            schedule["id"],
+            predispatch_refusal_event=None,
+            predispatch_refusal_count=0,
+        )
+        schedule["predispatch_refusal_event"] = None
+        schedule["predispatch_refusal_count"] = 0
 
     async def _reserve_max_runs_budget(self, schedule: dict) -> tuple[bool, _MaxRunsClaim | None]:
         """Atomically claim one top-level fire against schedule['max_runs'].
@@ -1941,9 +2024,8 @@ class SchedulerEngine:
         through to _fire_inner() (github cursor fold-in and recovery
         re-fire, respectively -- see its docstring).
 
-        Returns _fire_inner()'s dispatched flag: True once an external
-        process was confirmed to exist, False for a refusal that happened
-        before anything was dispatched.
+        Returns _fire_inner()'s flag: False for a refusal that happened
+        before anything was durably committed, True otherwise.
         """
         try:
             return await self._fire_inner(
@@ -2082,9 +2164,12 @@ class SchedulerEngine:
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
     ) -> bool:
-        """Fire one occurrence of *schedule*. Returns True once an external
-        process was confirmed to exist, False if the fire refused before
-        dispatching one.
+        """Fire one occurrence of *schedule*. Returns False only when the
+        fire refused before anything was durably committed for it, so the
+        caller may keep offering the trigger; True once the occurrence (and
+        with it any *extra_schedule_fields* cursor advance) is committed,
+        whether or not a process ultimately ran -- a commit with no launch
+        is re-fired by startup recovery, not by the caller.
 
         PRE-DISPATCH REFUSALS DO NOT CONSUME THE TRIGGER. Everything that
         can refuse without starting a process -- resolving the `li`
@@ -2119,6 +2204,12 @@ class SchedulerEngine:
         # confirmed to exist. Every exit path reads it to tell "nothing was
         # started" apart from "something was started and then failed".
         dispatched = False
+        # Flipped once the occurrence transaction commits -- the point past
+        # which the trigger (and, for a github_poll, its cursor advance) is
+        # durably spent. Between it and *dispatched* lies the window where a
+        # failure must leave the row for startup recovery instead of
+        # finalizing it.
+        occurrence_committed = False
         _tmp_path: str | None = None
 
         inv_id = uuid.uuid4().hex[:12]
@@ -2369,6 +2460,7 @@ class SchedulerEngine:
             if not written_occurrence:
                 await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
                 return False
+            occurrence_committed = True
             if rate_limit_claim is not None:
                 # The durable running row now owns the rolling-window slot.
                 rate_limit_claim.release()
@@ -2601,6 +2693,29 @@ class SchedulerEngine:
                 _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
             raise
         except Exception as exc:
+            if occurrence_committed and not dispatched:
+                # Failed after the occurrence (and any cursor advance)
+                # committed but before any process existed -- the same
+                # window the cancellation branch above leaves alone, and
+                # reachable by any awaited call in it, the pre-launch
+                # running-status write included. Finalizing the row here
+                # would take it out of the undispatched-recovery lane while
+                # the trigger is already spent, so nothing would ever run
+                # for this event. Leaving it "running" with dispatched_at
+                # NULL is byte-for-byte the state a crash here leaves, and
+                # _recover_undispatched_fires() re-fires it from its own
+                # trigger_context at the next startup. The caller is told
+                # the trigger was consumed (True), because the cursor did
+                # advance and the work is not lost -- it is queued for
+                # recovery, not refused.
+                _log.exception(
+                    "Schedule fire %s (run %s) failed after its occurrence "
+                    "committed but before its process was launched; leaving the "
+                    "run undispatched for startup recovery",
+                    schedule.get("name"),
+                    run_id,
+                )
+                return True
             if isinstance(exc, SchedulerCwdInheritRefusedError):
                 # A deliberate fail-closed refusal, not an internal error: the
                 # message already names the configured root and the daemon

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -421,6 +421,11 @@ class TestFireCancellationRecorded:
         async def blocking_spawn(
             argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None, on_launched=None
         ):
+            # The real spawn_and_wait confirms the child exists before it waits
+            # on it. That confirmation is what makes this the in-flight case:
+            # something is running, so cancelling it has to be recorded.
+            if on_launched is not None:
+                await on_launched()
             started.set()
             await asyncio.Event().wait()  # block until the _fire task is cancelled
 

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -671,6 +671,8 @@ _SCHEDULE_DETAIL_KEYS = sorted(
         "owner_key",
         "poll_interval_sec",
         "poller_consecutive_401",
+        "predispatch_refusal_count",
+        "predispatch_refusal_event",
         "project",
         "rate_limit",
         "recent_runs",

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -450,6 +450,14 @@ async def test_fire_inner_exception_records_failed_and_does_not_reraise():
     """Unexpected exception inside the main try block is caught, recorded, and swallowed."""
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
+    async def _raise_after_launch(*args, on_launched=None, **kwargs):
+        # Confirms the launch first: a failure of something that started is
+        # what gets recorded terminally. (An exception raised before any
+        # process exists instead leaves the run for startup recovery.)
+        if on_launched is not None:
+            await on_launched()
+        raise RuntimeError("unexpected")
+
     svc = _make_svc()
     engine = SchedulerEngine(svc=svc)
     schedule = _minimal_schedule()
@@ -461,7 +469,7 @@ async def test_fire_inner_exception_records_failed_and_does_not_reraise():
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+            new=AsyncMock(side_effect=_raise_after_launch),
         ),
     ):
         # Should not raise
@@ -2857,6 +2865,14 @@ async def test_fire_exception_records_the_real_exception_text_as_error_detail(st
     await _seed_schedule(state_db, schedule)
     run_id = "run-real-detail"
 
+    async def _raise_after_launch(*args, on_launched=None, **kwargs):
+        # A failure of something that started: that is what the handler
+        # records terminally (an exception before any process exists leaves
+        # the run undispatched for startup recovery instead).
+        if on_launched is not None:
+            await on_launched()
+        raise ModuleNotFoundError("No module named 'nope'")
+
     with (
         patch(
             "lionagi.studio.scheduler.subprocess.build_argv",
@@ -2864,7 +2880,7 @@ async def test_fire_exception_records_the_real_exception_text_as_error_detail(st
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=ModuleNotFoundError("No module named 'nope'")),
+            new=AsyncMock(side_effect=_raise_after_launch),
         ),
     ):
         await engine._fire(schedule, run_id, trigger_context={"scheduled": True})

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -15,6 +15,21 @@ import pytest
 
 NY = ZoneInfo("America/New_York")
 
+
+async def _cancel_after_launch(*args, on_launched=None, **kwargs):
+    """spawn_and_wait double for a cancellation that arrives once the child
+    process already exists.
+
+    Calling ``on_launched`` first is what makes this the post-dispatch case:
+    something ran, so the run is recorded as cancelled and its trigger stays
+    consumed. A cancellation that arrives before the process exists takes the
+    other branch entirely.
+    """
+    if on_launched is not None:
+        await on_launched()
+    raise asyncio.CancelledError()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -402,7 +417,7 @@ async def test_fire_cancellation_records_cancelled_run():
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=asyncio.CancelledError()),
+            new=_cancel_after_launch,
         ),
     ):
         with pytest.raises(asyncio.CancelledError):
@@ -414,7 +429,10 @@ async def test_fire_cancellation_records_cancelled_run():
     # would keep its real status while that placeholder replaced the cause it
     # recorded. The text now rides the guarded write, so losing the race writes
     # nothing at all.
-    svc.update_schedule_run.assert_not_awaited()
+    # on_launched's dispatched_at stamp is the only update_schedule_run write;
+    # nothing writes a status or cause through it.
+    assert svc.update_schedule_run.await_count == 1
+    assert set(svc.update_schedule_run.await_args_list[0].kwargs) == {"dispatched_at"}
     cancelled_calls = [
         c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "cancelled"
     ]
@@ -775,7 +793,7 @@ async def test_fire_cancellation_schedule_run_cas_miss_does_not_skip_side_effect
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=asyncio.CancelledError()),
+            new=_cancel_after_launch,
         ),
     ):
         with pytest.raises(asyncio.CancelledError):

--- a/tests/studio/test_scheduler_predispatch_cursor.py
+++ b/tests/studio/test_scheduler_predispatch_cursor.py
@@ -352,3 +352,192 @@ async def test_cancellation_after_launch_still_records_a_cancelled_run():
     assert cancelled[0].kwargs["reason_code"] == RunReasons.CANCELLED_SYSTEM
     fields = svc.create_schedule_run_and_advance.await_args_list[0].kwargs["schedule_fields"]
     assert fields["github_cursor"] == FIRST_EVENT_AT
+
+
+# ---------------------------------------------------------------------------
+# The refusal is not always a property of the schedule: bounded retry
+# ---------------------------------------------------------------------------
+
+
+def _poison_command_schedule(**overrides) -> dict:
+    """A command schedule whose one argument is rendered from the event's own
+    PR title -- so whether argv can be built at all depends on which event is
+    being fired, not on the schedule alone."""
+    base = _minimal_schedule(
+        action_kind="command",
+        action_command="echo",
+        action_command_args=["{{pr_title}}"],
+        action_extra_args=[],
+    )
+    base.update(overrides)
+    return base
+
+
+def _titled(pr_number: int, updated_at: str, title: str) -> GithubPollItem:
+    item = _item(pr_number, updated_at)
+    item.event["pr_title"] = title
+    return item
+
+
+# Renders to a leading '-', which build_argv rejects as flag injection.
+POISON_TITLE = "-dangerous"
+SAFE_TITLE = "a safe title"
+
+
+@pytest.fixture
+def _command_allowlisted(monkeypatch):
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "echo")
+
+
+@pytest.mark.asyncio
+async def test_event_specific_argv_failure_retries_before_the_limit(_command_allowlisted):
+    """Event 1's title cannot be rendered into an argument; event 2's can.
+    Below the refusal limit the poll still holds the cursor at event 1 and
+    stops, so the refusal is retried loudly rather than swallowed."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _poison_command_schedule()
+
+    spawn = AsyncMock(return_value=(0, ""))
+    with (
+        _poll(
+            _titled(1, FIRST_EVENT_AT, POISON_TITLE),
+            _titled(2, SECOND_EVENT_AT, SAFE_TITLE),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    spawn.assert_not_awaited()
+    assert _cursor_values_written(svc) == []
+    # The streak is recorded against the event it is holding back, so a later
+    # poll can tell a repeat of the same refusal from a fresh one.
+    streak = [
+        c for c in svc.update_schedule.await_args_list if "predispatch_refusal_count" in c.kwargs
+    ]
+    assert len(streak) == 1
+    assert streak[0].kwargs["predispatch_refusal_count"] == 1
+    assert streak[0].kwargs["predispatch_refusal_event"] == FIRST_EVENT_AT
+
+
+@pytest.mark.asyncio
+async def test_event_specific_argv_failure_progresses_at_the_limit(_command_allowlisted):
+    """At the limit the same refusal is taken as terminal for that one event:
+    the cursor moves past it and the next event -- which renders fine -- is
+    dispatched, so one poison title cannot block the queue behind it."""
+    from lionagi.studio.scheduler.engine import _MAX_PREDISPATCH_REFUSALS
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _poison_command_schedule(
+        predispatch_refusal_event=FIRST_EVENT_AT,
+        predispatch_refusal_count=_MAX_PREDISPATCH_REFUSALS - 1,
+    )
+
+    spawn = AsyncMock(return_value=(0, ""))
+    with (
+        _poll(
+            _titled(1, FIRST_EVENT_AT, POISON_TITLE),
+            _titled(2, SECOND_EVENT_AT, SAFE_TITLE),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    # Event 2 actually ran, with its own rendered argument.
+    spawn.assert_awaited_once()
+    assert spawn.await_args.args[0] == ["echo", SAFE_TITLE]
+    # The cursor is now past BOTH events -- event 1 because its refusal was
+    # taken as terminal, event 2 because it was dispatched. (Event 1's own
+    # advance is never written on its own: event 2's fire commits the later
+    # value in the same poll.)
+    written = _cursor_values_written(svc)
+    assert written
+    assert all(v == SECOND_EVENT_AT for v in written)
+    assert SECOND_EVENT_AT > FIRST_EVENT_AT
+    # The streak is cleared once the cursor is past the event it counted.
+    cleared = [
+        c
+        for c in svc.update_schedule.await_args_list
+        if c.kwargs.get("predispatch_refusal_count") == 0
+    ]
+    assert cleared
+    assert cleared[0].kwargs["predispatch_refusal_event"] is None
+
+
+# ---------------------------------------------------------------------------
+# Committed occurrence, no launch: the row stays in the recovery lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_launch_status_write_failure_leaves_the_run_recoverable():
+    """The running-status write between the occurrence commit and the spawn is
+    a separate awaited call. If it raises, the cursor is already spent, so
+    finalizing the run would strand the event with nothing ever launched for
+    it. The row must stay in the undispatched-recovery lane instead."""
+    svc = _make_svc()
+
+    async def _fail_the_pre_launch_status(entity_type, entity_id, **kwargs):
+        if entity_type == "schedule_run" and kwargs.get("new_status") == "running":
+            raise RuntimeError("state service unavailable")
+
+    svc.update_status = AsyncMock(side_effect=_fail_the_pre_launch_status)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    spawn = AsyncMock(return_value=(0, ""))
+    with (
+        _poll(_item(1, FIRST_EVENT_AT)),
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    spawn.assert_not_awaited()
+    # Committed as running with the cursor advance, and never stamped
+    # dispatched -- exactly the shape startup recovery scans for.
+    inserted = svc.create_schedule_run_and_advance.await_args_list[0].args[0]
+    assert inserted["status"] == "running"
+    assert inserted.get("dispatched_at") is None
+    # Only this event's own advance, committed with the occurrence (the
+    # trailing batched write re-states the same value).
+    assert set(_cursor_values_written(svc)) == {FIRST_EVENT_AT}
+    # Nothing terminal was written for it, so it is still in the lane.
+    assert _run_status_calls(svc, "failed") == []
+    assert _run_status_calls(svc, "cancelled") == []
+
+
+@pytest.mark.asyncio
+async def test_run_undispatched_by_a_pre_launch_failure_is_refired_on_startup():
+    """The other half of the same claim: a row left that way is re-fired from
+    its own trigger context by the startup scan, so the event is not lost."""
+    svc = _make_svc()
+    schedule = _minimal_schedule()
+    svc.get_schedule = AsyncMock(return_value={**schedule, "enabled": 1})
+    svc.list_undispatched_schedule_runs = AsyncMock(
+        return_value=[
+            {
+                "id": "run-stranded",
+                "schedule_id": schedule["id"],
+                "chain_depth": 0,
+                "trigger_context": {"github_events": [_item(1, FIRST_EVENT_AT).event]},
+            }
+        ]
+    )
+    engine = SchedulerEngine(svc=svc)
+
+    spawn = AsyncMock(return_value=(0, ""))
+    with (
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn),
+    ):
+        await engine._recover_undispatched_fires()
+        await asyncio.gather(*list(engine._fire_tasks), return_exceptions=True)
+
+    spawn.assert_awaited_once()
+    # Re-fired atomically with tombstoning the stranded row it replaces.
+    svc.tombstone_and_replace_schedule_run.assert_awaited_once()
+    orphan_id, replacement = svc.tombstone_and_replace_schedule_run.await_args.args
+    assert orphan_id == "run-stranded"
+    assert replacement["trigger_context"]["github_events"][0]["pr_number"] == 1

--- a/tests/studio/test_scheduler_predispatch_cursor.py
+++ b/tests/studio/test_scheduler_predispatch_cursor.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A github_poll trigger is consumed only if a process was started for it.
+
+The cursor advance rides the occurrence insert in one transaction, durably
+ahead of the spawn, so a poll that crashes mid-flight cannot re-fire events
+that already ran. That at-most-once boundary is correct for anything that got
+dispatched, and these tests pin it.
+
+It must not apply to refusals that happen before dispatch. An execution root
+that no longer resolves, an action that cannot be turned into a command line,
+or a shutdown that lands before the child exists all leave nothing running, so
+the event stays available and the next poll offers it again. Both halves are
+pinned here: a pre-dispatch refusal leaves the cursor where it was, a
+post-dispatch failure still moves it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.state.reasons import RunReasons
+from lionagi.studio.scheduler.engine import SchedulerEngine
+from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
+
+CURSOR_AT_TICK_START = "2026-07-07T09:00:00Z"
+FIRST_EVENT_AT = "2026-07-07T10:00:00Z"
+SECOND_EVENT_AT = "2026-07-07T11:00:00Z"
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "github_poll",
+        "github_repo": "acme/widgets",
+        "github_cursor": CURSOR_AT_TICK_START,
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "handle {{pr_number}}",
+        "action_agent": None,
+        "action_playbook": None,
+        # An execution root that resolves, so only the tests that mean to
+        # break it break it.
+        "action_cwd": "/",
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+        "last_fired_at": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.create_schedule_run_and_advance = AsyncMock()
+    svc.schedule_run_exists_since = AsyncMock(return_value=False)
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.get_invocation = AsyncMock(return_value=None)
+    svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
+    return svc
+
+
+def _item(pr_number: int, updated_at: str) -> GithubPollItem:
+    return GithubPollItem(
+        event={
+            "pr_number": pr_number,
+            "pr_title": f"PR {pr_number}",
+            "pr_url": f"https://github.com/acme/widgets/pull/{pr_number}",
+            "pr_author": "octocat",
+            "updated_at": updated_at,
+            "head_sha": f"sha{pr_number}",
+            "draft": False,
+        },
+        updated_at=updated_at,
+        dispatchable=True,
+    )
+
+
+def _poll(*items: GithubPollItem):
+    return patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(return_value=GithubPollResult(items=list(items), scan_complete=True)),
+    )
+
+
+def _build_argv_ok():
+    return patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        return_value=(["uv", "run", "li", "agent", "ping"], None),
+    )
+
+
+def _cursor_values_written(svc: AsyncMock) -> list[str]:
+    """Every github_cursor value this engine tried to persist, from both
+    write paths: the atomic occurrence-insert fold-in and the batched
+    trailing write _tick_github does for filtered/undispatched tails."""
+    written = [
+        call.kwargs["schedule_fields"]["github_cursor"]
+        for call in svc.create_schedule_run_and_advance.await_args_list
+        if "github_cursor" in call.kwargs["schedule_fields"]
+    ]
+    written += [
+        call.kwargs["github_cursor"]
+        for call in svc.update_schedule.await_args_list
+        if "github_cursor" in call.kwargs
+    ]
+    return written
+
+
+def _run_status_calls(svc: AsyncMock, status: str) -> list:
+    return [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[:1] == ("schedule_run",) and c.kwargs.get("new_status") == status
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pre-dispatch refusal: unresolvable execution root
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_execution_root_leaves_the_cursor_unmoved():
+    """The resolver refuses rather than run the action under a substituted
+    working directory. Nothing was dispatched, so the event must survive."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(action_cwd="/nonexistent/pruned-worktree")
+
+    spawn = AsyncMock(return_value=(0, ""))
+    with (
+        _poll(_item(1, FIRST_EVENT_AT)),
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    spawn.assert_not_awaited()
+    assert _cursor_values_written(svc) == []
+
+    # The run record for the refusal is unchanged: failed, with the reason
+    # code that names the refusal, and no exit code because nothing ran.
+    failed = _run_status_calls(svc, "failed")
+    assert len(failed) == 1
+    assert failed[0].kwargs["reason_code"] == RunReasons.FAILED_CWD_INHERIT_REFUSED
+    inserted = svc.create_schedule_run_and_advance.await_args_list[0].args[0]
+    assert inserted["status"] == "failed"
+    assert inserted.get("exit_code") is None
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_execution_root_still_advances_next_fire_at():
+    """Only the event-consuming cursor is held back. A cron schedule's own
+    clock still moves, so a refusing schedule does not spin on one tick."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(action_cwd="/nonexistent/pruned-worktree")
+
+    with (
+        _poll(_item(1, FIRST_EVENT_AT)),
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=AsyncMock()),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    fields = svc.create_schedule_run_and_advance.await_args_list[0].kwargs["schedule_fields"]
+    assert fields["last_fired_at"] > 0
+    assert "github_cursor" not in fields
+
+
+@pytest.mark.asyncio
+async def test_refusal_stops_the_poll_without_consuming_later_events():
+    """A refusal is a property of the schedule, not of the event, so the rest
+    of the batch would refuse identically. Stop, and leave every event of the
+    batch available."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(action_cwd="/nonexistent/pruned-worktree")
+
+    with (
+        _poll(_item(1, FIRST_EVENT_AT), _item(2, SECOND_EVENT_AT)),
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=AsyncMock()),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert svc.create_invocation.await_count == 1
+    assert _cursor_values_written(svc) == []
+
+
+@pytest.mark.asyncio
+async def test_unbuildable_action_args_leave_the_cursor_unmoved():
+    """The other pre-dispatch refusal: the action cannot be turned into a
+    command line, so no process is ever started for the event."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        _poll(_item(1, FIRST_EVENT_AT)),
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            side_effect=ValueError("bad action_kind"),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=AsyncMock()),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert _cursor_values_written(svc) == []
+    failed = _run_status_calls(svc, "failed")
+    assert len(failed) == 1
+    assert failed[0].kwargs["reason_code"] == RunReasons.FAILED_EXCEPTION
+
+
+# ---------------------------------------------------------------------------
+# Post-dispatch failure: at-most-once is preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_still_advances_the_cursor():
+    """A process ran and failed. Re-firing it would be a re-execution, which
+    is exactly the hazard the atomic advance exists to prevent."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        _poll(_item(1, FIRST_EVENT_AT)),
+        _build_argv_ok(),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(3, "boom")),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    fields = svc.create_schedule_run_and_advance.await_args_list[0].kwargs["schedule_fields"]
+    assert fields["github_cursor"] == FIRST_EVENT_AT
+    failed = _run_status_calls(svc, "failed")
+    assert len(failed) == 1
+    assert failed[0].kwargs["reason_code"] == RunReasons.FAILED_EXIT_NONZERO
+
+
+@pytest.mark.asyncio
+async def test_successful_run_advances_the_cursor():
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        _poll(_item(1, FIRST_EVENT_AT), _item(2, SECOND_EVENT_AT)),
+        _build_argv_ok(),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    advanced = [
+        call.kwargs["schedule_fields"]["github_cursor"]
+        for call in svc.create_schedule_run_and_advance.await_args_list
+    ]
+    assert advanced == [FIRST_EVENT_AT, SECOND_EVENT_AT]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation: which side of the split it lands on depends on the process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_launch_leaves_the_run_for_startup_recovery():
+    """A shutdown that lands after the occurrence committed but before the
+    child exists leaves the run exactly as a crash in that window would:
+    still "running", never dispatched. That is what startup recovery re-fires
+    from the run's own trigger_context, so the event is not spent. The
+    cancellation still propagates -- the daemon has to shut down."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    async def _cancel_before_launch(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    with (
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=_cancel_before_launch),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(
+                schedule,
+                "run-cancel-pre",
+                trigger_context={"github_events": [_item(1, FIRST_EVENT_AT).event]},
+                extra_schedule_fields={"github_cursor": FIRST_EVENT_AT},
+            )
+
+    # No terminal write, so the row stays in the undispatched-recovery lane.
+    assert _run_status_calls(svc, "cancelled") == []
+    svc.update_schedule_run.assert_not_awaited()
+    inserted = svc.create_schedule_run_and_advance.await_args_list[0].args[0]
+    assert inserted["status"] == "running"
+    assert "dispatched_at" not in inserted
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_launch_still_records_a_cancelled_run():
+    """The other side: the child process exists, so something ran. The run is
+    recorded terminally and its trigger stays consumed."""
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    async def _cancel_after_launch(*args, on_launched=None, **kwargs):
+        await on_launched()
+        raise asyncio.CancelledError()
+
+    with (
+        _build_argv_ok(),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=_cancel_after_launch),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(
+                schedule,
+                "run-cancel-post",
+                trigger_context={"github_events": [_item(1, FIRST_EVENT_AT).event]},
+                extra_schedule_fields={"github_cursor": FIRST_EVENT_AT},
+            )
+
+    cancelled = _run_status_calls(svc, "cancelled")
+    assert len(cancelled) == 1
+    assert cancelled[0].kwargs["reason_code"] == RunReasons.CANCELLED_SYSTEM
+    fields = svc.create_schedule_run_and_advance.await_args_list[0].kwargs["schedule_fields"]
+    assert fields["github_cursor"] == FIRST_EVENT_AT

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -720,7 +720,14 @@ async def test_fire_inner_exception_mints_schedule_run_failed():
 
 @pytest.mark.asyncio
 async def test_fire_cancellation_mints_schedule_run_cancelled():
+    """A cancellation that arrives once the child process exists still mints
+    the cancelled signal — something ran, so the run is recorded terminally."""
     from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    async def _cancel_after_launch(*args, on_launched=None, **kwargs):
+        if on_launched is not None:
+            await on_launched()
+        raise asyncio.CancelledError()
 
     svc = _make_svc()
     bus = SchedulerSignalBus()
@@ -736,7 +743,7 @@ async def test_fire_cancellation_mints_schedule_run_cancelled():
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=asyncio.CancelledError()),
+            new=_cancel_after_launch,
         ),
     ):
         with pytest.raises(asyncio.CancelledError):

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -694,6 +694,13 @@ async def test_fire_nonzero_exit_mints_schedule_run_failed():
 async def test_fire_inner_exception_mints_schedule_run_failed():
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
+    async def _raise_after_launch(*args, on_launched=None, **kwargs):
+        # The child existed before the failure, so this is a terminal failed
+        # run rather than an undispatched one left for startup recovery.
+        if on_launched is not None:
+            await on_launched()
+        raise RuntimeError("unexpected")
+
     svc = _make_svc()
     bus = SchedulerSignalBus()
     captured: list = []
@@ -708,7 +715,7 @@ async def test_fire_inner_exception_mints_schedule_run_failed():
         ),
         patch(
             "lionagi.studio.scheduler.subprocess.spawn_and_wait",
-            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+            new=AsyncMock(side_effect=_raise_after_launch),
         ),
     ):
         await engine._fire(schedule, "run-005", trigger_context={"scheduled": True})


### PR DESCRIPTION
## Behavior change — read this first

One path changes behavior in a way a reviewer should decide on deliberately, not discover later.

Previously, when a schedule's action arguments could not be built, the cursor advance was folded in
**on purpose**, with a comment defending it: a permanently misconfigured schedule would otherwise
never advance past the offending event and would re-fail on it forever. This change removes that
and treats unbuildable arguments as a pre-dispatch refusal like the others, because an argv failure
is a property of the schedule's action configuration rather than of the event — so it will fail on
the next event too, and advancing bought nothing except discarding events silently while still
failing. Stopping the poll on the first refusal bounds the cost to one failed run per tick instead
of one per event.

**The trade, stated plainly:** a genuinely event-specific render failure — a single poison event
that fails to render while others would succeed — now blocks the queue until an operator
intervenes, where before it was skipped silently. This is loud-over-silent by choice, and it is a
real trade rather than a free win. If the queue-blocking risk is judged too high, the alternatives
are a bounded refusal count before the cursor is allowed past, or an alarm on repeated refusal;
either can be added without disturbing the rest of this change.

## Problem

A `github_poll` schedule advances `github_cursor` to an event's `updated_at` inside the same transaction as the occurrence insert, durably **before** the action is spawned.

For an action that actually ran, that is deliberate and correct: it closes a double-fire hazard where a crash mid-poll would re-fetch and re-fire events that had already executed. At-most-once is the right choice there.

The bug is that the same finality applied to refusals that happen **before anything is dispatched**. When a schedule's configured execution root can no longer be resolved to an existing directory, the scheduler refuses to run the action under a substituted working directory and raises — but the cursor had already moved past the event. The trigger was spent on a run that started nothing, and no later poll re-offered it. The resulting run record is the tell: `status failed`, `exit_code: null`, no sessions — nothing ever ran.

A daemon shutdown that cancels an in-flight poll after the commit but before the spawn loses its event the same way.

## Invariant

> The cursor advances past an event only if a process was actually started for it.

- **Pre-dispatch refusal** — execution root unresolvable, action arguments unbuildable, admission refused, cancellation before the child exists: the event stays available. Nothing ran, so re-firing is not a re-execution.
- **Post-dispatch failure** — the process started and exited non-zero, timed out, or was killed: at-most-once is preserved exactly. Something ran, so re-firing is the hazard the current design correctly avoids.

## Approach

**Validate before committing**, rather than compensating after. Every check that can refuse without starting a process — resolving the `li` executable, building argv, resolving the execution root — now runs ahead of the occurrence transaction. All three are reads (directory existence, a project lookup, argv construction), so running them earlier has no side effect, and a refusal now happens while the cursor still points at the event.

Restoring the cursor afterwards was the alternative, and it is not sound here: the `github_cursor` assignment is deliberately monotonic (it only moves if the new value sorts above the stored one), because a poll reads the cursor at tick start and writes it back much later, and that guard is what stops a stale snapshot from undoing an operator's deliberate cursor move. A restore is by definition a backward write, so it would either be swallowed by the guard or, written unguarded, clobber exactly the concurrent advance the guard exists to protect.

Cancellation cannot be handled by ordering alone, since it can arrive at any await. It is handled by classification instead: a cancellation that lands after the commit but before the child process exists now leaves the run exactly as a crash in that same window does — still `running`, never dispatched. That is precisely the state the existing startup-recovery scan re-fires from the run's own trigger context, so the event is replayed rather than lost. The `CancelledError` still propagates untouched, so the daemon shuts down as before. A cancellation after the child exists keeps writing its terminal `cancelled` record, unchanged.

Because a pre-dispatch refusal is a property of the schedule rather than of the event, a refusal also stops the rest of the poll instead of letting every remaining event refuse identically and burn a rate-limit and `max_runs` unit doing it.

## Behavior preserved

- Reason codes and run records for genuine failures are unchanged: a refusal is still a `failed` run carrying the reason code that names it, with no exit code.
- `last_fired_at` / `next_fire_at` still advance on a refusal, so only the event-consuming cursor is held back and a cron schedule does not spin.
- Non-zero exit, timeout, and kill all still consume the trigger.

## Tests

`tests/studio/test_scheduler_predispatch_cursor.py` pins both sides:

- an unresolvable execution root leaves the cursor unmoved, still records the failed run with its reason code, and never spawns;
- the same refusal still advances `next_fire_at`;
- a refusal stops the poll without consuming later events;
- unbuildable action arguments leave the cursor unmoved;
- a non-zero exit still advances the cursor;
- a successful run advances it per event;
- a cancellation **before** launch writes no terminal status and leaves the run in the undispatched-recovery lane;
- a cancellation **after** launch still records the cancelled run and keeps the cursor advanced.

Five of these fail on the unmodified code; the three post-dispatch ones pass on both, which is the point — they pin behavior that must not change.

Existing `spawn_and_wait` doubles across three test files never confirmed a launch while describing an in-flight or shutdown-cancelled process. They now call `on_launched`, as the real `spawn_and_wait` does before it waits on the child, so they model the case they were written to describe.

Full run over the scheduler and studio suites: **2010 tests, 0 failures**.

## Note

Do not merge yet — this is sequenced behind a release currently in flight.


## Known residual

`spawn_and_wait` can still raise *after* the occurrence commits but before any process exists — an
`OSError` from the launch itself, for example — and that case still consumes the trigger. It is on
the far side of the commit by construction, so the reordering here cannot reach it, and neither
compensation nor startup-recovery routing fits it. Tracked separately in #2544 rather than widened
into this change.
