### PR TITLE
fix(mcp): identify a job's process group before signalling it

### DIFF
--- a/lionagi/mcp/config.py
+++ b/lionagi/mcp/config.py
@@ -27,6 +27,13 @@ JOBS_DIR = LIONAGI_HOME / "mcp" / "jobs"
 # the child starts, so the id we return is race-free.
 RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"
 
+# Stamped into every job's child environment at spawn and read back off live
+# processes to confirm they belong to the run that started them. Deliberately
+# not RUN_ID_ENV_VAR, which the CLI consumes to pick a run directory and which
+# a descendant is free to rewrite for its own sub-run: a kill decision must not
+# rest on a variable another subsystem owns and can reassign.
+JOB_MARKER_ENV_VAR = "LIONAGI_MCP_JOB_RUN_ID"
+
 # Explicit override for the argv prefix that invokes the ``li`` CLI, split on
 # whitespace. Rarely needed: the server runs inside lionagi's own environment,
 # so the interpreter running it already resolves the CLI (see li_command).

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -583,12 +583,21 @@ def _tail(path: str | None, limit: int = 4000) -> str | None:
     return data[-limit:] if len(data) > limit else data
 
 
-def _list_artifacts(run_id: str) -> list[str]:
+def _list_artifacts(run_id: str) -> tuple[list[str], str]:
+    """The persisted artifacts of *run_id*, and whether the traversal completed.
+
+    A traversal that fails answers with the empty list and ``"unreadable"``, never
+    with the empty list alone. "This run wrote no artifacts" is a claim about the
+    run; "the artifacts could not be listed" is a claim about the read, and a
+    caller that is told the first when the second happened has been told something
+    false about the run.
+    """
     adir = config.run_dir(run_id) / "artifacts"
     try:
-        return sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
+        found = sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
     except OSError:
-        return []
+        return [], "unreadable"
+    return found, "ok"
 
 
 def _split_at_sentinel(flags: Sequence[str]) -> tuple[list[str], list[str]]:
@@ -1397,7 +1406,9 @@ def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
 
     ``record_state`` carries what was read, the same way ``status`` reports it, and
     ``error`` names that state rather than reporting every failed read as an
-    unknown run.
+    unknown run. ``artifacts_state`` does the same for the artifact traversal, so
+    an empty ``artifacts`` means the run wrote none rather than standing in for a
+    listing that failed.
     """
     job, record_state = _read_job_state(run_id)
     if job is None:
@@ -1408,6 +1419,7 @@ def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
             "error": _NO_RECORD_ERROR.get(record_state, "no such job"),
         }
     st = status(run_id)
+    artifacts, artifacts_state = _list_artifacts(run_id)
     return {
         "run_id": run_id,
         "known": True,
@@ -1417,7 +1429,8 @@ def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
         "outcome": st["outcome"],
         "reason_code": st["reason_code"],
         "console": _tail(job.get("log"), limit=tail_chars),
-        "artifacts": _list_artifacts(run_id),
+        "artifacts": artifacts,
+        "artifacts_state": artifacts_state,
         "run_dir": str(config.run_dir(run_id)),
     }
 
@@ -1917,11 +1930,19 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     An entry whose record could not be used is listed with the state of that read
     in ``record_state``, the same field ``status`` reports, so a damaged record is
     visible here as a damaged record rather than as a job with no kind and an
-    unknown status.
+    unknown status. That is a per-run failure, and one damaged record must not cost
+    the caller the runs beside it.
+
+    The directory read itself is different, and is allowed to fail. A listing has
+    no field in which to say it could not be read, so answering the empty list
+    would say "there are no jobs at all" about a directory nobody could look in.
+    The caller is better served by the error. Only a directory that is not there is
+    answered as no jobs: nothing has written one yet, which is exactly the fact the
+    empty listing states.
     """
     try:
         entries = sorted(config.JOBS_DIR.iterdir(), reverse=True)
-    except OSError:
+    except FileNotFoundError:
         return []
     out: list[dict[str, Any]] = []
     for d in entries:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -109,6 +109,13 @@ _CREATE_TIME_TOLERANCE = 0.1
 # Reason codes carried by kill(). The human `reason` explains the particular
 # case; the code is what a caller can branch on without matching prose.
 KILL_NO_SUCH_JOB = "no_such_job"
+# The record is on disk and cannot be used. Two codes rather than one, on the same
+# axis as everything else here: bytes that could not be read or parsed may read
+# differently on the next call, whereas a record that parsed cleanly into something
+# other than an object will answer identically every time and only a person can
+# resolve it.
+KILL_RECORD_UNREADABLE = "job_record_unreadable"
+KILL_RECORD_WRONG_SHAPE = "job_record_wrong_shape"
 KILL_NO_PID = "no_pid_on_record"
 KILL_SIGNALLED = "signalled"
 KILL_PROCESS_GONE = "process_gone"
@@ -179,14 +186,52 @@ def _write_job(record: dict[str, Any]) -> None:
         raise
 
 
-def _read_job(run_id: str) -> dict[str, Any] | None:
+def _short_repr(value: Any, limit: int = 60) -> str:
+    """A recorded value, shown as written and bounded in length.
+
+    Reporting the value as written rather than as coerced lets a reader see the
+    damage instead of a plausible-looking substitute. It came off disk, though, and
+    a JSON number or string has no length limit, so the record must not get to
+    choose how long an answer is.
+    """
+    shown = repr(value)
+    return shown if len(shown) <= limit else f"{shown[:limit]}… ({len(shown)} characters)"
+
+
+def _read_job_state(run_id: str) -> tuple[dict[str, Any] | None, str]:
+    """The job record for *run_id*, and why there isn't one when there isn't.
+
+    ``("absent", "unreadable", "wrong_shape")`` are three different facts and only
+    the first means the run is unknown. A record whose bytes cannot be read or
+    parsed is present and damaged; a record that parses to a JSON value that is not
+    an object — an array, a string, ``null`` — is present, intact and unusable.
+    Reporting either as "no such job" tells an operator to stop looking for a run
+    whose file is sitting on disk.
+
+    The record is returned only in the ``"ok"`` case, so nothing downstream can
+    reach a value this did not admit.
+    """
     p = config.job_dir(run_id) / "job.json"
     if not p.exists():
-        return None
+        return None, "absent"
     try:
-        return json.loads(p.read_text())
+        record = json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
-        return None
+        return None, "unreadable"
+    if not isinstance(record, dict):
+        return None, "wrong_shape"
+    return record, "ok"
+
+
+def _read_job(run_id: str) -> dict[str, Any] | None:
+    """The job record, or None when there is no usable one.
+
+    Every reader that only needs the record goes through here and gets what it
+    always got, including a falsy answer to fall back on. A caller that has to tell
+    an unknown run from a damaged file — and only ``kill()`` does — reads the state
+    alongside it instead.
+    """
+    return _read_job_state(run_id)[0]
 
 
 def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
@@ -1356,10 +1401,32 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     stated here rather than papered over, because the guarantee is "never signalled
     without an identification", not "never signals the wrong group".
     """
-    job = _read_job(run_id)
-    if job is None:
+    job, state = _read_job_state(run_id)
+    if state == "absent":
         return _kill_result(
             run_id, killed=False, reason="no such job", reason_code=KILL_NO_SUCH_JOB
+        )
+    if state == "unreadable":
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"the record for {run_id} is on disk but could not be read or parsed, so "
+                "nothing is known about the run it describes and nothing was signalled; "
+                "the file itself is what has to be looked at"
+            ),
+            reason_code=KILL_RECORD_UNREADABLE,
+        )
+    if state == "wrong_shape" or job is None:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"the record for {run_id} holds valid JSON that is not an object, so it "
+                "carries no fields to identify a process with and nothing was signalled; "
+                "the file itself is what has to be looked at"
+            ),
+            reason_code=KILL_RECORD_WRONG_SHAPE,
         )
 
     # First, and before any number on the record is probed or dereferenced. A
@@ -1372,10 +1439,29 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             run_id, killed=False, reason="no pid on record", reason_code=KILL_NO_PID, pid=pid
         )
 
+    # A record written before a run's process identity was captured does not carry
+    # these keys at all. That is the only thing that means the record is old: a key
+    # that is present and holds the wrong type says the opposite — it was written by
+    # code that knows about these fields, and what it wrote is damaged. The two get
+    # different answers, because one is expected and ages out while the other is
+    # worth looking into.
+    if "pid_create_time" not in job and "pgid" not in job:
+        return _refuse_legacy_record(run_id, pid)
     created = job.get("pid_create_time")
     pgid = job.get("pgid")
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
-        return _refuse_legacy_record(run_id, pid)
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"the identity recorded for pid {pid} is not usable — start time "
+                f"{_short_repr(created)}, process group {_short_repr(pgid)} — so this "
+                "record cannot identify its own process and nothing was signalled; reap "
+                "the group by hand after confirming the process is this run's"
+            ),
+            reason_code=KILL_IDENTITY_UNUSABLE,
+            pid=pid,
+        )
     # Three values reach here that look like numbers and cannot act as one. A NaN or
     # an infinity passes every type and range check above and then loses silently to
     # every comparison below, so the leader would be reported as a recycled pid. A
@@ -1392,13 +1478,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     except OverflowError:
         unusable = True
     if unusable:
-        # The value is reported as written rather than as coerced, so a reader sees
-        # the damage instead of a plausible-looking timestamp — but it came off disk
-        # and a JSON number has no length limit, so it is capped before it goes into
-        # a reason a caller has to read.
-        shown = repr(created)
-        if len(shown) > 60:
-            shown = f"{shown[:60]}… ({len(shown)} characters)"
+        shown = _short_repr(created)
         return _kill_result(
             run_id,
             killed=False,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -125,15 +125,16 @@ KILL_NO_PID = "no_pid_on_record"
 KILL_SIGNALLED = "signalled"
 KILL_PROCESS_GONE = "process_gone"
 KILL_PERMISSION_DENIED = "permission_denied"
-# The record was written before a run's process identity was recorded, so the
-# pid on it cannot be told apart from a reused one and nothing can be signalled
-# for it. Its own code, so a reader can tell an old record from a refusal
-# decided about a record that does carry an identity.
-KILL_LEGACY_NO_IDENTITY = "legacy_record_no_process_identity"
+# The record carries neither identity field, so the pid on it cannot be told
+# apart from a reused one and nothing can be signalled for it. The code names
+# what was read off the record and not why the fields are absent, which the
+# reading does not establish. Its own code, so a reader can tell this from a
+# refusal decided about a record that does carry an identity.
+KILL_NO_RECORDED_IDENTITY = "no_recorded_process_identity"
 # The identity fields are present and of the right type but hold a value nothing
 # can be compared against where a start time belongs. Its own code rather than the
-# one above: that one says a record is old and expected, this one says a record is
-# damaged, and only the second is worth investigating.
+# one above: that one says the fields are absent, this one says they are there and
+# damaged, and the two point an operator at different things to do.
 KILL_IDENTITY_UNUSABLE = "recorded_identity_unusable"
 # Identity-bearing records. Split by what a caller would do next: a mismatch or
 # a foreign group is settled and will not change on a retry, while an unreadable
@@ -1596,8 +1597,8 @@ def _signal_leader_group(
     return _signal_group(run_id, job, pid, pgid, sig, KILL_SIGNALLED)
 
 
-def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
-    """Refuse a record written before a run's process identity was recorded.
+def _refuse_record_without_identity(run_id: str, pid: int) -> dict[str, Any]:
+    """Refuse a record that carries no process identity at all.
 
     Such a record carries a pid and nothing that distinguishes it from a pid the
     OS has since handed to an unrelated process. The missing fields cannot be
@@ -1606,13 +1607,13 @@ def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
     the pid at this point is exactly the step that resolves a reused pid to a
     stranger's group. So nothing is signalled.
 
-    The refusal leads with what was read off the record — both fields absent —
-    and offers the age of the record as the explanation rather than as the
-    finding. What is observed is that the fields are missing; that they are
-    missing because the record predates them follows from every write since
-    having set them, which is a fact about this code and not a measurement of
-    this file. Stating the inference alone would hand an operator a history the
-    refusal never established.
+    The refusal says only what the read established: both fields are absent, so
+    the pid cannot be told from a reused one and no group was signalled. It does
+    not say when the record was written. That no current writer omits the fields
+    rules out one origin; it does not choose among the others, and a record
+    altered after it was written is absent the same way an old one is. An
+    operator told the record is old would go looking for a different remedy than
+    one told the record cannot identify its process.
 
     The pid rides along on the refusal, because it is the only handle an operator
     has for reaping the group by hand, and this is the last place it is reported.
@@ -1622,12 +1623,10 @@ def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
         killed=False,
         reason=(
             f"this record carries neither a start time nor a process group, so pid {pid} "
-            "cannot be distinguished from a reused one and no group was signalled; every "
-            "write since those fields existed sets them, so a record missing both was "
-            "written before they were captured; reap the group by hand after confirming "
-            "the process is this run's"
+            "cannot be distinguished from a reused one and no group was signalled; reap "
+            "the group by hand after confirming the process is this run's"
         ),
-        reason_code=KILL_LEGACY_NO_IDENTITY,
+        reason_code=KILL_NO_RECORDED_IDENTITY,
         pid=pid,
     )
 
@@ -1651,7 +1650,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     refuses: the refusal says which fact was missing, and a refusal with an
     accurate reason is the outcome being aimed at, not the largest possible
     number of processes stopped. That holds without exception, including for a
-    record written before these fields existed — such a record cannot confirm
+    record carrying no process identity at all — such a record cannot confirm
     anything, so it is refused and its group is left for an operator to reap by
     hand.
 
@@ -1758,14 +1757,15 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             run_id, killed=False, reason="no pid on record", reason_code=KILL_NO_PID, pid=pid
         )
 
-    # A record written before a run's process identity was captured does not carry
-    # these keys at all. That is the only thing that means the record is old: a key
-    # that is present and holds the wrong type says the opposite — it was written by
-    # code that knows about these fields, and what it wrote is damaged. The two get
-    # different answers, because one is expected and ages out while the other is
-    # worth looking into.
+    # Neither key on the record at all. What that establishes is that this record
+    # cannot identify its process, not how it came to be that way — an absent key
+    # says nothing about when or by what it was written. A key that is present and
+    # holds the wrong type is a different observation: something that knows about
+    # these fields wrote a value nothing can be compared against. The two get
+    # different answers because they leave an operator with different things to
+    # look at, not because one of them dates the record.
     if "pid_create_time" not in job and "pgid" not in job:
-        return _refuse_legacy_record(run_id, pid)
+        return _refuse_record_without_identity(run_id, pid)
     created = job.get("pid_create_time")
     pgid = job.get("pgid")
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -244,7 +244,10 @@ def _read_job_state(run_id: str) -> tuple[dict[str, Any] | None, str]:
         return None, "unreadable"
     try:
         record = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, RecursionError):
+        # Deeply nested input exhausts the decoder's stack rather than failing to
+        # parse, so it arrives as neither a syntax error nor anything else this
+        # reader would recognise. It is still a record that could not be read.
         return None, "unreadable"
     if not isinstance(record, dict):
         return None, "wrong_shape"
@@ -618,7 +621,17 @@ def _list_artifacts(run_id: str) -> tuple[list[str], str]:
     for root, _dirs, names in os.walk(adir, onerror=_note):
         for name in names:
             path = Path(root) / name
-            if path.is_file():
+            try:
+                is_file = path.is_file()
+            except OSError:
+                # A directory can be listable and still not searchable, so a name
+                # can arrive from the walk and its metadata still be out of reach.
+                # The entry is one the caller will not hear about, which is the
+                # same shortfall the state reports; the walk continues, because
+                # the entries after it are still true.
+                unreadable = True
+                continue
+            if is_file:
                 found.append(str(path.relative_to(adir)))
     return sorted(found), "unreadable" if unreadable else "ok"
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -153,7 +153,9 @@ KILL_GROUP_MARKERS_CONFLICT = "group_markers_conflict"
 KILL_GROUP_PREDATES_RUN = "group_predates_run"
 KILL_GROUP_SCAN_INCOMPLETE = "group_scan_incomplete"
 # The group was inspected end to end and simply yielded no evidence of ownership:
-# no member's marker could be read. Separate from an incomplete scan, because that
+# every member's environment was read and none of them carries a marker. Separate
+# from an incomplete scan, which covers a member whose environment would not open
+# at all, because that
 # one is a measurement that failed and may answer on the next call, while this one
 # is the measurement succeeding and returning nothing — the same call will keep
 # returning it, and only an operator can settle the group.
@@ -384,12 +386,13 @@ def _spawned_pgid(pid: int) -> int:
         return pid
 
 
-def _pinned_member(pid: int, pgid: int) -> tuple[str, tuple[int, float, str | None] | None]:
+def _pinned_member(pid: int, pgid: int) -> tuple[str, tuple[int, float, str | None, bool] | None]:
     """Everything *pid* has to say as a member of *pgid*, read as one observation.
 
-    ``("found", (pid, create_time, marker))`` when a single process answered all
-    of it, ``("gone", None)`` when the pid holds no live member of this group,
-    and ``("unknown", None)`` when the reads could not be tied to one process.
+    ``("found", (pid, create_time, marker, marker_read))`` when a single process
+    answered all of it, ``("gone", None)`` when the pid holds no live member of
+    this group, and ``("unknown", None)`` when the reads could not be tied to one
+    process.
 
     Group, start time and marker are three facts, each read by pid, and a pid
     the OS reassigns between two of those reads answers the later ones as the
@@ -399,6 +402,11 @@ def _pinned_member(pid: int, pgid: int) -> tuple[str, tuple[int, float, str | No
     that tells a recycled pid from the process that held it, and it is what
     binds the other two to the same process. Failing the bracket is "unknown" —
     a measurement that did not come off, never evidence about the group.
+
+    *marker_read* travels with the marker because a None marker alone does not
+    say which of two things happened. The environment read and held no marker,
+    and the environment could not be read at all, are the same None; only this
+    flag tells a member that was inspected from one that refused inspection.
     """
     state, created = _process_create_time(pid)
     if state == "gone":
@@ -411,23 +419,24 @@ def _pinned_member(pid: int, pgid: int) -> tuple[str, tuple[int, float, str | No
         return "gone", None
     except OSError:
         return "unknown", None
-    _marker_state, marker = _process_marker(pid)
+    marker_state, marker = _process_marker(pid)
     again, created_again = _process_create_time(pid)
     if again != "found" or created_again != created:
         return "unknown", None
     if not in_group:
         return "gone", None
-    return "found", (pid, created, marker)
+    return "found", (pid, created, marker, marker_state == "found")
 
 
-def _live_group_members(pgid: int) -> tuple[list[tuple[int, float, str | None]], bool]:
+def _live_group_members(pgid: int) -> tuple[list[tuple[int, float, str | None, bool]], bool]:
     """Live members of process group *pgid*, and whether the scan was complete.
 
     Returns ``(members, complete)`` where each member is ``(pid, create_time,
-    marker)``. All three arrive together, from :func:`_pinned_member`, so that a
-    caller weighing a member's marker and a member's age is weighing one
-    process. The group read in the loop below only narrows the process table to
-    candidates; the membership that counts is the one read inside the bracket.
+    marker, marker_read)``. All of it arrives together, from
+    :func:`_pinned_member`, so that a caller weighing a member's marker and a
+    member's age is weighing one process. The group read in the loop below only
+    narrows the process table to candidates; the membership that counts is the
+    one read inside the bracket.
 
     A process that vanishes mid-scan is simply not a live member; a process
     whose group or identity could not be read leaves *complete* false, because
@@ -437,10 +446,15 @@ def _live_group_members(pgid: int) -> tuple[list[tuple[int, float, str | None]],
     as gone. Zombies are excluded: an unreaped corpse still counts as a group
     member to the kernel, so counting it would report a group that is empty of
     running work as live.
+
+    *complete* is about membership coverage and nothing else. A member whose
+    marker could not be read was still seen — its pid, group and start time all
+    answered — so it opens no gap in the membership, and it is reported as a
+    member carrying *marker_read* false rather than as a member the scan missed.
     """
     import psutil
 
-    members: list[tuple[int, float, str | None]] = []
+    members: list[tuple[int, float, str | None, bool]] = []
     complete = True
     try:
         pids = psutil.pids()
@@ -517,16 +531,21 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     being younger than the run is consistent with the group being ours and
     equally consistent with an unrelated group that simply started later, so it
     is not an identification and is never treated as one. A dead leader whose
-    group yields no readable marker is ``"unproven"`` — inspected in full,
-    and found to carry no evidence either way.
+    group yields no marker, every member's environment having been read, is
+    ``"unproven"`` — inspected in full, and found to carry no evidence either
+    way.
 
     ``"gone"`` when nothing live is left in the group, and ``"unknown"`` when
-    the scan itself could not be completed — a member it could not read leaves a
-    group that may hold work the scan never saw.
+    the scan itself could not be completed. Two things leave it incomplete: a
+    member it could not read at all, which leaves a group that may hold work the
+    scan never saw, and a member it saw whose environment refused to be read,
+    which leaves the marker rule undecided on a process it did see. Neither is a
+    finding about the group, and both may answer on the next call, so they are
+    the same news and share an answer.
     """
     members, complete = _live_group_members(pgid)
 
-    markers = {marker for _, _, marker in members if marker is not None}
+    markers = {marker for _, _, marker, _ in members if marker is not None}
     if len(markers) > 1:
         return "conflict", "marker"
     if markers:
@@ -537,8 +556,10 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     if not members:
         return "gone", "scan"
     floor = spawned_at - _CREATE_TIME_TOLERANCE
-    if any(created < floor for _, created, _ in members):
+    if any(created < floor for _, created, _, _ in members):
         return "not_ours", "start_time"
+    if any(not marker_read for _, _, _, marker_read in members):
+        return "unknown", "marker"
     return "unproven", "start_time"
 
 
@@ -1854,9 +1875,11 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
         )
     # Each refusal gets its own code, because they are not the same news, and each
     # reason reports what the probe saw rather than the history that would explain
-    # it. A foreign marker, a conflict, an older member and a group with no marker
-    # at all are settled and will read the same on every retry; an incomplete scan
-    # is a measurement that failed and may succeed on the next call.
+    # it. A foreign marker, a conflict, an older member and a group whose members
+    # were all read and carry no marker are settled and will read the same on every
+    # retry; an incomplete scan is a measurement that failed and may succeed on the
+    # next call, and a member whose environment would not open is such a failure —
+    # the marker it withheld is one the next call may well read.
     if verdict == "conflict":
         detail = f"live members of group {pgid} carry different run ids in their environment"
         code = KILL_GROUP_MARKERS_CONFLICT

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -231,23 +231,30 @@ def _read_job_state(run_id: str) -> tuple[dict[str, Any] | None, str]:
     found to be missing. Only "the file is not there" is absence; every other way
     the read can fail is a record that is present and could not be got at.
 
-    Bytes that are not valid UTF-8 are one of those ways, and they are named
-    explicitly because they do not arrive as ``OSError``: the file opens and reads,
-    and the decode is what fails.
+    "Every other way" is meant literally, so the guards are written to be total
+    rather than to list the failures anyone thought of. Bytes are damaged in ways
+    that are not guessable in advance: they fail to be text before they fail to be
+    JSON, and they exhaust the decoder's stack rather than failing to parse at all.
+    Naming those one at a time produces a list that is correct until the next shape
+    arrives, and the caller cannot use a classification that is only mostly total.
+
+    What makes the broad guards safe here is the size of what they cover, not the
+    exceptions they name. Each wraps a single expression that does one thing and
+    holds no logic of its own, so anything raised inside it came from the read or
+    the parse and is a record this function could not establish. A guard this broad
+    over a block with branching in it would be hiding bugs instead of classifying
+    damage; that is the property to preserve if this code grows.
     """
     p = config.job_dir(run_id) / "job.json"
     try:
         raw = p.read_text()
     except FileNotFoundError:
         return None, "absent"
-    except (OSError, UnicodeDecodeError):
+    except Exception:
         return None, "unreadable"
     try:
         record = json.loads(raw)
-    except (json.JSONDecodeError, RecursionError):
-        # Deeply nested input exhausts the decoder's stack rather than failing to
-        # parse, so it arrives as neither a syntax error nor anything else this
-        # reader would recognise. It is still a record that could not be read.
+    except Exception:
         return None, "unreadable"
     if not isinstance(record, dict):
         return None, "wrong_shape"
@@ -277,6 +284,15 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
     a caller must treat it as "did not learn anything" and fall back to what it
     already knew, because the alternative is calling a run finished on the
     strength of a read that never happened.
+
+    "Any reason at all" is meant literally, so the two guards below are total
+    rather than lists of the failures anyone thought of. Both are safe for the
+    same reason the record reader's are: each covers a single expression that
+    spawns or parses and holds no logic of its own, so anything raised inside it
+    came from the read. The output arrives from another program, which makes the
+    parse the widest surface here — bytes that exhaust the decoder's stack fail
+    to parse without raising a parse error — and a caller cannot fall back on an
+    answer that is only mostly total.
     """
     argv = [*config.li_command(), "lifecycle", run_id, "--machine"]
     try:
@@ -286,7 +302,7 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
             timeout=LIFECYCLE_TIMEOUT_SECONDS,
             check=False,
         )
-    except (OSError, subprocess.SubprocessError):
+    except Exception:
         return None
 
     if len(completed.stdout) > _LIFECYCLE_OUTPUT_LIMIT:
@@ -296,7 +312,7 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
         return None
     try:
         envelope = json.loads(text)
-    except json.JSONDecodeError:
+    except Exception:
         return None
     if not isinstance(envelope, dict) or not envelope.get("ok"):
         return None
@@ -311,9 +327,15 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
 
 
 def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
+    """The run manifest, or None when there is not one to be had.
+
+    Total for the same reason the record reader is: the caller is told only whether
+    there is a manifest to show, so every way of not getting one is the same answer,
+    and the guard covers a single expression that reads and parses and nothing else.
+    """
     try:
         return json.loads(config.run_manifest(run_id).read_text())
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except Exception:
         return None
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -32,6 +32,7 @@ have been without it.
 from __future__ import annotations
 
 import json
+import math
 import os
 import shlex
 import signal
@@ -117,6 +118,11 @@ KILL_PERMISSION_DENIED = "permission_denied"
 # for it. Its own code, so a reader can tell an old record from a refusal
 # decided about a record that does carry an identity.
 KILL_LEGACY_NO_IDENTITY = "legacy_record_no_process_identity"
+# The identity fields are present and of the right type but hold a value nothing
+# can be compared against — a NaN or an infinity where a start time belongs. Its
+# own code rather than the one above: that one says a record is old and expected,
+# this one says a record is damaged, and only the second is worth investigating.
+KILL_IDENTITY_UNUSABLE = "recorded_identity_unusable"
 # Identity-bearing records. Split by what a caller would do next: a mismatch or
 # a foreign group is settled and will not change on a retry, while an unreadable
 # probe or an incomplete scan is a measurement that failed and may succeed later.
@@ -1341,6 +1347,25 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
         return _refuse_legacy_record(run_id, pid)
     spawned_at = float(created)
+    # A NaN or an infinity passes every type and range check above and then loses
+    # silently to every comparison below: a NaN start time is never within
+    # tolerance of a live one, so the leader would be reported as a recycled pid.
+    # That names the wrong fact — nothing was established about the pid at all,
+    # only that this record cannot say anything about it.
+    if not math.isfinite(spawned_at):
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"the start time recorded for pid {pid} is {spawned_at}, which nothing "
+                "can be compared against, so this record cannot identify its own "
+                "process and nothing was signalled; reap the group by hand after "
+                "confirming the process is this run's"
+            ),
+            reason_code=KILL_IDENTITY_UNUSABLE,
+            pid=pid,
+            pgid=pgid,
+        )
 
     if _pid_alive(pid):
         state, live_created = _process_create_time(pid)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -370,6 +370,37 @@ def _pid_alive(pid: int | None) -> bool:
     return True
 
 
