### PR TITLE
Stop a bounded wait holding its window open for a run whose process is gone

### DIFF
--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -529,7 +529,10 @@ is configured, sends a terminal notice.
   orphan under D6 sends no notice, because it never reaches a terminal status, and it does
   not resolve under polling either. A consumer that reads this decision as "the poll always
   gets there in the end" has the right fallback and the wrong stopping condition, which is
-  what the consumer obligation on a still-pending bounded wait is for.
+  what the consumer obligation on an unresolved bounded wait is for. D10 names such a run
+  in the result rather than leaving it among the ids still pending, so the stopping
+  condition is reachable without a timer; deciding what to do once it is reached is still
+  the consumer's.
 - The outcome of the delivery attempt is recorded and surfaced on `status` under D7's
   availability shape. `attempted: false` means no delivery was configured, which is a
   valid configuration and not a failure — and is a different fact from a delivery that
@@ -566,7 +569,7 @@ request.
   is nicer is not the point. Every status-bearing path in this contract resolves through one
   authority, and an orphan is terminal on all of them or on none.
 
-**Two additions this ADR makes, which ADR-0066 does not state.** They are marked as
+**Three additions this ADR makes, which ADR-0066 does not state.** They are marked as
 extensions rather than folded into the list above, because presenting a new decision as an
 existing one tells every reader there is nothing left to reconcile, which is the most
 effective way to prevent it being reconciled:
@@ -580,10 +583,36 @@ effective way to prevent it being reconciled:
 - **Every entry carries `outcome`** as well as `terminal`, per D4. ADR-0066 D6's entry
   contract lists kind, status, terminality and reason code, so a conforming ADR-0066
   implementation would omit the field this contract requires for reporting a result.
+- **An id that waiting cannot resolve does not hold the window open.** A run whose process
+  is gone with no end recorded has stopped, and both writers of an end are past it, so
+  further polling cannot change its answer. Such ids are returned in their own list,
+  `stopped_without_end`, rather than in `pending`, and the call returns as soon as every
+  remaining id is either terminal or in that list. It is a separate list and not a per-id
+  error, because observing them succeeded. Nothing about the record changes: the entry
+  stays non-terminal with a null outcome, and a run that does record an end afterwards is
+  classified terminal by the next observation exactly as before. `all_terminal` stays false
+  while any id is in the list, because a run that stopped without recording an end is not a
+  completed one.
 
-Both need a forward amendment to ADR-0066 D6 to keep the two documents in agreement; until
-that lands, this ADR is the stricter of the two and an implementation satisfying it also
-satisfies ADR-0066.
+  **What this costs, stated rather than discovered.** The window's duration was doing two
+  jobs: bounding the observation, and rate-limiting a caller that keeps re-asking about a
+  run which never resolves. Returning early removes the second. A consumer that loops until
+  `all_terminal` with no backoff of its own turns a visible stall into a hot loop, which is
+  worse than the stall this removes. That is why the consumer obligation below names both
+  shapes rather than only the expired-window one.
+
+The first two need a forward amendment to ADR-0066 D6 to keep the two documents in
+agreement; until that lands, this ADR is the stricter of the two on them and an
+implementation satisfying it also satisfies ADR-0066.
+
+**The third is a divergence, not a strengthening, and is called one here** rather than
+folded in beside them. ADR-0066 D6 states the result as the entries plus `all_terminal`,
+`timed_out`, and the list of ids still pending; under it, a stopped run is pending and
+stays pending, and a conforming ADR-0066 implementation reports it that way every time.
+An implementation satisfying this extension therefore does **not** also satisfy ADR-0066
+D6 — it answers the same question differently. The two documents are in conflict until
+ADR-0066 D6 is amended, and this ADR does not resolve that by declaring itself stricter,
+because "stricter" would be the same move this section exists to refuse.
 
 **Why this is taken up rather than deferred.** An earlier draft deferred bounded wait on
 the grounds that timeout, signal and disconnect had no v1 answer. That was wrong about
@@ -669,16 +698,21 @@ being asked of them in one place.
 7. **Never treat a terminal notice as proof, or as the only discovery path** (D9).
    Delivery can fail, and the record of that failure lives in state a non-polling
    consumer is not reading.
