### PR TITLE
Show role descriptions in the planner roster

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -8,6 +8,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -95,20 +96,61 @@ def available_roles() -> list[str]:
     return sorted(set(list_roles()) | set(list_agents()))
 
 
+def _first_sentence(text: str) -> str:
+    """Opening sentence of ``text``, truncated so one role cannot crowd out
+    the roster."""
+    first = text.split(". ", 1)[0].strip()
+    return (first[:160] + "…") if len(first) > 161 else first
+
+
+_MISSION_LABEL = re.compile(r"^\*\*mission\*\*\s*:?\s*", re.IGNORECASE)
+_MARKDOWN_FURNITURE = re.compile(r"^(#|-{3,}|\||>|```|`[^`]*`$)")
+
+
+def _profile_summary(profile: AgentProfile) -> str:
+    """One line describing what a user profile is for.
+
+    Profiles state their purpose on a ``**Mission**:`` line; when a file has
+    none, its first paragraph of prose is the next best summary.
+    """
+    body = profile.raw_body or profile.system_prompt or ""
+    paragraphs = [
+        " ".join(line.strip() for line in block.splitlines() if line.strip())
+        for block in re.split(r"\n\s*\n", body)
+    ]
+    paragraphs = [p for p in paragraphs if p]
+    for p in paragraphs:
+        if _MISSION_LABEL.match(p):
+            return _MISSION_LABEL.sub("", p).strip(" `*")
+    prose = (p for p in paragraphs if not _MARKDOWN_FURNITURE.match(p))
+    return next(prose, "").strip(" `*")
+
+
 def _role_blurb(role: str, default_model: str) -> str:
+    """Roster line body: what the role is for, and what it will run on.
+
+    A built-in role's description is written as selection guidance, so it is
+    preferred over the profile body even when both exist; the profile still
+    contributes the model.
+    """
     try:
-        p = load_agent_profile(role)
-        return f"user profile (model: {p.model or default_model})"
+        profile = load_agent_profile(role)
     except FileNotFoundError:
-        pass
+        profile = None
+
     from lionagi.casts.pattern import Role
 
     try:
-        desc = Role.load(role).description
+        summary = _first_sentence(Role.load(role).description)
     except ValueError:
-        return ""
-    first = desc.split(". ", 1)[0].strip()
-    return (first[:160] + "…") if len(first) > 161 else first
+        summary = ""
+    if not summary and profile is not None:
+        summary = _first_sentence(_profile_summary(profile))
+
+    if profile is None:
+        return summary
+    model = f"(model: {profile.model or default_model})"
+    return f"{summary} {model}" if summary else f"user profile {model}"
 
 
 def role_roster(default_model: str) -> str:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -129,9 +129,13 @@ def _profile_summary(profile: AgentProfile) -> str:
 def _role_blurb(role: str, default_model: str) -> str:
     """Roster line body: what the role is for, and what it will run on.
 
-    A built-in role's description is written as selection guidance, so it is
-    preferred over the profile body even when both exist; the profile still
-    contributes the model.
+    The description has to match the body that will actually run, or the
+    roster describes one thing while the worker does another. A profile that
+    defines its own system prompt replaces the built-in role body entirely, so
+    for those the profile's summary is the accurate description. A profile that
+    only sets a model or effort leaves the built-in body in place and has no
+    summary of its own to offer, so those fall through to the built-in
+    description on their own.
     """
     try:
         profile = load_agent_profile(role)
@@ -140,12 +144,12 @@ def _role_blurb(role: str, default_model: str) -> str:
 
     from lionagi.casts.pattern import Role
 
-    try:
-        summary = _first_sentence(Role.load(role).description)
-    except ValueError:
-        summary = ""
-    if not summary and profile is not None:
-        summary = _first_sentence(_profile_summary(profile))
+    summary = _first_sentence(_profile_summary(profile)) if profile is not None else ""
+    if not summary:
+        try:
+            summary = _first_sentence(Role.load(role).description)
+        except ValueError:
+            summary = ""
 
     if profile is None:
         return summary

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -112,8 +112,11 @@ def _profile_summary(profile: AgentProfile) -> str:
 
     Profiles state their purpose on a ``**Mission**:`` line; when a file has
     none, its first paragraph of prose is the next best summary.