+def _askable_pid(value: object) -> int | None:
+    """The recorded pid if the OS can be asked about it at all, otherwise None.
+
+    A pid is a C integer to every call that takes one, so a record can carry a
+    perfectly good Python int that no probe can express, and a probe handed one
+    raises before it looks anything up. The bound is the platform's and not ours,
+    so it is established by asking rather than by a constant of our own choosing.
+    Signal 0 asks about a process without disturbing it, which is what the
+    liveness probe does with it too.
+
+    The type check is here rather than at each caller because a record is JSON
+    from disk: the value can be a string, a list, or anything else that survives
+    a parse, and every probe below takes an integer. A bool is an int to
+    isinstance and arrives as 0 or 1, both of which mean something else entirely
+    to a group signal, so it is refused alongside them.
+
+    Only the overflow is caught, because only the overflow is a question about
+    the number. Any other failure of that call is a failure of the probe, and
+    reporting it as an unusable pid would blame the record for it.
+    """
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 1:
+        return None
+    try:
+        os.kill(value, 0)
+    except OverflowError:
+        return None
+    except OSError:
+        pass
+    return value
+
+
 def _process_create_time(pid: int) -> tuple[str, float | None]:
     """When the process at *pid* started: ``("found", t)``, ``("gone", None)``
     or ``("unknown", None)``.
@@ -1350,25 +1381,53 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
 
     The second element names what was established, so a caller can tell the
     readings apart rather than infer them: ``"confirmed"``, ``"recycled"``,
-    ``"gone"`` (the pid held no live process by the time its identity was read),
-    ``"unreadable"`` (the identity probe errored, so nothing was established and
-    the liveness probe stands), ``"not_recorded"`` (the record captured no start
-    time) and ``"unusable"`` (it captured one that no start time can be compared
-    against). None when there was no live pid to identify.
+    ``"gone"`` (the pid held no live process when it was read), ``"unreadable"``
+    (the identity probe errored, so nothing was established and the liveness
+    probe stands), ``"not_recorded"`` (the record captured no start time),
+    ``"unusable"`` (it captured one that no start time can be compared against)
+    and ``"unusable_pid"`` (the record's pid is not a number the OS can be asked
+    about, so no probe was made and the answer is not a finding of death). None
+    when there was no live pid to identify.
 
-    Where no identity was captured the answer is the liveness probe alone,
-    exactly as before: a pid probe is all such a record ever had, and calling
-    those runs orphaned would be a claim their data does not support. A probe
-    that errored is treated the same way, because a failed read is not evidence
-    of death.
+    Two separate questions are settled here in the order their evidence allows.
+    Whether the pid holds a live process at all needs only the pid, so it is
+    asked first and on every path. Whether that live process is *this run's*
+    needs the recorded start time, so it is asked second and only where one was
+    recorded; without it the liveness answer stands alone, because a pid probe is
+    all such a record has for that second question, and calling those runs
+    recycled would be a claim their data does not support. A probe that errored
+    is treated the same way, because a failed read is not evidence of death.
+
+    Keeping the first question ahead of the record matters: the liveness probe
+    reaps only its own children, so a process that exited under a different
+    parent — any job whose server is not the one that spawned it — is a zombie
+    that ``kill -0`` reports as alive. Deciding that from the record would leave
+    every record without a start time reporting an exited run as running, and
+    ``possibly_orphaned``, the field that exists for a process gone with no end
+    recorded, would be false in exactly the case it is meant to catch.
     """
-    alive = _pid_alive(pid)
-    if not alive or job is None or not isinstance(pid, int):
-        return alive, None
+    asked = _askable_pid(pid)
+    if asked is None:
+        return False, "unusable_pid"
+    if not _pid_alive(asked):
+        return False, None
 
+    # Whether that pid still holds a live process is settled here, before the
+    # record is consulted, because settling it does not need the record. The
+    # liveness probe reaps only its own children, so a process that exited under
+    # a different parent stays a zombie, and asking the OS whether the pid exists
+    # answers yes for as long as it does. The probe below tells a zombie from a
+    # live process from the pid alone, which is why it runs on every path and not
+    # only where a start time was recorded to compare against.
+    state, live_created = _process_create_time(asked)
+    if state == "gone":
+        return False, "gone"
+
+    if job is None:
+        return True, None
     recorded = job.get("pid_create_time")
     if recorded is None:
-        return alive, "not_recorded"
+        return True, "not_recorded"
     # The same three values kill() refuses: a bool is an int to isinstance and
     # arrives as a moment in 1970, a NaN loses every comparison silently, and an
     # unbounded JSON integer fails the conversion that any comparison needs.
@@ -1378,13 +1437,10 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
     except (TypeError, ValueError, OverflowError):
         usable = False
     if not usable:
-        return alive, "unusable"
+        return True, "unusable"
 
-    state, live_created = _process_create_time(pid)
-    if state == "gone":
-        return False, "gone"
     if state != "found" or live_created is None:
-        return alive, "unreadable"
+        return True, "unreadable"
     if _start_time_matches(live_created, spawned_at):
         return True, "confirmed"
     return False, "recycled"
@@ -1410,11 +1466,12 @@ def status(run_id: str) -> dict[str, Any]:
     pid number now: where the record carries the start time captured at spawn, a
     number the OS has handed on reports as not alive. ``pid_identity`` says how
     that was settled — ``"confirmed"``, ``"recycled"``, ``"gone"``,
-    ``"unreadable"``, ``"not_recorded"``, ``"unusable"``, or null when there was
-    no live pid to identify — so a caller can tell a process that vanished from a
-    number that now belongs to someone else, which are different things to do
-    next. A record written without a start time is answered by the pid probe
-    alone, as it always was.
+    ``"unreadable"``, ``"not_recorded"``, ``"unusable"``, ``"unusable_pid"``, or
+    null when there was no live pid to identify — so a caller can tell a process
+    that vanished from a number that now belongs to someone else, which are
+    different things to do next. A record written without a start time still
+    reports a process that has exited as not alive; what it cannot report is
+    whether a live process at that pid is this run's.
     ``possibly_orphaned`` flags a run whose process is gone with no end recorded;
     it is advisory and never makes the run terminal.
     ``notify_delivery`` reports whether the terminal notice was delivered.
@@ -1837,11 +1894,26 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     # First, and before any number on the record is probed or dereferenced. A
     # pid of 0 means the caller's own process group to killpg, and 1 is init;
     # a record carrying either — a placeholder, a truncated write, a test
-    # double — must never reach a group signal.
-    pid = job.get("pid")
-    if not isinstance(pid, int) or pid <= 1:
+    # double — must never reach a group signal. The same gate settles the shape
+    # and the range, because the record is JSON from disk and the probes below
+    # all take a C integer: a value of the wrong type, or one past what the
+    # platform can express, would raise out of the first probe to touch it.
+    recorded_pid = job.get("pid")
+    pid = _askable_pid(recorded_pid)
+    if pid is None:
         return _kill_result(
-            run_id, killed=False, reason="no pid on record", reason_code=KILL_NO_PID, pid=pid
+            run_id,
+            killed=False,
+            reason=(
+                "no pid on record"
+                if recorded_pid is None
+                else (
+                    "no pid on record that can identify a process to signal; the "
+                    f"record carries {_short_repr(recorded_pid)}"
+                )
+            ),
+            reason_code=KILL_NO_PID,
+            pid=recorded_pid,
         )
 
     # Neither key on the record at all. What that establishes is that this record

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -36,6 +36,7 @@ import math
 import os
 import shlex
 import signal
+import stat
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -630,6 +631,16 @@ def _list_artifacts(run_id: str) -> tuple[list[str], str]:
     A directory that is not there is not a failed read. Nothing writes one until a
     run persists something, so its absence is exactly what an empty list of
     artifacts means.
+
+    The per-entry check asks for the metadata itself rather than for a verdict
+    about it. The convenience predicates answer a question this function is not
+    asking: they report what the entry is, and report a false when they could not
+    find out, which are two different answers arriving as one value. Which of
+    those a caller gets has changed across interpreter versions, so relying on one
+    to raise makes the shortfall visible on some and invisible on others. Asking
+    for the metadata keeps the distinction in this function, where the difference
+    between "not a file" and "could not be looked at" is exactly what the state is
+    for.
     """
     adir = config.run_dir(run_id) / "artifacts"
     unreadable = False
@@ -644,7 +655,12 @@ def _list_artifacts(run_id: str) -> tuple[list[str], str]:
         for name in names:
             path = Path(root) / name
             try:
-                is_file = path.is_file()
+                mode = path.stat().st_mode
+            except FileNotFoundError:
+                # Gone between the walk naming it and this look at it. Nothing was
+                # withheld, so there is no shortfall to report, exactly as the
+                # directory-level callback treats the same disappearance.
+                continue
             except OSError:
                 # A directory can be listable and still not searchable, so a name
                 # can arrive from the walk and its metadata still be out of reach.
@@ -653,7 +669,7 @@ def _list_artifacts(run_id: str) -> tuple[list[str], str]:
                 # the entries after it are still true.
                 unreadable = True
                 continue
-            if is_file:
+            if stat.S_ISREG(mode):
                 found.append(str(path.relative_to(adir)))
     return sorted(found), "unreadable" if unreadable else "ok"
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1411,13 +1411,19 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     exited, which is the case worth reaping, and a pid the OS handed to an
     unrelated process, which must never be signalled.
 
-    Nothing is signalled that the record does not identify. A probe that errors
-    is unknown, and unknown refuses: the refusal says which fact was missing, and
-    a refusal with an accurate reason is the outcome being aimed at, not the
-    largest possible number of processes stopped. That holds without exception,
-    including for a record written before these fields existed — such a record
-    cannot confirm anything, so it is refused and its group is left for an
-    operator to reap by hand.
+    Nothing is signalled that the record does not identify — a statement about
+    what is decided here, not about where the signal lands. Identification and
+    the signal are separate system calls and the interval between them belongs
+    to the OS, so the delivered guarantee is best-effort identification followed
+    by a signal, never an atomic one; the last paragraph of this contract says
+    what that costs, and it is not a caveat on the sentence so much as the
+    sentence's actual scope. A probe that errors is unknown, and unknown
+    refuses: the refusal says which fact was missing, and a refusal with an
+    accurate reason is the outcome being aimed at, not the largest possible
+    number of processes stopped. That holds without exception, including for a
+    record written before these fields existed — such a record cannot confirm
+    anything, so it is refused and its group is left for an operator to reap by
+    hand.
 
     What that buys, stated exactly, because the difference matters to anyone
     relying on it. Every signal is preceded by a positive identification: either

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -352,10 +352,17 @@ def _live_group_members(pgid: int) -> tuple[list[tuple[int, float]], bool]:
 def _process_marker(pid: int) -> tuple[str, str | None]:
     """The run marker carried by the process at *pid*.
 
-    ``("found", value_or_None)`` when the environment was read — a None value
-    means the process simply does not carry the marker. ``("unknown", None)``
-    when the environment could not be read at all, which is a probe that
-    failed and never evidence about the process.
+    ``("found", value_or_None)`` when the environment was read, ``("unknown",
+    None)`` when it raised — a probe that failed, and never evidence about the
+    process.
+
+    A None value is weaker than it looks and must not be read as "this process
+    does not carry the marker". macOS returns an *empty* environment, without
+    raising, for a process running a protected system binary, so a declined
+    disclosure and a genuinely absent marker arrive identically. That is safe
+    only in one direction: an unreadable environment contributes no marker, and
+    no marker can only ever withhold ownership, never assert it. Nothing here
+    may be inverted into evidence that a group is not this run's.
     """
     import psutil
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -297,11 +297,8 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
 
 
 def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
-    p = config.run_manifest(run_id)
-    if not p.exists():
-        return None
     try:
-        return json.loads(p.read_text())
+        return json.loads(config.run_manifest(run_id).read_text())
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -531,13 +528,19 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
 
 
 def _tail(path: str | None, limit: int = 4000) -> str | None:
+    """The last *limit* characters of the log, or None when there is no tail to
+    show.
+
+    A log that cannot be read reports as no tail rather than as an error. Unlike
+    the job record, the tail is advisory — the caller has already been told the
+    run exists and what state it is in — so there is nothing an operator would do
+    differently on "no log yet" versus "the log could not be read", and neither is
+    worth failing the surrounding call for.
+    """
     if not path:
         return None
-    p = Path(path)
-    if not p.exists():
-        return None
     try:
-        data = p.read_text(errors="replace")
+        data = Path(path).read_text(errors="replace")
     except OSError:
         return None
     return data[-limit:] if len(data) > limit else data
@@ -545,9 +548,10 @@ def _tail(path: str | None, limit: int = 4000) -> str | None:
 
 def _list_artifacts(run_id: str) -> list[str]:
     adir = config.run_dir(run_id) / "artifacts"
-    if not adir.exists():
+    try:
+        return sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
+    except OSError:
         return []
-    return sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
 
 
 def _split_at_sentinel(flags: Sequence[str]) -> tuple[list[str], list[str]]:
@@ -1744,10 +1748,12 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
 
 def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[str, Any]]:
     """Recent jobs, newest first (run_id sorts by timestamp)."""
-    if not config.JOBS_DIR.exists():
+    try:
+        entries = sorted(config.JOBS_DIR.iterdir(), reverse=True)
+    except OSError:
         return []
     out: list[dict[str, Any]] = []
-    for d in sorted(config.JOBS_DIR.iterdir(), reverse=True):
+    for d in entries:
         if not d.is_dir():
             continue
         st = status(d.name)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -113,16 +113,22 @@ KILL_SIGNALLED = "signalled"
 KILL_PROCESS_GONE = "process_gone"
 KILL_PERMISSION_DENIED = "permission_denied"
 # The record was written before a run's process identity was recorded, so the
-# pid on it cannot be told apart from a reused one. Its own codes, so a reader
-# can tell an old record from a refusal this build actually decided.
+# pid on it cannot be told apart from a reused one and nothing can be signalled
+# for it. Its own code, so a reader can tell an old record from a refusal
+# decided about a record that does carry an identity.
 KILL_LEGACY_NO_IDENTITY = "legacy_record_no_process_identity"
-KILL_LEGACY_ALREADY_ENDED = "legacy_record_already_ended"
-KILL_LEGACY_ALREADY_EXITED = "legacy_record_already_exited"
-# Identity-bearing records.
+# Identity-bearing records. Split by what a caller would do next: a mismatch or
+# a foreign group is settled and will not change on a retry, while an unreadable
+# probe or an incomplete scan is a measurement that failed and may succeed later.
 KILL_PID_RECYCLED = "pid_recycled"
 KILL_LEADER_UNVERIFIABLE = "leader_identity_unreadable"
+KILL_LEADER_GROUP_MISMATCH = "leader_group_mismatch"
+KILL_LEADER_GROUP_UNREADABLE = "leader_group_unreadable"
 KILL_GROUP_GONE = "group_gone"
-KILL_GROUP_UNVERIFIED = "group_identity_unverified"
+KILL_GROUP_FOREIGN = "group_belongs_to_another_run"
+KILL_GROUP_MARKERS_CONFLICT = "group_markers_conflict"
+KILL_GROUP_PREDATES_RUN = "group_predates_run"
+KILL_GROUP_SCAN_INCOMPLETE = "group_scan_incomplete"
 
 
 def _now_iso() -> str:
@@ -360,6 +366,13 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     is the same evidence pointing the other way: the group number has been
     reused.
 
+    Every readable marker is collected before the rule is applied, because
+    deciding on the first one read would make the verdict depend on the order
+    the process table happened to be enumerated in — the same group could then
+    be accepted or refused between two calls. Markers that disagree are
+    ``"conflict"``: two runs cannot both own a group, so whatever produced the
+    disagreement is unexplained, and an unexplained group is not signalled.
+
     The start time decides only by exclusion, and covers what the marker
     cannot — a run recorded before the marker existed, and a member whose
     environment cannot be read. It is an inequality rather than an
@@ -373,13 +386,15 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     """
     members, complete = _live_group_members(pgid)
 
+    markers = set()
     for pid, _ in members:
         state, marker = _process_marker(pid)
-        if state != "found" or marker is None:
-            continue
-        if marker == run_id:
-            return "ours", "marker"
-        return "not_ours", "marker"
+        if state == "found" and marker is not None:
+            markers.add(marker)
+    if len(markers) > 1:
+        return "conflict", "marker"
+    if markers:
+        return ("ours" if markers == {run_id} else "not_ours"), "marker"
 
     if not complete:
         return "unknown", "scan"
@@ -1218,61 +1233,74 @@ def _signal_group(
     )
 
 
-def _kill_legacy_record(run_id: str, job: dict[str, Any], pid: int, sig: int) -> dict[str, Any]:
-    """Kill a record written before a run's process identity was recorded.
+def _signal_leader_group(
+    run_id: str, job: dict[str, Any], pid: int, pgid: int, sig: int
+) -> dict[str, Any]:
+    """Signal *pgid*, once the confirmed leader at *pid* is shown to be in it.
 
-    Nothing here can tell this run's pid from a reused one, so the behaviour is
-    the one that predates identity, unchanged, and the reason codes say which
-    record this was. The missing fields cannot be filled in after the fact: the
-    process they describe is the one that was spawned, and nothing observable
-    now can recover when it started.
+    The caller has established that *pid* is the process this run spawned. What
+    is still open is whether the *pgid* on the record is that process's group:
+    the two numbers are stored separately, and a record whose pgid is wrong would
+    otherwise direct a signal at an unrelated group. Read the leader's group and
+    require equality. If they differ, or the group cannot be read, refuse — with
+    different codes, because a mismatch is a settled fact about the record while
+    an unreadable group is a probe that may answer on a later call.
     """
-    if _record_is_terminal(job):
-        recorded = job.get("status", "unknown")
-        # The pid rides along on the refusal. A record can be marked terminal
-        # while its group leader is still alive: the terminal status is persisted
-        # from the lifecycle transition, and the run's own teardown finishes
-        # after that. Refusing is still right, because this pid may equally have
-        # been reused by then and nothing on this record can tell the two apart.
-        # But an operator reaping a group that really did outlive its recorded
-        # end needs the number, and this is the last place it is reported.
+    try:
+        live_pgid = os.getpgid(pid)
+    except (ProcessLookupError, PermissionError, OSError) as e:
         return _kill_result(
             run_id,
             killed=False,
             reason=(
-                f"already ended as {recorded}; pid not signalled because "
-                "it may since have been reused"
+                f"pid {pid} is this run's leader but its process group could not be "
+                f"read ({e}), so group {pgid} could not be confirmed to be its group; "
+                "nothing was signalled"
             ),
-            reason_code=KILL_LEGACY_ALREADY_ENDED,
+            reason_code=KILL_LEADER_GROUP_UNREADABLE,
             pid=pid,
+            pgid=pgid,
         )
-    if not _pid_alive(pid):
+    if live_pgid != pgid:
         return _kill_result(
             run_id,
             killed=False,
-            reason="already exited",
-            reason_code=KILL_LEGACY_ALREADY_EXITED,
+            reason=(
+                f"pid {pid} is this run's leader but is in group {live_pgid}, not the "
+                f"recorded group {pgid}; neither group was signalled because the "
+                "record disagrees with the running process"
+            ),
+            reason_code=KILL_LEADER_GROUP_MISMATCH,
             pid=pid,
+            pgid=pgid,
         )
-    try:
-        pgid = os.getpgid(pid)
-    except ProcessLookupError:
-        return _kill_result(
-            run_id,
-            killed=False,
-            reason="process gone",
-            reason_code=KILL_PROCESS_GONE,
-            pid=pid,
-        )
-    except PermissionError as e:
-        return _kill_result(
-            run_id,
-            killed=False,
-            reason=f"permission denied: {e}",
-            reason_code=KILL_PERMISSION_DENIED,
-            pid=pid,
-        )
-    return _signal_group(run_id, job, pid, pgid, sig, KILL_LEGACY_NO_IDENTITY)
+    return _signal_group(run_id, job, pid, pgid, sig, KILL_SIGNALLED)
+
+
+def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
+    """Refuse a record written before a run's process identity was recorded.
+
+    Such a record carries a pid and nothing that distinguishes it from a pid the
+    OS has since handed to an unrelated process. The missing fields cannot be
+    filled in after the fact — they describe the process that was spawned, and
+    nothing observable now recovers when it started — and deriving a group from
+    the pid at this point is exactly the step that resolves a reused pid to a
+    stranger's group. So nothing is signalled.
+
+    The pid rides along on the refusal, because it is the only handle an operator
+    has for reaping the group by hand, and this is the last place it is reported.
+    """
+    return _kill_result(
+        run_id,
+        killed=False,
+        reason=(
+            f"this record predates process-identity capture, so pid {pid} cannot be "
+            "distinguished from a reused one and no group was signalled; reap the "
+            "group by hand after confirming the process is this run's"
+        ),
+        reason_code=KILL_LEGACY_NO_IDENTITY,
+        pid=pid,
+    )
 
 
 def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
@@ -1287,7 +1315,10 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     Nothing is signalled on an unconfirmed identity. A probe that errors is
     unknown, and unknown refuses: the refusal says which fact was missing, and
     a refusal with an accurate reason is the outcome being aimed at, not the
-    largest possible number of processes stopped.
+    largest possible number of processes stopped. That holds without exception,
+    including for a record written before these fields existed — such a record
+    cannot confirm anything, so it is refused and its group is left for an
+    operator to reap by hand.
     """
     job = _read_job(run_id)
     if job is None:
@@ -1308,7 +1339,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     created = job.get("pid_create_time")
     pgid = job.get("pgid")
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
-        return _kill_legacy_record(run_id, job, pid, sig)
+        return _refuse_legacy_record(run_id, pid)
     spawned_at = float(created)
 
     if _pid_alive(pid):
@@ -1327,9 +1358,16 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             )
         if state == "found" and live_created is not None:
             if abs(live_created - spawned_at) <= _CREATE_TIME_TOLERANCE:
-                # Identity confirmed. The group signalled is the one recorded at
-                # spawn, never one re-derived from the pid now.
-                return _signal_group(run_id, job, pid, pgid, sig, KILL_SIGNALLED)
+                # The leader is confirmed to be the process this run spawned, so
+                # its group can be read now and required to be the recorded one.
+                # Without that equality the recorded pgid is only a number that
+                # passed a range check, and a damaged or hand-edited record would
+                # aim the signal at whatever group holds that number. Reading the
+                # group is safe here and nowhere else on this path: it is safe
+                # because the pid was just identified, and the number signalled
+                # is still the recorded one — the read only decides whether to
+                # signal at all, so a reused pid cannot substitute its own group.
+                return _signal_leader_group(run_id, job, pid, pgid, sig)
             return _kill_result(
                 run_id,
                 killed=False,
@@ -1365,15 +1403,31 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             pid=pid,
             pgid=pgid,
         )
-    if verdict == "not_ours" and rule == "marker":
-        detail = f"group {pgid} holds a process started by a different run, so the group number has been reused"
+    # Each refusal gets its own code, because they are not the same news. A
+    # foreign marker, a conflict and an older member are settled facts about the
+    # group and will read the same on every retry; an incomplete scan is a
+    # measurement that failed and may succeed on the next call.
+    if verdict == "conflict":
+        detail = (
+            f"group {pgid} holds processes stamped with different run ids, so which "
+            "run it belongs to is unexplained"
+        )
+        code = KILL_GROUP_MARKERS_CONFLICT
+    elif verdict == "not_ours" and rule == "marker":
+        detail = (
+            f"group {pgid} holds a process started by a different run, so the group "
+            "number has been reused"
+        )
+        code = KILL_GROUP_FOREIGN
     elif verdict == "not_ours":
         detail = (
             f"group {pgid} holds a process that started before this run did, so the "
             "group number has been reused"
         )
+        code = KILL_GROUP_PREDATES_RUN
     else:
         detail = f"group {pgid} could not be fully inspected"
+        code = KILL_GROUP_SCAN_INCOMPLETE
     return _kill_result(
         run_id,
         killed=False,
@@ -1381,7 +1435,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             f"the leader has exited and {detail}; the group could not be confirmed "
             "to be this run's, so nothing was signalled"
         ),
-        reason_code=KILL_GROUP_UNVERIFIED,
+        reason_code=code,
         pid=pid,
         pgid=pgid,
     )

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -116,6 +116,11 @@ KILL_NO_SUCH_JOB = "no_such_job"
 # resolve it.
 KILL_RECORD_UNREADABLE = "job_record_unreadable"
 KILL_RECORD_WRONG_SHAPE = "job_record_wrong_shape"
+# The record parsed into an object and names a run other than the one asked about.
+# Its own code rather than the shape ones above: those say a file has to be looked
+# at by a person, while this one names the run the record does describe, and acting
+# on it is a call this caller can make on its own.
+KILL_RECORD_FOREIGN_RUN = "job_record_names_another_run"
 KILL_NO_PID = "no_pid_on_record"
 KILL_SIGNALLED = "signalled"
 KILL_PROCESS_GONE = "process_gone"
