### PR TITLE
fix(cli): a play kill exits non-zero instead of reporting a termination it did not perform

### DIFF
--- a/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
+++ b/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
@@ -1,10 +1,52 @@
 # ADR-0104: `li kill` reaping of detached-play workers and terminal-notify on kill
 
-- **Status**: Accepted (2026-07-15; implementation merged)
-- **Kind**: Implemented (the reaping and terminal-notify behavior specified here is on main)
+- **Status**: Accepted (2026-07-15), amended 2026-07-27 — see Amendment 1
+- **Kind**: Partially implemented. D1/D2 (play-worker reaping) shipped code that
+  cannot reach a worker; that code is removed and the guidance corrected. D3/D5
+  (terminal-notify on kill) are unaffected.
 - **Area**: cli-surface
 - **Date**: 2026-07-13
 - **Relations**: extends ADR-0058 (unified lifecycle transition service, whose terminal-callback emit this ADR relies on); none superseded
+
+## Amendment 1 (2026-07-27) — D1 and D2 shipped a reap that reaches nothing
+
+**The delivered-behaviour claim in this ADR was wrong.** D1/D2 below state that
+`li kill <play_id>` reaps the play's worker chain, and the status line above used
+to say the behaviour was on main. Code implementing that shape did merge, so the
+claim was not fabricated — but the code cannot do what the ADR says it does, and
+so the operator expectation this ADR set out to fix was left in place under a new
+description.
+
+The mechanism is the `plays.session_id` linkage D1 resolves through. The play
+creation path never binds it: a play row is written without a session id, and the
+worker sessions a play starts carry no back-reference to the play. So
+`_list_running_children` on a play resolves to zero children on every play this
+code path produces, and the transitive walk added for it terminates immediately.
+The result was a kill that reported success while every worker process kept
+running — a worse failure than the original no-op, because the original at least
+did not claim to have stopped anything.
+
+**A writer for the column does exist.** The Studio show importer binds
+`plays.session_id` when it materialises a play from an imported show, so the
+column is not dead by construction and the join D1 added is not unreachable in
+principle. Measured against a development store carrying 400 play rows: none had
+`session_id` bound, no session was named for an imported show, and none carried
+a show topic; a control query on the same table returned 400 rows with a non-NULL
+status, so the store and the query were both live. **The correction is therefore
+"measured-unreachable", not "impossible by construction".** Anyone reinstating
+the join should establish that the binding writer is reachable on the path they
+care about, rather than inferring reachability from the column's existence.
+
+**What replaces it.** `li kill <play_id>` no longer pretends. It marks the play
+row cancelled, states plainly that the worker processes were not stopped and why
+(a play records no link to the sessions it started), points the operator at
+`li monitor` to find the running session ids, and exits non-zero. `--recursive`
+on a play is documented as a no-op for the same reason.
+
+**What is still open.** Making a play kill actually reach its workers needs the
+missing link written at play-creation time. That is a capability change with its
+own design question (which writer owns the binding, and what a play with several
+worker sessions means), tracked separately. This amendment does not decide it.
 
 ## Depth contract
 
@@ -95,8 +137,10 @@ resolves notify from settings only, and never sees a run's per-run override.
 | the kill→terminal-emit behavior is untested | D5: add a regression test locking that a kill emits a terminal envelope and reaps play workers |
 
 **Out of scope:**
-- The identity-guard `_check_pid_identity` behavior (create_time + `LIONAGI_SESSION_ID`
-  + cmdline) — unchanged; owned by the existing kill safety design.
+
+- The identity-guard `_check_pid_identity` behavior (create_time,
+  `LIONAGI_SESSION_ID`, cmdline) — unchanged; owned by the existing kill safety
+  design.
 - `--all-stale` sweep semantics — unchanged (it already excludes plays/shows by
   design as orchestrators without direct PIDs).
 - Show-level reaping — shows are not in `EXECUTION_ENTITY_KINDS` and are out of the
@@ -105,6 +149,10 @@ resolves notify from settings only, and never sees a run's per-run override.
 ## Decision
 
 ### D1 — Transitive `play → session[→ invocation]` reaping
+
+> **Amended 2026-07-27 — this decision is withdrawn.** The linkage it resolves
+> through is never bound on the play-creation path, so the branch described below
+> reaches zero children on every play it was written for. See Amendment 1.
 
 `_list_running_children` gains a `play` branch that resolves the play's running
 worker chain, and the recursive kill walks transitively (BFS) rather than one
