### PR TITLE
fix(ln): reject non-finite floats where a JSON null would be undetectable

### DIFF
--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -272,13 +272,10 @@ async def _import_one_run(
         total_branches += 1
 
     if session_msg_ids:
-        from sqlalchemy import text
-
-        async with db._tx() as conn:
-            await conn.execute(
-                text("UPDATE progressions SET collection = :col WHERE id = :id"),
-                {"col": json.dumps(session_msg_ids), "id": session_prog_id},
-            )
+        # Through the DB operation rather than a local UPDATE: the ids come from
+        # an imported file, and a hand-rolled json.dumps here would hand the
+        # driver a finished string that no serializer gets to check.
+        await db.set_progression(session_prog_id, session_msg_ids)
         await db.update_session(
             run_id,
             first_msg_id=session_msg_ids[0],
@@ -824,7 +821,7 @@ async def _import_runs() -> dict[str, int]:
 
 async def _import_teams() -> dict[str, int]:
     """Backfill ~/.lionagi/teams/*.json into the teams + team_messages tables."""
-    from sqlalchemy import text
+    from sqlalchemy import JSON, bindparam, text
 
     from lionagi.state.db import StateDB
 
@@ -874,7 +871,7 @@ async def _import_teams() -> dict[str, int]:
                     "created_at": created_at,
                     "updated_at": created_at,
                     "member_count": len(members),
-                    "members": json.dumps(members),
+                    "members": members,
                     "status": "active",
                 }
             )
@@ -911,34 +908,34 @@ async def _import_teams() -> dict[str, int]:
                         "recipient": recipient,
                         "content": content,
                         "summary": (content[:200] + "…") if len(content) > 200 else None,
-                        "read_by": json.dumps(read_by_arr),
+                        "read_by": read_by_arr,
                         "session_id": None,
                     }
                 )
                 counts["messages"] += 1
 
+            # members and read_by are bound as JSON so the engine's serializer
+            # encodes them; imported team files are outside data, and a
+            # pre-serialized string would be handed to the driver unchecked.
+            team_stmt = text(
+                "INSERT INTO teams "
+                "(id, name, created_at, updated_at, member_count, members, status) "
+                "VALUES (:id, :name, :created_at, :updated_at, "
+                ":member_count, :members, :status)"
+            ).bindparams(bindparam("members", type_=JSON))
+            msg_stmt = text(
+                "INSERT INTO team_messages "
+                "(id, team_id, created_at, sender, recipient, content, "
+                "summary, read_by, session_id) "
+                "VALUES (:id, :team_id, :created_at, :sender, :recipient, "
+                ":content, :summary, :read_by, :session_id)"
+            ).bindparams(bindparam("read_by", type_=JSON))
+
             async with db._tx() as conn:
                 for row in rows_to_insert:
-                    await conn.execute(
-                        text(
-                            "INSERT INTO teams "
-                            "(id, name, created_at, updated_at, member_count, members, status) "
-                            "VALUES (:id, :name, :created_at, :updated_at, "
-                            ":member_count, :members, :status)"
-                        ),
-                        row,
-                    )
+                    await conn.execute(team_stmt, row)
                 for mrow in msg_rows:
-                    await conn.execute(
-                        text(
-                            "INSERT INTO team_messages "
-                            "(id, team_id, created_at, sender, recipient, content, "
-                            "summary, read_by, session_id) "
-                            "VALUES (:id, :team_id, :created_at, :sender, :recipient, "
-                            ":content, :summary, :read_by, :session_id)"
-                        ),
-                        mrow,
-                    )
+                    await conn.execute(msg_stmt, mrow)
 
     return counts
 

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -6,10 +6,12 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import datetime as dt
 import decimal
 import math
 import re
+import sys
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import lru_cache
@@ -208,17 +210,55 @@ def make_options(
 # orjson writes inf, -inf and nan as `null`, which is indistinguishable from a
 # genuine null on read: the value silently changes and no consumer can detect it.
 # JSON has no representation for these, so serialization fails loudly instead.
+#
+# Detection walks the object the way orjson does. That means covering every form
+# orjson encodes natively, because those never reach default(); a walk that follows
+# only default() sees nothing inside a dataclass, an Enum or a numpy array and
+# reports the payload clean. The forms orjson encodes natively and that can carry a
+# float are: float, dict, list, tuple (and their subclasses), dataclass instances,
+# Enum members (written by value), and numpy arrays and scalars under
+# OPT_SERIALIZE_NUMPY. The remaining native forms -- str, int, bool, None, bytes,
+# datetime, date, time and UUID -- cannot contain a float. Everything else reaches
+# orjson through default(), and the walk follows that conversion. The residual gap
+# is a future orjson gaining a new native container type; the version in use is
+# pinned by the dependency range and this list is checked against it.
 
 
-def _locate_non_finite(obj: Any, default: Callable[[Any], Any], path: str = "$") -> str | None:
+def _numpy_non_finite(obj: Any, path: str) -> str | None | Literal[False]:
+    """Path of the first non-finite element if obj is a numpy float array/scalar.
+
+    Returns False when obj is not a numpy value, distinguishing "not mine to judge"
+    from "checked and clean".
+    """
+    np = sys.modules.get("numpy")
+    # numpy cannot have produced this object if it was never imported.
+    if np is None or not isinstance(obj, np.ndarray | np.generic):
+        return False
+    # Only float dtypes can be non-finite; int, bool and datetime64 cannot, and
+    # np.isfinite raises on the object and string dtypes orjson refuses anyway.
+    if obj.dtype.kind != "f":
+        return None
+    bad = ~np.isfinite(obj)
+    if not bad.any():
+        return None
+    if obj.ndim == 0:
+        return path
+    index = np.unravel_index(int(np.argmax(bad)), obj.shape)
+    return path + "".join(f"[{int(i)}]" for i in index)
+
+
+def _locate_non_finite(
+    obj: Any, default: Callable[[Any], Any], opt: int, path: str = "$"
+) -> str | None:
     """Return the path of the first non-finite float reachable from obj, else None.
 
-    Mirrors how orjson traverses the object, including the default() hook, so the
-    reported path matches what would have been written.
+    Mirrors how orjson traverses the object, including the natively-encoded forms
+    that bypass default() and the default() hook itself, so the reported path
+    matches what would have been written.
     """
     typ = obj.__class__
     # Concrete types first: isinstance against the collections ABCs is an order of
-    # magnitude slower, and these cover everything orjson serializes natively.
+    # magnitude slower, and these cover the overwhelming majority of nodes.
     if typ is float:
         return None if math.isfinite(obj) else path
     if typ in (str, int, bool, bytes) or obj is None:
@@ -229,7 +269,7 @@ def _locate_non_finite(obj: Any, default: Callable[[Any], Any], path: str = "$")
             # written as the key "null" and lost the same way a value would be.
             if key.__class__ is float and not math.isfinite(key):
                 return f"{path}.<key>"
-            found = _locate_non_finite(value, default, f"{path}.{key}")
+            found = _locate_non_finite(value, default, opt, f"{path}.{key}")
             if found is not None:
                 return found
         return None
@@ -237,25 +277,45 @@ def _locate_non_finite(obj: Any, default: Callable[[Any], Any], path: str = "$")
         isinstance(obj, Sequence | set | frozenset) and not isinstance(obj, str | bytes)
     ):
         for index, value in enumerate(obj):
-            found = _locate_non_finite(value, default, f"{path}[{index}]")
+            found = _locate_non_finite(value, default, opt, f"{path}[{index}]")
             if found is not None:
                 return found
         return None