@@ -1311,6 +1316,20 @@ def _signal_leader_group(
     require equality. If they differ, or the group cannot be read, refuse — with
     different codes, because a mismatch is a settled fact about the record while
     an unreadable group is a probe that may answer on a later call.
+
+    Then ask the leader itself. Every process a run spawns carries the run id in
+    its environment, so a leader that reads back a *different* run's id says the
+    record does not describe it, whatever its numbers matched — the same evidence
+    the group route acts on when the leader is gone, read here from the one
+    process that has already been identified rather than from the group at large.
+    The group's other rules stay where they are: they answer a different question,
+    which member of a group can speak for it, and that question is settled here.
+
+    The marker only ever withholds a signal. An absent or unreadable one leaves
+    the decision exactly where the numbers left it, because those two arrive
+    identically — a process whose environment is not disclosed reads as carrying
+    no marker — and requiring one to permit a signal would turn every process
+    that cannot be read into a job that can never be reaped.
     """
     try:
         live_pgid = os.getpgid(pid)
@@ -1337,6 +1356,20 @@ def _signal_leader_group(
                 "record disagrees with the running process"
             ),
             reason_code=KILL_LEADER_GROUP_MISMATCH,
+            pid=pid,
+            pgid=pgid,
+        )
+    state, marker = _process_marker(pid)
+    if state == "found" and marker is not None and marker != run_id:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"pid {pid} matches this record but carries a different run's id in "
+                f"its environment, so group {pgid} is that run's work and not this "
+                "one's; nothing was signalled"
+            ),
+            reason_code=KILL_GROUP_FOREIGN,
             pid=pid,
             pgid=pgid,
         )
@@ -1378,8 +1411,8 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     exited, which is the case worth reaping, and a pid the OS handed to an
     unrelated process, which must never be signalled.
 
-    Nothing is signalled on an unconfirmed identity. A probe that errors is
-    unknown, and unknown refuses: the refusal says which fact was missing, and
+    Nothing is signalled that the record does not identify. A probe that errors
+    is unknown, and unknown refuses: the refusal says which fact was missing, and
     a refusal with an accurate reason is the outcome being aimed at, not the
     largest possible number of processes stopped. That holds without exception,
     including for a record written before these fields existed — such a record
@@ -1391,7 +1424,22 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     the live leader's start time matches the record and its current group is the
     recorded one, or a live member of the recorded group carries this run's id in
     its environment. A group is never signalled because it merely looks young
-    enough. But the identification and the signal are two separate system calls,
+    enough. Where a process can be asked which run it belongs to, an answer
+    naming another run refuses on either route; where it cannot be asked, the
+    silence decides nothing, since an environment that is withheld and one that
+    is empty come back the same and treating either as a denial would strand
+    every job whose processes cannot be read.
+
+    What no check here establishes is who wrote the record. The fields are
+    compared against the running process, so they identify a process that is
+    still the one described; they cannot show that this run described it. A
+    record that has been rewritten with a live stranger's numbers, by something
+    already able to write into this user's job store, is refused only when that
+    stranger names a different run of its own. The store's own integrity is the
+    boundary that would settle it, and it is not a boundary a field comparison
+    can draw.
+
+    Identification and the signal are two separate system calls,
     and there is no way to make them one: ``killpg`` takes a group number, not a
     reference to the group that was inspected, and there is no "signal this group
     only if it still holds the process I verified" operation to reach for. So in
@@ -1427,6 +1475,28 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
                 "the file itself is what has to be looked at"
             ),
             reason_code=KILL_RECORD_WRONG_SHAPE,
+        )
+
+    # The record names the run it describes, and every write of one puts this
+    # run's own id there. So a record found under one run that names another was
+    # not written for the run being killed — copied, restored over, or edited —
+    # and its numbers describe some other run's process. Unlike every probe below,
+    # this costs nothing when it is wrong about a healthy record: the field is
+    # written here rather than measured, so a disagreement is never a reading that
+    # failed. Checked before the pid is even looked at, because no probe of a
+    # number from a record that does not belong here is worth making.
+    recorded_run_id = job.get("run_id")
+    if recorded_run_id != run_id:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"the record stored for {run_id} names run "
+                f"{_short_repr(recorded_run_id)} instead, so the process it describes "
+                f"is not this run's and nothing was signalled; kill that run by its own "
+                "id if it is the one meant to stop"
+            ),
+            reason_code=KILL_RECORD_FOREIGN_RUN,
         )
 
     # First, and before any number on the record is probed or dereferenced. A

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -100,6 +100,30 @@ WAIT_MAX_POLL_SECONDS = 60.0
 # interpreter path so it runs regardless of PATH in the CLI's environment.
 _NOTIFY_MODULE = "lionagi.mcp._notify_hook"
 
+# A process start time is read from the kernel in clock ticks, so two reads of
+# the same process can differ in the last decimal. Compared within this
+# tolerance, the same way the CLI's own kill path compares it.
+_CREATE_TIME_TOLERANCE = 0.1
+
+# Reason codes carried by kill(). The human `reason` explains the particular
+# case; the code is what a caller can branch on without matching prose.
+KILL_NO_SUCH_JOB = "no_such_job"
+KILL_NO_PID = "no_pid_on_record"
+KILL_SIGNALLED = "signalled"
+KILL_PROCESS_GONE = "process_gone"
+KILL_PERMISSION_DENIED = "permission_denied"
+# The record was written before a run's process identity was recorded, so the
+# pid on it cannot be told apart from a reused one. Its own codes, so a reader
+# can tell an old record from a refusal this build actually decided.
+KILL_LEGACY_NO_IDENTITY = "legacy_record_no_process_identity"
+KILL_LEGACY_ALREADY_ENDED = "legacy_record_already_ended"
+KILL_LEGACY_ALREADY_EXITED = "legacy_record_already_exited"
+# Identity-bearing records.
+KILL_PID_RECYCLED = "pid_recycled"
+KILL_LEADER_UNVERIFIABLE = "leader_identity_unreadable"
+KILL_GROUP_GONE = "group_gone"
+KILL_GROUP_UNVERIFIED = "group_identity_unverified"
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -231,6 +255,140 @@ def _pid_alive(pid: int | None) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _process_create_time(pid: int) -> tuple[str, float | None]:
+    """When the process at *pid* started: ``("found", t)``, ``("gone", None)``
+    or ``("unknown", None)``.
+
+    Three answers, not two. "unknown" is a probe that errored — the process may
+    well be there — and a caller must never read it as death or as licence to
+    signal. A zombie answers "gone": it has exited, holds its pid until it is
+    reaped, and cannot be a recycled pid while it does.
+    """
+    import psutil
+
+    try:
+        proc = psutil.Process(pid)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return "gone", None
+        return "found", proc.create_time()
+    except psutil.NoSuchProcess:
+        return "gone", None
+    except (psutil.Error, OSError):
+        return "unknown", None
+
+
+def _spawned_pgid(pid: int) -> int:
+    """The process group of a just-spawned child.
+
+    Read from the OS, with the child's pid as the fallback: it was started with
+    ``start_new_session``, so it leads its own group and the two are equal by
+    construction. Recorded at spawn because deriving it at kill time is what
+    lets a reused pid resolve to a stranger's group.
+    """
+    try:
+        return os.getpgid(pid)
+    except OSError:
+        return pid
+
+
+def _live_group_members(pgid: int) -> tuple[list[tuple[int, float]], bool]:
+    """Live members of process group *pgid*, and whether the scan was complete.
+
+    Returns ``(members, complete)`` where each member is ``(pid, create_time)``.
+    A process that vanishes mid-scan is simply not a live member; a process
+    whose group or start time could not be read leaves *complete* false,
+    because the group may then hold a member this scan never saw. Zombies are
+    excluded: an unreaped corpse still counts as a group member to the kernel,
+    so counting it would report a group that is empty of running work as live.
+    """
+    import psutil
+
+    members: list[tuple[int, float]] = []
+    complete = True
+    try:
+        pids = psutil.pids()
+    except (psutil.Error, OSError):
+        return [], False
+
+    for pid in pids:
+        if pid <= 1:
+            continue
+        try:
+            if os.getpgid(pid) != pgid:
+                continue
+        except ProcessLookupError:
+            continue
+        except OSError:
+            complete = False
+            continue
+        state, created = _process_create_time(pid)
+        if state == "found" and created is not None:
+            members.append((pid, created))
+        elif state == "unknown":
+            complete = False
+    return members, complete
+
+
+def _process_marker(pid: int) -> tuple[str, str | None]:
+    """The run marker carried by the process at *pid*.
+
+    ``("found", value_or_None)`` when the environment was read — a None value
+    means the process simply does not carry the marker. ``("unknown", None)``
+    when the environment could not be read at all, which is a probe that
+    failed and never evidence about the process.
+    """
+    import psutil
+
+    try:
+        return "found", psutil.Process(pid).environ().get(config.JOB_MARKER_ENV_VAR)
+    except (psutil.Error, OSError, UnicodeDecodeError):
+        return "unknown", None
+
+
+def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str]:
+    """Whether the live group *pgid* can be the group this run spawned.
+
+    Returns the verdict and the rule that reached it. Two rules, tried in that
+    order:
+
+    The marker decides positively. Every process the run spawned carries the
+    run id in its environment, so a live member that reads back this run's id
+    identifies the group outright — members share a pgid, so one confirmed
+    member makes the group this run's. A member carrying a *different* run's id
+    is the same evidence pointing the other way: the group number has been
+    reused.
+
+    The start time decides only by exclusion, and covers what the marker
+    cannot — a run recorded before the marker existed, and a member whose
+    environment cannot be read. It is an inequality rather than an
+    identification: every member starting at or after the run did is consistent
+    with the group being ours but equally consistent with an unrelated group
+    that happens to be younger, so it is the fallback and never the primary.
+
+    ``"gone"`` when nothing live is left in the group, and ``"unknown"`` when
+    neither rule could establish anything — a member the scan could not read
+    leaves a group that may hold work this scan never saw.
+    """
+    members, complete = _live_group_members(pgid)
+
+    for pid, _ in members:
+        state, marker = _process_marker(pid)
+        if state != "found" or marker is None:
+            continue
+        if marker == run_id:
+            return "ours", "marker"
+        return "not_ours", "marker"
+
+    if not complete:
+        return "unknown", "scan"
+    if not members:
+        return "gone", "scan"
+    floor = spawned_at - _CREATE_TIME_TOLERANCE
+    if all(created >= floor for _, created in members):
+        return "ours", "start_time"
+    return "not_ours", "start_time"
 
 
 def _tail(path: str | None, limit: int = 4000) -> str | None:
@@ -675,6 +833,10 @@ def submit(
     # environment that claims it is running under an interactive harness.
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
     env[config.RUN_ID_ENV_VAR] = run_id
+    # The child carries the run that started it. Every process it goes on to
+    # spawn inherits this, so a live member of the group can later be asked
+    # what it belongs to instead of being guessed at from when it started.
+    env[config.JOB_MARKER_ENV_VAR] = run_id
 
     # Only "agent" hands the instruction over in a file; flow and fanout take it
     # as a positional, so a long one has to fit in the process argument vector.
@@ -702,6 +864,8 @@ def submit(
     record = {
         "run_id": run_id,
         "pid": None,
+        "pid_create_time": None,
+        "pgid": None,
         "kind": kind,
         "argv": argv,
         "cwd": cwd,
@@ -749,8 +913,20 @@ def submit(
 
     # Attach the pid without rewriting status: if the hook already recorded a
     # terminal in the (tiny) spawn window, re-reading here preserves it.
+    #
+    # The pid goes down with the two things that say WHICH process it was: when
+    # that process started, and the group it leads. A pid number on its own is
+    # not an identity — the OS hands it out again once the process is reaped —
+    # so a kill holding only a number cannot tell the run it started from
+    # whatever occupies that number later. The start time is read here, while
+    # the child is certainly the one just spawned; a read that fails leaves it
+    # null, which kill() reads as "no identity was captured" rather than as any
+    # claim about the process.
     latest = _read_job(run_id) or record
     latest["pid"] = proc.pid
+    _state, created = _process_create_time(proc.pid)
+    latest["pid_create_time"] = created
+    latest["pgid"] = _spawned_pgid(proc.pid)
     latest["spawn_state"] = "started"
     _write_job(latest)
 
@@ -972,51 +1148,243 @@ def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
     }
 
 
-def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
-    """Signal the whole process group of *run_id*."""
-    job = _read_job(run_id)
-    if job is None:
-        return {"run_id": run_id, "killed": False, "reason": "no such job"}
-    # Before the pid is read, let alone signalled. A record that already ended
-    # keeps its pid, and the operating system reuses pid numbers: probing that
-    # number can find an unrelated live process, and signalling it would kill a
-    # stranger's process group and report success. The write below would also
-    # relabel a run that completed or was cancelled as "killed".
+def _kill_result(
+    run_id: str,
+    *,
+    killed: bool,
+    reason: str | None,
+    reason_code: str,
+    pid: Any = None,
+    pgid: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "killed": killed,
+        "reason": reason,
+        "reason_code": reason_code,
+        "pid": pid,
+        "pgid": pgid,
+    }
+
+
+def _mark_killed(job: dict[str, Any]) -> None:
+    """Record the kill on the job record.
+
+    A record that already carries an end keeps it. The run really did finish
+    the way it says, and what was signalled here is work that outlived that end
+    — overwriting ``completed`` with ``killed`` would replace how the run came
+    out with how its stragglers were cleaned up.
+    """
+    if _record_is_terminal(job):
+        job["group_reaped_at"] = _now_iso()
+    else:
+        job["status"] = "killed"
+        job["finished_at"] = _now_iso()
+    _write_job(job)
+
+
+def _signal_group(
+    run_id: str,
+    job: dict[str, Any],
+    pid: int,
+    pgid: int,
+    sig: int,
+    reason_code: str,
+) -> dict[str, Any]:
+    """Signal *pgid* and record the outcome on the job record."""
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason="process gone",
+            reason_code=KILL_PROCESS_GONE,
+            pid=pid,
+            pgid=pgid,
+        )
+    except PermissionError as e:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=f"permission denied: {e}",
+            reason_code=KILL_PERMISSION_DENIED,
+            pid=pid,
+            pgid=pgid,
+        )
+    _mark_killed(job)
+    return _kill_result(
+        run_id, killed=True, reason=None, reason_code=reason_code, pid=pid, pgid=pgid
+    )
+
+
+def _kill_legacy_record(run_id: str, job: dict[str, Any], pid: int, sig: int) -> dict[str, Any]:
+    """Kill a record written before a run's process identity was recorded.
+
+    Nothing here can tell this run's pid from a reused one, so the behaviour is
+    the one that predates identity, unchanged, and the reason codes say which
+    record this was. The missing fields cannot be filled in after the fact: the
+    process they describe is the one that was spawned, and nothing observable
+    now can recover when it started.
+    """
     if _record_is_terminal(job):
         recorded = job.get("status", "unknown")
         # The pid rides along on the refusal. A record can be marked terminal
         # while its group leader is still alive: the terminal status is persisted
         # from the lifecycle transition, and the run's own teardown finishes
         # after that. Refusing is still right, because this pid may equally have
-        # been reused by then and nothing here can tell the two apart. But an
-        # operator reaping a group that really did outlive its recorded end needs
-        # the number, and this is the last place it is reported.
-        return {
-            "run_id": run_id,
-            "killed": False,
-            "reason": f"already ended as {recorded}; pid not signalled because it may since have been reused",
-            "pid": job.get("pid"),
-        }
-    pid = job.get("pid")
-    if not pid or pid <= 1:  # never signal pgid 0/1 (self/init)
-        return {"run_id": run_id, "killed": False, "reason": "no pid on record"}
+        # been reused by then and nothing on this record can tell the two apart.
+        # But an operator reaping a group that really did outlive its recorded
+        # end needs the number, and this is the last place it is reported.
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"already ended as {recorded}; pid not signalled because "
+                "it may since have been reused"
+            ),
+            reason_code=KILL_LEGACY_ALREADY_ENDED,
+            pid=pid,
+        )
     if not _pid_alive(pid):
-        return {"run_id": run_id, "killed": False, "reason": "already exited"}
-
-    reason: str | None = None
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason="already exited",
+            reason_code=KILL_LEGACY_ALREADY_EXITED,
+            pid=pid,
+        )
     try:
-        os.killpg(os.getpgid(pid), sig)
-        killed = True
+        pgid = os.getpgid(pid)
     except ProcessLookupError:
-        killed, reason = False, "process gone"
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason="process gone",
+            reason_code=KILL_PROCESS_GONE,
+            pid=pid,
+        )
     except PermissionError as e:
-        killed, reason = False, f"permission denied: {e}"
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=f"permission denied: {e}",
+            reason_code=KILL_PERMISSION_DENIED,
+            pid=pid,
+        )
+    return _signal_group(run_id, job, pid, pgid, sig, KILL_LEGACY_NO_IDENTITY)
 
-    if killed:
-        job["status"] = "killed"
-        job["finished_at"] = _now_iso()
-        _write_job(job)
-    return {"run_id": run_id, "killed": killed, "reason": reason, "pid": pid}
+
+def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
+    """Signal the process group *run_id* was spawned into.
+
+    The record carries what the pid alone cannot: when the leader started, and
+    the group it was given at spawn. Those turn the two cases a bare pid
+    confuses into decidable ones — a group still running after its leader
+    exited, which is the case worth reaping, and a pid the OS handed to an
+    unrelated process, which must never be signalled.
+
+    Nothing is signalled on an unconfirmed identity. A probe that errors is
+    unknown, and unknown refuses: the refusal says which fact was missing, and
+    a refusal with an accurate reason is the outcome being aimed at, not the
+    largest possible number of processes stopped.
+    """
+    job = _read_job(run_id)
+    if job is None:
+        return _kill_result(
+            run_id, killed=False, reason="no such job", reason_code=KILL_NO_SUCH_JOB
+        )
+
+    # First, and before any number on the record is probed or dereferenced. A
+    # pid of 0 means the caller's own process group to killpg, and 1 is init;
+    # a record carrying either — a placeholder, a truncated write, a test
+    # double — must never reach a group signal.
+    pid = job.get("pid")
+    if not isinstance(pid, int) or pid <= 1:
+        return _kill_result(
+            run_id, killed=False, reason="no pid on record", reason_code=KILL_NO_PID, pid=pid
+        )
+
+    created = job.get("pid_create_time")
+    pgid = job.get("pgid")
+    if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
+        return _kill_legacy_record(run_id, job, pid, sig)
+    spawned_at = float(created)
+
+    if _pid_alive(pid):
+        state, live_created = _process_create_time(pid)
+        if state == "unknown":
+            return _kill_result(
+                run_id,
+                killed=False,
+                reason=(
+                    f"pid {pid} is alive but its start time could not be read, so it "
+                    "cannot be confirmed to be this run; nothing was signalled"
+                ),
+                reason_code=KILL_LEADER_UNVERIFIABLE,
+                pid=pid,
+                pgid=pgid,
+            )
+        if state == "found" and live_created is not None:
+            if abs(live_created - spawned_at) <= _CREATE_TIME_TOLERANCE:
+                # Identity confirmed. The group signalled is the one recorded at
+                # spawn, never one re-derived from the pid now.
+                return _signal_group(run_id, job, pid, pgid, sig, KILL_SIGNALLED)
+            return _kill_result(
+                run_id,
+                killed=False,
+                reason=(
+                    f"pid {pid} now belongs to a different process (started "
+                    f"{live_created:.3f}, this run started {spawned_at:.3f}); "
+                    "nothing was signalled"
+                ),
+                reason_code=KILL_PID_RECYCLED,
+                pid=pid,
+                pgid=pgid,
+            )
+        # "gone": it exited between the liveness probe and this read. Fall
+        # through — its group may well still be running.
+
+    # The leader is gone. Its group can outlive it, and that group is what the
+    # run's work is actually in, so it is reapable — but only once the group
+    # itself is identified, since a pgid is a pid number and is reused like one.
+    #
+    # Identified from the group's own live members, never by looking at the
+    # leader's pid again: the liveness probe reaps an exited child, after which
+    # that pid is free for the OS to hand to an unrelated process, and a second
+    # read of it would describe whoever holds it now.
+    verdict, rule = _group_identity(pgid, spawned_at, run_id)
+    if verdict == "ours":
+        return _signal_group(run_id, job, pid, pgid, sig, KILL_SIGNALLED)
+    if verdict == "gone":
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=f"already exited; no live process remains in group {pgid}",
+            reason_code=KILL_GROUP_GONE,
+            pid=pid,
+            pgid=pgid,
+        )
+    if verdict == "not_ours" and rule == "marker":
+        detail = f"group {pgid} holds a process started by a different run, so the group number has been reused"
+    elif verdict == "not_ours":
+        detail = (
+            f"group {pgid} holds a process that started before this run did, so the "
+            "group number has been reused"
+        )
+    else:
+        detail = f"group {pgid} could not be fully inspected"
+    return _kill_result(
+        run_id,
+        killed=False,
+        reason=(
+            f"the leader has exited and {detail}; the group could not be confirmed "
+            "to be this run's, so nothing was signalled"
+        ),
+        reason_code=KILL_GROUP_UNVERIFIED,
+        pid=pid,
+        pgid=pgid,
+    )
 
 
 def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[str, Any]]:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -119,9 +119,9 @@ KILL_PERMISSION_DENIED = "permission_denied"
 # decided about a record that does carry an identity.
 KILL_LEGACY_NO_IDENTITY = "legacy_record_no_process_identity"
 # The identity fields are present and of the right type but hold a value nothing
-# can be compared against — a NaN or an infinity where a start time belongs. Its
-# own code rather than the one above: that one says a record is old and expected,
-# this one says a record is damaged, and only the second is worth investigating.
+# can be compared against where a start time belongs. Its own code rather than the
+# one above: that one says a record is old and expected, this one says a record is
+# damaged, and only the second is worth investigating.
 KILL_IDENTITY_UNUSABLE = "recorded_identity_unusable"
 # Identity-bearing records. Split by what a caller would do next: a mismatch or
 # a foreign group is settled and will not change on a retry, while an unreadable
@@ -135,6 +135,12 @@ KILL_GROUP_FOREIGN = "group_belongs_to_another_run"
 KILL_GROUP_MARKERS_CONFLICT = "group_markers_conflict"
 KILL_GROUP_PREDATES_RUN = "group_predates_run"
 KILL_GROUP_SCAN_INCOMPLETE = "group_scan_incomplete"
+# The group was inspected end to end and simply yielded no evidence of ownership:
+# no member's marker could be read. Separate from an incomplete scan, because that
+# one is a measurement that failed and may answer on the next call, while this one
+# is the measurement succeeding and returning nothing — the same call will keep
+# returning it, and only an operator can settle the group.
+KILL_GROUP_OWNERSHIP_UNPROVEN = "group_ownership_unproven"
 
 
 def _now_iso() -> str:
@@ -379,16 +385,18 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     ``"conflict"``: two runs cannot both own a group, so whatever produced the
     disagreement is unexplained, and an unexplained group is not signalled.
 
-    The start time decides only by exclusion, and covers what the marker
-    cannot — a run recorded before the marker existed, and a member whose
-    environment cannot be read. It is an inequality rather than an
-    identification: every member starting at or after the run did is consistent
-    with the group being ours but equally consistent with an unrelated group
-    that happens to be younger, so it is the fallback and never the primary.
+    The start time can only ever exclude. A member that started before this run
+    did cannot be work this run spawned, so the group number has been handed on
+    and the answer is ``"not_ours"``. The converse does not follow: every member
+    being younger than the run is consistent with the group being ours and
+    equally consistent with an unrelated group that simply started later, so it
+    is not an identification and is never treated as one. A dead leader whose
+    group yields no readable marker is ``"unproven"`` — inspected in full,
+    and found to carry no evidence either way.
 
     ``"gone"`` when nothing live is left in the group, and ``"unknown"`` when
-    neither rule could establish anything — a member the scan could not read
-    leaves a group that may hold work this scan never saw.
+    the scan itself could not be completed — a member it could not read leaves a
+    group that may hold work the scan never saw.
     """
     members, complete = _live_group_members(pgid)
 
@@ -407,9 +415,9 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     if not members:
         return "gone", "scan"
     floor = spawned_at - _CREATE_TIME_TOLERANCE
-    if all(created >= floor for _, created in members):
-        return "ours", "start_time"
-    return "not_ours", "start_time"
+    if any(created < floor for _, created in members):
+        return "not_ours", "start_time"
+    return "unproven", "start_time"
 
 
 def _tail(path: str | None, limit: int = 4000) -> str | None:
@@ -1325,6 +1333,21 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     including for a record written before these fields existed — such a record
     cannot confirm anything, so it is refused and its group is left for an
     operator to reap by hand.
+
+    What that buys, stated exactly, because the difference matters to anyone
+    relying on it. Every signal is preceded by a positive identification: either
+    the live leader's start time matches the record and its current group is the
+    recorded one, or a live member of the recorded group carries this run's id in
+    its environment. A group is never signalled because it merely looks young
+    enough. But the identification and the signal are two separate system calls,
+    and there is no way to make them one: ``killpg`` takes a group number, not a
+    reference to the group that was inspected, and there is no "signal this group
+    only if it still holds the process I verified" operation to reach for. So in
+    the window between the two, the identified group can empty and its number be
+    handed to an unrelated group, which would then receive the signal. The window
+    is small and closing it is not possible with process groups alone; it is
+    stated here rather than papered over, because the guarantee is "never signalled
+    without an identification", not "never signals the wrong group".
     """
     job = _read_job(run_id)
     if job is None:
@@ -1346,19 +1369,34 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     pgid = job.get("pgid")
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
         return _refuse_legacy_record(run_id, pid)
-    # Two values reach here that look like numbers and cannot act as one. A NaN or
+    # Three values reach here that look like numbers and cannot act as one. A NaN or
     # an infinity passes every type and range check above and then loses silently to
     # every comparison below, so the leader would be reported as a recycled pid. A
     # boolean is an int as far as isinstance is concerned, so a start time of `true`
-    # arrives as 1.0 — a moment in 1970 — and mismatches the same way. Both name the
-    # wrong fact: nothing was established about the pid at all, only that this record
-    # cannot say anything about it.
-    if isinstance(created, bool) or not math.isfinite(float(created)):
+    # arrives as 1.0 — a moment in 1970 — and mismatches the same way. And a JSON
+    # integer is unbounded, so a record can carry one too large to be a float at all;
+    # converting it is the only way to compare it, and the conversion is what fails,
+    # so that refusal has to be decided from the failure rather than after it. All
+    # three name the wrong fact if they are allowed through: nothing was established
+    # about the pid, only that this record cannot say anything about it.
+    try:
+        spawned_at = float(created)
+        unusable = isinstance(created, bool) or not math.isfinite(spawned_at)
+    except OverflowError:
+        unusable = True
+    if unusable:
+        # The value is reported as written rather than as coerced, so a reader sees
+        # the damage instead of a plausible-looking timestamp — but it came off disk
+        # and a JSON number has no length limit, so it is capped before it goes into
+        # a reason a caller has to read.
+        shown = repr(created)
+        if len(shown) > 60:
+            shown = f"{shown[:60]}… ({len(shown)} characters)"
         return _kill_result(
             run_id,
             killed=False,
             reason=(
-                f"the start time recorded for pid {pid} is {created!r}, which no start "
+                f"the start time recorded for pid {pid} is {shown}, which no start "
                 "time can be compared against, so this record cannot identify its own "
                 "process and nothing was signalled; reap the group by hand after "
                 "confirming the process is this run's"
@@ -1367,7 +1405,6 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             pid=pid,
             pgid=pgid,
         )
-    spawned_at = float(created)
 
     if _pid_alive(pid):
         state, live_created = _process_create_time(pid)
@@ -1430,28 +1467,26 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             pid=pid,
             pgid=pgid,
         )
-    # Each refusal gets its own code, because they are not the same news. A
-    # foreign marker, a conflict and an older member are settled facts about the
-    # group and will read the same on every retry; an incomplete scan is a
-    # measurement that failed and may succeed on the next call.
+    # Each refusal gets its own code, because they are not the same news, and each
+    # reason reports what the probe saw rather than the history that would explain
+    # it. A foreign marker, a conflict, an older member and a group with no marker
+    # at all are settled and will read the same on every retry; an incomplete scan
+    # is a measurement that failed and may succeed on the next call.
     if verdict == "conflict":
-        detail = (
-            f"group {pgid} holds processes stamped with different run ids, so which "
-            "run it belongs to is unexplained"
-        )
+        detail = f"live members of group {pgid} carry different run ids in their environment"
         code = KILL_GROUP_MARKERS_CONFLICT
     elif verdict == "not_ours" and rule == "marker":
-        detail = (
-            f"group {pgid} holds a process started by a different run, so the group "
-            "number has been reused"
-        )
+        detail = f"a live member of group {pgid} carries a different run's id in its environment"
         code = KILL_GROUP_FOREIGN
     elif verdict == "not_ours":
-        detail = (
-            f"group {pgid} holds a process that started before this run did, so the "
-            "group number has been reused"
-        )
+        detail = f"a live member of group {pgid} started before this run did"
         code = KILL_GROUP_PREDATES_RUN
+    elif verdict == "unproven":
+        detail = (
+            f"no live member of group {pgid} carries a readable run id, and starting "
+            "after this run did is not evidence of belonging to it"
+        )
+        code = KILL_GROUP_OWNERSHIP_UNPROVEN
     else:
         detail = f"group {pgid} could not be fully inspected"
         code = KILL_GROUP_SCAN_INCOMPLETE

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -359,6 +359,17 @@ def _process_create_time(pid: int) -> tuple[str, float | None]:
         return "unknown", None
 
 
+def _start_time_matches(observed: float, recorded: float) -> bool:
+    """Whether a start time read now is the one recorded for this run at spawn.
+
+    Within a tolerance, because the two are separate reads of a clock the kernel
+    keeps in ticks. Only for a recorded value against a live one: two live reads
+    of the same process must be equal, and letting those drift would weaken the
+    check that tells a recycled pid from the process that held it.
+    """
+    return abs(observed - recorded) <= _CREATE_TIME_TOLERANCE
+
+
 def _spawned_pgid(pid: int) -> int:
     """The process group of a just-spawned child.
 
@@ -1219,6 +1230,61 @@ def _server_identity() -> dict[str, str]:
     return {"version": version, "module": str(Path(__file__).resolve().parent)}
 
 
+def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[bool, str | None]:
+    """Whether the process *this run* spawned is alive, and what settled it.
+
+    A pid number is not an identity. Once the run's process exits and the OS
+    hands its number to something else, a probe of that number answers about a
+    stranger, and a run that ended would report as running for as long as the
+    stranger lives. So where the record captured the start time of the process
+    it spawned, that identity is confirmed here before liveness is reported, and
+    a number now held by a different process reports this run's process as not
+    alive — which is the truth about the run, and what raises
+    ``possibly_orphaned``, the field that exists for a process gone with no end
+    recorded.
+
+    The second element names what was established, so a caller can tell the
+    readings apart rather than infer them: ``"confirmed"``, ``"recycled"``,
+    ``"gone"`` (the pid held no live process by the time its identity was read),
+    ``"unreadable"`` (the identity probe errored, so nothing was established and
+    the liveness probe stands), ``"not_recorded"`` (the record captured no start
+    time) and ``"unusable"`` (it captured one that no start time can be compared
+    against). None when there was no live pid to identify.
+
+    Where no identity was captured the answer is the liveness probe alone,
+    exactly as before: a pid probe is all such a record ever had, and calling
+    those runs orphaned would be a claim their data does not support. A probe
+    that errored is treated the same way, because a failed read is not evidence
+    of death.
+    """
+    alive = _pid_alive(pid)
+    if not alive or job is None or not isinstance(pid, int):
+        return alive, None
+
+    recorded = job.get("pid_create_time")
+    if recorded is None:
+        return alive, "not_recorded"
+    # The same three values kill() refuses: a bool is an int to isinstance and
+    # arrives as a moment in 1970, a NaN loses every comparison silently, and an
+    # unbounded JSON integer fails the conversion that any comparison needs.
+    try:
+        spawned_at = float(recorded)
+        usable = not isinstance(recorded, bool) and math.isfinite(spawned_at)
+    except (TypeError, ValueError, OverflowError):
+        usable = False
+    if not usable:
+        return alive, "unusable"
+
+    state, live_created = _process_create_time(pid)
+    if state == "gone":
+        return False, "gone"
+    if state != "found" or live_created is None:
+        return alive, "unreadable"
+    if _start_time_matches(live_created, spawned_at):
+        return True, "confirmed"
+    return False, "recycled"
+
+
 def status(run_id: str) -> dict[str, Any]:
     """Current state of *run_id*.
 
@@ -1235,6 +1301,15 @@ def status(run_id: str) -> dict[str, Any]:
     to write it: a killed or crashed run leaves a manifest still reading
     ``running`` forever. It is one-directional evidence, so read ``status`` here,
     not ``run["status"]``.
+    ``alive`` is about the process this run spawned, not about whatever holds its
+    pid number now: where the record carries the start time captured at spawn, a
+    number the OS has handed on reports as not alive. ``pid_identity`` says how
+    that was settled — ``"confirmed"``, ``"recycled"``, ``"gone"``,
+    ``"unreadable"``, ``"not_recorded"``, ``"unusable"``, or null when there was
+    no live pid to identify — so a caller can tell a process that vanished from a
+    number that now belongs to someone else, which are different things to do
+    next. A record written without a start time is answered by the pid probe
+    alone, as it always was.
     ``possibly_orphaned`` flags a run whose process is gone with no end recorded;
     it is advisory and never makes the run terminal.
     ``notify_delivery`` reports whether the terminal notice was delivered.
@@ -1251,7 +1326,7 @@ def status(run_id: str) -> dict[str, Any]:
     job, record_state = _read_job_state(run_id)
     manifest = _read_run_manifest(run_id)
     pid = job.get("pid") if job else None
-    alive = _pid_alive(pid)
+    alive, pid_identity = _run_process_liveness(job, pid)
 
     lifecycle = None
     if _needs_lifecycle_read(job, alive):
@@ -1271,6 +1346,7 @@ def status(run_id: str) -> dict[str, Any]:
         "spawn_state": derived["spawn_state"],
         "possibly_orphaned": derived["possibly_orphaned"],
         "alive": alive,
+        "pid_identity": pid_identity,
         "pid": pid,
         "submitted_at": (job or {}).get("submitted_at"),
         "finished_at": (job or {}).get("finished_at"),
@@ -1730,7 +1806,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
                 pgid=pgid,
             )
         if state == "found" and live_created is not None:
-            if abs(live_created - spawned_at) <= _CREATE_TIME_TOLERANCE:
+            if _start_time_matches(live_created, spawned_at):
                 # The leader is confirmed to be the process this run spawned, so
                 # its group can be read now and required to be the recorded one.
                 # Without that equality the recorded pgid is only a number that

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -140,6 +140,11 @@ KILL_IDENTITY_UNUSABLE = "recorded_identity_unusable"
 # probe or an incomplete scan is a measurement that failed and may succeed later.
 KILL_PID_RECYCLED = "pid_recycled"
 KILL_LEADER_UNVERIFIABLE = "leader_identity_unreadable"
+# The leader's start time was read twice around the reads that describe its
+# group, and the two readings are not the same value. Separate from the code
+# above, which says the start time could not be read at all: here it was read,
+# twice, and what came back does not describe one process.
+KILL_LEADER_IDENTITY_CHANGED = "leader_identity_changed"
 KILL_LEADER_GROUP_MISMATCH = "leader_group_mismatch"
 KILL_LEADER_GROUP_UNREADABLE = "leader_group_unreadable"
 KILL_GROUP_GONE = "group_gone"
@@ -244,8 +249,7 @@ def _read_job(run_id: str) -> dict[str, Any] | None:
 
     Every reader that only needs the record goes through here and gets what it
     always got, including a falsy answer to fall back on. A caller that has to tell
-    an unknown run from a damaged file — and only ``kill()`` does — reads the state
-    alongside it instead.
+    an unknown run from a damaged file reads the state alongside it instead.
     """
     return _read_job_state(run_id)[0]
 
@@ -1236,8 +1240,15 @@ def status(run_id: str) -> dict[str, Any]:
     ``notify_delivery`` reports whether the terminal notice was delivered.
     ``server`` identifies the implementation that answered, so a caller can tell
     which build it is talking to rather than inferring it from behaviour.
+
+    ``known`` says whether a usable record was obtained, and ``record_state`` says
+    what was read to answer that: ``"ok"``, or ``"absent"``, ``"unreadable"`` or
+    ``"wrong_shape"`` when it was not. Only ``"absent"`` means the run is unknown.
+    A record whose bytes cannot be read, or that parses to something other than an
+    object, is a file sitting on disk, and reporting it as an unknown run tells an
+    operator to stop looking for the run it describes.
     """
-    job = _read_job(run_id)
+    job, record_state = _read_job_state(run_id)
     manifest = _read_run_manifest(run_id)
     pid = job.get("pid") if job else None
     alive = _pid_alive(pid)
@@ -1267,20 +1278,42 @@ def status(run_id: str) -> dict[str, Any]:
         "run": manifest,
         "log_tail": _tail((job or {}).get("log")),
         "known": job is not None,
+        "record_state": record_state,
         "server": _server_identity(),
     }
 
 
+# What to tell a caller that asked about a run whose record could not be used.
+# One message per way the read can fail, because "no such job" is true of exactly
+# one of them and sends an operator away from a file that is on disk.
+_NO_RECORD_ERROR = {
+    "absent": "no such job",
+    "unreadable": "the record for this job is on disk and could not be read or parsed",
+    "wrong_shape": "the record for this job holds valid JSON that is not an object",
+}
+
+
 def output(run_id: str, tail_chars: int = 20000) -> dict[str, Any]:
     """Terminal output of *run_id*: the console (an agent's final response prints
-    here) plus any persisted artifacts."""
-    job = _read_job(run_id)
+    here) plus any persisted artifacts.
+
+    ``record_state`` carries what was read, the same way ``status`` reports it, and
+    ``error`` names that state rather than reporting every failed read as an
+    unknown run.
+    """
+    job, record_state = _read_job_state(run_id)
     if job is None:
-        return {"run_id": run_id, "known": False, "error": "no such job"}
+        return {
+            "run_id": run_id,
+            "known": False,
+            "record_state": record_state,
+            "error": _NO_RECORD_ERROR.get(record_state, "no such job"),
+        }
     st = status(run_id)
     return {
         "run_id": run_id,
         "known": True,
+        "record_state": record_state,
         "status": st["status"],
         "terminal": st["terminal"],
         "outcome": st["outcome"],
@@ -1362,17 +1395,18 @@ def _signal_group(
 
 
 def _signal_leader_group(
-    run_id: str, job: dict[str, Any], pid: int, pgid: int, sig: int
+    run_id: str, job: dict[str, Any], pid: int, pgid: int, sig: int, observed_at: float
 ) -> dict[str, Any]:
     """Signal *pgid*, once the confirmed leader at *pid* is shown to be in it.
 
-    The caller has established that *pid* is the process this run spawned. What
-    is still open is whether the *pgid* on the record is that process's group:
-    the two numbers are stored separately, and a record whose pgid is wrong would
-    otherwise direct a signal at an unrelated group. Read the leader's group and
-    require equality. If they differ, or the group cannot be read, refuse — with
-    different codes, because a mismatch is a settled fact about the record while
-    an unreadable group is a probe that may answer on a later call.
+    The caller has established that *pid* is the process this run spawned, and
+    *observed_at* is the start time it read to establish it. What is still open is
+    whether the *pgid* on the record is that process's group: the two numbers are
+    stored separately, and a record whose pgid is wrong would otherwise direct a
+    signal at an unrelated group. Read the leader's group and require equality. If
+    they differ, or the group cannot be read, refuse — with different codes,
+    because a mismatch is a settled fact about the record while an unreadable
+    group is a probe that may answer on a later call.
 
     Then ask the leader itself. Every process a run spawns carries the run id in
     its environment, so a leader that reads back a *different* run's id says the
@@ -1387,6 +1421,22 @@ def _signal_leader_group(
     identically — a process whose environment is not disclosed reads as carrying
     no marker — and requiring one to permit a signal would turn every process
     that cannot be read into a job that can never be reaped.
+
+    Group and marker are read by pid, after the start time that identified the pid
+    was read, so neither is bound to that identification on its own. A run's leader
+    leads its own group, which means the number it holds is at once its pid and its
+    pgid: when it exits and the whole group drains, the OS is free to hand that one
+    number to a new session leader whose group number is the same value — so the
+    equality above can hold of a process this run never spawned, and the marker
+    cannot make up the difference, being able to withhold a signal and never to
+    permit one. So the two reads are bracketed by the start time, exactly as a
+    group member's are: read again afterwards and required to equal *observed_at*
+    exactly. Exactly, not within the tolerance the record is compared under — that
+    tolerance is for a value written to disk at spawn against one read now, while
+    these are two reads of the same kernel value, and allowing them to drift would
+    weaken the one check that tells a recycled number from the process that held
+    it. A re-read that fails, or that answers with a different process, is a
+    measurement that did not come off, and it refuses.
     """
     try:
         live_pgid = os.getpgid(pid)
@@ -1417,6 +1467,22 @@ def _signal_leader_group(
             pgid=pgid,
         )
     state, marker = _process_marker(pid)
+    again, created_again = _process_create_time(pid)
+    if again != "found" or created_again != observed_at:
+        return _kill_result(
+            run_id,
+            killed=False,
+            reason=(
+                f"pid {pid} matched this run's leader, but reading its start time again "
+                f"after its group and environment answered {created_again!r} rather than "
+                f"{observed_at!r}, so those answers do not describe the process that "
+                f"matched and group {pgid} was not confirmed to be this run's; nothing "
+                "was signalled"
+            ),
+            reason_code=KILL_LEADER_IDENTITY_CHANGED,
+            pid=pid,
+            pgid=pgid,
+        )
     if state == "found" and marker is not None and marker != run_id:
         return _kill_result(
             run_id,
@@ -1669,12 +1735,12 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
                 # its group can be read now and required to be the recorded one.
                 # Without that equality the recorded pgid is only a number that
                 # passed a range check, and a damaged or hand-edited record would
-                # aim the signal at whatever group holds that number. Reading the
-                # group is safe here and nowhere else on this path: it is safe
-                # because the pid was just identified, and the number signalled
-                # is still the recorded one — the read only decides whether to
-                # signal at all, so a reused pid cannot substitute its own group.
-                return _signal_leader_group(run_id, job, pid, pgid, sig)
+                # aim the signal at whatever group holds that number. The start
+                # time just read goes over with it, because that group read and
+                # the environment read beside it are made by pid and are not
+                # otherwise tied to this comparison; there they are bracketed by
+                # it.
+                return _signal_leader_group(run_id, job, pid, pgid, sig, live_created)
             return _kill_result(
                 run_id,
                 killed=False,
@@ -1747,7 +1813,13 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
 
 
 def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[str, Any]]:
-    """Recent jobs, newest first (run_id sorts by timestamp)."""
+    """Recent jobs, newest first (run_id sorts by timestamp).
+
+    An entry whose record could not be used is listed with the state of that read
+    in ``record_state``, the same field ``status`` reports, so a damaged record is
+    visible here as a damaged record rather than as a job with no kind and an
+    unknown status.
+    """
     try:
         entries = sorted(config.JOBS_DIR.iterdir(), reverse=True)
     except OSError:
@@ -1770,6 +1842,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "reason_code": st["reason_code"],
                 "submitted_at": st["submitted_at"],
                 "finished_at": st["finished_at"],
+                "record_state": st["record_state"],
             }
         )
         if len(out) >= limit:
@@ -1784,6 +1857,12 @@ def _wait_entry(run_id: Any) -> dict[str, Any]:
     rather than raising, so one bad id never costs the caller the ids beside it.
     Every entry carries the full lifecycle shape, error or not, so a caller reads
     the same keys in both cases.
+
+    An id with no record is ``not_found``; an id whose record is present and
+    unusable is ``record_unusable``, and says which way it is unusable. They are
+    different news — the first is a run nobody submitted, the second is a file to
+    go and look at — and calling both of them not found sends an operator away
+    from the second.
     """
     entry: dict[str, Any] = {
         "run_id": run_id,
@@ -1802,7 +1881,13 @@ def _wait_entry(run_id: Any) -> dict[str, Any]:
 
     st = status(run_id)
     if not st["known"]:
-        entry["error"] = {"kind": "not_found", "message": f"no job with id {run_id}"}
+        if st["record_state"] == "absent":
+            entry["error"] = {"kind": "not_found", "message": f"no job with id {run_id}"}
+        else:
+            entry["error"] = {
+                "kind": "record_unusable",
+                "message": f"{_NO_RECORD_ERROR[st['record_state']]}: {run_id}",
+            }
         return entry
 
     entry.update(

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -230,13 +230,17 @@ def _read_job_state(run_id: str) -> tuple[dict[str, Any] | None, str]:
     more plainly, a path whose directory cannot be searched is not a path that was
     found to be missing. Only "the file is not there" is absence; every other way
     the read can fail is a record that is present and could not be got at.
+
+    Bytes that are not valid UTF-8 are one of those ways, and they are named
+    explicitly because they do not arrive as ``OSError``: the file opens and reads,
+    and the decode is what fails.
     """
     p = config.job_dir(run_id) / "job.json"
     try:
         raw = p.read_text()
     except FileNotFoundError:
         return None, "absent"
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None, "unreadable"
     try:
         record = json.loads(raw)
@@ -306,7 +310,7 @@ def _read_lifecycle(run_id: str) -> dict[str, Any] | None:
 def _read_run_manifest(run_id: str) -> dict[str, Any] | None:
     try:
         return json.loads(config.run_manifest(run_id).read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -586,18 +586,37 @@ def _tail(path: str | None, limit: int = 4000) -> str | None:
 def _list_artifacts(run_id: str) -> tuple[list[str], str]:
     """The persisted artifacts of *run_id*, and whether the traversal completed.
 
-    A traversal that fails answers with the empty list and ``"unreadable"``, never
-    with the empty list alone. "This run wrote no artifacts" is a claim about the
-    run; "the artifacts could not be listed" is a claim about the read, and a
-    caller that is told the first when the second happened has been told something
-    false about the run.
+    A traversal that fails answers ``"unreadable"``, never with the empty list
+    alone. "This run wrote no artifacts" is a claim about the run; "the artifacts
+    could not be listed" is a claim about the read, and a caller that is told the
+    first when the second happened has been told something false about the run.
+
+    The walk is asked to report its errors rather than raise them. Denying a read
+    does not always raise: a directory whose own read permission is refused yields
+    nothing at all, so a traversal that only catches exceptions would answer that
+    the run wrote nothing and call that answer complete. A partly readable tree
+    returns the files it did reach, since those are true, alongside the state that
+    says the list is short.
+
+    A directory that is not there is not a failed read. Nothing writes one until a
+    run persists something, so its absence is exactly what an empty list of
+    artifacts means.
     """
     adir = config.run_dir(run_id) / "artifacts"
-    try:
-        found = sorted(str(p.relative_to(adir)) for p in adir.rglob("*") if p.is_file())
-    except OSError:
-        return [], "unreadable"
-    return found, "ok"
+    unreadable = False
+
+    def _note(exc: OSError) -> None:
+        nonlocal unreadable
+        if not isinstance(exc, FileNotFoundError):
+            unreadable = True
+
+    found: list[str] = []
+    for root, _dirs, names in os.walk(adir, onerror=_note):
+        for name in names:
+            path = Path(root) / name
+            if path.is_file():
+                found.append(str(path.relative_to(adir)))
+    return sorted(found), "unreadable" if unreadable else "ok"
 
 
 def _split_at_sentinel(flags: Sequence[str]) -> tuple[list[str], list[str]]:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1439,6 +1439,19 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     boundary that would settle it, and it is not a boundary a field comparison
     can draw.
 
+    So the store is a trusted input, and that is a premise of this function
+    rather than an oversight in it. It is also not a weakness worth engineering
+    against: the store lives in the invoking user's own directory, and anything
+    able to rewrite a record there can call ``killpg`` on that user's processes
+    directly, without going through here. Nothing kept beside the record helps,
+    since the same writer reaches it too, and an identifier held only in this
+    process would break the one property the recorded identity exists to
+    provide, which is that a run stays reapable after the server that spawned it
+    restarts. What is claimed, then, is the guarantee relative to a record this
+    run wrote: given that, no signal is sent without a positive identification.
+    Provenance of the record itself is out of scope and is not implied anywhere
+    in the result.
+
     Identification and the signal are two separate system calls,
     and there is no way to make them one: ``killpg`` takes a group number, not a
     reference to the group that was inspected, and there is no "signal this group

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -215,13 +215,24 @@ def _read_job_state(run_id: str) -> tuple[dict[str, Any] | None, str]:
 
     The record is returned only in the ``"ok"`` case, so nothing downstream can
     reach a value this did not admit.
+
+    Absence is established by the read itself rather than by a separate question
+    about whether the path is there. Asking first and reading second answers a
+    question nobody asked — the path may become unreadable between the two — and,
+    more plainly, a path whose directory cannot be searched is not a path that was
+    found to be missing. Only "the file is not there" is absence; every other way
+    the read can fail is a record that is present and could not be got at.
     """
     p = config.job_dir(run_id) / "job.json"
-    if not p.exists():
-        return None, "absent"
     try:
-        record = json.loads(p.read_text())
-    except (OSError, json.JSONDecodeError):
+        raw = p.read_text()
+    except FileNotFoundError:
+        return None, "absent"
+    except OSError:
+        return None, "unreadable"
+    try:
+        record = json.loads(raw)
+    except json.JSONDecodeError:
         return None, "unreadable"
     if not isinstance(record, dict):
         return None, "wrong_shape"
@@ -361,19 +372,63 @@ def _spawned_pgid(pid: int) -> int:
         return pid
 
 
-def _live_group_members(pgid: int) -> tuple[list[tuple[int, float]], bool]:
+def _pinned_member(pid: int, pgid: int) -> tuple[str, tuple[int, float, str | None] | None]:
+    """Everything *pid* has to say as a member of *pgid*, read as one observation.
+
+    ``("found", (pid, create_time, marker))`` when a single process answered all
+    of it, ``("gone", None)`` when the pid holds no live member of this group,
+    and ``("unknown", None)`` when the reads could not be tied to one process.
+
+    Group, start time and marker are three facts, each read by pid, and a pid
+    the OS reassigns between two of those reads answers the later ones as the
+    replacement process. A verdict assembled from those answers would describe
+    no process that ever existed, so the reads are bracketed by the start time:
+    read before, read again after, required to be unchanged. That is the value
+    that tells a recycled pid from the process that held it, and it is what
+    binds the other two to the same process. Failing the bracket is "unknown" —
+    a measurement that did not come off, never evidence about the group.
+    """
+    state, created = _process_create_time(pid)
+    if state == "gone":
+        return "gone", None
+    if state != "found" or created is None:
+        return "unknown", None
+    try:
+        in_group = os.getpgid(pid) == pgid
+    except ProcessLookupError:
+        return "gone", None
+    except OSError:
+        return "unknown", None
+    _marker_state, marker = _process_marker(pid)
+    again, created_again = _process_create_time(pid)
+    if again != "found" or created_again != created:
+        return "unknown", None
+    if not in_group:
+        return "gone", None
+    return "found", (pid, created, marker)
+
+
+def _live_group_members(pgid: int) -> tuple[list[tuple[int, float, str | None]], bool]:
     """Live members of process group *pgid*, and whether the scan was complete.
 
-    Returns ``(members, complete)`` where each member is ``(pid, create_time)``.
+    Returns ``(members, complete)`` where each member is ``(pid, create_time,
+    marker)``. All three arrive together, from :func:`_pinned_member`, so that a
+    caller weighing a member's marker and a member's age is weighing one
+    process. The group read in the loop below only narrows the process table to
+    candidates; the membership that counts is the one read inside the bracket.
+
     A process that vanishes mid-scan is simply not a live member; a process
-    whose group or start time could not be read leaves *complete* false,
-    because the group may then hold a member this scan never saw. Zombies are
-    excluded: an unreaped corpse still counts as a group member to the kernel,
-    so counting it would report a group that is empty of running work as live.
+    whose group or identity could not be read leaves *complete* false, because
+    the group may then hold a member this scan never saw. A member that cannot
+    be pinned is never quietly dropped instead: a scan that reported itself
+    complete while a member went unread would let a live group be answered for
+    as gone. Zombies are excluded: an unreaped corpse still counts as a group
+    member to the kernel, so counting it would report a group that is empty of
+    running work as live.
     """
     import psutil
 
-    members: list[tuple[int, float]] = []
+    members: list[tuple[int, float, str | None]] = []
     complete = True
     try:
         pids = psutil.pids()
@@ -391,9 +446,9 @@ def _live_group_members(pgid: int) -> tuple[list[tuple[int, float]], bool]:
         except OSError:
             complete = False
             continue
-        state, created = _process_create_time(pid)
-        if state == "found" and created is not None:
-            members.append((pid, created))
+        state, member = _pinned_member(pid, pgid)
+        if state == "found" and member is not None:
+            members.append(member)
         elif state == "unknown":
             complete = False
     return members, complete
@@ -438,7 +493,9 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     Every readable marker is collected before the rule is applied, because
     deciding on the first one read would make the verdict depend on the order
     the process table happened to be enumerated in — the same group could then
-    be accepted or refused between two calls. Markers that disagree are
+    be accepted or refused between two calls. Each marker arrives already tied
+    to the member that carries it and to that member's age, so no rule here
+    reasons about a pid, only about processes the scan pinned. Markers that disagree are
     ``"conflict"``: two runs cannot both own a group, so whatever produced the
     disagreement is unexplained, and an unexplained group is not signalled.
 
@@ -457,11 +514,7 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     """
     members, complete = _live_group_members(pgid)
 
-    markers = set()
-    for pid, _ in members:
-        state, marker = _process_marker(pid)
-        if state == "found" and marker is not None:
-            markers.add(marker)
+    markers = {marker for _, _, marker in members if marker is not None}
     if len(markers) > 1:
         return "conflict", "marker"
     if markers:
@@ -472,7 +525,7 @@ def _group_identity(pgid: int, spawned_at: float, run_id: str) -> tuple[str, str
     if not members:
         return "gone", "scan"
     floor = spawned_at - _CREATE_TIME_TOLERANCE
-    if any(created < floor for _, created in members):
+    if any(created < floor for _, created, _ in members):
         return "not_ours", "start_time"
     return "unproven", "start_time"
 
@@ -1386,6 +1439,14 @@ def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
     the pid at this point is exactly the step that resolves a reused pid to a
     stranger's group. So nothing is signalled.
 
+    The refusal leads with what was read off the record — both fields absent —
+    and offers the age of the record as the explanation rather than as the
+    finding. What is observed is that the fields are missing; that they are
+    missing because the record predates them follows from every write since
+    having set them, which is a fact about this code and not a measurement of
+    this file. Stating the inference alone would hand an operator a history the
+    refusal never established.
+
     The pid rides along on the refusal, because it is the only handle an operator
     has for reaping the group by hand, and this is the last place it is reported.
     """
@@ -1393,9 +1454,11 @@ def _refuse_legacy_record(run_id: str, pid: int) -> dict[str, Any]:
         run_id,
         killed=False,
         reason=(
-            f"this record predates process-identity capture, so pid {pid} cannot be "
-            "distinguished from a reused one and no group was signalled; reap the "
-            "group by hand after confirming the process is this run's"
+            f"this record carries neither a start time nor a process group, so pid {pid} "
+            "cannot be distinguished from a reused one and no group was signalled; every "
+            "write since those fields existed sets them, so a record missing both was "
+            "written before they were captured; reap the group by hand after confirming "
+            "the process is this run's"
         ),
         reason_code=KILL_LEGACY_NO_IDENTITY,
         pid=pid,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1346,19 +1346,20 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     pgid = job.get("pgid")
     if not isinstance(created, int | float) or not isinstance(pgid, int) or pgid <= 1:
         return _refuse_legacy_record(run_id, pid)
-    spawned_at = float(created)
-    # A NaN or an infinity passes every type and range check above and then loses
-    # silently to every comparison below: a NaN start time is never within
-    # tolerance of a live one, so the leader would be reported as a recycled pid.
-    # That names the wrong fact — nothing was established about the pid at all,
-    # only that this record cannot say anything about it.
-    if not math.isfinite(spawned_at):
+    # Two values reach here that look like numbers and cannot act as one. A NaN or
+    # an infinity passes every type and range check above and then loses silently to
+    # every comparison below, so the leader would be reported as a recycled pid. A
+    # boolean is an int as far as isinstance is concerned, so a start time of `true`
+    # arrives as 1.0 — a moment in 1970 — and mismatches the same way. Both name the
+    # wrong fact: nothing was established about the pid at all, only that this record
+    # cannot say anything about it.
+    if isinstance(created, bool) or not math.isfinite(float(created)):
         return _kill_result(
             run_id,
             killed=False,
             reason=(
-                f"the start time recorded for pid {pid} is {spawned_at}, which nothing "
-                "can be compared against, so this record cannot identify its own "
+                f"the start time recorded for pid {pid} is {created!r}, which no start "
+                "time can be compared against, so this record cannot identify its own "
                 "process and nothing was signalled; reap the group by hand after "
                 "confirming the process is this run's"
             ),
@@ -1366,6 +1367,7 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
             pid=pid,
             pgid=pgid,
         )
+    spawned_at = float(created)
 
     if _pid_alive(pid):
         state, live_created = _process_create_time(pid)

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -397,6 +397,14 @@ def test_kill_signals_a_live_leader_whose_environment_names_no_run(
     marker to signal would strand every job whose processes cannot be read. Both
     of those answers are covered here, because the distinction the code must not
     start drawing between them is invisible to a single case.
+
+    It is also where the scope of the whole identity check ends, and the case is
+    pinned here rather than only described in prose. A record rewritten to hold
+    a live stranger's pid, start time and group reaches this same assertion: if
+    that stranger names no run, it is signalled. Nothing in the record can say
+    who wrote it, so the guarantee is relative to a record this run wrote, and a
+    store that can be rewritten is a store whose writer could signal these
+    processes without going through here at all.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -223,7 +223,6 @@ def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded
 
     assert killpg_calls == [], "a job that already ended must not be signalled"
     assert out["killed"] is False
-    assert recorded["status"] in out["reason"]
     # The refusal reports the pid: a group that really did outlive its recorded
     # end can only be found by an operator if this number survives the refusal.
     assert out["pid"] == 4242
@@ -233,25 +232,6 @@ def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded
     after = jobs._read_job(rid)
     assert after["status"] == recorded["status"]
     assert after.get("finished_at") == recorded.get("finished_at")
-
-
-def test_kill_signals_the_process_group_of_a_live_run(sandbox, monkeypatch):
-    """The whole point of kill: a live, non-terminal run gets SIGTERM by group."""
-    killpg_calls: list[tuple] = []
-    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 9000 + pid)
-    monkeypatch.setattr(jobs.os, "killpg", lambda *a: killpg_calls.append(a))
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
-
-    rid = jobs.new_run_id()
-    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
-
-    out = jobs.kill(rid)
-
-    assert killpg_calls == [(9000 + 4242, signal.SIGTERM)]
-    assert out["killed"] is True and out["reason"] is None and out["pid"] == 4242
-    after = jobs._read_job(rid)
-    assert after["status"] == "killed" and after["finished_at"] is not None
-    assert jobs.status(rid)["terminal"] is True
 
 
 _SPAWNED_AT = 1_700_000_000.0
@@ -280,15 +260,16 @@ def no_stray_signal(monkeypatch):
     Three jobs, all following from the same fact: the pids in these records are
     numbers the test made up, and some live process may well hold each of them.
     It records what was signalled so a test can assert on it; it replaces
-    os.getpgid with a raise, since resolving a group from a made-up pid would
-    aim a real signal at whoever holds that number; and it stubs the marker read
-    to "unreadable", so no test reaches into a real process's environment. A
-    test exercising the marker overrides that last one with its own stub.
+    os.getpgid with a raise, so a test that needs the live leader's group has to
+    say which group that is rather than reading whatever real process holds its
+    invented pid; and it stubs the marker read to "unreadable", so no test
+    reaches into a real process's environment. A test exercising the marker or
+    the leader's group overrides the relevant stub with its own.
     """
     calls: list[tuple] = []
 
     def refuse_getpgid(pid):
-        raise AssertionError(f"the group must come from the record, not from pid {pid}")
+        raise AssertionError(f"pid {pid} is invented; the test must stub its group")
 
     monkeypatch.setattr(jobs.os, "getpgid", refuse_getpgid)
     monkeypatch.setattr(jobs.os, "killpg", lambda *a: calls.append(a))
@@ -314,9 +295,11 @@ def test_submit_records_the_identity_of_the_process_it_spawned(sandbox, monkeypa
 def test_kill_signals_the_recorded_group_when_identity_matches(
     sandbox, monkeypatch, no_stray_signal
 ):
-    """The happy path: the leader is alive and is the process we started."""
+    """The happy path: the leader is alive, is the process we started, and is
+    in the group the record names."""
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 0.02))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
 
     rid = _identity_record()
     out = jobs.kill(rid)
@@ -326,6 +309,53 @@ def test_kill_signals_the_recorded_group_when_identity_matches(
     assert out["pgid"] == 7777
     after = jobs._read_job(rid)
     assert after["status"] == "killed" and after["finished_at"] is not None
+
+
+def test_kill_refuses_when_the_live_leader_is_in_a_different_group(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A stored group number that the confirmed leader is not actually in.
+
+    The leader passes the identity check, so the old code signalled the recorded
+    group on the strength of it having been an integer above one. A record whose
+    pgid was damaged or edited would then aim a signal at whatever group holds
+    that number. Neither number is signalled.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 4242)
+
+    rid = _identity_record(pgid=987654)
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "a record's pgid alone must license no signal"
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_LEADER_GROUP_MISMATCH
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+@pytest.mark.parametrize("error", [ProcessLookupError(), PermissionError(1, "not permitted")])
+def test_kill_refuses_when_the_live_leaders_group_cannot_be_read(
+    sandbox, monkeypatch, no_stray_signal, error
+):
+    """An unreadable group is a probe that failed, and it refuses like any other.
+
+    Its own code, separate from a mismatch: nothing has been established about
+    the record here, so this is the case where a later call may still succeed.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+
+    def raising_getpgid(pid):
+        raise error
+
+    monkeypatch.setattr(jobs.os, "getpgid", raising_getpgid)
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_LEADER_GROUP_UNREADABLE
 
 
 def test_kill_refuses_a_recycled_pid(sandbox, monkeypatch, no_stray_signal):
@@ -472,8 +502,64 @@ def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch,
     out = jobs.kill(_identity_record())
 
     assert no_stray_signal == []
-    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_FOREIGN
     assert "started by a different run" in out["reason"]
+
+
+@pytest.mark.parametrize("order", [("this-run", "other-run"), ("other-run", "this-run")])
+def test_kill_refuses_a_group_whose_members_carry_conflicting_markers(
+    sandbox, monkeypatch, no_stray_signal, order
+):
+    """Two markers disagree, and the verdict must not depend on which is read first.
+
+    Deciding on the first readable marker made the answer a function of the order
+    the process table was enumerated in: the same two members returned "ours" one
+    way round and "not_ours" the other. Both orders now reach the same refusal,
+    and a disagreement is its own outcome rather than being reported as either
+    ownership claim.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        lambda pgid: ([(5001, _SPAWNED_AT + 1.0), (5002, _SPAWNED_AT + 2.0)], True),
+    )
+
+    rid = _identity_record()
+    seen = {pid: (rid if m == "this-run" else m) for pid, m in zip([5001, 5002], order)}
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", seen[pid]))
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "an unexplained group must not be signalled"
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_GROUP_MARKERS_CONFLICT
+    assert "different run ids" in out["reason"]
+
+
+def test_kill_identifies_a_group_whose_members_all_carry_this_runs_marker(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Agreeing markers across several members still identify the group.
+
+    The conflict rule must refuse disagreement without refusing agreement: a run
+    that spawned more than one process is the ordinary case, and every member
+    reading back the same run id is the strongest evidence available here.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        # Both older than the record, so only the marker can license this signal.
+        lambda pgid: ([(5001, _SPAWNED_AT - 60.0), (5002, _SPAWNED_AT - 30.0)], True),
+    )
+
+    rid = _identity_record()
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
 
 
 @pytest.mark.parametrize(
@@ -530,21 +616,27 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
 
 
 @pytest.mark.parametrize(
-    "members",
+    ("members", "expected_code"),
     [
-        # A member older than the run: this group number was reused.
-        ([(5001, _SPAWNED_AT - 60.0)], True),
+        # A member older than the run: this group number was reused. Settled —
+        # a retry reads the same thing.
+        (([(5001, _SPAWNED_AT - 60.0)], True), jobs.KILL_GROUP_PREDATES_RUN),
         # The scan could not read every candidate, so a member may be unseen.
-        ([(5001, _SPAWNED_AT + 3.0)], False),
-        ([], False),
+        # A measurement that failed, and a retry may answer.
+        (([(5001, _SPAWNED_AT + 3.0)], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
+        (([], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
     ],
 )
-def test_kill_refuses_a_group_it_cannot_confirm(sandbox, monkeypatch, no_stray_signal, members):
+def test_kill_refuses_a_group_it_cannot_confirm(
+    sandbox, monkeypatch, no_stray_signal, members, expected_code
+):
     """A pgid is a pid number and is reused like one.
 
     With the leader gone, the recorded group number alone licenses nothing: an
     accurate refusal is the outcome being aimed at here, not the largest number
-    of processes stopped.
+    of processes stopped. Each refusal carries its own code, because "this group
+    is another run's" and "the inspection did not finish" are different news to a
+    caller deciding whether to try again.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(jobs, "_live_group_members", lambda pgid: members)
@@ -552,7 +644,7 @@ def test_kill_refuses_a_group_it_cannot_confirm(sandbox, monkeypatch, no_stray_s
     out = jobs.kill(_identity_record())
 
     assert no_stray_signal == []
-    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+    assert out["killed"] is False and out["reason_code"] == expected_code
 
 
 def test_kill_reports_a_group_with_nothing_live_left_in_it(sandbox, monkeypatch, no_stray_signal):
@@ -604,7 +696,7 @@ def test_kill_refuses_a_terminal_record_whose_group_is_unconfirmable(
     out = jobs.kill(rid)
 
     assert no_stray_signal == []
-    assert out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+    assert out["reason_code"] == jobs.KILL_GROUP_PREDATES_RUN
     assert "could not be confirmed" in out["reason"]
     assert jobs._read_job(rid)["status"] == "completed"
 
@@ -639,46 +731,35 @@ def test_kill_never_dereferences_a_pid_it_must_not_signal(
     assert out["killed"] is False and out["reason_code"] == jobs.KILL_NO_PID
 
 
-def test_kill_falls_back_to_pid_liveness_on_a_record_without_identity(sandbox, monkeypatch):
-    """A record written before identity was recorded keeps its old behaviour.
+@pytest.mark.parametrize(
+    "record",
+    [
+        # No identity fields at all: written before they were captured.
+        {},
+        # Present but malformed, which says as little as absent does.
+        {"pid_create_time": "not-a-number", "pgid": 7777},
+        {"pid_create_time": _SPAWNED_AT, "pgid": "7777"},
+        {"pid_create_time": _SPAWNED_AT, "pgid": 0},
+        {"pid_create_time": None, "pgid": None},
+    ],
+)
+def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
+    sandbox, monkeypatch, no_stray_signal, record
+):
+    """A record with no usable identity is refused rather than signalled.
 
-    The fields were never captured and nothing observable now can recover them,
-    so such a record is signalled the way it always was — and says so with its
-    own reason code, which is how a reader tells an old record from a refusal
-    this build decided.
+    Deriving a group from the pid at this point is the pid-reuse step the identity
+    fields exist to remove: the pid may have been handed to an unrelated process
+    since, and its group would then be a stranger's. Nothing about the process is
+    probed either — a liveness answer would not distinguish the two cases, so the
+    refusal does not depend on one.
     """
-    killpg_calls: list[tuple] = []
-    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 9000 + pid)
-    monkeypatch.setattr(jobs.os, "killpg", lambda *a: killpg_calls.append(a))
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
     monkeypatch.setattr(
         jobs,
         "_live_group_members",
-        lambda pgid: pytest.fail("a legacy record has no group to verify"),
+        lambda pgid: pytest.fail("a record without an identity has no group to verify"),
     )
-
-    rid = jobs.new_run_id()
-    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
-    out = jobs.kill(rid)
-
-    assert killpg_calls == [(9000 + 4242, signal.SIGTERM)]
-    assert out["killed"] is True and out["reason_code"] == jobs.KILL_LEGACY_NO_IDENTITY
-    assert jobs._read_job(rid)["status"] == "killed"
-
-
-def test_kill_refuses_a_legacy_record_whose_pid_is_gone(sandbox, monkeypatch, no_stray_signal):
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
-
-    rid = jobs.new_run_id()
-    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
-    out = jobs.kill(rid)
-
-    assert no_stray_signal == []
-    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_ALREADY_EXITED
-
-
-def test_kill_refuses_a_legacy_record_that_already_ended(sandbox, monkeypatch, no_stray_signal):
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
 
     rid = jobs.new_run_id()
     jobs._write_job(
@@ -686,18 +767,44 @@ def test_kill_refuses_a_legacy_record_that_already_ended(sandbox, monkeypatch, n
             "run_id": rid,
             "pid": 4242,
             "kind": "agent",
-            "status": "completed",
-            "finished_at": "2026-01-01T00:00:00+00:00",
+            "status": "running",
             "log": None,
+            **record,
         }
     )
     out = jobs.kill(rid)
 
-    assert no_stray_signal == []
-    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_ALREADY_ENDED
-    assert "may since have been reused" in out["reason"]
+    assert no_stray_signal == [], "a pid without an identity must license no signal"
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_NO_IDENTITY
+    assert out["pid"] == 4242, "the operator needs the number to reap the group by hand"
+    assert "predates process-identity capture" in out["reason"]
+    assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
 
 
+def _process_table_enumerable() -> tuple[bool, str]:
+    """Whether this machine lets us list the process table at all.
+
+    The group-identity rules are built on enumerating processes, and some
+    sandboxes refuse it outright: ``psutil.pids()`` raises, ``_live_group_members``
+    correctly reports an incomplete scan, and a test that needs a real measurement
+    has nothing to measure. That is an environment that cannot run the check, not
+    a regression, and it must not read like one. Only the enumeration itself is
+    probed — a machine that can list processes and still gets the wrong answer
+    fails, which is the case worth failing on.
+    """
+    import psutil
+
+    try:
+        psutil.pids()
+    except (psutil.Error, OSError) as e:
+        return False, f"this environment cannot enumerate the process table: {e!r}"
+    return True, ""
+
+
+_CAN_ENUMERATE, _NO_ENUMERATION_REASON = _process_table_enumerable()
+
+
+@pytest.mark.skipif(not _CAN_ENUMERATE, reason=_NO_ENUMERATION_REASON or "process table readable")
 def test_a_group_outlives_its_leader_and_is_reaped_by_identity(sandbox):
     """End to end against real processes: the defect, and the fix, unmocked.
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1602,6 +1602,62 @@ def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkey
         os.chmod(run_dir, 0o700)
 
 
+def test_a_record_of_invalid_bytes_is_an_unusable_record_not_an_exception(sandbox):
+    """Corruption that is not JSON corruption.
+
+    The record is bytes on disk, and bytes can fail to be text before they ever
+    fail to be JSON. That failure does not arrive as ``OSError`` — the file opens
+    and reads fine — so a reader guarding only the open and the parse lets it out.
+
+    Every surface here shares one reader, which is what makes this worth asserting
+    at the surfaces rather than at the helper: the listing in particular promises
+    that one damaged record does not cost the caller the runs beside it, and an
+    exception out of the shared reader breaks that promise for every run at once.
+    """
+    ok_rid = jobs.new_run_id()
+    jobs._write_job({"run_id": ok_rid, "pid": None, "kind": "agent", "status": "running"})
+
+    bad_rid = jobs.new_run_id()
+    bad_dir = config.job_dir(bad_rid)
+    bad_dir.mkdir(parents=True, exist_ok=True)
+    (bad_dir / "job.json").write_bytes(b'\xff\xfe{"run_id": "not utf-8"}')
+
+    # Control: the truncated-JSON case already reports unusable, so a passing
+    # assertion below is about the bytes and not about damaged records generally.
+    trunc_rid = jobs.new_run_id()
+    trunc_dir = config.job_dir(trunc_rid)
+    trunc_dir.mkdir(parents=True, exist_ok=True)
+    (trunc_dir / "job.json").write_text('{"run_id": "truncated"')
+    assert jobs.status(trunc_rid)["record_state"] == "unreadable"
+
+    assert jobs.status(bad_rid)["record_state"] == "unreadable"
+    assert jobs.status(bad_rid)["known"] is False
+    assert jobs.output(bad_rid)["record_state"] == "unreadable"
+    assert jobs.kill(bad_rid)["reason_code"] == jobs.KILL_RECORD_UNREADABLE
+
+    listed = {j["run_id"]: j.get("record_state") for j in jobs.list_jobs()}
+    assert listed[bad_rid] == "unreadable"
+    assert listed[ok_rid] == "ok", "one damaged record must not cost the runs beside it"
+
+
+def test_a_run_manifest_of_invalid_bytes_does_not_escape_the_surface_that_reads_it(sandbox):
+    """The manifest is advisory, which is an argument about its value and not a
+    licence to raise. A read that returns nothing costs the caller one display
+    field; a read that raises costs them the whole surface.
+    """
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+    manifest = config.run_manifest(rid)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+
+    manifest.write_text('{"run_id": "readable"}')
+    assert jobs.status(rid)["run"] == {"run_id": "readable"}, "control: the manifest is read"
+
+    manifest.write_bytes(b"\xff\xfe not utf-8")
+    assert jobs.status(rid)["run"] is None
+    assert jobs.status(rid)["known"] is True, "the record is fine; only the manifest is not"
+
+
 def test_an_artifacts_directory_that_denies_its_own_read_is_not_a_run_that_wrote_nothing(
     sandbox,
 ):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -417,6 +417,85 @@ def test_kill_signals_a_live_leader_whose_environment_names_no_run(
     assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
 
 
+def _leader_reads(monkeypatch, answers):
+    """Answer each read of the leader's start time from *answers*, in call order.
+
+    Lets a test hand the leader's pid to another process partway through the
+    kill without a real race.
+    """
+    reads = iter(answers)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: next(reads, answers[-1]))
+
+
+def test_kill_refuses_a_leader_whose_number_is_handed_on_under_the_group_read(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The live leader's group and marker have to describe the pid that matched.
+
+    A run's leader is started in its own session, so the one number is both its
+    pid and its pgid. When it exits and its group drains, that number is free,
+    and the OS can hand it to a new session leader whose pgid is again the same
+    number. A kill that matched the start time just before that happened then
+    reads a group equal to the recorded one — from a process this run never
+    spawned — and the marker cannot correct it, since an absent or unreadable one
+    only ever withholds a signal.
+
+    So the start time is read again after those reads and required to be
+    unchanged, and here it is not.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _leader_reads(monkeypatch, [("found", _SPAWNED_AT), ("found", _SPAWNED_AT + 400.0)])
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 4242)
+
+    rid = _identity_record(pid=4242, pgid=4242)
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "a group read from a replacement licenses nothing"
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_LEADER_IDENTITY_CHANGED
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+@pytest.mark.parametrize("second_read", [("unknown", None), ("gone", None)])
+def test_kill_refuses_when_the_leaders_start_time_cannot_be_read_back(
+    sandbox, monkeypatch, no_stray_signal, second_read
+):
+    """A bracket that cannot be closed is a measurement that did not come off.
+
+    Whether the second read errored or found nothing there, what the group and
+    the marker said is no longer tied to the process that matched, and an
+    untied answer is never licence to signal.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _leader_reads(monkeypatch, [("found", _SPAWNED_AT), second_read])
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 4242)
+
+    out = jobs.kill(_identity_record(pid=4242, pgid=4242))
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_LEADER_IDENTITY_CHANGED
+
+
+def test_kill_signals_a_leader_that_is_the_same_process_at_both_reads(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The control the refusals above are worth nothing without.
+
+    Every one of them asserts that a kill refused, which a bracket that always
+    refused would satisfy as readily as a correct one. An ordinary leader — alive,
+    unchanged across both reads, in the recorded group — is still signalled.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _leader_reads(monkeypatch, [("found", _SPAWNED_AT), ("found", _SPAWNED_AT)])
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 4242)
+
+    out = jobs.kill(_identity_record(pid=4242, pgid=4242))
+
+    assert no_stray_signal == [(4242, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+
+
 def test_kill_refuses_a_record_that_names_a_different_run(sandbox, monkeypatch):
     """A record found under one run, describing another.
 
@@ -995,6 +1074,68 @@ def test_every_surface_survives_a_record_it_cannot_use(sandbox, text):
     assert jobs.status(rid)["run_id"] == rid
     assert jobs.output(rid)["run_id"] == rid
     assert isinstance(jobs.list_jobs(), list)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_state"),
+    [
+        ("{", "unreadable"),
+        ('{"run_id": "x", ', "unreadable"),
+        ("[]", "wrong_shape"),
+        ("null", "wrong_shape"),
+    ],
+)
+def test_the_read_surfaces_name_a_damaged_record_rather_than_an_unknown_run(
+    sandbox, text, expected_state
+):
+    """kill() tells a damaged record from an absent one; the readers did not.
+
+    They dropped the state the read established and answered from the record
+    being None, so a file sitting on disk came back as ``known: false``, as "no
+    such job", and as a wait entry saying the run was not found. An operator
+    reading any of those stops looking for a run whose record is right there,
+    and the surfaces disagree with kill() about the same file.
+
+    Each assertion below carries an id with no record at all beside it, so the
+    values are shown to distinguish the two cases rather than merely to exist.
+    """
+    rid = jobs.new_run_id()
+    _write_raw_record(rid, text)
+    absent = jobs.new_run_id()
+
+    st = jobs.status(rid)
+    assert st["known"] is False, "no usable record was obtained, and that has not changed"
+    assert st["record_state"] == expected_state
+    assert jobs.status(absent)["record_state"] == "absent"
+
+    got = jobs.output(rid)
+    assert got["known"] is False
+    assert got["record_state"] == expected_state
+    assert "no such job" not in got["error"]
+    assert jobs.output(absent)["error"] == "no such job"
+
+    entry = jobs._wait_entry(rid)
+    assert entry["error"]["kind"] == "record_unusable"
+    assert jobs._wait_entry(absent)["error"]["kind"] == "not_found"
+
+    listed = {j["run_id"]: j["record_state"] for j in jobs.list_jobs()}
+    assert listed == {rid: expected_state}
+
+
+def test_a_usable_record_reads_back_as_one(sandbox, monkeypatch):
+    """The control for the four cases above.
+
+    They assert that a damaged record is named as damaged. A reader that named
+    every record damaged would satisfy all of them, and would fail this.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+
+    assert jobs.status(rid)["record_state"] == "ok"
+    assert jobs.status(rid)["known"] is True
+    assert jobs.output(rid)["record_state"] == "ok"
+    assert jobs._wait_entry(rid)["error"] is None
+    assert [j["record_state"] for j in jobs.list_jobs()] == ["ok"]
 
 
 def test_a_readable_record_is_still_read(sandbox, monkeypatch, no_stray_signal):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1602,17 +1602,31 @@ def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkey
         os.chmod(run_dir, 0o700)
 
 
-def test_a_record_of_invalid_bytes_is_an_unusable_record_not_an_exception(sandbox):
-    """Corruption that is not JSON corruption.
+# Each entry is a way a record on disk can be damaged. They are listed together
+# because the reader's contract is one claim about all of them — a record that
+# cannot be used is reported as unusable — and because the ways bytes fail are
+# not guessable in advance. Four of these were found one at a time, each after
+# the previous had been called handled. A new shape belongs in this list.
+DAMAGED_RECORDS = [
+    pytest.param(b'{"run_id": "truncated"', "unreadable", id="truncated-json"),
+    pytest.param(b'\xff\xfe{"run_id": "x"}', "unreadable", id="not-utf8"),
+    pytest.param(b"[" * 10000, "unreadable", id="nested-past-the-decoder-stack"),
+    pytest.param(b'"a string, not an object"', "wrong_shape", id="json-but-not-an-object"),
+    pytest.param(b"[1, 2, 3]", "wrong_shape", id="json-array"),
+    pytest.param(b"", "unreadable", id="empty-file"),
+]
 
-    The record is bytes on disk, and bytes can fail to be text before they ever
-    fail to be JSON. That failure does not arrive as ``OSError`` — the file opens
-    and reads fine — so a reader guarding only the open and the parse lets it out.
 
-    Every surface here shares one reader, which is what makes this worth asserting
-    at the surfaces rather than at the helper: the listing in particular promises
-    that one damaged record does not cost the caller the runs beside it, and an
-    exception out of the shared reader breaks that promise for every run at once.
+@pytest.mark.parametrize("payload,expected_state", DAMAGED_RECORDS)
+def test_a_damaged_record_is_reported_as_damaged_by_every_surface(sandbox, payload, expected_state):
+    """One contract, asserted at the surfaces rather than at the reader.
+
+    The reader promises that a record which cannot be used is reported as
+    unusable, never raised. Asserting that at the helper would miss what makes it
+    matter: four public surfaces share this reader, and the listing in particular
+    promises that one damaged record does not cost the caller the runs beside it.
+    An exception out of the shared reader breaks that promise for every run at
+    once, so a healthy sibling record is part of every case here.
     """
     ok_rid = jobs.new_run_id()
     jobs._write_job({"run_id": ok_rid, "pid": None, "kind": "agent", "status": "running"})
@@ -1620,23 +1634,16 @@ def test_a_record_of_invalid_bytes_is_an_unusable_record_not_an_exception(sandbo
     bad_rid = jobs.new_run_id()
     bad_dir = config.job_dir(bad_rid)
     bad_dir.mkdir(parents=True, exist_ok=True)
-    (bad_dir / "job.json").write_bytes(b'\xff\xfe{"run_id": "not utf-8"}')
+    (bad_dir / "job.json").write_bytes(payload)
 
-    # Control: the truncated-JSON case already reports unusable, so a passing
-    # assertion below is about the bytes and not about damaged records generally.
-    trunc_rid = jobs.new_run_id()
-    trunc_dir = config.job_dir(trunc_rid)
-    trunc_dir.mkdir(parents=True, exist_ok=True)
-    (trunc_dir / "job.json").write_text('{"run_id": "truncated"')
-    assert jobs.status(trunc_rid)["record_state"] == "unreadable"
-
-    assert jobs.status(bad_rid)["record_state"] == "unreadable"
-    assert jobs.status(bad_rid)["known"] is False
-    assert jobs.output(bad_rid)["record_state"] == "unreadable"
-    assert jobs.kill(bad_rid)["reason_code"] == jobs.KILL_RECORD_UNREADABLE
+    st = jobs.status(bad_rid)
+    assert st["record_state"] == expected_state
+    assert st["known"] is False
+    assert jobs.output(bad_rid)["record_state"] == expected_state
+    assert jobs.kill(bad_rid)["killed"] is False
 
     listed = {j["run_id"]: j.get("record_state") for j in jobs.list_jobs()}
-    assert listed[bad_rid] == "unreadable"
+    assert listed[bad_rid] == expected_state
     assert listed[ok_rid] == "ok", "one damaged record must not cost the runs beside it"
 
 
@@ -1701,6 +1708,43 @@ def test_an_artifacts_directory_that_denies_its_own_read_is_not_a_run_that_wrote
         assert got["artifacts_state"] == "unreadable"
     finally:
         os.chmod(adir, 0o700)
+
+
+def test_an_entry_whose_metadata_is_out_of_reach_does_not_escape_the_listing(sandbox):
+    """A directory can be listable and not searchable at the same time.
+
+    Read permission gets the walk the names; search permission is what it takes
+    to stat them. With one and not the other, an entry arrives from the walk and
+    then fails inspection, which is a per-entry failure the directory-level error
+    callback never sees. The traversal is short by that entry, which is what the
+    state says, and the entries beside it are still true.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root searches a directory whose mode denies it, so the case cannot be set up")
+
+    rid = jobs.new_run_id()
+    adir = config.run_dir(rid) / "artifacts"
+    adir.mkdir(parents=True)
+    (adir / "a.txt").write_text("x")
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+
+    assert jobs.output(rid)["artifacts"] == ["a.txt"], "control: readable and searchable"
+    assert jobs.output(rid)["artifacts_state"] == "ok"
+
+    os.chmod(adir, 0o600)  # readable, not searchable
+    try:
+        try:
+            os.stat(adir / "a.txt")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory search permission")
+
+        got = jobs.output(rid)
+        assert got["artifacts_state"] == "unreadable"
+        assert got["known"] is True, "only the traversal fell short"
+    finally:
+        os.chmod(adir, 0o755)
 
 
 def test_a_partly_readable_artifact_tree_returns_what_it_reached(sandbox):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1602,6 +1602,88 @@ def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkey
         os.chmod(run_dir, 0o700)
 
 
+def test_an_artifacts_directory_that_denies_its_own_read_is_not_a_run_that_wrote_nothing(
+    sandbox,
+):
+    """The failing read that does not raise.
+
+    Denying the search bit on a *parent* makes the traversal raise, and the test
+    above covers that. Denying read on the artifacts directory *itself* does not
+    raise: the walk simply yields nothing. So a traversal that learns about failure
+    only by catching exceptions reports this run as having written no artifacts,
+    and reports that answer as complete.
+
+    That is the same conflation the state field exists to remove, surviving inside
+    the field meant to remove it, which is worse than the ambiguity it replaced: a
+    caller reading no artifacts and a state of ok has been told the read succeeded.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root reads a directory whose mode denies it, so the case cannot be set up")
+
+    rid = jobs.new_run_id()
+    adir = config.run_dir(rid) / "artifacts"
+    adir.mkdir(parents=True)
+    (adir / "a.txt").write_text("x")
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+
+    # Control: the artifact is found while the directory is readable. Without it,
+    # an empty list below could mean the fixture never wrote anything.
+    assert jobs.output(rid)["artifacts"] == ["a.txt"]
+    assert jobs.output(rid)["artifacts_state"] == "ok"
+
+    os.chmod(adir, 0o000)
+    try:
+        try:
+            list(adir.iterdir())
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory read permission")
+
+        got = jobs.output(rid)
+        assert got["known"] is True
+        assert got["artifacts_state"] == "unreadable"
+    finally:
+        os.chmod(adir, 0o700)
+
+
+def test_a_partly_readable_artifact_tree_returns_what_it_reached(sandbox):
+    """A read that fails part way through still found real files.
+
+    Discarding them would trade one false answer for another: the run did write
+    these, and saying so costs nothing. The state carries the fact that the list is
+    short, so the caller can tell a complete listing from a truncated one without
+    losing the part that was read.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root reads a directory whose mode denies it, so the case cannot be set up")
+
+    rid = jobs.new_run_id()
+    adir = config.run_dir(rid) / "artifacts"
+    locked = adir / "locked"
+    locked.mkdir(parents=True)
+    (adir / "top.txt").write_text("x")
+    (locked / "hidden.txt").write_text("y")
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+
+    assert jobs.output(rid)["artifacts"] == ["locked/hidden.txt", "top.txt"]
+
+    os.chmod(locked, 0o000)
+    try:
+        try:
+            list(locked.iterdir())
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory read permission")
+
+        got = jobs.output(rid)
+        assert got["artifacts"] == ["top.txt"], "what was reached is still true"
+        assert got["artifacts_state"] == "unreadable", "and the listing is known to be short"
+    finally:
+        os.chmod(locked, 0o700)
+
+
 def test_listing_a_jobs_directory_it_cannot_get_at_is_not_an_empty_listing(sandbox):
     """An unsearchable jobs directory is not an empty one.
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1572,6 +1572,7 @@ def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkey
     assert st["log_tail"] == "a line of log\n"
     assert st["run"] == {"run_id": rid}
     assert jobs.output(rid)["artifacts"] == ["a.txt"]
+    assert jobs.output(rid)["artifacts_state"] == "ok"
     assert [j["run_id"] for j in jobs.list_jobs()] == [rid]
 
     os.chmod(run_dir, 0o000)
@@ -1591,19 +1592,23 @@ def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkey
         got = jobs.output(rid)
         assert got["known"] is True
         assert got["console"] is None
-        assert got["artifacts"] == []
+        # The empty list is not the answer here — it is what "no artifacts" looks
+        # like, and this run wrote one. The state is what carries the difference,
+        # and without it the caller is told the run produced nothing.
+        assert got["artifacts_state"] == "unreadable"
 
         assert [j["run_id"] for j in jobs.list_jobs()] == [rid]
     finally:
         os.chmod(run_dir, 0o700)
 
 
-def test_listing_jobs_survives_a_jobs_directory_it_cannot_get_at(sandbox):
-    """Listing answers with what it can see, including nothing.
+def test_listing_a_jobs_directory_it_cannot_get_at_is_not_an_empty_listing(sandbox):
+    """An unsearchable jobs directory is not an empty one.
 
-    An unsearchable jobs directory is not an empty one, but a listing has no
-    field in which to say so, and the caller asked for jobs rather than for the
-    errno. The record surfaces are where that distinction is kept.
+    A listing has no field in which to say the read failed, so answering the empty
+    list says "there are no jobs at all" about a directory nobody could look in.
+    The read is allowed to fail instead, and the surface turns that into a per-op
+    error rather than into a wrong answer.
     """
     if os.geteuid() == 0:
         pytest.skip("root searches a directory whose mode denies it, so the case cannot be set up")
@@ -1619,9 +1624,29 @@ def test_listing_jobs_survives_a_jobs_directory_it_cannot_get_at(sandbox):
             pass
         else:
             pytest.skip("this filesystem does not enforce directory search permission")
-        assert jobs.list_jobs() == []
+
+        with pytest.raises(OSError):
+            jobs.list_jobs()
+
+        import asyncio
+
+        from lionagi.mcp import dispatch
+
+        out = asyncio.run(dispatch.request([{"op": "job.list"}]))["ops"][0]
+        assert out["ok"] is False
+        assert out["error"]["kind"] == "internal"
     finally:
         os.chmod(config.JOBS_DIR, 0o700)
+
+
+def test_listing_jobs_before_any_job_is_written_is_empty(sandbox):
+    """A jobs directory that is not there is no jobs, and says so.
+
+    Nothing creates it until the first record is written, so the fresh case has to
+    stay an ordinary empty listing rather than becoming an error about a read.
+    """
+    assert not config.JOBS_DIR.exists()
+    assert jobs.list_jobs() == []
 
 
 @pytest.mark.parametrize(

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1144,6 +1144,92 @@ def test_every_surface_survives_a_record_it_cannot_get_at(sandbox, monkeypatch, 
         os.chmod(job_dir, 0o700)
 
 
+def test_every_surface_survives_a_run_directory_it_cannot_get_at(sandbox, monkeypatch):
+    """The same rule, for the run's own directory rather than the job record.
+
+    The log, the artifacts and the run manifest live under the CLI's run
+    directory, which the job record only points at. So a readable record can name
+    a directory this process cannot search, and asking whether those paths exist
+    raises there exactly as it does for the record.
+
+    The manifest is read before the log tail, so a fix confined to the tail would
+    leave all three surfaces raising on the manifest instead. This asserts on the
+    surfaces rather than on any one read, which is what makes it notice that.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root searches a directory whose mode denies it, so the case cannot be set up")
+
+    rid = jobs.new_run_id()
+    run_dir = config.run_dir(rid)
+    (run_dir / "artifacts").mkdir(parents=True)
+    (run_dir / "artifacts" / "a.txt").write_text("x")
+    (run_dir / "run.json").write_text(f'{{"run_id": "{rid}"}}')
+    log = run_dir / "job.log"
+    log.write_text("a line of log\n")
+    jobs._write_job(
+        {"run_id": rid, "pid": None, "kind": "agent", "status": "running", "log": str(log)}
+    )
+
+    # The control arm has to reach all three, or the permission arm below proves
+    # nothing: a surface that never opened the log cannot demonstrate surviving
+    # an unreadable one.
+    st = jobs.status(rid)
+    assert st["known"] is True
+    assert st["log_tail"] == "a line of log\n"
+    assert st["run"] == {"run_id": rid}
+    assert jobs.output(rid)["artifacts"] == ["a.txt"]
+    assert [j["run_id"] for j in jobs.list_jobs()] == [rid]
+
+    os.chmod(run_dir, 0o000)
+    try:
+        try:
+            log.read_text()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory search permission")
+
+        st = jobs.status(rid)
+        assert st["known"] is True, "the record is readable; only what it points at is not"
+        assert st["log_tail"] is None
+        assert st["run"] is None
+
+        got = jobs.output(rid)
+        assert got["known"] is True
+        assert got["console"] is None
+        assert got["artifacts"] == []
+
+        assert [j["run_id"] for j in jobs.list_jobs()] == [rid]
+    finally:
+        os.chmod(run_dir, 0o700)
+
+
+def test_listing_jobs_survives_a_jobs_directory_it_cannot_get_at(sandbox):
+    """Listing answers with what it can see, including nothing.
+
+    An unsearchable jobs directory is not an empty one, but a listing has no
+    field in which to say so, and the caller asked for jobs rather than for the
+    errno. The record surfaces are where that distinction is kept.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root searches a directory whose mode denies it, so the case cannot be set up")
+
+    rid = _identity_record()
+    assert [j["run_id"] for j in jobs.list_jobs()] == [rid]
+
+    os.chmod(config.JOBS_DIR, 0o000)
+    try:
+        try:
+            list(config.JOBS_DIR.iterdir())
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory search permission")
+        assert jobs.list_jobs() == []
+    finally:
+        os.chmod(config.JOBS_DIR, 0o700)
+
+
 @pytest.mark.parametrize(
     "identity",
     [

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -237,6 +237,21 @@ def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded
 _SPAWNED_AT = 1_700_000_000.0
 
 
+def _raise(exc: BaseException):
+    """A stand-in for an OS call that fails, whatever arguments it is handed.
+
+    The signatures differ across the calls being doubled, so the replacement
+    accepts anything and raises the one exception the test is about. Raising an
+    instance rather than a class keeps errno and message available to the code
+    under test, which several of these guards put into what they report.
+    """
+
+    def _fail(*args, **kwargs):
+        raise exc
+
+    return _fail
+
+
 def _live_process(monkeypatch, created: float = _SPAWNED_AT):
     """Make both process probes agree that the pid holds a live process.
 
@@ -2365,3 +2380,238 @@ def test_an_ordinary_prompt_is_not_caught_by_the_size_guard(tmp_path, monkeypatc
 
     # Returns rather than raising.
     assert jobs._reject_oversized_argv(argv, env, kind="flow") is None
+
+
+# --- The failure classification of each guarded OS read -----------------------
+#
+# Each guard below decides what the caller is told when one specific probe
+# fails. A guard nothing drives is a branch whose answer has never been read
+# back, so these exercise them one at a time, each against a control that shows
+# the same code path answering differently when the probe succeeds.
+
+
+def test_a_waitpid_failure_that_is_not_a_missing_child_does_not_decide_liveness(monkeypatch):
+    """waitpid can fail for reasons that say nothing about the process.
+
+    Only ChildProcessError carries information here: it means the pid is not
+    ours to reap, so the direct probe is authoritative. Any other failure of
+    waitpid is a failed measurement, and a failed measurement must not become
+    the answer. The direct probe still decides, in both directions.
+    """
+    monkeypatch.setattr(jobs.os, "waitpid", _raise(OSError(5, "I/O error")))
+
+    monkeypatch.setattr(jobs.os, "kill", lambda pid, sig: None)
+    assert jobs._pid_alive(4242) is True
+
+    monkeypatch.setattr(jobs.os, "kill", _raise(ProcessLookupError()))
+    assert jobs._pid_alive(4242) is False
+
+
+def test_a_process_we_may_not_signal_is_alive_rather_than_absent(monkeypatch):
+    """Refusing to signal a process is the OS confirming it exists.
+
+    A pid held by another user answers the existence probe with a permission
+    error, which is a positive answer to the only question being asked. Reading
+    it as absence would report a live run as finished.
+    """
+    monkeypatch.setattr(jobs.os, "waitpid", _raise(ChildProcessError()))
+
+    monkeypatch.setattr(jobs.os, "kill", _raise(PermissionError(1, "not permitted")))
+    assert jobs._pid_alive(4242) is True
+
+    # The control: the same shape of refusal from the same call, for a pid that
+    # genuinely holds nothing, is the other answer.
+    monkeypatch.setattr(jobs.os, "kill", _raise(ProcessLookupError()))
+    assert jobs._pid_alive(4242) is False
+
+
+def test_a_start_time_probe_that_errors_is_unknown_and_never_gone(monkeypatch):
+    """An errored identity probe must not read as death.
+
+    "gone" licenses the caller to stop looking; "unknown" does not. A probe that
+    failed knows nothing about the process, which may well be running, so the
+    two answers cannot be folded together.
+    """
+    import psutil
+
+    monkeypatch.setattr(psutil, "Process", _raise(psutil.AccessDenied(4242)))
+    assert jobs._process_create_time(4242) == ("unknown", None)
+
+    monkeypatch.setattr(psutil, "Process", _raise(OSError(5, "I/O error")))
+    assert jobs._process_create_time(4242) == ("unknown", None)
+
+    # The control: the answer that does mean the process is gone.
+    monkeypatch.setattr(psutil, "Process", _raise(psutil.NoSuchProcess(4242)))
+    assert jobs._process_create_time(4242) == ("gone", None)
+
+
+def test_a_member_whose_group_read_fails_is_told_apart_from_one_that_exited(monkeypatch):
+    """Two ways a group read ends without an answer, and they are not the same.
+
+    A pid that no longer exists is not a member of the group, which is a fact.
+    A group read that failed for any other reason established nothing, and
+    reporting it as absence would let a scan call itself complete while a live
+    member went unseen.
+    """
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
+
+    monkeypatch.setattr(jobs.os, "getpgid", _raise(ProcessLookupError()))
+    assert jobs._pinned_member(4242, 7777) == ("gone", None)
+
+    monkeypatch.setattr(jobs.os, "getpgid", _raise(OSError(1, "not permitted")))
+    assert jobs._pinned_member(4242, 7777) == ("unknown", None)
+
+    # The control: the same call succeeding produces a member, so the two
+    # refusals above are the guards answering and not the setup failing.
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
+    state, member = jobs._pinned_member(4242, 7777)
+    assert state == "found" and member is not None and member[0] == 4242
+
+
+def test_a_process_table_that_cannot_be_read_reports_an_incomplete_scan(monkeypatch):
+    """No process table, no membership claim.
+
+    Returning an empty member list with the scan marked complete would say the
+    group holds nothing running, on the strength of a read that never happened.
+    The empty list is only ever safe alongside the flag that says so.
+    """
+    import psutil
+
+    monkeypatch.setattr(psutil, "pids", _raise(psutil.AccessDenied()))
+    assert jobs._live_group_members(7777) == ([], False)
+
+    monkeypatch.setattr(psutil, "pids", _raise(OSError(1, "not permitted")))
+    assert jobs._live_group_members(7777) == ([], False)
+
+
+def test_a_candidate_whose_group_cannot_be_read_leaves_the_scan_incomplete(monkeypatch):
+    """One unreadable candidate is a gap in the membership, not a non-member.
+
+    The pid may be in this group. Skipping it quietly would let the scan report
+    a complete view of a group it had not finished reading.
+    """
+    import psutil
+
+    monkeypatch.setattr(psutil, "pids", lambda: [4242])
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
+
+    monkeypatch.setattr(jobs.os, "getpgid", _raise(OSError(1, "not permitted")))
+    members, complete = jobs._live_group_members(7777)
+    assert members == [] and complete is False
+
+    # A candidate that simply exited is a non-member and no gap at all, so the
+    # scan over the same single pid is complete.
+    monkeypatch.setattr(jobs.os, "getpgid", _raise(ProcessLookupError()))
+    members, complete = jobs._live_group_members(7777)
+    assert members == [] and complete is True
+
+
+def test_a_group_that_is_gone_at_the_moment_of_the_signal_is_reported_as_gone(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The group can end between being identified and being signalled.
+
+    Nothing was killed, and the reason has to say that rather than claim a
+    signal landed. The record is left alone: a run this call did not stop must
+    not be written down as stopped by it.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
+    monkeypatch.setattr(jobs.os, "killpg", _raise(ProcessLookupError()))
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_PROCESS_GONE
+    assert out["pgid"] == 7777
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+def test_a_group_we_may_not_signal_is_reported_as_refused_not_as_stopped(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A refused signal is a live group this call did not stop.
+
+    It is the case most easily mistaken for success, because the group was
+    correctly identified and the call returned without an error reaching the
+    caller. The operator has to be told the process is still running.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
+    monkeypatch.setattr(jobs.os, "killpg", _raise(PermissionError(1, "not permitted")))
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_PERMISSION_DENIED
+    assert "permission denied" in out["reason"]
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+def test_an_artifact_that_disappears_after_being_named_is_not_a_failed_listing(
+    sandbox, monkeypatch
+):
+    """A file removed mid-walk withheld nothing.
+
+    The walk names entries and the metadata is read afterwards, so a file that
+    is deleted in between is simply not there. That is a true empty answer, and
+    marking the listing unreadable for it would report a shortfall that did not
+    happen — which is the same error as the opposite case, in the other
+    direction.
+    """
+    adir = config.run_dir("run-x") / "artifacts"
+    adir.mkdir(parents=True)
+    (adir / "kept.txt").write_text("still here")
+
+    real_stat = Path.stat
+
+    def vanishing(self, *a, **kw):
+        if self.name == "gone.txt":
+            raise FileNotFoundError(2, "No such file or directory")
+        return real_stat(self, *a, **kw)
+
+    monkeypatch.setattr(
+        jobs.os, "walk", lambda d, onerror=None: [(str(adir), [], ["kept.txt", "gone.txt"])]
+    )
+    monkeypatch.setattr(Path, "stat", vanishing)
+
+    found, state = jobs._list_artifacts("run-x")
+
+    assert found == ["kept.txt"]
+    assert state == "ok", "a file that vanished is an absence, not an unreadable listing"
+
+
+def test_an_artifact_whose_metadata_is_refused_does_make_the_listing_unreadable(
+    sandbox, monkeypatch
+):
+    """The control for the case above, and the distinction the state exists for.
+
+    Here the entry is real and was withheld, so the caller is short a file it
+    was never told about. Same loop, same continue, opposite state.
+    """
+    adir = config.run_dir("run-y") / "artifacts"
+    adir.mkdir(parents=True)
+    (adir / "kept.txt").write_text("still here")
+
+    real_stat = Path.stat
+
+    def refused(self, *a, **kw):
+        if self.name == "locked.txt":
+            raise PermissionError(1, "Operation not permitted")
+        return real_stat(self, *a, **kw)
+
+    monkeypatch.setattr(
+        jobs.os, "walk", lambda d, onerror=None: [(str(adir), [], ["kept.txt", "locked.txt"])]
+    )
+    monkeypatch.setattr(Path, "stat", refused)
+
+    found, state = jobs._list_artifacts("run-y")
+
+    assert found == ["kept.txt"]
+    assert state == "unreadable"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -778,15 +778,10 @@ def test_kill_never_dereferences_a_pid_it_must_not_signal(
 
 @pytest.mark.parametrize(
     "record",
-    [
-        # No identity fields at all: written before they were captured.
-        {},
-        # Present but malformed, which says as little as absent does.
-        {"pid_create_time": "not-a-number", "pgid": 7777},
-        {"pid_create_time": _SPAWNED_AT, "pgid": "7777"},
-        {"pid_create_time": _SPAWNED_AT, "pgid": 0},
-        {"pid_create_time": None, "pgid": None},
-    ],
+    # No identity keys at all, which is the one thing that means the record was
+    # written before they existed. A record that carries the keys and bad values
+    # is damaged rather than old, and gets its own answer.
+    [{}],
 )
 def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     sandbox, monkeypatch, no_stray_signal, record
@@ -866,6 +861,122 @@ def test_kill_refuses_a_record_whose_start_time_cannot_be_compared(
     # The value came off disk and a JSON number has no length limit, so it must not
     # be able to set the size of a reason a caller has to read.
     assert len(out["reason"]) < 400, "a record must not choose how long the answer is"
+
+
+def _write_raw_record(rid: str, text: str) -> None:
+    d = config.job_dir(rid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "job.json").write_text(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_code"),
+    [
+        # Present, and its bytes cannot be parsed. A retry may read differently.
+        ("{", jobs.KILL_RECORD_UNREADABLE),
+        ('{"run_id": "x", ', jobs.KILL_RECORD_UNREADABLE),
+        # Present, parses cleanly, and is not an object. A retry cannot help.
+        ("[]", jobs.KILL_RECORD_WRONG_SHAPE),
+        ('"a string"', jobs.KILL_RECORD_WRONG_SHAPE),
+        ("null", jobs.KILL_RECORD_WRONG_SHAPE),
+        ("42", jobs.KILL_RECORD_WRONG_SHAPE),
+    ],
+)
+def test_kill_refuses_a_damaged_record_without_calling_it_absent(
+    sandbox, no_stray_signal, text, expected_code
+):
+    """A file that is present and unusable is not a run that never existed.
+
+    Both were reported as "no such job", which tells an operator to stop looking
+    for a record that is sitting on disk — and two of these shapes did not refuse
+    at all, they raised out of the call. The refusal now says which of the two
+    happened, and says the file is the thing to look at.
+    """
+    rid = jobs.new_run_id()
+    _write_raw_record(rid, text)
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == expected_code
+    assert "no such job" not in out["reason"]
+    assert rid in out["reason"]
+
+
+@pytest.mark.parametrize("text", ["[]", '"a string"', "42", "{"])
+def test_every_surface_survives_a_record_it_cannot_use(sandbox, text):
+    """The record is read by more than one verb, so one of them refusing is not enough.
+
+    A JSON value that is not an object used to reach ``.get()`` on whichever surface
+    read it, so status and output raised as readily as kill did — and status is what
+    an observer polls. Each must return something a caller can read.
+    """
+    rid = jobs.new_run_id()
+    _write_raw_record(rid, text)
+
+    assert jobs.kill(rid)["killed"] is False
+    assert jobs.status(rid)["run_id"] == rid
+    assert jobs.output(rid)["run_id"] == rid
+    assert isinstance(jobs.list_jobs(), list)
+
+
+def test_a_readable_record_is_still_read(sandbox, monkeypatch, no_stray_signal):
+    """Guards the precondition every refusal above depends on.
+
+    All of this rests on the reader admitting an ordinary record unchanged. If the
+    shape check ever rejected one, every surface would degrade to a refusal and the
+    tests for the damaged cases would keep passing, because they only ever assert
+    that a refusal happened.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+
+    rid = _identity_record()
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
+
+    assert jobs._read_job(rid)["pgid"] == 7777
+    assert jobs.kill(rid)["killed"] is True
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"pid_create_time": "not-a-number", "pgid": 7777},
+        {"pid_create_time": _SPAWNED_AT, "pgid": "7777"},
+        {"pid_create_time": _SPAWNED_AT, "pgid": 0},
+        {"pid_create_time": None, "pgid": None},
+        # Half-written: the keys exist because the writer knows about them.
+        {"pid_create_time": _SPAWNED_AT},
+        {"pgid": 7777},
+    ],
+)
+def test_kill_does_not_call_a_damaged_identity_an_old_record(
+    sandbox, monkeypatch, no_stray_signal, identity
+):
+    """Present-but-wrong is not the same news as absent, and must not borrow its sentence.
+
+    The refusal for a record written before these fields existed says exactly that
+    about its age. A record carrying the keys was written by code that knows them,
+    so the age claim is false of it however bad the values are — and unlike an old
+    record, this one is worth looking into.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
+
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None, **identity}
+    )
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_IDENTITY_UNUSABLE
+    assert "predates" not in out["reason"], "the record is not old, it is damaged"
+    assert out["pid"] == 4242
 
 
 def _process_table_enumerable() -> tuple[bool, str]:

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -155,7 +155,7 @@ def test_status_running_then_terminal(sandbox, monkeypatch):
     monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(999_999))
     rid = jobs.submit("agent", [], prompt="x")["run_id"]
 
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     assert jobs.status(rid)["status"] == "running"
 
     # pid gone, no terminal record captured -> exited
@@ -235,6 +235,20 @@ def test_kill_refuses_a_record_that_already_ended(sandbox, monkeypatch, recorded
 
 
 _SPAWNED_AT = 1_700_000_000.0
+
+
+def _live_process(monkeypatch, created: float = _SPAWNED_AT):
+    """Make both process probes agree that the pid holds a live process.
+
+    A pid is asked two separate questions: whether it holds a live process at
+    all, and when that process started. A double that answers only the first
+    describes a state no operating system produces — a pid that answers ``kill
+    -0`` and is absent from the process table is a process that has exited and
+    is waiting to be reaped, which is the opposite of alive. Tests that mean
+    "this run is still running" have to say so to both.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", created))
 
 
 def _identity_record(pid: int = 4242, pgid: int = 7777, created: float = _SPAWNED_AT, **extra):
@@ -646,16 +660,20 @@ def test_status_reports_a_pid_that_emptied_between_the_two_reads(sandbox, monkey
 def test_status_leaves_a_record_that_cannot_identify_its_process_on_the_pid_probe(
     sandbox, monkeypatch, recorded, identity
 ):
-    """No identity was captured, so a pid probe is all this record ever had.
+    """No identity was captured, so nothing is compared — liveness still is.
 
-    Flipping these to stopped would claim the process is gone on the strength of
-    data that says nothing about it either way.
+    Two questions are asked of a pid, and only the second one needs this record.
+    Whether the pid holds a live process is answerable from the pid alone, so it
+    is settled here as on every other path. Whether that live process is *this
+    run's* is what these records cannot say, and nothing is compared to pretend
+    otherwise. Flipping these to stopped on the strength of the missing field
+    would claim the process is gone on data that says nothing about it either way.
     """
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     monkeypatch.setattr(
         jobs,
-        "_process_create_time",
-        lambda pid: pytest.fail("a record with no usable identity has nothing to compare"),
+        "_start_time_matches",
+        lambda *a: pytest.fail("a record with no usable identity has nothing to compare"),
     )
 
     st = jobs.status(_identity_record(created=recorded))
@@ -682,6 +700,119 @@ def test_status_identifies_nothing_when_no_live_pid_holds_the_number(sandbox, mo
     assert st["pid_identity"] is None
     assert st["status"] == "exited"
     assert st["possibly_orphaned"] is True
+
+
+@pytest.mark.parametrize("recorded", [None, "not-a-number", float("nan"), True])
+def test_a_process_that_exited_reports_gone_even_with_no_identity_to_compare(
+    sandbox, monkeypatch, recorded
+):
+    """The record cannot identify the process, and the process has still exited.
+
+    A pid that answers ``kill -0`` and holds no process is one that exited and
+    has not been reaped. Reading the record first and the process second would
+    make every record without a usable start time report an exited run as
+    running, and turn ``possibly_orphaned`` off in the one case it exists for.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("gone", None))
+
+    st = jobs.status(_identity_record(created=recorded))
+
+    assert st["alive"] is False
+    assert st["pid_identity"] == "gone"
+    assert st["status"] == "exited"
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
+def test_a_process_that_exited_under_another_parent_does_not_read_as_alive(sandbox):
+    """The same case with a real process instead of a double.
+
+    The liveness probe reaps only its own children, so it can only settle the
+    question for a job it spawned itself. Every other server sharing the job
+    store is in the position this test is in: the exited process here is a
+    grandchild, so nothing this test does can reap it, and ``kill -0`` keeps
+    answering yes for as long as it sits there. A live control runs through the
+    same assertions in the same invocation, so a probe that had simply stopped
+    working could not produce this result.
+    """
+    import subprocess
+    import sys
+    import time
+
+    # Fork a grandchild that exits at once, report its pid, and stay alive
+    # without reaping it. The parent of the zombie is the child, never pytest.
+    source = (
+        "import os, sys, time\n"
+        "pid = os.fork()\n"
+        "if pid == 0:\n"
+        "    os._exit(0)\n"
+        "sys.stdout.write(f'{pid}\\n')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(30)\n"
+    )
+    child = subprocess.Popen(
+        [sys.executable, "-c", source], stdout=subprocess.PIPE, text=True, start_new_session=True
+    )
+    try:
+        zombie = int(child.stdout.readline().strip())
+        deadline = time.monotonic() + 10
+        while jobs._process_create_time(zombie)[0] != "gone" and time.monotonic() < deadline:
+            time.sleep(0.02)
+        if jobs._process_create_time(zombie)[0] != "gone":
+            pytest.skip("the grandchild did not become an unreaped zombie here")
+
+        # The probe that cannot tell, and the probe that can, on the same pid.
+        assert jobs._pid_alive(zombie) is True
+        assert jobs._process_create_time(zombie)[0] == "gone"
+
+        exited = jobs.status(_identity_record(pid=zombie, created=None))
+        assert exited["alive"] is False
+        assert exited["pid_identity"] == "gone"
+        assert exited["possibly_orphaned"] is True
+
+        # Live control: the child itself, running, read the same way.
+        running = jobs.status(_identity_record(pid=child.pid, created=None))
+        assert running["alive"] is True
+        assert running["pid_identity"] == "not_recorded"
+        assert running["status"] == "running"
+    finally:
+        child.kill()
+        child.wait()
+
+
+@pytest.mark.parametrize("recorded_pid", ["4242", 4242.0, [4242], {"pid": 4242}, 10**40, 2**63])
+def test_a_pid_the_os_cannot_be_asked_about_is_refused_rather_than_raised(
+    sandbox, recorded_pid, no_stray_signal
+):
+    """A record is JSON from disk, and every probe below it takes a C integer.
+
+    A value of the wrong type or past what the platform can express raises out of
+    the first probe to touch it, which turns a damaged record into a failed read
+    of both surfaces rather than into the refusal the record has earned.
+    """
+    rid = _identity_record(pid=recorded_pid)
+
+    out = jobs.kill(rid)
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_NO_PID
+    assert "no pid on record" in out["reason"]
+
+    st = jobs.status(rid)
+    assert st["alive"] is False
+    assert st["pid_identity"] == "unusable_pid"
+    assert st["known"] is True
+    assert st["record_state"] == "ok"
+
+
+def test_a_usable_pid_is_not_refused_by_the_shape_gate(sandbox, monkeypatch, no_stray_signal):
+    """The control for the table above: a well-formed pid still reaches the probes."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    st = jobs.status(_identity_record(pid=4242))
+
+    assert st["pid_identity"] != "unusable_pid"
+    assert st["alive"] is False
 
 
 def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_stray_signal):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -550,6 +550,140 @@ def test_kill_refuses_when_the_leaders_start_time_is_unreadable(
     assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEADER_UNVERIFIABLE
 
 
+def test_status_reports_a_reused_pid_as_not_this_runs_process(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A stranger holding the run's old pid number must not read as the run.
+
+    Nothing recorded an end for this run, so the only thing standing between it
+    and "running forever" is the identity check: without it the liveness probe
+    answers about whatever process now holds the number, and the run reports
+    healthy for as long as that process lives. It also silences the one field
+    that would say otherwise, since a run flagged possibly_orphaned is exactly a
+    run whose process is gone with no end recorded.
+
+    kill() refuses this same record as a reused pid, so the two surfaces are
+    asserted together: one module answering one record two ways is the defect.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 5000))
+
+    rid = _identity_record()
+    st = jobs.status(rid)
+
+    assert st["alive"] is False
+    assert st["pid_identity"] == "recycled"
+    assert st["status"] == "exited"
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["possibly_orphaned"] is True
+    assert jobs.kill(rid)["reason_code"] == jobs.KILL_PID_RECYCLED
+    assert no_stray_signal == []
+
+
+def test_status_reports_a_confirmed_process_as_running(sandbox, monkeypatch):
+    """The healthy case is unchanged, and the comparison keeps its tolerance.
+
+    The start time is read from a clock kept in ticks, so a live read of the
+    process this run spawned can differ from the recorded value in the last
+    decimal. Comparing it exactly would report every live run as recycled.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 0.02))
+
+    st = jobs.status(_identity_record())
+
+    assert st["alive"] is True
+    assert st["pid_identity"] == "confirmed"
+    assert st["status"] == "running"
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is False
+
+
+def test_status_does_not_read_a_failed_identity_probe_as_death(sandbox, monkeypatch):
+    """A probe that errored established nothing, so the liveness probe stands.
+
+    Reporting the run as stopped here would invent a death out of a measurement
+    that did not come off, and stopped is what a caller stops waiting on.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("unknown", None))
+
+    st = jobs.status(_identity_record())
+
+    assert st["alive"] is True
+    assert st["pid_identity"] == "unreadable"
+    assert st["status"] == "running"
+    assert st["possibly_orphaned"] is False
+
+
+def test_status_reports_a_pid_that_emptied_between_the_two_reads(sandbox, monkeypatch):
+    """The process exited between the liveness probe and the identity read."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("gone", None))
+
+    st = jobs.status(_identity_record())
+
+    assert st["alive"] is False
+    assert st["pid_identity"] == "gone"
+    assert st["status"] == "exited"
+    assert st["possibly_orphaned"] is True
+
+
+@pytest.mark.parametrize(
+    ("recorded", "identity"),
+    [
+        # submit() writes a null start time whenever the read at spawn failed,
+        # and a record written before identity capture has the same shape.
+        (None, "not_recorded"),
+        # Present, and holding something no start time can be compared against:
+        # a damaged record, which is different news from an old one.
+        ("not-a-number", "unusable"),
+        (float("nan"), "unusable"),
+        (True, "unusable"),
+    ],
+)
+def test_status_leaves_a_record_that_cannot_identify_its_process_on_the_pid_probe(
+    sandbox, monkeypatch, recorded, identity
+):
+    """No identity was captured, so a pid probe is all this record ever had.
+
+    Flipping these to stopped would claim the process is gone on the strength of
+    data that says nothing about it either way.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        jobs,
+        "_process_create_time",
+        lambda pid: pytest.fail("a record with no usable identity has nothing to compare"),
+    )
+
+    st = jobs.status(_identity_record(created=recorded))
+
+    assert st["alive"] is True
+    assert st["pid_identity"] == identity
+    assert st["status"] == "running"
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is False
+
+
+def test_status_identifies_nothing_when_no_live_pid_holds_the_number(sandbox, monkeypatch):
+    """Nothing answered the liveness probe, so there was no process to identify."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_process_create_time",
+        lambda pid: pytest.fail("a pid holding nothing must not be probed for identity"),
+    )
+
+    st = jobs.status(_identity_record())
+
+    assert st["alive"] is False
+    assert st["pid_identity"] is None
+    assert st["status"] == "exited"
+    assert st["possibly_orphaned"] is True
+
+
 def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_stray_signal):
     """The case a leader-liveness gate refuses: `li` exits, its workers do not.
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -389,7 +389,8 @@ def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_st
 
     The children are spawned into the leader's group and outlive it, so the
     group is what has to be signalled — and it is still identifiable after the
-    leader is gone, because every member started after the run did.
+    leader is gone, because the run stamped its id into every process it started
+    and a surviving member reads it back.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
@@ -397,6 +398,7 @@ def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_st
     )
 
     rid = _identity_record()
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
@@ -487,11 +489,10 @@ def test_kill_identifies_the_group_by_the_marker_the_run_stamped(
 
 
 def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch, no_stray_signal):
-    """The same evidence pointing the other way, where start time would allow.
+    """The same evidence pointing the other way, and it is what excludes.
 
-    Every member started after this run did, so the inequality is satisfied and
-    the fallback would signal. The marker names a different run, which is a
-    positive identification that the group number has been handed on.
+    Every member started after this run did, so the start time excludes nothing.
+    The marker names a different run, which is what settles it.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
@@ -503,7 +504,12 @@ def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch,
 
     assert no_stray_signal == []
     assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_FOREIGN
-    assert "started by a different run" in out["reason"]
+    # The sentence reports what was read, not the history that would explain it.
+    # An environment variable is what was observed; who spawned the process, and
+    # whether a group number was handed on, was not.
+    assert "carries a different run's id in its environment" in out["reason"]
+    assert "started by" not in out["reason"]
+    assert "reused" not in out["reason"]
 
 
 @pytest.mark.parametrize("order", [("this-run", "other-run"), ("other-run", "this-run")])
@@ -565,17 +571,25 @@ def test_kill_identifies_a_group_whose_members_all_carry_this_runs_marker(
 @pytest.mark.parametrize(
     "marker",
     [
-        # Read fine, but the process predates the marker: a run recorded by an
-        # older build, whose children were never stamped.
+        # The environment was read and simply holds no run id.
         ("found", None),
         # The environment could not be read at all.
         ("unknown", None),
     ],
 )
-def test_kill_falls_back_to_start_time_when_the_marker_is_no_help(
+def test_kill_refuses_a_group_that_is_merely_young_enough(
     sandbox, monkeypatch, no_stray_signal, marker
 ):
-    """Neither confirmed nor refuted, so the inequality decides — as before."""
+    """Starting after this run did is not evidence of belonging to it.
+
+    Every member here is younger than the record, which is exactly what an
+    unrelated group occupying a reused group number looks like: the number was
+    freed when this run's group emptied, and whoever took it necessarily started
+    later. The inequality can rule a group out and can never rule one in, so with
+    no marker to read there is nothing left that identifies this group, and both
+    ways of failing to read one — no id present, and no readable environment —
+    have to refuse.
+    """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
         jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
@@ -584,8 +598,36 @@ def test_kill_falls_back_to_start_time_when_the_marker_is_no_help(
 
     out = jobs.kill(_identity_record())
 
-    assert no_stray_signal == [(7777, signal.SIGTERM)]
-    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+    assert no_stray_signal == [], "a young group is not thereby this run's group"
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_GROUP_OWNERSHIP_UNPROVEN
+    assert "not evidence of belonging to it" in out["reason"]
+
+
+def test_kill_still_excludes_a_group_holding_a_member_older_than_the_run(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The start time keeps the half of its job that is sound.
+
+    It cannot identify a group, but it can still rule one out: a process that was
+    already running before this run started cannot be work this run spawned. That
+    refusal is a different fact from having no evidence at all, and keeps its own
+    code.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        lambda pgid: ([(5001, _SPAWNED_AT + 3.0), (5002, _SPAWNED_AT - 60.0)], True),
+    )
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["reason_code"] == jobs.KILL_GROUP_PREDATES_RUN
+    # Observation, not inferred history: a member's age is what was measured.
+    assert "started before this run did" in out["reason"]
+    assert "reused" not in out["reason"]
 
 
 def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
@@ -610,7 +652,9 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
         jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
     )
 
-    out = jobs.kill(_identity_record())
+    rid = _identity_record()
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
+    out = jobs.kill(rid)
 
     assert out["killed"] is True and no_stray_signal == [(7777, signal.SIGTERM)]
 
@@ -673,6 +717,7 @@ def test_kill_reaps_a_live_group_behind_a_terminal_record(sandbox, monkeypatch, 
     )
 
     rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
@@ -781,19 +826,34 @@ def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
 
 
-@pytest.mark.parametrize("created", [float("nan"), float("inf"), float("-inf"), True, False])
+@pytest.mark.parametrize(
+    "created",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        False,
+        # A JSON integer has no bound, so a record can carry one that is not a
+        # float at all. Converting it to compare it is what fails.
+        int("9" * 400),
+        -int("9" * 400),
+    ],
+)
 def test_kill_refuses_a_record_whose_start_time_cannot_be_compared(
     sandbox, monkeypatch, no_stray_signal, created
 ):
     """A start time that cannot act as one says nothing about the pid.
 
-    Each of these satisfies the type check and then loses every comparison below
-    it. A NaN is never within tolerance of a live start time. A boolean is an int
-    to isinstance, so ``true`` becomes 1.0 and compares as a moment in 1970. Either
-    way the leader would be reported as a reused pid, and that is the wrong fact —
-    nothing has been established about the pid at all, only that the record cannot
-    describe it. The refusal is the same, but the code and the reason must not
-    claim otherwise.
+    Each of these satisfies the type check and then fails to act as a start time.
+    A NaN is never within tolerance of a live one. A boolean is an int to
+    isinstance, so ``true`` becomes 1.0 and compares as a moment in 1970. An
+    integer too large for a float cannot be converted at all, and would leave the
+    call raising out of a tool that promises a refusal. Each would otherwise have
+    the leader reported as a reused pid, or nothing reported at all, and both are
+    the wrong answer — nothing has been established about the pid, only that the
+    record cannot describe it. The refusal is the same, but the code and the
+    reason must not claim otherwise.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
 
@@ -803,6 +863,9 @@ def test_kill_refuses_a_record_whose_start_time_cannot_be_compared(
     assert out["killed"] is False
     assert out["reason_code"] == jobs.KILL_IDENTITY_UNUSABLE
     assert "reused" not in out["reason"], "the pid was never established to be anything"
+    # The value came off disk and a JSON number has no length limit, so it must not
+    # be able to set the size of a reason a caller has to read.
+    assert len(out["reason"]) < 400, "a record must not choose how long the answer is"
 
 
 def _process_table_enumerable() -> tuple[bool, str]:
@@ -834,14 +897,27 @@ def test_a_group_outlives_its_leader_and_is_reaped_by_identity(sandbox):
 
     A leader that backgrounds a child and exits leaves the child running in the
     group it created. Nothing is mocked here: the record carries the identity
-    submit() records, the leader really exits and is really reaped, and the
-    group is enumerated from the OS.
+    submit() records, the leader is started with the run id in its environment
+    exactly as submit() starts one, the leader really exits and is really reaped,
+    and the group is enumerated from the OS. The surviving child inherited the
+    marker, which is what identifies the group once its leader is gone.
+
+    The survivor is an interpreter rather than a shell utility on purpose. macOS
+    does not disclose the environment of its own protected system binaries, so a
+    ``sleep`` left in the group would read back as carrying no marker and the run
+    would be unidentifiable for a reason that has nothing to do with this code.
+    A `li` worker is an interpreter, and this stays faithful to that.
     """
+    import shlex
     import subprocess
+    import sys
     import time
 
+    rid = jobs.new_run_id()
+    survivor = f'{shlex.quote(sys.executable)} -c "import time; time.sleep(30)"'
     proc = subprocess.Popen(  # noqa: S603,S607
-        ["sh", "-c", "sleep 30 & sleep 0.5"],
+        ["sh", "-c", f"{survivor} & sleep 0.5"],
+        env={**os.environ, config.JOB_MARKER_ENV_VAR: rid},
         start_new_session=True,
     )
     # start_new_session, so the group is the leader's own pid. Held before
@@ -858,7 +934,7 @@ def test_a_group_outlives_its_leader_and_is_reaped_by_identity(sandbox):
         members, complete = jobs._live_group_members(pgid)
         assert complete and members, "the child outlived its leader in the group"
 
-        rid = _identity_record(pid=proc.pid, pgid=pgid, created=created)
+        _identity_record(pid=proc.pid, pgid=pgid, created=created, run_id=rid)
         out = jobs.kill(rid, signal.SIGKILL)
 
         assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -254,6 +254,498 @@ def test_kill_signals_the_process_group_of_a_live_run(sandbox, monkeypatch):
     assert jobs.status(rid)["terminal"] is True
 
 
+_SPAWNED_AT = 1_700_000_000.0
+
+
+def _identity_record(pid: int = 4242, pgid: int = 7777, created: float = _SPAWNED_AT, **extra):
+    """A job record carrying the process identity submit() now writes."""
+    rec = {
+        "run_id": jobs.new_run_id(),
+        "pid": pid,
+        "pid_create_time": created,
+        "pgid": pgid,
+        "kind": "agent",
+        "status": "running",
+        "log": None,
+    }
+    rec.update(extra)
+    jobs._write_job(rec)
+    return rec["run_id"]
+
+
+@pytest.fixture
+def no_stray_signal(monkeypatch):
+    """Keep a test's invented pids away from every real process on this machine.
+
+    Three jobs, all following from the same fact: the pids in these records are
+    numbers the test made up, and some live process may well hold each of them.
+    It records what was signalled so a test can assert on it; it replaces
+    os.getpgid with a raise, since resolving a group from a made-up pid would
+    aim a real signal at whoever holds that number; and it stubs the marker read
+    to "unreadable", so no test reaches into a real process's environment. A
+    test exercising the marker overrides that last one with its own stub.
+    """
+    calls: list[tuple] = []
+
+    def refuse_getpgid(pid):
+        raise AssertionError(f"the group must come from the record, not from pid {pid}")
+
+    monkeypatch.setattr(jobs.os, "getpgid", refuse_getpgid)
+    monkeypatch.setattr(jobs.os, "killpg", lambda *a: calls.append(a))
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
+    return calls
+
+
+def test_submit_records_the_identity_of_the_process_it_spawned(sandbox, monkeypatch):
+    """A pid alone is not an identity, so the start time and group go with it."""
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(4242))
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs, "_spawned_pgid", lambda pid: pid)
+
+    rec = jobs._read_job(jobs.submit("agent", [], prompt="x")["run_id"])
+
+    assert rec["pid"] == 4242
+    assert rec["pid_create_time"] == _SPAWNED_AT
+    # start_new_session makes the child its own group leader, so the group is
+    # its own pid — recorded rather than re-derived at kill time.
+    assert rec["pgid"] == 4242
+
+
+def test_kill_signals_the_recorded_group_when_identity_matches(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The happy path: the leader is alive and is the process we started."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 0.02))
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+    assert out["pgid"] == 7777
+    after = jobs._read_job(rid)
+    assert after["status"] == "killed" and after["finished_at"] is not None
+
+
+def test_kill_refuses_a_recycled_pid(sandbox, monkeypatch, no_stray_signal):
+    """An alive pid that started at a different time is a different process."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 900))
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "a reused pid must cost a stranger nothing"
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_PID_RECYCLED
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+def test_kill_refuses_when_the_leaders_start_time_is_unreadable(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A probe that errored is unknown, and unknown is never licence to signal."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("unknown", None))
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEADER_UNVERIFIABLE
+
+
+def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_stray_signal):
+    """The case a leader-liveness gate refuses: `li` exits, its workers do not.
+
+    The children are spawned into the leader's group and outlive it, so the
+    group is what has to be signalled — and it is still identifiable after the
+    leader is gone, because every member started after the run did.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+    after = jobs._read_job(rid)
+    assert after["status"] == "killed" and after["finished_at"] is not None
+
+
+def test_submit_stamps_the_run_id_into_the_child_environment(sandbox, monkeypatch):
+    """The marker every later identity check reads back off the group."""
+    seen: dict = {}
+
+    def fake_popen(*a, **k):
+        seen.update(k.get("env") or {})
+        return _FakeProc(4242)
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+
+    rid = jobs.submit("agent", [], prompt="x")["run_id"]
+
+    assert seen[config.JOB_MARKER_ENV_VAR] == rid
+
+
+def test_a_real_child_carries_the_marker_and_it_reads_back(sandbox):
+    """The mechanism itself, against a real process rather than a stub.
+
+    Reading another process's environment is a platform capability, not a
+    given, and the whole marker rule rests on it. This is the check that says
+    it works here — and, if it ever stops working, says so directly instead of
+    leaving the identity rule to quietly fall back forever.
+    """
+    import subprocess
+    import sys
+    import time
+
+    proc = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        env={**os.environ, config.JOB_MARKER_ENV_VAR: "marker-under-test"},
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            state, marker = jobs._process_marker(proc.pid)
+            if state == "found" and marker is not None:
+                break
+            time.sleep(0.05)
+        assert (state, marker) == ("found", "marker-under-test")
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_process_marker_reports_an_unreadable_process_as_unknown():
+    """A probe that failed is unknown — never "carries no marker"."""
+    # A pid that cannot be read: reaped children of another parent are gone by
+    # the time we ask, and this one was ours and is fully waited on.
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen([sys.executable, "-c", ""])  # noqa: S603
+    proc.wait(timeout=10)
+
+    assert jobs._process_marker(proc.pid) == ("unknown", None)
+
+
+def test_kill_identifies_the_group_by_the_marker_the_run_stamped(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A positive identification, where the start-time rule alone would refuse.
+
+    The member here is *older* than the recorded spawn, which the start-time
+    inequality reads as a reused group number. The marker says otherwise and
+    outranks it: members share a pgid, so one member carrying this run's id
+    makes the group this run's whatever the clock suggests.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60.0)], True)
+    )
+
+    rid = _identity_record()
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+
+
+def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch, no_stray_signal):
+    """The same evidence pointing the other way, where start time would allow.
+
+    Every member started after this run did, so the inequality is satisfied and
+    the fallback would signal. The marker names a different run, which is a
+    positive identification that the group number has been handed on.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", "some-other-run"))
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+    assert "started by a different run" in out["reason"]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        # Read fine, but the process predates the marker: a run recorded by an
+        # older build, whose children were never stamped.
+        ("found", None),
+        # The environment could not be read at all.
+        ("unknown", None),
+    ],
+)
+def test_kill_falls_back_to_start_time_when_the_marker_is_no_help(
+    sandbox, monkeypatch, no_stray_signal, marker
+):
+    """Neither confirmed nor refuted, so the inequality decides — as before."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: marker)
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+
+
+def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Guards a precondition the group branch depends on.
+
+    The liveness probe reaps an exited child, and the OS is then free to hand
+    that pid to an unrelated process. So once the leader reads as gone, its pid
+    is a number that no longer describes anything, and the group decision is
+    taken from the group's own members instead. Nothing here fails today; it
+    fails the moment someone reintroduces a leader read into this branch, which
+    would otherwise go unnoticed and be wrong only intermittently.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_process_create_time",
+        lambda pid: pytest.fail(f"pid {pid} may have been reaped and reused"),
+    )
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+
+    out = jobs.kill(_identity_record())
+
+    assert out["killed"] is True and no_stray_signal == [(7777, signal.SIGTERM)]
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        # A member older than the run: this group number was reused.
+        ([(5001, _SPAWNED_AT - 60.0)], True),
+        # The scan could not read every candidate, so a member may be unseen.
+        ([(5001, _SPAWNED_AT + 3.0)], False),
+        ([], False),
+    ],
+)
+def test_kill_refuses_a_group_it_cannot_confirm(sandbox, monkeypatch, no_stray_signal, members):
+    """A pgid is a pid number and is reused like one.
+
+    With the leader gone, the recorded group number alone licenses nothing: an
+    accurate refusal is the outcome being aimed at here, not the largest number
+    of processes stopped.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(jobs, "_live_group_members", lambda pgid: members)
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+
+
+def test_kill_reports_a_group_with_nothing_live_left_in_it(sandbox, monkeypatch, no_stray_signal):
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(jobs, "_live_group_members", lambda pgid: ([], True))
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_GONE
+    assert "already exited" in out["reason"]
+
+
+def test_kill_reaps_a_live_group_behind_a_terminal_record(sandbox, monkeypatch, no_stray_signal):
+    """A recorded end does not mean the work stopped, and reaping it is the point.
+
+    The notify hook marks the record terminal when the run reports its status;
+    processes it left in its group can still be running. Once that group is
+    confirmed to be this run's, it is signalled — and the recorded end survives,
+    because how the run came out is not the same fact as how its stragglers were
+    cleaned up.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+    )
+
+    rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True
+    after = jobs._read_job(rid)
+    assert after["status"] == "completed"
+    assert after["finished_at"] == "2026-01-01T00:00:00+00:00"
+    assert after["group_reaped_at"] is not None
+
+
+def test_kill_refuses_a_terminal_record_whose_group_is_unconfirmable(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The refusal says identity is unverified, not that reuse is certain."""
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60)], True)
+    )
+
+    rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["reason_code"] == jobs.KILL_GROUP_UNVERIFIED
+    assert "could not be confirmed" in out["reason"]
+    assert jobs._read_job(rid)["status"] == "completed"
+
+
+@pytest.mark.parametrize("bad_pid", [None, 0, 1, "4242"])
+def test_kill_never_dereferences_a_pid_it_must_not_signal(
+    sandbox, monkeypatch, no_stray_signal, bad_pid
+):
+    """0 is the caller's own process group to killpg and 1 is init.
+
+    Refused before any probe, and before the identity fields are read: a record
+    carrying a placeholder must not reach a group signal by any route, including
+    the ones this change added.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
+
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": bad_pid,
+            "pid_create_time": _SPAWNED_AT,
+            "pgid": 7777,
+            "kind": "agent",
+            "status": "running",
+            "log": None,
+        }
+    )
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_NO_PID
+
+
+def test_kill_falls_back_to_pid_liveness_on_a_record_without_identity(sandbox, monkeypatch):
+    """A record written before identity was recorded keeps its old behaviour.
+
+    The fields were never captured and nothing observable now can recover them,
+    so such a record is signalled the way it always was — and says so with its
+    own reason code, which is how a reader tells an old record from a refusal
+    this build decided.
+    """
+    killpg_calls: list[tuple] = []
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 9000 + pid)
+    monkeypatch.setattr(jobs.os, "killpg", lambda *a: killpg_calls.append(a))
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        lambda pgid: pytest.fail("a legacy record has no group to verify"),
+    )
+
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
+    out = jobs.kill(rid)
+
+    assert killpg_calls == [(9000 + 4242, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_LEGACY_NO_IDENTITY
+    assert jobs._read_job(rid)["status"] == "killed"
+
+
+def test_kill_refuses_a_legacy_record_whose_pid_is_gone(sandbox, monkeypatch, no_stray_signal):
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": 4242, "kind": "agent", "status": "running", "log": None})
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_ALREADY_EXITED
+
+
+def test_kill_refuses_a_legacy_record_that_already_ended(sandbox, monkeypatch, no_stray_signal):
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 4242,
+            "kind": "agent",
+            "status": "completed",
+            "finished_at": "2026-01-01T00:00:00+00:00",
+            "log": None,
+        }
+    )
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_ALREADY_ENDED
+    assert "may since have been reused" in out["reason"]
+
+
+def test_a_group_outlives_its_leader_and_is_reaped_by_identity(sandbox):
+    """End to end against real processes: the defect, and the fix, unmocked.
+
+    A leader that backgrounds a child and exits leaves the child running in the
+    group it created. Nothing is mocked here: the record carries the identity
+    submit() records, the leader really exits and is really reaped, and the
+    group is enumerated from the OS.
+    """
+    import subprocess
+    import time
+
+    proc = subprocess.Popen(  # noqa: S603,S607
+        ["sh", "-c", "sleep 30 & sleep 0.5"],
+        start_new_session=True,
+    )
+    # start_new_session, so the group is the leader's own pid. Held before
+    # anything that can raise, so the cleanup below always has a group to reap.
+    pgid = proc.pid
+    try:
+        state, created = jobs._process_create_time(proc.pid)
+        assert state == "found" and created is not None
+        assert jobs._spawned_pgid(proc.pid) == pgid
+
+        proc.wait(timeout=10)  # the leader exits and is reaped; the child runs on
+        assert jobs._pid_alive(proc.pid) is False
+
+        members, complete = jobs._live_group_members(pgid)
+        assert complete and members, "the child outlived its leader in the group"
+
+        rid = _identity_record(pid=proc.pid, pgid=pgid, created=created)
+        out = jobs.kill(rid, signal.SIGKILL)
+
+        assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if not jobs._live_group_members(pgid)[0]:
+                break
+            time.sleep(0.05)
+        assert jobs._live_group_members(pgid) == ([], True)
+    finally:
+        # Whatever the assertions did, this test's own group leaves nothing behind.
+        if pgid > 1:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+
 @pytest.mark.parametrize("cli_status", ["timed_out", "cancelled", "aborted", "completed_empty"])
 def test_mark_terminal_records_cli_status_verbatim(sandbox, monkeypatch, cli_status):
     """The CLI's terminal status is authoritative and recorded verbatim.

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -781,17 +781,19 @@ def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
 
 
-@pytest.mark.parametrize("created", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("created", [float("nan"), float("inf"), float("-inf"), True, False])
 def test_kill_refuses_a_record_whose_start_time_cannot_be_compared(
     sandbox, monkeypatch, no_stray_signal, created
 ):
-    """A start time that is not a real number says nothing about the pid.
+    """A start time that cannot act as one says nothing about the pid.
 
-    It is a float, so it passes the type check, and then loses every comparison
-    below it: a NaN is never within tolerance of a live start time, so the leader
-    would be reported as a reused pid. That is the wrong fact — nothing has been
-    established about the pid at all, only that the record cannot describe it. The
-    refusal is the same, but the code and the reason must not claim otherwise.
+    Each of these satisfies the type check and then loses every comparison below
+    it. A NaN is never within tolerance of a live start time. A boolean is an int
+    to isinstance, so ``true`` becomes 1.0 and compares as a moment in 1970. Either
+    way the leader would be reported as a reused pid, and that is the wrong fact —
+    nothing has been established about the pid at all, only that the record cannot
+    describe it. The refusal is the same, but the code and the reason must not
+    claim otherwise.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -694,7 +694,7 @@ def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_st
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid, True)], True)
     )
 
     rid = _identity_record()
