### PR TITLE
fix(tools): two docstrings that describe behaviour the code refuses

### DIFF
--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -139,10 +139,11 @@ class BashTool(LionTool):
                 reader/editor/search tools.
 
                 Enforces a configurable timeout (default 30 s, max 5 min). Output
-                exceeding 100 KB per stream is truncated — narrow what the command
-                prints, or have the program write its own file (e.g. an -o/--output
-                flag) and read that with the reader tool. Shell redirection is not
-                available here.
+                exceeding 100 KB per stream is truncated. Supported remedies:
+                - `head -n 20 FILE` — print only the part you need
+                - `PROG --output FILE` — let the program write the bulk itself,
+                  then read FILE back with the reader tool
+                Not available here: `PROG > FILE`, or any other shell redirection.
 
                 Recovery hints:
                 - 'command not found': check the executable is installed and in PATH

--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -139,8 +139,10 @@ class BashTool(LionTool):
                 reader/editor/search tools.
 
                 Enforces a configurable timeout (default 30 s, max 5 min). Output
-                exceeding 100 KB per stream is truncated — redirect to a file and
-                use the reader tool for large outputs.
+                exceeding 100 KB per stream is truncated — narrow what the command
+                prints, or have the program write its own file (e.g. an -o/--output
+                flag) and read that with the reader tool. Shell redirection is not
+                available here.
 
                 Recovery hints:
                 - 'command not found': check the executable is installed and in PATH

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -51,7 +51,10 @@ class MessengerRequest(BaseModel):
     )
     to: str | list[str] | None = Field(
         None,
-        description="Recipient name(s). Required for 'send' and 'wakeup'.",
+        description=(
+            "Recipient name(s). Required for 'send' and 'wakeup'. 'send' accepts "
+            "a name or a list of names; 'wakeup' takes a single name."
+        ),
     )
     content: str | None = Field(
         None,
@@ -134,9 +137,10 @@ class LionMessenger(LionTool):
         ) -> str:
             """Send messages to teammates, receive pending ones, signal
             done/finished, wake a teammate, or send a help signal. action in
-            {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to
-            (name or list of names) and content are required for
-            send/wakeup, neither is required for receive; content (the
+            {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to and
+            content are required for send/wakeup — 'send' takes a name or a
+            list of names, 'wakeup' takes a single name and wakes only one
+            teammate per call; neither is required for receive; content (the
             reason) is required for help, urgency is optional (defaults to
             'fyi')."""
             if action == "receive":

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -53,7 +53,9 @@ class MessengerRequest(BaseModel):
         None,
         description=(
             "Recipient name(s). Required for 'send' and 'wakeup'. 'send' accepts "
-            "a name or a list of names; 'wakeup' takes a single name."
+            "a name or a list of names and delivers to every one of them. "
+            "'wakeup' wakes exactly one teammate: pass a name, or a list, in "
+            "which case only its first name is woken and the rest are ignored."
         ),
     )
     content: str | None = Field(
@@ -139,10 +141,11 @@ class LionMessenger(LionTool):
             done/finished, wake a teammate, or send a help signal. action in
             {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to and
             content are required for send/wakeup — 'send' takes a name or a
-            list of names, 'wakeup' takes a single name and wakes only one
-            teammate per call; neither is required for receive; content (the
-            reason) is required for help, urgency is optional (defaults to
-            'fyi')."""
+            list of names and delivers to every one of them, 'wakeup' wakes
+            exactly one teammate and accepts a name or a list, in which case
+            only its first name is woken and the rest are ignored; neither is
+            required for receive; content (the reason) is required for help,
+            urgency is optional (defaults to 'fyi')."""
             if action == "receive":
                 pending = exchange.receive(sender_id)
                 if not pending:

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -137,7 +137,13 @@ class LionMessenger(LionTool):
             content: str = None,
             urgency: str = None,
         ) -> str:
-            """Send messages to teammates, receive pending ones, signal
+            """Team messaging and signals. 'wakeup' takes one name; a list's rest are ignored.
+
+            Only the summary line above is extracted into the generated tool
+            description, so the recipient rule a caller would otherwise be
+            surprised by is stated there rather than below.
+
+            Send messages to teammates, receive pending ones, signal
             done/finished, wake a teammate, or send a help signal. action in
             {'send', 'receive', 'done', 'finished', 'wakeup', 'help'}; to and
             content are required for send/wakeup — 'send' takes a name or a

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -380,3 +380,23 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
     assert killpg_calls == [], f"os.killpg must not be called for pid={invalid_pid!r}"
     mock_proc.kill.assert_called_once()
     assert resp.timed_out is True
+
+
+# ---------------------------------------------------------------------------
+# Tool description stays consistent with the guard
+# ---------------------------------------------------------------------------
+
+
+async def test_docstring_recovery_advice_is_executable():
+    """Advice the tool gives for oversized output must survive its own guard.
+
+    The command guard rejects shell redirection, so telling the caller to
+    redirect large output into a file would hand it an unusable remedy.
+    """
+    tool = BashTool()
+
+    resp = await tool.handle_request(BashRequest(command="echo x > /tmp/lionagi_doc_check"))
+    assert resp.return_code == -1, "redirection is expected to be rejected"
+
+    doc = tool.to_tool().func_callable.__doc__
+    assert "redirect to a file" not in doc

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -4,6 +4,7 @@
 """Tests for BashTool: request model, response model, execution, security."""
 
 import asyncio
+import re
 import sys
 
 import pytest
@@ -388,46 +389,61 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
 # ---------------------------------------------------------------------------
 
 
-async def test_docstring_recovery_advice_is_executable(tmp_path):
-    """Advice the tool gives for oversized output must survive its own guard.
+def _truncation_advice(doc: str) -> tuple[list[str], list[str]]:
+    """Split the oversized-output advice into the commands it offers and the ones it rules out.
 
-    Two halves, so advice and guard cannot drift apart in either direction:
-    the remedy the guard rejects is neither advised nor runnable, and each
-    remedy the advice does name is run here through the guard that would have
-    to accept it. The assertions pin which remedy is recommended, not the
-    sentence recommending it — a reworded docstring keeping the same two
-    remedies still passes.
+    Returns (offered, ruled_out) as literal command templates, read off the
+    docstring's own structure rather than matched against expected wording.
+    """
+    offered_at = doc.index("Supported remedies:")
+    ruled_out_at = doc.index("Not available here:")
+    offered = re.findall(r"`([^`]+)`", doc[offered_at:ruled_out_at])
+    ruled_out = re.findall(r"`([^`]+)`", doc[ruled_out_at:].split("\n\n")[0])
+    return offered, ruled_out
+
+
+async def test_docstring_recovery_advice_is_executable(tmp_path):
+    """The commands the oversized-output advice names must match what the guard allows.
+
+    Every command listed as a supported remedy is run here and must succeed;
+    every command listed as unavailable is run here and must be refused by the
+    guard. Neither list is compared against expected prose — both are read out
+    of the docstring — so rewording the advice keeps this green, while moving a
+    command between the lists, or changing the guard so a listed remedy stops
+    running, turns it red.
     """
     tool = BashTool()
     doc = tool.to_tool().func_callable.__doc__
+    offered, ruled_out = _truncation_advice(doc)
+    assert offered, "advice must name at least one supported remedy"
+    assert ruled_out, "advice must name at least one unavailable alternative"
 
-    # The rejected remedy: not advised, and demonstrably unusable.
-    resp = await tool.handle_request(BashRequest(command=f"echo x > {tmp_path / 'redirected.txt'}"))
-    assert resp.return_code == -1, "redirection is expected to be rejected"
-    assert "redirect to a file" not in doc
-
-    # Remedy 1 — narrow what the command prints. Named, and a narrowed command runs.
-    assert "narrow" in doc, "advice must name narrowing the command's own output"
-    noisy = tmp_path / "noisy.txt"
-    noisy.write_text("line\n" * 200)
-    resp = await tool.handle_request(BashRequest(command=f"head -n 1 {noisy}"))
-    assert resp.return_code == 0, resp.stderr
-    assert resp.stdout.strip() == "line"
-
-    # Remedy 2 — let the program write its own file, then read it with the
-    # reader tool. Named, and an --output style invocation runs.
-    assert "--output" in doc, "advice must name the program's own output flag"
-    assert "reader tool" in doc, "advice must name what reads the file back"
+    # Placeholders the listed commands may use, bound to things this test can
+    # run inside tmp_path. A remedy using an unknown placeholder is a failure,
+    # not a silent skip.
+    payload = tmp_path / "payload.txt"
+    payload.write_text("line\n" * 200)
     writer = tmp_path / "writer.py"
     writer.write_text(
         "import sys\n"
         "out = sys.argv[sys.argv.index('--output') + 1]\n"
         "open(out, 'w').write('generated\\n')\n"
     )
-    produced = tmp_path / "produced.txt"
-    resp = await tool.handle_request(
-        BashRequest(command=f"{sys.executable} {writer} --output {produced}")
-    )
-    assert resp.return_code == 0, resp.stderr
-    assert produced.read_text() == "generated\n"
-    assert resp.stdout == "", "the remedy only helps if the bulk never comes back as output"
+    fixtures = {"FILE": str(payload), "PROG": f"{sys.executable} {writer}"}
+
+    def runnable(template: str) -> str:
+        used = set(re.findall(r"\b[A-Z]{2,}\b", template))
+        assert used <= set(fixtures), f"advice names remedies this test cannot run: {template!r}"
+        for name, value in fixtures.items():
+            template = template.replace(name, value)
+        return template
+
+    for template in offered:
+        resp = await tool.handle_request(BashRequest(command=runnable(template)))
+        assert resp.return_code == 0, f"advised remedy {template!r} does not run: {resp.stderr}"
+
+    for template in ruled_out:
+        resp = await tool.handle_request(BashRequest(command=runnable(template)))
+        assert resp.return_code == -1, (
+            f"{template!r} is advertised as unavailable but the guard let it through"
+        )

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -4,6 +4,7 @@
 """Tests for BashTool: request model, response model, execution, security."""
 
 import asyncio
+import sys
 
 import pytest
 from pydantic import ValidationError
@@ -387,16 +388,46 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
 # ---------------------------------------------------------------------------
 
 
-async def test_docstring_recovery_advice_is_executable():
+async def test_docstring_recovery_advice_is_executable(tmp_path):
     """Advice the tool gives for oversized output must survive its own guard.
 
-    The command guard rejects shell redirection, so telling the caller to
-    redirect large output into a file would hand it an unusable remedy.
+    Two halves, so advice and guard cannot drift apart in either direction:
+    the remedy the guard rejects is neither advised nor runnable, and each
+    remedy the advice does name is run here through the guard that would have
+    to accept it. The assertions pin which remedy is recommended, not the
+    sentence recommending it — a reworded docstring keeping the same two
+    remedies still passes.
     """
     tool = BashTool()
-
-    resp = await tool.handle_request(BashRequest(command="echo x > /tmp/lionagi_doc_check"))
-    assert resp.return_code == -1, "redirection is expected to be rejected"
-
     doc = tool.to_tool().func_callable.__doc__
+
+    # The rejected remedy: not advised, and demonstrably unusable.
+    resp = await tool.handle_request(BashRequest(command=f"echo x > {tmp_path / 'redirected.txt'}"))
+    assert resp.return_code == -1, "redirection is expected to be rejected"
     assert "redirect to a file" not in doc
+
+    # Remedy 1 — narrow what the command prints. Named, and a narrowed command runs.
+    assert "narrow" in doc, "advice must name narrowing the command's own output"
+    noisy = tmp_path / "noisy.txt"
+    noisy.write_text("line\n" * 200)
+    resp = await tool.handle_request(BashRequest(command=f"head -n 1 {noisy}"))
+    assert resp.return_code == 0, resp.stderr
+    assert resp.stdout.strip() == "line"
+
+    # Remedy 2 — let the program write its own file, then read it with the
+    # reader tool. Named, and an --output style invocation runs.
+    assert "--output" in doc, "advice must name the program's own output flag"
+    assert "reader tool" in doc, "advice must name what reads the file back"
+    writer = tmp_path / "writer.py"
+    writer.write_text(
+        "import sys\n"
+        "out = sys.argv[sys.argv.index('--output') + 1]\n"
+        "open(out, 'w').write('generated\\n')\n"
+    )
+    produced = tmp_path / "produced.txt"
+    resp = await tool.handle_request(
+        BashRequest(command=f"{sys.executable} {writer} --output {produced}")
+    )
+    assert resp.return_code == 0, resp.stderr
+    assert produced.read_text() == "generated\n"
+    assert resp.stdout == "", "the remedy only helps if the bulk never comes back as output"

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -389,16 +389,29 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
 # ---------------------------------------------------------------------------
 
 
+_ADVICE_LABELS = ("Supported remedies", "Not available here")
+_LABEL_PATTERN = re.compile(r"(?<![`\w])([A-Z][A-Za-z ]{2,40}):")
+
+
 def _truncation_advice(doc: str) -> tuple[list[str], list[str]]:
     """Split the oversized-output advice into the commands it offers and the ones it rules out.
 
     Returns (offered, ruled_out) as literal command templates, read off the
     docstring's own structure rather than matched against expected wording.
+
+    Only two labels carry meaning: commands before the second one are offered,
+    commands after it are ruled out. A label this split has no rule for would be
+    silently folded into one of those two lists, so it fails here instead.
     """
     offered_at = doc.index("Supported remedies:")
     ruled_out_at = doc.index("Not available here:")
+    ruled_out_text = doc[ruled_out_at:].split("\n\n")[0]
+    labels = set(_LABEL_PATTERN.findall(doc[offered_at:ruled_out_at] + ruled_out_text))
+    assert labels == set(_ADVICE_LABELS), (
+        f"the advice uses a label with no defined meaning: {sorted(labels)}"
+    )
     offered = re.findall(r"`([^`]+)`", doc[offered_at:ruled_out_at])
-    ruled_out = re.findall(r"`([^`]+)`", doc[ruled_out_at:].split("\n\n")[0])
+    ruled_out = re.findall(r"`([^`]+)`", ruled_out_text)
     return offered, ruled_out
 
 
@@ -443,7 +456,20 @@ async def test_docstring_recovery_advice_is_executable(tmp_path):
         assert resp.return_code == 0, f"advised remedy {template!r} does not run: {resp.stderr}"
 
     for template in ruled_out:
-        resp = await tool.handle_request(BashRequest(command=runnable(template)))
+        command = runnable(template)
+        resp = await tool.handle_request(BashRequest(command=command))
         assert resp.return_code == -1, (
             f"{template!r} is advertised as unavailable but the guard let it through"
+        )
+        # -1 is also what a signalled or unspawnable child reports, so pin the
+        # refusal itself: the guard's own diagnostic, naming this command, and a
+        # response that never entered the timeout path because nothing ran.
+        assert "shell control operators are not supported" in resp.stderr.lower(), (
+            f"{template!r} returned -1 without the guard refusing it: {resp.stderr!r}"
+        )
+        assert command in resp.stderr, (
+            f"the refusal does not name the command it rejected: {resp.stderr!r}"
+        )
+        assert not resp.timed_out, (
+            f"{template!r} was refused before execution, so it cannot have timed out"
         )

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -455,3 +455,38 @@ class TestMessengerBindUnknownAction:
         tool = m.bind(branch, roster={})
         result = tool.func_callable(action="bogus")
         assert "Unknown action: bogus" in result
+
+
+# ---------------------------------------------------------------------------
+# Tool description stays consistent with wakeup's recipient handling
+# ---------------------------------------------------------------------------
+
+
+class TestMessengerWakeupDescription:
+    def test_wakeup_list_wakes_first_name_only_and_says_so(self):
+        """A list passed to wakeup reaches its first name only, and both
+        LLM-facing descriptions of `to` say that.
+
+        `wakeup` accepts the same `to` shapes as `send` but resolves a list to
+        its first entry, so a caller told it takes one name would never learn
+        what the other names in a list do — they are dropped in silence.
+        """
+        ex = Exchange()
+        m = LionMessenger(exchange=ex)
+        events = []
+        m.on("wakeup", lambda **kw: events.append(kw))
+        branch = _make_branch(ex)
+        alice_id, bob_id = uuid4(), uuid4()
+        ex.register(alice_id)
+        ex.register(bob_id)
+        tool = m.bind(branch, roster={"alice": alice_id, "bob": bob_id})
+
+        result = tool.func_callable(action="wakeup", to=["alice", "bob"], content="rise")
+
+        assert "Woke up alice" in result
+        assert [e["target"] for e in events] == ["alice"], "only the first name is woken"
+        assert len(branch._included) == 1, "bob gets no message"
+
+        field_desc = MessengerRequest.model_fields["to"].description
+        assert "first name is woken" in field_desc
+        assert "first name is woken" in tool.func_callable.__doc__

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -489,4 +489,7 @@ class TestMessengerWakeupDescription:
 
         field_desc = MessengerRequest.model_fields["to"].description
         assert "first name is woken" in field_desc
-        assert "first name is woken" in tool.func_callable.__doc__
+        assert "the rest are ignored" in field_desc
+        doc = tool.func_callable.__doc__
+        assert "first name is woken" in doc
+        assert "the rest are ignored" in doc

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -487,9 +487,16 @@ class TestMessengerWakeupDescription:
         assert [e["target"] for e in events] == ["alice"], "only the first name is woken"
         assert len(branch._included) == 1, "bob gets no message"
 
-        field_desc = MessengerRequest.model_fields["to"].description
-        assert "first name is woken" in field_desc
-        assert "the rest are ignored" in field_desc
-        doc = tool.func_callable.__doc__
-        assert "first name is woken" in doc
-        assert "the rest are ignored" in doc
+        # Read the generated schema, not the source strings it is built from:
+        # what the model acts on is the schema, and a generation regression
+        # leaves the sources correct while the model is told nothing.
+        function = tool.tool_schema["function"]
+        to_desc = function["parameters"]["properties"]["to"]["description"]
+        func_desc = function["description"]
+
+        # Claim 1 — a list wakes its first name.
+        assert "first name is woken" in to_desc
+        assert "takes one name" in func_desc
+        # Claim 2 — the names after the first are dropped, not woken too.
+        assert "the rest are ignored" in to_desc
+        assert "rest are ignored" in func_desc


### PR DESCRIPTION
Two docstrings told a caller to do something the code refuses, or described a
parameter shape without saying what the code does with it. Both are read by an
LLM caller as the tool contract, so a wrong one produces a call that fails for a
reason the caller was told would work — or, worse, one that silently does less
than it appears to.

**The bash tool's recovery advice.** Its docstring suggested redirecting output
to a file when a command produces too much of it. The guard rejects redirection,
so following the advice turns a truncation into a hard refusal. The docstring now
describes what the guard actually permits.

**The messenger wakeup parameter.** `to` is typed `str | list[str] | None` for
every action, with no per-action validation, and `wakeup` resolves a list to its
first entry — one message, one event, and the remaining names dropped without a
word. The docstrings said only that `to` is "a name or list of names, required
for send/wakeup", which is true of the accepted shapes and silent on the drop.
Both LLM-facing strings — the `to` field description and the bound callable's
docstring, since both render into the schema the model reads — now say that
`wakeup` wakes exactly one teammate and that a list's first name is the one
woken. `send`'s behaviour is stated next to it so the asymmetry is visible where
a caller picks a shape.

Note on the second one: the linked issue offers "clarify that lists are supported
only for `send`" as one option. That is not what landed, because it is not true
of the code — a list *is* accepted by `wakeup`. Describing the first-name-wins
resolution removes the harm the issue names (an agent believing every teammate was
alerted) without changing runtime behaviour, which is what a docstring fix should
leave alone.

A test for each locks it in the direction that matters. The bash one executes the
rejected command, confirms the guard really does refuse it, then asserts the
docstring no longer advises it. The messenger one wakes a two-name list and
asserts only the first teammate receives an event and a message, then asserts
both descriptions say so. In both cases a docstring assertion alone would pass
against any wording; the behaviour half is what makes the test discriminate.

Closes #2342
Closes #2344

## Verification

Full suite on this branch: 15912 tests, 6 non-passing, 19 skipped, 272s
(`--maxfail=200`, junit-xml parsed rather than counted from progress dots).

An earlier revision of this description reported 15911 tests with a different
sixth non-passing test. Both numbers have moved for ordinary reasons: the count is
one higher because this revision adds the messenger test, and the sixth
non-passing test is a different member of the same flaky set.

Five of the six are the standing optional-extra failures also present on the base
commit: ollama endpoint and model construction, docling import, an HTML fixture
reader, and the async postgres adapter. The sixth,
`test_race_multiple_exceptions_vs_success[asyncio]`, re-runs green in isolation on
this same tree (2 passed) — under parallel load `race()` surfaced a loser's
exception ahead of the winner's result. Nothing in this change touches
concurrency primitives.