+    # Remaining natively-encoded forms, none of which reach default().
+    if isinstance(obj, float):
+        # A float subclass orjson accepts, notably numpy's float64.
+        return None if math.isfinite(obj) else path
+    if opt & orjson.OPT_SERIALIZE_NUMPY:
+        found = _numpy_non_finite(obj, path)
+        if found is not False:
+            return found
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        if not opt & orjson.OPT_PASSTHROUGH_DATACLASS:
+            for field in dataclasses.fields(obj):
+                found = _locate_non_finite(
+                    getattr(obj, field.name), default, opt, f"{path}.{field.name}"
+                )
+                if found is not None:
+                    return found
+            return None
+    elif isinstance(obj, Enum):
+        # orjson writes an Enum member by its value, never through default().
+        return _locate_non_finite(obj.value, default, opt, path)
     # Anything else reaches orjson through default(); follow the same conversion.
     try:
         converted = default(obj)
     except Exception:
         return None
-    return _locate_non_finite(converted, default, path)
+    return _locate_non_finite(converted, default, opt, path)
 
 
 def _dumpb(obj: Any, default: Callable[[Any], Any], opt: int) -> bytes:
     """orjson.dumps, rejecting payloads whose non-finite floats would become null."""
     out = orjson.dumps(obj, default=default, option=opt)
     # Every non-finite float produces a literal `null`, so a null-free result is
-    # provably clean and the walk below only runs on the rare candidate payload.
+    # provably clean and the walk below only runs on a payload that has one.
     if b"null" in out:
