### PR TITLE
DO NOT MERGE: deliberately failing probe

### DIFF
--- a/tests/test_zz_branch_protection_probe.py
+++ b/tests/test_zz_branch_protection_probe.py
@@ -1,0 +1,5 @@
+def test_branch_protection_probe():
+    """Deliberately failing. Throwaway probe branch, never merged."""
+    observed = 1
+    expected = 2
+    assert observed == expected


### PR DESCRIPTION
Throwaway. Carries one test that fails on purpose, to confirm the required status check blocks a merge. Closed and deleted as soon as that is measured.