### PR TITLE
fix(mcp): report only the profiles that shadow the spelling asked for

### DIFF
--- a/lionagi/mcp/roster.py
+++ b/lionagi/mcp/roster.py
@@ -82,10 +82,12 @@ def _roots() -> list[dict[str, Any]]:
 
 
 def _placement(name: str) -> dict[str, Any]:
-    """Every file declaring *name*, in resolution order — the first one is what runs.
+    """Every file *name* itself resolves to, in resolution order — the first one runs.
 
-    Built from the same per-directory resolver ``load_agent_profile`` uses, and
-    walked in the same order, so the file named here is the file that was read.
+    Built from the same per-directory candidates ``load_agent_profile`` uses,
+    walked in the same order and narrowed by the same spelling rule, so the file
+    named here is the file that was read and everything after it is a file this
+    name really does displace.
     """
     from lionagi._paths import find_lionagi_dirs
     from lionagi.cli._providers import _profile_path_candidates, _resolve_plugin_profile_path
@@ -97,9 +99,22 @@ def _placement(name: str) -> dict[str, Any]:
             # layouts share a directory, so a single root can hold two
             # declarations of the same name and the loser is displaced just as
             # surely as one in a root further down.
+            #
+            # Within one spelling, though. '-' and '_' stand in for each other
+            # only where the spelling asked for is absent, so a directory
+            # holding both holds two profiles that each still resolve under
+            # their own name. Grouping by spelling and keeping the one the
+            # resolver would read leaves the other out of this answer entirely,
+            # rather than reporting a profile a caller can run as displaced.
+            declared: dict[str, list[Path]] = {}
             for path in _profile_path_candidates(d / "agents", name):
                 if path.is_file():
-                    found.append({"path": str(path), "scope": _scope(d)})
+                    declared.setdefault(path.stem, []).append(path)
+            # No file spelled as asked: the fallback spellings are what is left
+            # to report, and a directory holding more than one of those is the
+            # ambiguity the resolver refuses rather than ranks.
+            resolving = declared.get(name) or [p for paths in declared.values() for p in paths]
+            found.extend({"path": str(path), "scope": _scope(d)} for path in resolving)
     plugin_path = _resolve_plugin_profile_path(name)
     if plugin_path is not None:
         found.append({"path": str(plugin_path), "scope": "plugin"})

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -163,6 +163,52 @@ def test_a_same_root_loser_is_listed_before_a_further_root(roots):
     ]
 
 
+def test_the_other_separator_spelling_is_a_second_profile_not_a_displaced_one(roots):
+    """One directory, both spellings, and each name still selects its own file.
+
+    ``-`` and ``_`` are interchangeable only when the spelling asked for is
+    absent, so a directory holding both holds two profiles a caller can run
+    separately. Listing either under the other's ``shadowed`` would tell a
+    reader a profile cannot be selected when a request for it selects it.
+    """
+    hyphen = write_profile(roots.proj, "postmortem-lead", "---\nmodel: hyphen-model\n---\nh\n")
+    underscore = write_profile(roots.proj, "postmortem_lead", "---\nmodel: under-model\n---\nu\n")
+
+    shown = op("profile.show", {"name": "postmortem-lead"})["result"]
+    assert shown["source"]["path"] == str(hyphen)
+    assert shown["resolved"]["model"] == "hyphen-model"
+    assert shown["shadowed"] == []
+
+    shown = op("profile.show", {"name": "postmortem_lead"})["result"]
+    assert shown["source"]["path"] == str(underscore)
+    assert shown["resolved"]["model"] == "under-model"
+    assert shown["shadowed"] == []
+
+
+def test_a_displaced_layout_is_still_shadowed_beside_the_other_spelling(roots):
+    """Both claims the shadowed list has to keep making, in one directory.
+
+    ``postmortem-lead`` is declared twice, in both layouts, and only the
+    directory one is ever read — naming the flat file is the whole point of the
+    list. ``postmortem_lead`` is a third file that runs under its own name, so
+    it belongs nowhere in that list. Reporting neither would drop the
+    diagnostic rather than correct it.
+    """
+    directory_layout = roots.proj / "postmortem-lead" / "postmortem-lead.md"
+    directory_layout.parent.mkdir(parents=True)
+    directory_layout.write_text("---\nmodel: directory-model\n---\ndirectory\n")
+    flat_layout = write_profile(roots.proj, "postmortem-lead", "---\nmodel: flat-model\n---\nf\n")
+    underscore = write_profile(roots.proj, "postmortem_lead", "---\nmodel: under-model\n---\nu\n")
+
+    shown = op("profile.show", {"name": "postmortem-lead"})["result"]
+
+    assert shown["source"]["path"] == str(directory_layout)
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
+    assert op("profile.show", {"name": "postmortem_lead"})["result"]["source"]["path"] == str(
+        underscore
+    )
+
+
 def test_the_verb_agrees_with_the_loader_a_run_would_use(roots):
     """Compared on a profile that declares almost nothing, and on every field.
 


### PR DESCRIPTION
## The problem

`-` and `_` are interchangeable in a profile name only where the spelling asked
for is absent. So an agents directory holding both `postmortem-lead.md` and
`postmortem_lead.md` holds two profiles, and each request resolves its own file.

`_placement()` walked the full candidate list without applying that rule, so
`profile.show` for either name listed the other under `shadowed` — telling a
reader a profile cannot be selected when a request for it selects it.

## What changed

Group the candidates found in a root by spelling and report only the group the
resolver would read. Where no file is spelled as asked, the fallback spellings
are what is left to report.

The list keeps saying `shadowed` for the state that really is one: two layouts of
the same spelling in a directory, where only the directory-layout file is ever
read. A fix that stopped reporting shadows altogether would have removed the
diagnostic rather than corrected it, so the tests cover both directions — a
genuine shadow still reported, and an alternate spelling no longer reported.

Closes #2555