-8. **Have a defined policy for a run still pending when a bounded wait expires** (D10,
-   D6). This is the obligation created by v1's liveness choice, and it is the one most
-   likely to be skipped, because most runs resolve and the case looks like an edge. It is
-   not an edge: v1 states that nothing terminalises an orphan, so a consumer that runs
-   long enough **will** meet a run that is pending and never resolves, and this contract
-   does not supply the policy for it. Give up after N attempts, escalate to a human, mark
-   it abandoned in your own store — any of those is conforming. Having no policy is not,
+8. **Have a defined policy for a run a bounded wait does not resolve** (D10, D6). Two
+   shapes reach you and both need the policy: an id still in `pending` when the window
+   expires, and an id in `stopped_without_end`, which comes back at once and comes back
+   every time. This is the obligation created by v1's liveness choice, and it is the one
+   most likely to be skipped, because most runs resolve and the case looks like an edge.
+   It is not an edge: v1 states that nothing terminalises an orphan, so a consumer that
+   runs long enough **will** meet a run that never resolves, and this contract does not
+   supply the policy for it. Give up after N attempts, escalate to a human, mark it
+   abandoned in your own store — any of those is conforming. Having no policy is not,
    because the failure mode is a consumer that waits forever on a run nobody will ever
    finish, or three integrators each inventing a different timeout behaviour, which is
    the divergence removed from the specification arriving back through the consumers.
+   Note specifically that a `stopped_without_end` id does not consume the window, so the
+   window is not backpressure for it: a loop that re-asks needs a delay of its own, or it
+   replaces a stall with a hot loop.
 
 ## Consequences
 
@@ -703,13 +737,15 @@ version increment and a coordinated update.
 
 **Accepted in v1, and stated rather than discovered.** A run whose process dies without
 recording a terminal, or whose producer dies before spawning it, stays non-terminal for as
-long as its record exists. A consumer's bounded wait will return it as pending every time.
-Two earlier revisions tried to close this with a rule every reader would apply, and both
-produced worse failures than the one they removed: a healthy child reported as terminally
-failed, and two hosts disagreeing about one unchanged record. Closing it properly needs a
-fenced reconciler with process-incarnation evidence, which is a protocol with its own
-failure modes rather than a clause, so it is written out in the deferred section instead of
-half-specified here. A visible stall is the honest cost of not having built that yet.
+long as its record exists. A consumer's bounded wait reports it as stopped without an end
+every time, and never as finished. Two earlier revisions tried to close this with a rule
+every reader would apply, and both produced worse failures than the one they removed: a
+healthy child reported as terminally failed, and two hosts disagreeing about one unchanged
+record. Closing it properly needs a fenced reconciler with process-incarnation evidence,
+which is a protocol with its own failure modes rather than a clause, so it is written out
+in the deferred section instead of half-specified here. Naming the run is not resolving it:
+the caller learns at once that nobody will finish this run, and still has to decide what to
+do about it, which is what consumer obligation 8 is for.
 
 **New failure modes.** A consumer pinned to v1 against an implementation that dropped
 v1 refuses to register rather than misbehaving, which operationally looks like a

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -99,7 +99,7 @@ wake it. A consumer restart across a successful delivery loses it the same way.
 | Distinguishing absence from failure | D7: every read-derived field carries its own availability and reason |
 | Process-level faults | D8: a valid envelope is authoritative; exit status is the transport-level answer, with a defined precedence |
 | Terminal notification | D9: a notification is a prompt to read state, never proof and never the only path |
-| Bounded observation | D10: `wait` is bounded, returns partial results, and takes ADR-0066 D6 with two marked extensions and one marked divergence |
+| Bounded observation | D10: `wait` is bounded, returns partial results, and takes ADR-0066 D6 with two marked extensions and one clause D6 leaves open decided here |
 
 Out of scope:
 
@@ -110,8 +110,9 @@ Out of scope:
   binary path.
 - **The MCP tool surface itself.** ADR-0066 decides that. This ADR constrains what
   those tools return, which is a strictly smaller question, and D10 takes ADR-0066 D6
-  as written rather than re-deciding it, marking its two additions as additions and its
-  one departure as a departure.
+  as written rather than re-deciding it, marking its two additions as additions and
+  saying plainly where D6 underdetermines a rule that an implementation must nonetheless
+  settle.
 - **Hosted / multi-tenant concerns.** No tenancy appears in this contract; a hosted
   join is built above it, not inside it.
 - **Playbook and flow semantics.** What a flow *does* is unchanged here.
@@ -541,7 +542,7 @@ is configured, sends a terminal notice.
 - Artifacts are written before the notice is sent, so a consumer woken by the notice
   finds the outputs already present.
 
-### D10 — Bounded observation, taken from ADR-0066 D6, extended in two places and departed from in one
+### D10 — Bounded observation, taken from ADR-0066 D6, extended in two places and completed in one
 
 `wait` takes ids, a maximum wait, and a poll interval; both numbers are clamped to
 documented bounds and the effective values are echoed back. `0` is a legal snapshot
@@ -584,36 +585,64 @@ effective way to prevent it being reconciled:
 - **Every entry carries `outcome`** as well as `terminal`, per D4. ADR-0066 D6's entry
   contract lists kind, status, terminality and reason code, so a conforming ADR-0066
   implementation would omit the field this contract requires for reporting a result.