+
+    Only the authored body is read. ``system_prompt`` also carries the shared
+    LION preamble, which every profile has and none of them is about.
     """
-    body = profile.raw_body or profile.system_prompt or ""
+    body = profile.raw_body or ""
     paragraphs = [
         " ".join(line.strip() for line in block.splitlines() if line.strip())
         for block in re.split(r"\n\s*\n", body)
@@ -129,13 +132,12 @@ def _profile_summary(profile: AgentProfile) -> str:
 def _role_blurb(role: str, default_model: str) -> str:
     """Roster line body: what the role is for, and what it will run on.
 
-    The description has to match the body that will actually run, or the
-    roster describes one thing while the worker does another. A profile that
-    defines its own system prompt replaces the built-in role body entirely, so
-    for those the profile's summary is the accurate description. A profile that
-    only sets a model or effort leaves the built-in body in place and has no
-    summary of its own to offer, so those fall through to the built-in
-    description on their own.
+    The description has to match the body that will actually run, or the roster
+    describes one thing while the worker does another. A profile with an
+    authored body replaces the built-in role body, so for those the profile's
+    own summary is the accurate description. A profile that only sets fields
+    like a model authors no body, leaves the built-in composing, and is
+    described by the built-in — the same authored-body signal decides both.
     """
     try:
         profile = load_agent_profile(role)
@@ -718,11 +720,13 @@ async def build_worker_branch(
     )
 
     # Casts-role workers route through the factory; verbatim-prompt workers set
-    # the string directly (no Role to compose from).
+    # the string directly (no Role to compose from). A profile takes the
+    # verbatim path only when it authored a body — one that just sets a model
+    # or an effort has no body to run, and leaves the role composing as usual.
     verbatim_system: str | None = None
     if system_prompt_override is not None:
         verbatim_system = system_prompt_override
-    elif not env.bare and w_profile and w_profile.system_prompt:
+    elif not env.bare and w_profile and w_profile.raw_body:
         verbatim_system = w_profile.system_prompt
     elif env.bare or not _is_casts_role(role):
         verbatim_system = bare_worker_system(grant_spawn=grant_spawn)

--- a/tests/cli/orchestrate/test_role_roster.py
+++ b/tests/cli/orchestrate/test_role_roster.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The planner roster line for each role: description plus model."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli._providers import AgentProfile
+from lionagi.cli.orchestrate import _orchestration as orch
+
+
+@pytest.fixture
+def stub_profiles(monkeypatch):
+    """Serve profiles from a dict instead of the user's agents directories."""
+    table: dict[str, AgentProfile] = {}
+
+    def fake_load(name: str) -> AgentProfile:
+        try:
+            return table[name]
+        except KeyError:
+            raise FileNotFoundError(name) from None
+
+    monkeypatch.setattr(orch, "load_agent_profile", fake_load)
+    return table
+
+
+class TestRoleBlurb:
+    def test_builtin_with_profile_keeps_description_and_names_model(self, stub_profiles):
+        from lionagi.casts.pattern import Role
+
+        stub_profiles["critic"] = AgentProfile(
+            name="critic",
+            raw_body="# Critic\n\n**Mission**: gate the release.",
+            model="codex/gpt-5",
+        )
+        blurb = orch._role_blurb("critic", "openai/gpt-4.1-mini")
+
+        opening = Role.load("critic").description.split(". ", 1)[0]
+        assert opening[:60] in blurb
+        assert "(model: codex/gpt-5)" in blurb
+
+    def test_builtin_without_profile_is_description_only(self, stub_profiles):
+        blurb = orch._role_blurb("contrarian", "openai/gpt-4.1-mini")
+        assert "minority" in blurb
+        assert "model:" not in blurb
+
+    def test_profile_only_role_gets_a_non_empty_blurb(self, stub_profiles):
+        stub_profiles["deckhand"] = AgentProfile(
+            name="deckhand",
+            raw_body=(
+                "# alpha[Deckhand]\n\n"
+                "`deckhand -> LION`\n\n"
+                "**Mission**: keep the rigging sound and the decks clear.\n\n"
+                "## Identity\n\nYou are the deckhand.\n"
+            ),
+            model="codex/gpt-5",
+        )
+        blurb = orch._role_blurb("deckhand", "openai/gpt-4.1-mini")
+
+        assert "keep the rigging sound and the decks clear" in blurb
+        assert "(model: codex/gpt-5)" in blurb
+        assert "user profile" not in blurb
+
+    def test_profile_without_mission_uses_its_first_prose(self, stub_profiles):
+        stub_profiles["deckhand"] = AgentProfile(
+            name="deckhand",
+            raw_body=("# Deckhand\n\nYou keep the rigging sound. Second sentence is dropped.\n"),
+            model="codex/gpt-5",
+        )
+        blurb = orch._role_blurb("deckhand", "openai/gpt-4.1-mini")
+
+        assert blurb.startswith("You keep the rigging sound")
+        assert "Second sentence" not in blurb
+
+    def test_unusable_profile_body_falls_back_to_the_plain_line(self, stub_profiles):
+        stub_profiles["deckhand"] = AgentProfile(
+            name="deckhand", raw_body="# Deckhand\n\n---\n\n| a | b |\n", model=None
+        )
+        blurb = orch._role_blurb("deckhand", "openai/gpt-4.1-mini")
+
+        assert blurb == "user profile (model: openai/gpt-4.1-mini)"
+
+    def test_long_description_is_capped(self, stub_profiles):
+        stub_profiles["deckhand"] = AgentProfile(
+            name="deckhand", raw_body="# Deckhand\n\n**Mission**: " + "rope " * 200, model=None
+        )
+        blurb = orch._role_blurb("deckhand", "openai/gpt-4.1-mini")
+
+        assert "…" in blurb
+        assert len(blurb.split(" (model:")[0]) <= 161
+
+
+class TestRoleRoster:
+    def test_one_line_per_role(self):
+        roster = orch.role_roster("openai/gpt-4.1-mini")
+        lines = roster.split("\n")[1:]
+        assert len(lines) == len(orch.available_roles())
+        assert all(line.startswith("- ") for line in lines)
+
+    def test_every_line_carries_a_description(self):
+        roster = orch.role_roster("openai/gpt-4.1-mini")
+        bare = [
+            line
+            for line in roster.split("\n")[1:]
+            if line.split(": ", 1)[1].startswith("user profile (model:")
+        ]
+        assert bare == []