@@ -776,7 +776,7 @@ def test_kill_identifies_the_group_by_the_marker_the_run_stamped(
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60.0, rid)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60.0, rid, True)], True)
     )
 
     rid = _identity_record()
@@ -796,7 +796,7 @@ def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch,
     monkeypatch.setattr(
         jobs,
         "_live_group_members",
-        lambda pgid: ([(5001, _SPAWNED_AT + 3.0, "some-other-run")], True),
+        lambda pgid: ([(5001, _SPAWNED_AT + 3.0, "some-other-run", True)], True),
     )
 
     out = jobs.kill(_identity_record())
@@ -828,7 +828,10 @@ def test_kill_refuses_a_group_whose_members_carry_conflicting_markers(
         jobs,
         "_live_group_members",
         lambda pgid: (
-            [(5001, _SPAWNED_AT + 1.0, seen[5001]), (5002, _SPAWNED_AT + 2.0, seen[5002])],
+            [
+                (5001, _SPAWNED_AT + 1.0, seen[5001], True),
+                (5002, _SPAWNED_AT + 2.0, seen[5002], True),
+            ],
             True,
         ),
     )
@@ -858,7 +861,10 @@ def test_kill_identifies_a_group_whose_members_all_carry_this_runs_marker(
         jobs,
         "_live_group_members",
         # Both older than the record, so only the marker can license this signal.
-        lambda pgid: ([(5001, _SPAWNED_AT - 60.0, rid), (5002, _SPAWNED_AT - 30.0, rid)], True),
+        lambda pgid: (
+            [(5001, _SPAWNED_AT - 60.0, rid, True), (5002, _SPAWNED_AT - 30.0, rid, True)],
+            True,
+        ),
     )
 
     rid = _identity_record()