-- **An id that waiting cannot resolve does not hold the window open.** A run whose process
-  is gone with no end recorded has stopped, and both writers of an end are past it, so
-  further polling cannot change its answer. Such ids are returned in their own list,
-  `stopped_without_end`, rather than in `pending`, and the call returns as soon as every
-  remaining id is either terminal or in that list. It is a separate list and not a per-id
-  error, because observing them succeeded. Nothing about the record changes: the entry
-  stays non-terminal with a null outcome, and a run that does record an end afterwards is
-  classified terminal by the next observation exactly as before. `all_terminal` stays false
-  while any id is in the list, because a run that stopped without recording an end is not a
-  completed one.
+- **An id that waiting cannot resolve does not hold the window open, and the producer pays
+  a floor for it.** A run whose process is gone with no end recorded has stopped, and both
+  writers of an end are past it, so further polling cannot change its answer. Such ids are
+  returned in their own list, `stopped_without_end`, rather than in `pending`, and the call
+  stops re-observing once every remaining id is either terminal or in that list. It is a
+  separate list and not a per-id error, because observing them succeeded. Nothing about the
+  record changes: the entry stays non-terminal with a null outcome, and a run that does
+  record an end afterwards is classified terminal by the next observation exactly as
+  before. `all_terminal` stays false while any id is in the list, because a run that stopped
+  without recording an end is not a completed one.
 
-  **What this costs, stated rather than discovered.** The window's duration was doing two
-  jobs: bounding the observation, and rate-limiting a caller that keeps re-asking about a
-  run which never resolves. Returning early removes the second. A consumer that loops until
-  `all_terminal` with no backoff of its own turns a visible stall into a hot loop, which is
-  worse than the stall this removes. That is why the consumer obligation below names both
-  shapes rather than only the expired-window one.
+  **The window was doing two jobs, and the second one stays here.** Its duration bounded the
+  observation and also rate-limited a caller that keeps re-asking about a run which never
+  resolves. Dropping such ids from `pending` removes the second, and a consumer looping
+  until `all_terminal` with no backoff of its own would turn a visible stall into a hot
+  loop, which is worse than the stall it removes. So a call that would return without having
+  waited at all, while at least one id is in `stopped_without_end`, first sleeps one poll
+  interval — bounded by whatever is left of the window — and observes once more. The trigger
+  is a property of the observation the call is about to return, not of any history, so it
+  applies on a first observation as much as a later one.
 
-The first two need a forward amendment to ADR-0066 D6 to keep the two documents in
-agreement; until that lands, this ADR is the stricter of the two on them and an
+  This is a floor on the call, not a charge added to it. A call that already waited on a
+  running id has met it and pays nothing extra, and `max_wait=0` is untaxed by construction,
+  having no window to spend, so it remains the documented snapshot. The cost no shape avoids
+  is a caller joining an already-finished batch beside one stopped id: it pays at most one
+  poll interval, once per call. That is accepted deliberately rather than engineered around.
+  It is bounded and small, the hazard it replaces is unbounded spin at a shared boundary,
+  and that asymmetry decides it without a measurement of how often either case occurs —
+  which neither party to the decision had. The extra observation is not wasted either, since
+  it is exactly the interval in which a slow end-writer finishes.
+
+  **Why the producer and not the consumer.** Both were live options and the choice is not
+  obvious. Pacing enforced here is enforced once for every client, including clients written
+  before this rule and clients we do not control; a documented duty to back off is honoured
+  only by the clients that read it. The decisive evidence is local: this ADR's own consumer
+  obligation 8 was silently disarmed by a code change while its text sat unchanged. A
+  boundary whose safety depends on N independent clients continuing to behave is not a
+  boundary.
+
+The first two extensions need a forward amendment to ADR-0066 D6 to keep the two documents
+in agreement; until that lands, this ADR is the stricter of the two on them and an
 implementation satisfying it also satisfies ADR-0066.
 
