### PR TITLE
test: decide the adump snapshot's exclusion instead of racing for it

### DIFF
--- a/tests/protocols/generic/test_pile_cross_lock.py
+++ b/tests/protocols/generic/test_pile_cross_lock.py
@@ -223,42 +223,30 @@ async def test_async_with_block_excludes_sync_thread():
     assert got == [item]
 
 
-class _ContentionSignallingLock:
-    """The pile's sync lock, announcing when *watched* blocks on it.
+def _sync_lock_is_held_against_other_threads(pile: Pile) -> bool:
+    """Whether *pile*'s sync lock is currently held against a foreign thread.
 
-    Signalling from inside the acquisition is the whole point. A signal sent by
-    the includer just *before* it calls `include()` proves only that a line ran;
-    the thread can then be descheduled, and the snapshot proceeds having never
-    been contended. Here the announcement happens after the lock's holder has
-    been established and before the waiting thread can get past it, so a
-    snapshot that observes the signal knows a synchronous caller is committed to
-    the lock it holds.
+    A non-blocking acquire from a thread that does not own the lock answers
+    this outright, with no scheduling window to lose: it fails exactly when
+    some other thread holds the lock. That is what makes this a decidable
+    question rather than a race.
+
+    It has to run on a foreign thread. The lock is reentrant, so the same
+    thread that holds it would succeed and report the opposite of the truth.
     """
+    acquired: list[bool] = []
 
-    def __init__(self, real, watched: threading.Thread, contending: threading.Event):
-        self._real = real
-        self._watched = watched
-        self._contending = contending
+    def attempt():
+        got = pile._lock.acquire(blocking=False)
+        if got:
+            pile._lock.release()
+        acquired.append(got)
 
-    def _announce(self) -> None:
-        if threading.current_thread() is self._watched:
-            self._contending.set()
-
-    def acquire(self, *args, **kwargs):
-        self._announce()
-        return self._real.acquire(*args, **kwargs)
-
-    def release(self):
-        return self._real.release()
-
-    def __enter__(self):
-        self._announce()
-        self._real.acquire()
-        return self
-
-    def __exit__(self, *exc_info):
-        self._real.release()
-        return False
+    t = threading.Thread(target=attempt)
+    t.start()
+    t.join(5)
+    assert acquired, "lock probe thread did not finish"
+    return not acquired[0]
 
 
 async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
@@ -268,14 +256,31 @@ async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     # The slow call has to be one adump actually makes under the lock for this
     # obj_key. The json path builds its records with _ordered_records() and
     # never touches to_df, which only the parquet path calls.
+    #
+    # Nothing here waits on a clock, and nothing depends on which thread the
+    # scheduler picks. Earlier versions of this test tried to catch a racing
+    # include in the act, which leaves a window where the include has not yet
+    # reached the lock and the snapshot passes having excluded nothing. The
+    # decidable question is whether the snapshot HOLDS the lock while it reads,
+    # since include() acquires that same lock: if it is held, no synchronous
+    # caller can be inside include(), and the race does not need to be run.
     pile = Pile()
     pile.include([_Item() for _ in range(3)])
 
     in_snapshot = threading.Event()
-    contending = threading.Event()
     real_ordered_records = pile._ordered_records
     snapshot_sizes: list[int] = []
+    lock_held_during_snapshot: list[bool] = []
     included: list = []
+
+    def slow_ordered_records(*a, **kw):
+        lock_held_during_snapshot.append(_sync_lock_is_held_against_other_threads(pile))
+        in_snapshot.set()
+        records = real_ordered_records(*a, **kw)
+        snapshot_sizes.append(len(records))
+        return records
+
+    object.__setattr__(pile, "_ordered_records", slow_ordered_records)
 
     def includer():
         assert in_snapshot.wait(10), "adump never entered its snapshot region"
@@ -283,21 +288,6 @@ async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
         included.append(True)
 
     t = threading.Thread(target=includer)
-    object.__setattr__(pile, "_lock", _ContentionSignallingLock(pile._lock, t, contending))
-
-    def slow_ordered_records(*a, **kw):
-        in_snapshot.set()
-        # Wait for the includer to reach the lock rather than budgeting an
-        # interval for it to get there. There is no sleep here on purpose: a
-        # wall-clock budget is what lets a loaded machine turn this into a pass
-        # that exercised nothing.
-        assert contending.wait(10), "includer never contended for the pile lock"
-        records = real_ordered_records(*a, **kw)
-        snapshot_sizes.append(len(records))
-        return records
-
-    object.__setattr__(pile, "_ordered_records", slow_ordered_records)
-
     t.start()
     try:
         # Bounded, so a regression that wedges the locking path fails this test
@@ -306,9 +296,12 @@ async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     finally:
         t.join(5)
 
-    # The exclusion itself, asserted on content rather than on a clock: the
-    # include was already blocked on the lock when the records were read, so a
-    # snapshot that still sees three records is one no mutation interleaved with.
+    # The exclusion, established rather than raced for.
+    assert lock_held_during_snapshot == [True], (
+        "adump must hold the pile's sync lock while it reads its snapshot"
+    )
+    # And the consequence: a concurrent include cannot be inside the collection
+    # while that snapshot is taken.
     assert snapshot_sizes == [3]
     assert included, "sync include must eventually complete after adump releases"
     assert len(pile) == 4

--- a/tests/protocols/generic/test_pile_cross_lock.py
+++ b/tests/protocols/generic/test_pile_cross_lock.py
@@ -9,8 +9,6 @@ import asyncio
 import threading
 import time
 
-import pytest
-
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile
 
@@ -228,24 +226,38 @@ async def test_async_with_block_excludes_sync_thread():
 async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     # While adump holds its snapshot region, a sync-thread include() must not
     # interleave; it lands only after the region releases.
-    pytest.importorskip("pandas", reason="adump serializes through the optional pandas adapter")
+    #
+    # The slow call has to be one adump actually makes under the lock for this
+    # obj_key. The json path builds its records with _ordered_records() and
+    # never touches to_df, which only the parquet path calls.
     pile = Pile()
     pile.include([_Item() for _ in range(3)])
 
     in_snapshot = threading.Event()
-    real_to_df = pile.to_df
+    include_issued = threading.Event()
+    real_ordered_records = pile._ordered_records
+    snapshot_sizes: list[int] = []
 
-    def slow_to_df(*a, **kw):
+    def slow_ordered_records(*a, **kw):
         in_snapshot.set()
-        time.sleep(0.3)
-        return real_to_df(*a, **kw)
+        # Hand off rather than budget an interval for the other thread to
+        # start: a loaded machine must not be able to turn this into a pass
+        # that exercised nothing. The short sleep that remains only lets an
+        # already-running thread reach the lock, and can weaken the exercise,
+        # never fail it.
+        assert include_issued.wait(10), "includer thread never issued include()"
+        time.sleep(0.05)
+        records = real_ordered_records(*a, **kw)
+        snapshot_sizes.append(len(records))
+        return records
 
-    object.__setattr__(pile, "to_df", slow_to_df)
+    object.__setattr__(pile, "_ordered_records", slow_ordered_records)
 
     included: list = []
 
     def includer():
-        in_snapshot.wait(5)
+        assert in_snapshot.wait(10), "adump never entered its snapshot region"
+        include_issued.set()
         pile.include(_Item())
         included.append(True)
 
@@ -254,6 +266,10 @@ async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     await pile.adump(tmp_path / "dump.json", obj_key="json")
     t.join(5)
 
+    # The exclusion itself, asserted on content rather than on a clock: the
+    # include was already waiting when the region opened, so a snapshot that
+    # still sees three records is one no mutation interleaved with.
+    assert snapshot_sizes == [3]
     assert included, "sync include must eventually complete after adump releases"
     assert len(pile) == 4
 

--- a/tests/protocols/generic/test_pile_cross_lock.py
+++ b/tests/protocols/generic/test_pile_cross_lock.py
@@ -223,6 +223,44 @@ async def test_async_with_block_excludes_sync_thread():
     assert got == [item]
 
 
+class _ContentionSignallingLock:
+    """The pile's sync lock, announcing when *watched* blocks on it.
+
+    Signalling from inside the acquisition is the whole point. A signal sent by
+    the includer just *before* it calls `include()` proves only that a line ran;
+    the thread can then be descheduled, and the snapshot proceeds having never
+    been contended. Here the announcement happens after the lock's holder has
+    been established and before the waiting thread can get past it, so a
+    snapshot that observes the signal knows a synchronous caller is committed to
+    the lock it holds.
+    """
+
+    def __init__(self, real, watched: threading.Thread, contending: threading.Event):
+        self._real = real
+        self._watched = watched
+        self._contending = contending
+
+    def _announce(self) -> None:
+        if threading.current_thread() is self._watched:
+            self._contending.set()
+
+    def acquire(self, *args, **kwargs):
+        self._announce()
+        return self._real.acquire(*args, **kwargs)
+
+    def release(self):
+        return self._real.release()
+
+    def __enter__(self):
+        self._announce()
+        self._real.acquire()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._real.release()
+        return False
+
+
 async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     # While adump holds its snapshot region, a sync-thread include() must not
     # interleave; it lands only after the region releases.
@@ -234,41 +272,43 @@ async def test_adump_snapshot_excludes_sync_thread_mutation(tmp_path):
     pile.include([_Item() for _ in range(3)])
 
     in_snapshot = threading.Event()
-    include_issued = threading.Event()
+    contending = threading.Event()
     real_ordered_records = pile._ordered_records
     snapshot_sizes: list[int] = []
+    included: list = []
+
+    def includer():
+        assert in_snapshot.wait(10), "adump never entered its snapshot region"
+        pile.include(_Item())
+        included.append(True)
+
+    t = threading.Thread(target=includer)
+    object.__setattr__(pile, "_lock", _ContentionSignallingLock(pile._lock, t, contending))
 
     def slow_ordered_records(*a, **kw):
         in_snapshot.set()
-        # Hand off rather than budget an interval for the other thread to
-        # start: a loaded machine must not be able to turn this into a pass
-        # that exercised nothing. The short sleep that remains only lets an
-        # already-running thread reach the lock, and can weaken the exercise,
-        # never fail it.
-        assert include_issued.wait(10), "includer thread never issued include()"
-        time.sleep(0.05)
+        # Wait for the includer to reach the lock rather than budgeting an
+        # interval for it to get there. There is no sleep here on purpose: a
+        # wall-clock budget is what lets a loaded machine turn this into a pass
+        # that exercised nothing.
+        assert contending.wait(10), "includer never contended for the pile lock"
         records = real_ordered_records(*a, **kw)
         snapshot_sizes.append(len(records))
         return records
 
     object.__setattr__(pile, "_ordered_records", slow_ordered_records)
 
-    included: list = []
-
-    def includer():
-        assert in_snapshot.wait(10), "adump never entered its snapshot region"
-        include_issued.set()
-        pile.include(_Item())
-        included.append(True)
-
-    t = threading.Thread(target=includer)
     t.start()
-    await pile.adump(tmp_path / "dump.json", obj_key="json")
-    t.join(5)
+    try:
+        # Bounded, so a regression that wedges the locking path fails this test
+        # instead of hanging the worker that runs it.
+        await asyncio.wait_for(pile.adump(tmp_path / "dump.json", obj_key="json"), 30)
+    finally:
+        t.join(5)
 
     # The exclusion itself, asserted on content rather than on a clock: the
-    # include was already waiting when the region opened, so a snapshot that
-    # still sees three records is one no mutation interleaved with.
+    # include was already blocked on the lock when the records were read, so a
+    # snapshot that still sees three records is one no mutation interleaved with.
     assert snapshot_sizes == [3]
     assert included, "sync include must eventually complete after adump releases"
     assert len(pile) == 4


### PR DESCRIPTION
## What this fixes

`test_adump_snapshot_excludes_sync_thread_mutation` intended to prove that a sync-thread
`include()` cannot interleave with the snapshot `adump` takes under the lock. It did not
prove that.

It patched `Pile.to_df` to hold the region open, but `adump` calls `to_df` only on the
parquet path:

```python
async with self._both_locks():
    snapshot_ids = set(self.collections.keys())
    df = self.to_df() if obj_key == "parquet" else None
    records = None if obj_key == "parquet" else self._ordered_records()
```

The test passes `obj_key="json"`, so the patched call was never reached. Nothing held the
region open, and the assertion reduced to a fixed wall-clock budget that the snapshot
normally won. Under load on Python 3.14 it lost, and the test flaked.

## What changed

The first two attempts here tried to catch a concurrent `include()` in the act: patch the
call the json path really makes, then hand off to the includer before reading the records.
Both left the same gap. Between announcing the include and the include actually reaching
the lock, a snapshot with **no locking at all** reads the pre-mutation records and the
assertion passes — so the property could hold or not hold and the test could not tell the
difference. Narrowing that window is the same mistake at a smaller scale, because the
window is a property of the approach rather than of any particular budget.

So the test no longer races. It asks a question that has an answer:

- While `_ordered_records()` is executing, attempt a **non-blocking acquire of the pile's
  sync lock from a foreign thread**, and assert that the attempt fails. That fails exactly
  when another thread holds the lock, with no scheduling window to lose.
- `include()` is `@synchronized` and acquires that same lock, so a snapshot holding it
  cannot have a synchronous caller inside the collection. The race does not need to be run.
- The probe must run on a **foreign** thread. `Pile._lock` is an `RLock`, so the thread
  holding it would succeed and report the opposite of the truth.

The includer is kept, released only after the probe records its result, so the previous
test's coverage (the include eventually lands, the pile reaches four items) is retained.
The `adump` await is bounded with `asyncio.wait_for` and the thread is joined in a
`finally`, so a locking regression fails this test rather than hanging the worker running
it.

## Verification

Run both ways against the real `Pile` contract, five runs each, by temporarily removing the
lock from `adump`'s snapshot region and restoring it:

| Snapshot region | Runs | Result |
|---|---|---|
| Guarded (as shipped) | 5 | pass |
| Unguarded (probe) | 5 | fail — 3 on the lock assertion, 2 on `RuntimeError: deque mutated during iteration` from the records read |

The second failure mode is the corruption the lock exists to prevent, surfacing before the
probe's assertion is reached. Both are correct detections; there were no passes with the
lock removed.

The probe was reverted; this PR touches only the test file. `ruff check` and
`ruff format --check` clean.