@@ -125,6 +173,7 @@ to each.
 ```
 
 **Exact semantics:**
+
 - `li kill <play_id> --recursive`: reap the play's running session and that
   session's running invocation (each a real PID kill via `_kill_one`), then mark
   the play row `blocked`. Order: children before parent (a worker is stopped before
@@ -151,6 +200,10 @@ join semantics to validate.
 
 ### D2 — Killing a play implies recursing into its workers
 
+> **Amended 2026-07-27 — this decision is withdrawn.** It rests on D1's reaping,
+> which reaches nothing. A play kill now reports the workers it cannot stop and
+> exits non-zero instead of implying it stopped them. See Amendment 1.
+
 Because a play row has no PID, `li kill <play_id>` **without** `--recursive` is
 close to useless — it blocks the row while the workers run on. This ADR decides
 that a play kill treats worker reaping as implied: `li kill <play_id>` reaps the
@@ -158,6 +211,7 @@ worker chain by default, and `--recursive` remains the explicit form for the
 session/invocation case (and a no-op-if-already-implied for plays).
 
 **Exact semantics:**
+
 - `li kill <play_id>`: reaps the play's worker chain (same as D1) and blocks the
   play row. No separate `--recursive` needed for the play case.
 - The output names each reaped child and the parent, so the operator sees the full
@@ -197,6 +251,7 @@ scope. Target design retained here so it is not a lost design.
 ### D5 — Regression test for kill→terminal-emit and play-worker reaping
 
 Add tests to `tests/cli/test_kill.py` that lock:
+
 - `li kill <play_id>` reaps the play's seeded running session + invocation (their
   rows go `cancelled`) and blocks the play row.
 - A kill of a session/invocation/play emits exactly one `RunTerminalEnvelope` to a
@@ -209,13 +264,19 @@ Add tests to `tests/cli/test_kill.py` that lock:
 
 ## Consequences
 
-- **Easier:** the operator expectation becomes true — one `li kill <play_id>` stops
-  a detached play and its workers; no manual child-id enumeration. The documented
-  caveat that `li kill` "does not yet stop detached `li play` workers" retires.
-- **Behavior change (D2):** `li kill <play_id>` now terminates the worker processes,
-  where before it only blocked the row. An operator who relied on the old row-only
-  behavior (rare — it stranded workers) sees processes actually stop. Called out in
-  the CHANGELOG under Changed.
+> **Amended 2026-07-27.** The first two bullets describe D1/D2, which are
+> withdrawn. What actually shipped is corrected inline below; see Amendment 1.
+
+- ~~**Easier:** the operator expectation becomes true — one `li kill <play_id>`
+  stops a detached play and its workers; no manual child-id enumeration.~~ It did
+  not become true. The caveat that `li kill` does not stop detached `li play`
+  workers stands, and is now stated by the command itself at the moment it
+  applies rather than left to documentation.
+- ~~**Behavior change (D2):** `li kill <play_id>` now terminates the worker
+  processes, where before it only blocked the row.~~ The worker processes were
+  never terminated. The behaviour change that shipped is the report: a play kill
+  marks the row cancelled, says which processes it did not stop and how to find
+  them, and exits non-zero.
 - **Harder / new failure modes:** the transitive walk touches more processes per
   kill; a partial reap (one child identity-mismatches or is already dead) is now a
   normal, reported outcome rather than an all-or-nothing. The result shape must make

--- a/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
+++ b/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
@@ -38,10 +38,31 @@ the join should establish that the binding writer is reachable on the path they
 care about, rather than inferring reachability from the column's existence.
 
 **What replaces it.** `li kill <play_id>` no longer pretends. It marks the play
-row cancelled, states plainly that the worker processes were not stopped and why
-(a play records no link to the sessions it started), points the operator at
-`li monitor` to find the running session ids, and exits non-zero. `--recursive`
-on a play is documented as a no-op for the same reason.
+row `blocked` — the terminal status a play has always taken on kill, as distinct
+from the `cancelled` a session or invocation takes — states plainly that the
+worker processes were not stopped and why (a play records no link to the sessions
+it started), points the operator at `li monitor` to find the running session ids,
+and exits non-zero. `--recursive` on a play is documented as a no-op for the same
+reason.
+
+**Everything below that depends on D1 or D2 is historical.** The decision bodies,
+their exact semantics, the D3 sentence about one notification per reaped child,
+the D5 reaping test, the transitive-walk entries under Consequences, the
+current-vs-ideal deltas, and the alternatives rejected in favour of reaping all
+describe a contract that was never delivered. They are kept because an ADR is a
+record of what was decided and why, not a description of the current system, and
+because the reasoning is what a future attempt should argue with. None of them
+should be read as a statement about how the command behaves.
+
+**The kill path is not the only consumer.** `--all-stale` decides whether to
+sweep a play by asking whether its linked session has terminated, and that check
+returns false whenever the link is unset — so the sweep skips every play for the
+same reason the reap reached none, and the CLI reference describes a swept play
+being cancelled alongside its worker session, which cannot happen. That is a
+distinct command with its own decision to make (skip silently, or say so the way
+the kill now does), so it is reported separately rather than folded in here.
+Recorded because the premise is shared: anyone fixing the binding fixes both, and
+anyone reading only this amendment would fix one.
 
 **What is still open.** Making a play kill actually reach its workers needs the
 missing link written at play-creation time. That is a capability change with its
@@ -234,6 +255,11 @@ on a per-leg `cmd; notify` wrapper (which SIGKILL bypasses) or a per-run `--noti
 transition emits its own envelope, so with settings-notify a `li kill <play_id>`
 that reaps three workers fires the notify for each.
 
