### PR TITLE
fix(cli): keep the fallback terminal envelope faithful to what happened

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -362,9 +362,15 @@ async def _resolve_invocation_terminal_flow(
 
 def _fallback_notify_reason(status: str) -> str:
     """Reason code for a best-effort terminal-notify envelope emitted when
-    invocation finalization itself raised (see `_run_flow`'s finally block)
-    -- *status* here is the flow's own already-computed terminal status, not
-    a value read back from the (never-committed) invocation row."""
+    invocation finalization itself raised before resolving a reason (see
+    `_run_flow`'s finally block) -- *status* here is the flow's own
+    already-computed terminal status, not a value read back from the
+    (never-committed) invocation row.
+
+    The mapping deliberately matches what `_resolve_invocation_terminal_flow`
+    would have returned for the same status, so a consumer sees the same cause
+    for the same run whether or not finalization failed. In particular an
+    aborted flow is a SIGINT cancellation."""
     from lionagi.state.reasons import RunReasons
 
     return {
@@ -372,7 +378,7 @@ def _fallback_notify_reason(status: str) -> str:
         "completed_empty": RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
         "failed": RunReasons.FAILED_EXCEPTION,
         "timed_out": RunReasons.TIMED_OUT_DEADLINE,
-        "aborted": RunReasons.ABORTED_USER,
+        "aborted": RunReasons.CANCELLED_SIGINT,
         "cancelled": RunReasons.CANCELLED_SYSTEM,
     }.get(status, RunReasons.FAILED_EXCEPTION)
 
@@ -1881,6 +1887,11 @@ async def _run_flow(
                 from lionagi.state.db import StateDB
 
                 _invocation_previous_status = "unknown"
+                # Populated once resolution succeeds, so the fallback below can
+                # tell "resolution never produced an outcome" from "resolution
+                # produced one and only the write failed".
+                inv_status: str | None = None
+                inv_rc: str | None = None
                 try:
                     async with StateDB() as _status_db:
                         _invocation_row = await _status_db.get_invocation(invocation_id)
@@ -1919,10 +1930,16 @@ async def _run_flow(
                     # invocation's entity -- any --notify / notify.on_terminal
                     # handler scoped to it would otherwise be silently
                     # dropped exactly when a notification is most needed.
-                    # Emit a best-effort envelope directly, using the flow's
-                    # own already-computed terminal status as a fallback
-                    # (mirrors the unconditional fire_terminal_notify() call
-                    # this code path replaced).
+                    # Emit a best-effort envelope directly (mirrors the
+                    # unconditional fire_terminal_notify() call this code path
+                    # replaced). Report the invocation status/reason that
+                    # resolution already settled when it got that far -- the
+                    # failure may have been only in the write, and the resolved
+                    # outcome can differ from the flow's own coarser status
+                    # (a clean flow whose children produced no evidence
+                    # resolves to completed_empty). Fall back to the flow's own
+                    # terminal status only when resolution itself never
+                    # produced one.
                     try:
                         import uuid as _uuid
 
@@ -1933,13 +1950,16 @@ async def _run_flow(
                             RunTerminalEnvelope,
                         )
 
+                        _notify_status = inv_status or _terminal_status
+                        _notify_reason = inv_rc or _fallback_notify_reason(_notify_status)
+
                         await DEFAULT_TERMINAL_CALLBACKS.emit(
                             RunTerminalEnvelope(
                                 event_id=str(_uuid.uuid4()),
                                 entity=EntityRef(kind="invocation", id=invocation_id),
                                 previous_status=_invocation_previous_status,
-                                terminal_status=_terminal_status,
-                                reason_code=_fallback_notify_reason(_terminal_status),
+                                terminal_status=_notify_status,
+                                reason_code=_notify_reason,
                                 occurred_at=_ended_at,
                                 correlation=Correlation(invocation_id=invocation_id),
                                 durable=False,

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -477,6 +477,137 @@ async def test_fallback_terminal_envelope_has_last_known_previous_status(
     assert emitted[0].previous_status is not None
 
 
+async def test_fallback_envelope_keeps_resolved_status_when_only_the_write_fails(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The fallback envelope must distinguish "resolution never ran" from
+    "resolution ran and only the write failed".
+
+    `_resolve_invocation_terminal_flow` can downgrade a flow whose own
+    execution finished clean to `completed_empty` (no child produced
+    evidence). When resolution succeeds and only the subsequent status write
+    raises, the resolved status/reason are known-good and must be what the
+    envelope reports -- reporting the flow's own coarser `completed` instead
+    would tell a `--notify` consumer the run succeeded on exactly the path
+    where its outcome was already known to be empty.
+    """
+    from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+    from lionagi.state.reasons import RunReasons
+
+    env = _make_env(tmp_path)
+    invocation_id = str(uuid4())
+    await _make_invocation(temp_db_path, invocation_id)
+    emitted = []
+    callback_name = f"test.resolved.{invocation_id}"
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        callback_name,
+        emitted.append,
+        kinds=["invocation"],
+        ids=[invocation_id],
+    )
+
+    real_update_status = StateDB.update_status
+
+    async def _fail_only_the_invocation_write(self, entity_type, entity_id, **kwargs):
+        if entity_type == "invocation":
+            raise RuntimeError("status write failed after resolution already succeeded")
+        return await real_update_status(self, entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(StateDB, "update_status", _fail_only_the_invocation_write)
+
+    try:
+        with (
+            patch(
+                "lionagi.cli.orchestrate.flow.setup_orchestration",
+                AsyncMock(return_value=env),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._run_flow_inner",
+                AsyncMock(return_value="ok result"),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._resolve_invocation_terminal_flow",
+                AsyncMock(
+                    return_value=(
+                        "completed_empty",
+                        RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+                        "Flow exited clean but produced no evidence.",
+                        [],
+                        {"child_statuses": ["completed_empty"]},
+                    )
+                ),
+            ),
+        ):
+            result, terminal_status = await _run_flow(
+                "claude", "do the thing", invocation_id=invocation_id
+            )
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+
+    assert result == "ok result"
+    assert terminal_status == "completed"
+
+    assert len(emitted) == 1
+    assert emitted[0].terminal_status == "completed_empty", (
+        "fallback envelope discarded the already-resolved invocation status"
+    )
+    assert emitted[0].reason_code == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
+
+
+async def test_fallback_envelope_reports_an_interrupted_flow_as_sigint_not_user_abort(
+    temp_db_path: Path, tmp_path: Path
+):
+    """An interrupted flow is a SIGINT cancellation, and the fallback
+    envelope must say so.
+
+    `aborted` is the flow's terminal status for an interrupt; its cause is
+    the SIGINT reason that a normal invocation finalization of the very same
+    run records. Emitting a distinct user-abort reason here would make the
+    cause a consumer sees depend on whether finalization happened to fail,
+    for a run that was interrupted identically either way."""
+    from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS
+    from lionagi.state.reasons import RunReasons
+
+    env = _make_env(tmp_path)
+    invocation_id = str(uuid4())
+    await _make_invocation(temp_db_path, invocation_id)
+    emitted = []
+    callback_name = f"test.sigint.{invocation_id}"
+    DEFAULT_TERMINAL_CALLBACKS.register(
+        callback_name,
+        emitted.append,
+        kinds=["invocation"],
+        ids=[invocation_id],
+    )
+
+    try:
+        with (
+            patch(
+                "lionagi.cli.orchestrate.flow.setup_orchestration",
+                AsyncMock(return_value=env),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._run_flow_inner",
+                AsyncMock(side_effect=KeyboardInterrupt()),
+            ),
+            patch(
+                "lionagi.cli.orchestrate.flow._resolve_invocation_terminal_flow",
+                AsyncMock(side_effect=RuntimeError("db hiccup during invocation finalize")),
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            await _run_flow("claude", "do the thing", invocation_id=invocation_id)
+    finally:
+        DEFAULT_TERMINAL_CALLBACKS.unregister(callback_name)
+
+    assert len(emitted) == 1
+    assert emitted[0].terminal_status == "aborted"
+    assert emitted[0].reason_code == RunReasons.CANCELLED_SIGINT, (
+        "an interrupted flow was reported with a cause other than the SIGINT "
+        "one a normal finalization of the same run records"
+    )
+
+
 async def test_run_flow_fires_hook_without_invocation_id(temp_db_path: Path, tmp_path: Path):
     """A `--notify` run with no --invocation scopes to the session id
     instead, and the payload's own invocation_id field stays null; no


### PR DESCRIPTION
When a flow's finalization raised after the invocation status had already been
resolved, the fallback terminal envelope reported `completed` — the default —
rather than the status that had been resolved moments earlier. And a run
interrupted by SIGINT reported `run.aborted.user` where the normal finalization
path records `run.cancelled.sigint`, so the same event carried a different reason
code depending on which path emitted it.

Two changes in `flow.py`. The `aborted` status now maps to `CANCELLED_SIGINT`,
matching the normal path. And the fallback prefers the already-resolved
`inv_status` and `inv_rc`, which are initialised to `None` before the `try` —
that initialisation is what carries the distinction between "resolution never
ran" and "resolution succeeded and only the write failed".

The two fixes cannot mask each other, and that was measured rather than argued:
reverting each one alone fails only its own test.

Closes #2360
Closes #2361

## An adjacent question, not a finding

`_run_flow` returns `_terminal_status` while the invocation row is written with
`inv_status`, so a `completed_empty` invocation may still return `completed` on
the success path. Two immediate return sites were read; whether that reaches a
process exit code was not traced, so this is recorded as a question rather than a
defect.

## Verification

Targeted: 12 passed with both fixes applied, and each fix reverted alone fails
only its own test.

Broad run over `tests/cli/` and `tests/state/`: rc 1 with two failures, one of
them in `test_live_persist.py`, which is one of only two files referencing the
symbol changed here — so it could not be waved off. Three discriminators were
run: both tests at the branch base with changes stashed, both with the changes
applied, and both files in full (142 tests). All three rc 0.

That makes the two failures **not attributable to this change by any
discriminator run**, which is a weaker claim than pre-existing flakiness. The
full suite was not run at base, and that is the only control that would show them
failing there too. Unreproduced is not absent.