-**The third is a divergence, not a strengthening, and is called one here** rather than
-folded in beside them. ADR-0066 D6 states the result as the entries plus `all_terminal`,
-`timed_out`, and the list of ids still pending; under it, a stopped run is pending and
-stays pending, and a conforming ADR-0066 implementation reports it that way every time.
-An implementation satisfying this extension therefore does **not** also satisfy ADR-0066
-D6 — it answers the same question differently. The two documents are in conflict until
-ADR-0066 D6 is amended, and this ADR does not resolve that by declaring itself stricter,
-because "stricter" would be the same move this section exists to refuse.
+**The third is a definition of something ADR-0066 D6 leaves open**, and it is the clause to
+read carefully. D6 states the result as the entries plus `all_terminal`, `timed_out`, and
+the list of ids still pending. It names that key and nowhere says which ids qualify for it,
+so it does not by itself decide where a run that stopped without an end belongs. A reading
+is available on which it does: D6 names a per-id error channel for ids that could not be
+observed, and naming one exclusion can be read as ruling out others. That reading is
+recorded here because it was argued seriously, not because it is adopted. It is not
+adopted — the error channel is for ids observation could not resolve, while a stopped id
+was observed and classified, so naming that channel does not settle the pending rule by
+exclusion. The honest conclusion is that D6 underdetermines this, and an underdetermined
+clause is settled by amending it rather than by either document assuming its own reading.
+The forward amendment therefore states the partition outright: `pending`,
+`stopped_without_end` and terminal are disjoint and exhaustive over every observed id.
+That is the invariant this contract's implementation already tests, so the amendment
+records a rule that is enforced rather than adding one that is not.
 
 **Why this is taken up rather than deferred.** An earlier draft deferred bounded wait on
 the grounds that timeout, signal and disconnect had no v1 answer. That was wrong about
@@ -711,9 +740,13 @@ being asked of them in one place.
    because the failure mode is a consumer that waits forever on a run nobody will ever
    finish, or three integrators each inventing a different timeout behaviour, which is
    the divergence removed from the specification arriving back through the consumers.
-   Note specifically that a `stopped_without_end` id does not consume the window, so the
-   window is not backpressure for it: a loop that re-asks needs a delay of its own, or it
-   replaces a stall with a hot loop.
+
+   On pacing, this obligation describes rather than requires. A `stopped_without_end` id
+   does not consume the window, so the window is not backpressure for it — the producer
+   spends a one-interval floor instead (D10), and the correctness of the boundary does not
+   depend on you. A backoff of your own is still recommended, because a floor set by the
+   poll interval is a floor and not a policy, and only you know how often re-asking about
+   an unresolvable run is worth anything.
 
 ## Consequences
 
@@ -764,9 +797,12 @@ the escape hatch: a breaking change is expressible as a version increment rather
 negotiation. D8 could be dropped without touching the envelope, at the cost of P7
 returning. D10 cannot be dropped without re-opening the contradiction with ADR-0066, and
 its two marked extensions cannot be dropped without leaving the two documents disagreeing
-about what a wait entry contains and what a disconnect does. Its one marked departure is
-the opposite case: it is what puts the two documents into disagreement, and it is
-reversible only until a consumer has been written against it.
+about what a wait entry contains and what a disconnect does. The clause it decides where
+D6 is silent is the opposite case: nothing forces it, an implementation could have put
+stopped ids in `pending` and stayed conforming, and it is reversible only until a consumer
+has been written against it. The producer floor attached to it is cheaper to reverse than
+to introduce, since removing a minimum call duration cannot break a caller that was
+tolerating it.
 
 ## Alternatives considered
 

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -99,7 +99,7 @@ wake it. A consumer restart across a successful delivery loses it the same way.
 | Distinguishing absence from failure | D7: every read-derived field carries its own availability and reason |
 | Process-level faults | D8: a valid envelope is authoritative; exit status is the transport-level answer, with a defined precedence |
 | Terminal notification | D9: a notification is a prompt to read state, never proof and never the only path |
-| Bounded observation | D10: `wait` is bounded, returns partial results, and takes ADR-0066 D6 with two marked extensions |
+| Bounded observation | D10: `wait` is bounded, returns partial results, and takes ADR-0066 D6 with two marked extensions and one marked divergence |
 
 Out of scope:
 
@@ -110,7 +110,8 @@ Out of scope:
   binary path.
 - **The MCP tool surface itself.** ADR-0066 decides that. This ADR constrains what
   those tools return, which is a strictly smaller question, and D10 takes ADR-0066 D6
-  as written rather than re-deciding it, marking its two additions as additions.
+  as written rather than re-deciding it, marking its two additions as additions and its
+  one departure as a departure.
 - **Hosted / multi-tenant concerns.** No tenancy appears in this contract; a hosted
   join is built above it, not inside it.
 - **Playbook and flow semantics.** What a flow *does* is unchanged here.
@@ -540,7 +541,7 @@ is configured, sends a terminal notice.
 - Artifacts are written before the notice is sent, so a consumer woken by the notice
   finds the outputs already present.
 
-### D10 — Bounded observation, taken from ADR-0066 D6 and extended in two places
+### D10 — Bounded observation, taken from ADR-0066 D6, extended in two places and departed from in one
 
 `wait` takes ids, a maximum wait, and a poll interval; both numbers are clamped to
 documented bounds and the effective values are echoed back. `0` is a legal snapshot