+> **Amended 2026-07-27.** The notify contract in this decision shipped and holds.
+> The last sentence does not: a play kill reaps no workers, so it fires one
+> envelope for the play row itself and none for the workers, which keep running.
+> A kill of a session or invocation still fires per entity as described.
+
 ### D4 — Persist a run's resolved `--notify` override (DEFERRED)
 
 **DEFERRED.** To close the last notify case — a run launched with a per-run
@@ -262,6 +288,13 @@ Add tests to `tests/cli/test_kill.py` that lock:
 - A play with `NULL`/dangling `session_id` blocks the play row and warns, reaping
   nothing (no crash).
 
+> **Amended 2026-07-27.** The first and third bullets test D1/D2 and are
+> withdrawn with them; no test can lock a reap that cannot happen. What shipped
+> instead is a test that a play kill leaves both worker rows running, marks the
+> play row `blocked`, reports the workers it did not stop naming that same
+> status, and exits non-zero. The second bullet, the terminal-envelope test, is
+> unaffected and did ship.
+
 ## Consequences
 
 > **Amended 2026-07-27.** The first two bullets describe D1/D2, which are
@@ -275,30 +308,46 @@ Add tests to `tests/cli/test_kill.py` that lock:
 - ~~**Behavior change (D2):** `li kill <play_id>` now terminates the worker
   processes, where before it only blocked the row.~~ The worker processes were
   never terminated. The behaviour change that shipped is the report: a play kill
-  marks the row cancelled, says which processes it did not stop and how to find
+  marks the row `blocked`, says which processes it did not stop and how to find
   them, and exits non-zero.
-- **Harder / new failure modes:** the transitive walk touches more processes per
+- ~~**Harder / new failure modes:** the transitive walk touches more processes per
   kill; a partial reap (one child identity-mismatches or is already dead) is now a
-  normal, reported outcome rather than an all-or-nothing. The result shape must make
-  "reaped X, skipped Y" legible.
-- **Maintenance:** a contributor must know that (a) plays reach workers via
-  `plays.session_id`, (b) the terminal-emit condition in `service.py` is what makes
-  kill-path notify work and is now covered by a test, (c) the per-run `--notify`
-  override case is a documented DEFERRED gap, not an accidental one.
-- **Cost of reversal:** D1/D2 are localized to `cli/kill.py` and revert cleanly.
-  D3 is documentation. D5 is additive tests.
+  normal, reported outcome rather than an all-or-nothing.~~ There is no transitive
+  walk; it was removed with D1. A play kill touches no worker process, so there is
+  no partial reap to make legible.
+- **Maintenance:** a contributor must know that ~~(a) plays reach workers via
+  `plays.session_id`,~~ (a) plays do **not** reach workers — neither end of the
+  pair references the other on the path that creates them, which is why the kill
+  reports rather than reaps; (b) the terminal-emit condition in `service.py` is
+  what makes kill-path notify work and is covered by a test; (c) the per-run
+  `--notify` override case is a documented DEFERRED gap, not an accidental one.
+- **Cost of reversal:** D1/D2 were localized to `cli/kill.py` and did revert
+  cleanly, which is how they came out. D3 is documentation. D5 is additive tests.
 
 ## Current-vs-ideal delta
 
-| # | Delta | Size | Issue |
-|---|-------|------|-------|
-| 1 | Add `play → session[→ invocation]` transitive reaping to `_list_running_children` + recursive driver | M | (filled at issue-open) |
-| 2 | Make `li kill <play_id>` reap workers by default (D2) | S | (filled at issue-open) |
-| 3 | Document settings `notify.on_terminal` as the kill-notify contract; default-config recommendation | S | (filled at issue-open) |
-| 4 | Regression tests: play-worker reaping + kill→terminal-emit (D5) | S | (filled at issue-open) |
-| 5 | DEFERRED: persist resolved per-run `--notify` override for the kill process (D4) | M | (deferred) |
+> **Amended 2026-07-27.** Rows 1, 2 and the reaping half of row 4 were delivered
+> as code that reaches nothing, and are withdrawn — see the Status column. They
+> are listed rather than deleted so the record shows what was attempted.
+
+| # | Delta | Size | Status |
+|---|-------|------|--------|
+| 1 | Add `play → session[→ invocation]` transitive reaping to `_list_running_children` + recursive driver | M | WITHDRAWN — the link it resolves through is never bound |
+| 2 | Make `li kill <play_id>` reap workers by default (D2) | S | WITHDRAWN — depends on row 1 |
+| 3 | Document settings `notify.on_terminal` as the kill-notify contract; default-config recommendation | S | Delivered |
+| 4 | Regression tests: play-worker reaping + kill→terminal-emit (D5) | S | Terminal-emit delivered; the reaping test withdrawn with rows 1-2 |
+| 5 | DEFERRED: persist resolved per-run `--notify` override for the kill process (D4) | M | Still deferred |
+| 6 | Report the unreachable workers, exit non-zero, and name the status actually written | S | Delivered in place of rows 1-2 |
+| 7 | Bind a play to the sessions it starts, so a play kill can reach them at all | M | Open — the capability rows 1-2 assumed already existed |
 
 ## Alternatives considered