@@ -881,7 +887,7 @@ def test_kill_refuses_a_group_that_is_merely_young_enough(sandbox, monkeypatch, 
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, None)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, None, True)], True)
     )
 
     out = jobs.kill(_identity_record())
@@ -906,7 +912,10 @@ def test_kill_still_excludes_a_group_holding_a_member_older_than_the_run(
     monkeypatch.setattr(
         jobs,
         "_live_group_members",
-        lambda pgid: ([(5001, _SPAWNED_AT + 3.0, None), (5002, _SPAWNED_AT - 60.0, None)], True),
+        lambda pgid: (
+            [(5001, _SPAWNED_AT + 3.0, None, True), (5002, _SPAWNED_AT - 60.0, None, True)],
+            True,
+        ),
     )
 
     out = jobs.kill(_identity_record())
@@ -937,7 +946,7 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
         lambda pid: pytest.fail(f"pid {pid} may have been reaped and reused"),
     )
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid, True)], True)
     )
 
     rid = _identity_record()
@@ -951,10 +960,10 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
     [
         # A member older than the run: this group number was reused. Settled —
         # a retry reads the same thing.
-        (([(5001, _SPAWNED_AT - 60.0, None)], True), jobs.KILL_GROUP_PREDATES_RUN),
+        (([(5001, _SPAWNED_AT - 60.0, None, True)], True), jobs.KILL_GROUP_PREDATES_RUN),
         # The scan could not read every candidate, so a member may be unseen.
         # A measurement that failed, and a retry may answer.
-        (([(5001, _SPAWNED_AT + 3.0, None)], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
+        (([(5001, _SPAWNED_AT + 3.0, None, True)], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
         (([], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
     ],
 )
@@ -1000,7 +1009,7 @@ def test_kill_reaps_a_live_group_behind_a_terminal_record(sandbox, monkeypatch, 
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid, True)], True)
     )
 
     rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
@@ -1020,7 +1029,7 @@ def test_kill_refuses_a_terminal_record_whose_group_is_unconfirmable(
     """The refusal says identity is unverified, not that reuse is certain."""
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60, None)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60, None, True)], True)
     )
 
     rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
