### PR TITLE
fix(cli): treat '-' and '_' as the same agent profile name

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -52,6 +52,7 @@ __all__ = (
     "resolve_model_spec",
     "resolve_persisted_effort",
     "AgentProfile",
+    "AmbiguousProfileNameError",
     "build_agent_profile_catalog",
     "build_deadline_preamble",
     "list_agents",
@@ -378,15 +379,33 @@ def _unreadable_symlink_target(path: Path) -> str | None:
         return "<unreadable>"
 
 
+class AmbiguousProfileNameError(ValueError):
+    """One agents dir declares a name under both '-' and '_' spellings."""
+
+
+def _name_spellings(name: str) -> tuple[str, ...]:
+    """NAME plus its separator spellings, requested spelling first.
+
+    '-' and '_' are interchangeable in a profile name, so a role written
+    ``postmortem-lead`` everywhere else still finds ``postmortem_lead.md``.
+    """
+    return tuple(dict.fromkeys((name, name.replace("-", "_"), name.replace("_", "-"))))
+
+
 def _profile_path_candidates(agents_dir: Path, name: str) -> tuple[Path, ...]:
     """Where NAME may live in one agents dir, in the order resolution tries them.
 
-    Two layouts share a directory, so a root can hold more than one declaration
-    of the same name. Anything reporting which files declare a profile has to
-    walk the same candidates in the same order as the resolver, or it reports a
-    displaced file in one root while missing one in another.
+    Two layouts share a directory, and either may spell the name with '-' or
+    '_', so a root can hold more than one declaration of the same name.
+    Anything reporting which files declare a profile has to walk the same
+    candidates in the same order as the resolver, or it reports a displaced
+    file in one root while missing one in another.
     """
-    return (agents_dir / name / f"{name}.md", agents_dir / f"{name}.md")
+    return tuple(
+        path
+        for spelling in _name_spellings(name)
+        for path in (agents_dir / spelling / f"{spelling}.md", agents_dir / f"{spelling}.md")
+    )
 
 
 def _resolve_profile_path(
@@ -395,14 +414,39 @@ def _resolve_profile_path(
     *,
     unreadable_symlinks: list[tuple[Path, str]] | None = None,
 ) -> Path | None:
-    """Return profile path for NAME, recording unreadable candidate symlinks."""
-    for candidate in _profile_path_candidates(agents_dir, name):
-        if candidate.is_file():
-            return candidate
-        target = _unreadable_symlink_target(candidate)
-        if target is not None and unreadable_symlinks is not None:
-            unreadable_symlinks.append((candidate, target))
-    return None
+    """Return profile path for NAME, recording unreadable candidate symlinks.
+
+    The spelling actually asked for wins outright when it exists. Only a
+    request that does *not* name an existing file falls back to the other
+    separator spelling, so a directory deliberately holding two profiles that
+    differ only in separator keeps resolving both, exactly as it did before
+    the spellings became interchangeable.
+
+    Failing that, two spellings matching one request in a single directory are
+    an error rather than a ranking: whichever one lost would be invisible to
+    the caller. Two spellings in *different* roots are ordinary shadowing,
+    decided by root order, and are resolved by the caller walking the roots.
+    """
+    resolved: dict[str, Path] = {}
+    for spelling in _name_spellings(name):
+        for candidate in (agents_dir / spelling / f"{spelling}.md", agents_dir / f"{spelling}.md"):
+            if candidate.is_file():
+                resolved.setdefault(spelling, candidate)
+                continue
+            target = _unreadable_symlink_target(candidate)
+            if target is not None and unreadable_symlinks is not None:
+                unreadable_symlinks.append((candidate, target))
+
+    if name in resolved:
+        return resolved[name]
+    if len(resolved) > 1:
+        matched = ", ".join(str(p) for p in resolved.values())
+        raise AmbiguousProfileNameError(
+            f"Agent profile name '{name}' is ambiguous in {agents_dir}: "
+            f"'-' and '_' are interchangeable, and both spellings exist ({matched}). "
+            "Rename or remove one of them."
+        )
+    return next(iter(resolved.values()), None)
 
 
 def _plugin_agent_profiles() -> dict[str, tuple[str, Path]]:

--- a/tests/agent/test_profile_name_normalization.py
+++ b/tests/agent/test_profile_name_normalization.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for '-' / '_' equivalence in agent profile names, and its ambiguity guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli._providers import (
+    AmbiguousProfileNameError,
+    _resolve_profile_path,
+    load_agent_profile,
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+# ── per-directory resolver ───────────────────────────────────────────
+
+
+def test_hyphen_request_resolves_underscore_file(tmp_path: Path) -> None:
+    agents_dir = tmp_path / "agents"
+    path = _write(agents_dir / "postmortem_lead.md", "x\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem-lead") == path
+
+
+def test_underscore_request_resolves_underscore_file(tmp_path: Path) -> None:
+    agents_dir = tmp_path / "agents"
+    path = _write(agents_dir / "postmortem_lead.md", "x\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem_lead") == path
+
+
+def test_underscore_request_resolves_hyphen_file(tmp_path: Path) -> None:
+    agents_dir = tmp_path / "agents"
+    path = _write(agents_dir / "postmortem-lead.md", "x\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem_lead") == path
+
+
+def test_hyphen_request_resolves_underscore_directory_layout(tmp_path: Path) -> None:
+    agents_dir = tmp_path / "agents"
+    path = _write(agents_dir / "postmortem_lead" / "postmortem_lead.md", "x\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem-lead") == path
+
+
+def test_exact_spelling_wins_when_both_spellings_exist(tmp_path: Path) -> None:
+    """A request naming an existing file resolves to it, never to the other spelling.
+
+    A directory deliberately holding two profiles that differ only in separator
+    resolved both before the spellings became interchangeable, and still does.
+    Nothing is being silently ranked here: the caller named one of them.
+    """
+    agents_dir = tmp_path / "agents"
+    hyphen = _write(agents_dir / "postmortem-lead.md", "hyphen\n")
+    underscore = _write(agents_dir / "postmortem_lead.md", "underscore\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem-lead") == hyphen
+    assert _resolve_profile_path(agents_dir, "postmortem_lead") == underscore
+
+
+def test_mixed_separator_request_with_no_exact_file_is_ambiguous(tmp_path: Path) -> None:
+    """Ambiguity survives exactly where the request itself is ambiguous.
+
+    The requested spelling does not exist, and normalizing it finds two
+    different files. There is no named file to prefer, and resolving to either
+    would make the other invisible.
+    """
+    agents_dir = tmp_path / "agents"
+    underscored = _write(agents_dir / "postmortem_lead_v2.md", "underscore\n")
+    hyphenated = _write(agents_dir / "postmortem-lead-v2.md", "hyphen\n")
+
+    with pytest.raises(AmbiguousProfileNameError) as excinfo:
+        _resolve_profile_path(agents_dir, "postmortem-lead_v2")
+    message = str(excinfo.value)
+    assert "postmortem-lead_v2" in message
+    assert str(underscored) in message
+    assert str(hyphenated) in message
+
+
+def test_one_spelling_in_both_layouts_is_not_ambiguous(tmp_path: Path) -> None:
+    """Directory layout still beats flat layout for the same spelling."""
+    agents_dir = tmp_path / "agents"
+    dir_path = _write(agents_dir / "postmortem_lead" / "postmortem_lead.md", "dir\n")
+    _write(agents_dir / "postmortem_lead.md", "flat\n")
+
+    assert _resolve_profile_path(agents_dir, "postmortem-lead") == dir_path
+
+
+# ── full loader across both lookup roots ─────────────────────────────
+
+
+@pytest.fixture
+def two_roots(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    """A project-local agents dir (cwd walk-up) and a user-level one (HOME)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(project)
+    return project / ".lionagi" / "agents", tmp_path / ".lionagi" / "agents"
+
+
+def test_loader_resolves_hyphen_request_in_project_root(two_roots) -> None:
+    project_agents, _ = two_roots
+    _write(project_agents / "postmortem_lead.md", "---\nmodel: project\n---\n\nbody\n")
+
+    assert load_agent_profile("postmortem-lead").model == "project"
+
+
+def test_loader_resolves_hyphen_request_in_user_root(two_roots) -> None:
+    _, home_agents = two_roots
+    _write(home_agents / "postmortem_lead.md", "---\nmodel: home\n---\n\nbody\n")
+
+    assert load_agent_profile("postmortem-lead").model == "home"
+
+
+def test_project_root_still_beats_user_root(two_roots) -> None:
+    project_agents, home_agents = two_roots
+    _write(project_agents / "postmortem_lead.md", "---\nmodel: project\n---\n\nbody\n")
+    _write(home_agents / "postmortem_lead.md", "---\nmodel: home\n---\n\nbody\n")
+
+    assert load_agent_profile("postmortem_lead").model == "project"
+
+
+def test_project_root_beats_user_root_across_spellings(two_roots) -> None:
+    """Root order decides; the requested spelling does not promote a lower root."""
+    project_agents, home_agents = two_roots
+    _write(project_agents / "postmortem_lead.md", "---\nmodel: project\n---\n\nbody\n")
+    _write(home_agents / "postmortem-lead.md", "---\nmodel: home\n---\n\nbody\n")
+
+    assert load_agent_profile("postmortem-lead").model == "project"
+    assert load_agent_profile("postmortem_lead").model == "project"
+
+
+def test_loader_prefers_the_exact_spelling_within_one_root(two_roots) -> None:
+    """Both spellings present in one root: each request gets the file it named."""
+    project_agents, _ = two_roots
+    _write(project_agents / "postmortem-lead.md", "---\nmodel: hyphen\n---\n\nbody\n")
+    _write(project_agents / "postmortem_lead.md", "---\nmodel: underscore\n---\n\nbody\n")
+
+    assert load_agent_profile("postmortem-lead").model == "hyphen"
+    assert load_agent_profile("postmortem_lead").model == "underscore"
+
+
+def test_loader_reports_ambiguity_when_nothing_matches_exactly(two_roots) -> None:
+    project_agents, _ = two_roots
+    underscored = _write(project_agents / "postmortem_lead_v2.md", "---\nmodel: a\n---\n\nbody\n")
+    hyphenated = _write(project_agents / "postmortem-lead-v2.md", "---\nmodel: b\n---\n\nbody\n")
+
+    with pytest.raises(AmbiguousProfileNameError) as excinfo:
+        load_agent_profile("postmortem-lead_v2")
+    message = str(excinfo.value)
+    assert "postmortem-lead_v2" in message
+    assert str(underscored) in message
+    assert str(hyphenated) in message


### PR DESCRIPTION
fix(cli): treat '-' and '_' as the same agent profile name

A role written `postmortem-lead` everywhere else did not resolve to
`postmortem_lead.md`, so a profile that exists was unreachable under its
canonical name, and a caller asking for it silently got default
configuration instead of the profile's own model, effort and settings.
Profile resolution now tries the requested spelling plus its all-hyphen
and all-underscore forms, in every lookup root.

The spelling actually requested still wins outright whenever it exists.
Only a request that names no existing file falls back to the other
separator spelling, so a directory deliberately holding two profiles that
differ only in separator keeps resolving both exactly as it did before.

Where a request matches no file directly and normalizing it finds more
than one, that is an ambiguity in the request rather than a ranking
problem, and it raises AmbiguousProfileNameError naming every matched
path. Resolving to either one would make the other invisible. Two
spellings in different roots stay ordinary shadowing, decided by the
existing root order.

Candidate construction stays shared with the placement reporting in the
MCP roster, so what it reports is still what the resolver reads.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