+
+> **Amended 2026-07-27.** Both process-model alternatives below were rejected in
+> favour of reaping the recorded worker entities, and that comparison assumed the
+> recorded link exists. It does not. So the rejections stand on their own
+> reasoning but not on the comparison that decided them, and the option the
+> amendment actually took — report the workers the command cannot reach, and exit
+> non-zero — is not among them because it was not considered.
 
 - **Require `--recursive` for plays (keep bare `li kill <play_id>` row-only).**
   Rejected: preserves the exact footgun reported — the common invocation keeps

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,7 +25,7 @@ worker.
 | `li monitor run ID...` | Wait for scheduled runs and their chains; optionally keep watching |
 | `li agent status [ID]` | Read stable session/invocation status, optionally as JSON |
 | `li o ctl {status,pause,resume,msg}` | Inspect or steer a live flow by ID |
-| `li kill ID` | Terminate one running entity or sweep stale processes; play kills also reap the linked worker chain; show ids are not directly killable ([details](#li-kill)) |
+| `li kill ID` | Terminate one running entity or sweep stale processes; play kills cannot reach their workers and exit non-zero saying so; show ids are not directly killable ([details](#li-kill)) |
 
 ### Reuse, coordination, and operation
 
@@ -550,7 +550,7 @@ already dead. Source: `cli/kill.py` (`add_kill_subparser`).
 
 ```bash
 li kill abc123                        # kill by id prefix
-li kill <play-id>                     # also reaps the play's linked worker session
+li kill <session-id>                  # stop a worker process
 li kill abc123 --reason 'stuck'
 li kill abc123 --recursive            # kill + direct children (session -> invocation)
 li kill --all-stale                   # sweep dead-PID sessions/invocations
@@ -569,10 +569,14 @@ li kill --all-stale --dry-run
 | `--grace SECS` | 5.0 | Wait after SIGTERM before escalating to SIGKILL |
 
 **`--recursive` scope boundary.** Recursion only reaches PID-bearing workers,
-and it stops at the play level:
+and orchestrator rows have no path to theirs:
 
-- Killing a **play** always reaps its linked worker session (and that
-  session's invocation), with or without `--recursive`.
+- Killing a **play** cannot reach its workers. A play row stores no link to
+  the sessions it started, and a worker session stores no play reference, so
+  there is no key to resolve them by. The kill marks the play row `blocked`,
+  prints an error naming the workers it could not stop, and **exits 1** — a
+  play kill never reports success it did not achieve. Kill the worker session
+  ids directly (`li monitor` lists them).
 - Killing a **session** with `--recursive` also cancels its linked invocation.
 - A **show** id cannot be killed directly today: only `running` rows are
   killable, and show rows persist as `active` (never `running`), so

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -323,7 +323,12 @@ async def _persist_cancel(
     reason_summary: str,
     evidence: dict[str, Any],
 ) -> None:
-    """Write cancelled status + status_transition row."""
+    """Write the entity's terminal status + status_transition row.
+
+    The status is per entity kind, not one word: a session or invocation goes
+    ``cancelled``, a play goes ``blocked``, a show goes ``aborted``. Anything
+    reported to an operator has to name the one that was actually written.
+    """
     from lionagi.state.db import (
         PLAY_TERMINAL_STATUSES,
         SHOW_TERMINAL_STATUSES,
@@ -557,7 +562,7 @@ async def _do_kill(
 
         if play_workers_unreachable:
             log_error(
-                f"play {row['id'][:12]} is marked cancelled, but its worker "
+                f"play {row['id'][:12]} is marked blocked, but its worker "
                 "processes were NOT stopped: a play records no link to the "
                 "sessions it started, so they cannot be resolved from the play "
                 "id. Find the running sessions with `li monitor` and kill those "

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -8,7 +8,6 @@ import argparse
 import os
 import signal
 import time
-from collections import deque
 from typing import Any, Literal
 
 import psutil
@@ -271,7 +270,6 @@ def _terminate_pid(
 
 # Only sessions/invocations carry PIDs; plays/shows are orchestrators.
 _STALE_SWEEP_ORDER = ("sessions", "invocations")
-_MAX_RECURSIVE_CHILDREN = 100
 
 
 async def _list_running_children(
@@ -287,19 +285,11 @@ async def _list_running_children(
         for row in rows:
             children.append(("plays", "play", db._row_to_dict(row)))
 
-    if entity_type == "play":
-        rows = await db.fetch_all(
-            "SELECT sessions.* FROM plays "
-            "JOIN sessions ON sessions.id = plays.session_id "
-            "WHERE plays.id = ? AND sessions.status = 'running'",
-            (entity_id,),
-        )
-        if not rows:
-            warn(f"play {entity_id[:12]} has no running worker session to reap")
-        for row in rows:
-            session_row = db._row_to_dict(row)
-            children.append(("sessions", "session", session_row))
-            children.extend(await _list_running_children(db, "session", session_row["id"]))
+    # A play has no branch here on purpose. Nothing records which sessions a
+    # play started: no writer binds plays.session_id, and a worker session
+    # carries no play reference either, so there is no key to resolve a play's
+    # workers by. `_do_kill` reports that gap instead of walking a link that
+    # would never match.
 
     if entity_type == "session":
         rows = await db.fetch_all(
@@ -321,35 +311,6 @@ async def _list_running_children(
         for row in rows:
             children.append(("sessions", "session", db._row_to_dict(row)))
 
-    return children
-
-
-async def _walk_running_children(
-    db: Any, entity_type: str, entity_id: str
-) -> list[tuple[str, str, dict[str, Any]]]:
-    """Discover running descendants breadth-first and return them deepest-first."""
-    frontier = deque(await _list_running_children(db, entity_type, entity_id))
-    seen = {(entity_type, entity_id)}
-    children: list[tuple[str, str, dict[str, Any]]] = []
-
-    while frontier:
-        table, child_type, child_row = frontier.popleft()
-        child_id = child_row["id"]
-        child_key = (child_type, child_id)
-        if child_key in seen:
-            continue
-        if len(children) >= _MAX_RECURSIVE_CHILDREN:
-            warn(
-                f"recursive kill stopped after {_MAX_RECURSIVE_CHILDREN} children; "
-                "remaining descendants were not reaped"
-            )
-            break
-
-        seen.add(child_key)
-        children.append((table, child_type, child_row))
-        frontier.extend(await _list_running_children(db, child_type, child_id))
-
-    children.reverse()
     return children
 
 
@@ -538,9 +499,13 @@ async def _do_kill(
         results = []
         blocked = []
 
-        if entity_type == "play":
-            children = await _walk_running_children(db, entity_type, row["id"])
-        elif entity_type == "show":
+        # A play kill can only mark the play row terminal: nothing links a play
+        # to the sessions it started, so its workers cannot be found from the
+        # play id. That is a failed kill, not a quiet success, and the exit code
+        # below says so.
+        play_workers_unreachable = entity_type == "play"
+
+        if entity_type == "show":
             # ADR-0104 explicitly defers show-level reaping: a show kill only
             # marks the show row terminal. --recursive is a documented no-op
             # here rather than a partial reap of the show's plays/workers.
@@ -589,6 +554,16 @@ async def _do_kill(
             blocked.append(r)
         else:
             print(f"killed {entity_type} {row['id'][:12]} (signal={r['signal']}, pid={r['pid']})")
+
+        if play_workers_unreachable:
+            log_error(
+                f"play {row['id'][:12]} is marked cancelled, but its worker "
+                "processes were NOT stopped: a play records no link to the "
+                "sessions it started, so they cannot be resolved from the play "
+                "id. Find the running sessions with `li monitor` and kill those "
+                "ids directly."
+            )
+            return 1
 
     return 1 if blocked else 0
 
@@ -856,16 +831,16 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
             "The entity's status is set to 'cancelled' (sessions/invocations), "
             "'blocked' (plays), or 'aborted' (shows) with reason tracking per "
             "ADR-0028.\n\n"
-            "Recursion boundary: --recursive walks play -> session -> invocation "
-            "and always reaches the PID-bearing workers. A SHOW kill ('active' "
-            "-> 'aborted') only marks the show row terminal: --recursive has no "
-            "effect on shows, since reaping a show's plays/workers is deferred "
-            "per ADR-0104. To stop a show's work, kill its play ids or session "
-            "ids directly; --all-stale cancels play and show rows once their "
-            "workers are gone.\n\n"
+            "Recursion boundary: --recursive kills a session's or invocation's "
+            "direct children, which are the PID-bearing workers. PLAY and SHOW "
+            "rows are orchestrator records with no stored link to the sessions "
+            "they started, so killing one only marks that row terminal and exits "
+            "non-zero (plays) to say the workers are still running. To stop that "
+            "work, kill the session ids directly; --all-stale cancels play and "
+            "show rows once their workers are gone.\n\n"
             "Examples:\n"
             "  li kill abc123                        # kill by id prefix\n"
-            "  li kill <play-id>                     # also reap linked workers\n"
+            "  li kill <session-id>                  # stop a worker process\n"
             "  li kill abc123 --reason 'stuck'\n"
             "  li kill abc123 --recursive            # kill + direct children\n"
             "  li kill --all-stale                   # sweep dead-PID rows\n"
@@ -894,9 +869,8 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help=(
             "Also kill direct child entities (e.g. invocations spawned by a session). "
-            "Play kills always reap their linked workers regardless. Has no effect on show "
-            "kills, which never reap their plays -- kill the play or session id directly to "
-            "stop a show's workers."
+            "Has no effect on play or show kills, which cannot reach their workers -- "
+            "kill the session ids directly to stop them."
         ),
     )
     kill.add_argument(

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -108,8 +108,13 @@ async def _seed_play(
     show_id: str,
     *,
     status: str = "running",
-    session_id: str | None = None,
 ) -> str:
+    """Seed a play row the way a real one is written: with no session link.
+
+    `session_id` is deliberately not a parameter here. No writer populates that
+    column, so a test that set it would be asserting against a state the
+    running system never reaches.
+    """
     play_id = str(uuid.uuid4())
     await db.create_play(
         {
@@ -117,7 +122,6 @@ async def _seed_play(
             "show_id": show_id,
             "name": f"play-{play_id[:8]}",
             "status": status,
-            "session_id": session_id,
         }
     )
     return play_id
@@ -1193,111 +1197,52 @@ async def test_list_running_children_show_behavior_is_unchanged(temp_db_path: Pa
     assert [(kind, row["id"]) for _, kind, row in children] == [("play", running_play_id)]
 
 
-async def test_walk_running_children_stops_at_safety_cap(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_do_kill_play_leaves_workers_running_and_exits_non_zero(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ):
-    """The transitive walk terminates and warns if malformed links exceed its cap."""
+    """A play kill cannot reach the play's workers, and reports that as a failure.
+
+    Both rows here are shaped the way the running system shapes them: the play
+    row carries no session link, and the worker session carries no play
+    reference, so neither end of the pair can name the other. The kill marks
+    the play row terminal, leaves the worker session running, and exits
+    non-zero so a caller cannot read the run as stopped.
+    """
     import lionagi.cli.kill as kill_mod
+    from lionagi.cli._logging import configure_cli_logging
 
-    async def fake_children(db: Any, entity_type: str, entity_id: str):
-        next_id = str(int(entity_id) + 1)
-        return [("sessions", "session", {"id": next_id})]
-
-    warnings: list[str] = []
-    monkeypatch.setattr(kill_mod, "_MAX_RECURSIVE_CHILDREN", 2)
-    monkeypatch.setattr(kill_mod, "_list_running_children", fake_children)
-    monkeypatch.setattr(kill_mod, "warn", warnings.append)
-
-    children = await kill_mod._walk_running_children(object(), "play", "0")
-
-    assert [row["id"] for _, _, row in children] == ["2", "1"]
-    assert warnings == [
-        "recursive kill stopped after 2 children; remaining descendants were not reaped"
-    ]
-
-
-async def test_walk_running_children_cycle_terminates_without_cap_warning(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """A finite session/invocation cycle is deduplicated before the cap check."""
-    import lionagi.cli.kill as kill_mod
-
-    session = ("sessions", "session", {"id": "session-a"})
-    invocation = ("invocations", "invocation", {"id": "invocation-b"})
-    graph = {
-        ("play", "play-root"): [session],
-        ("session", "session-a"): [invocation],
-        ("invocation", "invocation-b"): [session],
-    }
-    calls: list[tuple[str, str]] = []
-
-    async def fake_children(db: Any, entity_type: str, entity_id: str):
-        calls.append((entity_type, entity_id))
-        return graph.get((entity_type, entity_id), [])
-
-    warnings: list[str] = []
-    monkeypatch.setattr(kill_mod, "_MAX_RECURSIVE_CHILDREN", 2)
-    monkeypatch.setattr(kill_mod, "_list_running_children", fake_children)
-    monkeypatch.setattr(kill_mod, "warn", warnings.append)
-
-    children = await kill_mod._walk_running_children(object(), "play", "play-root")
-
-    assert [row["id"] for _, _, row in children] == ["invocation-b", "session-a"]
-    assert calls == [
-        ("play", "play-root"),
-        ("session", "session-a"),
-        ("invocation", "invocation-b"),
-    ]
-    assert warnings == []
-
-
-async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
-    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    """A bare play kill reaps its linked session and invocation before the play."""
-    import lionagi.cli.kill as kill_mod
+    configure_cli_logging(verbose=False)
 
     signalled_pids: list[int] = []
-    persisted_entities: list[tuple[str, str]] = []
-    original_persist_cancel = kill_mod._persist_cancel
 
     def fake_terminate(pid: int, **kwargs: Any) -> str:
-        assert pid > 1
         signalled_pids.append(pid)
         return "sigterm"
 
-    async def record_persist_cancel(
-        db: Any, entity_type: str, entity_id: str, **kwargs: Any
-    ) -> None:
-        persisted_entities.append((entity_type, entity_id))
-        await original_persist_cancel(db, entity_type, entity_id, **kwargs)
-
     monkeypatch.setattr(kill_mod, "_terminate_pid", fake_terminate)
-    monkeypatch.setattr(kill_mod, "_persist_cancel", record_persist_cancel)
 
     async with StateDB() as db:
         invocation_id = await _seed_invocation(db, status="running", pid=42002)
-        session_id = await _seed_session(db, status="running", pid=42001)
-        await db.update_session(session_id, invocation_id=invocation_id)
+        worker_session_id = await _seed_session(db, status="running", pid=42001)
+        await db.update_session(worker_session_id, invocation_id=invocation_id)
         show_id = await _seed_show(db)
-        play_id = await _seed_play(db, show_id, session_id=session_id)
+        play_id = await _seed_play(db, show_id)
 
+    capsys.readouterr()
     rc = await _do_kill(play_id)
+    captured = capsys.readouterr()
 
-    assert rc == 0
-    assert signalled_pids == [42002, 42001]
-    assert persisted_entities == [
-        ("invocation", invocation_id),
-        ("session", session_id),
-        ("play", play_id),
-    ]
+    assert rc == 1
+    assert "worker processes were NOT stopped" in captured.err.replace("\n", " ")
+    # No worker was signalled: the play row has no path to either of them.
+    assert signalled_pids == []
     async with StateDB() as db:
-        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (session_id,)))[
-            "status"
-        ] == "cancelled"
+        assert (
+            await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (worker_session_id,))
+        )["status"] == "running"
         assert (
             await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (invocation_id,))
-        )["status"] == "cancelled"
+        )["status"] == "running"
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
             "status"
         ] == "blocked"
@@ -1351,7 +1296,7 @@ async def test_do_kill_recursive_show_does_not_reap_play_workers(
         session_id = await _seed_session(db, status="running", pid=43001)
         await db.update_session(session_id, invocation_id=invocation_id)
         show_id = await _seed_show(db)  # default status="active" -- no mocking
-        play_id = await _seed_play(db, show_id, session_id=session_id)
+        play_id = await _seed_play(db, show_id)
 
     monkeypatch.setattr("lionagi.cli.kill._terminate_pid", fake_terminate)
 
@@ -1432,7 +1377,7 @@ async def test_do_kill_play_emits_blocked_terminal_envelope(temp_db_path: Path):
     async with StateDB() as db:
         session_id = await _seed_session(db, status="running")
         show_id = await _seed_show(db)
-        play_id = await _seed_play(db, show_id, session_id=session_id)
+        play_id = await _seed_play(db, show_id)
 
     received: list[RunTerminalEnvelope] = []
 
@@ -1447,7 +1392,8 @@ async def test_do_kill_play_emits_blocked_terminal_envelope(temp_db_path: Path):
         ids=[play_id],
     )
     try:
-        assert await _do_kill(play_id) == 0
+        # Non-zero: the play row went terminal, but its workers were not reached.
+        assert await _do_kill(play_id) == 1
     finally:
         DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
 
@@ -1458,58 +1404,6 @@ async def test_do_kill_play_emits_blocked_terminal_envelope(temp_db_path: Path):
     assert envelope.previous_status == "running"
     assert envelope.terminal_status == "blocked"
     assert envelope.reason_code == RunReasons.CANCELLED_MANUAL_KILL
-
-
-async def test_do_kill_play_without_session_warns_and_continues(
-    temp_db_path: Path, capsys: pytest.CaptureFixture[str]
-):
-    """A NULL play session link is status-only but never silently misleading."""
-    from lionagi.cli._logging import configure_cli_logging
-
-    configure_cli_logging(verbose=False)
-    async with StateDB() as db:
-        show_id = await _seed_show(db)
-        play_id = await _seed_play(db, show_id, session_id=None)
-
-    capsys.readouterr()
-    rc = await _do_kill(play_id)
-
-    assert rc == 0
-    assert f"play {play_id[:12]} has no running worker session to reap" in capsys.readouterr().err
-    async with StateDB() as db:
-        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
-            "status"
-        ] == "blocked"
-
-
-async def test_do_kill_play_with_dangling_session_warns_and_continues(
-    temp_db_path: Path, capsys: pytest.CaptureFixture[str]
-):
-    """A non-NULL play link with no session row warns and still blocks the play."""
-    import sqlite3
-
-    from lionagi.cli._logging import configure_cli_logging
-
-    configure_cli_logging(verbose=False)
-    dangling_session_id = str(uuid.uuid4())
-    async with StateDB() as db:
-        show_id = await _seed_show(db)
-        play_id = await _seed_play(db, show_id)
-
-    with sqlite3.connect(temp_db_path) as conn:
-        conn.execute(
-            "UPDATE plays SET session_id = ? WHERE id = ?",
-            (dangling_session_id, play_id),
-        )
-
-    capsys.readouterr()
-    assert await _do_kill(play_id) == 0
-
-    assert f"play {play_id[:12]} has no running worker session to reap" in capsys.readouterr().err
-    async with StateDB() as db:
-        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
-            "status"
-        ] == "blocked"
 
 
 async def test_do_kill_recursive_kills_child_invocations(

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -1243,9 +1243,14 @@ async def test_do_kill_play_leaves_workers_running_and_exits_non_zero(
         assert (
             await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (invocation_id,))
         )["status"] == "running"
-        assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
+        play_status = (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
             "status"
-        ] == "blocked"
+        ]
+    assert play_status == "blocked"
+    # The message has to name the status that was actually written. Asserting the
+    # literal word here would pass just as well against a message that names a
+    # status the kill never wrote, which is what it used to do.
+    assert f"is marked {play_status}" in captured.err.replace("\n", " ")
 
 
 async def test_do_kill_active_show_succeeds(temp_db_path: Path):

--- a/tests/mcp/golden_projections/kill.json
+++ b/tests/mcp/golden_projections/kill.json
@@ -2,7 +2,7 @@
   "path": "kill",
   "schema": {
     "additionalProperties": false,
-    "description": "Kill a running lionagi entity by id, or sweep all stale running entities whose underlying OS process is dead.\n\nThe entity's status is set to 'cancelled' (sessions/invocations), 'blocked' (plays), or 'aborted' (shows) with reason tracking per ADR-0028.\n\nRecursion boundary: --recursive walks play -> session -> invocation and always reaches the PID-bearing workers. A SHOW kill ('active' -> 'aborted') only marks the show row terminal: --recursive has no effect on shows, since reaping a show's plays/workers is deferred per ADR-0104. To stop a show's work, kill its play ids or session ids directly; --all-stale cancels play and show rows once their workers are gone.\n\nExamples:\n  li kill abc123                        # kill by id prefix\n  li kill <play-id>                     # also reap linked workers\n  li kill abc123 --reason 'stuck'\n  li kill abc123 --recursive            # kill + direct children\n  li kill --all-stale                   # sweep dead-PID rows\n  li kill --all-stale --threshold 3600  # only rows older than 1h\n  li kill --all-stale --dry-run",
+    "description": "Kill a running lionagi entity by id, or sweep all stale running entities whose underlying OS process is dead.\n\nThe entity's status is set to 'cancelled' (sessions/invocations), 'blocked' (plays), or 'aborted' (shows) with reason tracking per ADR-0028.\n\nRecursion boundary: --recursive kills a session's or invocation's direct children, which are the PID-bearing workers. PLAY and SHOW rows are orchestrator records with no stored link to the sessions they started, so killing one only marks that row terminal and exits non-zero (plays) to say the workers are still running. To stop that work, kill the session ids directly; --all-stale cancels play and show rows once their workers are gone.\n\nExamples:\n  li kill abc123                        # kill by id prefix\n  li kill <session-id>                  # stop a worker process\n  li kill abc123 --reason 'stuck'\n  li kill abc123 --recursive            # kill + direct children\n  li kill --all-stale                   # sweep dead-PID rows\n  li kill --all-stale --threshold 3600  # only rows older than 1h\n  li kill --all-stale --dry-run",
     "properties": {
       "all_stale": {
         "default": false,
@@ -35,7 +35,7 @@
       },
       "recursive": {
         "default": false,
-        "description": "Also kill direct child entities (e.g. invocations spawned by a session). Play kills always reap their linked workers regardless. Has no effect on show kills, which never reap their plays -- kill the play or session id directly to stop a show's workers.",
+        "description": "Also kill direct child entities (e.g. invocations spawned by a session). Has no effect on play or show kills, which cannot reach their workers -- kill the session ids directly to stop them.",
         "type": "boolean",
         "x-flag": "--recursive"
       },


### PR DESCRIPTION
## The problem

`li kill <play_id>` resolved a play's workers by joining `plays.session_id`,
killed that chain, then marked the play row `blocked`. Nothing in production
ever populates that column, so the join matched nothing on every real play: the
command warned on stderr, transitioned the row, and **exited 0** while the
worker processes kept running.

Exit code and silence are the two signals a caller reads, and both said the kill
had worked. A supervisor script gating on `$?` would proceed as though the work
were stopped.

## What changed

A play kill still marks the row `blocked` — that transition is real and stops
the play being re-dispatched — but it now prints an error saying the worker
processes were not stopped, why they could not be resolved, and where to find
them, and **exits 1**. It cannot name them: not being able to resolve them from
the play id is the whole point. Earlier wording in this branch's commit message
says it names them, which overstates what the code does; the squash message will
not repeat that. The help text and the CLI reference are
corrected to describe that boundary instead of the reaping that never happened;
those three prose surfaces asserted the reap independently of the code, so
leaving them would have preserved the claim the code change removes.

The dead join and the transitive descendant walk are removed rather than left in
place. Keeping a resolution path that cannot fire is the same defect in a new
spelling, and the walk had no other caller once plays stopped using it: the show
branch is explicitly empty and every other entity type uses the flat child
lookup.

## Why the link cannot simply be repaired here

There is no other key to resolve by. `sessions.show_topic` and
`show_play_name` would be exactly right and are equally unwritten — declared,
read, never passed a value. And `li play NAME` is rewritten to `li o flow -p
NAME`, which persists through a generic path that creates a session and no
`plays` row at all, so a directly-launched play has no row to link from.

Binding the two is a dispatch-side decision about which layer owns the link, not
a query change. That is #2582.

## Tests

The regression seeds a running play alongside a running worker session with no
link in either direction — the shape production actually produces — and asserts
the whole failure signature: nothing signalled, both worker rows still
`running`, play row `blocked`, exit code 1.

The play seeding helper no longer accepts a session id at all, so a future test
cannot reconstruct the linked state that made the previous coverage pass against
an unreachable path. Three tests were removed: two drove the deleted walk
through a monkeypatched child lookup and so never exercised the real link
either, and two asserted the old exit-0-plus-warning contract that is now the
only play case.

## What this does not do

It does not make a play kill reach its workers. The operator still has to find
the running session ids and kill those directly. ADR-0104 describes the
transitive reap as delivered; this states plainly that it is not, and #2582
carries what closing it would take.

This change corrects a behaviour ADR-0104 describes as delivered, so the ADR
needs amending (or the capability delivering) alongside it.

Closes #2384.