@@ -1282,7 +1291,7 @@ def test_a_readable_record_is_still_read(sandbox, monkeypatch, no_stray_signal):
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid, True)], True)
     )
 
     rid = _identity_record()
@@ -1361,24 +1370,106 @@ def test_a_member_that_changes_identity_mid_scan_cannot_lose_the_start_time_excl
 def test_a_member_whose_environment_is_closed_still_counts_as_a_member(
     sandbox, monkeypatch, no_stray_signal
 ):
-    """Guards the precondition the pinned scan depends on.
+    """An unreadable environment withholds a marker; it does not hide a member.
 
-    An unreadable environment is the ordinary case for a process this user
-    cannot introspect, and it withholds a marker rather than failing the scan.
-    If pinning ever treated it as an unpinnable member, every such group would
-    report an incomplete scan and no job with an unreadable process in it could
-    be reaped at all — this fails the moment that happens.
+    A process this user cannot introspect is still a process the scan saw: its
+    pid, group and start time all answered. Counting it is what keeps the group
+    from being answered for as gone and signalled away, so it is reported as a
+    member — one whose marker is unread rather than absent, which is why the
+    refusal is the retryable one.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     rid = _identity_record()
     _scan_one_candidate(monkeypatch, 7777, [_SPAWNED_AT + 3.0], None)
     monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
 
