### PR TITLE
fix(state): move the schema stamp with the migrations, check SQLite before enabling WAL

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -115,6 +115,14 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+# Shape of the schema this code applies. ``_apply_schema`` stamps it into
+# ``schema_meta.version`` on every open, so the recorded version describes the
+# database as it stands after migrations rather than as it was created. Bump it
+# whenever a migration changes the shape a reader would see -- a new table, a
+# rebuilt CHECK constraint, a column whose meaning changed. Version "1" is the
+# original shape, before the migrations now applied on open existed.
+SCHEMA_VERSION = "2"
+
 
 def state_db_file() -> Path | None:
     """The local file a default ``StateDB()`` would open, if it opens one at all.
@@ -800,11 +808,16 @@ class StateDB:
             await self._reconcile_indexes(conn)
             # Seed immutable reference rows; ON CONFLICT DO NOTHING is safe to
             # re-run on every open() because the rows are identity-stable.
+            # The version row is the exception: the migrations above rewrite an
+            # older database into the current shape, so the stamp has to move
+            # with them. DO UPDATE, not DO NOTHING, or a migrated database keeps
+            # reporting the version it was created at.
             await conn.execute(
                 text(
-                    "INSERT INTO schema_meta (key, value) VALUES ('version', '1') "
-                    "ON CONFLICT (key) DO NOTHING"
-                )
+                    "INSERT INTO schema_meta (key, value) VALUES ('version', :version) "
+                    "ON CONFLICT (key) DO UPDATE SET value = excluded.value"
+                ),
+                {"version": SCHEMA_VERSION},
             )
             await conn.execute(
                 text(

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -6,16 +6,60 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
+import sqlite3
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 from lionagi._paths import LIONAGI_HOME
 
+_log = logging.getLogger(__name__)
+
 # sqlite busy_timeout (ms) applied to every connection. Tunable so tests that
 # deliberately hold a write lock fail fast instead of waiting the full default.
 _SQLITE_BUSY_TIMEOUT_MS = 5000
+
+
+def has_wal_reset_fix(version_info: tuple[int, ...]) -> bool:
+    """Whether a linked SQLite carries the fix for the WAL-reset corruption race.
+
+    SQLite documents a data race between a starting checkpoint and a commit that
+    resets the WAL file: the checkpoint misses the reset, mis-sets a WAL-index
+    header field, and a later checkpoint then skips part of the committed
+    transaction, corrupting the database. It reaches every WAL-mode release from
+    3.7.0 up to and including 3.51.2, and is fixed in 3.51.3, with backports on
+    the 3.44 and 3.50 branches. Exposure needs two connections writing or
+    checkpointing at the same instant, which is exactly what this store does.
+    """
+    v = tuple(version_info[:3])
+    if v >= (3, 51, 3):
+        return True
+    if v[:2] == (3, 44) and v >= (3, 44, 6):
+        return True
+    if v[:2] == (3, 50) and v >= (3, 50, 7):
+        return True
+    return v < (3, 7, 0)  # predates WAL entirely; journal_mode=WAL is not honoured
+
+
+_wal_reset_warning_emitted = False
+
+
+def _warn_if_wal_reset_unfixed() -> None:
+    """Warn once per process when WAL is about to be enabled on a library that
+    still carries the WAL-reset corruption race."""
+    global _wal_reset_warning_emitted
+    if _wal_reset_warning_emitted or has_wal_reset_fix(sqlite3.sqlite_version_info):
+        return
+    _wal_reset_warning_emitted = True
+    _log.warning(
+        "Linked SQLite %s predates the fix for the WAL-reset corruption race "
+        "(fixed in 3.51.3; backported to 3.44.6 and 3.50.7). WAL is still enabled "
+        "because concurrent readers and writers depend on it; upgrade the SQLite "
+        "library to remove the exposure.",
+        sqlite3.sqlite_version,
+    )
 
 
 def _json_serializer(obj):
@@ -106,6 +150,7 @@ def make_engine(url: str, **overrides):
     dialect = dialect_of(url)
 
     if dialect == "sqlite":
+        _warn_if_wal_reset_unfixed()
         kwargs: dict = {"echo": False, "json_serializer": _dumps_with_uuid}
         kwargs.update(overrides)
         engine = create_async_engine(url, **kwargs)

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   value   TEXT NOT NULL
 );
 
-INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('version', '1');
+-- Must match SCHEMA_VERSION in db.py, which re-stamps this row on every open
+-- so a migrated database reports the shape it now has.
+INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('version', '2');
 INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('created_at', strftime('%s', 'now'));
 
 -- ── Message types (int enum for lion_class) ───────────────────────────────

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy import text
 
-from lionagi.state.db import StateDB
+from lionagi.state.db import SCHEMA_VERSION, StateDB
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -129,7 +129,7 @@ async def test_open_close():
 
     # Schema is available after open
     version = await state.schema_version()
-    assert version == "1"
+    assert version == SCHEMA_VERSION
 
     await state.close()
     assert state._engine is None
@@ -139,7 +139,7 @@ async def test_context_manager():
     """async with opens and closes cleanly."""
     async with StateDB(":memory:") as state:
         version = await state.schema_version()
-        assert version == "1"
+        assert version == SCHEMA_VERSION
     assert state._engine is None
 
 
@@ -359,8 +359,8 @@ async def test_schema_creates_all_tables(db: StateDB):
 
 
 async def test_schema_version(db: StateDB):
-    """schema_version() returns '1'."""
-    assert await db.schema_version() == "1"
+    """schema_version() returns the version this code applies."""
+    assert await db.schema_version() == SCHEMA_VERSION
 
 
 async def test_apply_schema_adds_missing_columns_on_old_db(tmp_path):

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -19,7 +19,7 @@ import uuid
 
 import pytest
 
-from lionagi.state.db import StateDB
+from lionagi.state.db import SCHEMA_VERSION, StateDB
 from lionagi.state.reasons import RunReasons
 
 # ── Shared helpers ────────────────────────────────────────────────────────────
@@ -158,9 +158,9 @@ async def _run_parity_suite(db: StateDB) -> None:
     # 5. get_session returns None for a missing id
     assert await db.get_session(_uid()) is None
 
-    # 6. schema_version is '1'
+    # 6. schema_version is the version this code applies
     ver = await db.schema_version()
-    assert ver == "1", f"schema_version must be '1', got {ver!r}"
+    assert ver == SCHEMA_VERSION, f"schema_version must be {SCHEMA_VERSION!r}, got {ver!r}"
 
     # 7. insert_session_signal assigns sequential seq (MAX+1 path / PG advisory lock)
     s1 = await db.insert_session_signal(

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -402,3 +402,81 @@ def _create_in_schema(sync_conn, schema_name: str) -> None:
     for table in _meta.sorted_tables:
         table.tometadata(scoped)
     scoped.create_all(sync_conn, checkfirst=True)
+
+
+# ── WAL-reset precondition ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("version_info", "fixed"),
+    [
+        ((3, 6, 23), True),  # predates WAL; journal_mode=WAL is not honoured
+        ((3, 7, 0), False),  # first WAL release, first affected release
+        ((3, 44, 5), False),
+        ((3, 44, 6), True),  # backport branch
+        ((3, 45, 0), False),  # later than the 3.44 backport, still unfixed
+        ((3, 46, 0), False),
+        ((3, 50, 6), False),
+        ((3, 50, 7), True),  # backport branch
+        ((3, 51, 0), False),
+        ((3, 51, 2), False),  # last affected release
+        ((3, 51, 3), True),  # fix
+        ((3, 53, 0), True),
+    ],
+)
+def test_has_wal_reset_fix(version_info, fixed):
+    from lionagi.state.engine import has_wal_reset_fix
+
+    assert has_wal_reset_fix(version_info) is fixed
+
+
+class _RecordingLog:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, msg, *args):
+        self.warnings.append(msg % args if args else msg)
+
+
+def _engine_with_recorded_log(monkeypatch, tmp_path, version_info, version_str):
+    import lionagi.state.engine as engine_mod
+
+    recorder = _RecordingLog()
+    monkeypatch.setattr(engine_mod, "_log", recorder)
+    monkeypatch.setattr(engine_mod, "_wal_reset_warning_emitted", False)
+    monkeypatch.setattr(sqlite3, "sqlite_version_info", version_info)
+    monkeypatch.setattr(sqlite3, "sqlite_version", version_str)
+    engine = engine_mod.make_engine(f"sqlite+aiosqlite:///{tmp_path / 'v.db'}")
+    return recorder, engine
+
+
+async def test_make_engine_warns_on_unfixed_sqlite(monkeypatch, tmp_path):
+    """Enabling WAL on a library that still carries the WAL-reset race is
+    reported, not assumed away."""
+    recorder, engine = _engine_with_recorded_log(monkeypatch, tmp_path, (3, 46, 0), "3.46.0")
+    try:
+        assert len(recorder.warnings) == 1
+        assert "3.46.0" in recorder.warnings[0]
+        assert "3.51.3" in recorder.warnings[0]
+    finally:
+        await engine.dispose()
+
+
+async def test_make_engine_warns_once_per_process(monkeypatch, tmp_path):
+    import lionagi.state.engine as engine_mod
+
+    recorder, engine = _engine_with_recorded_log(monkeypatch, tmp_path, (3, 46, 0), "3.46.0")
+    second = engine_mod.make_engine(f"sqlite+aiosqlite:///{tmp_path / 'v2.db'}")
+    try:
+        assert len(recorder.warnings) == 1
+    finally:
+        await engine.dispose()
+        await second.dispose()
+
+
+async def test_make_engine_silent_on_fixed_sqlite(monkeypatch, tmp_path):
+    recorder, engine = _engine_with_recorded_log(monkeypatch, tmp_path, (3, 51, 3), "3.51.3")
+    try:
+        assert recorder.warnings == []
+    finally:
+        await engine.dispose()

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -1036,3 +1036,68 @@ async def test_dispatched_at_migration_backfills_preexisting_running_rows(tmp_pa
         assert orphans == []
     finally:
         await state.close()
+
+
+def _create_legacy_session_status_db(db_path: Path) -> None:
+    """Create a database whose sessions table still carries the four-value
+    status CHECK that ``_drop_legacy_session_status_check`` rebuilds away."""
+    from lionagi.state.db import _SCHEMA_PATH
+
+    schema = _SCHEMA_PATH.read_text()
+    current = "  status          TEXT,\n"
+    assert current in schema, "sessions.status declaration not found in schema.sql"
+    legacy = schema.replace(
+        current,
+        "  status          TEXT CHECK(status IS NULL OR status IN "
+        "('running', 'completed', 'failed', 'aborted')),\n",
+        1,
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(legacy)
+
+
+def _sessions_create_sql(db_path: Path) -> str:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'"
+        ).fetchone()
+    return row[0] or ""
+
+
+def _schema_meta_version(db_path: Path) -> str | None:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT value FROM schema_meta WHERE key='version'").fetchone()
+    return row[0] if row else None
+
+
+async def test_migrated_db_reports_current_schema_version(tmp_path):
+    """A database whose tables were rewritten on open reports the version this
+    code applies, not the version it was created at."""
+    from lionagi.state.db import SCHEMA_VERSION, StateDB
+
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_session_status_db(db_path)
+    # Stand in for a database created by an older release: the version row says
+    # "1" and the sessions table still has the old CHECK.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE schema_meta SET value = '1' WHERE key = 'version'")
+    assert _schema_meta_version(db_path) == "1"
+    assert "'aborted')" in _sessions_create_sql(db_path)
+
+    state = StateDB(f"sqlite+aiosqlite:///{db_path}")
+    async with state:
+        version = await state.schema_version()
+
+    # The migration ran ...
+    assert "'aborted')" not in _sessions_create_sql(db_path)
+    # ... so the stamp moved with it.
+    assert version == SCHEMA_VERSION
+    assert _schema_meta_version(db_path) == SCHEMA_VERSION
+
+
+def test_schema_sql_seed_version_matches_constant():
+    """schema.sql seeds the same version the applying code stamps."""
+    from lionagi.state.db import _SCHEMA_PATH, SCHEMA_VERSION
+
+    seed = f"INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('version', '{SCHEMA_VERSION}');"
+    assert seed in _SCHEMA_PATH.read_text()


### PR DESCRIPTION
Two preconditions the store assumed without checking. Both now either move with
reality or say so out loud.

## The schema stamp did not move across migrations

`_apply_schema` seeded `schema_meta.version` with a literal `'1'` under
`ON CONFLICT (key) DO NOTHING`. That is write-once by construction: it records
what the database was created at, never what it has since become. The on-open
migrations rewrite an older database into the current shape and the stamp stays
where it was, so a reader asking the version to decide whether a migration ran
gets an answer that cannot distinguish the two cases.

Reproduced by building a database carrying the legacy four-value `sessions.status`
CHECK that `_drop_legacy_session_status_check` exists to rebuild away, opening it
through `StateDB`, and reading both the live DDL and the stamp: the CHECK is gone,
so the migration really ran, and the version is still `'1'`, byte-identical to a
freshly created database.

The version row now writes `DO UPDATE SET value = excluded.value` against a new
`SCHEMA_VERSION` constant, currently `"2"`. The other two seeded rows keep
`DO NOTHING`, which is right for them — they are identity-stable and the version
row is not. `schema.sql` seeds the same literal so a database built straight from
the SQL file agrees, and a test asserts the two stay equal, because they are now
two spellings of one fact.

What the stamp means is worth stating so it is not mistaken for more: there is no
versioned migration ledger here, only idempotent on-open reconciliation. So
`SCHEMA_VERSION` says "this database has been through the current code's
migrations", not "these specific numbered steps ran".

Closes #2429

## WAL was enabled without checking the linked library

`make_engine` issues `PRAGMA journal_mode = WAL` on every SQLite connection and
never reads `sqlite_version`. SQLite documents a data race in which a checkpoint
starting concurrently with a commit that resets the WAL file mis-sets a WAL-index
header field, and a later checkpoint then skips part of that committed
transaction. It affects every release from 3.7.0 through 3.51.2 and is fixed in
3.51.3, with backports on the 3.44 and 3.50 branches. Exposure needs two
connections writing or checkpointing at the same instant, which is what this
store does.

`has_wal_reset_fix()` now encodes that range, including the two backport branches
and the gap where a higher version is less fixed than a lower one, and
`make_engine` warns once per process on the SQLite path when the linked library
is affected. The local library here is 3.46.0, inside the affected range — the
issue's claim that it was newer than the fix is wrong.

**WAL stays on.** That is the part most worth arguing with. Downgrading to
`journal_mode=DELETE` would change locking semantics every caller already depends
on, to avoid a race the vendor rates as needing simultaneous multi-connection
checkpoint and commit; refusing to open would be worse. So this converts
"assumed, silent" into "checked, stated". If the intended contract is to refuse
an affected library, that is a policy decision this does not make.

Closes #2430

## Where the issues are wrong

#2429's evidence block reports the migrated database losing all four `sessions`
foreign keys (`session_fks: 0`). Measured here, both sides show 4. The FK-loss
half does not reproduce; the version half reproduces exactly. So the defect fixed
is the one the title states, not the one the evidence implies.

#2430 states the local linked library is newer than the fix. It is 3.46.0, which
is inside the affected range. The issue's conclusion — that no gate exists — is
right; its reassurance about the local library is the kind of wrong that would
have justified deferring.

## Two further defects found, not fixed

`lionagi/studio/services/_db.py` issues the same unconditional
`PRAGMA journal_mode = WAL` on the studio-local connection, with no version check
either — the same precondition on a different store, outside the path #2430
names. It deserves the same warn-versus-refuse decision rather than a copied
warning.

`PRAGMA journal_mode` returns the mode actually in force and `_apply_pragmas`
discards it, so a connection that cannot enter WAL proceeds silently in another
mode. Not fixed naively, because in-memory databases legitimately return
`memory`; it needs a real decision about which URLs must be WAL.

## Verification

`tests/state` plus the studio test that builds a database straight from
`schema.sql`: rc 0, 840 tests, 833 passed, 7 skipped, 0 failed. The 7 skips are
all `asyncpg not installed`, so the PostgreSQL path of the version-stamp change
is unverified by execution here; the `ON CONFLICT ... DO UPDATE` form is standard
on both backends but was not run against PostgreSQL.

`tests/mcp/test_lifecycle_verb_is_readonly.py`, `tests/cli/test_scheduler_flow_yaml.py`
and `tests/fixtures`: rc 0, 40 passed. That second set was run specifically because
turning `DO NOTHING` into `DO UPDATE` makes the version row a real write on every
open, and one of those tests asserts that a verb presenting itself as a read does
not write `schema_meta`. It passes because the read-only open path skips
`_apply_schema` entirely.

Counting method: this repo's pytest configuration prints no `N passed` summary
line, so the counts come from parsing progress characters out of the captured
logs and the return codes were taken from the pytest process itself, not after a
pipe. The full repository suite was not run locally; CI on this PR is that run.

The affected-version boundaries come from sqlite.org's own changelog and WAL
documentation. That is one publisher, not two independent sources, and the
boundaries encoded in `has_wal_reset_fix` are therefore uncorroborated against a
second one.
