### PR TITLE
fix(mcp): refuse help and ops in the same request instead of dropping the ops

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -804,6 +804,15 @@ async def _run_one(entry: Any) -> dict[str, Any]:
 async def request(ops: list[dict[str, Any]] | None = None, help: Any = None) -> dict[str, Any]:  # noqa: A002 — `help` is the parameter name the surface advertises
     """Run a batch of ops, or answer a help request. Never raises for one bad op."""
     if help is not None and help is not False:
+        # A catalog and a set of op results are different shapes, so one reply
+        # cannot carry both, and answering half of the request would look like
+        # success to a caller whose other half never ran.
+        if ops:
+            raise ValueError(
+                "help and ops cannot be combined in one call: help returns the catalog "
+                "and ops returns one result per op, which are different shapes. Send the "
+                "help request and the ops as two separate calls."
+            )
         return _help(help)
     if ops is None:
         raise ValueError(

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -803,6 +803,12 @@ async def _run_one(entry: Any) -> dict[str, Any]:
 
 async def request(ops: list[dict[str, Any]] | None = None, help: Any = None) -> dict[str, Any]:  # noqa: A002 — `help` is the parameter name the surface advertises
     """Run a batch of ops, or answer a help request. Never raises for one bad op."""
+    # Shape first, before the help branch: otherwise a malformed ops is judged on
+    # truthiness, so an empty dict slips past as "no ops" and is discarded in
+    # silence, while a non-empty one is reported as a help conflict rather than
+    # as the wrong type it is.
+    if ops is not None and not isinstance(ops, list):
+        raise ValueError(f"ops is a list of {{op, args}} objects, got {type(ops).__name__}")
     if help is not None and help is not False:
         # A catalog and a set of op results are different shapes, so one reply
         # cannot carry both, and answering half of the request would look like
@@ -819,8 +825,6 @@ async def request(ops: list[dict[str, Any]] | None = None, help: Any = None) -> 
             "pass ops, or help=true for the catalog. This tool dispatches namespaced "
             "verbs; help=true lists them with their required parameters."
         )
-    if not isinstance(ops, list):
-        raise ValueError(f"ops is a list of {{op, args}} objects, got {type(ops).__name__}")
     if not ops:
         raise ValueError("ops is empty; pass at least one {op, args} object")
     if len(ops) > MAX_OPS:

--- a/lionagi/mcp/server.py
+++ b/lionagi/mcp/server.py
@@ -65,7 +65,9 @@ async def request(
     a one-line summary, and — for the verbs whose ops must carry one — the
     ``schema_fingerprint`` to send with the call, which is enough to write the
     common call without a second round-trip. ``help='<verb>'`` returns that
-    verb's full schema.
+    verb's full schema. Ask for help in its own call: a catalog and a list of op
+    results are different shapes, so one reply cannot carry both, and a request
+    that asks for both is refused rather than answered in half.
 
     Results come back as ``{'status': 'success'|'partial', 'ops': [...]}``, one
     entry per op in the order given, each ``{'ok': true, 'op', 'result'}`` or

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -154,6 +154,29 @@ def test_help_with_an_empty_ops_list_is_a_plain_help_call():
     assert call(help=True, ops=[]) == call(help=True)
 
 
+@pytest.mark.parametrize("bad", [{}, {"op": "server.info"}, "server.info"])
+def test_help_alongside_a_malformed_ops_reports_the_wrong_type(bad):
+    """A malformed ops is judged on its shape, not on whether it is truthy.
+
+    Deciding by truthiness split these three: the empty dict was falsey, so it
+    was read as "no ops" and dropped in silence, which is the very thing this
+    refusal exists to prevent. The other two were truthy and came back blamed on
+    the help conflict rather than on being the wrong type.
+    """
+    with pytest.raises(ValueError, match="ops is a list"):
+        call(help=True, ops=bad)
+
+
+@pytest.mark.parametrize("bad", [{}, {"op": "server.info"}, "server.info"])
+def test_a_malformed_ops_reports_the_same_way_with_and_without_help(bad):
+    """Whether help was asked for cannot change what a wrong type is called."""
+    with pytest.raises(ValueError, match="ops is a list") as with_help:
+        call(help=True, ops=bad)
+    with pytest.raises(ValueError, match="ops is a list") as without_help:
+        call(ops=bad)
+    assert str(with_help.value) == str(without_help.value)
+
+
 # ── closed validation, and the schema that comes back with the refusal ───────
 #
 # These request the submit fixture even though none of them should reach it: if

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -114,6 +114,46 @@ def test_ops_over_the_documented_maximum_is_an_error_not_a_truncation():
         call(ops=over)
 
 
+# ── help and ops are separate calls ──────────────────────────────────────────
+#
+# The two answers have different shapes, so there is no reply that could carry
+# both. Running the ops and dropping the catalog, or the reverse, would look
+# like success to a caller whose other half never happened — so the pair is
+# refused by name instead.
+
+
+def test_help_alongside_ops_is_refused_and_names_both_parameters():
+    with pytest.raises(ValueError) as refusal:
+        call(help=True, ops=[{"op": "server.info"}])
+    message = str(refusal.value)
+    assert "help" in message and "ops" in message
+
+
+def test_help_alongside_ops_refuses_before_any_op_runs(submitted):
+    with pytest.raises(ValueError):
+        call(
+            help=True,
+            ops=[spawn_op("agent.submit", {"prompt": "hi", "agent": "implementer"})],
+        )
+    assert submitted == {}
+
+
+def test_help_alone_still_answers_with_the_catalog():
+    answer = call(help=True)
+    assert answer["verbs"]
+    assert "ops" not in answer
+
+
+def test_ops_alone_still_run():
+    answer = call(ops=[{"op": "server.info"}])
+    assert answer["status"] == "success"
+    assert answer["ops"][0]["ok"] is True
+
+
+def test_help_with_an_empty_ops_list_is_a_plain_help_call():
+    assert call(help=True, ops=[]) == call(help=True)
+
+
 # ── closed validation, and the schema that comes back with the refusal ───────
 #
 # These request the submit fixture even though none of them should reach it: if


### PR DESCRIPTION
fix(mcp): refuse help and ops in the same request instead of dropping the ops

The dispatcher short-circuited into the help path whenever help was truthy, so
a caller who sent ops alongside a help lookup got the catalog back and their
operations were never examined. The reply was shaped exactly like success, so
there was nothing to tell them their work had not run.

A catalog and a list of op results are different shapes, so one reply cannot
carry both, and answering half the request would keep looking like success.
The pair is now refused by name, in the same whole-request refusal shape this
surface already uses for an absent, malformed, empty or oversized ops list.

Single-parameter behaviour is unchanged: help alone still returns the catalog,
ops alone still runs, and an absent or empty ops alongside help is still a
plain help call.

The advertised tool description said nothing about the two being exclusive, so
a caller could only discover it by being refused. It now says help takes its
own call, which is the same thing the refusal says.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


Closes #2546
