### PR TITLE
Show one roster line per role when spellings differ

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -91,11 +91,13 @@ def parse_orchestrator_provider(model_spec: str) -> tuple[str | None, str | None
 
 
 def _role_key(name: str) -> str:
-    """The name a role is known by regardless of which separator it is spelled with.
+    """A name reduced to the separator-independent form the loaders key on.
 
-    ``-`` and ``_`` are interchangeable in a profile name, so both spellings
-    resolve to one profile and one built-in role module. Keying on that makes
-    the roster agree with the loaders instead of listing one role twice.
+    Both spellings reach one built-in role module, so this is what decides
+    whether a profile names a built-in. It is not a claim that two spellings are
+    always one profile: when both files exist, profile resolution gives the exact
+    spelling priority and they are two profiles. ``available_roles`` handles that
+    case separately.
     """
     return name.replace("-", "_")
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -90,11 +90,29 @@ def parse_orchestrator_provider(model_spec: str) -> tuple[str | None, str | None
     return ms.model, provider
 
 
+def _role_key(name: str) -> str:
+    """The name a role is known by regardless of which separator it is spelled with.
+
+    ``-`` and ``_`` are interchangeable in a profile name, so both spellings
+    resolve to one profile and one built-in role module. Keying on that makes
+    the roster agree with the loaders instead of listing one role twice.
+    """
+    return name.replace("-", "_")
+
+
 def available_roles() -> list[str]:
-    """Casts roles + user profiles the orchestrator may assign to."""
+    """Casts roles + user profiles the orchestrator may assign to, one entry per role.
+
+    A profile whose file name spells the separator the other way is the same
+    role as the built-in it matches, so the built-in's spelling is the one
+    listed. A name with no built-in counterpart keeps the profile's spelling.
+    """
     from lionagi.casts.pattern import list_roles
 
-    return sorted(set(list_roles()) | set(list_agents()))
+    canonical = {_role_key(r): r for r in list_roles()}
+    for name in list_agents():
+        canonical.setdefault(_role_key(name), name)
+    return sorted(canonical.values())
 
 
 def _first_sentence(text: str) -> str:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -105,14 +105,16 @@ def available_roles() -> list[str]:
 
     A profile whose file name spells the separator the other way is the same
     role as the built-in it matches, so the built-in's spelling is the one
-    listed. A name with no built-in counterpart keeps the profile's spelling.
+    listed. Two profiles that differ only in separator and match no built-in
+    are a different case: profile resolution gives an exact spelling priority
+    over the other one, so both files are separately loadable and both stay on
+    the menu. Collapsing them would take a selectable profile off it.
     """
     from lionagi.casts.pattern import list_roles
 
-    canonical = {_role_key(r): r for r in list_roles()}
-    for name in list_agents():
-        canonical.setdefault(_role_key(name), name)
-    return sorted(canonical.values())
+    builtins = {_role_key(r): r for r in list_roles()}
+    profiles = [name for name in list_agents() if _role_key(name) not in builtins]
+    return sorted({*builtins.values(), *profiles})
 
 
 def _first_sentence(text: str) -> str:

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -212,11 +212,22 @@ async def plan(
     )
     raw = list(getattr(res, "assignments", None) or [])
     known = set(roles)
+    # '-' and '_' are interchangeable in a role name, so an assignment that
+    # spells the separator the other way still names a listed role. It is
+    # rewritten to the listed spelling, so everything downstream of the plan
+    # sees one name per role. An exact match always wins, and a spelling that
+    # would match more than one listed role is not resolved by guessing.
+    by_separator: dict[str, list[str]] = {}
+    for r in roles:
+        by_separator.setdefault(r.replace("-", "_"), []).append(r)
     valid: list[TaskAssignment] = []
     for ta in raw:
         if ta.assignee not in known:
-            logger.warning("plan: dropping assignment with unknown assignee %r", ta.assignee)
-            continue
+            matches = by_separator.get(ta.assignee.replace("-", "_"), [])
+            if len(matches) != 1:
+                logger.warning("plan: dropping assignment with unknown assignee %r", ta.assignee)
+                continue
+            ta = ta.model_copy(update={"assignee": matches[0]})
         valid.append(ta)
     if max_tasks and len(valid) > max_tasks:
         raise ValueError(

--- a/tests/cli/orchestrate/test_role_roster.py
+++ b/tests/cli/orchestrate/test_role_roster.py
@@ -235,3 +235,59 @@ class TestRoleRoster:
             if line.split(": ", 1)[1].startswith("user profile (model:")
         ]
         assert bare == []
+
+
+class TestAvailableRoles:
+    """One entry per role, whichever separator each side spells it with.
+
+    The built-in roles are the real catalog; only the agent profiles are
+    stubbed, so these never read the machine's own agents directories.
+    """
+
+    def test_profile_spelling_of_a_builtin_role_is_not_a_second_entry(self, monkeypatch):
+        from lionagi.casts.pattern import list_roles
+
+        monkeypatch.setattr(orch, "list_agents", lambda: ["postmortem_lead"])
+        roles = orch.available_roles()
+
+        assert "postmortem-lead" in roles
+        assert "postmortem_lead" not in roles
+        assert len(roles) == len(set(list_roles()))
+
+    def test_builtin_spelling_wins_whichever_side_is_listed_first(self, monkeypatch):
+        monkeypatch.setattr(orch, "list_agents", lambda: ["postmortem_lead"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["postmortem-lead"])
+
+        assert orch.available_roles() == ["postmortem-lead"]
+
+    def test_profile_only_name_keeps_its_own_spelling(self, monkeypatch):
+        monkeypatch.setattr(orch, "list_agents", lambda: ["deck_hand", "rigging-mate"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["critic"])
+
+        assert orch.available_roles() == ["critic", "deck_hand", "rigging-mate"]
+
+    def test_roster_carries_one_line_for_a_role_spelled_both_ways(self, monkeypatch, stub_profiles):
+        from lionagi.cli._providers import _parse_profile
+
+        stub_profiles["postmortem_lead"] = _parse_profile(
+            "postmortem_lead", "---\nmodel: codex/gpt-5\n---\n"
+        )
+        monkeypatch.setattr(orch, "list_agents", lambda: ["postmortem_lead"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["postmortem-lead"])
+
+        lines = orch.role_roster("openai/gpt-4.1-mini").split("\n")[1:]
+        assert len(lines) == 1
+        assert lines[0].startswith("- postmortem-lead: ")
+
+    def test_mode_roster_states_a_role_restriction_once(self, monkeypatch):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(orch, "list_agents", lambda: ["postmortem_lead"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["postmortem-lead"])
+        pack = SimpleNamespace(
+            config=lambda role: SimpleNamespace(modes_allow=["adversarial"], default_modes=[])
+        )
+
+        text = orch.mode_roster(pack)
+        assert text.count("accepts only adversarial") == 1
+        assert "postmortem_lead accepts" not in text

--- a/tests/cli/orchestrate/test_role_roster.py
+++ b/tests/cli/orchestrate/test_role_roster.py
@@ -266,6 +266,22 @@ class TestAvailableRoles:
 
         assert orch.available_roles() == ["critic", "deck_hand", "rigging-mate"]
 
+    def test_two_profile_only_spellings_both_stay_on_the_menu(self, monkeypatch):
+        """Profile resolution gives an exact spelling priority over the other one,
+        so two files differing only in separator are two selectable profiles."""
+        monkeypatch.setattr(orch, "list_agents", lambda: ["deck-hand", "deck_hand"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["critic"])
+
+        assert orch.available_roles() == ["critic", "deck-hand", "deck_hand"]
+
+    def test_a_builtin_still_absorbs_both_profile_spellings(self, monkeypatch):
+        """The built-in case is the opposite: Role.load accepts only the canonical
+        spelling, so neither profile spelling is a second role."""
+        monkeypatch.setattr(orch, "list_agents", lambda: ["deck-hand", "deck_hand"])
+        monkeypatch.setattr("lionagi.casts.pattern.list_roles", lambda: ["deck-hand"])
+
+        assert orch.available_roles() == ["deck-hand"]
+
     def test_roster_carries_one_line_for_a_role_spelled_both_ways(self, monkeypatch, stub_profiles):
         from lionagi.cli._providers import _parse_profile
 

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -445,3 +445,40 @@ class TestSpawnRoles:
         assert roles["architect"].capabilities is not None
         arch_caps = [s.name for s in roles["architect"].capabilities.__op_fields__]
         assert "spawn_request" in arch_caps
+
+
+class TestPlanAssigneeSpelling:
+    """'-' and '_' are interchangeable in a role name, so an assignment written
+    with the other separator names a listed role rather than an unknown one."""
+
+    @pytest.mark.asyncio
+    async def test_other_separator_resolves_to_the_listed_role(self):
+        orc = _FakeOrc([TaskAssignment(task="a", assignee="postmortem_lead")])
+        out = await plan(orc, "task", roles=["postmortem-lead"])
+        assert [a.assignee for a in out] == ["postmortem-lead"]
+
+    @pytest.mark.asyncio
+    async def test_resolution_runs_in_both_directions(self):
+        orc = _FakeOrc([TaskAssignment(task="a", assignee="deck-hand")])
+        out = await plan(orc, "task", roles=["deck_hand"])
+        assert [a.assignee for a in out] == ["deck_hand"]
+
+    @pytest.mark.asyncio
+    async def test_exact_match_is_left_alone(self):
+        orc = _FakeOrc([TaskAssignment(task="a", assignee="deck_hand")])
+        out = await plan(orc, "task", roles=["deck-hand", "deck_hand"])
+        assert [a.assignee for a in out] == ["deck_hand"]
+
+    @pytest.mark.asyncio
+    async def test_a_spelling_matching_two_listed_roles_is_dropped(self):
+        """Two listed roles can differ only in where each separator falls. A
+        third spelling matching both is not resolved by picking one."""
+        orc = _FakeOrc([TaskAssignment(task="a", assignee="deck-hand-two")])
+        out = await plan(orc, "task", roles=["deck-hand_two", "deck_hand-two"])
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_name_is_still_dropped(self):
+        orc = _FakeOrc([TaskAssignment(task="a", assignee="ghost_writer")])
+        out = await plan(orc, "task", roles=["deck_hand"])
+        assert out == []


### PR DESCRIPTION
Closes #2559.

`available_roles()` unioned built-in role names with agent-profile names as raw strings, so a profile file named with the other word separator listed the same role twice. A built-in role accepts only its canonical spelling, so a profile spelled the other way is the same role, and the roster was the only place reading the two as two.

The union now happens on that normalization, with the built-in's spelling winning. Every consumer — the planner's role list and the mode roster's per-role restrictions — sees one entry per role.

## Two profiles that differ only in separator are still two profiles

The normalization must not be applied to profile-only names. Profile resolution gives an exact spelling priority over the other one, deliberately, so a directory holding both `deck-hand.md` and `deck_hand.md` keeps resolving both and they are two separately selectable profiles. Collapsing them would take one off the planner's menu, and the planner's own tolerant lookup would then have rewritten an assignment naming the hidden one onto the surviving profile — a silent substitution rather than a hidden entry.

So the canonical map is seeded from built-ins, and a profile joins it only when its normalized key is not a built-in's.

## Why `plan()` is in the diff

Deduplicating the menu must not narrow what a plan may say. `plan()` drops any assignment whose assignee is not in the roster it was given, with only a warning, so removing a spelling from the roster would have silently discarded assignments written with it. An assignee that does not match exactly is now looked up on the same normalization; a unique match is rewritten to the listed spelling, while ambiguity and genuine unknowns are still dropped with the existing warning. With both profile-only spellings listed, an assignment naming either matches exactly and the fallback never runs.

The executor was already tolerant of both spellings; the narrowing sat one layer above it, in the admission gate.

## Tests

Twelve tests across `tests/cli/orchestrate/test_role_roster.py` and `tests/orchestration/test_patterns.py`. Built-in roles come from the real catalog and only `list_agents` is stubbed, so the tests do not read the machine's own agents directory.

Seven fail against the base commit. Five pass before and after and are guards rather than discriminators: a profile-only name keeping its own spelling, an exact match being left alone, an ambiguous spelling being dropped, an unrelated name still being dropped, and a built-in still absorbing both profile spellings.

`tests/cli/orchestrate/test_flow_planning.py::test_pack_routing_shown_in_dry_run` fails on some machines for an unrelated reason, tracked and fixed separately; it fails identically without this change.