--- a/tests/cli/orchestrate/test_role_roster.py
+++ b/tests/cli/orchestrate/test_role_roster.py
@@ -27,14 +27,30 @@ def stub_profiles(monkeypatch):
 
 
 class TestRoleBlurb:
-    def test_builtin_with_profile_keeps_description_and_names_model(self, stub_profiles):
+    def test_profile_body_describes_the_role_it_replaces(self, stub_profiles):
+        """A profile that defines a body replaces the built-in role body, so the
+        roster must describe the profile rather than the role it shadowed."""
         from lionagi.casts.pattern import Role
 
         stub_profiles["critic"] = AgentProfile(
             name="critic",
             raw_body="# Critic\n\n**Mission**: gate the release.",
+            system_prompt="# Critic\n\n**Mission**: gate the release.",
             model="codex/gpt-5",
         )
+        blurb = orch._role_blurb("critic", "openai/gpt-4.1-mini")
+
+        assert "gate the release" in blurb
+        assert "(model: codex/gpt-5)" in blurb
+        opening = Role.load("critic").description.split(". ", 1)[0]
+        assert opening[:60] not in blurb
+
+    def test_profile_that_only_sets_a_model_keeps_the_builtin_description(self, stub_profiles):
+        """Such a profile leaves the built-in body composing, so the built-in
+        description is the accurate one; the profile still names the model."""
+        from lionagi.casts.pattern import Role
+
+        stub_profiles["critic"] = AgentProfile(name="critic", model="codex/gpt-5")
         blurb = orch._role_blurb("critic", "openai/gpt-4.1-mini")
 
         opening = Role.load("critic").description.split(". ", 1)[0]