@@ -763,7 +764,9 @@ the escape hatch: a breaking change is expressible as a version increment rather
 negotiation. D8 could be dropped without touching the envelope, at the cost of P7
 returning. D10 cannot be dropped without re-opening the contradiction with ADR-0066, and
 its two marked extensions cannot be dropped without leaving the two documents disagreeing
-about what a wait entry contains and what a disconnect does.
+about what a wait entry contains and what a disconnect does. Its one marked departure is
+the opposite case: it is what puts the two documents into disagreement, and it is
+reversible only until a consumer has been written against it.
 
 ## Alternatives considered
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1108,10 +1108,10 @@ async def wait(
     """Observe *run_ids* until they are all terminal or the window closes.
 
     A bounded observation, not a subscription. It returns one entry per requested
-    id, in the order they were requested, plus ``all_terminal``, ``timed_out`` and
-    the ids still ``pending`` — never a bare boolean, because mixed outcomes are
-    the normal case and collapsing them forces the follow-up poll this call exists
-    to replace.
+    id, in the order they were requested, plus ``all_terminal``, ``timed_out``,
+    the ids still ``pending`` and the ids ``stopped_without_end`` — never a bare
+    boolean, because mixed outcomes are the normal case and collapsing them forces
+    the follow-up poll this call exists to replace.
 
     ``max_wait`` is clamped to ``[0, WAIT_MAX_SECONDS]`` and ``poll_interval`` to
     ``[WAIT_MIN_POLL_SECONDS, WAIT_MAX_POLL_SECONDS]``; the effective values are

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1125,6 +1125,17 @@ async def wait(
     the result and never stop the other ids being observed; they are not listed
     as pending, because waiting longer cannot resolve them.
 
+    A run whose process is gone with no end recorded meets that same criterion:
+    it has stopped, and both writers of an end are past it, so the window is not
+    held open for it either. Such ids are named in ``stopped_without_end`` — not
+    in ``pending``, which is what is still worth waiting for, and not as a per-id
+    ``error``, because observing them succeeded. Nothing about the record itself
+    changes: the entry stays non-terminal with a null outcome, and a run that
+    does get an end written afterwards is classified terminal by the next
+    observation as it always was. ``all_terminal`` therefore stays false while any
+    id is here, because a run that stopped without recording an end is not a
+    completed one.
+
     Observing does not touch the run. This function only reads: a wait that
     expires, or whose caller cancels or disconnects, leaves the durable record
     exactly as it was — cancelling an observation is not cancelling the work.
@@ -1140,9 +1151,14 @@ async def wait(
 
     entries: list[dict[str, Any]] = []
     pending: list[str] = []
+    stopped: list[str] = []
     while True:
         entries = [_wait_entry(rid) for rid in ordered]
-        pending = [e["run_id"] for e in entries if e["error"] is None and not e["terminal"]]
+        observed = [e for e in entries if e["error"] is None]
+        stopped = [e["run_id"] for e in observed if e["possibly_orphaned"]]
+        pending = [
+            e["run_id"] for e in observed if not e["terminal"] and not e["possibly_orphaned"]
+        ]
         if not pending:
             break
         remaining = deadline - anyio.current_time()
@@ -1153,9 +1169,10 @@ async def wait(
     errored = any(e["error"] is not None for e in entries)
     return {
         "runs": entries,
-        "all_terminal": not pending and not errored,
+        "all_terminal": not pending and not errored and not stopped,
         "timed_out": bool(pending),
         "pending": pending,
+        "stopped_without_end": stopped,
         "max_wait": eff_max,
         "poll_interval": eff_poll,
         "requested_max_wait": max_wait,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1136,6 +1136,18 @@ async def wait(
     id is here, because a run that stopped without recording an end is not a
     completed one.
 
+    Because such an id resolves nothing by waiting, a caller looping until
+    ``all_terminal`` would otherwise re-ask as fast as it can. So a call that
+    would return without having waited at all, while at least one id is
+    ``stopped_without_end``, first sleeps one poll interval — bounded by whatever
+    is left of the window — and observes again. This is a floor on the call, not
+    a charge added to it: a call that already waited on a running id has met it,
+    and ``max_wait=0`` is untaxed by construction, having no window to spend. The
+    extra observation is not wasted either, since it is exactly the interval in
+    which a slow end-writer finishes. Pacing belongs here because the boundary
+    can enforce it once for every client, while a documented duty to back off is
+    satisfied only by the clients that read it.
+
     Observing does not touch the run. This function only reads: a wait that
     expires, or whose caller cancels or disconnects, leaves the durable record
     exactly as it was — cancelling an observation is not cancelling the work.
@@ -1152,6 +1164,7 @@ async def wait(
     entries: list[dict[str, Any]] = []
     pending: list[str] = []
     stopped: list[str] = []
+    waited = False
     while True:
         entries = [_wait_entry(rid) for rid in ordered]
         observed = [e for e in entries if e["error"] is None]
@@ -1159,11 +1172,16 @@ async def wait(
         pending = [
             e["run_id"] for e in observed if not e["terminal"] and not e["possibly_orphaned"]
         ]
-        if not pending:
-            break
         remaining = deadline - anyio.current_time()
         if remaining <= 0:
             break
+        # Nothing left worth waiting for. Return now unless the only unresolved
+        # ids stopped without an end and this call has not waited at all — that
+        # is the shape a loop-until-all_terminal caller repeats as fast as it can
+        # ask, so the floor is spent here rather than left to every client.
+        if not pending and (waited or not stopped):
+            break
+        waited = True
         await anyio.sleep(min(eff_poll, remaining))
 
     errored = any(e["error"] is not None for e in entries)

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -342,6 +342,113 @@ async def test_wait_stops_as_soon_as_every_id_is_terminal(sandbox, monkeypatch):
     assert polls["n"] == 2
 
 
+async def test_wait_returns_at_once_when_the_process_is_gone(sandbox, monkeypatch):
+    """A run whose process is gone cannot be resolved by waiting longer.
+
+    Both writers of an end are past it, so the window is not held open for it.
+    The sleep is replaced by one that fails, so the assertion is that no poll
+    interval was ever entered rather than that the call felt quick.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=999_999)
+
+    import anyio
+
+    async def never(seconds):
+        raise AssertionError(f"slept {seconds}s on a run whose process is gone")
+
+    monkeypatch.setattr(anyio, "sleep", never)
+    res = await jobs.wait([rid], max_wait=600, poll_interval=5)
+
+    assert res["pending"] == []
+    assert res["stopped_without_end"] == [rid]
+    assert res["timed_out"] is False
+    # Stopped is not finished: nothing recorded how this run came out.
+    assert res["all_terminal"] is False
+    assert res["runs"][0]["terminal"] is False
+    assert res["runs"][0]["outcome"] is None
+    assert res["runs"][0]["possibly_orphaned"] is True
+    assert res["runs"][0]["error"] is None
+
+
+async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, monkeypatch):
+    """A stopped id is dropped from the wait; the ids that can still finish keep it."""
+    alive = {"value": True}
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pid == 4242 and alive["value"])
+    gone = jobs.new_run_id()
+    _record(gone, pid=999_999)
+    busy = jobs.new_run_id()
+    _record(busy, pid=4242)
+
+    polls = {"n": 0}
+    real_status = jobs.status
+
+    def counting_status(run_id):
+        if run_id == busy:
+            polls["n"] += 1
+            if polls["n"] == 2:  # the running run ends between two observations
+                alive["value"] = False
+                jobs.mark_terminal(run_id, "completed")
+        return real_status(run_id)
+
+    monkeypatch.setattr(jobs, "status", counting_status)
+    res = await jobs.wait([gone, busy], max_wait=30, poll_interval=0.01)
+
+    assert polls["n"] == 2  # the wait did keep observing the running id
+    assert res["pending"] == []
+    assert res["stopped_without_end"] == [gone]
+    assert res["timed_out"] is False
+    assert res["all_terminal"] is False  # one id never recorded an end
+    assert res["runs"][1]["terminal"] is True
+    assert res["runs"][1]["outcome"] == "succeeded"
+
+
+async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monkeypatch):
+    """Dropping a stopped id from the wait says nothing about the record.
+
+    An end written afterwards by either writer classifies exactly as it always
+    did, and the id is no longer reported as stopped without one.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=999_999)
+
+    stopped = await jobs.wait([rid], max_wait=0, poll_interval=1)
+    assert stopped["stopped_without_end"] == [rid]
+
+    jobs.mark_terminal(rid, "completed")
+    res = await jobs.wait([rid], max_wait=0, poll_interval=1)
+
+    assert res["stopped_without_end"] == []
+    assert res["pending"] == []
+    assert res["all_terminal"] is True
+    assert res["runs"][0]["terminal"] is True
+    assert res["runs"][0]["outcome"] == "succeeded"
+    assert res["runs"][0]["possibly_orphaned"] is False
+
+
+async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monkeypatch):
+    """max_wait=0 observes once and returns, whatever the ids turn out to be."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=999_999)
+
+    import anyio
+
+    slept: list[float] = []
+
+    async def no_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(anyio, "sleep", no_sleep)
+    res = await jobs.wait([rid], max_wait=0, poll_interval=5)
+
+    assert slept == []
+    assert res["max_wait"] == 0.0
+    assert res["stopped_without_end"] == [rid]
+
+
 # --- the argv the child is actually spawned with --------------------------------
 #
 # Everything above this point either mocks `jobs.submit` or reads records back, so

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -449,6 +449,44 @@ async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monke
     assert res["stopped_without_end"] == [rid]
 
 
