### PR TITLE
docs: correct the provider path and list in the architecture guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Override: `branch.operate(instruction=..., middle=my_callable)`. Force stream: `
 
 ### Service Layer (`service/`)
 
-**iModel** wraps any provider via `match_endpoint.py`. Providers in `connections/providers/`: OpenAI, Anthropic, Gemini, Ollama, NVIDIA NIM, Perplexity, Groq/OpenRouter.
+**iModel** wraps any provider via `service/connections/match_endpoint.py`. Providers live in `lionagi/providers/`, one package each: chat/model — `openai`, `anthropic`, `google`, `deepseek`, `groq`, `openrouter`, `ollama`, `nvidia_nim`, `perplexity`; search/retrieval — `exa`, `tavily`, `firecrawl`; framework and CLI integrations — `ag2`, `pi`.
 
 ### Operations (`operations/`)
 


### PR DESCRIPTION
The Service Layer section named `connections/providers/`, a path that does not exist. Provider packages live in `lionagi/providers/`. The list was also incomplete: it omitted DeepSeek and every search and framework integration.

Read from the directory rather than rewritten from memory, and grouped by what each package actually contains rather than by what its name suggests. `perplexity/` ships `chat.py`, so it stays with the chat providers; `exa`, `tavily` and `firecrawl` do not, so they are named as search and retrieval; `ag2` and `pi` are framework and CLI integrations rather than model vendors.

`match_endpoint.py` was the one correct half of the original sentence and is now spelled with its full path.

Docs-only. markdownlint clean.