+    members, complete = jobs._live_group_members(7777)
     out = jobs.kill(rid)
 
     assert no_stray_signal == []
-    # A complete scan that found no marker: unproven, not unfinished.
-    assert out["reason_code"] == jobs.KILL_GROUP_OWNERSHIP_UNPROVEN
+    assert [pid for pid, _, _, _ in members] == [5001], "the member was seen, so it counts"
+    assert complete, "a member that was seen opens no gap in the membership"
+    assert out["reason_code"] == jobs.KILL_GROUP_SCAN_INCOMPLETE
+
+
+def test_an_unread_marker_is_not_reported_as_a_group_carrying_none(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The two ways of coming back without a marker are different news.
+
+    A member whose environment was read and holds no marker settles the group:
+    every retry reads the same nothing, and only an operator can take it further.
+    A member whose environment would not open settles nothing — the marker it
+    withheld is one the next call may well read. Reported as the same answer,
+    the second tells an operator to stop retrying on a measurement that never
+    came off.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+
+    _scan_one_candidate(monkeypatch, 7777, [_SPAWNED_AT + 3.0], None)
+    read_and_absent = jobs.kill(rid)
+
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
+    could_not_read = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert read_and_absent["reason_code"] == jobs.KILL_GROUP_OWNERSHIP_UNPROVEN
+    assert could_not_read["reason_code"] == jobs.KILL_GROUP_SCAN_INCOMPLETE
+    assert read_and_absent["killed"] is False and could_not_read["killed"] is False
+
+
+def test_one_readable_marker_still_identifies_a_group_holding_an_unreadable_member(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Unread markers cost nothing that was reapable before.
+
+    Members share a pgid, so one member reading back this run's id identifies the
+    group whatever its neighbours would or would not disclose. The marker rule
+    runs ahead of every completeness question for exactly that reason, and a
+    group with one process this user cannot introspect is still reaped.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        lambda pgid: (
+            [(5001, _SPAWNED_AT + 1.0, None, False), (5002, _SPAWNED_AT + 2.0, rid, True)],
+            True,
+        ),
+    )
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+
+
+def test_a_member_older_than_the_run_still_excludes_past_an_unread_marker(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Unread markers do not displace the refusal the start time already reaches.
+
+    A member that was running before this run started rules the group out, and
+    that is a settled fact about a process the scan pinned. It keeps its own code
+    ahead of any question about what a neighbour's environment would disclose.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        jobs,
+        "_live_group_members",
+        lambda pgid: (
+            [(5001, _SPAWNED_AT + 3.0, None, False), (5002, _SPAWNED_AT - 60.0, None, True)],
+            True,
+        ),
+    )
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_GROUP_PREDATES_RUN
 
 
 def test_every_surface_survives_a_record_it_cannot_get_at(sandbox, monkeypatch, no_stray_signal):

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -358,6 +358,85 @@ def test_kill_refuses_when_the_live_leaders_group_cannot_be_read(
     assert out["reason_code"] == jobs.KILL_LEADER_GROUP_UNREADABLE
 
 
+def test_kill_refuses_a_live_leader_that_says_it_belongs_to_another_run(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A live leader whose every number matches, and which names another run.
+
+    The record's pid, start time and group all describe this process, so the
+    numbers alone license the signal. The process itself disagrees: it carries a
+    different run's id in the environment its parent gave it, which is exactly
+    the evidence the group route refuses on when the leader is gone. The same
+    evidence has to reach the same conclusion on the route where the leader is
+    still alive, or one branch of this decision trusts what the other rejects.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", "some-other-run"))
+
+    rid = _identity_record()
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "a process naming another run must not be signalled"
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_GROUP_FOREIGN
+    assert jobs._read_job(rid)["status"] == "running"
+
+
+@pytest.mark.parametrize("marker", [("unknown", None), ("found", None)])
+def test_kill_signals_a_live_leader_whose_environment_names_no_run(
+    sandbox, monkeypatch, no_stray_signal, marker
+):
+    """No marker withholds nothing, on the route where the leader is alive too.
+
+    This one passes before the marker was read here at all, and that is what it
+    is for: the marker may veto a signal and may never be required to permit
+    one. A process whose environment cannot be read and one whose environment is
+    genuinely empty arrive as the same answer — some platforms hand back an empty
+    environment for a protected binary rather than raising — so requiring a
+    marker to signal would strand every job whose processes cannot be read. Both
+    of those answers are covered here, because the distinction the code must not
+    start drawing between them is invisible to a single case.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: 7777)
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: marker)
+
+    out = jobs.kill(_identity_record())
+
+    assert no_stray_signal == [(7777, signal.SIGTERM)]
+    assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
+
+
+def test_kill_refuses_a_record_that_names_a_different_run(sandbox, monkeypatch):
+    """A record found under one run, describing another.
+
+    Every write of a record stamps the run it belongs to, so this field is not a
+    measurement that can fail — a record whose own id is not the one being killed
+    was put there by something other than the run being killed, and the process
+    its numbers describe is some other run's. Nothing is probed: the pid on such
+    a record has no claim on this call.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
+
+    rid = jobs.new_run_id()
+    other = jobs.new_run_id()
+    _write_raw_record(
+        rid,
+        f'{{"run_id": "{other}", "pid": 4242, "pgid": 7777, '
+        f'"pid_create_time": {_SPAWNED_AT}, "status": "running"}}',
+    )
+
+    out = jobs.kill(rid)
+
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_RECORD_FOREIGN_RUN
+    # The run the record does name is reported: it is the only handle a caller
+    # has for stopping the run that record actually describes.
+    assert other in out["reason"]
+
+
 def test_kill_refuses_a_recycled_pid(sandbox, monkeypatch, no_stray_signal):
     """An alive pid that started at a different time is a different process."""
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1647,6 +1647,37 @@ def test_a_damaged_record_is_reported_as_damaged_by_every_surface(sandbox, paylo
     assert listed[ok_rid] == "ok", "one damaged record must not cost the runs beside it"
 
 
+def test_a_read_failure_nobody_anticipated_is_still_an_unusable_record(sandbox, monkeypatch):
+    """The classification is total, and this is what says so.
+
+    The table above covers the damage shapes that are known. The reader's promise
+    is stronger than that list: it says every way the read can fail yields a state,
+    and a promise about shapes nobody has thought of cannot be tested by naming
+    more of them. So the failure here is deliberately one that means nothing --
+    what is being checked is that the reader classifies rather than recognises.
+    """
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+    assert jobs.status(rid)["record_state"] == "ok", "control: the record reads before patching"
+
+    class UnanticipatedFailure(Exception):
+        pass
+
+    real_read_text = Path.read_text
+
+    def failing_read_text(self, *a, **kw):
+        if self.name == "job.json":
+            raise UnanticipatedFailure("nothing in the reader has heard of this")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+    assert jobs.status(rid)["record_state"] == "unreadable"
+    assert jobs.output(rid)["record_state"] == "unreadable"
+    assert jobs.kill(rid)["reason_code"] == jobs.KILL_RECORD_UNREADABLE
+    assert [j["record_state"] for j in jobs.list_jobs()] == ["unreadable"]
+
+
 def test_a_run_manifest_of_invalid_bytes_does_not_escape_the_surface_that_reads_it(sandbox):
     """The manifest is advisory, which is an argument about its value and not a
     licence to raise. A read that returns nothing costs the caller one display
@@ -1663,6 +1694,43 @@ def test_a_run_manifest_of_invalid_bytes_does_not_escape_the_surface_that_reads_
     manifest.write_bytes(b"\xff\xfe not utf-8")
     assert jobs.status(rid)["run"] is None
     assert jobs.status(rid)["known"] is True, "the record is fine; only the manifest is not"
+
+
+def test_a_manifest_read_failure_nobody_anticipated_still_costs_only_the_manifest(
+    sandbox, monkeypatch
+):
+    """The manifest reader makes the same total promise the record reader does, so
+    it is checked the same way: with a failure that means nothing, which no list of
+    exception types could have named in advance.
+
+    The failure is aimed at the manifest alone. The record is read on the same call
+    and must survive, because the claim is not that the surface tolerates damage
+    generally -- it is that a manifest nobody can read costs the caller that one
+    field and nothing else.
+    """
+    rid = jobs.new_run_id()
+    jobs._write_job({"run_id": rid, "pid": None, "kind": "agent", "status": "running"})
+    manifest = config.run_manifest(rid)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text('{"run_id": "readable"}')
+    assert jobs.status(rid)["run"] == {"run_id": "readable"}, "control: the manifest is read"
+
+    class UnanticipatedFailure(Exception):
+        pass
+
+    real_read_text = Path.read_text
+
+    def failing_read_text(self, *a, **kw):
+        if self.name == "run.json":
+            raise UnanticipatedFailure("nothing in the reader has heard of this")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+    answer = jobs.status(rid)
+    assert answer["run"] is None
+    assert answer["record_state"] == "ok", "the record was reachable and still is"
+    assert answer["known"] is True
 
 
 def test_an_artifacts_directory_that_denies_its_own_read_is_not_a_run_that_wrote_nothing(

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -1073,9 +1073,8 @@ def test_kill_never_dereferences_a_pid_it_must_not_signal(
 
 @pytest.mark.parametrize(
     "record",
-    # No identity keys at all, which is the one thing that means the record was
-    # written before they existed. A record that carries the keys and bad values
-    # is damaged rather than old, and gets its own answer.
+    # No identity keys at all. A record that carries the keys and holds bad values
+    # is a different observation and gets its own answer.
     [{}],
 )
 def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
@@ -1110,13 +1109,42 @@ def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     out = jobs.kill(rid)
 
     assert no_stray_signal == [], "a pid without an identity must license no signal"
-    assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_NO_IDENTITY
+    assert out["killed"] is False and out["reason_code"] == jobs.KILL_NO_RECORDED_IDENTITY
     assert out["pid"] == 4242, "the operator needs the number to reap the group by hand"
-    # The observation first — both fields missing — with the age of the record
-    # offered as the explanation and not as something the refusal measured.
+    # What was read off the record: both fields missing, so the pid is unusable.
     assert "carries neither a start time nor a process group" in out["reason"]
-    assert "written before they were captured" in out["reason"]
     assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
+
+
+def test_kill_does_not_date_a_record_that_carries_no_identity(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Both fields absent is an observation about the record, not about its age.
+
+    This record is written here, seconds ago, by the current writer, with the two
+    identity keys removed. The refusal it draws must therefore not tell an operator
+    the record was written before those fields were captured: no current writer
+    omitting them rules out one origin, and a record altered after it was written
+    reads exactly like an old one. The remedies differ — age out a stale record
+    versus inspect one that was changed — so the sentence would point the wrong way.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
+
+    rid = _identity_record()
+    record = jobs._read_job(rid)
+    del record["pid_create_time"], record["pgid"]
+    jobs._write_job(record)
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_NO_RECORDED_IDENTITY
+    assert out["pid"] == 4242, "the operator needs the number to reap the group by hand"
+    assert "carries neither a start time nor a process group" in out["reason"]
+    for claim in ("written before", "predates", "legacy", "older", "since those fields"):
+        assert claim not in out["reason"], f"the refusal must not date the record: {claim!r}"
+    assert "legacy" not in out["reason_code"], "the code names the observation, not an origin"
 
 
 @pytest.mark.parametrize(
@@ -1608,15 +1636,15 @@ def test_listing_jobs_survives_a_jobs_directory_it_cannot_get_at(sandbox):
         {"pgid": 7777},
     ],
 )
-def test_kill_does_not_call_a_damaged_identity_an_old_record(
+def test_kill_does_not_call_a_damaged_identity_an_absent_one(
     sandbox, monkeypatch, no_stray_signal, identity
 ):
     """Present-but-wrong is not the same news as absent, and must not borrow its sentence.
 
-    The refusal for a record written before these fields existed says exactly that
-    about its age. A record carrying the keys was written by code that knows them,
-    so the age claim is false of it however bad the values are — and unlike an old
-    record, this one is worth looking into.
+    A record carrying the keys was written by something that knows about them, so
+    what an operator has to look at is the value it wrote — which is a different
+    thing to look at than a record that names no identity at all. Neither refusal
+    dates the record.
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -781,6 +781,28 @@ def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
 
 
+@pytest.mark.parametrize("created", [float("nan"), float("inf"), float("-inf")])
+def test_kill_refuses_a_record_whose_start_time_cannot_be_compared(
+    sandbox, monkeypatch, no_stray_signal, created
+):
+    """A start time that is not a real number says nothing about the pid.
+
+    It is a float, so it passes the type check, and then loses every comparison
+    below it: a NaN is never within tolerance of a live start time, so the leader
+    would be reported as a reused pid. That is the wrong fact — nothing has been
+    established about the pid at all, only that the record cannot describe it. The
+    refusal is the same, but the code and the reason must not claim otherwise.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pytest.fail("pid must not be probed"))
+
+    out = jobs.kill(_identity_record(created=created))
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_IDENTITY_UNUSABLE
+    assert "reused" not in out["reason"], "the pid was never established to be anything"
+
+
 def _process_table_enumerable() -> tuple[bool, str]:
     """Whether this machine lets us list the process table at all.
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -481,11 +481,10 @@ def test_kill_reaps_a_live_group_whose_leader_exited(sandbox, monkeypatch, no_st
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
     )
 
     rid = _identity_record()
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
@@ -564,11 +563,10 @@ def test_kill_identifies_the_group_by_the_marker_the_run_stamped(
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60.0, rid)], True)
     )
 
     rid = _identity_record()
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
@@ -583,9 +581,10 @@ def test_kill_refuses_a_group_carrying_another_runs_marker(sandbox, monkeypatch,
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs,
+        "_live_group_members",
+        lambda pgid: ([(5001, _SPAWNED_AT + 3.0, "some-other-run")], True),
     )
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", "some-other-run"))
 
     out = jobs.kill(_identity_record())
 
@@ -615,12 +614,14 @@ def test_kill_refuses_a_group_whose_members_carry_conflicting_markers(
     monkeypatch.setattr(
         jobs,
         "_live_group_members",
-        lambda pgid: ([(5001, _SPAWNED_AT + 1.0), (5002, _SPAWNED_AT + 2.0)], True),
+        lambda pgid: (
+            [(5001, _SPAWNED_AT + 1.0, seen[5001]), (5002, _SPAWNED_AT + 2.0, seen[5002])],
+            True,
+        ),
     )
 
     rid = _identity_record()
     seen = {pid: (rid if m == "this-run" else m) for pid, m in zip([5001, 5002], order)}
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", seen[pid]))
 
     out = jobs.kill(rid)
 
@@ -644,29 +645,17 @@ def test_kill_identifies_a_group_whose_members_all_carry_this_runs_marker(
         jobs,
         "_live_group_members",
         # Both older than the record, so only the marker can license this signal.
-        lambda pgid: ([(5001, _SPAWNED_AT - 60.0), (5002, _SPAWNED_AT - 30.0)], True),
+        lambda pgid: ([(5001, _SPAWNED_AT - 60.0, rid), (5002, _SPAWNED_AT - 30.0, rid)], True),
     )
 
     rid = _identity_record()
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
     assert out["killed"] is True and out["reason_code"] == jobs.KILL_SIGNALLED
 
 
-@pytest.mark.parametrize(
-    "marker",
-    [
-        # The environment was read and simply holds no run id.
-        ("found", None),
-        # The environment could not be read at all.
-        ("unknown", None),
-    ],
-)
-def test_kill_refuses_a_group_that_is_merely_young_enough(
-    sandbox, monkeypatch, no_stray_signal, marker
-):
+def test_kill_refuses_a_group_that_is_merely_young_enough(sandbox, monkeypatch, no_stray_signal):
     """Starting after this run did is not evidence of belonging to it.
 
     Every member here is younger than the record, which is exactly what an
@@ -679,9 +668,8 @@ def test_kill_refuses_a_group_that_is_merely_young_enough(
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, None)], True)
     )
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: marker)
 
     out = jobs.kill(_identity_record())
 
@@ -705,7 +693,7 @@ def test_kill_still_excludes_a_group_holding_a_member_older_than_the_run(
     monkeypatch.setattr(
         jobs,
         "_live_group_members",
-        lambda pgid: ([(5001, _SPAWNED_AT + 3.0), (5002, _SPAWNED_AT - 60.0)], True),
+        lambda pgid: ([(5001, _SPAWNED_AT + 3.0, None), (5002, _SPAWNED_AT - 60.0, None)], True),
     )
 
     out = jobs.kill(_identity_record())
@@ -736,11 +724,10 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
         lambda pid: pytest.fail(f"pid {pid} may have been reaped and reused"),
     )
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
     )
 
     rid = _identity_record()
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert out["killed"] is True and no_stray_signal == [(7777, signal.SIGTERM)]
@@ -751,10 +738,10 @@ def test_kill_decides_a_dead_leaders_group_without_reading_the_leader_again(
     [
         # A member older than the run: this group number was reused. Settled —
         # a retry reads the same thing.
-        (([(5001, _SPAWNED_AT - 60.0)], True), jobs.KILL_GROUP_PREDATES_RUN),
+        (([(5001, _SPAWNED_AT - 60.0, None)], True), jobs.KILL_GROUP_PREDATES_RUN),
         # The scan could not read every candidate, so a member may be unseen.
         # A measurement that failed, and a retry may answer.
-        (([(5001, _SPAWNED_AT + 3.0)], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
+        (([(5001, _SPAWNED_AT + 3.0, None)], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
         (([], False), jobs.KILL_GROUP_SCAN_INCOMPLETE),
     ],
 )
@@ -800,11 +787,10 @@ def test_kill_reaps_a_live_group_behind_a_terminal_record(sandbox, monkeypatch, 
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
     )
 
     rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
     out = jobs.kill(rid)
 
     assert no_stray_signal == [(7777, signal.SIGTERM)]
@@ -821,7 +807,7 @@ def test_kill_refuses_a_terminal_record_whose_group_is_unconfirmable(
     """The refusal says identity is unverified, not that reuse is certain."""
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT - 60, None)], True)
     )
 
     rid = _identity_record(status="completed", finished_at="2026-01-01T00:00:00+00:00")
@@ -904,7 +890,10 @@ def test_kill_refuses_a_record_that_cannot_confirm_an_identity(
     assert no_stray_signal == [], "a pid without an identity must license no signal"
     assert out["killed"] is False and out["reason_code"] == jobs.KILL_LEGACY_NO_IDENTITY
     assert out["pid"] == 4242, "the operator needs the number to reap the group by hand"
-    assert "predates process-identity capture" in out["reason"]
+    # The observation first — both fields missing — with the age of the record
+    # offered as the explanation and not as something the refusal measured.
+    assert "carries neither a start time nor a process group" in out["reason"]
+    assert "written before they were captured" in out["reason"]
     assert jobs._read_job(rid)["status"] == "running", "a refusal changes no recorded status"
 
 
@@ -1018,15 +1007,141 @@ def test_a_readable_record_is_still_read(sandbox, monkeypatch, no_stray_signal):
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0)], True)
+        jobs, "_live_group_members", lambda pgid: ([(5001, _SPAWNED_AT + 3.0, rid)], True)
     )
 
     rid = _identity_record()
-    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", rid))
 
     assert jobs._read_job(rid)["pgid"] == 7777
     assert jobs.kill(rid)["killed"] is True
     assert no_stray_signal == [(7777, signal.SIGTERM)]
+
+
+def _scan_one_candidate(monkeypatch, pgid, create_times, marker):
+    """Drive a real group scan over a single invented pid.
+
+    The process table yields one candidate whose group matches; every read of
+    that pid is answered from *create_times* in call order, so a caller can make
+    the pid change identity partway through the scan without a real race.
+    """
+    import psutil
+
+    monkeypatch.setattr(psutil, "pids", lambda: [5001])
+    monkeypatch.setattr(jobs.os, "getpgid", lambda pid: pgid)
+    reads = iter(create_times)
+    monkeypatch.setattr(
+        jobs, "_process_create_time", lambda pid: ("found", next(reads, create_times[-1]))
+    )
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("found", marker))
+
+
+def test_a_member_that_changes_identity_mid_scan_does_not_identify_the_group(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """A marker and the pid it was read from have to be the same process.
+
+    Membership, start time and marker are three reads addressed by pid, and a
+    pid the OS reassigns between them answers the later ones as the replacement.
+    A replacement carrying this run's id — a descendant moved into another group,
+    say — would then license a signal to a group no live member of which was ever
+    shown to be this run's. The scan has to notice that the identity moved, and
+    report itself incomplete rather than answer for the group.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+    # The first read describes the member; every later one describes whoever
+    # holds the pid now. The marker belongs to that second process.
+    _scan_one_candidate(monkeypatch, 7777, [_SPAWNED_AT + 3.0, _SPAWNED_AT + 90.0], rid)
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == [], "evidence from two processes identifies neither"
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_GROUP_SCAN_INCOMPLETE
+
+
+def test_a_member_that_changes_identity_mid_scan_cannot_lose_the_start_time_exclusion(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """The same composition, on the rule that refuses rather than the one that allows.
+
+    A member older than the run rules the group out. Read the start time off a
+    younger process that has since taken the pid and the exclusion disappears,
+    which is the direction that costs something: the group stops being refused
+    for a reason the scan can no longer see. An unpinnable member makes the scan
+    incomplete, so what is reported is a measurement that did not finish.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+    # A young replacement read first, the original older member read second.
+    _scan_one_candidate(monkeypatch, 7777, [_SPAWNED_AT + 3.0, _SPAWNED_AT - 60.0], None)
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    assert out["killed"] is False
+    assert out["reason_code"] == jobs.KILL_GROUP_SCAN_INCOMPLETE
+
+
+def test_a_member_whose_environment_is_closed_still_counts_as_a_member(
+    sandbox, monkeypatch, no_stray_signal
+):
+    """Guards the precondition the pinned scan depends on.
+
+    An unreadable environment is the ordinary case for a process this user
+    cannot introspect, and it withholds a marker rather than failing the scan.
+    If pinning ever treated it as an unpinnable member, every such group would
+    report an incomplete scan and no job with an unreadable process in it could
+    be reaped at all — this fails the moment that happens.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = _identity_record()
+    _scan_one_candidate(monkeypatch, 7777, [_SPAWNED_AT + 3.0], None)
+    monkeypatch.setattr(jobs, "_process_marker", lambda pid: ("unknown", None))
+
+    out = jobs.kill(rid)
+
+    assert no_stray_signal == []
+    # A complete scan that found no marker: unproven, not unfinished.
+    assert out["reason_code"] == jobs.KILL_GROUP_OWNERSHIP_UNPROVEN
+
+
+def test_every_surface_survives_a_record_it_cannot_get_at(sandbox, monkeypatch, no_stray_signal):
+    """A directory that cannot be searched is not a run that does not exist.
+
+    Asking whether the file is there and then reading it answers two questions,
+    and the first one cannot fail: a path under a directory with no search
+    permission is neither present nor absent to it. Reading directly is what
+    tells the two apart, and every surface that reads a record has to come back
+    with an answer rather than the errno.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root searches a directory whose mode denies it, so the case cannot be set up")
+
+    rid = _identity_record()
+    job_dir = config.job_dir(rid)
+    os.chmod(job_dir, 0o000)
+    try:
+        try:
+            (job_dir / "job.json").read_text()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this filesystem does not enforce directory search permission")
+
+        out = jobs.kill(rid)
+        assert no_stray_signal == []
+        assert out["killed"] is False
+        assert out["reason_code"] == jobs.KILL_RECORD_UNREADABLE
+        assert "could not be read" in out["reason"]
+
+        st = jobs.status(rid)
+        assert st["known"] is False
+
+        got = jobs.output(rid)
+        assert got["known"] is False
+    finally:
+        os.chmod(job_dir, 0o700)
 
 
 @pytest.mark.parametrize(

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -483,7 +483,10 @@ def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):
     running ids polls every second, and paying a subprocess per id per poll
     would be a real cost for an answer the record already has.
     """
+    # Both process probes, because the reader asks the pid two questions and a
+    # double that answers only "is it alive" describes a zombie, which is not.
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", 1_700_000_000.0))
     monkeypatch.setattr(
         jobs,
         "_read_lifecycle",

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -398,6 +398,84 @@ def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypa
     assert st["possibly_orphaned"] is True
 
 
+def test_output_that_defeats_the_parser_is_a_read_that_learned_nothing(home, monkeypatch):
+    """The reader promises None for any reason at all, and this is the reason a
+    list of exception types would have missed.
+
+    The bytes are well under the size limit and are not malformed in a way the
+    parser reports: they exhaust the decoder's stack instead, so a guard naming
+    parse errors does not cover them. What arrives here is another program's
+    stdout, so the parse is the one surface in this function whose input is
+    genuinely unconstrained, and a caller polling a run cannot be handed an
+    exception in place of "learned nothing".
+    """
+    monkeypatch.setattr(
+        config,
+        "li_command",
+        lambda: [sys.executable, "-c", "print('[' * 10000)"],
+    )
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    assert jobs._read_lifecycle(run_id) is None
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+    assert jobs._read_job(run_id)["finished_at"] is None, "nothing was concluded and none cached"
+
+
+def test_a_spawn_failure_nobody_anticipated_is_also_a_read_that_learned_nothing(home, monkeypatch):
+    """The other half of the same promise, checked the same way.
+
+    Spawning is the guard whose failures are hardest to enumerate, because they
+    come from the operating system rather than from this package. The failure
+    injected here means nothing on purpose: what is being checked is that the
+    reader treats a command it could not run as a fact it did not learn, rather
+    than recognising a particular way of not running it.
+    """
+    run_id = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": 999_999,
+            "kind": "agent",
+            "label": None,
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-07-25T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+    class UnanticipatedSpawnFailure(Exception):
+        pass
+
+    def refusing_run(*a, **kw):
+        raise UnanticipatedSpawnFailure("nothing in the reader has heard of this")
+
+    monkeypatch.setattr(subprocess, "run", refusing_run)
+
+    assert jobs._read_lifecycle(run_id) is None
+    st = jobs.status(run_id)
+    assert st["terminal"] is False
+    assert st["possibly_orphaned"] is True
+
+
 def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):
     """The read is only made where the record cannot already answer.
 

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -470,6 +470,29 @@ async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monke
     assert res["stopped_without_end"] == [rid]
 
 
+async def test_wait_does_not_hold_the_window_open_for_a_reused_pid(sandbox, monkeypatch):
+    """A run whose pid now belongs to someone else has stopped, not stalled.
+
+    wait observes through status, so a liveness answer taken from whatever holds
+    the number keeps the run in ``pending`` for the whole window and leaves
+    ``stopped_without_end`` empty — the caller waits out its budget on a run that
+    already ended, and is told nothing about why.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", 1_700_005_000.0))
+    rid = jobs.new_run_id()
+    _record(rid, pid=4242, pid_create_time=1_700_000_000.0, pgid=4242)
+
+    res = await jobs.wait([rid], max_wait=0, poll_interval=5)
+
+    assert res["pending"] == []
+    assert res["stopped_without_end"] == [rid]
+    assert res["all_terminal"] is False
+    assert res["runs"][0]["possibly_orphaned"] is True
+    assert res["runs"][0]["terminal"] is False
+    assert res["runs"][0]["error"] is None
+
+
 async def test_the_floor_never_outruns_the_window(sandbox, monkeypatch):
     """The floor is bounded by what is left of the window, not by the interval.
 

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -44,6 +44,19 @@ def _record(rid: str, **fields) -> None:
     jobs._write_job(base)
 
 
+def _live_process(monkeypatch, alive=lambda pid: True) -> None:
+    """Make both process probes agree that the pid holds a live process.
+
+    A pid is asked two separate questions: whether it holds a live process at
+    all, and when that process started. Answering only the first describes a
+    state no operating system produces — a pid that answers ``kill -0`` and is
+    absent from the process table is a process that has exited and is waiting to
+    be reaped, which is the opposite of alive.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", alive)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", 1_700_000_000.0))
+
+
 # --- terminal / outcome derivation ---------------------------------------------
 
 
@@ -107,7 +120,7 @@ def test_preparing_record_is_not_a_spawn_failure(sandbox, monkeypatch):
 
 
 def test_running_job_carries_null_outcome(sandbox, monkeypatch):
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     rid = jobs.new_run_id()
     _record(rid, pid=4242)
 
@@ -234,7 +247,7 @@ async def test_wait_returns_one_entry_per_id_in_input_order(sandbox, monkeypatch
 
 async def test_wait_snapshot_with_zero_max_wait(sandbox, monkeypatch):
     """max_wait=0 is a legal request for one observation, not an error."""
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     slept: list[float] = []
 
     async def no_sleep(seconds):
@@ -257,7 +270,7 @@ async def test_wait_snapshot_with_zero_max_wait(sandbox, monkeypatch):
 
 async def test_wait_expiry_keeps_what_was_learned(sandbox, monkeypatch):
     """A closed window is not an error: finished ids are still reported."""
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     done = jobs.new_run_id()
     _record(done, status="completed", finished_at="2026-07-25T00:01:00+00:00")
     busy = jobs.new_run_id()
@@ -305,7 +318,7 @@ async def test_wait_clamps_and_echoes_the_effective_numbers(sandbox, monkeypatch
 
 async def test_wait_does_not_touch_the_run(sandbox, monkeypatch):
     """An expired wait leaves the durable record byte-for-byte as it was."""
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    _live_process(monkeypatch)
     rid = jobs.new_run_id()
     _record(rid, pid=4242)
     before = (config.job_dir(rid) / "job.json").read_text()
@@ -531,7 +544,7 @@ async def test_every_unresolved_id_is_named_somewhere_in_the_result(sandbox, mon
     text sits unchanged while the shape it describes stops occurring, which is
     exactly how the obligation this replaces stopped covering a stopped run.
     """
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pid == 4242)
+    _live_process(monkeypatch, alive=lambda pid: pid == 4242)
     running = jobs.new_run_id()
     _record(running, pid=4242)
     stopped = jobs.new_run_id()


### PR DESCRIPTION
## The problem

A pid on its own is not an identity. The OS hands the number out again once the
process is reaped, so a job record — which outlives the process it names —
cannot tell the run it started from whatever occupies that number later.

That left `kill()` with two failure modes it could not distinguish:

- **A live group whose leader exited.** `li` backgrounds work and returns; its
  children keep running in the group it created. Gating on leader liveness
  reported "already exited" while the work was still running, and nothing could
  reap it.
- **A reused pid.** Deriving the group from the recorded pid at kill time could
  resolve to a group this run never spawned, signal it, and report success.

## What changed

`submit()` records what the pid alone cannot: when the leader started, the
process group it was given at spawn, and a run marker (`LIONAGI_MCP_JOB_RUN_ID`)
stamped into the child's environment that every process it spawns inherits.

`kill()` decides from those, and refuses on anything it cannot confirm:

| Case | Outcome |
|---|---|
| pid of 0, 1, or absent | refused before it is probed or dereferenced |
| live leader, start time matches | signals the group **recorded at spawn**, never one re-derived from the pid now |
| live leader, start time differs | pid was recycled — nothing is signalled |
| live leader, start time unreadable | unknown — nothing is signalled |
| leader gone, group confirmed ours | group is reaped |
| leader gone, group unconfirmable | nothing is signalled, with the reason |

Group membership is decided by the marker first, which identifies a member
*positively*: members share a pgid, so one member reading back this run's id
makes the group this run's. The spawn-time comparison stays as the fallback for
the two cases the marker cannot cover — records written before the marker
existed, and members whose environment cannot be read. It is an inequality
rather than an identification (an unrelated younger group also satisfies it),
which is why it is the fallback and not the primary. A member that is neither
confirmed nor refuted is unknown, and unknown refuses.

Records written before any of this was recorded keep their previous behaviour
under their own reason codes — the fields describe a process already spawned,
and nothing observable now can recover them.

Every outcome carries a `reason_code` a caller can branch on without matching
prose. Reaping a group behind a record that already ended keeps the recorded
end: how a run came out is a different fact from how its stragglers were
cleaned up.

## Tests

`tests/mcp/` is 635 tests. The full suite is green in CI on CPython 3.10 and
3.14.

Coverage includes both marker directions, both fallback paths, an unreadable
environment, and two tests against real processes — one that a group really does
outlive its leader and is reaped by identity, and one that a child's marker
really does read back on this platform, since the rule rests on that capability.

Tests use invented pids, so the fixture stubs `os.getpgid` to raise and the
marker read to "unreadable" — a made-up pid must never resolve to a real
process's group or environment.

Everything above turns on how a *failed* OS read is classified: a probe that
raises must not be allowed to read as "gone", because "gone" is the answer that
lets a signal proceed. So each of the 32 exception handlers across the 18
functions that read process, group and filesystem state was checked by removing
it alone and re-running the suite — a handler no test can distinguish is a
branch whose classification is unverified. Ten were undistinguished, eight of
them introduced by this change; each now has a test that drives exactly that
handler, named for the distinction it makes:

| Read | Failure | The distinction |
|---|---|---|
| leader liveness | `waitpid` errors other than a missing child | does not decide liveness |
| leader liveness | signalling refused | alive, not absent |
| start time | probe errors | unknown, never gone |
| group member | group read fails | told apart from one that exited |
| process table | cannot be read | scan reported incomplete |
| signal | group gone at the moment of the signal | reported gone |
| signal | signalling refused | refused, not stopped |
| artifact listing | entry disappears after being named | not a failed listing |

The removals were run under three controls each time: the unmodified tree
passes, the same parse-and-regenerate with no handler touched still passes, and
a handler believed covered does fail when removed.

## What this does not establish

- **Records written before these fields existed.** They keep their previous
  behaviour under their own reason codes. Nothing observable now recovers the
  spawn-time facts for a process already running.
- **Environments that cannot be read.** The marker is the positive identifier;
  where a member's environment is unreadable the spawn-time comparison is an
  inequality, not an identification, and an unrelated younger group satisfies
  it. That path refuses rather than signals, so the cost of the gap is a
  straggler left running, not a wrong group killed.
- **POSIX only.** Process groups, `getpgid` and `killpg` are the mechanism.
  There is no Windows path here and none is claimed.
- **The window between the last read and the signal.** Identification and the
  signal are two system calls and cannot be made one: `killpg` takes a group
  number, not a reference to the group that was inspected, and there is no
  "signal this group only if it still holds the process I verified" operation.
  If the identified group empties and its number is handed to an unrelated group
  inside that window, the new group receives the signal and the result reads
  `killed: true`. The guarantee this change makes is *never signalled without an
  identification*, which is not the same as *never signals the wrong group*.

  What changes is the size of the window. The group is no longer derived from
  the recorded pid at kill time; the leader's start time is re-read after its
  group and environment are read and required to match exactly, so the interval
  between the last identity read and the signal is two adjacent statements
  rather than the lifetime of the record. Closing it entirely needs a handle the
  kernel will not reissue — a cgroup or job object — which is a different
  mechanism than process groups and is not attempted here. That is tracked
  separately in #2576, including why it is a spawn-side decision and what it
  would mean per platform.