+async def test_every_unresolved_id_is_named_somewhere_in_the_result(sandbox, monkeypatch):
+    """No observed id may be left non-terminal and unnamed.
+
+    A caller is required to hold a policy for every id a wait does not resolve,
+    and that duty is only implementable if every such id arrives somewhere it
+    can be read. This pins the invariant rather than today's categories: a
+    future non-terminal state added to the classifier without being added to a
+    list fails here. A written obligation cannot catch that on its own — the
+    text sits unchanged while the shape it describes stops occurring, which is
+    exactly how the obligation this replaces stopped covering a stopped run.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pid == 4242)
+    running = jobs.new_run_id()
+    _record(running, pid=4242)
+    stopped = jobs.new_run_id()
+    _record(stopped, pid=999_999)
+    done = jobs.new_run_id()
+    _record(done, pid=999_999)
+    jobs.mark_terminal(done, "completed")
+    never_recorded = jobs.new_run_id()
+
+    res = await jobs.wait([running, stopped, done, never_recorded, ""], max_wait=0, poll_interval=1)
+
+    named = set(res["pending"]) | set(res["stopped_without_end"])
+    assert not (set(res["pending"]) & set(res["stopped_without_end"]))
+    for entry in res["runs"]:
+        if entry["terminal"]:
+            assert entry["run_id"] not in named
+        elif entry["error"] is None:
+            assert entry["run_id"] in named, (
+                f"{entry['run_id']!r} is non-terminal, was observed without error, and is "
+                "named in neither pending nor stopped_without_end -- nothing tells a "
+                "caller it has a decision to make about this id"
+            )
+    assert running in res["pending"]
+    assert stopped in res["stopped_without_end"]
+
+
 # --- the argv the child is actually spawned with --------------------------------
 #
 # Everything above this point either mocks `jobs.submit` or reads records back, so

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -342,12 +342,15 @@ async def test_wait_stops_as_soon_as_every_id_is_terminal(sandbox, monkeypatch):
     assert polls["n"] == 2
 
 
-async def test_wait_returns_at_once_when_the_process_is_gone(sandbox, monkeypatch):
-    """A run whose process is gone cannot be resolved by waiting longer.
+async def test_a_stopped_run_costs_one_poll_interval_and_no_more(sandbox, monkeypatch):
+    """A run whose process is gone cannot be resolved by waiting the window out.
 
-    Both writers of an end are past it, so the window is not held open for it.
-    The sleep is replaced by one that fails, so the assertion is that no poll
-    interval was ever entered rather than that the call felt quick.
+    Both writers of an end are past it, so the window is not held open for it —
+    but returning instantly would let a caller looping until ``all_terminal``
+    re-ask as fast as it can, so the boundary spends one poll interval first.
+    The assertion is on the sleeps actually entered, not on how long the call
+    felt: exactly one, of one interval. Against the previous behaviour the same
+    ids held the window for its full 600 seconds.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     rid = jobs.new_run_id()
@@ -355,12 +358,20 @@ async def test_wait_returns_at_once_when_the_process_is_gone(sandbox, monkeypatc
 
     import anyio
 
-    async def never(seconds):
-        raise AssertionError(f"slept {seconds}s on a run whose process is gone")
+    slept: list[float] = []
 
-    monkeypatch.setattr(anyio, "sleep", never)
+    async def no_sleep(seconds):
+        slept.append(seconds)
+        # The sleep is a no-op, so a version that keeps this id pending would
+        # spin here for the whole 600s window. Fail on the fourth interval
+        # instead, naming what it was still waiting for.
+        if len(slept) > 3:
+            raise AssertionError(f"still polling after {len(slept)} intervals on a stopped run")
+
+    monkeypatch.setattr(anyio, "sleep", no_sleep)
     res = await jobs.wait([rid], max_wait=600, poll_interval=5)
 
+    assert slept == [5]
     assert res["pending"] == []
     assert res["stopped_without_end"] == [rid]
     assert res["timed_out"] is False
@@ -373,7 +384,12 @@ async def test_wait_returns_at_once_when_the_process_is_gone(sandbox, monkeypatc
 
 
 async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, monkeypatch):
-    """A stopped id is dropped from the wait; the ids that can still finish keep it."""
+    """A stopped id is dropped from the wait; the ids that can still finish keep it.
+
+    The poll count also pins the floor as a minimum rather than a surcharge: this
+    call waited on a running id, so it has already met the floor and pays nothing
+    extra for the stopped one sitting beside it.
+    """
     alive = {"value": True}
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pid == 4242 and alive["value"])
     gone = jobs.new_run_id()
@@ -429,7 +445,12 @@ async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monk
 
 
 async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monkeypatch):
-    """max_wait=0 observes once and returns, whatever the ids turn out to be."""
+    """max_wait=0 observes once and returns, whatever the ids turn out to be.
+
+    This is also where the floor stops: a snapshot request has no window to spend,
+    so the id that would otherwise buy one poll interval buys nothing here. A
+    caller that asked not to wait is not made to.
+    """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     rid = jobs.new_run_id()
     _record(rid, pid=999_999)
@@ -446,6 +467,33 @@ async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monke
 
     assert slept == []
     assert res["max_wait"] == 0.0
+    assert res["stopped_without_end"] == [rid]
+
+
+async def test_the_floor_never_outruns_the_window(sandbox, monkeypatch):
+    """The floor is bounded by what is left of the window, not by the interval.
+
+    A caller who asked for half a second does not get five because one id stopped
+    without an end. Without the bound the floor could overrun a window the caller
+    chose, which would make the pacing the producer's decision rather than a
+    minimum inside the caller's own budget.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=999_999)
+
+    import anyio
+
+    slept: list[float] = []
+
+    async def no_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(anyio, "sleep", no_sleep)
+    res = await jobs.wait([rid], max_wait=0.5, poll_interval=5)
+
+    assert len(slept) == 1
+    assert 0 < slept[0] <= 0.5
     assert res["stopped_without_end"] == [rid]
 
 


