### PR TITLE
fix(mcp): scope the MCP passthrough diagnostics to the branch they observe

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -614,11 +614,18 @@ def _forward_mcp_to_cli_request(
         if mcp_path is not None:
             import logging
 
+            # Scope the claim to what this call can see: one branch, whose
+            # provider was resolved from this one spec. Sibling branches in the
+            # same run resolve their own providers and are not observable here,
+            # so saying "this run" would overstate a per-branch fact.
             logging.getLogger(__name__).warning(
                 "MCP config present in AgentSpec but the active provider (%s) has "
                 "no MCP passthrough; MCP servers will not be reachable for this "
-                "run.",
+                "branch (role %s, branch %s). Other branches resolve their own "
+                "providers and are not covered by this warning.",
                 provider,
+                spec.profile.role.name,
+                branch.id,
             )
         # No MCP-capable request model for this provider to forward into,
         # so this stays a silent no-op (mirrors _load_mcp's own shape).
@@ -638,12 +645,15 @@ def _forward_mcp_to_cli_request(
             import logging
 
             logging.getLogger(__name__).warning(
-                "Could not read/parse MCP config %r for forwarding to the "
-                "claude_code CLI request (%s: %s); MCP servers will not be "
-                "reachable for this run.",
+                "Could not read/parse MCP config %r for forwarding to the %s "
+                "CLI request (%s: %s); MCP servers will not be reachable for "
+                "this branch (role %s, branch %s).",
                 mcp_path,
+                provider,
                 type(exc).__name__,
                 exc,
+                spec.profile.role.name,
+                branch.id,
             )
             if spec.mcp_config_path:
                 # An explicitly configured path failing to parse is a

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -309,8 +309,9 @@ def _report_mcp_resolution(resolution: McpResolution, *, provider: str, cwd: str
         if resolution.servers is not None:
             warn(
                 f"MCP servers resolved from {resolution.source} are not carried to "
-                f"provider {provider!r}: only the Claude CLI lane accepts a server "
-                "set per request. This leg gets whatever that CLI discovers for itself."
+                f"provider {provider!r}: this spawn path only hands a resolved server "
+                "set to the Claude CLI lane. This leg gets whatever its own provider "
+                "resolves for itself."
             )
         return
 

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -1259,10 +1259,14 @@ async def test_forward_mcp_gemini_provider_warns_and_noops(tmp_path, caplog):
         branch = await create_agent(config, load_settings=False)
 
     assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
-    assert any(
-        "no MCP passthrough" in rec.message and "gemini_code" in rec.message
-        for rec in caplog.records
-    )
+    messages = [rec.getMessage() for rec in caplog.records if "no MCP passthrough" in rec.message]
+    assert len(messages) == 1
+    # This function sees one branch's provider. Sibling branches in the same
+    # run resolve their own, so the text must not claim the run.
+    assert "gemini_code" in messages[0]
+    assert "this branch" in messages[0]
+    assert "this run" not in messages[0]
+    assert str(branch.id) in messages[0]
 
 
 async def test_forward_mcp_gated_by_trust_project_settings_for_project_scope(tmp_path, monkeypatch):

--- a/tests/cli/test_agent_mcp_scope_messages.py
+++ b/tests/cli/test_agent_mcp_scope_messages.py
@@ -1,0 +1,58 @@
+"""The spawn-time MCP messages must claim only the scope they can observe.
+
+Each of these messages is emitted while setting up one leg. A message that says
+"this run" is read as covering every leg of a multi-agent run, but sibling legs
+resolve their own providers and their own MCP config, which this code never
+sees. So the text has to stay leg-scoped.
+"""
+
+import logging
+
+from lionagi.cli._logging import _WARN_LOGGER_NAME
+from lionagi.cli._mcp_resolve import McpResolution
+from lionagi.cli.agent import _report_mcp_resolution
+
+
+def _capture_warnings(fn):
+    """Collect `warn()` output without depending on propagation to the root
+    logger, which `configure_cli_logging` disables process-wide."""
+    records: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger(_WARN_LOGGER_NAME)
+    handler = _Collect()
+    logger.addHandler(handler)
+    try:
+        fn()
+    finally:
+        logger.removeHandler(handler)
+    return records
+
+
+def test_non_claude_provider_warning_is_leg_scoped():
+    resolution = McpResolution({"khive": {"command": "kkernel"}}, None, "/tmp/.mcp.json", "/tmp")
+    messages = _capture_warnings(
+        lambda: _report_mcp_resolution(resolution, provider="codex", cwd="/tmp")
+    )
+
+    assert len(messages) == 1
+    text = messages[0]
+    assert "this leg" in text.lower()
+    assert "this run" not in text.lower()
+    # The set is not carried here; that is not the same as no other lane in
+    # lionagi being able to accept one, which this function cannot know.
+    assert "only the claude cli lane accepts" not in text.lower()
+
+
+def test_no_servers_warning_is_leg_scoped():
+    resolution = McpResolution(None, "no_mcp_config_found", None, "/tmp")
+    messages = _capture_warnings(
+        lambda: _report_mcp_resolution(resolution, provider="claude_code", cwd="/tmp")
+    )
+
+    assert len(messages) == 1
+    assert "this leg" in messages[0].lower()
+    assert "this run" not in messages[0].lower()


### PR DESCRIPTION
fix(mcp): scope the MCP passthrough diagnostics to the branch they observe

_forward_mcp_to_cli_request runs once per branch and sees one AgentSpec and
one Branch, but both of its warnings ended in "MCP servers will not be
reachable for this run". In a multi-agent flow that reads as a verdict on
every leg, while sibling branches resolve their own providers and can reach
MCP normally. Both now say "this branch" and name the role and branch id, and
the passthrough warning states outright that it does not cover other branches.

The read/parse warning also hardcoded "the claude_code CLI request" on a path
reachable by codex as well, so a codex leg was told the wrong CLI. It now
names the provider it actually has.

_report_mcp_resolution explained a non-Claude spawn with "only the Claude CLI
lane accepts a server set per request". That is not true: the agent factory
forwards a resolved server set to codex as -c mcp_servers.<name>.<field>
overrides, which the codex request model serializes per request. What is true
is narrower, and is what it now says: this spawn path only hands the
launch-directory set to the Claude CLI lane.

Text only. No condition, no forwarded server set, and no return path changes.

Tests: the factory warning already had a test, extended to assert the text is
branch-scoped and carries the branch id. _report_mcp_resolution had none; adds
tests/cli/test_agent_mcp_scope_messages.py, which attaches its own handler to
the CLI warn logger rather than using caplog, because configure_cli_logging
turns off propagation on that logger process-wide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


Closes #2547
