### PR TITLE
fix(mcp): one predicate for which providers receive a forwarded MCP server set

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -9,7 +9,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from lionagi._errors import ConfigurationError
+from lionagi.ln import Unset
 from lionagi.ln.concurrency import is_coro_func
+from lionagi.ln.types import UnsetType
 from lionagi.session.branch import Branch
 
 from .spec import AgentSpec
@@ -48,8 +50,16 @@ async def create_agent(
     trusted_hook_modules: set[str] | frozenset[str] | None = None,
     chat_model: Any = None,
     log_config: Any = None,
+    resolved_mcp_servers: dict[str, Any] | None | UnsetType = Unset,
 ) -> Branch:
-    """Create a fully wired Branch from AgentSpec: settings → hooks → prompt → model → tools."""
+    """Create a fully wired Branch from AgentSpec: settings → hooks → prompt → model → tools.
+
+    ``resolved_mcp_servers`` is for a caller that already read a server set of
+    its own — it is handed to the CLI request verbatim and suppresses the
+    discovery this factory would otherwise do from the agent's own working
+    directory. ``None`` means "hand nothing over"; leaving it unset keeps the
+    discovery behaviour.
+    """
     spec = config
 
     if load_settings:
@@ -147,7 +157,12 @@ async def create_agent(
     _register_tools(branch, spec)
     _register_providers(branch, spec)
     await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
-    _forward_mcp_to_cli_request(branch, spec, trust_project_settings=trust_project_settings)
+    _forward_mcp_to_cli_request(
+        branch,
+        spec,
+        trust_project_settings=trust_project_settings,
+        resolved_servers=resolved_mcp_servers,
+    )
     _wire_external_hooks(branch, spec)
 
     if op := spec.emission_operable():
@@ -599,10 +614,33 @@ def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
     One answer for a capability with two transports: claude_code takes the set
     as a request kwarg, codex takes it as `-c mcp_servers.<name>.<field>`
     overrides. Both are implemented in ``_forward_mcp_to_cli_request`` below,
-    which is why the predicate lives here; callers that only report what a leg
-    will get must ask this rather than keep a second list.
+    which is why the predicate lives here rather than in a second list kept by
+    a caller. It answers what a provider is *capable* of, which is not the same
+    question as whether a given spawn handed anything over — for that, read
+    ``request_carries_forwarded_mcp`` off the request the spawn produced.
     """
     return provider in _MCP_FORWARDING_PROVIDERS
+
+
+def request_carries_forwarded_mcp(branch: Branch) -> bool:
+    """Whether a built CLI request actually carries a forwarded MCP server set.
+
+    The read counterpart of the writes ``_forward_mcp_to_cli_request`` makes
+    below: the two transports put the set in different places, so a caller that
+    reports what a leg is getting asks the request that was built rather than
+    re-deriving it from the provider name or from what it resolved itself.
+    Codex entries that only disable a server by name are not a set being handed
+    over, so they do not count.
+    """
+    config = getattr(getattr(branch.chat_model, "endpoint", None), "config", None)
+    kwargs = getattr(config, "kwargs", None) or {}
+    if kwargs.get("mcp_servers"):
+        return True
+    overrides = kwargs.get("config_overrides") or {}
+    return any(
+        key.startswith("mcp_servers.") and not (key.endswith(".enabled") and value is False)
+        for key, value in overrides.items()
+    )
 
 
 def _forward_mcp_to_cli_request(
@@ -610,23 +648,35 @@ def _forward_mcp_to_cli_request(
     spec: AgentSpec,
     *,
     trust_project_settings: bool = False,
+    resolved_servers: dict[str, Any] | None | UnsetType = Unset,
 ) -> None:
-    """Forward AgentSpec MCP fields into the claude_code CLI's own request.
+    """Forward an MCP server set into the CLI provider's own request.
 
     ``_load_mcp`` only reaches lionagi-native ``branch.acts`` tools (inert for
     CLI providers); this reaches the per-turn request kwargs a CLI provider
     subprocess actually reads. See docs/internals/runtime.md.
+
+    With ``resolved_servers`` given, that set is what gets handed over and no
+    config file is looked for: a caller that already resolved a set is saying
+    which servers this agent gets, and discovering a second one from the
+    agent's working directory would silently replace it.
     """
-    mcp_path = _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
-    if mcp_path is None and spec.mcp_servers is None:
-        # Nothing configured at all: no config file resolves and no explicit
-        # server-name filter was set. Nothing to forward.
+    caller_resolved = resolved_servers is not Unset
+    mcp_path = (
+        None
+        if caller_resolved
+        else _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
+    )
+    has_config = resolved_servers is not None if caller_resolved else mcp_path is not None
+    if not has_config and spec.mcp_servers is None:
+        # Nothing configured at all: no server set was handed in, no config
+        # file resolves, and no explicit server-name filter was set.
         return
 
     provider = getattr(branch.chat_model.endpoint.config, "provider", None)
 
     if not provider_accepts_forwarded_mcp(provider):
-        if mcp_path is not None:
+        if has_config:
             import logging
 
             # Scope the claim to what this call can see: one branch, whose
@@ -646,10 +696,13 @@ def _forward_mcp_to_cli_request(
         # so this stays a silent no-op (mirrors _load_mcp's own shape).
         return
 
-    if mcp_path is None:
+    if caller_resolved:
+        # Hand over exactly what the caller read, snapshot and all.
+        servers: dict = dict(resolved_servers or {})
+    elif mcp_path is None:
         # No config file resolves: the available-servers set is empty, which
         # matches the explicit-empty-allowlist case.
-        servers: dict = {}
+        servers = {}
     else:
         import json
         from pathlib import Path
@@ -683,7 +736,7 @@ def _forward_mcp_to_cli_request(
     # Keep the pre-filter server set: an explicit (possibly empty) allowlist
     # needs to know which discovered servers it excluded, not just which it
     # kept (see the codex disabling block below).
-    resolved_servers = servers
+    available_servers = servers
 
     if spec.mcp_servers is not None:
         # Explicit filter set (possibly empty): mirrors _load_mcp's
@@ -746,9 +799,9 @@ def _forward_mcp_to_cli_request(
         # by name instead. "Discovered" must include ambient/profile servers
         # codex would load on its own, not just the ones lionagi's own MCP
         # config resolved -- otherwise an allowlist enforced against an empty
-        # `resolved_servers` (no lionagi MCP config file resolved) is a
+        # `available_servers` (no lionagi MCP config file resolved) is a
         # no-op, leaving every ambient server enabled.
-        discovered_names = set(resolved_servers) | _discover_ambient_codex_mcp_server_names()
+        discovered_names = set(available_servers) | _discover_ambient_codex_mcp_server_names()
         for excluded_name in discovered_names:
             if excluded_name not in spec.mcp_servers:
                 overrides[f"mcp_servers.{excluded_name}.enabled"] = False

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -590,6 +590,21 @@ async def _load_mcp(
                 _attach_hooks(tool, spec, tool_name)
 
 
+_MCP_FORWARDING_PROVIDERS = frozenset({"claude_code", "codex"})
+
+
+def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
+    """Whether a provider's request can carry an MCP server set resolved by the caller.
+
+    One answer for a capability with two transports: claude_code takes the set
+    as a request kwarg, codex takes it as `-c mcp_servers.<name>.<field>`
+    overrides. Both are implemented in ``_forward_mcp_to_cli_request`` below,
+    which is why the predicate lives here; callers that only report what a leg
+    will get must ask this rather than keep a second list.
+    """
+    return provider in _MCP_FORWARDING_PROVIDERS
+
+
 def _forward_mcp_to_cli_request(
     branch: Branch,
     spec: AgentSpec,
@@ -610,7 +625,7 @@ def _forward_mcp_to_cli_request(
 
     provider = getattr(branch.chat_model.endpoint.config, "provider", None)
 
-    if provider not in ("claude_code", "codex"):
+    if not provider_accepts_forwarded_mcp(provider):
         if mcp_path is not None:
             import logging
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -306,10 +306,9 @@ def _report_mcp_resolution(
     for the one case where it is accurate: servers resolved and handed over.
 
     ``forwarded`` is the caller's answer to "does this spawn hand the resolved
-    set to the leg?" — it is read off the request that was just built, or off
-    ``provider_accepts_forwarded_mcp`` where the hand-off happens later during
-    agent construction. This function must not re-derive it from the provider
-    name: a second list here is what let the message contradict the spawn.
+    set to the leg?", read off the request that spawn built. This function must
+    not re-derive it from the provider name: a second list here is what let the
+    message contradict the spawn.
     """
     from lionagi.cli._logging import warn
 
@@ -522,18 +521,15 @@ async def _run_agent(
         )
         effort = resolve_persisted_effort(provider, chat_model, effort)
         # Two spawn shapes hand the set over in two different places, so the
-        # message has to ask the one that applies. A create_agent leg gets it
-        # from the forwarder a few lines below (both CLI transports); a plain
-        # leg gets only what build_chat_model already put on the request.
+        # message has to read the one that applies. A plain leg gets only what
+        # build_chat_model already put on the request, which is knowable here;
+        # a create_agent leg is handed the set inside create_agent, so its
+        # message waits for the request that call produces (below).
         takes_create_agent_path = preset == "coding" or has_role_key
-        if takes_create_agent_path:
-            from lionagi.agent.factory import provider_accepts_forwarded_mcp
-
-            forwarded = provider_accepts_forwarded_mcp(provider)
-        else:
+        if not takes_create_agent_path:
             built_config = getattr(getattr(chat_model, "endpoint", None), "config", None)
             forwarded = bool(built_config and "mcp_servers" in built_config.kwargs)
-        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd, forwarded=forwarded)
+            _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd, forwarded=forwarded)
 
         # Opt-in profile `role:` key switches a plain `-a <profile>` leg onto
         # the same create_agent path as --preset coding, parameterized by role.
@@ -541,7 +537,10 @@ async def _run_agent(
             took_create_agent_path = True
             # Use create_agent so CodingToolkit tools and path-guards are wired;
             # compose the profile extension into the spec before calling it.
-            from lionagi.agent.factory import create_agent
+            from lionagi.agent.factory import (
+                create_agent,
+                request_carries_forwarded_mcp,
+            )
 
             # Use profile.raw_body, not profile.system_prompt, to avoid
             # duplicating LION_SYSTEM_MESSAGE (see docs/internals/cli.md).
@@ -558,11 +557,24 @@ async def _run_agent(
             # of the profile's frontmatter — propagate an explicit opt-out.
             if profile is not None and not profile.lion_system:
                 spec.lion_system = False
+            # Hand over the set resolved from the submitting directory. Without
+            # it the factory looks for a config of its own, and a leg pointed
+            # at a checkout gets whatever is found near the target instead of
+            # what this command resolved and reported.
             branch = await create_agent(
                 spec,
                 chat_model=chat_model,
                 log_config=DataLoggerConfig(auto_save_on_exit=False),
                 load_settings=False,
+                resolved_mcp_servers=mcp_resolution.servers,
+            )
+            # The hand-over happened inside create_agent, so the request it
+            # produced is the only honest source for what this leg is getting.
+            _report_mcp_resolution(
+                mcp_resolution,
+                provider=provider,
+                cwd=cwd,
+                forwarded=request_carries_forwarded_mcp(branch),
             )
         else:
             branch = Branch(

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -295,23 +295,30 @@ class _ProgressReport:
         )
 
 
-def _report_mcp_resolution(resolution: McpResolution, *, provider: str, cwd: str | None) -> None:
+def _report_mcp_resolution(
+    resolution: McpResolution, *, provider: str, cwd: str | None, forwarded: bool
+) -> None:
     """Say at spawn time what tool surface the leg is actually getting.
 
     The whole point of resolving here is that a leg starting without the
     servers its instructions assume should be visible when it is launched
     rather than inferred from its output an hour later. Silence is reserved
     for the one case where it is accurate: servers resolved and handed over.
+
+    ``forwarded`` is the caller's answer to "does this spawn hand the resolved
+    set to the leg?" — it is read off the request that was just built, or off
+    ``provider_accepts_forwarded_mcp`` where the hand-off happens later during
+    agent construction. This function must not re-derive it from the provider
+    name: a second list here is what let the message contradict the spawn.
     """
     from lionagi.cli._logging import warn
 
-    if provider not in _CLAUDE_PROVIDER_NAMES:
+    if not forwarded:
         if resolution.servers is not None:
             warn(
                 f"MCP servers resolved from {resolution.source} are not carried to "
-                f"provider {provider!r}: this spawn path only hands a resolved server "
-                "set to the Claude CLI lane. This leg gets whatever its own provider "
-                "resolves for itself."
+                f"provider {provider!r} on this spawn path. This leg gets whatever "
+                "its own provider resolves for itself."
             )
         return
 
@@ -327,7 +334,7 @@ def _report_mcp_resolution(resolution: McpResolution, *, provider: str, cwd: str
     warn(
         f"no MCP servers are being handed to this leg ({resolution.reason}; searched "
         f"from {resolution.searched_from}). It will start with only whatever the "
-        f"Claude CLI discovers from {target} itself, which is where a leg pointed at "
+        f"{provider} CLI discovers from {target} itself, which is where a leg pointed at "
         "a checkout silently loses them. Pass --mcp-config PATH, or --no-mcp-config "
         "to state that this is intended."
     )
@@ -514,11 +521,23 @@ async def _run_agent(
             mcp_servers=mcp_resolution.servers,
         )
         effort = resolve_persisted_effort(provider, chat_model, effort)
-        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
+        # Two spawn shapes hand the set over in two different places, so the
+        # message has to ask the one that applies. A create_agent leg gets it
+        # from the forwarder a few lines below (both CLI transports); a plain
+        # leg gets only what build_chat_model already put on the request.
+        takes_create_agent_path = preset == "coding" or has_role_key
+        if takes_create_agent_path:
+            from lionagi.agent.factory import provider_accepts_forwarded_mcp
+
+            forwarded = provider_accepts_forwarded_mcp(provider)
+        else:
+            built_config = getattr(getattr(chat_model, "endpoint", None), "config", None)
+            forwarded = bool(built_config and "mcp_servers" in built_config.kwargs)
+        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd, forwarded=forwarded)
 
         # Opt-in profile `role:` key switches a plain `-a <profile>` leg onto
         # the same create_agent path as --preset coding, parameterized by role.
-        if preset == "coding" or has_role_key:
+        if takes_create_agent_path:
             took_create_agent_path = True
             # Use create_agent so CodingToolkit tools and path-guards are wired;
             # compose the profile extension into the spec before calling it.
@@ -617,7 +636,11 @@ async def _run_agent(
         # not the caller's directory.
         if mcp_resolution.servers is not None and provider in _CLAUDE_PROVIDER_NAMES:
             cfg["mcp_servers"] = mcp_resolution.servers
-        _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd)
+        # A resumed leg re-spawns from the persisted request, which is the only
+        # thing that decides what it carries — read the answer off it.
+        _report_mcp_resolution(
+            mcp_resolution, provider=provider, cwd=cwd, forwarded="mcp_servers" in cfg
+        )
 
     # Add the profile system prompt for every leg EXCEPT one whose branch carries
     # (or, on a brand-new leg, would carry) a create_agent-composed system message

--- a/tests/cli/test_agent_mcp_scope_messages.py
+++ b/tests/cli/test_agent_mcp_scope_messages.py
@@ -35,7 +35,7 @@ def _capture_warnings(fn):
 def test_non_claude_provider_warning_is_leg_scoped():
     resolution = McpResolution({"khive": {"command": "kkernel"}}, None, "/tmp/.mcp.json", "/tmp")
     messages = _capture_warnings(
-        lambda: _report_mcp_resolution(resolution, provider="codex", cwd="/tmp")
+        lambda: _report_mcp_resolution(resolution, provider="codex", cwd="/tmp", forwarded=False)
     )
 
     assert len(messages) == 1
@@ -50,7 +50,9 @@ def test_non_claude_provider_warning_is_leg_scoped():
 def test_no_servers_warning_is_leg_scoped():
     resolution = McpResolution(None, "no_mcp_config_found", None, "/tmp")
     messages = _capture_warnings(
-        lambda: _report_mcp_resolution(resolution, provider="claude_code", cwd="/tmp")
+        lambda: _report_mcp_resolution(
+            resolution, provider="claude_code", cwd="/tmp", forwarded=True
+        )
     )
 
     assert len(messages) == 1

--- a/tests/cli/test_agent_preset_mcp_handover.py
+++ b/tests/cli/test_agent_preset_mcp_handover.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A coding-preset leg must be handed the MCP servers resolved at submission.
+
+The whole point of resolving the server set from the submitting directory is
+that a leg pointed at a checkout without a config of its own still gets the
+servers its instructions assume. The coding preset builds its agent through
+the factory, which resolves an MCP config of its own unless it is handed one,
+so these spawn with a config that exists only where the command was submitted
+and assert the leg's request carries exactly that set — for both CLI
+transports, since they carry it in different places.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._logging import _HINT_LOGGER_NAME, _WARN_LOGGER_NAME
+
+
+@contextlib.contextmanager
+def _capture_cli_messages():
+    """Collect what the spawn tells its caller.
+
+    Handlers go on the CLI's own channels rather than through caplog: those
+    loggers stop propagating once CLI logging is configured, and whether that
+    has happened depends on what else ran in the session.
+    """
+    messages: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    handler = _Collect()
+    loggers = [logging.getLogger(name) for name in (_HINT_LOGGER_NAME, _WARN_LOGGER_NAME)]
+    restore = [(logger, logger.level) for logger in loggers]
+    for logger in loggers:
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    try:
+        yield messages
+    finally:
+        for logger, level in restore:
+            logger.removeHandler(handler)
+            logger.setLevel(level)
+
+
+SUBMITTED = {"khive": {"command": "kkernel", "args": ["serve"]}}
+NEARBY = {"decoy": {"command": "not-the-submitted-server"}}
+
+
+def _write_mcp_config(directory: Path, servers: dict) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / ".mcp.json"
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return path
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path):
+    """Stub everything the spawn does except building the branch itself."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    branches_created: list = []
+    real_branch_init = Branch.__init__
+
+    def spy_branch_init(self, *args, **kwargs):
+        real_branch_init(self, *args, **kwargs)
+        branches_created.append(self)
+
+    monkeypatch.setattr(Branch, "__init__", spy_branch_init)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(ctx, **kw):
+        return kw.get("status", "completed")
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return branches_created
+
+
+@pytest.fixture
+def spawn(monkeypatch, tmp_path):
+    """A submitting directory holding the config, and a target holding none.
+
+    HOME is redirected too: the factory's own resolution falls back to a
+    home-level config, and a real one on the machine running the tests would
+    otherwise decide the outcome.
+    """
+    branches_created = _wire_agent_stubs(monkeypatch, tmp_path)
+
+    submit_dir = tmp_path / "submit"
+    _write_mcp_config(submit_dir, SUBMITTED)
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    home = tmp_path / "home"
+    _write_mcp_config(home / ".lionagi", NEARBY)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(submit_dir)
+
+    return SimpleNamespace(
+        branches=branches_created,
+        submit_dir=submit_dir,
+        target_dir=target_dir,
+        home=home,
+    )
+
+
+def _forwarded_servers(branch) -> dict:
+    """The server set a built request carries, per transport."""
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    provider = branch.chat_model.endpoint.config.provider
+    if provider == "codex":
+        overrides = kwargs.get("config_overrides") or {}
+        servers: dict = {}
+        for key, value in overrides.items():
+            if not key.startswith("mcp_servers."):
+                continue
+            _, name, field = key.split(".", 2)
+            servers.setdefault(name, {})[field] = value
+        return servers
+    return kwargs.get("mcp_servers") or {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude_code/sonnet", "codex/gpt-5.3-codex"])
+async def test_preset_leg_gets_the_submitted_servers_not_the_target_directory(spawn, model):
+    """The config exists only where the command was submitted; --cwd has none."""
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(model, "go", preset="coding", cwd=str(spawn.target_dir), yolo=True)
+
+    branch = spawn.branches[-1]
+    forwarded = _forwarded_servers(branch)
+    assert set(forwarded) == {"khive"}
+    assert forwarded["khive"]["command"] == "kkernel"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude_code/sonnet", "codex/gpt-5.3-codex"])
+async def test_explicit_mcp_config_beats_a_config_at_the_target_directory(spawn, tmp_path, model):
+    """--mcp-config names the set; a config sitting at --cwd does not win."""
+    from lionagi.cli.agent import _run_agent
+
+    named = _write_mcp_config(tmp_path / "named", {"named": {"command": "named-server"}})
+    _write_mcp_config(spawn.target_dir, NEARBY)
+
+    await _run_agent(
+        model,
+        "go",
+        preset="coding",
+        cwd=str(spawn.target_dir),
+        yolo=True,
+        mcp_config=str(named),
+    )
+
+    assert set(_forwarded_servers(spawn.branches[-1])) == {"named"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude_code/sonnet", "codex/gpt-5.3-codex"])
+async def test_no_mcp_config_hands_nothing_over(spawn, model):
+    """--no-mcp-config is a choice: the leg's request carries no server set."""
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        model,
+        "go",
+        preset="coding",
+        cwd=str(spawn.target_dir),
+        yolo=True,
+        no_mcp_config=True,
+    )
+
+    assert _forwarded_servers(spawn.branches[-1]) == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude_code/sonnet", "codex/gpt-5.3-codex"])
+async def test_spawn_message_names_what_the_request_carries(spawn, model):
+    """What the caller is told and what the leg gets are the same servers."""
+    from lionagi.cli.agent import _run_agent
+
+    with _capture_cli_messages() as messages:
+        await _run_agent(model, "go", preset="coding", cwd=str(spawn.target_dir), yolo=True)
+
+    reported = "\n".join(messages)
+    assert "[mcp]" in reported
+    for name in _forwarded_servers(spawn.branches[-1]):
+        assert name in reported
+    assert "decoy" not in reported
+    assert "not carried" not in reported
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude_code/sonnet", "codex/gpt-5.3-codex"])
+async def test_no_mcp_config_is_not_reported_as_servers_handed_over(spawn, model):
+    from lionagi.cli.agent import _run_agent
+
+    with _capture_cli_messages() as messages:
+        await _run_agent(
+            model,
+            "go",
+            preset="coding",
+            cwd=str(spawn.target_dir),
+            yolo=True,
+            no_mcp_config=True,
+        )
+
+    assert not [m for m in messages if "[mcp]" in m or "not carried" in m]
+
+
+@pytest.mark.asyncio
+async def test_named_mcp_config_that_does_not_exist_still_refuses_the_spawn(spawn, tmp_path):
+    """An explicitly named config that cannot be used stays a loud failure."""
+    from lionagi.cli._mcp_resolve import McpConfigError
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(McpConfigError):
+        await _run_agent(
+            "claude_code/sonnet",
+            "go",
+            preset="coding",
+            cwd=str(spawn.target_dir),
+            yolo=True,
+            mcp_config=str(tmp_path / "nowhere" / ".mcp.json"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_named_mcp_config_that_does_not_parse_still_refuses_the_spawn(spawn, tmp_path):
+    from lionagi.cli._mcp_resolve import McpConfigError
+    from lionagi.cli.agent import _run_agent
+
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not json")
+
+    with pytest.raises(McpConfigError):
+        await _run_agent(
+            "claude_code/sonnet",
+            "go",
+            preset="coding",
+            cwd=str(spawn.target_dir),
+            yolo=True,
+            mcp_config=str(broken),
+        )

--- a/tests/cli/test_mcp_forwarding_predicate.py
+++ b/tests/cli/test_mcp_forwarding_predicate.py
@@ -1,0 +1,134 @@
+"""One answer to "does this provider receive a forwarded MCP server set?".
+
+The forwarding implementation and the spawn-time message a caller reads must
+agree. They used to keep separate provider lists, so a codex leg was told the
+resolved servers were unreachable and was then handed them anyway.
+"""
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from lionagi.agent.factory import (
+    _forward_mcp_to_cli_request,
+    provider_accepts_forwarded_mcp,
+)
+from lionagi.cli._logging import _WARN_LOGGER_NAME
+from lionagi.cli._mcp_resolve import McpResolution
+from lionagi.cli.agent import _report_mcp_resolution
+
+# Every provider name the CLI can route a leg to, plus one API provider, so a
+# new CLI backend cannot quietly land on the wrong side of the predicate.
+KNOWN_PROVIDERS = ["claude_code", "codex", "gemini-cli", "pi", "claude", "openai"]
+
+
+class _FakeConfig:
+    def __init__(self, provider):
+        self.provider = provider
+        self.kwargs: dict = {}
+
+
+class _FakeModel:
+    def __init__(self, provider):
+        self.endpoint = SimpleNamespace(config=_FakeConfig(provider))
+
+    def copy(self, **_):
+        return self
+
+
+def _fake_branch(provider):
+    return SimpleNamespace(chat_model=_FakeModel(provider), id="branch-1")
+
+
+def _fake_spec(mcp_config_path):
+    return SimpleNamespace(
+        mcp_config_path=str(mcp_config_path),
+        mcp_servers=None,
+        cwd=None,
+        profile=SimpleNamespace(role=SimpleNamespace(name="implementer")),
+    )
+
+
+@pytest.fixture
+def mcp_config(tmp_path):
+    path = tmp_path / ".mcp.json"
+    path.write_text(json.dumps({"mcpServers": {"khive": {"command": "kkernel"}}}))
+    return path
+
+
+def _capture_warnings(fn):
+    records: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger(_WARN_LOGGER_NAME)
+    handler = _Collect()
+    logger.addHandler(handler)
+    try:
+        fn()
+    finally:
+        logger.removeHandler(handler)
+    return records
+
+
+@pytest.mark.parametrize("provider", KNOWN_PROVIDERS)
+def test_predicate_matches_what_the_forwarder_does(provider, mcp_config):
+    """The predicate is true exactly when the request comes back carrying servers."""
+    branch = _fake_branch(provider)
+    _forward_mcp_to_cli_request(branch, _fake_spec(mcp_config))
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    request_carries_servers = bool(kwargs.get("mcp_servers")) or bool(
+        kwargs.get("config_overrides")
+    )
+
+    assert request_carries_servers is provider_accepts_forwarded_mcp(provider)
+
+
+def test_forwarding_providers_are_the_two_cli_transports():
+    accepted = {p for p in KNOWN_PROVIDERS if provider_accepts_forwarded_mcp(p)}
+    assert accepted == {"claude_code", "codex"}
+
+
+def test_unknown_provider_is_not_assumed_to_accept():
+    assert provider_accepts_forwarded_mcp(None) is False
+    assert provider_accepts_forwarded_mcp("not-a-provider") is False
+
+
+def test_codex_spawn_that_forwards_is_not_told_the_servers_are_unreachable():
+    """The message a codex leg's caller reads must match what the spawn does."""
+    resolution = McpResolution({"khive": {"command": "kkernel"}}, None, "/tmp/.mcp.json", "/tmp")
+    messages = _capture_warnings(
+        lambda: _report_mcp_resolution(resolution, provider="codex", cwd="/tmp", forwarded=True)
+    )
+    assert messages == []
+
+
+def test_codex_spawn_that_does_not_forward_still_says_so():
+    resolution = McpResolution({"khive": {"command": "kkernel"}}, None, "/tmp/.mcp.json", "/tmp")
+    messages = _capture_warnings(
+        lambda: _report_mcp_resolution(resolution, provider="codex", cwd="/tmp", forwarded=False)
+    )
+    assert len(messages) == 1
+    assert "not carried" in messages[0].lower()
+
+
+def test_build_chat_model_still_sets_the_server_kwarg_for_claude_only():
+    """The request-field question is narrower than the capability question:
+    the codex request model has no such field, so nothing is set there."""
+    from lionagi.cli._providers import build_chat_model
+
+    servers = {"khive": {"command": "kkernel"}}
+
+    claude = build_chat_model(
+        "claude_code", "claude-opus-4-5", False, False, None, mcp_servers=servers
+    )
+    assert claude.endpoint.config.kwargs["mcp_servers"] == servers
+
+    codex = build_chat_model("codex", "gpt-5.3-codex", False, False, None, mcp_servers=servers)
+    codex_kwargs = getattr(getattr(codex, "endpoint", None), "config", None)
+    assert codex_kwargs is None or "mcp_servers" not in codex_kwargs.kwargs


### PR DESCRIPTION
Closes #2552. Closes #2563.

Two commits. The first unifies which providers receive a caller-resolved MCP server set; the second makes the coding-preset path actually hand over the set that was resolved, which a review of the first found it did not.

## One predicate for which providers receive a forwarded set

Two places decided which providers receive a caller-resolved MCP server set, and they disagreed. The forwarder in the agent factory handled both CLI transports — `claude_code` takes the set as a request kwarg, codex takes it as `-c mcp_servers.<name>.<field>` overrides — while the message printed at spawn time keyed off the Claude provider names alone. A codex leg spawned through `create_agent` was told its resolved servers were unreachable and was then handed them a few lines later.

`provider_accepts_forwarded_mcp()` now lives next to the forwarding implementation and is what the forwarder's own gate asks. The provider list is gone from the reporting path.

`build_chat_model` still sets its `mcp_servers` kwarg for the Claude names only, and deliberately so: `CodexCodeRequest` has no such field, and setting it there would be inert. That narrowness is a property of the transport, not a disagreement about capability, and a test pins it as unchanged.

## Handing a coding-preset leg the servers resolved at submission

The reporting path turned out not to be asking quite the same question the forwarder answers. It serves three spawn shapes that hand the set over in different places, and reporting provider capability at the `create_agent` site suppressed a warning on a path that does not deliver: `--preset coding` (and a profile carrying a `role:` key) builds its `AgentSpec` with no MCP fields, so the forwarder resolved a second config of its own and wrote that over the request. `li agent --preset coding --mcp-config PATH` resolved PATH, reported PATH, and handed the leg something else. Both CLI transports took the rediscovered set.

`create_agent` and the forwarder now accept an already-resolved server set. When one is given it is what reaches the request and no config file is looked for at all — a caller that resolved a set is saying which servers this agent gets, and discovering a second one silently replaces it. `None` means hand nothing over, so `--no-mcp-config` still leaves the leg with nothing.

The spawn message for that path is now built from the request the hand-over produced, through a `request_carries_forwarded_mcp()` read that lives next to the code doing the writing. All three spawn shapes now follow one rule: read what the leg gets off its own request. An explicitly named `--mcp-config` that does not exist or does not parse stays a loud refusal at spawn.

The resolved set rides on the `create_agent` call rather than on `AgentSpec`: `AgentSpec.mcp_servers` is a name allowlist, and a serializable spec is the wrong home for a snapshot that can carry `env` or `http_headers` values.

## Tests

`tests/cli/test_mcp_forwarding_predicate.py` — the predicate agrees with what the forwarder does for each provider it handles, the spawn message matches what that spawn goes on to do, and `build_chat_model` is unchanged. Eleven cases collect; ten fail against the parent and the one that passes both before and after is the regression guard on `build_chat_model`. (An earlier version of this description said twelve. Measured: `pytest --collect-only` reports 11.)

`tests/cli/test_agent_preset_mcp_handover.py` — twelve cases across both CLI providers: a preset leg receives the submitted servers rather than a rediscovered set, an explicit `--mcp-config` beats a config present at the target directory, `--no-mcp-config` hands nothing over, and the spawn message agrees with the request in each case. Eight fail against the parent commit; the four that pass both before and after are guards on the `--mcp-config` failure modes and on the `--no-mcp-config` report.

## Known adjacent failure, not from this change

`tests/cli/orchestrate/test_flow_planning.py::test_pack_routing_shown_in_dry_run` fails on a machine with a `writer` agent profile installed, with and without this change. Filed as #2560 and fixed separately.