--- a/tests/cli/orchestrate/test_role_roster.py
+++ b/tests/cli/orchestrate/test_role_roster.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""The planner roster line for each role: description plus model."""
+"""The body a worker runs, and the roster line that advertises it.
+
+Both are decided by the same signal — whether the profile authored a body — so
+they are tested together: a drift between them is the roster describing one
+thing while the worker runs another.
+"""
 
 from __future__ import annotations
 
@@ -45,12 +50,19 @@ class TestRoleBlurb:
         opening = Role.load("critic").description.split(". ", 1)[0]
         assert opening[:60] not in blurb
 
-    def test_profile_that_only_sets_a_model_keeps_the_builtin_description(self, stub_profiles):
-        """Such a profile leaves the built-in body composing, so the built-in
-        description is the accurate one; the profile still names the model."""
+    def test_frontmatter_only_profile_falls_back_to_the_builtin_description(self, stub_profiles):
+        """A profile with no authored body has no summary of its own, and the
+        built-in role is what such a worker runs, so the built-in description is
+        the accurate line. Built from the parser rather than by hand: the parser
+        gives every profile a system prompt, so a hand-built one with an empty
+        system prompt would test a shape that never occurs."""
         from lionagi.casts.pattern import Role
+        from lionagi.cli._providers import _parse_profile
 
-        stub_profiles["critic"] = AgentProfile(name="critic", model="codex/gpt-5")
+        profile = _parse_profile("critic", "---\nmodel: codex/gpt-5\n---\n")
+        assert not profile.raw_body
+        assert profile.system_prompt, "the shared preamble must not be read as a summary"
+        stub_profiles["critic"] = profile
         blurb = orch._role_blurb("critic", "openai/gpt-4.1-mini")
 
         opening = Role.load("critic").description.split(". ", 1)[0]
@@ -108,14 +120,114 @@ class TestRoleBlurb:
         assert len(blurb.split(" (model:")[0]) <= 161
 
 
+@pytest.fixture
+def stub_roster(stub_profiles, monkeypatch):
+    """A roster built from a fixed profile set rather than from the machine's.
+
+    `role_roster` reaches the agents directories twice — once to list the names
+    and once per name to load them — so stubbing the loader alone still lets the
+    host's own profiles decide the result.
+    """
+    stub_profiles["deckhand"] = AgentProfile(
+        name="deckhand",
+        raw_body="# Deckhand\n\n**Mission**: keep the decks clear.",
+        model="codex/gpt-5",
+    )
+    stub_profiles["critic"] = AgentProfile(
+        name="critic",
+        raw_body="# Critic\n\n**Mission**: gate the release.",
+        system_prompt="# Critic\n\n**Mission**: gate the release.",
+        model="codex/gpt-5",
+    )
+    monkeypatch.setattr(orch, "list_agents", lambda: list(stub_profiles))
+    monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["critic", "contrarian"])
+    return stub_profiles
+
+
+@pytest.fixture
+def worker_env(tmp_path, monkeypatch):
+    """Enough of an orchestration environment to build one worker branch."""
+    from types import SimpleNamespace
+
+    from lionagi import iModel
+
+    class _Session:
+        def __init__(self):
+            self.branches = []
+
+        def include_branches(self, branch):
+            self.branches.append(branch)
+
+    monkeypatch.setattr(
+        orch,
+        "build_imodel_from_spec",
+        lambda *_a, **_kw: iModel(provider="openai", model="gpt-4o-mini", api_key="dummy-key"),
+    )
+    return SimpleNamespace(
+        run=SimpleNamespace(agent_artifact_dir=lambda name: tmp_path / name),
+        session=_Session(),
+        default_model_spec="openai/gpt-4o-mini",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=str(tmp_path),
+        team_data=None,
+        exchange=None,
+        messenger=None,
+        roster=None,
+        messenger_names=None,
+        pack=None,
+        _live_persist=None,
+        register_name=lambda _name: None,
+    )
+
+
+CRITIC_BODY_MARKER = "The null hypothesis is failure"
+
+
+class TestAuthoredBodySelection:
+    """Which body a worker actually runs — the claim the roster line makes."""
+
+    @pytest.mark.asyncio
+    async def test_frontmatter_only_profile_leaves_the_role_composing(
+        self, worker_env, stub_profiles
+    ):
+        from lionagi.cli._providers import _parse_profile
+
+        stub_profiles["critic"] = _parse_profile("critic", "---\neffort: high\n---\n")
+        branch, *_ = await orch.build_worker_branch(
+            worker_env, agent_id="critic", role="critic", explicit_name="critic"
+        )
+
+        assert CRITIC_BODY_MARKER in branch.system.rendered
+
+    @pytest.mark.asyncio
+    async def test_authored_body_replaces_the_role(self, worker_env, stub_profiles):
+        from lionagi.cli._providers import _parse_profile
+
+        stub_profiles["critic"] = _parse_profile(
+            "critic", "---\neffort: high\n---\n# Critic\n\n**Mission**: gate the release.\n"
+        )
+        branch, *_ = await orch.build_worker_branch(
+            worker_env, agent_id="critic", role="critic", explicit_name="critic"
+        )
+
+        assert "gate the release" in branch.system.rendered
+        assert CRITIC_BODY_MARKER not in branch.system.rendered
+
+
 class TestRoleRoster:
-    def test_one_line_per_role(self):
+    def test_one_line_per_role(self, stub_roster):
         roster = orch.role_roster("openai/gpt-4.1-mini")
         lines = roster.split("\n")[1:]
         assert len(lines) == len(orch.available_roles())
         assert all(line.startswith("- ") for line in lines)
 
-    def test_every_line_carries_a_description(self):
+    def test_every_line_carries_a_description(self, stub_roster):
         roster = orch.role_roster("openai/gpt-4.1-mini")
         bare = [
             line


### PR DESCRIPTION
Closes #2553.

The planner chooses each subtask's assignee from `role_roster()`, and that roster
is the only description of the roles it ever sees. `_role_blurb()` resolved a user
profile first and, when one existed, returned `user profile (model: X)` without
ever reaching a description. Since profiles are looked up by role name, every role
with a same-named profile lost its guidance.

Measured before and after, the same way, with the imported package asserted to
resolve to the tree under test inside the process that produced the count:
**0 of 49 roster lines carried a description before; 49 of 49 after.**

## Which description wins

The blurb now describes the body that will actually run, which is not always the
built-in one:

- A profile that defines its own system prompt **replaces** the built-in role body,
  so the profile's own summary is the accurate description. The built-in text there
  names a body that is never built.
- A profile that only sets a model or effort leaves the built-in body composing,
  and has no summary of its own, so those fall through to the built-in description
  without needing a special case.
- A profile with no built-in counterpart uses its own summary; when nothing usable
  can be read from it, the previous `user profile (model: X)` line remains.

The model is still named in every case where a profile supplies one — it is useful,
it is just not guidance on its own.

This precedence was inverted partway through: an earlier revision preferred the
built-in description whenever both existed, on the grounds that the built-in
descriptions are written as selection guidance and end in explicit "pick when"
clauses. That is true, and it is the weaker consideration. `contrarian` is the case
that settles it — the built-in role describes itself as preserving minority
positions and explicitly **not** as an adversarial attacker, while the profile
shadowing it is counsel for the opposition. Advertising the first for a worker that
is the second is worse than showing nothing.

## Reading a summary out of a profile

Profiles state their purpose on a `**Mission**:` line, so that is preferred, then
the first paragraph of prose, then the existing fallback. Two things that looked
obvious and are not, both found by checking the files rather than assuming their
shape:

- These files do **not** open with their mission. Every one opens with a heading and
  several carry an annotation line before it, so an implementation that takes the
  opening line returns the heading for eight roles and looks correct in a spot
  check.
- Prose-first would be wrong even though it reads better in a couple of cases: at
  least one profile's first prose paragraph is shared boilerplate, which would
  produce a confidently wrong blurb.

One honest caveat: some mission lines are notation-dense and read less plainly than
the built-in descriptions. That is a property of those files, and editing them is
out of scope here.

## Tests

8 new tests in `tests/cli/orchestrate/test_role_roster.py`, hermetic — profiles are
served from a fixture dict rather than from the machine's agents directories, so the
result does not depend on host configuration. 5 of 8 fail on the unmodified tree;
the 3 that pass both sides are preservation guards on the fallback line and on the
one-line-per-role invariant, which is what they are for.

Full `tests/cli` run: 2291 tests, 1 failure, and that failure is
`test_flow_planning.py::test_pack_routing_shown_in_dry_run`, which fails identically
on the unmodified tree because it reads ambient host configuration. It is unrelated
to this change and is tracked separately in #2548.

## Found while here, not fixed

`postmortem-lead` and `postmortem_lead` produce two roster lines for one role:
`available_roles()` unions raw name strings while profile resolution maps both
spellings to the same file. Both lines now carry the same description, so this
change does not make it worse, but it belongs in `available_roles()` and is a
separate fix.