-        found = _locate_non_finite(obj, default)
+        found = _locate_non_finite(obj, default, opt)
         if found is not None:
             raise ValueError(
                 f"cannot serialize non-finite float at {found}: JSON has no "
@@ -286,7 +346,14 @@ def json_dumpb(
     default: Callable[[Any], Any] | None = None,
     options: int | None = None,
 ) -> bytes:
-    """Serialize to bytes via orjson (fast path); safe_fallback=True for logging only."""
+    """Serialize to bytes via orjson (fast path); safe_fallback=True for logging only.
+
+    Raises ValueError for inf, -inf or nan anywhere in the payload, since orjson
+    writes those as `null` and a reader cannot tell that apart from a genuine null.
+    Detection covers floats in mappings and sequences, dataclass fields, Enum
+    values, numpy float arrays and scalars when `options` carries
+    OPT_SERIALIZE_NUMPY, and anything the `default` hook converts into those.
+    """
     if default is None:
         default = _cached_default(
             deterministic_sets=deterministic_sets,

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import contextlib
 import datetime as dt
 import decimal
+import math
 import re
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
@@ -202,6 +203,68 @@ def make_options(
     return opt
 
 
+# --------- non-finite float detection -----------------------------------------
+
+# orjson writes inf, -inf and nan as `null`, which is indistinguishable from a
+# genuine null on read: the value silently changes and no consumer can detect it.
+# JSON has no representation for these, so serialization fails loudly instead.
+
+
+def _locate_non_finite(obj: Any, default: Callable[[Any], Any], path: str = "$") -> str | None:
+    """Return the path of the first non-finite float reachable from obj, else None.
+
+    Mirrors how orjson traverses the object, including the default() hook, so the
+    reported path matches what would have been written.
+    """
+    typ = obj.__class__
+    # Concrete types first: isinstance against the collections ABCs is an order of
+    # magnitude slower, and these cover everything orjson serializes natively.
+    if typ is float:
+        return None if math.isfinite(obj) else path
+    if typ in (str, int, bool, bytes) or obj is None:
+        return None
+    if typ is dict or isinstance(obj, Mapping):
+        for key, value in obj.items():
+            # Non-string keys are stringified by orjson, so a non-finite one is
+            # written as the key "null" and lost the same way a value would be.
+            if key.__class__ is float and not math.isfinite(key):
+                return f"{path}.<key>"
+            found = _locate_non_finite(value, default, f"{path}.{key}")
+            if found is not None:
+                return found
+        return None
+    if typ in (list, tuple, set, frozenset) or (
+        isinstance(obj, Sequence | set | frozenset) and not isinstance(obj, str | bytes)
+    ):
+        for index, value in enumerate(obj):
+            found = _locate_non_finite(value, default, f"{path}[{index}]")
+            if found is not None:
+                return found
+        return None
+    # Anything else reaches orjson through default(); follow the same conversion.
+    try:
+        converted = default(obj)
+    except Exception:
+        return None
+    return _locate_non_finite(converted, default, path)
+
+
+def _dumpb(obj: Any, default: Callable[[Any], Any], opt: int) -> bytes:
+    """orjson.dumps, rejecting payloads whose non-finite floats would become null."""
+    out = orjson.dumps(obj, default=default, option=opt)
+    # Every non-finite float produces a literal `null`, so a null-free result is
+    # provably clean and the walk below only runs on the rare candidate payload.
+    if b"null" in out:
+        found = _locate_non_finite(obj, default)
+        if found is not None:
+            raise ValueError(
+                f"cannot serialize non-finite float at {found}: JSON has no "
+                "representation for inf, -inf or nan, and writing it would "
+                "silently record null in its place"
+            )
+    return out
+
+
 # --------- dump helpers -------------------------------------------------------
 
 
@@ -246,7 +309,7 @@ def json_dumpb(
             allow_non_str_keys=allow_non_str_keys,
         )
     )
-    return orjson.dumps(obj, default=default, option=opt)
+    return _dumpb(obj, default, opt)
 
 
 @overload
@@ -344,4 +407,4 @@ def json_lines_iter(
         opt = options | orjson.OPT_APPEND_NEWLINE
 
     for item in it:
-        yield orjson.dumps(item, default=default, option=opt)
+        yield _dumpb(item, default, opt)

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -209,7 +209,8 @@ def make_options(
 
 # orjson writes inf, -inf and nan as `null`, which is indistinguishable from a
 # genuine null on read: the value silently changes and no consumer can detect it.
-# JSON has no representation for these, so serialization fails loudly instead.
+# JSON has no representation for these, so callers that ask for the check get a
+# loud failure instead.
 #
 # Detection walks the object the way orjson does. That means covering every form
 # orjson encodes natively, because those never reach default(); a walk that follows
@@ -218,10 +219,23 @@ def make_options(
 # float are: float, dict, list, tuple (and their subclasses), dataclass instances,
 # Enum members (written by value), and numpy arrays and scalars under
 # OPT_SERIALIZE_NUMPY. The remaining native forms -- str, int, bool, None, bytes,
-# datetime, date, time and UUID -- cannot contain a float. Everything else reaches
-# orjson through default(), and the walk follows that conversion. The residual gap
-# is a future orjson gaining a new native container type; the version in use is
-# pinned by the dependency range and this list is checked against it.
+# datetime, date, time and UUID -- cannot contain a float.
+#
+# Two forms are outside what any walk can decide:
+#
+# * orjson.Fragment holds pre-serialized bytes that orjson copies into the output
+#   verbatim, without parsing them and without calling default(). A `null` inside a
+#   Fragment is indistinguishable from a `null` a non-finite float would have
+#   produced, because neither exists as a Python float by the time the Fragment is
+#   built. Fragment contents are the caller's to validate; the walk skips them.
+# * A future orjson may encode a container type natively that this list does not
+#   name, and the declared dependency floor is a minimum rather than an exact
+#   version, so a newer orjson can be installed. The list is written against the
+#   native types orjson documents; it is not enforced against the installed
+#   version at run time.
+#
+# Everything else reaches orjson through default(), and the walk follows that
+# conversion.
 
 
 def _numpy_non_finite(obj: Any, path: str) -> str | None | Literal[False]:
@@ -301,6 +315,10 @@ def _locate_non_finite(
     elif isinstance(obj, Enum):
         # orjson writes an Enum member by its value, never through default().
         return _locate_non_finite(obj.value, default, opt, path)
+    elif isinstance(obj, orjson.Fragment):
+        # Pre-serialized bytes, copied into the output unparsed. Whatever they
+        # contain was decided before this call and cannot be judged from here.
+        return None
     # Anything else reaches orjson through default(); follow the same conversion.
     try:
         converted = default(obj)
@@ -309,12 +327,26 @@ def _locate_non_finite(
     return _locate_non_finite(converted, default, opt, path)
 
 
-def _dumpb(obj: Any, default: Callable[[Any], Any], opt: int) -> bytes:
-    """orjson.dumps, rejecting payloads whose non-finite floats would become null."""
+def _dumpb(
+    obj: Any, default: Callable[[Any], Any], opt: int, check_non_finite: bool = False
+) -> bytes:
+    """orjson.dumps, optionally rejecting payloads whose non-finite floats become null.
+
+    The check is off by default because it costs a full Python-level traversal of
+    the object and there is no cheaper sound trigger for it. A non-finite float and
+    a `None` both emit the literal `null`, so the output cannot say which produced
+    it, and orjson exposes no hook that sees floats -- they are encoded natively and
+    never reach default(). Measured on a 200-item object with one legitimate null,
+    the traversal costs roughly 20x the dump it guards; even scanning the output for
+    `null` first costs about half a dump again, so gating on it does not help a
+    payload that has any null at all, which is most of them. Callers that persist a
+    value ask for the check explicitly; see json_dumpb.
+    """
     out = orjson.dumps(obj, default=default, option=opt)
     # Every non-finite float produces a literal `null`, so a null-free result is
-    # provably clean and the walk below only runs on a payload that has one.
-    if b"null" in out:
+    # provably clean and the walk is skipped. This only pays off once the caller has
+    # already opted into the check; as a gate on every dump it costs more than it saves.
+    if check_non_finite and b"null" in out:
         found = _locate_non_finite(obj, default, opt)
         if found is not None:
             raise ValueError(
@@ -343,16 +375,25 @@ def json_dumpb(
     passthrough_datetime: bool = False,
     safe_fallback: bool = False,
     fallback_clip: int = 2048,
+    check_non_finite: bool = False,
     default: Callable[[Any], Any] | None = None,
     options: int | None = None,
 ) -> bytes:
     """Serialize to bytes via orjson (fast path); safe_fallback=True for logging only.
 
-    Raises ValueError for inf, -inf or nan anywhere in the payload, since orjson
-    writes those as `null` and a reader cannot tell that apart from a genuine null.
-    Detection covers floats in mappings and sequences, dataclass fields, Enum
-    values, numpy float arrays and scalars when `options` carries
-    OPT_SERIALIZE_NUMPY, and anything the `default` hook converts into those.
+    orjson writes inf, -inf and nan as `null`, which a reader cannot tell apart from
+    a genuine null, so those values are lost silently. Pass check_non_finite=True to
+    raise ValueError instead, naming the path of the first offending value. Prefer it
+    wherever the result is persisted or handed to another system, where the loss is
+    durable and undetectable after the fact.
+
+    The check costs a full traversal of the payload -- roughly 20x the dump on an
+    object of a few thousand nodes -- which is why it is off by default. It covers
+    floats in mappings and sequences, dataclass fields, Enum values, numpy float
+    arrays and scalars when `options` carries OPT_SERIALIZE_NUMPY, and anything the
+    `default` hook converts into those. It cannot cover orjson.Fragment: those bytes
+    are copied into the output unparsed, so a `null` inside one is opaque to any
+    caller-side check and remains the responsibility of whoever built the Fragment.
     """
     if default is None:
         default = _cached_default(
@@ -376,7 +417,7 @@ def json_dumpb(
             allow_non_str_keys=allow_non_str_keys,
         )
     )
-    return _dumpb(obj, default, opt)
+    return _dumpb(obj, default, opt, check_non_finite)
 
 
 @overload
@@ -442,6 +483,7 @@ def json_lines_iter(
     passthrough_datetime: bool = False,
     safe_fallback: bool = False,
     fallback_clip: int = 2048,
+    check_non_finite: bool = False,
     # options
     naive_utc: bool = False,
     utc_z: bool = False,
@@ -450,7 +492,11 @@ def json_lines_iter(
     default: Callable[[Any], Any] | None = None,
     options: int | None = None,
 ) -> Iterable[bytes]:
-    """Stream iterable as NDJSON bytes (one orjson-serialized object per line, always newline-terminated)."""
+    """Stream iterable as NDJSON bytes (one orjson-serialized object per line, always newline-terminated).
+
+    check_non_finite=True raises ValueError on the first line holding an inf, -inf or
+    nan rather than writing it as `null`; see json_dumpb for what that costs and covers.
+    """
     if default is None:
         default = _cached_default(
             deterministic_sets=deterministic_sets,
@@ -474,4 +520,4 @@ def json_lines_iter(
         opt = options | orjson.OPT_APPEND_NEWLINE
 
     for item in it:
-        yield _dumpb(item, default, opt)
+        yield _dumpb(item, default, opt, check_non_finite)

--- a/lionagi/protocols/generic/element.py
+++ b/lionagi/protocols/generic/element.py
@@ -200,10 +200,20 @@ class Element(BaseModel):
         return cls.model_validate(data)
 
     def to_json(self, decode: bool = True, **kw) -> str:
-        """Serialize to JSON string."""
+        """Serialize to JSON string.
+
+        Raises ValueError if the element holds inf, -inf or nan: JSON cannot
+        represent them and they would be written as `null`, which no reader can
+        tell apart from a genuine null once the element has been stored.
+        """
         kw.pop("mode", None)
         dict_ = self._to_dict(**kw)
-        return json_dumps(dict_, default=DEFAULT_ELEMENT_SERIALIZER, decode=decode)
+        return json_dumps(
+            dict_,
+            default=DEFAULT_ELEMENT_SERIALIZER,
+            decode=decode,
+            check_non_finite=True,
+        )
 
     @classmethod
     def from_json(cls, json_str: str) -> Element:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -423,10 +423,15 @@ def _validate_columns(fields: dict[str, Any], allowed: frozenset[str]) -> None:
 
 
 def _to_json_column(value: Any) -> Any:
-    """Serialize value to JSON string for round-trippable storage."""
+    """Serialize value to JSON string for round-trippable storage.
+
+    Raises ValueError on inf, -inf or nan rather than storing them: JSON writes
+    them as `null`, and a row that has been written cannot afterwards be told
+    apart from one that always held a null there.
+    """
     if value is None or isinstance(value, bytes | bytearray | memoryview):
         return value
-    return _json_dumps(value)
+    return _json_dumps(value, check_non_finite=True)
 
 
 def _validate_session_status(status: Any) -> None:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -423,11 +423,13 @@ def _validate_columns(fields: dict[str, Any], allowed: frozenset[str]) -> None:
 
 
 def _to_json_column(value: Any) -> Any:
-    """Serialize value to JSON string for round-trippable storage.
+    """Serialize value to a JSON string for a TEXT column holding JSON.
 
-    Raises ValueError on inf, -inf or nan rather than storing them: JSON writes
-    them as `null`, and a row that has been written cannot afterwards be told
-    apart from one that always held a null there.
+    Columns bound as ``type_=JSON`` are serialized by the engine instead; this
+    is for the writes that hand the driver a finished string. Both reject inf,
+    -inf and nan rather than storing them, because neither the `null` orjson
+    writes nor the bare `NaN` the stdlib writes can be read back as the value
+    that was handed in.
     """
     if value is None or isinstance(value, bytes | bytearray | memoryview):
         return value
@@ -1887,7 +1889,11 @@ class StateDB:
                     "INSERT INTO progressions (id, created_at, collection) VALUES (:id, :ca, :col) "
                     "ON CONFLICT (id) DO NOTHING"
                 ),
-                {"id": progression_id, "ca": time.time(), "col": json.dumps(collection or [])},
+                {
+                    "id": progression_id,
+                    "ca": time.time(),
+                    "col": _to_json_column(collection or []),
+                },
             )
 
     async def get_progression(self, progression_id: str) -> list[str]:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1896,6 +1896,20 @@ class StateDB:
                 },
             )
 
+    async def set_progression(self, progression_id: str, collection: list[str]) -> None:
+        """Replace a progression's collection wholesale.
+
+        Exists so callers outside this module never have to hand the driver a
+        finished JSON string of their own: ``collection`` is a TEXT column, so a
+        pre-serialized value would bypass both the engine's JSON serializer and
+        the checked helper used here.
+        """
+        async with self._tx() as conn:
+            await conn.execute(
+                text("UPDATE progressions SET collection = :col WHERE id = :id"),
+                {"col": _to_json_column(collection or []), "id": progression_id},
+            )
+
     async def get_progression(self, progression_id: str) -> list[str]:
         async with self._read() as conn:
             row = (

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -25,7 +25,14 @@ def _json_serializer(obj):
 
 
 def _dumps_with_uuid(value):
-    return json.dumps(value, default=_json_serializer)
+    """Serializer for every JSON bind on every engine this module builds.
+
+    ``allow_nan=False`` makes the encoder raise on inf, -inf and nan instead of
+    writing the non-standard ``Infinity``/``NaN`` literals into durable storage,
+    where nothing downstream can read them back as JSON. It is a flag on the
+    encode pass that already runs, not an extra traversal of the payload.
+    """
+    return json.dumps(value, default=_json_serializer, allow_nan=False)
 
 
 def normalize_state_db_url(value: str | Path | None) -> str:

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -15,7 +15,7 @@ from typing import Any, Literal
 import anyio
 from fastapi import HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import text
+from sqlalchemy import JSON, bindparam, text
 from sqlalchemy.exc import OperationalError as _SAOperationalError
 
 from lionagi.cli._util import pid_alive as _pid_is_live
@@ -679,13 +679,13 @@ async def transition_sessions(
                         "WHERE id=:sid AND status='running'"
                         "  AND (last_message_at IS :slast OR last_message_at = :slast)"
                         "  AND (updated_at      IS :supd  OR updated_at      = :supd)"
-                    ),
+                    ).bindparams(bindparam("erefs", type_=JSON)),
                     {
                         "status": target_status,
                         "now": now,
                         "rcode": effective_reason_code,
                         "rsummary": effective_reason_summary,
-                        "erefs": json.dumps(effective_evidence_refs),
+                        "erefs": effective_evidence_refs,
                         "sid": sid,
                         "slast": _snap_last_msg,
                         "supd": _snap_updated,
@@ -701,7 +701,7 @@ async def transition_sessions(
                             " source, actor, created_at, metadata) "
                             "VALUES (:id, :etype, :eid, :prev, :status, "
                             " :rcode, :rsummary, :erefs, :source, :actor, :now, :meta)"
-                        ),
+                        ).bindparams(bindparam("erefs", type_=JSON), bindparam("meta", type_=JSON)),
                         {
                             "id": uuid.uuid4().hex,
                             "etype": "session",
@@ -710,17 +710,15 @@ async def transition_sessions(
                             "status": target_status,
                             "rcode": effective_reason_code,
                             "rsummary": effective_reason_summary,
-                            "erefs": json.dumps(effective_evidence_refs),
+                            "erefs": effective_evidence_refs,
                             "source": "admin",
                             "actor": actor,
                             "now": now,
-                            "meta": json.dumps(
-                                {
-                                    "legacy_reason": legacy_reason,
-                                    "health": health.value,
-                                    "process_alive": process_alive,
-                                }
-                            ),
+                            "meta": {
+                                "legacy_reason": legacy_reason,
+                                "health": health.value,
+                                "process_alive": process_alive,
+                            },
                         },
                     )
             if not cas_hit:

--- a/tests/libs/test_json_dump_non_finite.py
+++ b/tests/libs/test_json_dump_non_finite.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Non-finite floats must fail serialization rather than turn into null."""
+"""Non-finite floats fail serialization rather than turn into null, where asked."""
 
 import dataclasses
 import enum
@@ -24,57 +24,61 @@ class _Scored(Element):
 @pytest.mark.parametrize("bad", NON_FINITE)
 def test_json_dumps_rejects_non_finite(bad):
     with pytest.raises(ValueError, match="non-finite float at \\$.v"):
-        json_dumps({"v": bad})
+        json_dumps({"v": bad}, check_non_finite=True)
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)
 def test_json_dumpb_rejects_non_finite(bad):
     with pytest.raises(ValueError, match="non-finite float"):
-        json_dumpb({"v": bad})
+        json_dumpb({"v": bad}, check_non_finite=True)
 
 
 def test_error_reports_the_path_to_the_offending_value():
     with pytest.raises(ValueError, match="\\$\\.a\\[1\\]\\.b\\[0\\]"):
-        json_dumps({"a": [1.0, {"b": [float("inf")]}]})
+        json_dumps({"a": [1.0, {"b": [float("inf")]}]}, check_non_finite=True)
 
 
 def test_non_finite_inside_a_tuple_is_rejected():
     with pytest.raises(ValueError, match="\\$\\.t\\[1\\]"):
-        json_dumps({"t": (1.0, float("-inf"))})
+        json_dumps({"t": (1.0, float("-inf"))}, check_non_finite=True)
 
 
 def test_non_finite_inside_a_set_is_rejected():
     with pytest.raises(ValueError, match="non-finite float"):
-        json_dumps({"s": {float("nan")}}, deterministic_sets=True)
+        json_dumps({"s": {float("nan")}}, deterministic_sets=True, check_non_finite=True)
 
 
 def test_non_finite_dict_key_is_rejected():
     with pytest.raises(ValueError, match="non-finite float"):
-        json_dumps({float("inf"): 1}, allow_non_str_keys=True)
+        json_dumps({float("inf"): 1}, allow_non_str_keys=True, check_non_finite=True)
 
 
 def test_non_finite_reached_through_the_default_hook_is_rejected():
     """A nested Element is expanded by default(); the check follows it."""
     with pytest.raises(ValueError, match="\\$\\.e\\.value"):
-        json_dumps({"e": _Scored(value=float("inf"))})
+        json_dumps({"e": _Scored(value=float("inf"))}, check_non_finite=True)
 
 
 def test_safe_fallback_does_not_suppress_the_error():
     with pytest.raises(ValueError, match="non-finite float"):
-        json_dumps({"v": float("inf")}, safe_fallback=True)
+        json_dumps({"v": float("inf")}, safe_fallback=True, check_non_finite=True)
 
 
 def test_ndjson_stream_rejects_non_finite():
-    stream = json_lines_iter([{"a": 1.0}, {"b": float("inf")}])
+    stream = json_lines_iter([{"a": 1.0}, {"b": float("inf")}], check_non_finite=True)
     assert next(stream) == b'{"a":1.0}\n'
     with pytest.raises(ValueError, match="non-finite float"):
         next(stream)
 
 
-def test_compute_hash_rejects_non_finite():
-    """Without this, inf and None hash identically."""
-    with pytest.raises(ValueError, match="non-finite float"):
-        compute_hash({"v": float("inf")})
+def test_compute_hash_does_not_check_and_collides_on_non_finite():
+    """Hashing does not pay for the check, so inf and None still hash alike.
+
+    Recorded rather than fixed: compute_hash runs on every dict lookup that needs a
+    stable key, and the check costs a full traversal of the payload. A caller that
+    needs the distinction serializes with check_non_finite=True before hashing.
+    """
+    assert compute_hash({"v": float("inf")}) == compute_hash({"v": None})
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)
@@ -89,15 +93,71 @@ def test_element_to_dict_rejects_non_finite(mode):
         _Scored(value=float("inf")).to_dict(mode=mode)
 
 
+# --- what the check costs is only paid when it is asked for ---
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_check_is_off_by_default_and_orjson_behaviour_stands(bad):
+    """Unasked, the dump keeps orjson's semantics: the value is written as null.
+
+    This is the cost boundary. Running the check on every dump means traversing the
+    whole payload whenever it holds any null at all, which ordinary payloads do.
+    """
+    assert json_dumps({"v": bad}) == '{"v":null}'
+    assert json_dumpb({"v": bad}) == b'{"v":null}'
+
+
+def test_ndjson_stream_does_not_check_by_default():
+    stream = json_lines_iter([{"a": 1.0}, {"b": float("inf")}])
+    assert next(stream) == b'{"a":1.0}\n'
+    assert next(stream) == b'{"b":null}\n'
+
+
+def test_db_json_column_rejects_non_finite():
+    """The stored row is what cannot be repaired later, so this path checks."""
+    from lionagi.state.db import _to_json_column
+
+    assert _to_json_column({"v": 1.5}) == '{"v":1.5}'
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.v"):
+        _to_json_column({"v": float("inf")})
+
+
+# --- orjson.Fragment is an opaque boundary the check cannot see past ---
+
+
+def test_fragment_contents_are_not_checked():
+    """A Fragment is bytes orjson copies out verbatim, never calling default().
+
+    Nothing on this side of the call can tell a null the caller wrote from a null a
+    non-finite float would have produced, because by the time the Fragment exists
+    there is no float left to inspect. Recorded so a later change does not mistake
+    the silence for coverage.
+    """
+    payload = {"raw": orjson.Fragment(b'{"v":null}')}
+    assert json_dumpb(payload, check_non_finite=True) == b'{"raw":{"v":null}}'
+
+    # orjson does not parse Fragment bytes either, so it will emit a token that is
+    # not valid JSON if the caller supplies one.
+    invalid = {"raw": orjson.Fragment(b'{"v":NaN}')}
+    assert json_dumpb(invalid, check_non_finite=True) == b'{"raw":{"v":NaN}}'
+
+    # A non-finite float outside the Fragment is still found.
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.v"):
+        json_dumpb({"raw": orjson.Fragment(b"{}"), "v": float("inf")}, check_non_finite=True)
+
+
 # --- the guard must not disturb anything that is legitimately serializable ---
 
 
 def test_genuine_nulls_still_serialize():
     assert json_dumps({"a": None, "b": 1.5}) == '{"a":null,"b":1.5}'
+    assert json_dumps({"a": None, "b": 1.5}, check_non_finite=True) == '{"a":null,"b":1.5}'
 
 
 def test_string_containing_null_still_serializes():
+    """A `null` in a string value trips the cheap pre-scan; the walk must clear it."""
     assert json_dumps({"s": "null"}) == '{"s":"null"}'
+    assert json_dumps({"s": "null"}, check_non_finite=True) == '{"s":"null"}'
 
 
 def test_finite_float_key_still_serializes():
@@ -129,7 +189,7 @@ def test_dataclass_field_rejects_non_finite(bad):
         value: float
 
     with pytest.raises(ValueError, match="non-finite float at \\$\\.value"):
-        json_dumpb(Measurement(bad))
+        json_dumpb(Measurement(bad), check_non_finite=True)
 
 
 def test_nested_dataclass_reports_its_path():
@@ -142,7 +202,7 @@ def test_nested_dataclass_reports_its_path():
         inner: Inner
 
     with pytest.raises(ValueError, match="\\$\\.readings\\[0\\]\\.inner\\.value"):
-        json_dumpb({"readings": [Outer(Inner(float("nan")))]})
+        json_dumpb({"readings": [Outer(Inner(float("nan")))]}, check_non_finite=True)
 
 
 def test_finite_dataclass_still_serializes():
@@ -159,14 +219,18 @@ def test_enum_float_value_rejects_non_finite(bad):
     limit = enum.Enum("_Limit", {"EDGE": bad})
 
     with pytest.raises(ValueError, match="non-finite float at \\$\\.limit"):
-        json_dumpb({"limit": limit.EDGE})
+        json_dumpb({"limit": limit.EDGE}, check_non_finite=True)
 
 
 def test_numpy_array_rejects_non_finite():
     np = pytest.importorskip("numpy")
 
     with pytest.raises(ValueError, match="non-finite float at \\$\\[1\\]"):
-        json_dumpb(np.array([1.0, float("nan")]), options=orjson.OPT_SERIALIZE_NUMPY)
+        json_dumpb(
+            np.array([1.0, float("nan")]),
+            options=orjson.OPT_SERIALIZE_NUMPY,
+            check_non_finite=True,
+        )
 
 
 def test_numpy_multidimensional_array_reports_its_index():
@@ -176,6 +240,7 @@ def test_numpy_multidimensional_array_reports_its_index():
         json_dumpb(
             {"grid": np.array([[1.0, 2.0], [3.0, float("inf")]])},
             options=orjson.OPT_SERIALIZE_NUMPY,
+            check_non_finite=True,
         )
 
 
@@ -185,7 +250,7 @@ def test_numpy_scalar_rejects_non_finite(dtype_name):
     scalar = np.dtype(dtype_name).type(float("inf"))
 
     with pytest.raises(ValueError, match="non-finite float at \\$\\.v"):
-        json_dumpb({"v": scalar}, options=orjson.OPT_SERIALIZE_NUMPY)
+        json_dumpb({"v": scalar}, options=orjson.OPT_SERIALIZE_NUMPY, check_non_finite=True)
 
 
 def test_finite_numpy_arrays_still_serialize():
@@ -210,4 +275,5 @@ def test_dataclass_under_passthrough_follows_the_default_hook():
             Measurement(float("inf")),
             default=lambda o: {"value": o.value},
             options=orjson.OPT_PASSTHROUGH_DATACLASS,
+            check_non_finite=True,
         )

--- a/tests/libs/test_json_dump_non_finite.py
+++ b/tests/libs/test_json_dump_non_finite.py
@@ -3,8 +3,11 @@
 
 """Non-finite floats must fail serialization rather than turn into null."""
 
+import dataclasses
+import enum
 import math
 
+import orjson
 import pytest
 
 from lionagi.ln import json_dumpb, json_dumps, json_lines_iter
@@ -114,3 +117,97 @@ def test_extreme_but_finite_floats_are_untouched():
     assert restored["big"] == 1.7976931348623157e308
     assert restored["small"] == 5e-324
     assert math.copysign(1, restored["neg"]) == -1
+
+
+# --- forms orjson encodes natively, which never reach the default() hook ---
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_dataclass_field_rejects_non_finite(bad):
+    @dataclasses.dataclass
+    class Measurement:
+        value: float
+
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.value"):
+        json_dumpb(Measurement(bad))
+
+
+def test_nested_dataclass_reports_its_path():
+    @dataclasses.dataclass
+    class Inner:
+        value: float
+
+    @dataclasses.dataclass
+    class Outer:
+        inner: Inner
+
+    with pytest.raises(ValueError, match="\\$\\.readings\\[0\\]\\.inner\\.value"):
+        json_dumpb({"readings": [Outer(Inner(float("nan")))]})
+
+
+def test_finite_dataclass_still_serializes():
+    @dataclasses.dataclass
+    class Measurement:
+        value: float
+        note: str | None
+
+    assert json_dumpb(Measurement(1.5, None)) == b'{"value":1.5,"note":null}'
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_enum_float_value_rejects_non_finite(bad):
+    limit = enum.Enum("_Limit", {"EDGE": bad})
+
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.limit"):
+        json_dumpb({"limit": limit.EDGE})
+
+
+def test_numpy_array_rejects_non_finite():
+    np = pytest.importorskip("numpy")
+
+    with pytest.raises(ValueError, match="non-finite float at \\$\\[1\\]"):
+        json_dumpb(np.array([1.0, float("nan")]), options=orjson.OPT_SERIALIZE_NUMPY)
+
+
+def test_numpy_multidimensional_array_reports_its_index():
+    np = pytest.importorskip("numpy")
+
+    with pytest.raises(ValueError, match="\\$\\.grid\\[1\\]\\[1\\]"):
+        json_dumpb(
+            {"grid": np.array([[1.0, 2.0], [3.0, float("inf")]])},
+            options=orjson.OPT_SERIALIZE_NUMPY,
+        )
+
+
+@pytest.mark.parametrize("dtype_name", ["float16", "float32", "float64"])
+def test_numpy_scalar_rejects_non_finite(dtype_name):
+    np = pytest.importorskip("numpy")
+    scalar = np.dtype(dtype_name).type(float("inf"))
+
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.v"):
+        json_dumpb({"v": scalar}, options=orjson.OPT_SERIALIZE_NUMPY)
+
+
+def test_finite_numpy_arrays_still_serialize():
+    np = pytest.importorskip("numpy")
+    opt = orjson.OPT_SERIALIZE_NUMPY
+
+    assert json_dumpb(np.array([1.0, 2.5]), options=opt) == b"[1.0,2.5]"
+    # Integer and boolean dtypes cannot be non-finite and must not be probed.
+    assert json_dumpb(np.array([1, 2]), options=opt) == b"[1,2]"
+    assert json_dumpb(np.array([True, False]), options=opt) == b"[true,false]"
+
+
+def test_dataclass_under_passthrough_follows_the_default_hook():
+    """OPT_PASSTHROUGH_DATACLASS routes dataclasses to default(), so the walk must too."""
+
+    @dataclasses.dataclass
+    class Measurement:
+        value: float
+
+    with pytest.raises(ValueError, match="non-finite float at \\$\\.value"):
+        json_dumpb(
+            Measurement(float("inf")),
+            default=lambda o: {"value": o.value},
+            options=orjson.OPT_PASSTHROUGH_DATACLASS,
+        )

--- a/tests/libs/test_json_dump_non_finite.py
+++ b/tests/libs/test_json_dump_non_finite.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-finite floats must fail serialization rather than turn into null."""
+
+import math
+
+import pytest
+
+from lionagi.ln import json_dumpb, json_dumps, json_lines_iter
+from lionagi.ln._hash import compute_hash
+from lionagi.protocols.generic.element import Element
+
+NON_FINITE = [float("inf"), float("-inf"), float("nan")]
+
+
+class _Scored(Element):
+    value: float = 0.0
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_json_dumps_rejects_non_finite(bad):
+    with pytest.raises(ValueError, match="non-finite float at \\$.v"):
+        json_dumps({"v": bad})
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_json_dumpb_rejects_non_finite(bad):
+    with pytest.raises(ValueError, match="non-finite float"):
+        json_dumpb({"v": bad})
+
+
+def test_error_reports_the_path_to_the_offending_value():
+    with pytest.raises(ValueError, match="\\$\\.a\\[1\\]\\.b\\[0\\]"):
+        json_dumps({"a": [1.0, {"b": [float("inf")]}]})
+
+
+def test_non_finite_inside_a_tuple_is_rejected():
+    with pytest.raises(ValueError, match="\\$\\.t\\[1\\]"):
+        json_dumps({"t": (1.0, float("-inf"))})
+
+
+def test_non_finite_inside_a_set_is_rejected():
+    with pytest.raises(ValueError, match="non-finite float"):
+        json_dumps({"s": {float("nan")}}, deterministic_sets=True)
+
+
+def test_non_finite_dict_key_is_rejected():
+    with pytest.raises(ValueError, match="non-finite float"):
+        json_dumps({float("inf"): 1}, allow_non_str_keys=True)
+
+
+def test_non_finite_reached_through_the_default_hook_is_rejected():
+    """A nested Element is expanded by default(); the check follows it."""
+    with pytest.raises(ValueError, match="\\$\\.e\\.value"):
+        json_dumps({"e": _Scored(value=float("inf"))})
+
+
+def test_safe_fallback_does_not_suppress_the_error():
+    with pytest.raises(ValueError, match="non-finite float"):
+        json_dumps({"v": float("inf")}, safe_fallback=True)
+
+
+def test_ndjson_stream_rejects_non_finite():
+    stream = json_lines_iter([{"a": 1.0}, {"b": float("inf")}])
+    assert next(stream) == b'{"a":1.0}\n'
+    with pytest.raises(ValueError, match="non-finite float"):
+        next(stream)
+
+
+def test_compute_hash_rejects_non_finite():
+    """Without this, inf and None hash identically."""
+    with pytest.raises(ValueError, match="non-finite float"):
+        compute_hash({"v": float("inf")})
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_element_to_json_rejects_non_finite(bad):
+    with pytest.raises(ValueError, match="\\$\\.value"):
+        _Scored(value=bad).to_json()
+
+
+@pytest.mark.parametrize("mode", ["json", "db"])
+def test_element_to_dict_rejects_non_finite(mode):
+    with pytest.raises(ValueError, match="\\$\\.value"):
+        _Scored(value=float("inf")).to_dict(mode=mode)
+
+
+# --- the guard must not disturb anything that is legitimately serializable ---
+
+
+def test_genuine_nulls_still_serialize():
+    assert json_dumps({"a": None, "b": 1.5}) == '{"a":null,"b":1.5}'
+
+
+def test_string_containing_null_still_serializes():
+    assert json_dumps({"s": "null"}) == '{"s":"null"}'
+
+
+def test_finite_float_key_still_serializes():
+    assert json_dumps({1.5: 1, "z": None}, allow_non_str_keys=True) == '{"1.5":1,"z":null}'
+
+
+def test_finite_element_round_trips():
+    element = _Scored(value=1.5)
+    restored = _Scored.from_json(element.to_json())
+    assert restored.value == 1.5
+    assert restored.id == element.id
+
+
+def test_extreme_but_finite_floats_are_untouched():
+    payload = {"big": 1.7976931348623157e308, "small": 5e-324, "neg": -0.0}
+    restored = json_dumps(payload, as_loaded=True)
+    assert restored["big"] == 1.7976931348623157e308
+    assert restored["small"] == 5e-324
+    assert math.copysign(1, restored["neg"]) == -1

--- a/tests/state/test_json_bind_non_finite.py
+++ b/tests/state/test_json_bind_non_finite.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-finite floats must not reach a JSON column — the guard sits on the engine's
+JSON serializer, so it covers every JSON bind rather than one write method."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import StatementError
+
+from lionagi.state.db import StateDB, _to_json_column
+from lionagi.state.engine import _dumps_with_uuid
+
+NON_FINITE = [float("inf"), float("-inf"), float("nan")]
+
+
+@pytest.fixture
+async def db(tmp_path):
+    state = StateDB(tmp_path / "state.db")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def _artifact_count(db: StateDB) -> int:
+    async with db._read() as conn:
+        row = (await conn.execute(text("SELECT COUNT(*) AS n FROM artifacts"))).mappings().first()
+    return row["n"]
+
+
+# ── The shared JSON-bind serializer ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+def test_engine_json_serializer_rejects_non_finite(bad):
+    with pytest.raises(ValueError):
+        _dumps_with_uuid({"score": bad})
+
+
+def test_engine_json_serializer_rejects_nested_non_finite():
+    with pytest.raises(ValueError):
+        _dumps_with_uuid({"outer": [{"inner": float("nan")}]})
+
+
+def test_engine_json_serializer_keeps_ordinary_values():
+    assert _dumps_with_uuid({"a": 1.5, "b": None, "c": "x"}) == '{"a": 1.5, "b": null, "c": "x"}'
+
+
+# ── insert_artifact: rejected before a row exists ────────────────────────────
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+async def test_insert_artifact_rejects_non_finite_without_writing(db, bad):
+    before = await _artifact_count(db)
+    # The bind-time refusal reaches the caller wrapped by the driver layer; the
+    # value error underneath it is the guard.
+    with pytest.raises(StatementError) as excinfo:
+        await db.insert_artifact(kind="review", name="nonfinite", content={"score": bad})
+    assert isinstance(excinfo.value.orig, ValueError)
+    assert await _artifact_count(db) == before
+
+
+async def test_insert_artifact_update_rejects_non_finite_without_changing_the_row(db):
+    art_id = await db.insert_artifact(kind="review", name="upd", content={"score": 1.0})
+    with pytest.raises(StatementError):
+        await db.insert_artifact(kind="review", name="upd", content={"score": float("nan")})
+    async with db._read() as conn:
+        row = (
+            (
+                await conn.execute(
+                    text("SELECT content FROM artifacts WHERE id = :id"), {"id": art_id}
+                )
+            )
+            .mappings()
+            .first()
+        )
+    stored = row["content"]
+    if isinstance(stored, str):
+        stored = json.loads(stored)
+    assert stored == {"score": 1.0}
+
+
+# ── Ordinary content, including a genuine null, still writes ─────────────────
+
+
+async def test_ordinary_content_with_a_genuine_null_round_trips(db):
+    content = {"score": 0.5, "note": None, "items": [1, None, "two"], "big": 1e308}
+    art_id = await db.insert_artifact(kind="review", name="ok", content=content)
+    stored = (await db.get_artifact(art_id))["content"]
+    if isinstance(stored, str):
+        stored = json.loads(stored)
+    assert stored == content
+    assert stored["note"] is None
+    assert math.isfinite(stored["big"])
+
+
+# ── The TEXT-column JSON write goes through the checked helper ───────────────
+
+
+async def test_progression_collection_writes_through_the_checked_helper(db):
+    await db.create_progression("prog-ok", ["m1", "m2"])
+    assert await db.get_progression("prog-ok") == ["m1", "m2"]
+
+
+def test_to_json_column_rejects_non_finite():
+    with pytest.raises(ValueError):
+        _to_json_column({"score": float("inf")})

--- a/tests/state/test_json_bind_non_finite.py
+++ b/tests/state/test_json_bind_non_finite.py
@@ -110,3 +110,84 @@ async def test_progression_collection_writes_through_the_checked_helper(db):
 def test_to_json_column_rejects_non_finite():
     with pytest.raises(ValueError):
         _to_json_column({"score": float("inf")})
+
+
+@pytest.mark.parametrize("bad", NON_FINITE)
+async def test_set_progression_rejects_non_finite_leaving_the_row_unchanged(db, bad):
+    await db.create_progression("prog-set", ["m1"])
+    with pytest.raises(ValueError):
+        await db.set_progression("prog-set", ["m1", bad])
+    assert await db.get_progression("prog-set") == ["m1"]
+
+
+async def test_set_progression_replaces_an_ordinary_collection(db):
+    await db.create_progression("prog-replace", ["m1"])
+    await db.set_progression("prog-replace", ["m1", "m2", "m3"])
+    assert await db.get_progression("prog-replace") == ["m1", "m2", "m3"]
+
+
+# ── The run-import path writes its collections through the same helper ───────
+#
+# `li state import` reads run files written by other processes and parses them
+# with json.loads, which accepts the non-standard NaN/Infinity tokens. Nothing
+# on that path may hand the driver a JSON string of its own making.
+
+
+def _write_run_dir(root, *, msg_id_literal: str):
+    """A one-branch run directory whose single message id is `msg_id_literal`,
+    written as a raw JSON token so non-standard ones can be exercised."""
+    run_dir = root / "runs" / "run-1"
+    (run_dir / "branches").mkdir(parents=True)
+    (run_dir / "branches" / "b1.json").write_text(
+        '{"id": "b1", "messages": {"collections": '
+        f'[{{"id": {msg_id_literal}, "created_at": 1.0, "role": "user", "content": {{}}}}], '
+        '"progression": {"order": []}}}'
+    )
+    return run_dir
+
+
+async def _raw_collections(db: StateDB) -> list[str]:
+    async with db._read() as conn:
+        rows = (await conn.execute(text("SELECT collection FROM progressions"))).mappings().all()
+    return [r["collection"] for r in rows]
+
+
+# A NaN id is not exercised here: SQLite stores it as NULL, so the message
+# insert fails on the id column's NOT NULL constraint before any collection is
+# written, and the case would pass whether or not this guard exists.
+@pytest.mark.parametrize("literal", ["Infinity", "-Infinity"])
+async def test_import_writes_no_non_finite_collection(db, tmp_path, literal):
+    from lionagi.cli.state import _import_one_run
+
+    run_dir = _write_run_dir(tmp_path / "home", msg_id_literal=literal)
+    with pytest.raises(Exception):
+        await _import_one_run(db, "run-1", run_dir, {"kind": "agent"})
+
+    for stored in await _raw_collections(db):
+        assert "NaN" not in stored
+        assert "Infinity" not in stored
+        json.loads(stored)  # strict: every stored collection is standard JSON
+
+
+async def test_import_writes_the_session_collection_through_the_db_operation(db, tmp_path):
+    """The session-wide collection is set by the DB operation rather than by an
+    UPDATE the CLI builds itself — the CLI holds no JSON serializer of its own."""
+    from lionagi.cli.state import _import_one_run
+
+    calls: list[tuple[str, list[str]]] = []
+    real = db.set_progression
+
+    async def spy(progression_id, collection):
+        calls.append((progression_id, list(collection)))
+        await real(progression_id, collection)
+
+    db.set_progression = spy
+
+    run_dir = _write_run_dir(tmp_path / "home", msg_id_literal='"m1"')
+    _, branches, messages = await _import_one_run(db, "run-1", run_dir, {"kind": "agent"})
+
+    assert (branches, messages) == (1, 1)
+    assert len(calls) == 1, "the session collection must go through set_progression"
+    session_prog_id, collection = calls[0]
+    assert collection == ["m1"]
+    assert await db.get_progression(session_prog_id) == ["m1"]


### PR DESCRIPTION
`float("inf")`, `-inf` and `nan` reached storage as `null`. A reader cannot tell
that apart from a genuine null, so the value changed and nothing reported it.

The path that loses the data is `Element.to_json` and both `to_dict(mode="json")`
and `to_dict(mode="db")`, all of which build a dict with `model_dump()` — which
preserves the infinity — and then hand it to `ln.json_dumpb`, which is orjson.
orjson writes non-finite floats as `null` to match `JSON.stringify`. `db` is the
mode written to storage, so that is where it matters.

Serialization now fails loudly there, naming the path to the offending value,
matching `json.dumps(allow_nan=False)`.

Preserving the value was not available on this path: orjson has no option to emit
`Infinity`, and `Infinity` is not valid JSON, so the mode where the loss is worst
is the mode where the encoding cannot be used.

Closes #2467

## Correction: the check is opt-in, not universal

An earlier revision of this branch put the check inside `json_dumpb` and stated
that `to_json`, `json_dumps`, `compute_hash` and the NDJSON stream were therefore
all covered. **That is withdrawn.** The placement was right about coverage and
wrong about cost, by a factor that makes it unshippable.

The check is a Python-level traversal of the payload, gated on the output
containing a `null`. A `None` and a non-finite float both serialize to the
literal `null`, so the gate fires on ordinary data. Measured on a 200-item object
(`{"id", "text", "values"[10]} × 200`) whose only null is one optional field:

| payload | µs/dump | vs unguarded |
|---|---|---|
| with one legitimate `null` | 559.5 | **34.7×** |
| same object, that one key removed | 24.7 | 1.53× |

22.7× against its own control, from a single optional field.

**The gate is not cheap either.** `b"null" in out` is an O(output) scan: 18.8 µs
against a 31.8 µs `orjson.dumps` on that payload. So a *null-free* payload was
still paying about half a dump again for a scan that found nothing — enough on
its own to fail a regression threshold.

### Why not a better trigger

The question the gate wants to ask is "could this payload hold a non-finite
float". Measured on the same payload, in the same process:

| approach | cost | verdict |
|---|---|---|
| walk with the per-node path string dropped, path built only on a hit | 26.7× | a Python traversal is ~0.25 µs/node against a ~0.008 µs/node C dump |
| stdlib `json.dumps(allow_nan=False)` as a C-speed validator | 11.5× | best always-on candidate, still 10× over any sane threshold — and it raises `TypeError` on `Enum`, dataclasses, `datetime`, `UUID` and numpy, which orjson encodes natively |
| count nulls emitted against nulls explained | — | unsound: the literal `null` occurs inside string values, so the count over-reads and the accounting cannot close |
| detect during conversion | — | not available: orjson encodes floats natively and never routes them through `default()`, so there is no hook that sees a float |

There is no cheap sound trigger because there is no signal to read. The output
cannot say which nulls a float produced, and everything that inspects the Python
objects costs a traversal.

### What is on, and what protects the reported path

`json_dumpb`, `json_dumps` and `json_lines_iter` take `check_non_finite`,
defaulting to `False` — unasked, orjson's semantics stand. It is turned on at the
two boundaries where the loss is durable and unrepairable after the fact:

- `Element.to_json`, the single funnel for `to_dict(mode="json")` and
  `to_dict(mode="db")` — the path in the issue.
- the JSON column encoder behind every state write.

Both operate on bounded payloads, which is what makes the boundary affordable:
`Element.to_json` measures **4.8 µs** with the check on.

**`compute_hash` / `hash_dict` deliberately does not check**, which is a
reduction against the previous revision of this branch rather than a carry-over.
It runs on every dict that needs a stable key, and the consequence — `{"v": inf}`
and `{"v": None}` hash alike — is a collision rather than a durable write. A
caller who needs the distinction serializes with `check_non_finite=True` first.
The test that asserted the raise now records the collision, so the boundary is
pinned rather than forgotten.

### Ordinary-path cost after the change

Interleaved trial-by-trial against an unguarded `orjson.dumps` control in the
same process, 500 dumps/trial × 25 trials, on the same 200-item payload:

| | min | p25 |
|---|---|---|
| unguarded control | 16.03 µs | 17.11 µs |
| after this change | 16.83 µs | 17.23 µs |
| **ratio** | **1.05×** | **1.01×** |

Within measurement noise, which the shape predicts: on the default path
`_dumpb` now does `orjson.dumps` plus one boolean test, and the scan is
short-circuited away. Medians are omitted because the machine was under
substantial concurrent load and the control's median came out *above* the
treatment's, which is artifact rather than signal; the min and p25 of an
interleaved run are the defensible statistics here. CI's own benchmark job on a
quiet runner is the check this has not had.

## Detection has to cover what orjson encodes natively

The first version of this change followed the `default()` hook. That was not
enough, and the hole was the exact defect the change exists to prevent, surviving
inside the fix: orjson encodes several object forms natively and never calls
`default()` for them, so their non-finite floats still became `null`, the walk
found nothing, and the guard reported the payload clean. Three forms were
affected — dataclass instances, `Enum` members, and numpy arrays and scalars.
Dataclasses are used throughout this repository and the public `options` argument
makes the numpy route reachable, so neither is exotic.

Probing `orjson.dumps` directly for every form that can carry a float:

| form | orjson | covered |
|---|---|---|
| `float`, `dict`, `list`, `tuple` and subclasses | native | yes |
| dataclass instance | native → `{"value":null}` | yes |
| `Enum` member with a float value | native, written by value → `null` | yes |
| numpy float array / scalar, `OPT_SERIALIZE_NUMPY` | native → `[null]` | yes |
| dataclass under `OPT_PASSTHROUGH_DATACLASS` | routed to `default()` | yes |
| `orjson.Fragment` | native, bytes copied out unparsed | **no — see below** |
| `float` subclass | `TypeError`, not native | n/a |
| numpy without `OPT_SERIALIZE_NUMPY` | `TypeError` | n/a |

### Correction: `orjson.Fragment` is uncovered, and unfixably so

An earlier revision listed the uncovered set as "a future orjson version gaining
a new native container type". **That was incomplete.** `orjson.Fragment` is
already such a form:

```python
>>> orjson.dumps(orjson.Fragment(b'{"v":null}'), default=d)
b'{"v":null}'          # d was never called
>>> orjson.dumps(orjson.Fragment(b'{"v":NaN}'), default=d)
b'{"v":NaN}'           # not valid JSON, and orjson does not look
```

A Fragment is pre-serialized bytes that orjson copies into the output without
parsing them and without consulting `default()`. By the time one exists there is
no Python float left to inspect, so a `null` inside it cannot be attributed —
nothing on this side of the call can tell one the caller wrote from one a
non-finite float produced. This is a boundary, not a bug to fix later. It is
named in the `json_dumpb` docstring where a caller will see it, marked with an
explicit branch in the walk so the silence is deliberate rather than incidental,
and pinned by a test so a later change cannot quietly turn a known limitation
into an unknown one.

### Correction: the dependency range does not pin orjson

An earlier revision's comment ended "the version in use is pinned by the
dependency range and this list is checked against it". **Neither half held.**
`pyproject.toml` declares `orjson>=3.11.8` — a floor, not a pin, so a newer
orjson can be installed — and nothing verifies the list against the installed
version at run time. The comment now states what is actually true: the list is
written against the native types orjson documents, it is not enforced, and a
future orjson gaining a native container type is a live residual gap.

### The coverage boundary, stated

Written down in the module and in the `json_dumpb` docstring:

- **Covered**, when asked: `float`; `dict`, `list`, `tuple` and their subclasses;
  dataclass fields, unless `OPT_PASSTHROUGH_DATACLASS` routes them to
  `default()`; `Enum` values; numpy float arrays and scalars under
  `OPT_SERIALIZE_NUMPY`; and anything the `default` hook converts into one of
  those.
- **Deliberately not walked**, because they cannot contain a float: `str`, `int`,
  `bool`, `None`, `bytes`, `datetime`, `date`, `time`, `UUID`.
- **Uncovered**: `orjson.Fragment` contents, permanently; and a future orjson
  version gaining a new native container type.

## Two corrections to the issue

The issue attributes the loss to pydantic's `ser_json_inf_nan` default. On this
path pydantic's JSON serializer is never consulted — `model_dump()` returns the
float and orjson is what writes it — so changing that setting would have changed
nothing.

The issue's second reproduction, `"inf" in p.adapt_to("json")` being `False`, is
a case-sensitivity artifact of the probe. That adapter uses stdlib `json.dumps`
with `allow_nan` at its default, so it emits `Infinity` capitalised — the value
is not lost there. That path has a different defect, noted below, and this change
does not touch it.

## Adjacent defects found, not fixed

`JsonAdapter` (`lionagi/adapters/json_.py`) calls stdlib `json.dumps` with
`allow_nan` at its default, so `Pile.adapt_to("json")` emits bare `Infinity`,
`-Infinity` and `NaN` literals, which any strict RFC 8259 parser rejects. That is
a different and milder defect — loud rather than silent — and it deserves its own
decision about the adapter's contract rather than a copied answer.

Separately, `enum_as_name=True` on `get_orjson_default` looks like a no-op. It
installs an `Enum` entry in the `default()` table, but orjson encodes `Enum`
members natively by value and never calls `default()` for them, so a caller
asking for names would get values. Found while enumerating the native surface
above; not touched here, since it is a question about that option's contract.

## Verification

45 tests in the non-finite file: rc 0. They cover the walk's correctness
unchanged from the previous revision — dataclass fields including a nested path,
`Enum` float values across inf/-inf/nan, numpy 1-D and 2-D arrays and
float16/32/64 scalars — plus, new here: that the check is off by default for
`json_dumps`, `json_dumpb` and the NDJSON stream; that `Element.to_json`,
`to_dict("json")`, `to_dict("db")` and the JSON column encoder all raise; that
`compute_hash` collides on inf; and that Fragment contents are passed through
unchecked while a non-finite float beside a Fragment is still caught.

The full suite was run locally: 5 failures, all reproduced on the unmodified
branch head and all from optional dependencies absent in this environment
(`ollama`, `docling`, `asyncpg`). No failure is attributable to this change. The
runner did not emit a summary count line, so no total is claimed here; CI on this
PR is the complete run.

The PostgreSQL claim about `jsonb` rejecting `Infinity` is standard conformance
reasoning, not something executed here. It supports the argument against
preserving the literal but is not what rules it out; orjson being unable to emit
it at all is.
