### PR TITLE
Stub the profile loader in the pack-routing planning test

### DIFF
--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -12,7 +12,30 @@ import pytest
 
 from lionagi._errors import EmptyOutgoingContentError
 from lionagi.casts.emission import TaskAssignment
+from lionagi.cli._providers import AgentProfile
+from lionagi.cli.orchestrate import _orchestration as orch
 from lionagi.cli.orchestrate.flow import FlowPlanError, _parse_reactive, _run_flow_inner
+
+
+@pytest.fixture
+def stub_profiles(monkeypatch):
+    """Serve agent profiles from a dict instead of the machine's agents directories.
+
+    A user profile outranks a pack in model resolution, and profiles are
+    discovered from the git root, the working directory and its parents, and the
+    home directory — so a test that asserts on which source supplied a model
+    reads whatever profiles happen to be installed unless the loader is stubbed.
+    """
+    table: dict[str, AgentProfile] = {}
+
+    def fake_load(name: str) -> AgentProfile:
+        try:
+            return table[name]
+        except KeyError:
+            raise FileNotFoundError(name) from None
+
+    monkeypatch.setattr(orch, "load_agent_profile", fake_load)
+    return table
 
 
 class _FakeOrcBranch:
@@ -358,8 +381,12 @@ def _pack_env(tmp_path, orc, pack_yaml: str) -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_pack_routing_shown_in_dry_run(tmp_path):
-    """A pack with writer.model appears as (pack) in dry-run model resolution."""
+async def test_pack_routing_shown_in_dry_run(tmp_path, stub_profiles):
+    """A pack with writer.model appears as (pack) in dry-run model resolution.
+
+    No profile is registered, so the pack is the only source that can supply the
+    model — which is the routing this asserts.
+    """
     orc = _FakeOrcBranch(
         [SimpleNamespace(assignments=[TaskAssignment(task="draft docs", assignee="writer")])]
     )


### PR DESCRIPTION
Closes #2560.

`test_pack_routing_shown_in_dry_run` asserts that a pack supplies a worker's model, but it resolved that model through the real profile loader. A user profile outranks a pack in model resolution, so on a machine with a `writer` profile installed the test observed `writer: claude/claude-sonnet-5 (profile)` and failed. CI passes only because the runner has no profiles installed.

The test now takes a `stub_profiles` fixture that serves profiles from a dict and raises `FileNotFoundError` on a miss, the same shape `tests/cli/orchestrate/test_role_roster.py` already uses. It registers nothing, so the pack is the only source that can supply the model — which is the routing the test was written to assert. The assertion string is unchanged.

## Why not isolate by environment

Profile discovery reads the git root's `.lionagi`, then the working directory and each of its parents, then `~/.lionagi`. `Path.home()` does honour `HOME`, but a checkout inside the user's home tree is still found by the parent walk, so a `HOME` redirect alone does not isolate it. `HOME` plus a chdir outside the home tree does work and is used elsewhere in the suite. Stubbing the loader was preferred here because it isolates the one decision under test rather than the whole process.

## Verification

The full `test_flow_planning.py` module passes both with the host's profiles present and in a condition where no profiles are discoverable (empty `HOME` plus a working directory outside the home tree), 23 passed and rc 0 in each. A control probe was run in both conditions so an empty profile list is distinguishable from a failed read.

A differential across the resolution-relevant test files was run in both conditions: 612 passed, rc 0, identical in each. No sibling test needed a fix. Tests that assert on source tags in the same module take the `--workers` override path, which short-circuits before profile resolution is reached.