### PR DESCRIPTION
Closes #2566.

A background run whose process exits before either writer of an end has run is classified stopped-but-not-terminal, and that classification is deliberate: liveness is an observation about a pid, a pid can be reused or its probe denied, and two readers of one unchanged record must not disagree about whether it ended. Nothing here changes it.

What changes is the waiter. `wait` polled on the per-entry `terminal` field alone, so it kept such a run in `pending` and slept out the whole window before returning `timed_out`. Its own contract already states the rule that settles this: malformed and unknown ids are excluded from `pending` because waiting longer cannot resolve them, and a run whose process is gone meets that criterion — both writers of an end are past it. Those ids now come back in a `stopped_without_end` list, out of `pending`, and no longer hold the window open. Measured on a real spawn whose child exits at once: 6.01s to 0.01s on a 6s window.

The record is untouched. The entry stays non-terminal with a null outcome, `all_terminal` stays false while any id is in that list, a run that later records an end classifies terminal exactly as before, and `max_wait=0` remains a single-observation snapshot.

## This conflicts with ADR-0066 D6, and the second commit says so rather than papering over it

ADR-0066 D6 states the result as the entries plus `all_terminal`, `timed_out`, and the list of ids still pending. Under it a stopped run is pending and stays pending, every time. An implementation with this change answers that question differently, so it does not also satisfy D6.

