### PR TITLE
fix(cli): carry a refused MCP server set to orchestration workers

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -26,11 +26,12 @@ from lionagi import Branch, Session
 from lionagi._errors import ConfigurationError
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.agent.factory import register_profile_injection
+from lionagi.ln import Unset
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
 
-from .._logging import hint
+from .._logging import hint, warn
 from .._providers import (
     _CLAUDE_PROVIDER_NAMES,
     AgentProfile,
@@ -493,7 +494,8 @@ class OrchestrationEnv:
     pack: Pack | None = None
 
     # The MCP servers every worker in this run is handed, resolved once when the
-    # run was set up. None when the caller refused a set or none was found.
+    # run was set up. An empty dict is the caller having asked for no servers at
+    # all; None is there being no set to hand over, because none was found.
     mcp_servers: dict | None = None
 
     # None = no budget configured; workers skip the BUDGET preamble.
@@ -518,17 +520,39 @@ class OrchestrationEnv:
         return list(self._all_names)
 
 
-def _hand_mcp_servers(imodel, servers: dict | None) -> None:
+def _hand_mcp_servers(imodel, servers: dict | None, *, label: str) -> None:
     """Give one branch's model the run's server set, where it can carry one.
 
-    Only the Claude CLI lane accepts a server set per request; the other CLI
-    providers read a user-level config that no caller directory affects, so
-    handing them this here would drop it without a word.
+    An empty set and no set are different requests. ``{}`` is the caller having
+    asked for no servers, and only a provider that accepts a server set per
+    request can express it: handed ``{}``, the Claude CLI lane is told the whole
+    set is empty rather than being left to find its own. ``None`` is there being
+    nothing to hand over, and the model keeps whatever it would have used.
+
+    The other CLI providers read a user-level config that no caller directory
+    affects, so a set given here would be dropped without a word. That is
+    tolerable for servers the model would mostly have found anyway, but not for
+    a refusal — the caller who asked for none would go on believing they got
+    none, so *label* names the worker whose request could not carry it.
     """
     if servers is None:
         return
-    if imodel.endpoint.config.provider in _CLAUDE_PROVIDER_NAMES:
+    provider = imodel.endpoint.config.provider
+    if provider in _CLAUDE_PROVIDER_NAMES:
         imodel.endpoint.config.kwargs["mcp_servers"] = servers
+        if not servers:
+            # An empty set alone is merged with whatever the CLI discovers for
+            # itself, which leaves the discovered servers in place. The strict
+            # flag is what makes the handed set the entire set.
+            imodel.endpoint.config.kwargs["strict_mcp_config"] = True
+        return
+    if not servers:
+        warn(
+            f"{label}: --no-mcp-config was not applied. The {provider} provider "
+            "takes its MCP servers from its own configuration rather than from "
+            "the request, so this worker keeps the servers that configuration "
+            "gives it."
+        )
 
 
 async def setup_orchestration(
@@ -563,6 +587,11 @@ async def setup_orchestration(
         launch_dir=os.getcwd(),
         disabled=no_mcp_config,
     )
+    # A refusal resolves to no servers for the same reason a fruitless search
+    # does, and the two must not reach the workers as the same thing: one is a
+    # decision to hand over an empty set, the other is having nothing to hand
+    # over. Keep the decision as an empty set so it survives the handoff.
+    run_mcp_servers = {} if no_mcp_config else mcp_resolution.servers
 
     # Fail fast: a nonexistent --cwd must never silently spawn into a
     # provider-created directory. Forward the tilde-expanded path (providers never expand `~`).
@@ -603,7 +632,7 @@ async def setup_orchestration(
         fast=fast,
     )
     _orc_provider = orc_imodel.endpoint.config.provider
-    _hand_mcp_servers(orc_imodel, mcp_resolution.servers)
+    _hand_mcp_servers(orc_imodel, run_mcp_servers, label="orchestrator")
     effort = resolve_persisted_effort(_orc_provider, orc_imodel, effort)
     if cwd:
         orc_imodel.endpoint.config.kwargs.setdefault("repo", Path(cwd))
@@ -624,11 +653,16 @@ async def setup_orchestration(
     else:
         # Built-in "orchestrator" casts role via AgentSpec.compose + factory.
         orc_spec = AgentSpec.compose("orchestrator", pack=loaded_pack, grant_emissions=False)
+        # The factory discovers a config from the agent's own directory unless a
+        # caller hands it a set. A refusal has to be handed over for the same
+        # reason a set does: left to discover, the factory would find one and
+        # overwrite the empty set the orchestrator was just given.
         orc_branch = await create_agent(
             orc_spec,
             load_settings=False,
             chat_model=orc_imodel,
             log_config=orc_log_config,
+            resolved_mcp_servers={} if no_mcp_config else Unset,
         )
         orc_branch.name = "orchestrator"
     _session_id_env = os.environ.get("LIONAGI_SESSION_ID")
@@ -656,7 +690,7 @@ async def setup_orchestration(
         cwd=cwd,
         total_budget=total_budget,
         pack=loaded_pack,
-        mcp_servers=mcp_resolution.servers,
+        mcp_servers=run_mcp_servers,
     )
 
 
@@ -743,7 +777,7 @@ async def build_worker_branch(
         theme=env.theme,
         fast=w_fast,
     )
-    _hand_mcp_servers(w_imodel, getattr(env, "mcp_servers", None))
+    _hand_mcp_servers(w_imodel, getattr(env, "mcp_servers", None), label=agent_id)
     artifact_dir = env.run.agent_artifact_dir(agent_id)
     artifact_dir.mkdir(parents=True, exist_ok=True)
     w_imodel.endpoint.config.kwargs["repo"] = artifact_dir

--- a/tests/cli/orchestrate/test_no_mcp_config_handoff.py
+++ b/tests/cli/orchestrate/test_no_mcp_config_handoff.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li o flow` / `li o fanout` with `--no-mcp-config` must hand workers an empty
+MCP server set, not nothing at all.
+
+Handing over nothing is what the run does when it found no config: the worker
+then falls back to whatever its CLI discovers for itself. That is the opposite
+of what the flag asked for, and it is silent, so the two states are checked
+here on the command line the worker would actually be spawned with rather than
+on whether a helper was called.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import lionagi.cli.orchestrate._orchestration as orch_mod
+from lionagi.cli._runs import RunDir
+from lionagi.cli.orchestrate._orchestration import build_worker_branch, setup_orchestration
+from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+
+@pytest.fixture
+def tmp_run(monkeypatch, tmp_path):
+    """Keep run state under tmp_path, and start from a directory with no
+    .mcp.json above it so discovery is what the flag decides, not the tree."""
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
+
+    def _allocate(save_dir=None, run_id=None):
+        run = RunDir(
+            run_id="test-run",
+            state_root=tmp_path / "state",
+            artifact_root=tmp_path / "artifacts",
+        )
+        run.ensure_state_dirs()
+        run.ensure_artifact_root()
+        return run
+
+    monkeypatch.setattr(orch_mod, "allocate_run", _allocate)
+    return launch_dir
+
+
+async def _setup(*, no_mcp_config: bool):
+    return await setup_orchestration(
+        pattern_name="Fanout",
+        model_spec="claude_code/sonnet",
+        agent_name=None,
+        save_dir=None,
+        cwd=None,
+        yolo=False,
+        verbose=False,
+        effort=None,
+        theme=None,
+        no_mcp_config=no_mcp_config,
+    )
+
+
+async def _cli_args(imodel) -> list[str]:
+    """The argv the CLI child would be spawned with, off the live request."""
+    api_call = await imodel.create_event(prompt="hi")
+    request = api_call.payload["request"]
+    assert isinstance(request, ClaudeCodeRequest)
+    return request.as_cmd_args()
+
+
+@pytest.mark.asyncio
+async def test_no_mcp_config_reaches_the_worker_as_an_empty_server_set(tmp_run):
+    env = await _setup(no_mcp_config=True)
+
+    # The empty set is a decision and survives to the workers as one.
+    assert env.mcp_servers == {}
+
+    branch, _, _, _ = await build_worker_branch(env, agent_id="w1", role="implementer")
+    args = await _cli_args(branch.chat_model)
+
+    assert "--mcp-config" in args
+    assert args[args.index("--mcp-config") + 1] == json.dumps({"mcpServers": {}})
+    # Without this the empty set is merged with whatever the CLI finds by
+    # itself, which leaves the discovered servers in place.
+    assert "--strict-mcp-config" in args
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_gets_the_same_empty_server_set(tmp_run):
+    env = await _setup(no_mcp_config=True)
+    args = await _cli_args(env.orc_branch.chat_model)
+
+    assert args[args.index("--mcp-config") + 1] == json.dumps({"mcpServers": {}})
+    assert "--strict-mcp-config" in args
+
+
+@pytest.mark.asyncio
+async def test_no_config_found_hands_over_nothing_and_says_nothing(tmp_run):
+    """The contrast case: no flag and no config to find. The worker is handed
+    no set at all and keeps its own discovery, so no MCP argument is emitted."""
+    env = await _setup(no_mcp_config=False)
+
+    assert env.mcp_servers is None
+
+    branch, _, _, _ = await build_worker_branch(env, agent_id="w1", role="implementer")
+    args = await _cli_args(branch.chat_model)
+
+    assert "--mcp-config" not in args
+    assert "--strict-mcp-config" not in args
+
+
+def test_refusal_is_reported_when_the_provider_cannot_carry_it(caplog):
+    """A provider whose servers come from its own configuration cannot be told
+    the set is empty. Saying so is the point — the caller passed a flag."""
+    import logging
+
+    from lionagi.cli._providers import build_imodel_from_spec
+
+    imodel = build_imodel_from_spec("codex/gpt-5")
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        orch_mod._hand_mcp_servers(imodel, {}, label="reviewer-2")
+
+    assert "mcp_servers" not in imodel.endpoint.config.kwargs
+    assert "reviewer-2" in caplog.text
+    assert "--no-mcp-config" in caplog.text
+    assert "codex" in caplog.text
+
+
+def test_a_discovered_server_set_is_still_handed_over_silently(caplog):
+    """The report is for a refusal that could not be applied, not for every
+    provider that reads its own config — a non-empty set stays a no-op there."""
+    import logging
+
+    from lionagi.cli._providers import build_imodel_from_spec
+
+    imodel = build_imodel_from_spec("codex/gpt-5")
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        orch_mod._hand_mcp_servers(imodel, {"khive": {"command": "kkernel"}}, label="reviewer-2")
+
+    assert "mcp_servers" not in imodel.endpoint.config.kwargs
+    assert caplog.text == ""


### PR DESCRIPTION
## The problem

A caller asking for no MCP servers resolved to the same empty result as a run
that simply found no config, and the worker handoff dropped it. Claude workers
were then spawned with no `--mcp-config` at all and fell back to whatever servers
their own configuration provides: the flag asked for none, and the worker
silently got the ambient set.

## What changed

An empty server set and no server set are now different states all the way
through. A refusal is carried to the workers as an empty set; a provider that
accepts a server set per request is handed it explicitly.

For the Claude CLI that means `--mcp-config` with an empty `mcpServers` block
**plus** `--strict-mcp-config`. An empty set on its own is merged with whatever
the CLI discovers for itself, which leaves those servers in place — so passing
`{}` alone would have been a second refusal that does not refuse, and a test
asserting only the empty `--mcp-config` value would have passed while every
worker still received ambient servers.

The orchestrator branch also passes the empty set through `create_agent`, which
would otherwise discover a config from its own directory and overwrite it.

The other CLI providers read a user-level configuration that no caller directory
affects, so they cannot be told the set is empty. Rather than dropping the
refusal without a word, they now report which worker could not carry it and why.
Handing those providers a non-empty set stays the silent no-op it was.

## Tests

Five tests drive `setup_orchestration()` and `build_worker_branch()` for real and
read the answer off `request.as_cmd_args()` — the argv the CLI child would be
spawned with — rather than off a call to the helper. That is what distinguishes
the flag reaching the worker from the helper merely being invoked.

## Not addressed here

`create_agent` calls `_load_mcp` before the forwarding step and registers tools
into the ActionManager regardless of the flag. For a CLI orchestrator those tools
are inert, since `operate()` only surfaces `branch.acts` for non-CLI providers,
so the flag is honoured in practice today. For an API-model orchestrator the
tools would still be registered. Closing that needs a new `create_agent`
parameter, which is outside this change.

Closes #2561