ADR-0106 D10 already carries two extensions over D6 under a "stricter of the two, so satisfying it satisfies ADR-0066" line. This one is added as a third extension with that line explicitly **not** extended to it, because it is a divergence and not a strengthening — and calling a new decision an existing one is the move that section exists to refuse.

**ADR-0066 is Accepted, so the amendment it needs is not taken in this PR.** That is the open question this change is waiting on, not a follow-up nicety: until D6 is amended the two documents direct different implementations.

## Consumer obligation 8 is rewritten because this change disarms it

ADR-0106's obligation 8 attaches a caller's give-up policy to one shape: a run still pending when a bounded wait expires. That shape no longer occurs for a stopped run, so an integrator who implemented the obligation exactly as written would find it never fires for the case it was written for. It now names both shapes.

It also records what the change gives up, which is not obvious from the diff. The window's duration was doing two jobs: bounding the observation, and rate-limiting a caller that keeps re-asking about a run that never resolves. An id returned without consuming the window is not backpressure. A loop that re-asks until `all_terminal` with no delay of its own now spins, where before it stalled visibly — worse than the defect being fixed, for that caller.

The accepted-cost paragraph in Consequences is updated for the same reason: it asserted the behaviour this change removes.

## Tests

Four new tests in `tests/mcp/test_wait_and_spawn.py`, written before the source edit and run against the unmodified tree first. Two fail at baseline on the defect itself — a 5s sleep on a run whose process is gone, and 526 poll iterations where 2 are expected. Two fail at baseline only because they read the new key, and each carries an assertion that holds both before and after: that a stopped run which later records an end is still classified terminal, and that `max_wait=0` still sleeps zero times.

`tests/mcp/` is 509 passed. The repository-wide suite has not been run here; every test among the consumers of this function (`grep` over `tests/` and `lionagi/`) is inside `tests/mcp/`.
